### PR TITLE
fix(pyodide): route guest mutations to the mount and keep appends additive

### DIFF
--- a/integ/runtime/pyodide.json
+++ b/integ/runtime/pyodide.json
@@ -81,6 +81,174 @@
           }
         }
       ]
+    },
+    {
+      "id": "mkdir_mount",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import os; os.makedirs('/ram/a/b')\" && ls /ram/a",
+          "expect": {
+            "exit": 0,
+            "stdout": "b\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "unlink_mount",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "echo -n x > /ram/gone.txt && python3 -c \"from pathlib import Path; Path('/ram/gone.txt').unlink()\" && ls /ram",
+          "expect": {
+            "exit": 0,
+            "stdout": ""
+          }
+        }
+      ]
+    },
+    {
+      "id": "rmtree_mount",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "mkdir /ram/d && echo -n x > /ram/d/inner.txt && python3 -c \"import shutil; shutil.rmtree('/ram/d')\" && ls /ram",
+          "expect": {
+            "exit": 0,
+            "stdout": ""
+          }
+        }
+      ]
+    },
+    {
+      "id": "rename_mount",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "echo -n one > /ram/a.txt && python3 -c \"import os; os.rename('/ram/a.txt', '/ram/b.txt')\" && cat /ram/b.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "one"
+          }
+        }
+      ]
+    },
+    {
+      "id": "append_preserves_mount",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "keep.txt": "base"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/ram/keep.txt', 'a').write('-more')\" && cat /ram/keep.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "base-more"
+          }
+        }
+      ]
+    },
+    {
+      "id": "rename_across_mounts_refused",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram"
+          },
+          "/other": {
+            "resource": "ram"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "echo -n keep > /ram/c.txt && python3 -c \"import os; os.rename('/ram/c.txt', '/other/c.txt')\"",
+          "expect": {
+            "exit": 1
+          }
+        },
+        {
+          "command": "cat /ram/c.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "keep"
+          }
+        }
+      ]
     }
   ]
 }

--- a/typescript/packages/core/src/runtime/conformance.test.ts
+++ b/typescript/packages/core/src/runtime/conformance.test.ts
@@ -43,14 +43,10 @@ const MONTY_OPEN_UNSUPPORTED =
 // reaches the mount: a pre-boot file succeeds silently (exit 0), a
 // post-boot file fails with the MEMFS miss. Either way the mount never
 // changes.
-const PYODIDE_MUTATIONS_DROPPED =
-  'ts pyodide: mutation spellings are not intercepted, the mount never changes'
 
 // A writable open never backfills, so appending to a file the MEMFS
 // has not seen starts from empty and the close-flush overwrites the
 // mount content the run never read.
-const PYODIDE_APPEND_CLOBBERS =
-  'ts pyodide: open-for-append on an unseen file clobbers the mount content'
 
 // The workspace bridge has no APPEND op, so every append close
 // re-flushes the whole file: n appends ship O(n^2) bytes.
@@ -169,21 +165,18 @@ const PYODIDE_ROWS: Row[] = [
     spelling: 'os.mkdir',
     line: `python3 -c "import os; os.mkdir('/data/m1')"`,
     checks: [['ls /data', 'm1']],
-    broken: PYODIDE_MUTATIONS_DROPPED,
   },
   {
     capability: 'mkdir',
     spelling: 'os.makedirs',
     line: `python3 -c "import os; os.makedirs('/data/m2/deep')"`,
     checks: [['ls /data/m2', 'deep']],
-    broken: PYODIDE_MUTATIONS_DROPPED,
   },
   {
     capability: 'mkdir',
     spelling: 'Path.mkdir',
     line: `python3 -c "from pathlib import Path; Path('/data/m3').mkdir()"`,
     checks: [['ls /data', 'm3']],
-    broken: PYODIDE_MUTATIONS_DROPPED,
   },
   {
     capability: 'unlink',
@@ -191,7 +184,6 @@ const PYODIDE_ROWS: Row[] = [
     line: `python3 -c "import os; os.remove('/data/f1.txt')"`,
     setup: ['echo -n x > /data/f1.txt'],
     checks: [['ls /data', '!f1.txt']],
-    broken: PYODIDE_MUTATIONS_DROPPED,
   },
   {
     capability: 'unlink',
@@ -199,7 +191,6 @@ const PYODIDE_ROWS: Row[] = [
     line: `python3 -c "from pathlib import Path; Path('/data/f2.txt').unlink()"`,
     setup: ['echo -n x > /data/f2.txt'],
     checks: [['ls /data', '!f2.txt']],
-    broken: PYODIDE_MUTATIONS_DROPPED,
   },
   {
     capability: 'rmdir',
@@ -207,7 +198,6 @@ const PYODIDE_ROWS: Row[] = [
     line: `python3 -c "import os; os.rmdir('/data/d1')"`,
     setup: ['mkdir /data/d1'],
     checks: [['ls /data', '!d1']],
-    broken: PYODIDE_MUTATIONS_DROPPED,
   },
   {
     capability: 'rmdir',
@@ -215,7 +205,6 @@ const PYODIDE_ROWS: Row[] = [
     line: `python3 -c "import shutil; shutil.rmtree('/data/d3')"`,
     setup: ['mkdir /data/d3', 'echo -n x > /data/d3/inner.txt'],
     checks: [['ls /data', '!d3']],
-    broken: PYODIDE_MUTATIONS_DROPPED,
   },
   {
     capability: 'rename',
@@ -226,7 +215,6 @@ const PYODIDE_ROWS: Row[] = [
       ['cat /data/b1.txt', 'one'],
       ['ls /data', '!a1.txt'],
     ],
-    broken: PYODIDE_MUTATIONS_DROPPED,
   },
   {
     capability: 'rename',
@@ -234,13 +222,11 @@ const PYODIDE_ROWS: Row[] = [
     line: `python3 -c "from pathlib import Path; Path('/data/a3.txt').rename('/data/b3.txt')"`,
     setup: ['echo -n one > /data/a3.txt'],
     checks: [['cat /data/b3.txt', 'one']],
-    broken: PYODIDE_MUTATIONS_DROPPED,
   },
   {
-    // Refused today only because the unpatched os.rename misses in
-    // MEMFS (the file was seeded after boot); there is no cross-mount
-    // guard behind it. The observable contract still holds: nonzero
-    // exit, source intact, nothing lands on the other mount.
+    // The shim's patched os.rename compares the mount of each side and
+    // raises EXDEV, so this is a deliberate refusal rather than a
+    // MEMFS miss: nonzero exit, source intact, nothing on the other mount.
     capability: 'rename-cross',
     spelling: 'os.rename',
     line: `python3 -c "import os; os.rename('/data/c.txt', '/other/c.txt')"`,
@@ -290,7 +276,6 @@ const PYODIDE_ROWS: Row[] = [
     line: `python3 -c "\nfor part in ['b', 'c', 'd']:\n    with open('/data/log.txt', 'a') as f:\n        f.write(part)\n"`,
     setup: ['echo -n a > /data/log.txt'],
     checks: [['cat /data/log.txt', 'abcd']],
-    broken: PYODIDE_APPEND_CLOBBERS,
   },
   {
     capability: 'append-preserves',
@@ -298,7 +283,6 @@ const PYODIDE_ROWS: Row[] = [
     line: `python3 -c "f = open('/data/keep.txt', 'a'); f.write('Z'); f.close()"`,
     setup: ['echo -n a > /data/keep.txt'],
     checks: [['cat /data/keep.txt', 'aZ']],
-    broken: PYODIDE_APPEND_CLOBBERS,
   },
 ]
 

--- a/typescript/packages/core/src/runtime/conformance.test.ts
+++ b/typescript/packages/core/src/runtime/conformance.test.ts
@@ -179,6 +179,14 @@ const PYODIDE_ROWS: Row[] = [
     checks: [['ls /data', 'm3']],
   },
   {
+    // A relative operand only names a mount through the guest cwd, so
+    // the shim resolves against it before deciding what to record.
+    capability: 'mkdir',
+    spelling: 'os.mkdir relative to cwd',
+    line: `python3 -c "import os; os.chdir('/data'); os.mkdir('m4')"`,
+    checks: [['ls /data', 'm4']],
+  },
+  {
     capability: 'unlink',
     spelling: 'os.remove',
     line: `python3 -c "import os; os.remove('/data/f1.txt')"`,

--- a/typescript/packages/core/src/runtime/python/mirage_bridge.ts
+++ b/typescript/packages/core/src/runtime/python/mirage_bridge.ts
@@ -31,6 +31,21 @@ interface MirageStat {
   mtimeMs: number
 }
 
+/**
+ * One guest mutation, recorded in the order the script performed it.
+ * `write` and `append` carry their bytes because the drain runs after the
+ * script returns, when MEMFS holds only the final state: an atomic-write
+ * (write a temp file, rename it into place) would otherwise replay as a
+ * read of a path the rename already moved.
+ */
+export type MirageMutation =
+  | { readonly kind: 'write'; readonly path: string; readonly bytes: Uint8Array }
+  | { readonly kind: 'append'; readonly path: string; readonly bytes: Uint8Array }
+  | { readonly kind: 'mkdir'; readonly path: string }
+  | { readonly kind: 'unlink'; readonly path: string }
+  | { readonly kind: 'rmdir'; readonly path: string }
+  | { readonly kind: 'rename'; readonly path: string; readonly dst: string }
+
 export interface MirageBridge {
   fetch(path: string): Promise<Uint8Array>
   flush(path: string, bytes: Uint8Array): Promise<void>
@@ -48,34 +63,81 @@ export interface MirageBridge {
    */
   prefixes(): string[]
   /**
-   * Record a mount-prefixed path whose MEMFS content changed. This is the
-   * write half of the shim's contract and it is deliberately synchronous:
-   * Python's close() runs inside sync WASM frames where awaiting a bridge
-   * op needs JSPI stack switching, which most engines do not enable. The
-   * bytes already live in MEMFS, so close() only marks the path here and
-   * the runtime flushes after the script returns, where awaiting is free.
+   * Record one guest mutation. Every mark is deliberately synchronous:
+   * the guest's close(), os.mkdir() and os.rename() run inside sync WASM
+   * frames where awaiting a bridge op needs JSPI stack switching, which
+   * most engines do not enable. The guest records here and the runtime
+   * replays after the script returns, where awaiting is free.
+   *
+   * Args:
+   *   path: mount-prefixed path the mutation names.
+   *   bytes: the whole file for a write, the new tail for an append.
    */
-  markDirty(path: string): void
-  /** Drain the dirty set: the recorded paths, in mark order, cleared. */
-  takeDirty(): string[]
+  markWrite(path: string, bytes: Uint8Array): void
+  markAppend(path: string, bytes: Uint8Array): void
+  markMkdir(path: string): void
+  markUnlink(path: string): void
+  markRmdir(path: string): void
+  markRename(src: string, dst: string): void
+  /** Drain the journal: every mutation in guest order, cleared. */
+  takeMutations(): MirageMutation[]
+}
+
+function concatBytes(head: Uint8Array, tail: Uint8Array): Uint8Array {
+  const out = new Uint8Array(head.length + tail.length)
+  out.set(head, 0)
+  out.set(tail, head.length)
+  return out
 }
 
 export function createMirageBridge(
   dispatch: BridgeDispatchFn,
   listMounts: () => string[] = () => [],
 ): MirageBridge {
-  const dirty = new Set<string>()
+  const journal: MirageMutation[] = []
   return {
     prefixes() {
       return listMounts().map((p) => (p.endsWith('/') ? p : p + '/'))
     },
-    markDirty(path) {
-      dirty.add(path)
+    markWrite(path, bytes) {
+      // A guest buffer handed over by pyodide can be a view into WASM
+      // memory, which relocates when the heap grows; copy on arrival so
+      // the journal owns bytes that stay valid until the drain.
+      const owned = new Uint8Array(bytes)
+      const last = journal[journal.length - 1]
+      if (last?.kind === 'write' && last.path === path) {
+        journal[journal.length - 1] = { kind: 'write', path, bytes: owned }
+        return
+      }
+      journal.push({ kind: 'write', path, bytes: owned })
     },
-    takeDirty() {
-      const out = [...dirty]
-      dirty.clear()
-      return out
+    markAppend(path, bytes) {
+      const owned = new Uint8Array(bytes)
+      const last = journal[journal.length - 1]
+      if (last?.kind === 'append' && last.path === path) {
+        journal[journal.length - 1] = {
+          kind: 'append',
+          path,
+          bytes: concatBytes(last.bytes, owned),
+        }
+        return
+      }
+      journal.push({ kind: 'append', path, bytes: owned })
+    },
+    markMkdir(path) {
+      journal.push({ kind: 'mkdir', path })
+    },
+    markUnlink(path) {
+      journal.push({ kind: 'unlink', path })
+    },
+    markRmdir(path) {
+      journal.push({ kind: 'rmdir', path })
+    },
+    markRename(src, dst) {
+      journal.push({ kind: 'rename', path: src, dst })
+    },
+    takeMutations() {
+      return journal.splice(0, journal.length)
     },
     async fetch(path) {
       const out = await dispatch('READ', path)
@@ -134,6 +196,59 @@ export function createMirageBridge(
       }
       return out as MirageEntry[]
     },
+  }
+}
+
+/**
+ * Extend a mount file by `tail`.
+ *
+ * Read-modify-write, because no transport op appends yet: the whole file
+ * goes back over the wire per call, which is why the append-amplification
+ * conformance row stays marked. Correctness does not depend on that:
+ * the tail is only ever added to what the mount already holds.
+ *
+ * Args:
+ *   bridge: the mount bridge to read and write through.
+ *   path: mount path being extended.
+ *   tail: bytes the guest appended.
+ */
+async function appendOnMount(bridge: MirageBridge, path: string, tail: Uint8Array): Promise<void> {
+  let base: Uint8Array = new Uint8Array()
+  try {
+    base = await bridge.fetch(path)
+  } catch (err) {
+    // Absent is the normal case: an append may create the file. Any
+    // other cause (denied, backend down) fails the write below as well,
+    // so it still reaches the caller instead of quietly replacing the
+    // file's content with the tail alone.
+    console.warn(
+      `mirage append: ${path} has no base to extend: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+  await bridge.flush(path, concatBytes(base, tail))
+}
+
+/**
+ * Replay one recorded guest mutation against the mounts.
+ *
+ * Args:
+ *   bridge: the mount bridge to apply through.
+ *   mutation: the journal entry to apply.
+ */
+export async function applyMutation(bridge: MirageBridge, mutation: MirageMutation): Promise<void> {
+  switch (mutation.kind) {
+    case 'write':
+      return bridge.flush(mutation.path, mutation.bytes)
+    case 'append':
+      return appendOnMount(bridge, mutation.path, mutation.bytes)
+    case 'mkdir':
+      return bridge.mkdir(mutation.path)
+    case 'unlink':
+      return bridge.unlink(mutation.path)
+    case 'rmdir':
+      return bridge.rmdir(mutation.path)
+    case 'rename':
+      return bridge.rename(mutation.path, mutation.dst)
   }
 }
 

--- a/typescript/packages/core/src/runtime/python/mirage_bridge.ts
+++ b/typescript/packages/core/src/runtime/python/mirage_bridge.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { isMissingPath } from '../../utils/errors.ts'
 import type { BridgeDispatchFn } from '../types.ts'
 
 export interface MirageEntry {
@@ -204,8 +205,14 @@ export function createMirageBridge(
  *
  * Read-modify-write, because no transport op appends yet: the whole file
  * goes back over the wire per call, which is why the append-amplification
- * conformance row stays marked. Correctness does not depend on that:
- * the tail is only ever added to what the mount already holds.
+ * conformance row stays marked. It also leaves the append non-atomic
+ * against a concurrent writer, the same lost-update hazard whole-file
+ * flushing already carries; a transport append op closes both at once.
+ *
+ * Only a confirmed absence starts from an empty base, since an append
+ * may create the file. Every other read failure propagates: writing the
+ * tail on its own over a file that exists but is momentarily unreadable
+ * would replace content this run never saw.
  *
  * Args:
  *   bridge: the mount bridge to read and write through.
@@ -217,13 +224,7 @@ async function appendOnMount(bridge: MirageBridge, path: string, tail: Uint8Arra
   try {
     base = await bridge.fetch(path)
   } catch (err) {
-    // Absent is the normal case: an append may create the file. Any
-    // other cause (denied, backend down) fails the write below as well,
-    // so it still reaches the caller instead of quietly replacing the
-    // file's content with the tail alone.
-    console.warn(
-      `mirage append: ${path} has no base to extend: ${err instanceof Error ? err.message : String(err)}`,
-    )
+    if (!isMissingPath(err)) throw err
   }
   await bridge.flush(path, concatBytes(base, tail))
 }

--- a/typescript/packages/core/src/runtime/python/mirage_fs_shim.test.ts
+++ b/typescript/packages/core/src/runtime/python/mirage_fs_shim.test.ts
@@ -14,7 +14,12 @@
 
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { loadPyodideRuntime, type PyodideInterface } from './loader.ts'
-import { createMirageBridge, type MirageBridge, type MirageEntry } from './mirage_bridge.ts'
+import {
+  applyMutation,
+  createMirageBridge,
+  type MirageBridge,
+  type MirageEntry,
+} from './mirage_bridge.ts'
 import type { BridgeDispatchFn } from '../types.ts'
 import { MIRAGE_FS_SHIM_PY } from './mirage_fs_shim.ts'
 
@@ -24,11 +29,11 @@ interface Call {
   bytes?: Uint8Array
 }
 
-// The runtime's post-run drain: close() only marks paths dirty, the
-// flush happens host-side where awaiting the bridge needs no JSPI.
-async function drain(py: PyodideInterface, bridge: MirageBridge): Promise<void> {
-  for (const path of bridge.takeDirty()) {
-    await bridge.flush(path, py.FS.readFile(path) as Uint8Array)
+// The runtime's post-run drain: the guest only records mutations, and
+// they are applied host-side where awaiting the bridge needs no JSPI.
+async function drain(bridge: MirageBridge): Promise<void> {
+  for (const mutation of bridge.takeMutations()) {
+    await applyMutation(bridge, mutation)
   }
 }
 
@@ -86,7 +91,7 @@ describe('mirage_fs_shim', () => {
     lazyFiles.clear()
     lazyListings.clear()
     lazyListErrors.clear()
-    bridge.takeDirty()
+    bridge.takeMutations()
   })
 
   it('flushes a binary write to the bridge on close', async () => {
@@ -95,7 +100,7 @@ describe('mirage_fs_shim', () => {
 with open('/ram/hello.txt', 'wb') as f:
     f.write(b'world')
 `)
-    await drain(py, bridge)
+    await drain(bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -110,7 +115,7 @@ with open('/ram/hello.txt', 'wb') as f:
 with open('/tmp/x.txt', 'wb') as f:
     f.write(b'unbridged')
 `)
-    await drain(py, bridge)
+    await drain(bridge)
     expect(calls.filter((c) => c.op === 'WRITE')).toHaveLength(0)
   })
 
@@ -120,7 +125,7 @@ with open('/tmp/x.txt', 'wb') as f:
 with open('/ram/x.txt', 'w') as f:
     f.write('hello')
 `)
-    await drain(py, bridge)
+    await drain(bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -129,14 +134,14 @@ with open('/ram/x.txt', 'w') as f:
     expect(new TextDecoder().decode(w0.bytes)).toBe('hello')
   })
 
-  it('append mode flushes the full file content on close', async () => {
+  it('append mode lands the tail on top of the mount content', async () => {
     preload('/ram/log.txt', new TextEncoder().encode('a'))
     mounts.push('/ram/')
     await py.runPythonAsync(`
 with open('/ram/log.txt', 'ab') as f:
     f.write(b'b')
 `)
-    await drain(py, bridge)
+    await drain(bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -152,7 +157,7 @@ with open('/ram/log.txt', 'ab') as f:
 with open('/ram/x.txt', 'wb') as f:
     f.write(b'nope')
 `)
-    await drain(py, bridge)
+    await drain(bridge)
     expect(calls.filter((c) => c.op === 'WRITE')).toHaveLength(0)
   })
 
@@ -191,7 +196,7 @@ f.close()
       opened = false
     }
     void opened
-    await drain(py, bridge)
+    await drain(bridge)
     expect(calls.filter((c) => c.op === 'WRITE' && c.path === '/ram/../etc/x')).toHaveLength(0)
     expect(calls.filter((c) => c.op === 'WRITE' && c.path === '/etc/x')).toHaveLength(0)
   })
@@ -203,7 +208,7 @@ for i in range(5):
     with open('/ram/loop.txt', 'ab') as f:
         f.write(b'x')
 `)
-    await drain(py, bridge)
+    await drain(bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -220,7 +225,7 @@ with open('/ram/data.bin', 'r+b') as f:
     f.seek(2)
     f.write(b'\\x99\\x99')
 `)
-    await drain(py, bridge)
+    await drain(bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -236,7 +241,7 @@ with open('/ram/data.bin', 'r+b') as f:
 with open('/ram/x', 'wb') as f:
     f.write(b'y')
 `)
-    await drain(py, bridge)
+    await drain(bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -312,6 +317,52 @@ with open('/ram/cached/a.txt', 'rb') as f:
 `)
     expect(calls.filter((c) => c.op === 'LIST' && c.path === '/ram/cached/')).toHaveLength(1)
     expect(calls.filter((c) => c.op === 'READ' && c.path === '/ram/cached/a.txt')).toHaveLength(1)
+  })
+
+  it('records mutations a MEMFS miss would otherwise drop', async () => {
+    // Nothing here exists in MEMFS: the mount is the authority, and a
+    // path this interpreter never preloaded must not read as absent.
+    mounts.push('/ram/')
+    await py.runPythonAsync(`
+import os
+os.mkdir('/ram/fresh')
+os.remove('/ram/gone.txt')
+os.rmdir('/ram/olddir')
+`)
+    expect(bridge.takeMutations()).toEqual([
+      { kind: 'mkdir', path: '/ram/fresh' },
+      { kind: 'unlink', path: '/ram/gone.txt' },
+      { kind: 'rmdir', path: '/ram/olddir' },
+    ])
+  })
+
+  it('an append records only the tail, never the buffer it started from', async () => {
+    mounts.push('/ram/')
+    await py.runPythonAsync(`
+with open('/ram/unseen.txt', 'ab') as f:
+    f.write(b'tail')
+`)
+    const mutations = bridge.takeMutations()
+    expect(mutations).toHaveLength(1)
+    const only = mutations[0]
+    if (only?.kind !== 'append') throw new Error('expected an append')
+    expect(only.path).toBe('/ram/unseen.txt')
+    expect(new TextDecoder().decode(only.bytes)).toBe('tail')
+  })
+
+  it('a rename across two mounts raises EXDEV and records nothing', async () => {
+    mounts.push('/ram/', '/other/')
+    let raised = ''
+    try {
+      await py.runPythonAsync(`
+import os
+os.rename('/ram/a.txt', '/other/a.txt')
+`)
+    } catch (err) {
+      raised = err instanceof Error ? err.message : String(err)
+    }
+    expect(raised).toMatch(/Invalid cross-device link/)
+    expect(bridge.takeMutations()).toEqual([])
   })
 
   it('lazy backfill failure surfaces as FileNotFoundError', async () => {

--- a/typescript/packages/core/src/runtime/python/mirage_fs_shim.ts
+++ b/typescript/packages/core/src/runtime/python/mirage_fs_shim.ts
@@ -242,13 +242,18 @@ def _backfill(path):
     _populate_entries(parent_entries)
     return True
 
+# Absolute, because every mount test below compares against absolute
+# prefixes: guest code that chdirs into a mount and then names a relative
+# path ('child' after os.chdir('/data')) would otherwise miss every
+# prefix and mutate only MEMFS. abspath resolves against the guest cwd
+# and leaves an already-absolute path at what normpath would give.
 def _normalize_path(path):
     if isinstance(path, int):
         return None
     sp = path if isinstance(path, str) else os.fspath(path)
     if isinstance(sp, bytes):
         sp = sp.decode()
-    return sp
+    return os.path.abspath(sp)
 
 def _patched_listdir(path='.'):
     sp = _normalize_path(path)
@@ -308,7 +313,7 @@ def _patched_mkdir(path, mode=0o777, *, dir_fd=None):
     sp = _normalize_path(path)
     if sp is None or dir_fd is not None:
         return _mkdir(path, mode, dir_fd=dir_fd)
-    norm = os.path.normpath(sp)
+    norm = sp
     if not _under_prefix(norm):
         return _mkdir(path, mode, dir_fd=dir_fd)
     _makedirs_raw(os.path.dirname(norm))
@@ -319,7 +324,7 @@ def _patched_rmdir(path, *, dir_fd=None):
     sp = _normalize_path(path)
     if sp is None or dir_fd is not None:
         return _rmdir(path, dir_fd=dir_fd)
-    norm = os.path.normpath(sp)
+    norm = sp
     if not _under_prefix(norm):
         return _rmdir(path, dir_fd=dir_fd)
     try:
@@ -332,7 +337,7 @@ def _patched_unlink(path, *, dir_fd=None):
     sp = _normalize_path(path)
     if sp is None or dir_fd is not None:
         return _unlink(path, dir_fd=dir_fd)
-    norm = os.path.normpath(sp)
+    norm = sp
     if not _under_prefix(norm):
         return _unlink(path, dir_fd=dir_fd)
     try:
@@ -346,8 +351,8 @@ def _patched_rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None):
     dsp = _normalize_path(dst)
     if ssp is None or dsp is None or src_dir_fd is not None or dst_dir_fd is not None:
         return _rename(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
-    s = os.path.normpath(ssp)
-    d = os.path.normpath(dsp)
+    s = ssp
+    d = dsp
     if not _under_prefix(s) and not _under_prefix(d):
         return _rename(src, dst)
     # The dispatcher picks the mount from the source and addresses the
@@ -369,7 +374,7 @@ def _patched_open(file, mode='r', buffering=-1, encoding=None, errors=None, newl
     sp = file if isinstance(file, str) else os.fspath(file)
     if isinstance(sp, bytes):
         sp = sp.decode()
-    sp = os.path.normpath(sp)
+    sp = os.path.abspath(sp)
     under = _under_prefix(sp)
     writable = _is_writable_mode(mode)
     # A non-truncating writable open ('a', 'r+') keeps what the file

--- a/typescript/packages/core/src/runtime/python/mirage_fs_shim.ts
+++ b/typescript/packages/core/src/runtime/python/mirage_fs_shim.ts
@@ -19,7 +19,7 @@ import js
 import os
 import sys
 import types
-from pyodide.ffi import run_sync
+from pyodide.ffi import run_sync, to_js
 import _mirage_bridge as _mb
 
 _already_patched = getattr(builtins.open, '_mirage_patched', False)
@@ -31,6 +31,10 @@ if _already_patched:
     _stat = _shim._original_stat
     _scandir = _shim._original_scandir
     _mkdir = _shim._original_mkdir
+    _rmdir = _shim._original_rmdir
+    _unlink = _shim._original_unlink
+    _rename = _shim._original_rename
+    _lstat = _shim._original_lstat
 else:
     _open = builtins.open
     _io_open = io.open
@@ -38,6 +42,10 @@ else:
     _stat = os.stat
     _scandir = os.scandir
     _mkdir = os.mkdir
+    _rmdir = os.rmdir
+    _unlink = os.unlink
+    _rename = os.rename
+    _lstat = os.lstat
 
 def _under_prefix(path):
     if not isinstance(path, str):
@@ -47,42 +55,86 @@ def _under_prefix(path):
             return True
     return False
 
+# The mount serving a path, longest prefix first, or None. Two paths
+# belong to the same mount only when this agrees for both, which is what
+# the cross-mount rename guard needs. prefixes() is a sync JS call, so
+# this costs no stack switching.
+def _mount_of(path):
+    best = None
+    for p in _mb.prefixes():
+        if path == p.rstrip('/') or path.startswith(p):
+            if best is None or len(p) > len(best):
+                best = p
+    return best
+
 def _is_writable_mode(mode):
     for c in ('w', 'a', '+', 'x'):
         if c in mode:
             return True
     return False
 
-# close() only marks the path dirty on the bridge (a sync JS call): the
-# bytes are already in MEMFS, and awaiting the async flush op from these
-# sync WASM frames would need JSPI stack switching, which most engines do
-# not enable. The runtime flushes marked paths after the script returns.
+def _truncates(mode):
+    return 'w' in mode or 'x' in mode
+
+def _read_raw(path):
+    try:
+        with _open(path, 'rb') as f:
+            return f.read()
+    except OSError as exc:
+        js.console.warn('mirage flush: read back ' + path + ' failed: ' + str(exc))
+        return b''
+
+# close() only records on the bridge (a sync JS call): awaiting the async
+# op from these sync WASM frames would need JSPI stack switching, which
+# most engines do not enable. The runtime replays the journal after the
+# script returns.
+#
+# An append-mode handle records only the bytes it wrote, never the whole
+# file. That is what makes append safe on a file MEMFS has not seen: the
+# mount keeps whatever it already held and gains the tail, instead of
+# being overwritten by a buffer that started empty.
 class _FlushOnClose(io.FileIO):
     def __init__(self, path, mode='r', closefd=True, opener=None):
         super().__init__(path, mode=mode, closefd=closefd, opener=opener)
         self._mirage_path = os.fspath(path)
         self._mirage_dirty = False
+        self._mirage_append = 'a' in mode
+        self._mirage_delta = bytearray()
 
     def write(self, b):
         n = super().write(b)
         if n:
             self._mirage_dirty = True
+            if self._mirage_append:
+                self._mirage_delta += bytes(b)[:n]
         return n
 
     def writelines(self, lines):
+        # IOBase.writelines calls self.write per line, so the delta is
+        # already accumulated above; this only records the dirty edge.
         super().writelines(lines)
         self._mirage_dirty = True
 
     def truncate(self, size=None):
         out = super().truncate(size)
         self._mirage_dirty = True
+        # Truncation rewrites history the tail-only record cannot express,
+        # so fall back to shipping the whole file for this handle.
+        self._mirage_append = False
         return out
 
     def close(self):
         was_dirty = self._mirage_dirty and not self.closed
+        path = self._mirage_path
+        append = self._mirage_append
+        delta = bytes(self._mirage_delta)
         super().close()
-        if was_dirty:
-            _mb.markDirty(self._mirage_path)
+        if not was_dirty:
+            return
+        if append:
+            _mb.markAppend(path, to_js(delta))
+        else:
+            _mb.markWrite(path, to_js(_read_raw(path)))
 
 def _strip_bt(mode):
     return mode.replace('b', '').replace('t', '')
@@ -220,6 +272,17 @@ def _patched_stat(path, *, dir_fd=None, follow_symlinks=True):
             return _stat(sp, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
         raise
 
+def _patched_lstat(path, *, dir_fd=None):
+    sp = _normalize_path(path)
+    if sp is None:
+        return _lstat(path, dir_fd=dir_fd)
+    try:
+        return _lstat(sp, dir_fd=dir_fd)
+    except FileNotFoundError:
+        if _backfill(sp):
+            return _lstat(sp, dir_fd=dir_fd)
+        raise
+
 def _patched_scandir(path='.'):
     sp = _normalize_path(path)
     if sp is None:
@@ -231,6 +294,75 @@ def _patched_scandir(path='.'):
             return _scandir(sp)
         raise
 
+# The mutation patches below apply to MEMFS first, so the rest of the run
+# sees its own change, and then record on the bridge. They never consult
+# the bridge inline, so unlike the lazy backfill they need no JSPI.
+#
+# A MEMFS miss is not an error here and must not be raised: the mount is
+# the authority, and this interpreter only ever preloads a prefix once, so
+# anything a shell command created since is legitimately absent from MEMFS.
+# Refusing on that basis is exactly the bug this patch set removes. A path
+# that truly exists nowhere fails when the journal is replayed, which puts
+# the message on stderr and the run's exit code at 1.
+def _patched_mkdir(path, mode=0o777, *, dir_fd=None):
+    sp = _normalize_path(path)
+    if sp is None or dir_fd is not None:
+        return _mkdir(path, mode, dir_fd=dir_fd)
+    norm = os.path.normpath(sp)
+    if not _under_prefix(norm):
+        return _mkdir(path, mode, dir_fd=dir_fd)
+    _makedirs_raw(os.path.dirname(norm))
+    _mkdir(norm, mode)
+    _mb.markMkdir(norm)
+
+def _patched_rmdir(path, *, dir_fd=None):
+    sp = _normalize_path(path)
+    if sp is None or dir_fd is not None:
+        return _rmdir(path, dir_fd=dir_fd)
+    norm = os.path.normpath(sp)
+    if not _under_prefix(norm):
+        return _rmdir(path, dir_fd=dir_fd)
+    try:
+        _rmdir(norm)
+    except FileNotFoundError:
+        pass
+    _mb.markRmdir(norm)
+
+def _patched_unlink(path, *, dir_fd=None):
+    sp = _normalize_path(path)
+    if sp is None or dir_fd is not None:
+        return _unlink(path, dir_fd=dir_fd)
+    norm = os.path.normpath(sp)
+    if not _under_prefix(norm):
+        return _unlink(path, dir_fd=dir_fd)
+    try:
+        _unlink(norm)
+    except FileNotFoundError:
+        pass
+    _mb.markUnlink(norm)
+
+def _patched_rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None):
+    ssp = _normalize_path(src)
+    dsp = _normalize_path(dst)
+    if ssp is None or dsp is None or src_dir_fd is not None or dst_dir_fd is not None:
+        return _rename(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
+    s = os.path.normpath(ssp)
+    d = os.path.normpath(dsp)
+    if not _under_prefix(s) and not _under_prefix(d):
+        return _rename(src, dst)
+    # The dispatcher picks the mount from the source and addresses the
+    # destination against that same backend, so a cross-mount rename would
+    # drop the source and write into the wrong store. EXDEV is the POSIX
+    # answer, and the one that tells a caller to copy instead.
+    if _mount_of(s) != _mount_of(d):
+        raise OSError(18, 'Invalid cross-device link', s, None, d)
+    _makedirs_raw(os.path.dirname(d))
+    try:
+        _rename(s, d)
+    except FileNotFoundError:
+        pass
+    _mb.markRename(s, d)
+
 def _patched_open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None):
     if isinstance(file, int):
         return _open(file, mode, buffering, encoding, errors, newline, closefd, opener)
@@ -240,7 +372,11 @@ def _patched_open(file, mode='r', buffering=-1, encoding=None, errors=None, newl
     sp = os.path.normpath(sp)
     under = _under_prefix(sp)
     writable = _is_writable_mode(mode)
-    if under and not writable and not _exists_raw(sp):
+    # A non-truncating writable open ('a', 'r+') keeps what the file
+    # already holds, so it needs the same backfill a read does; only 'w'
+    # and 'x' start from nothing. Without this an update-in-place opened
+    # against a MEMFS miss would build its buffer from empty.
+    if under and (not writable or not _truncates(mode)) and not _exists_raw(sp):
         _backfill(sp)
     if under and writable:
         binary_mode = _strip_bt(mode) or 'r'
@@ -259,12 +395,40 @@ if not _already_patched:
     os.listdir = _patched_listdir
     os.stat = _patched_stat
     os.scandir = _patched_scandir
+    # Rebinding these six covers the whole family: os.makedirs calls the
+    # module's own mkdir, pathlib's Path.mkdir/unlink/rename and
+    # shutil.rmtree/move all reach the mutation through os, so no
+    # per-spelling patch list is needed and none can fall out of step.
+    os.mkdir = _patched_mkdir
+    os.rmdir = _patched_rmdir
+    os.unlink = _patched_unlink
+    os.remove = _patched_unlink
+    os.rename = _patched_rename
+    os.replace = _patched_rename
+    os.lstat = _patched_lstat
+    # Nothing reached over the bridge can act on a directory fd: the
+    # mount ops address paths. Saying so keeps a caller that chooses
+    # between a path-based and an fd-relative implementation on the one
+    # these patches can see.
+    os.supports_dir_fd = frozenset()
+    # shutil is already imported when the shim installs, so it cached
+    # that answer from the unpatched os and rmtree would still walk with
+    # openat/unlinkat, invisible here. Correct the cached gate. If
+    # upstream renames it, the rmtree conformance row goes red rather
+    # than dropping the mutation silently.
+    _shutil = sys.modules.get('shutil')
+    if _shutil is not None and hasattr(_shutil, '_use_fd_functions'):
+        _shutil._use_fd_functions = False
 
 _mod = types.ModuleType('_mirage_fs_shim')
 _mod._original_listdir = _listdir
 _mod._original_stat = _stat
 _mod._original_scandir = _scandir
 _mod._original_mkdir = _mkdir
+_mod._original_rmdir = _rmdir
+_mod._original_unlink = _unlink
+_mod._original_rename = _rename
+_mod._original_lstat = _lstat
 _mod._backfill = _backfill
 sys.modules['_mirage_fs_shim'] = _mod
 `

--- a/typescript/packages/core/src/runtime/python/mount.test.ts
+++ b/typescript/packages/core/src/runtime/python/mount.test.ts
@@ -146,7 +146,7 @@ describe('PyodideRuntime mount visibility', () => {
     })
     expect(result.exitCode).toBe(1)
     const stderr = new TextDecoder().decode(result.stderr ?? new Uint8Array())
-    expect(stderr).toContain('failed to flush /ram/out.txt')
+    expect(stderr).toContain('failed to write /ram/out.txt')
     expect(stderr).toContain('mount is read-only')
     await rt.close()
   }, 60_000)

--- a/typescript/packages/core/src/runtime/python/mount.test.ts
+++ b/typescript/packages/core/src/runtime/python/mount.test.ts
@@ -163,4 +163,64 @@ describe('PyodideRuntime mount visibility', () => {
     expect(result.exitCode).toBe(0)
     await rt.close()
   }, 60_000)
+
+  it('a failed mutation stops the replay instead of applying later entries', async () => {
+    const attempted: string[] = []
+    const dispatch: BridgeDispatchFn = (op, path) => {
+      attempted.push(`${op} ${path}`)
+      if (op === 'WRITE') return Promise.reject(new Error('backend hiccup'))
+      if (op === 'READ') return Promise.resolve(new Uint8Array())
+      if (op === 'LIST') return Promise.resolve([])
+      return Promise.resolve(undefined)
+    }
+    const rt = new PyodideRuntime()
+    rt.attach(dispatch, () => ['/ram/'])
+    const result = await rt.run({
+      code: [
+        'import os',
+        "open('/ram/tmp.txt', 'wb').write(b'new')",
+        "os.rename('/ram/tmp.txt', '/ram/final.txt')",
+      ].join('\n'),
+      args: [],
+      env: {},
+      stdin: new Uint8Array(),
+    })
+    // The rename must not run: its prerequisite write never landed, so
+    // replaying it could move a stale backend copy onto the destination.
+    expect(attempted.filter((c) => c.startsWith('RENAME'))).toHaveLength(0)
+    const stderr = new TextDecoder().decode(result.stderr ?? new Uint8Array())
+    expect(stderr).toContain('failed to write /ram/tmp.txt')
+    expect(stderr).toContain('skipped 1 later mutation(s)')
+    expect(result.exitCode).toBe(1)
+    await rt.close()
+  }, 60_000)
+
+  it('an unreadable base fails the append rather than replacing the file', async () => {
+    const writes: Uint8Array[] = []
+    const dispatch: BridgeDispatchFn = (op, path, bytes) => {
+      if (op === 'READ' && path === '/ram/log.txt') {
+        return Promise.reject(new Error('backend unavailable'))
+      }
+      if (op === 'READ') return Promise.resolve(new Uint8Array())
+      if (op === 'LIST') return Promise.resolve([])
+      if (op === 'WRITE' && bytes !== undefined) writes.push(new Uint8Array(bytes))
+      return Promise.resolve(undefined)
+    }
+    const rt = new PyodideRuntime()
+    rt.attach(dispatch, () => ['/ram/'])
+    const result = await rt.run({
+      code: `open('/ram/log.txt', 'a').write('tail')`,
+      args: [],
+      env: {},
+      stdin: new Uint8Array(),
+    })
+    // An error that is not a confirmed absence must not be read as an
+    // empty base, or the tail alone would overwrite the file.
+    expect(writes).toHaveLength(0)
+    expect(new TextDecoder().decode(result.stderr ?? new Uint8Array())).toContain(
+      'failed to append /ram/log.txt',
+    )
+    expect(result.exitCode).toBe(1)
+    await rt.close()
+  }, 60_000)
 })

--- a/typescript/packages/core/src/runtime/python/nojspi.test.ts
+++ b/typescript/packages/core/src/runtime/python/nojspi.test.ts
@@ -91,4 +91,80 @@ describe('PyodideRuntime without JSPI', () => {
     expect(result.exitCode).toBe(0)
     await rt.close()
   }, 60_000)
+
+  it('mutations reach the mount in guest order', async () => {
+    const calls: { op: string; path: string; dst?: string }[] = []
+    const dispatch: BridgeDispatchFn = async (op, path, _bytes, dst) => {
+      await new Promise((resolve) => setTimeout(resolve, 1))
+      calls.push(dst === undefined ? { op, path } : { op, path, dst })
+      if (op === 'READ') return new Uint8Array()
+      if (op === 'LIST') return []
+      return undefined
+    }
+    const rt = new PyodideRuntime()
+    rt.attach(dispatch, () => ['/ram/'])
+    const result = await rt.run({
+      code: [
+        'import os',
+        "os.mkdir('/ram/box')",
+        "open('/ram/box/f.txt', 'wb').write(b'hi')",
+        "os.rename('/ram/box/f.txt', '/ram/box/g.txt')",
+        "os.remove('/ram/box/g.txt')",
+        "os.rmdir('/ram/box')",
+      ].join('\n'),
+      args: [],
+      env: {},
+      stdin: new Uint8Array(),
+    })
+    expect(new TextDecoder().decode(result.stderr ?? new Uint8Array())).toBe('')
+    expect(result.exitCode).toBe(0)
+    const mutations = calls.filter((c) => c.op !== 'READ' && c.op !== 'LIST')
+    expect(mutations).toEqual([
+      { op: 'MKDIR', path: '/ram/box' },
+      { op: 'WRITE', path: '/ram/box/f.txt' },
+      { op: 'RENAME', path: '/ram/box/f.txt', dst: '/ram/box/g.txt' },
+      { op: 'UNLINK', path: '/ram/box/g.txt' },
+      { op: 'RMDIR', path: '/ram/box' },
+    ])
+    await rt.close()
+  }, 60_000)
+
+  it('appending to a file MEMFS never saw extends it, it does not replace it', async () => {
+    // The prefix preloads once per runtime, so a file the mount gained
+    // afterwards is legitimately absent from MEMFS. An append-mode open
+    // then starts from an empty buffer, and shipping that buffer whole
+    // would drop what the mount already held.
+    const files = new Map<string, Uint8Array>()
+    const writes: { path: string; text: string }[] = []
+    const dispatch: BridgeDispatchFn = async (op, path, bytes) => {
+      await new Promise((resolve) => setTimeout(resolve, 1))
+      if (op === 'READ') {
+        const found = files.get(path)
+        if (found === undefined) throw new Error(`no such file: ${path}`)
+        return found
+      }
+      if (op === 'LIST') {
+        return [...files].map(([p, v]) => ({ path: p, size: v.length, isDir: false }))
+      }
+      if (op === 'WRITE' && bytes !== undefined) {
+        files.set(path, new Uint8Array(bytes))
+        writes.push({ path, text: new TextDecoder().decode(bytes) })
+      }
+      return undefined
+    }
+    const rt = new PyodideRuntime()
+    rt.attach(dispatch, () => ['/ram/'])
+    await rt.run({ code: 'pass', args: [], env: {}, stdin: new Uint8Array() })
+    files.set('/ram/log.txt', new TextEncoder().encode('a'))
+    const result = await rt.run({
+      code: `\nfor part in ['b', 'c']:\n    with open('/ram/log.txt', 'a') as f:\n        f.write(part)\n`,
+      args: [],
+      env: {},
+      stdin: new Uint8Array(),
+    })
+    expect(new TextDecoder().decode(result.stderr ?? new Uint8Array())).toBe('')
+    expect(result.exitCode).toBe(0)
+    expect(new TextDecoder().decode(files.get('/ram/log.txt') ?? new Uint8Array())).toBe('abc')
+    await rt.close()
+  }, 60_000)
 })

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -26,7 +26,12 @@ import type {
 } from '../types.ts'
 import { createPyodideInterrupter, type PyodideInterrupter } from './interrupt.ts'
 import { loadPyodideRuntime, type PyodideInterface } from './loader.ts'
-import { createMirageBridge, preloadInto, type MirageBridge } from './mirage_bridge.ts'
+import {
+  applyMutation,
+  createMirageBridge,
+  preloadInto,
+  type MirageBridge,
+} from './mirage_bridge.ts'
 import type { BridgeDispatchFn } from '../types.ts'
 import { MIRAGE_FS_SHIM_PY } from './mirage_fs_shim.ts'
 import { PYTHON_EVAL_WRAPPER, PYTHON_REPL_WRAPPER, PYTHON_WRAPPER } from './wrapper.ts'
@@ -206,7 +211,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       if (armed?.disarm() === 'deadline') {
         throw new EvalError(`pyodide eval timed out after ${String(EVAL_INTERRUPT_SECONDS)}s`)
       }
-      const flushFailures = await this.drainDirty(pyodide)
+      const flushFailures = await this.drainMutations()
       const resultProxy = pyodide.globals.get('_eval_result') as
         | {
             toJs?: (opts?: Record<string, unknown>) => unknown
@@ -236,7 +241,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       }
     } catch (err) {
       const deadline = armed?.disarm() === 'deadline'
-      for (const failure of await this.drainDirty(pyodide)) console.warn(failure)
+      for (const failure of await this.drainMutations()) console.warn(failure)
       if (deadline) {
         throw new EvalError(`pyodide eval timed out after ${String(EVAL_INTERRUPT_SECONDS)}s`, {
           cause: err,
@@ -341,30 +346,22 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
   }
 
   /**
-   * Flush every path the shim marked dirty during the run. The guest
-   * cannot await the bridge from its sync WASM frames without JSPI, so
-   * close() only marks; MEMFS holds the final bytes, and one WRITE per
-   * path covers however many times the script reopened it. Returns one
-   * message per failed flush for the caller's stderr.
+   * Replay every mutation the shim recorded during the run, in the order
+   * the guest performed them. The guest cannot await the bridge from its
+   * sync WASM frames without JSPI, so it only records; ordering is what
+   * makes a create-then-rename or mkdir-then-write sequence land the same
+   * way it ran. Returns one message per failure for the caller's stderr.
    */
-  private async drainDirty(pyodide: PyodideInterface): Promise<string[]> {
-    if (this.bridge === null) return []
+  private async drainMutations(): Promise<string[]> {
+    const bridge = this.bridge
+    if (bridge === null) return []
     const failures: string[] = []
-    for (const path of this.bridge.takeDirty()) {
-      let bytes: Uint8Array
+    for (const mutation of bridge.takeMutations()) {
       try {
-        bytes = pyodide.FS.readFile(path) as Uint8Array
-      } catch {
-        // closed then unlinked locally; unlink does not propagate, so
-        // the mount keeps its previous content
-        console.warn(`mirage flush: ${path} marked dirty but missing from MEMFS, skipped`)
-        continue
-      }
-      try {
-        await this.bridge.flush(path, bytes)
+        await applyMutation(bridge, mutation)
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err)
-        failures.push(`python3: failed to flush ${path} to mount: ${detail}`)
+        failures.push(`python3: failed to ${mutation.kind} ${mutation.path} on mount: ${detail}`)
       }
     }
     return failures
@@ -412,7 +409,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       if (armed?.disarm() === 'deadline' && args.timeoutSeconds !== undefined) {
         throw new CommandTimeoutError(this.name, args.timeoutSeconds)
       }
-      const flushFailures = await this.drainDirty(pyodide)
+      const flushFailures = await this.drainMutations()
       const resultProxy = pyodide.globals.get('_result') as
         | {
             toJs?: (opts?: Record<string, unknown>) => unknown
@@ -445,7 +442,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       // Files closed before the failure are complete in MEMFS, so their
       // marks still flush; failures can only be warned here.
       const deadline = armed?.disarm() === 'deadline'
-      for (const failure of await this.drainDirty(pyodide)) console.warn(failure)
+      for (const failure of await this.drainMutations()) console.warn(failure)
       if (deadline && args.timeoutSeconds !== undefined) {
         throw new CommandTimeoutError(this.name, args.timeoutSeconds)
       }
@@ -487,7 +484,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
 
     try {
       await pyodide.runPythonAsync(PYTHON_REPL_WRAPPER)
-      const flushFailures = await this.drainDirty(pyodide)
+      const flushFailures = await this.drainMutations()
       const resultProxy = pyodide.globals.get('_repl_result') as
         | {
             toJs?: (opts?: Record<string, unknown>) => unknown

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -356,12 +356,26 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
     const bridge = this.bridge
     if (bridge === null) return []
     const failures: string[] = []
-    for (const mutation of bridge.takeMutations()) {
+    const pending = bridge.takeMutations()
+    for (let i = 0; i < pending.length; i++) {
+      const mutation = pending[i]
+      if (mutation === undefined) continue
       try {
         await applyMutation(bridge, mutation)
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err)
         failures.push(`python3: failed to ${mutation.kind} ${mutation.path} on mount: ${detail}`)
+        // Stop: the journal is a sequence, not a set. Replaying past a
+        // failure applies later entries against a prerequisite that was
+        // never established, which can put the mount in a state the guest
+        // never produced (a rename landing on a temp file the failed write
+        // left stale). Report what was dropped rather than truncating
+        // silently.
+        const dropped = pending.length - i - 1
+        if (dropped > 0) {
+          failures.push(`python3: skipped ${String(dropped)} later mutation(s) after that failure`)
+        }
+        break
       }
     }
     return failures


### PR DESCRIPTION
The pyodide shim patched only `open`, `os.listdir`, `os.stat` and `os.scandir`. Every mutation spelling changed pyodide's own MEMFS and never reached the mount, and a writable open never backfilled, so `open(path, 'a')` on a file MEMFS had not seen started from empty and the close-flush wrote that buffer over content the run never read. The prefix preloads once per runtime, so anything a shell command created after the first run was in exactly that state.

- Patch the `os` primitives (`mkdir`, `rmdir`, `unlink`, `remove`, `rename`, `replace`, `lstat`) rather than a list of spellings, since `os.makedirs`, `pathlib.Path.*` and `shutil` all reach the mutation through `os`.
- Record an append as the bytes that open wrote, never the whole file, so it can only add to what the mount already holds.
- Backfill on non-truncating writable opens (`a`, `r+`, not `w`/`x`).
- Refuse a cross-mount rename with EXDEV, decided in the guest from the mount prefixes.
- Replace the dirty-path set with an ordered mutation journal the runtime replays after the script. Writes carry their bytes because the drain sees only the final MEMFS state, so a write-then-rename would otherwise replay as a read of a path the rename already moved.

`shutil.rmtree` needed one more thing: pyodide imports shutil during bootstrap, so it had already cached `_use_fd_functions` from the unpatched `os` and walked with openat/unlinkat, which path-based patches cannot see. The shim now declares `os.supports_dir_fd` empty and corrects that cached gate.

No part of the mutation path consults the bridge inline, so unlike the lazy backfill none of it needs JSPI. The regression tests live in `nojspi.test.ts`, which deletes `WebAssembly.Suspending` before pyodide loads, and the new integ cases pass under plain tsx with no flag.

All eleven pyodide rows that the conformance suite marked broken now pass and are unmarked (43/43). The append-amplification row stays marked: the host still does read-modify-write because no transport has an append op, which is the next PR. `integ/runtime/pyodide.json` gains a case per fixed capability.