### PR TITLE
fix(email): bucket messages by IMAP INTERNALDATE when Date: is missing

### DIFF
--- a/python/mirage/commands/builtin/email/find.py
+++ b/python/mirage/commands/builtin/email/find.py
@@ -24,7 +24,7 @@ from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.email._client import fetch_headers
-from mirage.core.email.readdir import _date_from_header, _sanitize
+from mirage.core.email.readdir import _date_bucket, _sanitize
 from mirage.core.email.readdir import readdir as _readdir
 from mirage.core.email.scope import extract_folder
 from mirage.core.email.search import search_messages
@@ -150,7 +150,7 @@ async def _find_server_side(
     headers = await fetch_headers(accessor, folder, uids)
     results: list[str] = []
     for h in headers:
-        date_str = _date_from_header(h.get("date", ""))
+        date_str = _date_bucket(h)
         subject = _sanitize(h.get("subject", "No Subject"))
         uid = h.get("uid", "")
         filename = f"{subject}__{uid}.email.json"

--- a/python/mirage/commands/builtin/email/rg.py
+++ b/python/mirage/commands/builtin/email/rg.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
-
 from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.email.io import resolve_glob
@@ -30,6 +28,7 @@ from mirage.commands.spec.types import FlagView
 from mirage.core.email._client import fetch_message
 from mirage.core.email.read import read as email_read
 from mirage.core.email.readdir import readdir as _readdir
+from mirage.core.email.render import message_json_text
 from mirage.core.email.scope import extract_folder
 from mirage.core.email.search import _build_vfs_path, search_messages
 from mirage.core.email.stat import stat as _stat
@@ -83,9 +82,7 @@ async def rg(
                                       paths[0].resource_path) if paths else ""
         for uid in uids:
             msg = await fetch_message(accessor, folder, uid)
-            msg_text = json.dumps(msg,
-                                  ensure_ascii=False,
-                                  separators=(",", ":"))
+            msg_text = message_json_text(msg)
             vfs_path = _build_vfs_path(file_prefix, folder, msg)
             lines = msg_text.splitlines()
             matched = grep_lines(vfs_path,

--- a/python/mirage/commands/cli/builtin/himalaya/list.py
+++ b/python/mirage/commands/cli/builtin/himalaya/list.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
-
 from mirage.accessor.email import EmailAccessor
 from mirage.commands.cli.builtin.himalaya.query import (page_slice,
                                                         sort_headers,
@@ -22,6 +20,7 @@ from mirage.commands.cli.types import CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.core.email._client import fetch_headers, list_message_uids
 from mirage.core.email.config import EmailConfig
+from mirage.core.email.render import messages_json_bytes
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
 
@@ -42,6 +41,5 @@ async def list_envelopes(
     finally:
         await accessor.close()
     page_of = page_slice(sort_headers(headers, ()), page, page_size)
-    out = json.dumps(page_of, ensure_ascii=False,
-                     separators=(",", ":")).encode()
+    out = messages_json_bytes(page_of)
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/cli/builtin/himalaya/read.py
+++ b/python/mirage/commands/cli/builtin/himalaya/read.py
@@ -12,14 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
-
 from mirage.accessor.email import EmailAccessor
 from mirage.commands.cli.builtin.himalaya.util import first_text
 from mirage.commands.cli.types import CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.core.email._client import fetch_message, fetch_raw_message
 from mirage.core.email.config import EmailConfig
+from mirage.core.email.render import message_json_bytes
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
 
@@ -37,6 +36,7 @@ async def read(
         processed = await fetch_message(accessor, mailbox, uid)
     finally:
         await accessor.close()
-    out = json.dumps(processed, ensure_ascii=False,
-                     separators=(",", ":")).encode()
+    # The same renderer the mount serves, so `message read` and `cat` of
+    # the .email.json cannot drift apart.
+    out = message_json_bytes(processed)
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/cli/builtin/himalaya/search.py
+++ b/python/mirage/commands/cli/builtin/himalaya/search.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
-
 from mirage.accessor.email import EmailAccessor
 from mirage.commands.cli.builtin.himalaya.list import DEFAULT_PAGE_SIZE
 from mirage.commands.cli.builtin.himalaya.query import (page_slice,
@@ -24,6 +22,7 @@ from mirage.commands.cli.types import CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.core.email._client import fetch_headers, list_message_uids
 from mirage.core.email.config import EmailConfig
+from mirage.core.email.render import messages_json_bytes
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
 
@@ -47,6 +46,5 @@ async def search_envelopes(
     finally:
         await accessor.close()
     page_of = page_slice(sort_headers(headers, query.sorters), page, page_size)
-    out = json.dumps(page_of, ensure_ascii=False,
-                     separators=(",", ":")).encode()
+    out = messages_json_bytes(page_of)
     return yield_bytes(out), IOResult()

--- a/python/mirage/core/email/_client.py
+++ b/python/mirage/core/email/_client.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import re
 from email import policy
 from email.parser import BytesParser
 from typing import Any
@@ -20,6 +21,13 @@ import aioimaplib
 
 from mirage.accessor.email import EmailAccessor
 from mirage.core.email._parse import parse_rfc822
+
+INTERNAL_DATE_KEY = "internal_date"
+INTERNAL_DATE_RE = re.compile(r'INTERNALDATE "([^"]*)"')
+# Metadata is asked for ahead of the body: a server may answer the items
+# in the order they were requested, and anything after BODY[] lands on
+# the line *behind* the literal, where the parsers below never look.
+FETCH_ITEMS = "(UID FLAGS INTERNALDATE BODY.PEEK[])"
 
 
 async def select_folder(imap: aioimaplib.IMAP4_SSL, folder: str) -> None:
@@ -122,12 +130,13 @@ async def fetch_message(
     await select_folder(imap, folder)
     # BODY.PEEK[] instead of RFC822: reading a rendered file must not flip
     # \Seen on the mailbox, matching the imapflow client in the TS backend.
-    response = await imap.uid("fetch", uid, "(BODY.PEEK[] FLAGS)")
+    response = await imap.uid("fetch", uid, FETCH_ITEMS)
     raw_bytes = _extract_body(response)
     flags = _extract_flags(response)
     msg_dict = parse_rfc822(raw_bytes)
     msg_dict["uid"] = uid
     msg_dict["flags"] = flags
+    msg_dict[INTERNAL_DATE_KEY] = _extract_internal_date(response)
     return msg_dict
 
 
@@ -149,7 +158,7 @@ async def fetch_headers(
         # in the MIME structure, and listings must surface attachment dirs
         # without flipping \Seen (the gmail backend fetches full messages
         # on readdir the same way).
-        response = await imap.uid("fetch", uid_set, "(BODY.PEEK[] FLAGS UID)")
+        response = await imap.uid("fetch", uid_set, FETCH_ITEMS)
         results.extend(_parse_multi_fetch(response, batch))
     return results
 
@@ -216,6 +225,7 @@ def _parse_multi_fetch(response, uids: list[str]) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     current_uid = None
     current_flags: list[str] = []
+    current_internal = ""
 
     for item in response.lines:
         if isinstance(item, (bytes, bytearray)):
@@ -234,6 +244,7 @@ def _parse_multi_fetch(response, uids: list[str]) -> list[dict[str, Any]]:
                 pass
             if "FLAGS" in line:
                 current_flags = _extract_flags_from_line(line)
+            current_internal = _internal_date_from_line(line)
             continue
 
         if isinstance(item, (bytearray, )) and len(item) > 20:
@@ -244,11 +255,35 @@ def _parse_multi_fetch(response, uids: list[str]) -> list[dict[str, Any]]:
             msg_dict["uid"] = current_uid or (uids[len(results)] if
                                               len(results) < len(uids) else "")
             msg_dict["flags"] = current_flags
+            msg_dict[INTERNAL_DATE_KEY] = current_internal
             results.append(msg_dict)
             current_uid = None
             current_flags = []
+            current_internal = ""
 
     return results
+
+
+def _internal_date_from_line(line: str) -> str:
+    match = INTERNAL_DATE_RE.search(line)
+    return match.group(1) if match else ""
+
+
+def _extract_internal_date(response) -> str:
+    for item in response.lines:
+        # Literal payload arrives as a bytearray (same tell _extract_body
+        # uses); a message whose own text quotes an INTERNALDATE must not
+        # be read as the mailbox's.
+        if isinstance(item, bytearray):
+            continue
+        if isinstance(item, bytes):
+            line = item.decode(errors="replace")
+        else:
+            line = str(item)
+        found = _internal_date_from_line(line)
+        if found:
+            return found
+    return ""
 
 
 def _extract_flags_from_line(line: str) -> list[str]:

--- a/python/mirage/core/email/readdir.py
+++ b/python/mirage/core/email/readdir.py
@@ -13,12 +13,14 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import re
+from datetime import timezone
 from email.utils import parsedate_to_datetime
 from typing import Any
 
 from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
-from mirage.core.email._client import fetch_headers, list_message_uids
+from mirage.core.email._client import (INTERNAL_DATE_KEY, fetch_headers,
+                                       list_message_uids)
 from mirage.core.email.folders import list_folders
 from mirage.core.email.render import message_json_bytes
 from mirage.types import PathSpec
@@ -28,6 +30,7 @@ from mirage.utils.key_prefix import mount_key, mount_prefix_of
 TITLE_MAX = 80
 UNSAFE = re.compile(r"[^\w\s\-.]")
 MULTI_UNDERSCORE = re.compile(r"_+")
+EPOCH_DATE = "1970-01-01"
 
 
 def _sanitize(text: str) -> str:
@@ -44,12 +47,46 @@ def _msg_filename(subject: str, uid: str) -> str:
     return f"{_sanitize(subject)}__{uid}.email.json"
 
 
-def _date_from_header(date_str: str) -> str:
+def _parse_date(value: str) -> str | None:
+    if not value.strip():
+        return None
     try:
-        dt = parsedate_to_datetime(date_str)
-        return dt.strftime("%Y-%m-%d")
-    except Exception:
-        return "1970-01-01"
+        dt = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    # Normalized to UTC so one message buckets the same everywhere: the
+    # gmail backend and both TS backends already read their timestamps in
+    # UTC, and honoring the sender's offset instead put a message written
+    # at 23:30 -0500 in the day before the one gmail files it under.
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%d")
+
+
+def _date_bucket(message: dict[str, Any]) -> str:
+    """Pick the YYYY-MM-DD directory a message files under.
+
+    The ``Date:`` header wins, because it is the timestamp the sender
+    wrote and the one himalaya's date conditions search on (SENTON /
+    SENTSINCE / SENTBEFORE). It is also optional, and a message without
+    it used to fall straight to the epoch, collapsing the mount's only
+    organizing axis into a single 1970 directory. IMAP's own
+    INTERNALDATE (RFC 3501, server-assigned and always present) fills
+    that hole.
+
+    Args:
+        message (dict): a fetched message carrying ``date`` and
+            ``internal_date``.
+
+    Returns:
+        str: the bucket name, ``1970-01-01`` when neither timestamp
+            parses.
+    """
+    header = _parse_date(str(message.get("date", "")))
+    if header is not None:
+        return header
+    internal = _parse_date(str(message.get(INTERNAL_DATE_KEY, "")))
+    return internal if internal is not None else EPOCH_DATE
 
 
 async def readdir(
@@ -98,7 +135,7 @@ async def readdir(
         headers_list = await fetch_headers(accessor, folder_name, uids)
         date_groups: dict[str, list[dict[str, Any]]] = {}
         for hdr in headers_list:
-            date_str = _date_from_header(hdr.get("date", ""))
+            date_str = _date_bucket(hdr)
             date_groups.setdefault(date_str, []).append(hdr)
         date_entries: list[tuple[str, IndexEntry]] = []
         for date_str in sorted(date_groups.keys(), reverse=True):

--- a/python/mirage/core/email/readdir.py
+++ b/python/mirage/core/email/readdir.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import re
-from datetime import timezone
 from email.utils import parsedate_to_datetime
 from typing import Any
 
@@ -54,12 +53,12 @@ def _parse_date(value: str) -> str | None:
         dt = parsedate_to_datetime(value)
     except (TypeError, ValueError):
         return None
-    # Normalized to UTC so one message buckets the same everywhere: the
-    # gmail backend and both TS backends already read their timestamps in
-    # UTC, and honoring the sender's offset instead put a message written
-    # at 23:30 -0500 in the day before the one gmail files it under.
-    if dt.tzinfo is not None:
-        dt = dt.astimezone(timezone.utc)
+    # The calendar date as written, with no zone conversion. RFC 3501
+    # defines SENTON/SENTBEFORE/SENTSINCE (and ON/BEFORE/SINCE) as
+    # comparing the date "disregarding time and timezone", so a message
+    # written 05 Jan 23:30 -0500 answers a search for the 5th and has to
+    # sit in the 5th's directory. Converting to UTC would file it under
+    # the 6th and the search would select mail the directory lacks.
     return dt.strftime("%Y-%m-%d")
 
 

--- a/python/mirage/core/email/render.py
+++ b/python/mirage/core/email/render.py
@@ -15,6 +15,37 @@
 import json
 from typing import Any
 
+from mirage.core.email._client import INTERNAL_DATE_KEY
+
+
+def _message_document(message: dict[str, Any]) -> dict[str, Any]:
+    """Project a fetched message onto the document mirage serves.
+
+    INTERNALDATE is dropped: it is the mailbox's own arrival stamp, which
+    picks the date directory when the ``Date:`` header is missing, not a
+    field of the message. The gmail backend keeps its internalDate out of
+    the rendered JSON the same way.
+
+    Args:
+        message (dict): a fetched message from ``fetch_message`` or
+            ``fetch_headers``.
+
+    Returns:
+        dict: the message without its transport-only keys.
+    """
+    return {k: v for k, v in message.items() if k != INTERNAL_DATE_KEY}
+
+
+def message_json_text(message: dict[str, Any]) -> str:
+    """Render one parsed message as its .email.json text.
+
+    Args:
+        message (dict): parsed message dict from ``parse_rfc822``.
+    """
+    return json.dumps(_message_document(message),
+                      ensure_ascii=False,
+                      separators=(",", ":"))
+
 
 def message_json_bytes(message: dict[str, Any]) -> bytes:
     """Render one parsed message as its .email.json body.
@@ -25,5 +56,17 @@ def message_json_bytes(message: dict[str, Any]) -> bytes:
     # Single renderer for .email.json: the listing fetches the full message
     # with BODY.PEEK[] and parses it exactly like read() does, so sizing a
     # listed header dict here yields the byte length read() will return.
-    return json.dumps(message, ensure_ascii=False,
+    # Every other serializer of a fetched message routes through here too,
+    # so `himalaya message read` cannot drift from `cat`.
+    return message_json_text(message).encode()
+
+
+def messages_json_bytes(messages: list[dict[str, Any]]) -> bytes:
+    """Render a list of fetched messages as one JSON array.
+
+    Args:
+        messages (list[dict]): fetched messages, in output order.
+    """
+    return json.dumps([_message_document(m) for m in messages],
+                      ensure_ascii=False,
                       separators=(",", ":")).encode()

--- a/python/mirage/core/email/search.py
+++ b/python/mirage/core/email/search.py
@@ -12,12 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
 from typing import Any
 
 from mirage.accessor.email import EmailAccessor
 from mirage.core.email._client import fetch_message, list_message_uids
-from mirage.core.email.readdir import _date_from_header, _sanitize
+from mirage.core.email.readdir import _date_bucket, _sanitize
+from mirage.core.email.render import message_json_text
 from mirage.core.email.scope import EmailScope
 
 
@@ -76,7 +76,7 @@ async def search_messages(
 
 
 def _build_vfs_path(prefix: str, folder: str, msg: dict[str, Any]) -> str:
-    date_str = _date_from_header(msg.get("date", ""))
+    date_str = _date_bucket(msg)
     subject = _sanitize(msg.get("subject", "No Subject"))
     uid = msg.get("uid", "")
     filename = f"{subject}__{uid}.email.json"
@@ -102,7 +102,7 @@ async def search_and_format(
     pairs: list[tuple[str, str]] = []
     for uid in uids:
         msg = await fetch_message(accessor, folder, uid)
-        msg_text = json.dumps(msg, ensure_ascii=False, separators=(",", ":"))
+        msg_text = message_json_text(msg)
         vfs_path = _build_vfs_path(prefix, folder, msg)
         pairs.append((vfs_path, msg_text))
     return pairs

--- a/python/tests/commands/cli/builtin/himalaya/test_list.py
+++ b/python/tests/commands/cli/builtin/himalaya/test_list.py
@@ -29,6 +29,7 @@ def envelope(uid: str, day: int) -> dict:
         "uid": uid,
         "subject": f"s{uid}",
         "date": f"Mon, {day:02d} Feb 2026 10:00:00 +0000",
+        "internal_date": f"{day:02d}-Feb-2026 10:00:00 +0000",
     }
 
 
@@ -62,6 +63,9 @@ async def test_list_defaults_to_inbox_and_matches_everything(patched):
     data = json.loads(await materialize(out))
     # Most recent first, like upstream's `envelope list`.
     assert [d["uid"] for d in data] == ["3", "2", "1"]
+    # INTERNALDATE only picks the date directory; it is not an envelope
+    # field, and every envelope renders through the mount's renderer.
+    assert all("internal_date" not in d for d in data)
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/cli/builtin/himalaya/test_read.py
+++ b/python/tests/commands/cli/builtin/himalaya/test_read.py
@@ -34,7 +34,11 @@ async def test_read_takes_the_id_positionally_and_closes_the_accessor(
     async def fake_fetch(accessor, folder, uid):
         seen["accessor"] = accessor
         seen["args"] = (folder, uid)
-        return {"subject": "Hi", "uid": uid}
+        return {
+            "subject": "Hi",
+            "uid": uid,
+            "internal_date": "07-Aug-2026 20:54:05 +0000",
+        }
 
     async def fake_close(self):
         closed.append(self)
@@ -44,6 +48,8 @@ async def test_read_takes_the_id_positionally_and_closes_the_accessor(
     out, io = await read(
         CLIInvocation(CONFIG, texts=("7", ), flags={"mailbox": "INBOX"}))
     assert io.exit_code == 0
+    # Rendered through the mount's own renderer, so INTERNALDATE (which
+    # only picks the date directory) never reaches the output.
     assert json.loads(await materialize(out)) == {"subject": "Hi", "uid": "7"}
     assert isinstance(seen["accessor"], EmailAccessor)
     assert seen["accessor"].config is CONFIG

--- a/python/tests/core/email/test_client.py
+++ b/python/tests/core/email/test_client.py
@@ -17,8 +17,20 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from mirage.accessor.email import EmailAccessor
-from mirage.core.email._client import list_folders, list_message_uids
+from mirage.core.email._client import (fetch_headers, fetch_message,
+                                       list_folders, list_message_uids)
 from mirage.core.email.config import EmailConfig
+
+MESSAGE = (b"From: alice@example.com\r\n"
+           b"To: bob@example.com\r\n"
+           b"Subject: Hello\r\n"
+           b"MIME-Version: 1.0\r\n"
+           b"Content-Type: text/plain; charset=utf-8\r\n"
+           b"\r\n"
+           b"a message with no Date header at all\r\n")
+
+FETCH_LINE = (b'1 FETCH (FLAGS () INTERNALDATE "07-Aug-2026 20:54:05 +0000" '
+              b"UID 101 BODY[] {%d}" % len(MESSAGE))
 
 
 @pytest.fixture
@@ -134,3 +146,84 @@ async def test_a_refused_search_is_not_an_empty_result(accessor):
 
     with pytest.raises(ValueError, match="IMAP rejected the search"):
         await list_message_uids(accessor, "INBOX", "SENTON not-a-date")
+
+
+def _fetch_imap() -> AsyncMock:
+    mock_imap = AsyncMock()
+    mock_select_response = MagicMock()
+    mock_select_response.result = "OK"
+    mock_imap.select.return_value = mock_select_response
+
+    mock_fetch_response = MagicMock()
+    mock_fetch_response.lines = [
+        FETCH_LINE,
+        bytearray(MESSAGE),
+        b")",
+        b"FETCH completed.",
+    ]
+    mock_imap.uid.return_value = mock_fetch_response
+    return mock_imap
+
+
+@pytest.mark.asyncio
+async def test_fetch_headers_reads_internaldate(accessor):
+    accessor._imap = _fetch_imap()
+    accessor._imap.protocol = True
+
+    headers = await fetch_headers(accessor, "INBOX", ["101"])
+
+    assert len(headers) == 1
+    assert headers[0]["date"] == ""
+    assert headers[0]["internal_date"] == "07-Aug-2026 20:54:05 +0000"
+    assert headers[0]["uid"] == "101"
+
+
+@pytest.mark.asyncio
+async def test_fetch_message_reads_internaldate(accessor):
+    accessor._imap = _fetch_imap()
+    accessor._imap.protocol = True
+
+    msg = await fetch_message(accessor, "INBOX", "101")
+
+    assert msg["internal_date"] == "07-Aug-2026 20:54:05 +0000"
+
+
+@pytest.mark.asyncio
+async def test_a_message_quoting_internaldate_is_not_read_as_one(accessor):
+    quoted = b'the header reads INTERNALDATE "01-Jan-1990 00:00:00 +0000"\r\n'
+    body = MESSAGE + quoted
+    mock_imap = AsyncMock()
+    mock_select_response = MagicMock()
+    mock_select_response.result = "OK"
+    mock_imap.select.return_value = mock_select_response
+    mock_fetch_response = MagicMock()
+    # No INTERNALDATE on the descriptor line, and the message text quotes
+    # one: the literal payload must not answer for the mailbox.
+    mock_fetch_response.lines = [
+        b"1 FETCH (FLAGS () UID 101 BODY[] {%d}" % len(body),
+        bytearray(body),
+        b")",
+    ]
+    mock_imap.uid.return_value = mock_fetch_response
+    accessor._imap = mock_imap
+    accessor._imap.protocol = True
+
+    msg = await fetch_message(accessor, "INBOX", "101")
+
+    assert msg["internal_date"] == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_asks_for_metadata_before_the_body(accessor):
+    # A server may answer the items in the order they were requested, and
+    # anything after BODY[] lands on the line behind the literal, where
+    # neither response parser looks.
+    accessor._imap = _fetch_imap()
+    accessor._imap.protocol = True
+
+    await fetch_message(accessor, "INBOX", "101")
+
+    items = accessor._imap.uid.call_args[0][-1]
+    assert items.index("INTERNALDATE") < items.index("BODY.PEEK[]")
+    assert items.index("FLAGS") < items.index("BODY.PEEK[]")
+    assert items.index("UID") < items.index("BODY.PEEK[]")

--- a/python/tests/core/email/test_readdir.py
+++ b/python/tests/core/email/test_readdir.py
@@ -141,12 +141,18 @@ def test_date_bucket_reaches_the_epoch_only_with_neither():
     assert _date_bucket({}) == "1970-01-01"
 
 
-def test_date_bucket_reads_offsets_in_utc():
-    # The TS backend and both gmail backends bucket in UTC; honoring the
-    # sender's offset instead filed a late-evening message a day early.
+def test_date_bucket_keeps_the_calendar_date_as_written():
+    # RFC 3501 compares SENTON/SENTBEFORE/SENTSINCE (and ON/BEFORE/SINCE)
+    # "disregarding time and timezone", so a message written late on the
+    # 5th in -0500 answers a search for the 5th and belongs in the 5th's
+    # directory. Converting to UTC would file it under the 6th.
     assert _date_bucket({"date":
-                         "Mon, 05 Jan 2026 23:30:00 -0500"}) == "2026-01-06"
+                         "Mon, 05 Jan 2026 23:30:00 -0500"}) == "2026-01-05"
+    # The same in the other direction: early on the 5th in +0900 is still
+    # the 5th, not the 4th.
+    assert _date_bucket({"date":
+                         "Mon, 05 Jan 2026 01:30:00 +0900"}) == "2026-01-05"
     assert _date_bucket({
         "date": "",
-        "internal_date": " 7-Aug-2026 20:54:05 -0500",
-    }) == "2026-08-08"
+        "internal_date": " 7-Aug-2026 02:00:00 +1000",
+    }) == "2026-08-07"

--- a/python/tests/core/email/test_readdir.py
+++ b/python/tests/core/email/test_readdir.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.core.email.readdir import readdir
+from mirage.core.email.readdir import _date_bucket, readdir
 from mirage.core.email.render import message_json_bytes
 from mirage.types import PathSpec
 
@@ -37,6 +37,25 @@ HEADERS = [{
     "attachments": [],
     "uid": "101",
     "flags": ["\\Seen"],
+    "internal_date": "18-Mar-2024 08:00:00 +0000",
+}]
+
+NO_DATE_HEADERS = [{
+    "from": {
+        "name": "Alice",
+        "email": "alice@example.com"
+    },
+    "to": [{
+        "name": "",
+        "email": "bob@example.com"
+    }],
+    "subject": "Hello",
+    "date": "",
+    "body_text": "hi there",
+    "attachments": [],
+    "uid": "101",
+    "flags": [],
+    "internal_date": "07-Aug-2026 20:54:05 +0000",
 }]
 
 
@@ -71,3 +90,63 @@ async def test_readdir_folder_sizes_messages(accessor, index):
     listing = await index.list_dir("/INBOX/2024-01-15")
     lookup = await index.get(listing.entries[0])
     assert lookup.entry.size == len(message_json_bytes(HEADERS[0]))
+
+
+@pytest.mark.asyncio
+async def test_readdir_buckets_a_dateless_message_by_internaldate(
+        accessor, index):
+    # Without INTERNALDATE every message a sender left undated lands in
+    # one 1970 directory, which is the mount's only organizing axis.
+    with (patch("mirage.core.email.readdir.list_folders",
+                new_callable=AsyncMock,
+                return_value=["INBOX"]),
+          patch("mirage.core.email.readdir.list_message_uids",
+                new_callable=AsyncMock,
+                return_value=["101"]),
+          patch("mirage.core.email.readdir.fetch_headers",
+                new_callable=AsyncMock,
+                return_value=NO_DATE_HEADERS)):
+        result = await readdir(
+            accessor,
+            PathSpec(resource_path="INBOX",
+                     virtual="/INBOX",
+                     directory="/INBOX"), index)
+
+    assert result == ["/INBOX/2026-08-07"]
+
+
+def test_date_bucket_prefers_the_header():
+    assert _date_bucket({
+        "date": "Mon, 15 Jan 2024 10:00:00 +0000",
+        "internal_date": "18-Mar-2024 08:00:00 +0000",
+    }) == "2024-01-15"
+
+
+def test_date_bucket_falls_back_to_internaldate():
+    assert _date_bucket({
+        "date": "",
+        "internal_date": "07-Aug-2026 20:54:05 +0000",
+    }) == "2026-08-07"
+
+
+def test_date_bucket_falls_back_on_an_unparseable_header():
+    assert _date_bucket({
+        "date": "yesterday-ish",
+        "internal_date": "07-Aug-2026 20:54:05 +0000",
+    }) == "2026-08-07"
+
+
+def test_date_bucket_reaches_the_epoch_only_with_neither():
+    assert _date_bucket({"date": "", "internal_date": ""}) == "1970-01-01"
+    assert _date_bucket({}) == "1970-01-01"
+
+
+def test_date_bucket_reads_offsets_in_utc():
+    # The TS backend and both gmail backends bucket in UTC; honoring the
+    # sender's offset instead filed a late-evening message a day early.
+    assert _date_bucket({"date":
+                         "Mon, 05 Jan 2026 23:30:00 -0500"}) == "2026-01-06"
+    assert _date_bucket({
+        "date": "",
+        "internal_date": " 7-Aug-2026 20:54:05 -0500",
+    }) == "2026-08-08"

--- a/python/tests/core/email/test_render.py
+++ b/python/tests/core/email/test_render.py
@@ -1,0 +1,44 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+
+from mirage.core.email.render import message_json_bytes
+
+MESSAGE = {
+    "from": {
+        "name": "Alice",
+        "email": "alice@example.com"
+    },
+    "subject": "Hello",
+    "date": "",
+    "body_text": "hi there",
+    "uid": "101",
+    "flags": [],
+    "internal_date": "07-Aug-2026 20:54:05 +0000",
+}
+
+
+def test_internaldate_is_not_part_of_the_rendered_message():
+    body = json.loads(message_json_bytes(MESSAGE))
+    assert "internal_date" not in body
+    assert body["uid"] == "101"
+    assert body["date"] == ""
+
+
+def test_rendering_is_stable_whether_or_not_internaldate_is_present():
+    # readdir sizes a listed message with this renderer and read() serves
+    # it with the same one, so the two must agree byte for byte.
+    without = {k: v for k, v in MESSAGE.items() if k != "internal_date"}
+    assert message_json_bytes(MESSAGE) == message_json_bytes(without)

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/himalaya.test.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/himalaya.test.ts
@@ -22,6 +22,7 @@ import {
   type PathSpec,
 } from '@struktoai/mirage-core'
 import { EmailAccessor } from '../../../../accessor/email.ts'
+import { messageJsonBytes } from '../../../../core/email/render.ts'
 import { Workspace } from '../../../../workspace.ts'
 import {
   build,
@@ -36,6 +37,7 @@ import { forward } from './forward.ts'
 import { HIMALAYA } from './index.ts'
 import { listEnvelopes } from './list.ts'
 import { pageSlice, parseQuery, QueryError, sortHeaders, uidBudget } from './query.ts'
+import { read } from './read.ts'
 import { reply } from './reply.ts'
 import { searchEnvelopes } from './search.ts'
 import { send } from './send.ts'
@@ -70,6 +72,7 @@ const ORIGINAL = {
   attachments: [],
   uid: '7',
   flags: [],
+  internalDate: '2026-02-02T10:00:00.000Z',
 }
 
 const HEADERS: Record<string, unknown> = {
@@ -542,6 +545,25 @@ describe('himalaya verbs', () => {
     closeSpy.mockRestore()
   })
 
+  // `message read` and `cat` of the .email.json are the same document, so
+  // they share one renderer and INTERNALDATE reaches neither.
+  it('read serves exactly what the mount renders', async () => {
+    const closeSpy = vi.spyOn(EmailAccessor.prototype, 'close').mockResolvedValue()
+    const [out] = (await read({
+      config: CONFIG,
+      argv: [],
+      paths: [],
+      texts: ['7'],
+      flags: {},
+      stdin: null,
+      env: {},
+    })) as [Uint8Array, IOResult]
+    const bytes = await materialize(out)
+    expect(bytes).toEqual(messageJsonBytes(ORIGINAL))
+    expect(decode(bytes)).not.toContain('internalDate')
+    closeSpy.mockRestore()
+  })
+
   it('reply without an id is a usage error', async () => {
     await expect(
       reply({ config: CONFIG, argv: [], paths: [], texts: [], flags: {}, stdin: null, env: {} }),
@@ -596,8 +618,11 @@ describe('himalaya verbs', () => {
       stdin: null,
       env: {},
     })) as [Uint8Array, IOResult]
-    const rows = JSON.parse(decode(await materialize(out))) as { uid: string }[]
+    const rows = JSON.parse(decode(await materialize(out))) as Record<string, unknown>[]
     expect(rows.map((r) => r.uid)).toEqual(['2', '1'])
+    // INTERNALDATE only picks the date directory; it is not an envelope
+    // field, and every envelope renders through the mount's renderer.
+    expect(rows.every((r) => !('internalDate' in r))).toBe(true)
     expect(closeSpy).toHaveBeenCalledTimes(1)
     closeSpy.mockRestore()
   })

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/list.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/list.ts
@@ -22,11 +22,10 @@ import {
 import { EmailAccessor } from '../../../../accessor/email.ts'
 import { fetchHeaders, listMessageUids } from '../../../../core/email/_client.ts'
 import type { EmailConfig } from '../../../../core/email/config.ts'
+import { messagesJsonBytes } from '../../../../core/email/render.ts'
 import { pageSlice, sortHeaders, uidBudget } from './query.ts'
 
 export const DEFAULT_PAGE_SIZE = 25
-
-const ENC = new TextEncoder()
 
 export async function listEnvelopes(inv: CLIInvocation): Promise<CommandFnResult> {
   const fl = new FlagView(inv.flags)
@@ -44,6 +43,6 @@ export async function listEnvelopes(inv: CLIInvocation): Promise<CommandFnResult
     await accessor.close()
   }
   const pageOf = pageSlice(sortHeaders(headers, []), page, pageSize)
-  const out: ByteSource = ENC.encode(JSON.stringify(pageOf))
+  const out: ByteSource = messagesJsonBytes(pageOf)
   return [out, new IOResult()]
 }

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/read.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/read.ts
@@ -22,9 +22,8 @@ import {
 import { EmailAccessor } from '../../../../accessor/email.ts'
 import { fetchMessage, fetchRawMessage } from '../../../../core/email/_client.ts'
 import type { EmailConfig } from '../../../../core/email/config.ts'
+import { messageJsonBytes } from '../../../../core/email/render.ts'
 import { firstText } from './util.ts'
-
-const ENC = new TextEncoder()
 
 export async function read(inv: CLIInvocation): Promise<CommandFnResult> {
   const fl = new FlagView(inv.flags)
@@ -37,7 +36,9 @@ export async function read(inv: CLIInvocation): Promise<CommandFnResult> {
       return [raw, new IOResult()]
     }
     const processed = await fetchMessage(accessor, mailbox, uid)
-    const out: ByteSource = ENC.encode(JSON.stringify(processed))
+    // The same renderer the mount serves, so `message read` and `cat`
+    // of the .email.json cannot drift apart.
+    const out: ByteSource = messageJsonBytes(processed)
     return [out, new IOResult()]
   } finally {
     await accessor.close()

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/search.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/search.ts
@@ -22,10 +22,9 @@ import {
 import { EmailAccessor } from '../../../../accessor/email.ts'
 import { fetchHeaders, listMessageUids } from '../../../../core/email/_client.ts'
 import type { EmailConfig } from '../../../../core/email/config.ts'
+import { messagesJsonBytes } from '../../../../core/email/render.ts'
 import { DEFAULT_PAGE_SIZE } from './list.ts'
 import { pageSlice, parseQuery, sortHeaders, uidBudget } from './query.ts'
-
-const ENC = new TextEncoder()
 
 export async function searchEnvelopes(inv: CLIInvocation): Promise<CommandFnResult> {
   const fl = new FlagView(inv.flags)
@@ -46,6 +45,6 @@ export async function searchEnvelopes(inv: CLIInvocation): Promise<CommandFnResu
     await accessor.close()
   }
   const pageOf = pageSlice(sortHeaders(headers, query.sorters), page, pageSize)
-  const out: ByteSource = ENC.encode(JSON.stringify(pageOf))
+  const out: ByteSource = messagesJsonBytes(pageOf)
   return [out, new IOResult()]
 }

--- a/typescript/packages/node/src/core/email/_client.ts
+++ b/typescript/packages/node/src/core/email/_client.ts
@@ -19,6 +19,14 @@ import { parseRfc822, parseWithPayloads, type ParsedRfc822 } from './_parse.ts'
 export interface FetchedMessage extends ParsedRfc822 {
   uid: string
   flags: string[]
+  /** IMAP's own arrival stamp, ISO-8601, empty when the server omits it. */
+  internalDate: string
+}
+
+function internalDateOf(value: Date | string | undefined): string {
+  if (value === undefined) return ''
+  if (typeof value === 'string') return value
+  return value.toISOString()
 }
 
 export async function listFolders(accessor: EmailAccessor): Promise<string[]> {
@@ -293,7 +301,11 @@ export async function fetchMessage(
   const imap = await accessor.getImap()
   const lock = await lockMailbox(imap, folder)
   try {
-    const msg = await imap.fetchOne(uid, { source: true, flags: true, uid: true }, { uid: true })
+    const msg = await imap.fetchOne(
+      uid,
+      { source: true, flags: true, uid: true, internalDate: true },
+      { uid: true },
+    )
     if (msg === false) {
       throw new Error(`email: uid ${uid} not found in ${folder}`)
     }
@@ -303,6 +315,7 @@ export async function fetchMessage(
       ...parsed,
       uid,
       flags: msg.flags !== undefined ? [...msg.flags] : [],
+      internalDate: internalDateOf(msg.internalDate),
     }
   } finally {
     lock.release()
@@ -322,7 +335,11 @@ export async function fetchHeaders(
     for (const uid of uids) {
       // Full source (not headers-only): listings need the MIME structure
       // to surface attachment dirs, mirroring the python backend.
-      const msg = await imap.fetchOne(uid, { source: true, flags: true, uid: true }, { uid: true })
+      const msg = await imap.fetchOne(
+        uid,
+        { source: true, flags: true, uid: true, internalDate: true },
+        { uid: true },
+      )
       if (msg === false) continue
       const source = msg.source instanceof Buffer ? new Uint8Array(msg.source) : new Uint8Array(0)
       const parsed = await parseRfc822(source)
@@ -330,6 +347,7 @@ export async function fetchHeaders(
         ...parsed,
         uid,
         flags: msg.flags !== undefined ? [...msg.flags] : [],
+        internalDate: internalDateOf(msg.internalDate),
       })
     }
     return results

--- a/typescript/packages/node/src/core/email/readdir.test.ts
+++ b/typescript/packages/node/src/core/email/readdir.test.ts
@@ -120,7 +120,23 @@ describe('dateBucket', () => {
     expect(dateBucket(message({ date: '', internalDate: '' }))).toBe('1970-01-01')
   })
 
-  it('reads offsets in UTC', () => {
-    expect(dateBucket(message({ date: 'Mon, 05 Jan 2026 23:30:00 -0500' }))).toBe('2026-01-06')
+  // RFC 3501 compares SENTON/SENTBEFORE/SENTSINCE (and ON/BEFORE/SINCE)
+  // "disregarding time and timezone", so a message written late on the 5th
+  // in -0500 answers a search for the 5th and belongs in the 5th's
+  // directory. Converting to UTC would file it under the 6th.
+  it('keeps the calendar date as written', () => {
+    expect(dateBucket(message({ date: 'Mon, 05 Jan 2026 23:30:00 -0500' }))).toBe('2026-01-05')
+    expect(dateBucket(message({ date: 'Mon, 05 Jan 2026 01:30:00 +0900' }))).toBe('2026-01-05')
+  })
+
+  it('reads the obsolete zone names RFC 5322 still allows', () => {
+    expect(dateBucket(message({ date: 'Mon, 05 Jan 2026 23:30:00 EST' }))).toBe('2026-01-05')
+    expect(dateBucket(message({ date: 'Mon, 05 Jan 2026 23:30:00 GMT' }))).toBe('2026-01-05')
+  })
+
+  // A header with no zone at all: the wall clock is the answer, and it
+  // must not shift with the host's timezone.
+  it('keeps a zone-less header at its written wall clock', () => {
+    expect(dateBucket(message({ date: 'Mon, 05 Jan 2026 23:30:00' }))).toBe('2026-01-05')
   })
 })

--- a/typescript/packages/node/src/core/email/readdir.test.ts
+++ b/typescript/packages/node/src/core/email/readdir.test.ts
@@ -12,29 +12,43 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type * as ClientModule from './_client.ts'
 import type * as FoldersModule from './folders.ts'
 
-const HEADERS = [
-  {
+function message(overrides: Partial<ClientModule.FetchedMessage>): ClientModule.FetchedMessage {
+  return {
     from: { name: 'Alice', email: 'alice@example.com' },
+    reply_to: [],
     to: [{ name: '', email: 'bob@example.com' }],
+    cc: [],
     subject: 'Hello',
     date: 'Mon, 15 Jan 2024 10:00:00 +0000',
     body_text: 'hi there',
+    body_html: '',
+    snippet: 'hi there',
+    message_id: '<one@example.com>',
+    in_reply_to: null,
+    references: [],
+    has_attachments: false,
     attachments: [],
     uid: '101',
     flags: ['\\Seen'],
-  },
-]
+    internalDate: '2024-03-18T08:00:00.000Z',
+    ...overrides,
+  }
+}
+
+const HEADERS = [message({})]
+const NO_DATE_HEADERS = [message({ date: '', internalDate: '2026-08-07T20:54:05.000Z' })]
+let headersList = HEADERS
 
 vi.mock('./_client.ts', async () => {
   const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
   return {
     ...actual,
     listMessageUids: vi.fn(() => Promise.resolve(['101'])),
-    fetchHeaders: vi.fn(() => Promise.resolve(HEADERS)),
+    fetchHeaders: vi.fn(() => Promise.resolve(headersList)),
   }
 })
 
@@ -45,26 +59,68 @@ vi.mock('./folders.ts', async () => {
 
 import { PathSpec, RAMIndexCacheStore } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../accessor/email.ts'
-import { readdir } from './readdir.ts'
+import { dateBucket, readdir } from './readdir.ts'
 import { messageJsonBytes } from './render.ts'
 
 const ACCESSOR = { config: { maxMessages: 50 } } as unknown as EmailAccessor
 
+const SPEC = new PathSpec({
+  virtual: '/INBOX',
+  directory: '/INBOX',
+  resourcePath: 'INBOX',
+})
+
 describe('email readdir', () => {
+  afterEach(() => {
+    headersList = HEADERS
+  })
+
   it('stores the rendered message size on each listing entry', async () => {
     const index = new RAMIndexCacheStore()
-    const spec = new PathSpec({
-      virtual: '/INBOX',
-      directory: '/INBOX',
-      resourcePath: 'INBOX',
-    })
 
-    const dates = await readdir(ACCESSOR, spec, index)
+    const dates = await readdir(ACCESSOR, SPEC, index)
 
     expect(dates).toEqual(['/INBOX/2024-01-15'])
     const listing = await index.listDir('/INBOX/2024-01-15')
     const child = listing.entries?.[0] ?? ''
     const lookup = await index.get(child)
-    expect(lookup.entry?.size).toBe(messageJsonBytes(HEADERS[0]).byteLength)
+    expect(lookup.entry?.size).toBe(messageJsonBytes(message({})).byteLength)
+  })
+
+  // Without INTERNALDATE every message a sender left undated lands in one
+  // 1970 directory, which is the mount's only organizing axis.
+  it('buckets a message with no Date header by its INTERNALDATE', async () => {
+    headersList = NO_DATE_HEADERS
+    const index = new RAMIndexCacheStore()
+
+    const dates = await readdir(ACCESSOR, SPEC, index)
+
+    expect(dates).toEqual(['/INBOX/2026-08-07'])
+  })
+})
+
+describe('dateBucket', () => {
+  it('prefers the Date header', () => {
+    expect(dateBucket(message({}))).toBe('2024-01-15')
+  })
+
+  it('falls back to INTERNALDATE when the header is missing', () => {
+    expect(dateBucket(message({ date: '', internalDate: '2026-08-07T20:54:05.000Z' }))).toBe(
+      '2026-08-07',
+    )
+  })
+
+  it('falls back to INTERNALDATE when the header does not parse', () => {
+    expect(
+      dateBucket(message({ date: 'yesterday-ish', internalDate: '2026-08-07T20:54:05.000Z' })),
+    ).toBe('2026-08-07')
+  })
+
+  it('reaches the epoch only when neither timestamp parses', () => {
+    expect(dateBucket(message({ date: '', internalDate: '' }))).toBe('1970-01-01')
+  })
+
+  it('reads offsets in UTC', () => {
+    expect(dateBucket(message({ date: 'Mon, 05 Jan 2026 23:30:00 -0500' }))).toBe('2026-01-06')
   })
 })

--- a/typescript/packages/node/src/core/email/readdir.ts
+++ b/typescript/packages/node/src/core/email/readdir.ts
@@ -21,7 +21,7 @@ import {
   mountPrefixOf,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../accessor/email.ts'
-import { fetchHeaders, listMessageUids } from './_client.ts'
+import { fetchHeaders, listMessageUids, type FetchedMessage } from './_client.ts'
 import { listFolders } from './folders.ts'
 import { messageJsonBytes } from './render.ts'
 import type { ParsedAttachment } from './_parse.ts'
@@ -29,8 +29,9 @@ import type { ParsedAttachment } from './_parse.ts'
 const TITLE_MAX = 80
 const UNSAFE = /[^\w\s\-.]/g
 const MULTI_UNDERSCORE = /_+/g
+const EPOCH_DATE = '1970-01-01'
 
-function sanitize(text: string): string {
+export function sanitize(text: string): string {
   if (text.trim() === '') return 'No_Subject'
   let cleaned = text.replace(UNSAFE, '_').replace(/ /g, '_')
   cleaned = cleaned.replace(MULTI_UNDERSCORE, '_').replace(/^_+|_+$/g, '')
@@ -42,14 +43,28 @@ function msgFilename(subject: string, uid: string): string {
   return `${sanitize(subject)}__${uid}.email.json`
 }
 
-function dateFromHeader(dateStr: string): string {
-  if (dateStr === '') return '1970-01-01'
-  const d = new Date(dateStr)
-  if (Number.isNaN(d.getTime())) return '1970-01-01'
+function parseDate(value: string): string | null {
+  if (value.trim() === '') return null
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return null
   const yyyy = d.getUTCFullYear().toString().padStart(4, '0')
   const mm = (d.getUTCMonth() + 1).toString().padStart(2, '0')
   const dd = d.getUTCDate().toString().padStart(2, '0')
   return `${yyyy}-${mm}-${dd}`
+}
+
+/**
+ * Picks the YYYY-MM-DD directory a message files under.
+ *
+ * The `Date:` header wins, because it is the timestamp the sender wrote
+ * and the one himalaya's date conditions search on (SENTON / SENTSINCE /
+ * SENTBEFORE). It is also optional, and a message without it used to
+ * fall straight to the epoch, collapsing the mount's only organizing
+ * axis into a single 1970 directory. IMAP's own INTERNALDATE (RFC 3501,
+ * server-assigned and always present) fills that hole.
+ */
+export function dateBucket(message: FetchedMessage): string {
+  return parseDate(message.date) ?? parseDate(message.internalDate) ?? EPOCH_DATE
 }
 
 export async function readdir(
@@ -98,7 +113,7 @@ export async function readdir(
     const headersList = await fetchHeaders(accessor, folderName, uids)
     const dateGroups = new Map<string, typeof headersList>()
     for (const hdr of headersList) {
-      const dateStr = dateFromHeader(hdr.date)
+      const dateStr = dateBucket(hdr)
       let bucket = dateGroups.get(dateStr)
       if (bucket === undefined) {
         bucket = []

--- a/typescript/packages/node/src/core/email/readdir.ts
+++ b/typescript/packages/node/src/core/email/readdir.ts
@@ -43,14 +43,53 @@ function msgFilename(subject: string, uid: string): string {
   return `${sanitize(subject)}__${uid}.email.json`
 }
 
+// RFC 5322's obsolete zone names, the set `parsedate_to_datetime` knows.
+const NAMED_ZONES: Record<string, number> = {
+  UT: 0,
+  UTC: 0,
+  GMT: 0,
+  Z: 0,
+  EST: -300,
+  EDT: -240,
+  CST: -360,
+  CDT: -300,
+  MST: -420,
+  MDT: -360,
+  PST: -480,
+  PDT: -420,
+}
+
+/** Minutes east of UTC the timestamp states, null when it states none. */
+function statedOffset(value: string): number | null {
+  const numeric = /([+-])(\d{2}):?(\d{2})\s*$/.exec(value)
+  if (numeric !== null) {
+    const sign = numeric[1] === '-' ? -1 : 1
+    return sign * (Number(numeric[2]) * 60 + Number(numeric[3]))
+  }
+  const named = /([A-Z]{1,3})\s*$/.exec(value.toUpperCase())
+  return NAMED_ZONES[named?.[1] ?? ''] ?? null
+}
+
+function ymd(year: number, month: number, day: number): string {
+  return `${year.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`
+}
+
 function parseDate(value: string): string | null {
   if (value.trim() === '') return null
   const d = new Date(value)
   if (Number.isNaN(d.getTime())) return null
-  const yyyy = d.getUTCFullYear().toString().padStart(4, '0')
-  const mm = (d.getUTCMonth() + 1).toString().padStart(2, '0')
-  const dd = d.getUTCDate().toString().padStart(2, '0')
-  return `${yyyy}-${mm}-${dd}`
+  // The calendar date as written, with no zone conversion. RFC 3501
+  // defines SENTON/SENTBEFORE/SENTSINCE (and ON/BEFORE/SINCE) as
+  // comparing the date "disregarding time and timezone", so a message
+  // written 05 Jan 23:30 -0500 answers a search for the 5th and has to
+  // sit in the 5th's directory. `Date` only keeps the instant, so the
+  // stated offset is added back before reading the fields.
+  const offset = statedOffset(value)
+  // No zone stated: `new Date` read the wall clock as host-local, so the
+  // local fields hand it back exactly as written.
+  if (offset === null) return ymd(d.getFullYear(), d.getMonth() + 1, d.getDate())
+  const shifted = new Date(d.getTime() + offset * 60_000)
+  return ymd(shifted.getUTCFullYear(), shifted.getUTCMonth() + 1, shifted.getUTCDate())
 }
 
 /**

--- a/typescript/packages/node/src/core/email/render.test.ts
+++ b/typescript/packages/node/src/core/email/render.test.ts
@@ -1,0 +1,57 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import type { FetchedMessage } from './_client.ts'
+import { messageJsonBytes } from './render.ts'
+
+const MESSAGE: FetchedMessage = {
+  from: { name: 'Alice', email: 'alice@example.com' },
+  reply_to: [],
+  to: [{ name: '', email: 'bob@example.com' }],
+  cc: [],
+  subject: 'Hello',
+  date: '',
+  body_text: 'hi there',
+  body_html: '',
+  snippet: 'hi there',
+  message_id: '<one@example.com>',
+  in_reply_to: null,
+  references: [],
+  has_attachments: false,
+  attachments: [],
+  uid: '101',
+  flags: [],
+  internalDate: '2026-08-07T20:54:05.000Z',
+}
+
+const decoder = new TextDecoder()
+
+describe('messageJsonBytes', () => {
+  it('leaves INTERNALDATE out of the rendered message', () => {
+    const body = JSON.parse(decoder.decode(messageJsonBytes(MESSAGE))) as Record<string, unknown>
+
+    expect('internalDate' in body).toBe(false)
+    expect(body.uid).toBe('101')
+    expect(body.date).toBe('')
+  })
+
+  // readdir sizes a listed message with this renderer and read() serves it
+  // with the same one, so the two must agree byte for byte.
+  it('renders the same bytes whether or not INTERNALDATE is present', () => {
+    const withOut = { ...MESSAGE, internalDate: '' }
+
+    expect(messageJsonBytes(MESSAGE)).toEqual(messageJsonBytes(withOut))
+  })
+})

--- a/typescript/packages/node/src/core/email/render.ts
+++ b/typescript/packages/node/src/core/email/render.ts
@@ -12,11 +12,37 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { FetchedMessage } from './_client.ts'
+
 const encoder = new TextEncoder()
 
-export function messageJsonBytes(message: unknown): Uint8Array {
+/**
+ * Projects a fetched message onto the document mirage serves.
+ *
+ * INTERNALDATE is dropped: it is the mailbox's own arrival stamp, which
+ * picks the date directory when the `Date:` header is missing, not a
+ * field of the message. The gmail backend keeps its internalDate out of
+ * the rendered JSON the same way.
+ */
+function messageDocument(message: FetchedMessage): Partial<FetchedMessage> {
+  const body: Partial<FetchedMessage> = { ...message }
+  delete body.internalDate
+  return body
+}
+
+export function messageJsonText(message: FetchedMessage): string {
+  return JSON.stringify(messageDocument(message))
+}
+
+export function messageJsonBytes(message: FetchedMessage): Uint8Array {
   // Single renderer for .email.json: the listing fetches the full message
   // source and parses it exactly like read() does, so sizing a listed
-  // header dict here yields the byte length read() will return.
-  return encoder.encode(JSON.stringify(message))
+  // header dict here yields the byte length read() will return. Every
+  // other serializer of a fetched message routes through here too, so
+  // `himalaya message read` cannot drift from `cat`.
+  return encoder.encode(messageJsonText(message))
+}
+
+export function messagesJsonBytes(messages: readonly FetchedMessage[]): Uint8Array {
+  return encoder.encode(JSON.stringify(messages.map((m) => messageDocument(m))))
 }

--- a/typescript/packages/node/src/core/email/search.ts
+++ b/typescript/packages/node/src/core/email/search.ts
@@ -14,29 +14,9 @@
 
 import type { EmailAccessor } from '../../accessor/email.ts'
 import { fetchMessage, listMessageUids, type FetchedMessage } from './_client.ts'
+import { dateBucket, sanitize } from './readdir.ts'
+import { messageJsonText } from './render.ts'
 import type { EmailScope } from './scope.ts'
-
-const TITLE_MAX = 80
-const UNSAFE = /[^\w\s\-.]/g
-const MULTI_UNDERSCORE = /_+/g
-
-function sanitize(text: string): string {
-  if (text.trim() === '') return 'No_Subject'
-  let cleaned = text.replace(UNSAFE, '_').replace(/ /g, '_')
-  cleaned = cleaned.replace(MULTI_UNDERSCORE, '_').replace(/^_+|_+$/g, '')
-  if (cleaned.length > TITLE_MAX) cleaned = `${cleaned.slice(0, TITLE_MAX - 3)}...`
-  return cleaned
-}
-
-function dateFromHeader(dateStr: string): string {
-  if (dateStr === '') return '1970-01-01'
-  const d = new Date(dateStr)
-  if (Number.isNaN(d.getTime())) return '1970-01-01'
-  const yyyy = d.getUTCFullYear().toString().padStart(4, '0')
-  const mm = (d.getUTCMonth() + 1).toString().padStart(2, '0')
-  const dd = d.getUTCDate().toString().padStart(2, '0')
-  return `${yyyy}-${mm}-${dd}`
-}
 
 interface SearchOptions {
   text?: string | null
@@ -83,7 +63,7 @@ async function searchMessages(
 }
 
 function buildVfsPath(prefix: string, folder: string, msg: FetchedMessage): string {
-  const dateStr = dateFromHeader(msg.date)
+  const dateStr = dateBucket(msg)
   const subject = sanitize(msg.subject !== '' ? msg.subject : 'No Subject')
   const filename = `${subject}__${msg.uid}.email.json`
   return [prefix, folder, dateStr, filename].filter((p) => p !== '').join('/')
@@ -102,7 +82,7 @@ export async function searchAndFormat(
   const pairs: [string, string][] = []
   for (const uid of uids) {
     const msg = await fetchMessage(accessor, folder, uid)
-    const msgText = JSON.stringify(msg)
+    const msgText = messageJsonText(msg)
     const vfsPath = buildVfsPath(prefix, folder, msg)
     pairs.push([vfsPath, msgText])
   }


### PR DESCRIPTION
## Summary

- A message with no parseable `Date:` header bucketed at `1970-01-01`, collapsing `/mail/<FOLDER>/<YYYY-MM-DD>/` into one directory. The header still wins (it is what himalaya's `SENT*` conditions search on), INTERNALDATE fills the hole, epoch only if neither parses.
- FETCH now asks for metadata ahead of the body: a server may answer items in requested order, and anything after `BODY[]` lands on the line behind the literal where the parsers never look.
- Buckets use the calendar date **as written**, no zone conversion, in both languages. RFC 3501 compares `SENTON`/`SENTBEFORE`/`SENTSINCE` (and `ON`/`BEFORE`/`SINCE`) "disregarding time and timezone", so `05 Jan 23:30 -0500` belongs in the 5th's directory. TypeScript was converting to UTC and filing it under the 6th, which let a date search select mail its own directory did not contain; `Date` keeps only the instant, so the stated offset is parsed back out of the string and added before reading the fields.
- INTERNALDATE is transport metadata, not part of the message, so the single renderer drops it. The five other places that serialized a fetched message by hand (himalaya read/list/search, email rg, searchAndFormat) now route through that renderer, so `himalaya message read` cannot drift from `cat`.

## Test plan

- Live GreenMail, py and ts: an undated message files under its arrival date, a dated one under its header date, listing size == read length, INTERNALDATE not rendered.
- py and ts produce identical buckets for nine timestamps (numeric offsets both directions, `-0000`, GMT, EST, PDT, zone-less) under `TZ=UTC`, `America/New_York` and `Asia/Tokyo`.
- Mutation-checked: reverting the fallback, the drop, or the zone handling turns tests red in both languages.
- integ `--facet email` (85) and `--target cli-himalaya` (68) green on both hosts, no golden changes.
- `pre-commit run --all-files` clean, mypy 0, full TS node suite (2264) and py email/himalaya suites green.