### PR TITLE
test(runtime): conformance suite for runtime mount access

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -247,6 +247,13 @@ jobs:
           MIRAGE_QUICKJS_HOME: /tmp/quickjs
         run: uv run pytest tests/runtime/js/ -v --no-cov
 
+      - name: Run the runtime conformance suite
+        working-directory: python
+        env:
+          MIRAGE_WASI_HOME: /tmp/cpython-wasi
+          MIRAGE_QUICKJS_HOME: /tmp/quickjs
+        run: uv run pytest tests/runtime/test_conformance.py -v --no-cov
+
       - name: Install base package without the monty extra
         working-directory: python
         run: |

--- a/python/mirage/runtime/js/base.py
+++ b/python/mirage/runtime/js/base.py
@@ -22,8 +22,10 @@ class JsRuntime(LanguageRuntime):
     """The js tier: every runtime that interprets JavaScript source.
 
     Groups the engines behind the node/js commands (quickjs today), so
-    ``language`` is declared once and js-tier behavior has one home. A
-    new JavaScript engine subclasses this, not LanguageRuntime.
+    ``language`` and the default ``captures`` are declared once and
+    js-tier behavior has one home. A new JavaScript engine subclasses
+    this, not LanguageRuntime.
     """
 
     language: ClassVar[Language] = "js"
+    captures = ("node", "js")

--- a/python/mirage/runtime/js/quickjs.py
+++ b/python/mirage/runtime/js/quickjs.py
@@ -99,7 +99,6 @@ class QuickJsRuntime(JsRuntime, EvaluatorMixin):
     """
 
     name = "quickjs"
-    captures = ("node", "js")
 
     config_cls: ClassVar[type[RuntimeConfig]] = HomeConfig
     config: HomeConfig

--- a/python/mirage/runtime/python/base.py
+++ b/python/mirage/runtime/python/base.py
@@ -22,9 +22,11 @@ class PythonRuntime(LanguageRuntime):
     """The python tier: every runtime that interprets Python source.
 
     Groups the engines behind the python3/python commands (monty,
-    wasi, local here; pyodide in TypeScript), so ``language`` is
-    declared once and python-tier behavior has one home. A new Python
-    engine subclasses this, not LanguageRuntime.
+    wasi, local here; pyodide in TypeScript), so ``language`` and the
+    default ``captures`` are declared once and python-tier behavior
+    has one home. A new Python engine subclasses this, not
+    LanguageRuntime.
     """
 
     language: ClassVar[Language] = "python"
+    captures = ("python3", "python")

--- a/python/mirage/runtime/python/local.py
+++ b/python/mirage/runtime/python/local.py
@@ -40,7 +40,6 @@ class LocalRuntime(PythonRuntime):
     """
 
     name = "local"
-    captures = ("python3", "python")
 
     config_cls: ClassVar[type[RuntimeConfig]] = HomeConfig
     config: HomeConfig

--- a/python/mirage/runtime/python/monty.py
+++ b/python/mirage/runtime/python/monty.py
@@ -405,7 +405,6 @@ class MontyRuntime(PythonRuntime, EvaluatorMixin):
     """
 
     name = "monty"
-    captures = ("python3", "python")
 
     def __init__(
             self,

--- a/python/mirage/runtime/python/wasi.py
+++ b/python/mirage/runtime/python/wasi.py
@@ -68,7 +68,6 @@ class WasiRuntime(PythonRuntime):
     """
 
     name = "wasi"
-    captures = ("python3", "python")
 
     config_cls: ClassVar[type[RuntimeConfig]] = HomeConfig
     config: HomeConfig

--- a/python/tests/runtime/test_conformance.py
+++ b/python/tests/runtime/test_conformance.py
@@ -73,6 +73,8 @@ class Row:
         line_out (str | None): substring expected on the line's stdout.
         checks (tuple[tuple[str, str], ...]): shell verifications as
             (command, want) pairs; a want of "!x" asserts x is absent.
+            Every command must itself exit 0, or an absence want would
+            be satisfied by the empty stdout of a failed check.
     """
 
     capability: str
@@ -449,7 +451,11 @@ async def test_capability_reaches_the_mount(runtime: str, row: Row):
         if row.line_out is not None:
             assert row.line_out in out
         for cmd, want in row.checks:
-            _, seen = await _sh(ws, cmd)
+            code, seen = await _sh(ws, cmd)
+            # An absence assertion over the stdout of a command that
+            # failed is vacuous: a mount the mutation damaged answers
+            # nothing, and "x is gone" then holds for every x.
+            assert code == 0, f"check failed: {cmd}: exit {code}: {seen}"
             if want.startswith("!"):
                 assert want[1:] not in seen, f"{cmd}: unexpected {want[1:]}"
             else:

--- a/python/tests/runtime/test_conformance.py
+++ b/python/tests/runtime/test_conformance.py
@@ -1,0 +1,503 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from mirage import MountMode, Workspace
+from mirage.io.types import materialize
+from mirage.resource.ram import RAMResource
+from mirage.runtime.js.quickjs import QUICKJS_HOME_ENV
+from mirage.runtime.python.wasi import WASI_HOME_ENV
+from mirage.runtime.table import build_runtime
+from mirage.runtime.types import RunArgs
+from mirage.types import FileStat, FileType
+
+
+def _wasi_available() -> bool:
+    root = os.environ.get(WASI_HOME_ENV)
+    return bool(root) and (Path(root) / "python.wasm").is_file()
+
+
+def _quickjs_available() -> bool:
+    root = os.environ.get(QUICKJS_HOME_ENV)
+    return bool(root) and (Path(root) / "qjs-wasi.wasm").is_file()
+
+
+wasi_live = pytest.mark.skipif(
+    not _wasi_available(),
+    reason=f"{WASI_HOME_ENV} does not point at a CPython WASI build")
+quickjs_live = pytest.mark.skipif(
+    not _quickjs_available(),
+    reason=f"{QUICKJS_HOME_ENV} does not point at a quickjs WASI build")
+
+GUARDS = {"monty": (), "wasi": (wasi_live, ), "quickjs": (quickjs_live, )}
+
+APPEND_AMPLIFIED = (
+    "the shared wasm transport has no append op: every open-for-append "
+    "close re-flushes the whole file, so n appends ship O(n^2) bytes")
+
+
+@dataclass(frozen=True, slots=True)
+class Row:
+    """One capability row: a mutation in the runtime's own idiom.
+
+    The runtime line mutates, the shell verifies: assertions are made
+    on the mount through a shell command, never through the runtime
+    that wrote it, because the bug class is a runtime that mutates its
+    own private tree and reports success.
+
+    Args:
+        capability (str): the capability under test (mkdir, unlink,
+            rename-cross, ...), spelled the same in both languages.
+        spelling (str): the guest API spelling this row exercises. The
+            spelling axis is the point of the suite: which spellings a
+            runtime intercepts is exactly what diverges.
+        line (str): the interpreter command that performs the mutation.
+        setup (tuple[str, ...]): shell lines seeding the world.
+        exit_code (int): expected exit of the runtime line.
+        line_out (str | None): substring expected on the line's stdout.
+        checks (tuple[tuple[str, str], ...]): shell verifications as
+            (command, want) pairs; a want of "!x" asserts x is absent.
+    """
+
+    capability: str
+    spelling: str
+    line: str
+    setup: tuple[str, ...] = ()
+    exit_code: int = 0
+    line_out: str | None = None
+    checks: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass
+class CountingDispatch:
+    """Dispatch stub that records every op and the bytes it carried.
+
+    The seam for the append row: every runtime takes the dispatch as an
+    injected callable, so byte accounting needs no new hook. Supports
+    the full op vocabulary the runtimes emit (monty's OS callbacks and
+    GuestFs's bridge calls).
+
+    Args:
+        files (dict[str, bytes]): initial virtual file contents.
+    """
+
+    files: dict[str, bytes]
+    dirs: set[str] = field(default_factory=set)
+    ops: list[tuple[str, str, int]] = field(default_factory=list)
+
+    async def __call__(self, op, path, **kwargs):
+        virtual = path.virtual
+        payload = kwargs.get("data")
+        size = len(payload) if payload is not None else 0
+        self.ops.append((op, virtual, size))
+        if op == "read":
+            if virtual not in self.files:
+                raise FileNotFoundError(virtual)
+            return self.files[virtual], None
+        if op == "stat":
+            return self._stat(virtual), None
+        if op == "readdir":
+            prefix = virtual.rstrip("/") + "/"
+            names = {
+                p[len(prefix):].split("/")[0]
+                for p in self.files if p.startswith(prefix)
+            }
+            return sorted(names), None
+        if op == "write":
+            self.files[virtual] = bytes(payload)
+            return None, None
+        if op == "append":
+            self.files[virtual] = self.files.get(virtual, b"") + bytes(payload)
+            return None, None
+        if op == "create":
+            self.files.setdefault(virtual, b"")
+            return None, None
+        if op == "truncate":
+            self.files[virtual] = b""
+            return None, None
+        if op == "unlink":
+            self.files.pop(virtual, None)
+            return None, None
+        if op == "mkdir":
+            self.dirs.add(virtual)
+            return None, None
+        if op == "rmdir":
+            self.dirs.discard(virtual)
+            return None, None
+        if op == "rename":
+            dst = kwargs["dst"].virtual
+            self.files[dst] = self.files.pop(virtual)
+            return None, None
+        raise ValueError(f"unexpected op {op}")
+
+    def _stat(self, virtual: str) -> FileStat:
+        if virtual in self.files:
+            return FileStat(name=virtual.rsplit("/", 1)[-1],
+                            size=len(self.files[virtual]),
+                            type=FileType.TEXT)
+        trimmed = virtual.rstrip("/")
+        is_dir = trimmed in self.dirs or any(
+            p.startswith(trimmed + "/") for p in self.files)
+        if not is_dir:
+            raise FileNotFoundError(virtual)
+        return FileStat(name=trimmed.rsplit("/", 1)[-1],
+                        type=FileType.DIRECTORY)
+
+    def mutation_bytes(self) -> int:
+        return sum(size for op, _, size in self.ops
+                   if op in ("write", "append", "create", "truncate"))
+
+    def mutation_ops(self) -> list[str]:
+        return [
+            op for op, _, _ in self.ops
+            if op in ("write", "append", "create", "truncate")
+        ]
+
+
+MONTY_ROWS = (
+    Row("mkdir",
+        "Path.mkdir",
+        "python3 -c \"from pathlib import Path; Path('/data/made').mkdir()\"",
+        checks=(("ls /data", "made"), )),
+    Row("unlink",
+        "Path.unlink", "python3 -c "
+        "\"from pathlib import Path; Path('/data/gone.txt').unlink()\"",
+        setup=("echo -n x > /data/gone.txt", ),
+        checks=(("ls /data", "!gone.txt"), )),
+    Row("rmdir",
+        "Path.rmdir",
+        "python3 -c \"from pathlib import Path; Path('/data/hollow').rmdir()\"",
+        setup=("mkdir /data/hollow", ),
+        checks=(("ls /data", "!hollow"), )),
+    Row("rename",
+        "Path.rename", "python3 -c \"from pathlib import Path; "
+        "Path('/data/a.txt').rename('/data/b.txt')\"",
+        setup=("echo -n one > /data/a.txt", ),
+        checks=(("cat /data/b.txt", "one"), ("ls /data", "!a.txt"))),
+    Row("rename-cross",
+        "Path.rename", "python3 -c \"from pathlib import Path; "
+        "Path('/data/c.txt').rename('/other/c.txt')\"",
+        setup=("echo -n keep > /data/c.txt", ),
+        exit_code=1,
+        checks=(("cat /data/c.txt", "keep"), ("ls /other", "!c.txt"))),
+    Row("read",
+        "open",
+        "python3 -c \"print(open('/data/r.txt').read())\"",
+        setup=("echo -n seen > /data/r.txt", ),
+        line_out="seen"),
+    Row("write",
+        "open", "python3 -c \"f = open('/data/w1.txt', 'w'); "
+        "f.write('data'); f.close()\"",
+        checks=(("cat /data/w1.txt", "data"), )),
+    Row("write",
+        "Path.write_text", "python3 -c \"from pathlib import Path; "
+        "Path('/data/w2.txt').write_text('data')\"",
+        checks=(("cat /data/w2.txt", "data"), )),
+    Row("write-readonly",
+        "open",
+        "python3 -c \"open('/ro/x.txt', 'w').write('nope')\"",
+        exit_code=1,
+        checks=(("ls /ro", "!x.txt"), )),
+    Row("write-readonly",
+        "Path.write_text", "python3 -c \"from pathlib import Path; "
+        "Path('/ro/y.txt').write_text('nope')\"",
+        exit_code=1,
+        checks=(("ls /ro", "!y.txt"), )),
+    Row("stat",
+        "Path.stat", "python3 -c \"from pathlib import Path; "
+        "print(Path('/data/st.txt').stat().st_size)\"",
+        setup=("echo -n four > /data/st.txt", ),
+        line_out="4"),
+    Row("append",
+        "open", "python3 -c \"\nfor part in ['b', 'c', 'd']:\n"
+        "    with open('/data/log.txt', 'a') as f:\n"
+        "        f.write(part)\n\"",
+        setup=("echo -n a > /data/log.txt", ),
+        checks=(("cat /data/log.txt", "abcd"), )),
+    Row("append-preserves",
+        "open", "python3 -c \"f = open('/data/keep.txt', 'a'); "
+        "f.write('Z'); f.close()\"",
+        setup=("echo -n a > /data/keep.txt", ),
+        checks=(("cat /data/keep.txt", "aZ"), )),
+)
+
+WASI_ROWS = (
+    Row("mkdir",
+        "os.mkdir",
+        "python3 -c \"import os; os.mkdir('/data/m1')\"",
+        checks=(("ls /data", "m1"), )),
+    Row("mkdir",
+        "os.makedirs",
+        "python3 -c \"import os; os.makedirs('/data/m2/deep')\"",
+        checks=(("ls /data/m2", "deep"), )),
+    Row("mkdir",
+        "Path.mkdir",
+        "python3 -c \"from pathlib import Path; Path('/data/m3').mkdir()\"",
+        checks=(("ls /data", "m3"), )),
+    Row("unlink",
+        "os.remove",
+        "python3 -c \"import os; os.remove('/data/f1.txt')\"",
+        setup=("echo -n x > /data/f1.txt", ),
+        checks=(("ls /data", "!f1.txt"), )),
+    Row("unlink",
+        "Path.unlink", "python3 -c "
+        "\"from pathlib import Path; Path('/data/f2.txt').unlink()\"",
+        setup=("echo -n x > /data/f2.txt", ),
+        checks=(("ls /data", "!f2.txt"), )),
+    Row("rmdir",
+        "os.rmdir",
+        "python3 -c \"import os; os.rmdir('/data/d1')\"",
+        setup=("mkdir /data/d1", ),
+        checks=(("ls /data", "!d1"), )),
+    Row("rmdir",
+        "Path.rmdir",
+        "python3 -c \"from pathlib import Path; Path('/data/d2').rmdir()\"",
+        setup=("mkdir /data/d2", ),
+        checks=(("ls /data", "!d2"), )),
+    Row("rmdir",
+        "shutil.rmtree",
+        "python3 -c \"import shutil; shutil.rmtree('/data/d3')\"",
+        setup=("mkdir /data/d3", "echo -n x > /data/d3/inner.txt"),
+        checks=(("ls /data", "!d3"), )),
+    Row("rename",
+        "os.rename",
+        "python3 -c \"import os; os.rename('/data/a1.txt', '/data/b1.txt')\"",
+        setup=("echo -n one > /data/a1.txt", ),
+        checks=(("cat /data/b1.txt", "one"), ("ls /data", "!a1.txt"))),
+    Row("rename",
+        "os.replace",
+        "python3 -c \"import os; os.replace('/data/a2.txt', '/data/b2.txt')\"",
+        setup=("echo -n one > /data/a2.txt", ),
+        checks=(("cat /data/b2.txt", "one"), )),
+    Row("rename",
+        "Path.rename", "python3 -c \"from pathlib import Path; "
+        "Path('/data/a3.txt').rename('/data/b3.txt')\"",
+        setup=("echo -n one > /data/a3.txt", ),
+        checks=(("cat /data/b3.txt", "one"), )),
+    Row("rename",
+        "shutil.move", "python3 -c \"import shutil; "
+        "shutil.move('/data/a4.txt', '/data/b4.txt')\"",
+        setup=("echo -n one > /data/a4.txt", ),
+        checks=(("cat /data/b4.txt", "one"), )),
+    Row("rename-cross",
+        "os.rename",
+        "python3 -c \"import os; os.rename('/data/c.txt', '/other/c.txt')\"",
+        setup=("echo -n keep > /data/c.txt", ),
+        exit_code=1,
+        checks=(("cat /data/c.txt", "keep"), ("ls /other", "!c.txt"))),
+    Row("read",
+        "open",
+        "python3 -c \"print(open('/data/r.txt').read())\"",
+        setup=("echo -n seen > /data/r.txt", ),
+        line_out="seen"),
+    Row("write",
+        "open", "python3 -c \"f = open('/data/w1.txt', 'w'); "
+        "f.write('data'); f.close()\"",
+        checks=(("cat /data/w1.txt", "data"), )),
+    Row("write",
+        "Path.write_text", "python3 -c \"from pathlib import Path; "
+        "Path('/data/w2.txt').write_text('data')\"",
+        checks=(("cat /data/w2.txt", "data"), )),
+    Row("write-readonly",
+        "open",
+        "python3 -c \"open('/ro/x.txt', 'w').write('nope')\"",
+        exit_code=1,
+        checks=(("ls /ro", "!x.txt"), )),
+    Row("stat",
+        "Path.stat", "python3 -c \"from pathlib import Path; "
+        "print(Path('/data/st.txt').stat().st_size)\"",
+        setup=("echo -n four > /data/st.txt", ),
+        line_out="4"),
+    Row("append",
+        "open", "python3 -c \"\nfor part in ['b', 'c', 'd']:\n"
+        "    with open('/data/log.txt', 'a') as f:\n"
+        "        f.write(part)\n\"",
+        setup=("echo -n a > /data/log.txt", ),
+        checks=(("cat /data/log.txt", "abcd"), )),
+    Row("append-preserves",
+        "open", "python3 -c \"f = open('/data/keep.txt', 'a'); "
+        "f.write('Z'); f.close()\"",
+        setup=("echo -n a > /data/keep.txt", ),
+        checks=(("cat /data/keep.txt", "aZ"), )),
+)
+
+QUICKJS_ROWS = (
+    Row("mkdir",
+        "os.mkdir", "node -e \"const rc = os.mkdir('/data/m1'); "
+        "if (rc !== 0) throw new Error('rc ' + rc)\"",
+        checks=(("ls /data", "m1"), )),
+    Row("unlink",
+        "os.remove", "node -e \"const rc = os.remove('/data/f1.txt'); "
+        "if (rc !== 0) throw new Error('rc ' + rc)\"",
+        setup=("echo -n x > /data/f1.txt", ),
+        checks=(("ls /data", "!f1.txt"), )),
+    Row("rmdir",
+        "os.remove", "node -e \"const rc = os.remove('/data/d1'); "
+        "if (rc !== 0) throw new Error('rc ' + rc)\"",
+        setup=("mkdir /data/d1", ),
+        checks=(("ls /data", "!d1"), )),
+    Row("rename",
+        "os.rename",
+        "node -e \"const rc = os.rename('/data/a1.txt', '/data/b1.txt'); "
+        "if (rc !== 0) throw new Error('rc ' + rc)\"",
+        setup=("echo -n one > /data/a1.txt", ),
+        checks=(("cat /data/b1.txt", "one"), ("ls /data", "!a1.txt"))),
+    Row("rename-cross",
+        "os.rename",
+        "node -e \"console.log(os.rename('/data/c.txt', '/other/c.txt'))\"",
+        setup=("echo -n keep > /data/c.txt", ),
+        line_out="-44",
+        checks=(("cat /data/c.txt", "keep"), ("ls /other", "!c.txt"))),
+    Row("read",
+        "std.open", "node -e \"const f = std.open('/data/r.txt', 'r'); "
+        "console.log(f.readAsString()); f.close()\"",
+        setup=("echo -n seen > /data/r.txt", ),
+        line_out="seen"),
+    Row("write",
+        "std.open", "node -e \"const w = std.open('/data/w1.txt', 'w'); "
+        "w.puts('data'); w.close()\"",
+        checks=(("cat /data/w1.txt", "data"), )),
+    Row("write-readonly",
+        "std.open",
+        "node -e \"const e = {}; const w = std.open('/ro/x.txt', 'w', e); "
+        "console.log(w === null, e.errno)\"",
+        line_out="true 2",
+        checks=(("ls /ro", "!x.txt"), )),
+    Row("stat",
+        "os.stat", "node -e \"const [st, e] = os.stat('/data/st.txt'); "
+        "console.log(e, st.size)\"",
+        setup=("echo -n four > /data/st.txt", ),
+        line_out="0 4"),
+    Row("append",
+        "std.open", "node -e \"for (const part of ['b', 'c', 'd']) { "
+        "const w = std.open('/data/log.txt', 'a'); "
+        "w.puts(part); w.close() }\"",
+        setup=("echo -n a > /data/log.txt", ),
+        checks=(("cat /data/log.txt", "abcd"), )),
+    Row("append-preserves",
+        "std.open", "node -e \"const w = std.open('/data/keep.txt', 'a'); "
+        "w.puts('Z'); w.close()\"",
+        setup=("echo -n a > /data/keep.txt", ),
+        checks=(("cat /data/keep.txt", "aZ"), )),
+)
+
+
+def _world(runtime: str) -> Workspace:
+    return Workspace(
+        {
+            "/data": RAMResource(),
+            "/other": RAMResource(),
+            "/ro": (RAMResource(), MountMode.READ),
+        },
+        mode=MountMode.EXEC,
+        runtimes=[runtime, "vfs"],
+    )
+
+
+async def _sh(ws: Workspace, line: str) -> tuple[int, str]:
+    io = await ws.execute(line)
+    out = (await materialize(io.stdout)).decode()
+    return io.exit_code, out
+
+
+def _rows():
+    out = []
+    tables = (("monty", MONTY_ROWS), ("wasi", WASI_ROWS), ("quickjs",
+                                                           QUICKJS_ROWS))
+    for runtime, rows in tables:
+        for row in rows:
+            out.append(
+                pytest.param(runtime,
+                             row,
+                             id=f"{runtime}-{row.capability}-{row.spelling}",
+                             marks=GUARDS[runtime]))
+    return out
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime,row", _rows())
+async def test_capability_reaches_the_mount(runtime: str, row: Row):
+    """One mutation in the runtime's idiom, verified through the shell.
+
+    Args:
+        runtime (str): registry name of the runtime under test.
+        row (Row): the capability row to execute.
+    """
+    ws = _world(runtime)
+    try:
+        for line in row.setup:
+            code, out = await _sh(ws, line)
+            assert code == 0, f"setup failed: {line}: {out}"
+        code, out = await _sh(ws, row.line)
+        assert code == row.exit_code, f"{row.line}: exit {code}: {out}"
+        if row.line_out is not None:
+            assert row.line_out in out
+        for cmd, want in row.checks:
+            _, seen = await _sh(ws, cmd)
+            if want.startswith("!"):
+                assert want[1:] not in seen, f"{cmd}: unexpected {want[1:]}"
+            else:
+                assert want in seen, f"{cmd}: wanted {want}, saw {seen!r}"
+    finally:
+        await ws.close()
+
+
+APPEND_LOOP_PY = ("for i in range(8):\n"
+                  "    with open('/data/log.txt', 'a') as f:\n"
+                  "        f.write('xyz')")
+APPEND_LOOP_JS = ("for (let i = 0; i < 8; i++) { "
+                  "const w = std.open('/data/log.txt', 'a'); "
+                  "w.puts('xyz'); w.close() }")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime",
+    [
+        pytest.param("monty"),
+        pytest.param("wasi",
+                     marks=(wasi_live,
+                            pytest.mark.xfail(strict=True,
+                                              reason=APPEND_AMPLIFIED))),
+        pytest.param("quickjs",
+                     marks=(quickjs_live,
+                            pytest.mark.xfail(strict=True,
+                                              reason=APPEND_AMPLIFIED))),
+    ],
+)
+async def test_append_ships_only_the_deltas(runtime: str):
+    """Eight appends of three bytes must ship 24 bytes, not O(n^2).
+
+    The dispatch is counted rather than the outcome compared: every
+    amplifying runtime still produces the right final content, so the
+    file alone cannot distinguish one append from a full rewrite per
+    close.
+
+    Args:
+        runtime (str): registry name of the runtime under test.
+    """
+    dispatch = CountingDispatch({"/data/log.txt": b"S" * 64})
+    rt = build_runtime(runtime)
+    rt.attach(dispatch, lambda: ["/data/"])
+    code = APPEND_LOOP_JS if runtime == "quickjs" else APPEND_LOOP_PY
+    result = await rt.run(RunArgs(code=code))
+    await rt.close()
+    assert result.exit_code == 0, result.stderr
+    assert dispatch.files["/data/log.txt"] == b"S" * 64 + b"xyz" * 8
+    assert dispatch.mutation_bytes() == 24, dispatch.mutation_ops()

--- a/python/tests/runtime/test_conformance.py
+++ b/python/tests/runtime/test_conformance.py
@@ -181,8 +181,8 @@ MONTY_ROWS = (
         setup=("echo -n x > /data/gone.txt", ),
         checks=(("ls /data", "!gone.txt"), )),
     Row("rmdir",
-        "Path.rmdir",
-        "python3 -c \"from pathlib import Path; Path('/data/hollow').rmdir()\"",
+        "Path.rmdir", "python3 -c \"from pathlib import Path; "
+        "Path('/data/hollow').rmdir()\"",
         setup=("mkdir /data/hollow", ),
         checks=(("ls /data", "!hollow"), )),
     Row("rename",

--- a/python/tests/runtime/test_language.py
+++ b/python/tests/runtime/test_language.py
@@ -52,6 +52,17 @@ def test_language_is_declared_once_per_tier():
     assert QuickJsRuntime.language == "js"
 
 
+def test_captures_default_is_declared_once_per_tier():
+    # The head words are a language fact like `language` itself: the
+    # tier declares them, engines inherit, and a class (EchoRuntime
+    # above) or an instance can still override.
+    for cls in (MontyRuntime, WasiRuntime, LocalRuntime):
+        assert cls.captures == ("python3", "python")
+    assert QuickJsRuntime.captures == ("node", "js")
+    assert EchoRuntime.captures == ("echo-run", )
+    assert EchoRuntime(captures=("only", )).captures == ("only", )
+
+
 def test_tiers_are_language_runtimes():
     assert issubclass(PythonRuntime, LanguageRuntime)
     assert issubclass(JsRuntime, LanguageRuntime)

--- a/python/tests/workspace/test_runtime_binding.py
+++ b/python/tests/workspace/test_runtime_binding.py
@@ -112,7 +112,6 @@ def test_config_vfs_entry_takes_no_options():
 
 class AlphaRuntime(PythonRuntime):
     name = "alpha"
-    captures = ("python3", "python")
 
     async def run(self, args: RunArgs) -> RunResult:
         return RunResult(stdout=b"ran-alpha\n", stderr=None, exit_code=0)
@@ -120,7 +119,6 @@ class AlphaRuntime(PythonRuntime):
 
 class BetaRuntime(PythonRuntime):
     name = "beta"
-    captures = ("python3", "python")
 
     async def run(self, args: RunArgs) -> RunResult:
         return RunResult(stdout=b"ran-beta\n", stderr=None, exit_code=0)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -9552,11 +9552,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.14.2"
+version = "6.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
 ]
 
 [[package]]

--- a/typescript/packages/core/src/runtime/conformance.test.ts
+++ b/typescript/packages/core/src/runtime/conformance.test.ts
@@ -419,6 +419,10 @@ async function runRow(ws: Workspace, row: Row): Promise<void> {
   if (row.lineOut !== undefined) expect(stdoutStr(io)).toContain(row.lineOut)
   for (const [cmd, want] of row.checks ?? []) {
     const check = await ws.execute(cmd)
+    // An absence assertion over the stdout of a command that failed is
+    // vacuous: a mount the mutation damaged answers nothing, and "x is
+    // gone" then holds for every x.
+    expect(check.exitCode, `check failed: ${cmd} -> ${stderrStr(check)}`).toBe(0)
     const out = stdoutStr(check)
     if (want.startsWith('!')) {
       expect(out, `${cmd} still shows ${want.slice(1)}`).not.toContain(want.slice(1))

--- a/typescript/packages/core/src/runtime/conformance.test.ts
+++ b/typescript/packages/core/src/runtime/conformance.test.ts
@@ -1,0 +1,588 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { OpsRegistry } from '../ops/registry.ts'
+import { RAMResource } from '../resource/ram/ram.ts'
+import { MountMode } from '../types.ts'
+import { getTestParser, stderrStr, stdoutStr } from '../workspace/fixtures/workspace_fixture.ts'
+import { Workspace } from '../workspace/workspace.ts'
+import { MontyRuntime } from './python/monty.ts'
+import { PyodideRuntime } from './python/pyodide.ts'
+import { QuickJsRuntime } from './js/quickjs.ts'
+import type { BridgeDispatchFn, RunArgs } from './types.ts'
+
+// The runtime conformance suite: one capability table, executed against
+// every runtime in that runtime's own idiom, with the outcome verified
+// on the MOUNT through a shell command, never through the runtime that
+// wrote it. The spelling axis is the point: which guest spellings a
+// runtime intercepts is exactly what diverges (mirrors the python
+// tests/runtime/test_conformance.py). Known-broken rows run as
+// it.fails with the reason beside the table; the mark comes off as
+// each one is fixed.
+
+// ts monty bridges only the typed Path arms; builtin open (any mode)
+// and Path.stat answer PermissionError on mount paths, so no append
+// spelling exists at all. py monty serves all of them.
+const MONTY_OPEN_UNSUPPORTED =
+  'ts monty: builtin open and Path.stat answer PermissionError on mount paths'
+
+// The pyodide shim patches only open/io.open, os.listdir, os.stat and
+// os.scandir, so every mutation spelling mutates MEMFS and never
+// reaches the mount: a pre-boot file succeeds silently (exit 0), a
+// post-boot file fails with the MEMFS miss. Either way the mount never
+// changes.
+const PYODIDE_MUTATIONS_DROPPED =
+  'ts pyodide: mutation spellings are not intercepted, the mount never changes'
+
+// A writable open never backfills, so appending to a file the MEMFS
+// has not seen starts from empty and the close-flush overwrites the
+// mount content the run never read.
+const PYODIDE_APPEND_CLOBBERS =
+  'ts pyodide: open-for-append on an unseen file clobbers the mount content'
+
+// The workspace bridge has no APPEND op, so every append close
+// re-flushes the whole file: n appends ship O(n^2) bytes.
+const APPEND_AMPLIFIED = 'the bridge has no append op: each close re-flushes the whole file'
+
+interface Row {
+  capability: string
+  spelling: string
+  line: string
+  setup?: string[]
+  exitCode?: number
+  lineOut?: string
+  checks?: [cmd: string, want: string][]
+  broken?: string
+}
+
+const MONTY_ROWS: Row[] = [
+  {
+    capability: 'mkdir',
+    spelling: 'Path.mkdir',
+    line: `python3 -c "from pathlib import Path; Path('/data/made').mkdir()"`,
+    checks: [['ls /data', 'made']],
+  },
+  {
+    capability: 'unlink',
+    spelling: 'Path.unlink',
+    line: `python3 -c "from pathlib import Path; Path('/data/gone.txt').unlink()"`,
+    setup: ['echo -n x > /data/gone.txt'],
+    checks: [['ls /data', '!gone.txt']],
+  },
+  {
+    capability: 'rmdir',
+    spelling: 'Path.rmdir',
+    line: `python3 -c "from pathlib import Path; Path('/data/hollow').rmdir()"`,
+    setup: ['mkdir /data/hollow'],
+    checks: [['ls /data', '!hollow']],
+  },
+  {
+    capability: 'rename',
+    spelling: 'Path.rename',
+    line: `python3 -c "from pathlib import Path; Path('/data/a.txt').rename('/data/b.txt')"`,
+    setup: ['echo -n one > /data/a.txt'],
+    checks: [
+      ['cat /data/b.txt', 'one'],
+      ['ls /data', '!a.txt'],
+    ],
+  },
+  {
+    capability: 'rename-cross',
+    spelling: 'Path.rename',
+    line: `python3 -c "from pathlib import Path; Path('/data/c.txt').rename('/other/c.txt')"`,
+    setup: ['echo -n keep > /data/c.txt'],
+    exitCode: 1,
+    checks: [
+      ['cat /data/c.txt', 'keep'],
+      ['ls /other', '!c.txt'],
+    ],
+  },
+  {
+    capability: 'read',
+    spelling: 'open',
+    line: `python3 -c "print(open('/data/r.txt').read())"`,
+    setup: ['echo -n seen > /data/r.txt'],
+    lineOut: 'seen',
+    broken: MONTY_OPEN_UNSUPPORTED,
+  },
+  {
+    capability: 'write',
+    spelling: 'open',
+    line: `python3 -c "f = open('/data/w1.txt', 'w'); f.write('data'); f.close()"`,
+    checks: [['cat /data/w1.txt', 'data']],
+    broken: MONTY_OPEN_UNSUPPORTED,
+  },
+  {
+    capability: 'write',
+    spelling: 'Path.write_text',
+    line: `python3 -c "from pathlib import Path; Path('/data/w2.txt').write_text('data')"`,
+    checks: [['cat /data/w2.txt', 'data']],
+  },
+  {
+    capability: 'write-readonly',
+    spelling: 'Path.write_text',
+    line: `python3 -c "from pathlib import Path; Path('/ro/y.txt').write_text('nope')"`,
+    exitCode: 1,
+    checks: [['ls /ro', '!y.txt']],
+  },
+  {
+    capability: 'stat',
+    spelling: 'Path.stat',
+    line: `python3 -c "from pathlib import Path; print(Path('/data/st.txt').stat().st_size)"`,
+    setup: ['echo -n four > /data/st.txt'],
+    lineOut: '4',
+    broken: MONTY_OPEN_UNSUPPORTED,
+  },
+  {
+    capability: 'append',
+    spelling: 'open',
+    line: `python3 -c "\nfor part in ['b', 'c', 'd']:\n    with open('/data/log.txt', 'a') as f:\n        f.write(part)\n"`,
+    setup: ['echo -n a > /data/log.txt'],
+    checks: [['cat /data/log.txt', 'abcd']],
+    broken: MONTY_OPEN_UNSUPPORTED,
+  },
+  {
+    capability: 'append-preserves',
+    spelling: 'open',
+    line: `python3 -c "f = open('/data/keep.txt', 'a'); f.write('Z'); f.close()"`,
+    setup: ['echo -n a > /data/keep.txt'],
+    checks: [['cat /data/keep.txt', 'aZ']],
+    broken: MONTY_OPEN_UNSUPPORTED,
+  },
+]
+
+const PYODIDE_ROWS: Row[] = [
+  {
+    capability: 'mkdir',
+    spelling: 'os.mkdir',
+    line: `python3 -c "import os; os.mkdir('/data/m1')"`,
+    checks: [['ls /data', 'm1']],
+    broken: PYODIDE_MUTATIONS_DROPPED,
+  },
+  {
+    capability: 'mkdir',
+    spelling: 'os.makedirs',
+    line: `python3 -c "import os; os.makedirs('/data/m2/deep')"`,
+    checks: [['ls /data/m2', 'deep']],
+    broken: PYODIDE_MUTATIONS_DROPPED,
+  },
+  {
+    capability: 'mkdir',
+    spelling: 'Path.mkdir',
+    line: `python3 -c "from pathlib import Path; Path('/data/m3').mkdir()"`,
+    checks: [['ls /data', 'm3']],
+    broken: PYODIDE_MUTATIONS_DROPPED,
+  },
+  {
+    capability: 'unlink',
+    spelling: 'os.remove',
+    line: `python3 -c "import os; os.remove('/data/f1.txt')"`,
+    setup: ['echo -n x > /data/f1.txt'],
+    checks: [['ls /data', '!f1.txt']],
+    broken: PYODIDE_MUTATIONS_DROPPED,
+  },
+  {
+    capability: 'unlink',
+    spelling: 'Path.unlink',
+    line: `python3 -c "from pathlib import Path; Path('/data/f2.txt').unlink()"`,
+    setup: ['echo -n x > /data/f2.txt'],
+    checks: [['ls /data', '!f2.txt']],
+    broken: PYODIDE_MUTATIONS_DROPPED,
+  },
+  {
+    capability: 'rmdir',
+    spelling: 'os.rmdir',
+    line: `python3 -c "import os; os.rmdir('/data/d1')"`,
+    setup: ['mkdir /data/d1'],
+    checks: [['ls /data', '!d1']],
+    broken: PYODIDE_MUTATIONS_DROPPED,
+  },
+  {
+    capability: 'rmdir',
+    spelling: 'shutil.rmtree',
+    line: `python3 -c "import shutil; shutil.rmtree('/data/d3')"`,
+    setup: ['mkdir /data/d3', 'echo -n x > /data/d3/inner.txt'],
+    checks: [['ls /data', '!d3']],
+    broken: PYODIDE_MUTATIONS_DROPPED,
+  },
+  {
+    capability: 'rename',
+    spelling: 'os.rename',
+    line: `python3 -c "import os; os.rename('/data/a1.txt', '/data/b1.txt')"`,
+    setup: ['echo -n one > /data/a1.txt'],
+    checks: [
+      ['cat /data/b1.txt', 'one'],
+      ['ls /data', '!a1.txt'],
+    ],
+    broken: PYODIDE_MUTATIONS_DROPPED,
+  },
+  {
+    capability: 'rename',
+    spelling: 'Path.rename',
+    line: `python3 -c "from pathlib import Path; Path('/data/a3.txt').rename('/data/b3.txt')"`,
+    setup: ['echo -n one > /data/a3.txt'],
+    checks: [['cat /data/b3.txt', 'one']],
+    broken: PYODIDE_MUTATIONS_DROPPED,
+  },
+  {
+    // Refused today only because the unpatched os.rename misses in
+    // MEMFS (the file was seeded after boot); there is no cross-mount
+    // guard behind it. The observable contract still holds: nonzero
+    // exit, source intact, nothing lands on the other mount.
+    capability: 'rename-cross',
+    spelling: 'os.rename',
+    line: `python3 -c "import os; os.rename('/data/c.txt', '/other/c.txt')"`,
+    setup: ['echo -n keep > /data/c.txt'],
+    exitCode: 1,
+    checks: [
+      ['cat /data/c.txt', 'keep'],
+      ['ls /other', '!c.txt'],
+    ],
+  },
+  {
+    capability: 'read',
+    spelling: 'open',
+    line: `python3 -c "print(open('/data/r.txt').read())"`,
+    setup: ['echo -n seen > /data/r.txt'],
+    lineOut: 'seen',
+  },
+  {
+    capability: 'write',
+    spelling: 'open',
+    line: `python3 -c "f = open('/data/w1.txt', 'w'); f.write('data'); f.close()"`,
+    checks: [['cat /data/w1.txt', 'data']],
+  },
+  {
+    capability: 'write',
+    spelling: 'Path.write_text',
+    line: `python3 -c "from pathlib import Path; Path('/data/w2.txt').write_text('data')"`,
+    checks: [['cat /data/w2.txt', 'data']],
+  },
+  {
+    capability: 'write-readonly',
+    spelling: 'open',
+    line: `python3 -c "f = open('/ro/x.txt', 'w'); f.write('nope'); f.close()"`,
+    exitCode: 1,
+    checks: [['ls /ro', '!x.txt']],
+  },
+  {
+    capability: 'stat',
+    spelling: 'os.stat',
+    line: `python3 -c "import os; print(os.stat('/data/st.txt').st_size)"`,
+    setup: ['echo -n four > /data/st.txt'],
+    lineOut: '4',
+  },
+  {
+    capability: 'append',
+    spelling: 'open',
+    line: `python3 -c "\nfor part in ['b', 'c', 'd']:\n    with open('/data/log.txt', 'a') as f:\n        f.write(part)\n"`,
+    setup: ['echo -n a > /data/log.txt'],
+    checks: [['cat /data/log.txt', 'abcd']],
+    broken: PYODIDE_APPEND_CLOBBERS,
+  },
+  {
+    capability: 'append-preserves',
+    spelling: 'open',
+    line: `python3 -c "f = open('/data/keep.txt', 'a'); f.write('Z'); f.close()"`,
+    setup: ['echo -n a > /data/keep.txt'],
+    checks: [['cat /data/keep.txt', 'aZ']],
+    broken: PYODIDE_APPEND_CLOBBERS,
+  },
+]
+
+const QUICKJS_ROWS: Row[] = [
+  {
+    capability: 'mkdir',
+    spelling: 'os.mkdir',
+    line: `node -e "const rc = os.mkdir('/data/m1'); if (rc !== 0) throw new Error('rc ' + rc)"`,
+    checks: [['ls /data', 'm1']],
+  },
+  {
+    capability: 'unlink',
+    spelling: 'os.remove',
+    line: `node -e "const rc = os.remove('/data/f1.txt'); if (rc !== 0) throw new Error('rc ' + rc)"`,
+    setup: ['echo -n x > /data/f1.txt'],
+    checks: [['ls /data', '!f1.txt']],
+  },
+  {
+    capability: 'rmdir',
+    spelling: 'os.remove',
+    line: `node -e "const rc = os.remove('/data/d1'); if (rc !== 0) throw new Error('rc ' + rc)"`,
+    setup: ['mkdir /data/d1'],
+    checks: [['ls /data', '!d1']],
+  },
+  {
+    capability: 'rename',
+    spelling: 'os.rename',
+    line: `node -e "const rc = os.rename('/data/a1.txt', '/data/b1.txt'); if (rc !== 0) throw new Error('rc ' + rc)"`,
+    setup: ['echo -n one > /data/a1.txt'],
+    checks: [
+      ['cat /data/b1.txt', 'one'],
+      ['ls /data', '!a1.txt'],
+    ],
+  },
+  {
+    capability: 'rename-cross',
+    spelling: 'os.rename',
+    line: `node -e "console.log(os.rename('/data/c.txt', '/other/c.txt'))"`,
+    setup: ['echo -n keep > /data/c.txt'],
+    lineOut: '-44',
+    checks: [
+      ['cat /data/c.txt', 'keep'],
+      ['ls /other', '!c.txt'],
+    ],
+  },
+  {
+    capability: 'read',
+    spelling: 'std.open',
+    line: `node -e "const f = std.open('/data/r.txt', 'r'); console.log(f.readAsString()); f.close()"`,
+    setup: ['echo -n seen > /data/r.txt'],
+    lineOut: 'seen',
+  },
+  {
+    capability: 'write',
+    spelling: 'std.open',
+    line: `node -e "const w = std.open('/data/w1.txt', 'w'); w.puts('data'); w.close()"`,
+    checks: [['cat /data/w1.txt', 'data']],
+  },
+  {
+    // The refusal is std.open answering null; the errno field of the
+    // error object is not filled by the synthesized std.open, so only
+    // the null is pinned here.
+    capability: 'write-readonly',
+    spelling: 'std.open',
+    line: `node -e "const e = {}; const w = std.open('/ro/x.txt', 'w', e); console.log(w === null)"`,
+    lineOut: 'true',
+    checks: [['ls /ro', '!x.txt']],
+  },
+  {
+    capability: 'stat',
+    spelling: 'os.stat',
+    line: `node -e "const [st, e] = os.stat('/data/st.txt'); console.log(e, st.size)"`,
+    setup: ['echo -n four > /data/st.txt'],
+    lineOut: '0 4',
+  },
+  {
+    capability: 'append',
+    spelling: 'std.open',
+    line: `node -e "for (const part of ['b', 'c', 'd']) { const w = std.open('/data/log.txt', 'a'); w.puts(part); w.close() }"`,
+    setup: ['echo -n a > /data/log.txt'],
+    checks: [['cat /data/log.txt', 'abcd']],
+  },
+  {
+    capability: 'append-preserves',
+    spelling: 'std.open',
+    line: `node -e "const w = std.open('/data/keep.txt', 'a'); w.puts('Z'); w.close()"`,
+    setup: ['echo -n a > /data/keep.txt'],
+    checks: [['cat /data/keep.txt', 'aZ']],
+  },
+]
+
+async function world(runtime: string): Promise<Workspace> {
+  const parser = await getTestParser()
+  const ops = new OpsRegistry()
+  const data = new RAMResource()
+  const other = new RAMResource()
+  const ro = new RAMResource()
+  ops.registerResource(data)
+  ops.registerResource(other)
+  ops.registerResource(ro)
+  const ws = new Workspace(
+    {},
+    { mode: MountMode.EXEC, ops, shellParser: parser, runtimes: [runtime, 'vfs'] },
+  )
+  ws.addMount('/data', data, MountMode.WRITE)
+  ws.addMount('/other', other, MountMode.WRITE)
+  ws.addMount('/ro', ro, MountMode.READ)
+  return ws
+}
+
+async function runRow(ws: Workspace, row: Row): Promise<void> {
+  for (const s of row.setup ?? []) {
+    const io = await ws.execute(s)
+    expect(io.exitCode, `setup failed: ${s} -> ${stderrStr(io)}`).toBe(0)
+  }
+  const io = await ws.execute(row.line)
+  expect(io.exitCode, `${row.line} -> ${stderrStr(io)}`).toBe(row.exitCode ?? 0)
+  if (row.lineOut !== undefined) expect(stdoutStr(io)).toContain(row.lineOut)
+  for (const [cmd, want] of row.checks ?? []) {
+    const check = await ws.execute(cmd)
+    const out = stdoutStr(check)
+    if (want.startsWith('!')) {
+      expect(out, `${cmd} still shows ${want.slice(1)}`).not.toContain(want.slice(1))
+    } else {
+      expect(out, `${cmd} does not show ${want}`).toContain(want)
+    }
+  }
+}
+
+// The boot line runs the interpreter once before any row seeds a file,
+// so every seed is post-boot whatever order (or subset) the rows run
+// in. Pyodide preloads mount prefixes into MEMFS at boot, and a row
+// outcome must not depend on whether its seed made that snapshot.
+function conformance(label: string, runtime: string, boot: string, rows: Row[]): void {
+  describe(label, () => {
+    let ws: Workspace
+    beforeAll(async () => {
+      ws = await world(runtime)
+      const io = await ws.execute(boot)
+      expect(io.exitCode, `boot failed: ${stderrStr(io)}`).toBe(0)
+    }, 240_000)
+    afterAll(async () => {
+      await ws.close()
+    })
+    for (const row of rows) {
+      const name = `${row.capability} via ${row.spelling}`
+      if (row.broken === undefined) {
+        it(name, () => runRow(ws, row), 120_000)
+      } else {
+        it.fails(`${name} [known broken]`, () => runRow(ws, row), 120_000)
+      }
+    }
+  })
+}
+
+conformance('monty conformance', 'monty', 'python3 -c "pass"', MONTY_ROWS)
+conformance('pyodide conformance', 'pyodide', 'python3 -c "pass"', PYODIDE_ROWS)
+conformance('quickjs conformance', 'quickjs', 'node -e "1"', QUICKJS_ROWS)
+
+interface CountingBridge {
+  dispatch: BridgeDispatchFn
+  files: Map<string, Uint8Array>
+  mutationBytes: () => number
+  mutationOps: () => string[]
+}
+
+function makeCountingBridge(seed: Record<string, string>): CountingBridge {
+  const enc = new TextEncoder()
+  const files = new Map<string, Uint8Array>()
+  for (const [key, value] of Object.entries(seed)) files.set(key, enc.encode(value))
+  const dirs = new Set<string>()
+  const ops: [op: string, path: string, bytes: number][] = []
+  const dispatch: BridgeDispatchFn = (op, path, bytes, dst) => {
+    ops.push([op, path, bytes?.length ?? 0])
+    if (op === 'READ') {
+      const hit = files.get(path)
+      if (hit === undefined) return Promise.reject(new Error(`ENOENT ${path}`))
+      return Promise.resolve(new Uint8Array(hit))
+    }
+    if (op === 'WRITE') {
+      files.set(path, bytes === undefined ? new Uint8Array() : new Uint8Array(bytes))
+      return Promise.resolve(undefined)
+    }
+    if (op === 'STAT') {
+      const hit = files.get(path)
+      if (hit !== undefined) return Promise.resolve({ size: hit.length, isDir: false, mtimeMs: 0 })
+      const dir = path.replace(/\/$/, '')
+      const isDir = dirs.has(dir) || [...files.keys()].some((p) => p.startsWith(dir + '/'))
+      if (isDir) return Promise.resolve({ size: 0, isDir: true, mtimeMs: 0 })
+      return Promise.reject(new Error(`ENOENT ${path}`))
+    }
+    if (op === 'LIST') {
+      const prefix = path.replace(/\/$/, '') + '/'
+      const entries: { path: string; size: number; isDir: boolean }[] = []
+      for (const [p, content] of files) {
+        if (p.startsWith(prefix) && !p.slice(prefix.length).includes('/')) {
+          entries.push({ path: p, size: content.length, isDir: false })
+        }
+      }
+      return Promise.resolve(entries)
+    }
+    if (op === 'UNLINK') {
+      files.delete(path)
+      return Promise.resolve(undefined)
+    }
+    if (op === 'MKDIR') {
+      dirs.add(path)
+      return Promise.resolve(undefined)
+    }
+    if (op === 'RMDIR') {
+      dirs.delete(path)
+      return Promise.resolve(undefined)
+    }
+    const moved = files.get(path)
+    if (moved !== undefined && dst !== undefined) {
+      files.delete(path)
+      files.set(dst, moved)
+    }
+    return Promise.resolve(undefined)
+  }
+  const mutationBytes = () =>
+    ops.filter(([op]) => op === 'WRITE').reduce((total, [, , size]) => total + size, 0)
+  const mutationOps = () =>
+    ops.filter(([op]) => op === 'WRITE').map(([op, path]) => `${op} ${path}`)
+  return { dispatch, files, mutationBytes, mutationOps }
+}
+
+const APPEND_LOOP_PY =
+  "for i in range(8):\n    with open('/data/log.txt', 'a') as f:\n        f.write('xyz')"
+const APPEND_LOOP_JS =
+  "for (let i = 0; i < 8; i++) { const w = std.open('/data/log.txt', 'a'); w.puts('xyz'); w.close() }"
+
+function runArgs(code: string): RunArgs {
+  return { code, args: [], env: {}, stdin: null }
+}
+
+// Eight appends of three bytes must ship 24 bytes, not O(n^2). The
+// dispatch is counted rather than the outcome compared: an amplifying
+// runtime still produces the right final content, so the file alone
+// cannot tell one append from a full rewrite per close.
+describe('append ships only the deltas', () => {
+  it.fails(
+    `monty [${MONTY_OPEN_UNSUPPORTED}]`,
+    async () => {
+      const counting = makeCountingBridge({ '/data/log.txt': 'S'.repeat(64) })
+      const rt = new MontyRuntime()
+      rt.attach(counting.dispatch, () => ['/data/'])
+      const result = await rt.run(runArgs(APPEND_LOOP_PY))
+      await rt.close()
+      expect(result.exitCode).toBe(0)
+      expect(counting.mutationBytes(), counting.mutationOps().join(', ')).toBe(24)
+    },
+    120_000,
+  )
+
+  it.fails(
+    `pyodide [${APPEND_AMPLIFIED}]`,
+    async () => {
+      const counting = makeCountingBridge({ '/data/log.txt': 'S'.repeat(64) })
+      const rt = new PyodideRuntime()
+      rt.attach(counting.dispatch, () => ['/data/'])
+      const result = await rt.run(runArgs(APPEND_LOOP_PY))
+      await rt.close()
+      expect(result.exitCode).toBe(0)
+      const dec = new TextDecoder()
+      expect(dec.decode(counting.files.get('/data/log.txt'))).toBe('S'.repeat(64) + 'xyz'.repeat(8))
+      expect(counting.mutationBytes(), counting.mutationOps().join(', ')).toBe(24)
+    },
+    120_000,
+  )
+
+  it.fails(
+    `quickjs [${APPEND_AMPLIFIED}]`,
+    async () => {
+      const counting = makeCountingBridge({ '/data/log.txt': 'S'.repeat(64) })
+      const rt = new QuickJsRuntime()
+      rt.attach(counting.dispatch, () => ['/data/'])
+      const result = await rt.run(runArgs(APPEND_LOOP_JS))
+      await rt.close()
+      expect(result.exitCode).toBe(0)
+      const dec = new TextDecoder()
+      expect(dec.decode(counting.files.get('/data/log.txt'))).toBe('S'.repeat(64) + 'xyz'.repeat(8))
+      expect(counting.mutationBytes(), counting.mutationOps().join(', ')).toBe(24)
+    },
+    120_000,
+  )
+})

--- a/typescript/packages/core/src/runtime/js/base.ts
+++ b/typescript/packages/core/src/runtime/js/base.ts
@@ -13,15 +13,22 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { LanguageRuntime } from '../language.ts'
-import type { RuntimeLanguage } from '../types.ts'
+import type { RuntimeLanguage, RuntimeOptions } from '../types.ts'
 
 /**
  * The js tier: every runtime that interprets JavaScript source.
  *
  * Groups the engines behind the node/js commands (quickjs today), so
- * `language` is declared once and js-tier behavior has one home. A
- * new JavaScript engine subclasses this, not LanguageRuntime.
+ * `language` and the default captures are declared once and js-tier
+ * behavior has one home. A new JavaScript engine subclasses this, not
+ * LanguageRuntime.
  */
 export abstract class JsRuntime extends LanguageRuntime {
   readonly language: RuntimeLanguage = 'js'
+  /** The tier's head words: the class-default captures of every js engine. */
+  static readonly commands: readonly string[] = ['node', 'js'] as const
+
+  constructor(options: RuntimeOptions<object> = {}, configKeys: readonly string[] = []) {
+    super(options, JsRuntime.commands, configKeys)
+  }
 }

--- a/typescript/packages/core/src/runtime/js/quickjs.ts
+++ b/typescript/packages/core/src/runtime/js/quickjs.ts
@@ -162,13 +162,12 @@ const QUICKJS_CONFIG_KEYS: readonly string[] = ['home']
 export class QuickJsRuntime extends JsRuntime implements Evaluator {
   readonly name = QUICKJS_RUNTIME
   readonly [EVALUATOR] = true as const
-  static readonly commands: readonly string[] = ['node', 'js'] as const
   private newAsyncModule: NewAsyncModule | null = null
   private workspaceBridge: BridgeDispatchFn | null = null
   private listMounts: () => string[] = () => []
 
   constructor(options: RuntimeOptions = {}) {
-    super(options, QuickJsRuntime.commands, QUICKJS_CONFIG_KEYS)
+    super(options, QUICKJS_CONFIG_KEYS)
   }
 
   override attach(dispatch: BridgeDispatchFn, listMounts: () => string[]): void {

--- a/typescript/packages/core/src/runtime/python/base.ts
+++ b/typescript/packages/core/src/runtime/python/base.ts
@@ -13,16 +13,23 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { LanguageRuntime } from '../language.ts'
-import type { RuntimeLanguage } from '../types.ts'
+import type { RuntimeLanguage, RuntimeOptions } from '../types.ts'
 
 /**
  * The python tier: every runtime that interprets Python source.
  *
  * Groups the engines behind the python3/python commands (pyodide,
  * monty here; wasi, local in Python and @struktoai/mirage-node), so
- * `language` is declared once and python-tier behavior has one home.
- * A new Python engine subclasses this, not LanguageRuntime.
+ * `language` and the default captures are declared once and
+ * python-tier behavior has one home. A new Python engine subclasses
+ * this, not LanguageRuntime.
  */
 export abstract class PythonRuntime extends LanguageRuntime {
   readonly language: RuntimeLanguage = 'python'
+  /** The tier's head words: the class-default captures of every python engine. */
+  static readonly commands: readonly string[] = ['python3', 'python'] as const
+
+  constructor(options: RuntimeOptions<object> = {}, configKeys: readonly string[] = []) {
+    super(options, PythonRuntime.commands, configKeys)
+  }
 }

--- a/typescript/packages/core/src/runtime/python/monty.ts
+++ b/typescript/packages/core/src/runtime/python/monty.ts
@@ -130,7 +130,6 @@ function toEvalValue(value: unknown): EvalValue {
 export class MontyRuntime extends PythonRuntime implements Evaluator {
   readonly name = MONTY_RUNTIME
   readonly [EVALUATOR] = true as const
-  static readonly commands: readonly string[] = ['python3', 'python'] as const
   private workspaceBridge: BridgeDispatchFn | null = null
   private listMounts: () => string[] = () => []
   private module: MontyModuleLike | null = null
@@ -139,7 +138,7 @@ export class MontyRuntime extends PythonRuntime implements Evaluator {
   private readonly evalSessions = new Map<string, MontySessionLike>()
 
   constructor(options: RuntimeOptions = {}) {
-    super(options, MontyRuntime.commands, [])
+    super(options)
   }
 
   override attach(dispatch: BridgeDispatchFn, listMounts: () => string[]): void {

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -128,7 +128,6 @@ const EVAL_INTERRUPT_SECONDS = 10
 export class PyodideRuntime extends PythonRuntime implements Evaluator {
   readonly name = PYODIDE_RUNTIME
   readonly [EVALUATOR] = true as const
-  static readonly commands: readonly string[] = ['python3', 'python'] as const
   private pyodide: PyodideInterface | null = null
   private initPromise: Promise<PyodideInterface> | null = null
   private bootstrapPromise: Promise<void> | null = null
@@ -148,7 +147,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
   private interrupterTried = false
 
   constructor(options: RuntimeOptions<PyodideConfig> = {}) {
-    super(options, PyodideRuntime.commands, PYODIDE_CONFIG_KEYS)
+    super(options, PYODIDE_CONFIG_KEYS)
     const config = this.config as PyodideConfig
     this.autoLoadFromImports = config.autoLoadFromImports ?? true
     this.bootstrapCode = config.bootstrapCode ?? null

--- a/typescript/packages/core/src/runtime/table.test.ts
+++ b/typescript/packages/core/src/runtime/table.test.ts
@@ -41,6 +41,15 @@ describe('runtime table', () => {
     expect(candidates('grep')).toEqual([])
   })
 
+  it('captures default is declared once per tier', () => {
+    // The head words are a language fact like `language` itself: the
+    // tier declares them, engines inherit, an instance still overrides.
+    expect([...new MontyRuntime().captures]).toEqual(['python3', 'python'])
+    expect([...new PyodideRuntime().captures]).toEqual(['python3', 'python'])
+    expect([...new QuickJsRuntime().captures]).toEqual(['node', 'js'])
+    expect([...new MontyRuntime({ captures: ['only'] }).captures]).toEqual(['only'])
+  })
+
   it('default entries end with the vfs runtime', () => {
     expect(DEFAULT_ENTRIES[DEFAULT_ENTRIES.length - 1]).toBe('vfs')
   })

--- a/typescript/packages/node/src/runtime/python/local.ts
+++ b/typescript/packages/node/src/runtime/python/local.ts
@@ -37,12 +37,11 @@ const LOCAL_CONFIG_KEYS: readonly string[] = ['home']
  */
 export class LocalRuntime extends PythonRuntime {
   readonly name = 'local'
-  static readonly commands: readonly string[] = ['python3', 'python'] as const
   private readonly python: string
   private readonly children = new Set<ChildProcess>()
 
   constructor(options: RuntimeOptions = {}) {
-    super(options, LocalRuntime.commands, LOCAL_CONFIG_KEYS)
+    super(options, LOCAL_CONFIG_KEYS)
     const home = (this.config as { home?: string }).home
     const chosen = home !== undefined && home !== '' ? home : process.env[LOCAL_HOME_ENV]
     this.python = chosen !== undefined && chosen !== '' ? chosen : 'python3'


### PR DESCRIPTION
Adds the runtime conformance suite: one capability table (mkdir, unlink, rmdir, rename, cross-mount rename refused, read, write, read-only refusal, stat, append, append-preserves) executed per runtime in that runtime's own idiom, with every mutation asserted on the mount through shell commands, never through the runtime that wrote it.

- `python/tests/runtime/test_conformance.py`: monty, wasi, quickjs. The wasi/quickjs rows skip without `MIRAGE_WASI_HOME` / `MIRAGE_QUICKJS_HOME`; the CI runtime job gained a step that provides both.
- `typescript/packages/core/src/runtime/conformance.test.ts`: monty, pyodide, quickjs. Each describe boots the interpreter before any row seeds, since pyodide preloads mount prefixes into MEMFS at boot and seed order flips outcomes.
- A counting dispatch on `attach()` asserts 8 appends of 3 bytes ship exactly 24 mutation bytes, which separates a real append from a whole-file re-flush per close that the final file content alone cannot detect.
- Known-broken rows are `pytest.mark.xfail(strict=True)` / `it.fails` with the reason recorded, so a fix flips them loudly: ts pyodide drops every mutation spelling and `open('a')` on an unseen file clobbers mount content; ts monty answers PermissionError for builtin `open()` and `Path.stat` (the JS binding cannot return a file handle from an os callback); the four wasm-transport runtimes amplify appends (620 bytes for 24 new) because neither transport has an append op.

The first commit declares the default `captures` once per language tier, a small follow-up to #726 that never landed there.