### PR TITLE
fix(parity): close out Block A — find multi-root walk, honest error classes, one filetype table, dify stat depth, /dev/null removal (#609)

### DIFF
--- a/integ/fixtures/filetype/tables.json
+++ b/integ/fixtures/filetype/tables.json
@@ -1,0 +1,59 @@
+{
+  "extension_map": {
+    "json": "json",
+    "jsonl": "json",
+    "csv": "csv",
+    "tsv": "csv",
+    "txt": "text",
+    "md": "text",
+    "log": "text",
+    "py": "text",
+    "js": "text",
+    "ts": "text",
+    "yaml": "text",
+    "yml": "text",
+    "toml": "text",
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "zip": "application/zip",
+    "gz": "application/gzip",
+    "gzip": "application/gzip",
+    "pdf": "application/pdf"
+  },
+  "mime_by_extension": {
+    "csv": "text/csv",
+    "gif": "image/gif",
+    "gz": "application/gzip",
+    "htm": "text/html",
+    "html": "text/html",
+    "jpeg": "image/jpeg",
+    "jpg": "image/jpeg",
+    "json": "application/json",
+    "md": "text/markdown",
+    "pdf": "application/pdf",
+    "png": "image/png",
+    "svg": "image/svg+xml",
+    "tar": "application/x-tar",
+    "txt": "text/plain",
+    "xml": "text/xml",
+    "zip": "application/zip"
+  },
+  "mimetype_map": {
+    "application/pdf": "application/pdf",
+    "application/zip": "application/zip",
+    "application/gzip": "application/gzip",
+    "application/json": "json",
+    "image/png": "image/png",
+    "image/jpeg": "image/jpeg",
+    "image/gif": "image/gif",
+    "text/csv": "csv"
+  },
+  "image_type_by_extension": {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif"
+  }
+}

--- a/integ/resources/dify/stat.json
+++ b/integ/resources/dify/stat.json
@@ -12,6 +12,19 @@
         "stdout": "0 /knowledge/guides/auth\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "df_stat_mtime",
+      "seq": 580023,
+      "targets": [
+        "dify"
+      ],
+      "command": "stat -c '%y' /knowledge/guides/auth",
+      "expect": {
+        "exit": 0,
+        "stdout": "2024-05-21T09:00:00Z\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/unix/checksum/tier2.json
+++ b/integ/unix/checksum/tier2.json
@@ -21,7 +21,11 @@
       "seq": 910039,
       "targets": ["ram", "disk"],
       "command": "mkdir -p /data/t2checksum2 && printf '00000000000000000000000000000000  /data/not-there\n' > /data/t2checksum2/sums && md5sum --check --ignore-missing /data/t2checksum2/sums && echo ignored",
-      "expect": { "exit": 0, "stdout": "ignored\n", "stderr": "" },
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "md5sum: /data/t2checksum2/sums: no file was verified\n"
+      },
       "flags": ["check", "ignore-missing"]
     },
     {
@@ -29,7 +33,11 @@
       "seq": 910040,
       "targets": ["ram", "disk"],
       "command": "mkdir -p /data/t2checksum3 && printf 'bad\n' > /data/t2checksum3/sums && sha1sum --check --warn /data/t2checksum3/sums 2>&1; echo warn=$?; sha1sum --check --strict /data/t2checksum3/sums > /dev/null 2>&1; echo strict=$?",
-      "expect": { "exit": 0, "stdout": "WARNING: 1 line is improperly formatted\nwarn=0\nstrict=1\n", "stderr": "" },
+      "expect": {
+        "exit": 0,
+        "stdout": "sha1sum: /data/t2checksum3/sums: 1: improperly formatted SHA1 checksum line\nsha1sum: /data/t2checksum3/sums: no properly formatted checksum lines found\nwarn=1\nstrict=1\n",
+        "stderr": ""
+      },
       "flags": ["check", "warn", "strict"]
     },
     {

--- a/integ/unix/find/roots.json
+++ b/integ/unix/find/roots.json
@@ -1,0 +1,132 @@
+{
+  "cases": [
+    {
+      "id": "find_roots_provision",
+      "seq": 785,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "box"
+      ],
+      "command": "mkdir -p /data/roots1/sub && printf 'r1\\n' > /data/roots1/r1.txt && printf 'r2\\n' > /data/roots1/sub/r2.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_roots_operand_order",
+      "seq": 786,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "box"
+      ],
+      "command": "find /data/roots1 /data/a.txt -name '*.txt'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/roots1/r1.txt\n/data/roots1/sub/r2.txt\n/data/a.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_roots_duplicate_walks_twice",
+      "seq": 787,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "find /data/a.txt /data/a.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/a.txt\n/data/a.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_roots_missing_middle_keeps_output",
+      "seq": 788,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "find /data/a.txt /data/nope /data/b.txt",
+      "expect": {
+        "exit": 1,
+        "stdout": "/data/a.txt\n/data/b.txt\n",
+        "stderr": "find: '/data/nope': No such file or directory\n"
+      }
+    }
+  ]
+}

--- a/python/mirage/commands/builtin/constants.py
+++ b/python/mirage/commands/builtin/constants.py
@@ -36,10 +36,6 @@ FILE_MIME_MAP: dict[str, str] = {
     "application/zip": "application/zip",
     "application/gzip": "application/gzip",
     "application/pdf": "application/pdf",
-    "parquet": "application/octet-stream",
-    "orc": "application/octet-stream",
-    "feather": "application/octet-stream",
-    "hdf5": "application/octet-stream",
 }
 
 # GNU `file -i` reports a symlink by its inode type, never by whatever

--- a/python/mirage/commands/builtin/generic/checksum.py
+++ b/python/mirage/commands/builtin/generic/checksum.py
@@ -6,7 +6,9 @@ from mirage.commands.builtin.utils.lines import split_lines
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
+from mirage.utils.errors import WALK_ERRORS, fs_strerror
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
+from mirage.utils.path import resolve_path
 
 
 class Digest(Protocol):
@@ -81,12 +83,23 @@ def _parse_check_line(line: str, algorithm: str) -> tuple[str, str] | None:
     return plain.group(1).lower(), plain.group(2)
 
 
-def _resolve_check_target(filename: str, mount_prefix: str) -> str | PathSpec:
-    if mount_prefix and filename.startswith(mount_prefix + "/"):
-        return PathSpec(virtual=filename,
-                        directory=filename,
-                        resource_path=mount_key(filename, mount_prefix))
-    return filename
+def _resolve_check_target(filename: str, cwd: str,
+                          mount_prefix: str) -> PathSpec:
+    """PathSpec for a recorded name, resolved like GNU against the cwd.
+
+    Args:
+        filename (str): the name exactly as the checksum file records it.
+        cwd (str): the invoking command's working directory.
+        mount_prefix (str): the checksum file's mount prefix.
+    """
+    virtual = resolve_path(filename, cwd)
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=mount_key(virtual, mount_prefix))
+
+
+def _count_noun(count: int, singular: str, plural: str) -> str:
+    return singular if count == 1 else f"{count} {plural}"
 
 
 async def _hash_check(
@@ -95,48 +108,87 @@ async def _hash_check(
     read_stream: Callable[..., AsyncIterator[bytes]],
     factory: DigestFactory,
     algorithm: str,
+    cwd: str,
     strict: bool,
     ignore_missing: bool,
     status: bool,
     quiet: bool,
     warn: bool,
 ) -> tuple[bytes, bytes | None, int]:
+    prog = f"{algorithm}sum"
     data = (await read_bytes(path)).decode(errors="replace")
-    mount_prefix = mount_prefix_of(
-        path.virtual, path.resource_path) if isinstance(path, PathSpec) else ""
+    mount_prefix = mount_prefix_of(path.virtual, path.resource_path)
+    check_label = path.raw_path or path.virtual
     lines: list[str] = []
-    failed = False
+    stderr_lines: list[str] = []
+    verified = 0
+    mismatched = 0
+    read_failures = 0
     malformed = 0
-    for line in split_lines(data):
+    for lineno, line in enumerate(split_lines(data), start=1):
         if not line.strip():
             continue
         parsed = _parse_check_line(line, algorithm)
         if parsed is None:
             malformed += 1
+            if warn:
+                stderr_lines.append(
+                    f"{prog}: {check_label}: {lineno}: improperly formatted "
+                    f"{algorithm.upper()} checksum line")
             continue
         expected_hash, filename = parsed
-        target = _resolve_check_target(filename, mount_prefix)
+        target = _resolve_check_target(filename, cwd, mount_prefix)
         h = factory()
         try:
             async for chunk in read_stream(target):
                 h.update(chunk)
-        except FileNotFoundError:
-            if ignore_missing:
+        except WALK_ERRORS as exc:
+            # GNU --ignore-missing skips only absence; a permission or
+            # transport-shaped failure still reports and fails the check.
+            if ignore_missing and isinstance(exc,
+                                             (FileNotFoundError, ValueError)):
                 continue
+            strerror = fs_strerror(exc) or str(exc)
+            stderr_lines.append(f"{prog}: {filename}: {strerror}")
             lines.append(f"{filename}: FAILED open or read")
-            failed = True
+            read_failures += 1
             continue
         if h.hexdigest() == expected_hash:
+            verified += 1
             if not quiet:
                 lines.append(f"{filename}: OK")
         else:
             lines.append(f"{filename}: FAILED")
-            failed = True
-    stderr = None
-    if warn and malformed:
-        count = f"{malformed} lines are" if malformed != 1 else "1 line is"
-        stderr = f"WARNING: {count} improperly formatted\n".encode()
-    exit_code = 1 if failed or (strict and malformed) else 0
+            mismatched += 1
+    # GNU's terminal diagnostics and WARNING block, in its order: the two
+    # fatal shapes come alone, the summaries print even without --warn,
+    # and --status silences the summaries but not the per-file strerror
+    # lines (pinned against coreutils 9.7).
+    if not verified and not mismatched and not read_failures and malformed:
+        stderr_lines.append(
+            f"{prog}: {check_label}: no properly formatted checksum lines "
+            "found")
+        return b"", ("\n".join(stderr_lines) + "\n").encode(), 1
+    if ignore_missing and not verified and not mismatched \
+            and not read_failures:
+        stderr_lines.append(f"{prog}: {check_label}: no file was verified")
+        return b"", ("\n".join(stderr_lines) + "\n").encode(), 1
+    if not status:
+        if malformed:
+            noun = _count_noun(malformed, "1 line is", "lines are")
+            stderr_lines.append(
+                f"{prog}: WARNING: {noun} improperly formatted")
+        if read_failures:
+            noun = _count_noun(read_failures, "1 listed file", "listed files")
+            stderr_lines.append(f"{prog}: WARNING: {noun} could not be read")
+        if mismatched:
+            noun = _count_noun(mismatched, "1 computed checksum",
+                               "computed checksums")
+            stderr_lines.append(f"{prog}: WARNING: {noun} did NOT match")
+    stderr = ("\n".join(stderr_lines) +
+              "\n").encode() if stderr_lines else None
+    exit_code = 1 if mismatched or read_failures or (strict
+                                                     and malformed) else 0
     output = b"" if status else (("\n".join(lines) +
                                   "\n").encode() if lines else b"")
     return output, stderr, exit_code
@@ -159,11 +211,13 @@ async def hashsum(
     status: bool = False,
     quiet: bool = False,
     warn: bool = False,
+    cwd: PathSpec | str = "/",
 ) -> tuple[ByteSource | None, IOResult]:
     if check and paths:
+        cwd_dir = cwd.virtual if isinstance(cwd, PathSpec) else (cwd or "/")
         out, stderr, exit_code = await _hash_check(paths[0], read_bytes,
                                                    read_stream, factory,
-                                                   algorithm, strict,
+                                                   algorithm, cwd_dir, strict,
                                                    ignore_missing, status,
                                                    quiet, warn)
         return out, IOResult(exit_code=exit_code, stderr=stderr)

--- a/python/mirage/commands/builtin/generic/checksum.py
+++ b/python/mirage/commands/builtin/generic/checksum.py
@@ -121,6 +121,7 @@ async def _hash_check(
     check_label = path.raw_path or path.virtual
     lines: list[str] = []
     stderr_lines: list[str] = []
+    parsed_lines = 0
     verified = 0
     mismatched = 0
     read_failures = 0
@@ -136,6 +137,7 @@ async def _hash_check(
                     f"{prog}: {check_label}: {lineno}: improperly formatted "
                     f"{algorithm.upper()} checksum line")
             continue
+        parsed_lines += 1
         expected_hash, filename = parsed
         target = _resolve_check_target(filename, cwd, mount_prefix)
         h = factory()
@@ -160,19 +162,18 @@ async def _hash_check(
         else:
             lines.append(f"{filename}: FAILED")
             mismatched += 1
-    # GNU's terminal diagnostics and WARNING block, in its order: the two
-    # fatal shapes come alone, the summaries print even without --warn,
-    # and --status silences the summaries but not the per-file strerror
-    # lines (pinned against coreutils 9.7).
-    if not verified and not mismatched and not read_failures and malformed:
+    # GNU's terminal diagnostics and WARNING block, in its order (pinned
+    # against coreutils 9.7): a file with no properly formatted line is
+    # fatal on its own, even under --status. "No file was verified" means
+    # --ignore-missing left zero OK lines — mismatches included — and
+    # follows the summaries; --status silences it (and the summaries, but
+    # not the per-file strerror lines) while its exit 1 stands.
+    if not parsed_lines:
         stderr_lines.append(
             f"{prog}: {check_label}: no properly formatted checksum lines "
             "found")
         return b"", ("\n".join(stderr_lines) + "\n").encode(), 1
-    if ignore_missing and not verified and not mismatched \
-            and not read_failures:
-        stderr_lines.append(f"{prog}: {check_label}: no file was verified")
-        return b"", ("\n".join(stderr_lines) + "\n").encode(), 1
+    nothing_verified = ignore_missing and not verified
     if not status:
         if malformed:
             noun = _count_noun(malformed, "1 line is", "lines are")
@@ -185,10 +186,12 @@ async def _hash_check(
             noun = _count_noun(mismatched, "1 computed checksum",
                                "computed checksums")
             stderr_lines.append(f"{prog}: WARNING: {noun} did NOT match")
+        if nothing_verified:
+            stderr_lines.append(f"{prog}: {check_label}: no file was verified")
     stderr = ("\n".join(stderr_lines) +
               "\n").encode() if stderr_lines else None
-    exit_code = 1 if mismatched or read_failures or (strict
-                                                     and malformed) else 0
+    exit_code = 1 if (mismatched or read_failures or nothing_verified or
+                      (strict and malformed)) else 0
     output = b"" if status else (("\n".join(lines) +
                                   "\n").encode() if lines else b"")
     return output, stderr, exit_code

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -121,23 +121,13 @@ def missing_start_line(search_path: PathSpec) -> str:
     """GNU's stderr line for a start point that does not exist.
 
     One spelling of the diagnostic, because both find paths emit it: the
-    native-op path returns it alone, the walk collects one per operand.
+    native-op path and the walk each collect one per operand.
 
     Args:
         search_path (PathSpec): the start point, as the operand named it.
     """
     label = search_path.raw_path or search_path.virtual
     return f"find: '{label}': No such file or directory"
-
-
-def missing_start(search_path: PathSpec) -> tuple[bytes, IOResult]:
-    """GNU's result for a start point that does not exist.
-
-    Args:
-        search_path (PathSpec): the start point, as the operand named it.
-    """
-    stderr = (missing_start_line(search_path) + "\n").encode()
-    return b"", IOResult(stderr=stderr, exit_code=1)
 
 
 def is_link(links: LinkView | None, search: PathSpec) -> bool:
@@ -356,7 +346,6 @@ async def find(
     links: LinkView | None = None,
     follow: bool = False,
 ) -> tuple[ByteSource | None, IOResult]:
-    search_path = paths[0]
     args = parse_find_args(texts,
                            name=name,
                            type=type,
@@ -367,6 +356,56 @@ async def find(
                            path=path,
                            mindepth=mindepth,
                            empty=empty)
+    searches = paths if paths else [
+        PathSpec(virtual="/", directory="/", resource_path="")
+    ]
+    # GNU find walks every start point in operand order — duplicates and
+    # all — names each one it cannot stat, keeps going with the rest, and
+    # exits 1; the rows already found still print.
+    results: list[str] = []
+    missing: list[str] = []
+    for search_path in searches:
+        rows = await _find_root(search_path,
+                                args,
+                                find_core=find_core,
+                                stat_path=stat_path,
+                                stat=stat,
+                                dir_empty=dir_empty,
+                                links=links,
+                                follow=follow)
+        if rows is None:
+            missing.append(missing_start_line(search_path))
+            continue
+        results.extend(rows)
+    if missing:
+        return format_records(results), IOResult(
+            stderr=("\n".join(missing) + "\n").encode(), exit_code=1)
+    return format_records(results), IOResult()
+
+
+async def _find_root(
+    search_path: PathSpec,
+    args: FindArgs,
+    *,
+    find_core: Callable[..., Awaitable[list[str]]],
+    stat_path: StatPath | None,
+    stat: Callable[[PathSpec], Awaitable[FileStat]] | None,
+    dir_empty: Callable[[PathSpec], Awaitable[bool]] | None,
+    links: LinkView | None,
+    follow: bool,
+) -> list[str] | None:
+    """One start point's rows on the native-op path, None when missing.
+
+    Args:
+        search_path (PathSpec): the start point, as the operand named it.
+        args (FindArgs): parsed find expression, shared across operands.
+        find_core (Callable): the backend's native find op.
+        stat_path (StatPath | None): dispatcher-backed stat probe.
+        stat (Callable | None): overlay-aware stat for the mtime filter.
+        dir_empty (Callable | None): emptiness probe for ``-empty``.
+        links (LinkView | None): the namespace's symlink facts.
+        follow (bool): whether ``-L`` follows namespace links.
+    """
     # A start point that is itself a symlink has no backend inode, so
     # neither the existence guard nor the backend walk can see it. GNU's
     # default -P reports the link and stops there, which is exactly what
@@ -381,13 +420,14 @@ async def find(
         try:
             await stat(search_path)
         except (FileNotFoundError, ValueError):
-            return missing_start(search_path)
+            return None
     root_prefix = mount_prefix_of(search_path.virtual,
                                   search_path.resource_path)
     # `-path` matches the display path as printed; stamp the mount
     # prefix onto Path nodes before the backend walks mount-relative
-    # keys (#396).
-    args.tree = prefix_path_nodes(args_to_tree(args), root_prefix)
+    # keys (#396). Stamped into a per-operand tree — args is shared by
+    # every start point and must stay unprefixed.
+    tree = prefix_path_nodes(args_to_tree(args), root_prefix)
     # With a stat wired, the mtime window is applied by the overlay-
     # aware post-filter below, not pushed into the core: backend cores
     # only see native times and would drop files whose mtime lives in
@@ -404,9 +444,9 @@ async def find(
                                 stat_path,
                                 is_link=root_is_link)
     if start.missing:
-        return missing_start(search_path)
+        return None
     if not start.walk and not root_is_link:
-        return format_records(start.results), IOResult()
+        return start.results
     results: list[str] = [] if root_is_link else await find_core(
         search_path,
         name=args.name,
@@ -422,7 +462,7 @@ async def find(
         iname=args.iname,
         path_pattern=args.path_pattern,
         empty=args.empty,
-        tree=args.tree,
+        tree=tree,
     )
     # GNU lists a directory start point itself before descending into it,
     # so it is named even when it holds nothing. Decided here rather than
@@ -447,8 +487,7 @@ async def find(
             root_empty = not has_link_children(links, search_path.virtual)
         results = with_root_row(
             results, search_path,
-            root_dir_results(search_path, args, args.tree,
-                             is_empty=root_empty))
+            root_dir_results(search_path, args, tree, is_empty=root_empty))
     if stat is not None:
         results = await apply_mtime_filter(results,
                                            mtime_min=args.mtime_min,
@@ -464,10 +503,9 @@ async def find(
                                         root_prefix,
                                         search_path.mount_path.strip("/"),
                                         args,
-                                        args.tree,
+                                        tree,
                                         follow=follow))
-    results = respell_raw(results, search_path.virtual, search_path.raw_path)
-    return format_records(results), IOResult()
+    return respell_raw(results, search_path.virtual, search_path.raw_path)
 
 
 def _modified_ts(modified: str | None) -> float | None:

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -378,8 +378,9 @@ async def find(
             continue
         results.extend(rows)
     if missing:
-        return format_records(results), IOResult(
-            stderr=("\n".join(missing) + "\n").encode(), exit_code=1)
+        return format_records(results), IOResult(stderr=("\n".join(missing) +
+                                                         "\n").encode(),
+                                                 exit_code=1)
     return format_records(results), IOResult()
 
 

--- a/python/mirage/commands/builtin/generic/md5sum.py
+++ b/python/mirage/commands/builtin/generic/md5sum.py
@@ -21,6 +21,7 @@ async def md5sum(
     status: bool = False,
     quiet: bool = False,
     warn: bool = False,
+    cwd: PathSpec | str = "/",
 ) -> tuple[ByteSource | None, IOResult]:
     return await hashsum(paths,
                          factory=hashlib.md5,
@@ -36,7 +37,8 @@ async def md5sum(
                          ignore_missing=ignore_missing,
                          status=status,
                          quiet=quiet,
-                         warn=warn)
+                         warn=warn,
+                         cwd=cwd)
 
 
 __all__ = ["md5sum"]

--- a/python/mirage/commands/builtin/generic/sha1sum.py
+++ b/python/mirage/commands/builtin/generic/sha1sum.py
@@ -21,6 +21,7 @@ async def sha1sum(
     status: bool = False,
     quiet: bool = False,
     warn: bool = False,
+    cwd: PathSpec | str = "/",
 ) -> tuple[ByteSource | None, IOResult]:
     return await hashsum(paths,
                          factory=hashlib.sha1,
@@ -36,7 +37,8 @@ async def sha1sum(
                          ignore_missing=ignore_missing,
                          status=status,
                          quiet=quiet,
-                         warn=warn)
+                         warn=warn,
+                         cwd=cwd)
 
 
 __all__ = ["sha1sum"]

--- a/python/mirage/commands/builtin/generic/sha256sum.py
+++ b/python/mirage/commands/builtin/generic/sha256sum.py
@@ -21,6 +21,7 @@ async def sha256sum(
     status: bool = False,
     quiet: bool = False,
     warn: bool = False,
+    cwd: PathSpec | str = "/",
 ) -> tuple[ByteSource | None, IOResult]:
     return await hashsum(paths,
                          factory=hashlib.sha256,
@@ -36,7 +37,8 @@ async def sha256sum(
                          ignore_missing=ignore_missing,
                          status=status,
                          quiet=quiet,
-                         warn=warn)
+                         warn=warn,
+                         cwd=cwd)
 
 
 __all__ = ["sha256sum"]

--- a/python/mirage/commands/builtin/generic/sha384sum.py
+++ b/python/mirage/commands/builtin/generic/sha384sum.py
@@ -21,6 +21,7 @@ async def sha384sum(
     status: bool = False,
     quiet: bool = False,
     warn: bool = False,
+    cwd: PathSpec | str = "/",
 ) -> tuple[ByteSource | None, IOResult]:
     return await hashsum(paths,
                          factory=hashlib.sha384,
@@ -36,7 +37,8 @@ async def sha384sum(
                          ignore_missing=ignore_missing,
                          status=status,
                          quiet=quiet,
-                         warn=warn)
+                         warn=warn,
+                         cwd=cwd)
 
 
 __all__ = ["sha384sum"]

--- a/python/mirage/commands/builtin/generic/sha512sum.py
+++ b/python/mirage/commands/builtin/generic/sha512sum.py
@@ -21,6 +21,7 @@ async def sha512sum(
     status: bool = False,
     quiet: bool = False,
     warn: bool = False,
+    cwd: PathSpec | str = "/",
 ) -> tuple[ByteSource | None, IOResult]:
     return await hashsum(paths,
                          factory=hashlib.sha512,
@@ -36,7 +37,8 @@ async def sha512sum(
                          ignore_missing=ignore_missing,
                          status=status,
                          quiet=quiet,
-                         warn=warn)
+                         warn=warn,
+                         cwd=cwd)
 
 
 __all__ = ["sha512sum"]

--- a/python/mirage/commands/builtin/generic_bind/builders/common.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/common.py
@@ -22,8 +22,7 @@ from mirage.commands.builtin.generic_bind.adapter import CommandIO
 from mirage.io.stream import materialize
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileType, PathSpec
-from mirage.utils.errors import (FS_ERRORS, MISS_ERRORS, eisdir,
-                                 fs_error_line)
+from mirage.utils.errors import FS_ERRORS, MISS_ERRORS, eisdir, fs_error_line
 from mirage.utils.path import norm, parent
 
 

--- a/python/mirage/commands/builtin/generic_bind/builders/common.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/common.py
@@ -22,7 +22,8 @@ from mirage.commands.builtin.generic_bind.adapter import CommandIO
 from mirage.io.stream import materialize
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileType, PathSpec
-from mirage.utils.errors import FS_ERRORS, eisdir, fs_error_line
+from mirage.utils.errors import (FS_ERRORS, MISS_ERRORS, eisdir,
+                                 fs_error_line)
 from mirage.utils.path import norm, parent
 
 
@@ -61,7 +62,7 @@ async def _is_implicit_dir(ops: CommandIO, accessor: Accessor, path: PathSpec,
     if not key:
         try:
             entries = await ops.readdir(accessor, path, index)
-        except Exception:
+        except MISS_ERRORS:
             return False
         return bool(entries)
     parent_key = key.rsplit("/", 1)[0] if "/" in key else ""
@@ -71,7 +72,7 @@ async def _is_implicit_dir(ops: CommandIO, accessor: Accessor, path: PathSpec,
                            resource_path=parent_key)
     try:
         entries = await ops.readdir(accessor, parent_path, index)
-    except Exception:
+    except MISS_ERRORS:
         return False
     return any(norm(entry) == target for entry in entries)
 

--- a/python/mirage/commands/builtin/generic_bind/builders/md5sum.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/md5sum.py
@@ -37,6 +37,7 @@ async def md5sum(
     w: bool = False,
     z: bool = False,
     index: IndexCacheStore = NULL_INDEX,
+    cwd: PathSpec | str = "/",
     **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
     fl = FlagView(flags, spec=SPECS["md5sum"])
@@ -57,7 +58,8 @@ async def md5sum(
                        ignore_missing=fl.as_bool("ignore_missing"),
                        status=fl.as_bool("status"),
                        quiet=fl.as_bool("quiet"),
-                       warn=w or fl.as_bool("warn")), err)
+                       warn=w or fl.as_bool("warn"),
+                       cwd=cwd), err)
 
 
 BUILDER = Builder('md5sum', md5sum, None, False, None, read=True)

--- a/python/mirage/commands/builtin/generic_bind/builders/sha1sum.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/sha1sum.py
@@ -59,7 +59,7 @@ async def sha1sum(
                         status=fl.as_bool("status"),
                         quiet=fl.as_bool("quiet"),
                         warn=w or fl.as_bool("warn"),
-                       cwd=cwd), err)
+                        cwd=cwd), err)
 
 
 BUILDER = Builder('sha1sum', sha1sum, None, False, None, read=True)

--- a/python/mirage/commands/builtin/generic_bind/builders/sha1sum.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/sha1sum.py
@@ -37,6 +37,7 @@ async def sha1sum(
     w: bool = False,
     z: bool = False,
     index: IndexCacheStore = NULL_INDEX,
+    cwd: PathSpec | str = "/",
     **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
     fl = FlagView(flags, spec=SPECS["sha1sum"])
@@ -57,7 +58,8 @@ async def sha1sum(
                         ignore_missing=fl.as_bool("ignore_missing"),
                         status=fl.as_bool("status"),
                         quiet=fl.as_bool("quiet"),
-                        warn=w or fl.as_bool("warn")), err)
+                        warn=w or fl.as_bool("warn"),
+                       cwd=cwd), err)
 
 
 BUILDER = Builder('sha1sum', sha1sum, None, False, None, read=True)

--- a/python/mirage/commands/builtin/generic_bind/builders/sha256sum.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/sha256sum.py
@@ -62,7 +62,7 @@ async def sha256sum(
                                 status=fl.as_bool("status"),
                                 quiet=fl.as_bool("quiet"),
                                 warn=w or fl.as_bool("warn"),
-                       cwd=cwd), err)
+                                cwd=cwd), err)
 
 
 BUILDER = Builder('sha256sum', sha256sum, None, False, None, read=True)

--- a/python/mirage/commands/builtin/generic_bind/builders/sha256sum.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/sha256sum.py
@@ -38,6 +38,7 @@ async def sha256sum(
     w: bool = False,
     z: bool = False,
     index: IndexCacheStore = NULL_INDEX,
+    cwd: PathSpec | str = "/",
     **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
     fl = FlagView(flags, spec=SPECS["sha256sum"])
@@ -60,7 +61,8 @@ async def sha256sum(
                                 ignore_missing=fl.as_bool("ignore_missing"),
                                 status=fl.as_bool("status"),
                                 quiet=fl.as_bool("quiet"),
-                                warn=w or fl.as_bool("warn")), err)
+                                warn=w or fl.as_bool("warn"),
+                       cwd=cwd), err)
 
 
 BUILDER = Builder('sha256sum', sha256sum, None, False, None, read=True)

--- a/python/mirage/commands/builtin/generic_bind/builders/sha384sum.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/sha384sum.py
@@ -38,6 +38,7 @@ async def sha384sum(
     w: bool = False,
     z: bool = False,
     index: IndexCacheStore = NULL_INDEX,
+    cwd: PathSpec | str = "/",
     **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
     fl = FlagView(flags, spec=SPECS["sha384sum"])
@@ -60,7 +61,8 @@ async def sha384sum(
                                 ignore_missing=fl.as_bool("ignore_missing"),
                                 status=fl.as_bool("status"),
                                 quiet=fl.as_bool("quiet"),
-                                warn=w or fl.as_bool("warn")), err)
+                                warn=w or fl.as_bool("warn"),
+                       cwd=cwd), err)
 
 
 BUILDER = Builder('sha384sum', sha384sum, None, False, None, read=True)

--- a/python/mirage/commands/builtin/generic_bind/builders/sha384sum.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/sha384sum.py
@@ -62,7 +62,7 @@ async def sha384sum(
                                 status=fl.as_bool("status"),
                                 quiet=fl.as_bool("quiet"),
                                 warn=w or fl.as_bool("warn"),
-                       cwd=cwd), err)
+                                cwd=cwd), err)
 
 
 BUILDER = Builder('sha384sum', sha384sum, None, False, None, read=True)

--- a/python/mirage/commands/builtin/generic_bind/builders/sha512sum.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/sha512sum.py
@@ -62,7 +62,7 @@ async def sha512sum(
                                 status=fl.as_bool("status"),
                                 quiet=fl.as_bool("quiet"),
                                 warn=w or fl.as_bool("warn"),
-                       cwd=cwd), err)
+                                cwd=cwd), err)
 
 
 BUILDER = Builder('sha512sum', sha512sum, None, False, None, read=True)

--- a/python/mirage/commands/builtin/generic_bind/builders/sha512sum.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/sha512sum.py
@@ -38,6 +38,7 @@ async def sha512sum(
     w: bool = False,
     z: bool = False,
     index: IndexCacheStore = NULL_INDEX,
+    cwd: PathSpec | str = "/",
     **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
     fl = FlagView(flags, spec=SPECS["sha512sum"])
@@ -60,7 +61,8 @@ async def sha512sum(
                                 ignore_missing=fl.as_bool("ignore_missing"),
                                 status=fl.as_bool("status"),
                                 quiet=fl.as_bool("quiet"),
-                                warn=w or fl.as_bool("warn")), err)
+                                warn=w or fl.as_bool("warn"),
+                       cwd=cwd), err)
 
 
 BUILDER = Builder('sha512sum', sha512sum, None, False, None, read=True)

--- a/python/mirage/commands/builtin/grep_helper.py
+++ b/python/mirage/commands/builtin/grep_helper.py
@@ -641,7 +641,7 @@ async def grep_recursive(
                         results.append(entry)
                 else:
                     results.extend(f"{entry}:{r}" for r in file_results)
-            except Exception as exc:
+            except WALK_ERRORS as exc:
                 if warnings is not None:
                     warnings.append(f"grep: {entry}: {exc}")
                 continue
@@ -667,7 +667,7 @@ async def grep_recursive(
                     results.extend(file_results)
                 else:
                     results.extend(f"{entry}:{r}" for r in file_results)
-            except Exception as exc:
+            except WALK_ERRORS as exc:
                 if warnings is not None:
                     warnings.append(f"grep: {entry}: {exc}")
                 continue

--- a/python/mirage/commands/builtin/rg_helper.py
+++ b/python/mirage/commands/builtin/rg_helper.py
@@ -159,7 +159,7 @@ async def rg_folder(
                     results.append(f"{entry}:{pfx}")
             if count_only and file_count > 0:
                 results.append(f"{entry}:{file_count}")
-        except Exception as exc:
+        except WALK_ERRORS as exc:
             if warnings is not None:
                 warnings.append(f"rg: {entry}: {exc}")
 
@@ -210,7 +210,7 @@ async def rg_full(
         try:
             data = (await
                     read_bytes_fn(path)).decode(errors="replace").splitlines()
-        except Exception as exc:
+        except WALK_ERRORS as exc:
             if warnings is not None:
                 warnings.append(f"rg: {path}: {exc}")
             return []
@@ -328,7 +328,7 @@ async def rg_full(
                     results.append(
                         str(file_count
                             ) if no_filename else f"{entry}:{file_count}")
-            except Exception as exc:
+            except WALK_ERRORS as exc:
                 if warnings is not None:
                     warnings.append(f"rg: {entry}: {exc}")
                 continue

--- a/python/mirage/core/email/stat.py
+++ b/python/mirage/core/email/stat.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import logging
-from mimetypes import guess_type as _guess_mime
 
 from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
@@ -21,15 +20,10 @@ from mirage.core.email._client import list_folders
 from mirage.core.email.readdir import readdir as _readdir
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent
-from mirage.utils.filetype import filetype_from_mimetype
+from mirage.utils.filetype import guess_type
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
 logger = logging.getLogger(__name__)
-
-
-def _guess_filetype(filename: str) -> FileType:
-    mime, _ = _guess_mime(filename)
-    return filetype_from_mimetype(mime or "")
 
 
 async def stat(
@@ -89,7 +83,7 @@ async def stat(
             extra={"uid": result.entry.id},
         )
     if rt == "email/attachment":
-        ft = _guess_filetype(result.entry.vfs_name)
+        ft = guess_type(result.entry.vfs_name)
         return FileStat(
             name=result.entry.vfs_name,
             type=ft,

--- a/python/mirage/core/gmail/stat.py
+++ b/python/mirage/core/gmail/stat.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import logging
-from mimetypes import guess_type as _guess_mime
 
 from mirage.accessor.gmail import GmailAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
@@ -21,15 +20,10 @@ from mirage.core.gmail.labels import list_labels
 from mirage.core.gmail.readdir import readdir as _readdir
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent
-from mirage.utils.filetype import filetype_from_mimetype
+from mirage.utils.filetype import guess_type
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
 logger = logging.getLogger(__name__)
-
-
-def _guess_filetype(filename: str) -> FileType:
-    mime, _ = _guess_mime(filename)
-    return filetype_from_mimetype(mime or "")
 
 
 async def stat(
@@ -98,7 +92,7 @@ async def stat(
             extra={"message_id": result.entry.id},
         )
     if rt == "gmail/attachment":
-        ft = _guess_filetype(result.entry.vfs_name)
+        ft = guess_type(result.entry.vfs_name)
         return FileStat(
             name=result.entry.vfs_name,
             type=ft,

--- a/python/mirage/core/lancedb/stat.py
+++ b/python/mirage/core/lancedb/stat.py
@@ -19,13 +19,7 @@ from mirage.core.lancedb.read import read
 from mirage.core.lancedb.scope import (LanceDBGroupScope, LanceDBRowScope,
                                        ScopeLevel, detect_scope)
 from mirage.types import FileStat, FileType, PathSpec
-
-_IMAGE_TYPES = {
-    "png": FileType.IMAGE_PNG,
-    "jpg": FileType.IMAGE_JPEG,
-    "jpeg": FileType.IMAGE_JPEG,
-    "gif": FileType.IMAGE_GIF,
-}
+from mirage.utils.filetype import image_type_for_extension
 
 
 def _name_of(path: PathSpec) -> str:
@@ -54,7 +48,7 @@ async def stat(
     if not isinstance(scope, LanceDBRowScope):
         raise FileNotFoundError(path.virtual)
     if scope.blob:
-        file_type = _IMAGE_TYPES.get(config.blob_ext, FileType.BINARY)
+        file_type = image_type_for_extension(config.blob_ext)
     else:
         file_type = FileType.TEXT
     # The row-dir readdir seeds exact card sizes; blob entries and a cold

--- a/python/mirage/core/qdrant/stat.py
+++ b/python/mirage/core/qdrant/stat.py
@@ -19,13 +19,7 @@ from mirage.core.qdrant.read import read
 from mirage.core.qdrant.scope import (QdrantGroupScope, QdrantRowScope,
                                       ScopeLevel, detect_scope)
 from mirage.types import FileStat, FileType, PathSpec
-
-_IMAGE_TYPES = {
-    "png": FileType.IMAGE_PNG,
-    "jpg": FileType.IMAGE_JPEG,
-    "jpeg": FileType.IMAGE_JPEG,
-    "gif": FileType.IMAGE_GIF,
-}
+from mirage.utils.filetype import image_type_for_extension
 
 
 def _name_of(path: PathSpec) -> str:
@@ -54,7 +48,7 @@ async def stat(
     if not isinstance(scope, QdrantRowScope):
         raise FileNotFoundError(path.virtual)
     if scope.kind == "blob":
-        file_type = _IMAGE_TYPES.get(config.blob_ext, FileType.BINARY)
+        file_type = image_type_for_extension(config.blob_ext)
     else:
         file_type = FileType.TEXT
     # The row-dir readdir seeds exact rendered sizes; a cold index falls

--- a/python/mirage/resource/dev/dev.py
+++ b/python/mirage/resource/dev/dev.py
@@ -24,32 +24,77 @@ _ZERO_CHUNK_SIZE = 1 << 20
 
 
 class _DevFiles(dict[str, bytes]):
+    """Real backing store plus a synthetic /null, /zero overlay.
+
+    The synthetic device names read as empty/zeros and swallow writes until
+    they are deleted (GNU: ``rm /dev/null`` succeeds and the path is gone).
+    A deleted name is tombstoned; the next write stores real bytes, which
+    is GNU's rm-then-redirect recreation as a regular file.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._tombstones: set[str] = set()
+
+    def _synthetic_active(self, name: str) -> bool:
+        return (name in _DEV_NAMES and name not in self._tombstones
+                and not dict.__contains__(self, "/" + name))
+
+    def _synthetic_names(self) -> list[str]:
+        return [
+            "/" + name for name in ("null", "zero")
+            if self._synthetic_active(name)
+        ]
 
     def __contains__(self, key: object) -> bool:
         if not isinstance(key, str):
             return False
-        name = key.strip("/")
-        return name in _DEV_NAMES
+        if dict.__contains__(self, key):
+            return True
+        return self._synthetic_active(key.strip("/"))
 
     def __getitem__(self, key: str) -> bytes:
+        if dict.__contains__(self, key):
+            return dict.__getitem__(self, key)
         name = key.strip("/")
-        if name == "null":
-            return b""
-        if name == "zero":
-            return b"\x00" * _ZERO_CHUNK_SIZE
+        if self._synthetic_active(name):
+            return b"" if name == "null" else b"\x00" * _ZERO_CHUNK_SIZE
         raise KeyError(key)
 
     def __setitem__(self, key: str, value: bytes) -> None:
-        pass
+        name = key.strip("/")
+        if self._synthetic_active(name):
+            return
+        dict.__setitem__(self, key, value)
+        self._tombstones.discard(name)
 
-    def pop(self, key: str, default=None):
-        return default
+    def __delitem__(self, key: str) -> None:
+        name = key.strip("/")
+        if dict.__contains__(self, key):
+            dict.__delitem__(self, key)
+            if name in _DEV_NAMES:
+                self._tombstones.add(name)
+            return
+        if self._synthetic_active(name):
+            self._tombstones.add(name)
+            return
+        raise KeyError(key)
+
+    def pop(self, key: str, default: bytes | None = None) -> bytes | None:
+        if key not in self:
+            return default
+        value = self[key]
+        del self[key]
+        return value
 
     def __iter__(self):
-        return iter(["/null", "/zero"])
+        return iter([*self._synthetic_names(), *dict.__iter__(self)])
+
+    def __len__(self) -> int:
+        return len(self._synthetic_names()) + dict.__len__(self)
 
     def keys(self):
-        return ["/null", "/zero"]
+        return [*self._synthetic_names(), *dict.keys(self)]
 
 
 class DevStore(RAMStore):

--- a/python/mirage/resource/dev/dev.py
+++ b/python/mirage/resource/dev/dev.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from typing import TypeVar, overload
+
 from mirage.accessor.ram import RAMAccessor
 from mirage.commands.builtin.ram import COMMANDS
 from mirage.ops.ram import OPS as RAM_OPS
@@ -21,6 +23,8 @@ from mirage.types import ResourceName
 
 _DEV_NAMES = frozenset({"null", "zero"})
 _ZERO_CHUNK_SIZE = 1 << 20
+_POP_MISSING = object()
+_T = TypeVar("_T")
 
 
 class _DevFiles(dict[str, bytes]):
@@ -80,8 +84,22 @@ class _DevFiles(dict[str, bytes]):
             return
         raise KeyError(key)
 
-    def pop(self, key: str, default: bytes | None = None) -> bytes | None:
+    @overload
+    def pop(self, key: str, /) -> bytes:
+        ...
+
+    @overload
+    def pop(self, key: str, default: bytes, /) -> bytes:
+        ...
+
+    @overload
+    def pop(self, key: str, default: _T, /) -> bytes | _T:
+        ...
+
+    def pop(self, key: str, default: object = _POP_MISSING, /) -> object:
         if key not in self:
+            if default is _POP_MISSING:
+                raise KeyError(key)
             return default
         value = self[key]
         del self[key]

--- a/python/mirage/utils/filetype.py
+++ b/python/mirage/utils/filetype.py
@@ -21,6 +21,7 @@ EXTENSION_MAP: dict[str, FileType] = {
     "tsv": FileType.CSV,
     "txt": FileType.TEXT,
     "md": FileType.TEXT,
+    "log": FileType.TEXT,
     "py": FileType.TEXT,
     "js": FileType.TEXT,
     "ts": FileType.TEXT,
@@ -33,6 +34,7 @@ EXTENSION_MAP: dict[str, FileType] = {
     "gif": FileType.IMAGE_GIF,
     "zip": FileType.ZIP,
     "gz": FileType.GZIP,
+    "gzip": FileType.GZIP,
     "pdf": FileType.PDF,
 }
 
@@ -100,6 +102,26 @@ def guess_type(path: str) -> FileType:
     """
     ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
     return EXTENSION_MAP.get(ext, DEFAULT_TYPE)
+
+
+IMAGE_TYPE_BY_EXTENSION: dict[str, FileType] = {
+    "png": FileType.IMAGE_PNG,
+    "jpg": FileType.IMAGE_JPEG,
+    "jpeg": FileType.IMAGE_JPEG,
+    "gif": FileType.IMAGE_GIF,
+}
+
+
+def image_type_for_extension(ext: str) -> FileType:
+    """Return the FileType for a bare image extension.
+
+    Args:
+        ext (str): extension without the dot (e.g. ``png``).
+
+    Returns:
+        FileType: matched image type, or BINARY for anything else.
+    """
+    return IMAGE_TYPE_BY_EXTENSION.get(ext.lower(), FileType.BINARY)
 
 
 def filetype_from_mimetype(mime: str) -> FileType:

--- a/python/tests/commands/builtin/generic/test_checksum.py
+++ b/python/tests/commands/builtin/generic/test_checksum.py
@@ -151,6 +151,54 @@ async def test_ignore_missing_with_nothing_verified():
 
 
 @pytest.mark.asyncio
+async def test_status_silences_no_file_verified_but_keeps_exit():
+    stdout, stderr, code = await _run_check({"/sums.txt": "5aabc  /gone\n"},
+                                            ignore_missing=True,
+                                            status=True)
+    assert stdout == ""
+    assert stderr == ""
+    assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_status_keeps_the_no_properly_formatted_fatal():
+    stdout, stderr, code = await _run_check({"/sums.txt": "junk\n"},
+                                            status=True)
+    assert stdout == ""
+    assert stderr == ("md5sum: /sums.txt: no properly formatted checksum "
+                      "lines found\n")
+    assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_malformed_plus_ignored_skip_is_no_file_verified():
+    # A parsed line whose target --ignore-missing skips must not read as
+    # "no properly formatted checksum lines found".
+    stdout, stderr, code = await _run_check(
+        {"/sums.txt": "junk\n5aabc  /gone\n"}, ignore_missing=True)
+    assert stdout == ""
+    assert stderr == ("md5sum: WARNING: 1 line is improperly formatted\n"
+                      "md5sum: /sums.txt: no file was verified\n")
+    assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_ignore_missing_with_only_a_mismatch_reports_both():
+    # GNU: zero OK lines under --ignore-missing is "no file was verified"
+    # even when a mismatch was read and reported.
+    stdout, stderr, code = await _run_check(
+        {
+            "/sums.txt": "5aface  /a.txt\n",
+            "/a.txt": "cafe",
+        },
+        ignore_missing=True)
+    assert stdout == "/a.txt: FAILED\n"
+    assert stderr == ("md5sum: WARNING: 1 computed checksum did NOT match\n"
+                      "md5sum: /sums.txt: no file was verified\n")
+    assert code == 1
+
+
+@pytest.mark.asyncio
 async def test_status_keeps_strerror_lines_and_drops_summaries():
     stdout, stderr, code = await _run_check(
         {

--- a/python/tests/commands/builtin/generic/test_checksum.py
+++ b/python/tests/commands/builtin/generic/test_checksum.py
@@ -53,7 +53,8 @@ def _fs(files: dict[str, str]):
     return read_bytes, read_stream
 
 
-async def _run_check(files: dict[str, str], cwd: str = "/",
+async def _run_check(files: dict[str, str],
+                     cwd: str = "/",
                      **flags: bool) -> tuple[str, str, int]:
     read_bytes, read_stream = _fs(files)
     out, io = await hashsum([_spec("/sums.txt")],
@@ -94,8 +95,7 @@ async def test_relative_recorded_name_resolves_against_cwd():
         {
             "/sums.txt": "5aabc  f.txt\n",
             "/data/f.txt": "abc",
-        },
-        cwd="/data")
+        }, cwd="/data")
     assert stdout == "f.txt: OK\n"
     assert stderr == ""
     assert code == 0
@@ -134,8 +134,7 @@ async def test_mismatch_counts_into_not_match_warning():
 
 @pytest.mark.asyncio
 async def test_all_malformed_fails_alone():
-    stdout, stderr, code = await _run_check(
-        {"/sums.txt": "junk\nmore junk\n"})
+    stdout, stderr, code = await _run_check({"/sums.txt": "junk\nmore junk\n"})
     assert stdout == ""
     assert stderr == ("md5sum: /sums.txt: no properly formatted checksum "
                       "lines found\n")
@@ -170,7 +169,8 @@ async def test_warn_adds_per_line_diagnostics():
         {
             "/sums.txt": "bad line\n5aabc  /ok.txt\n",
             "/ok.txt": "abc",
-        }, warn=True)
+        },
+        warn=True)
     assert stdout == "/ok.txt: OK\n"
     assert stderr == ("md5sum: /sums.txt: 1: improperly formatted MD5 "
                       "checksum line\n"

--- a/python/tests/commands/builtin/generic/test_checksum.py
+++ b/python/tests/commands/builtin/generic/test_checksum.py
@@ -1,0 +1,178 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.commands.builtin.generic.checksum import hashsum
+from mirage.types import PathSpec
+
+
+class _FakeDigest:
+
+    def __init__(self):
+        self._data = b""
+
+    def update(self, data: bytes) -> None:
+        self._data += data
+
+    def hexdigest(self) -> str:
+        # Content-addressed fake: '5a' + the body's text, which the check
+        # line parser accepts as hex when bodies are hex-safe.
+        return "5a" + self._data.decode()
+
+
+def _spec(path: str) -> PathSpec:
+    return PathSpec(virtual=path,
+                    directory=path,
+                    resource_path=path.lstrip("/"),
+                    raw_path=path)
+
+
+def _fs(files: dict[str, str]):
+
+    async def read_bytes(p: PathSpec) -> bytes:
+        return files[p.virtual].encode()
+
+    async def read_stream(p: PathSpec):
+        assert isinstance(p, PathSpec)
+        if p.virtual not in files:
+            raise FileNotFoundError(p.virtual)
+        yield files[p.virtual].encode()
+
+    return read_bytes, read_stream
+
+
+async def _run_check(files: dict[str, str], cwd: str = "/",
+                     **flags: bool) -> tuple[str, str, int]:
+    read_bytes, read_stream = _fs(files)
+    out, io = await hashsum([_spec("/sums.txt")],
+                            factory=_FakeDigest,
+                            algorithm="md5",
+                            read_bytes=read_bytes,
+                            read_stream=read_stream,
+                            check=True,
+                            cwd=cwd,
+                            **flags)
+    stdout = out.decode() if isinstance(out, bytes) else ""
+    stderr = io.stderr.decode() if io.stderr else ""
+    return stdout, stderr, io.exit_code
+
+
+# GNU coreutils 9.7, pinned on debian:stable-slim: the per-file strerror
+# lines and the WARNING block are stderr, FAILED lines are stdout, and
+# --status silences everything except the strerror lines.
+
+
+@pytest.mark.asyncio
+async def test_missing_recorded_file_reports_both_channels():
+    stdout, stderr, code = await _run_check({
+        "/sums.txt": "5aabc  /ok.txt\n5aabc  /miss.txt\n",
+        "/ok.txt": "abc",
+    })
+    assert stdout == "/ok.txt: OK\n/miss.txt: FAILED open or read\n"
+    assert stderr == ("md5sum: /miss.txt: No such file or directory\n"
+                      "md5sum: WARNING: 1 listed file could not be read\n")
+    assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_relative_recorded_name_resolves_against_cwd():
+    # The old resolver passed relative names to the backend as bare str,
+    # which died on `.virtual` before any GNU diagnostic could print.
+    stdout, stderr, code = await _run_check(
+        {
+            "/sums.txt": "5aabc  f.txt\n",
+            "/data/f.txt": "abc",
+        },
+        cwd="/data")
+    assert stdout == "f.txt: OK\n"
+    assert stderr == ""
+    assert code == 0
+
+
+@pytest.mark.asyncio
+async def test_non_fs_read_failure_propagates():
+
+    async def read_bytes(p: PathSpec) -> bytes:
+        return b"5aabc  /f.txt\n"
+
+    async def read_stream(p: PathSpec):
+        raise RuntimeError("S3 GET f failed: 403 Forbidden")
+        yield b""
+
+    with pytest.raises(RuntimeError, match="403 Forbidden"):
+        await hashsum([_spec("/sums.txt")],
+                      factory=_FakeDigest,
+                      algorithm="md5",
+                      read_bytes=read_bytes,
+                      read_stream=read_stream,
+                      check=True)
+
+
+@pytest.mark.asyncio
+async def test_mismatch_counts_into_not_match_warning():
+    stdout, stderr, code = await _run_check({
+        "/sums.txt": "5aface  /a.txt\n5aface  /b.txt\n",
+        "/a.txt": "face",
+        "/b.txt": "cafe",
+    })
+    assert stdout == "/a.txt: OK\n/b.txt: FAILED\n"
+    assert stderr == "md5sum: WARNING: 1 computed checksum did NOT match\n"
+    assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_all_malformed_fails_alone():
+    stdout, stderr, code = await _run_check(
+        {"/sums.txt": "junk\nmore junk\n"})
+    assert stdout == ""
+    assert stderr == ("md5sum: /sums.txt: no properly formatted checksum "
+                      "lines found\n")
+    assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_ignore_missing_with_nothing_verified():
+    stdout, stderr, code = await _run_check({"/sums.txt": "5aabc  /gone\n"},
+                                            ignore_missing=True)
+    assert stdout == ""
+    assert stderr == "md5sum: /sums.txt: no file was verified\n"
+    assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_status_keeps_strerror_lines_and_drops_summaries():
+    stdout, stderr, code = await _run_check(
+        {
+            "/sums.txt": "5aabc  /ok.txt\n5aabc  /miss.txt\n",
+            "/ok.txt": "abc",
+        },
+        status=True)
+    assert stdout == ""
+    assert stderr == "md5sum: /miss.txt: No such file or directory\n"
+    assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_warn_adds_per_line_diagnostics():
+    stdout, stderr, code = await _run_check(
+        {
+            "/sums.txt": "bad line\n5aabc  /ok.txt\n",
+            "/ok.txt": "abc",
+        }, warn=True)
+    assert stdout == "/ok.txt: OK\n"
+    assert stderr == ("md5sum: /sums.txt: 1: improperly formatted MD5 "
+                      "checksum line\n"
+                      "md5sum: WARNING: 1 line is improperly formatted\n")
+    assert code == 0

--- a/python/tests/commands/builtin/generic/test_find.py
+++ b/python/tests/commands/builtin/generic/test_find.py
@@ -813,3 +813,108 @@ async def test_find_without_stat_path_walks_as_before():
     stdout, io = await find([_file_spec()], (), find_core=core)
     assert io.exit_code == 0
     assert stdout == b"/mnt/a.txt\n"
+
+
+def _stat_map(stats: dict[str, FileStat | None]):
+
+    async def fn(virtual: str) -> FileStat | None:
+        return stats.get(virtual)
+
+    return fn
+
+
+_DIR_STAT = FileStat(name="d", type=FileType.DIRECTORY)
+_FILE_STAT = FileStat(name="f", size=6, type=FileType.TEXT)
+
+
+# GNU findutils 4.10.0, pinned on debian:stable-slim:
+#   find A B           -> A's rows, then B's rows (operand order, never
+#                         re-sorted across operands)
+#   find A A           -> A's rows twice (no dedupe)
+#   find A <missing> B -> A's and B's rows still print, the missing
+#                         operand gets the diagnostic, and find exits 1
+
+
+@pytest.mark.asyncio
+async def test_find_walks_every_start_point_in_operand_order():
+    calls: list[str] = []
+
+    async def core(path: PathSpec, **_kw) -> list[str]:
+        calls.append(path.virtual)
+        return ["/sub/z.txt"] if path.virtual == "/mnt/sub" else []
+
+    stdout, io = await find(
+        [
+            _file_spec(virtual="/mnt/sub", key="sub"),
+            _file_spec(virtual="/mnt/a.txt", key="a.txt"),
+        ],
+        (),
+        find_core=core,
+        stat_path=_stat_map({
+            "/mnt/sub": _DIR_STAT,
+            "/mnt/a.txt": _FILE_STAT
+        }),
+    )
+    assert io.exit_code == 0
+    # /mnt/a.txt sorts before /mnt/sub; operand order must win anyway.
+    assert stdout == b"/mnt/sub\n/mnt/sub/z.txt\n/mnt/a.txt\n"
+    # The file start point is reported, never walked.
+    assert calls == ["/mnt/sub"]
+
+
+@pytest.mark.asyncio
+async def test_find_duplicate_start_points_walk_twice():
+
+    async def core(_path: PathSpec, **_kw) -> list[str]:
+        return ["/sub/z.txt"]
+
+    root = _file_spec(virtual="/mnt/sub", key="sub")
+    stdout, io = await find([root, root], (),
+                            find_core=core,
+                            stat_path=_stat_map({"/mnt/sub": _DIR_STAT}))
+    assert io.exit_code == 0
+    assert stdout == b"/mnt/sub\n/mnt/sub/z.txt\n" * 2
+
+
+@pytest.mark.asyncio
+async def test_find_missing_middle_operand_keeps_partial_output():
+    """The rows already found survive a missing operand (GNU).
+
+    The native-op path used to return the diagnostic alone, discarding
+    every other operand's rows along with the missing one's.
+    """
+
+    async def core(path: PathSpec, **_kw) -> list[str]:
+        return ["/sub/z.txt"] if path.virtual == "/mnt/sub" else []
+
+    stdout, io = await find(
+        [
+            _file_spec(virtual="/mnt/sub", key="sub"),
+            _file_spec(virtual="/mnt/nope", key="nope"),
+            _file_spec(virtual="/mnt/a.txt", key="a.txt"),
+        ],
+        (),
+        find_core=core,
+        stat_path=_stat_map({
+            "/mnt/sub": _DIR_STAT,
+            "/mnt/a.txt": _FILE_STAT
+        }),
+    )
+    assert io.exit_code == 1
+    assert stdout == b"/mnt/sub\n/mnt/sub/z.txt\n/mnt/a.txt\n"
+    assert io.stderr == b"find: '/mnt/nope': No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_find_no_operands_defaults_to_the_mount_root():
+
+    async def core(path: PathSpec, **_kw) -> list[str]:
+        assert path.virtual == "/"
+        return ["/a.txt"]
+
+    stdout, io = await find([], (),
+                            find_core=core,
+                            stat_path=_stat_path(
+                                FileStat(name="/", type=FileType.DIRECTORY)))
+    assert io.exit_code == 0
+    assert stdout == b"/\n/a.txt\n"

--- a/python/tests/commands/builtin/generic/test_find.py
+++ b/python/tests/commands/builtin/generic/test_find.py
@@ -826,7 +826,6 @@ def _stat_map(stats: dict[str, FileStat | None]):
 _DIR_STAT = FileStat(name="d", type=FileType.DIRECTORY)
 _FILE_STAT = FileStat(name="f", size=6, type=FileType.TEXT)
 
-
 # GNU findutils 4.10.0, pinned on debian:stable-slim:
 #   find A B           -> A's rows, then B's rows (operand order, never
 #                         re-sorted across operands)

--- a/python/tests/commands/builtin/generic_bind/builders/test_find.py
+++ b/python/tests/commands/builtin/generic_bind/builders/test_find.py
@@ -106,3 +106,38 @@ async def test_walk_honors_multiple_start_points():
     assert "/mnt/notes.txt" in lines
     assert lines.index("/mnt/table1/rows.jsonl") < lines.index(
         "/mnt/notes.txt")
+
+
+@pytest.mark.asyncio
+async def test_native_find_honors_multiple_start_points():
+    stat_calls: list[str] = []
+
+    async def find_op(_accessor, path, **_kw):
+        key = "/" + path.resource_path.strip("/") if path.resource_path \
+            else "/"
+        if key == "/table1":
+            return ["/table1/rows.jsonl"]
+        if key == "/notes.txt":
+            return ["/notes.txt"]
+        return []
+
+    ops = _ops(stat_calls, find_op=find_op)
+    roots = [
+        PathSpec(virtual="/mnt/table1",
+                 directory="/mnt/table1",
+                 resolved=False,
+                 resource_path="table1"),
+        PathSpec(virtual="/mnt/notes.txt",
+                 directory="/mnt",
+                 resolved=False,
+                 resource_path="notes.txt"),
+    ]
+    stdout, _io = await find(ops, None, roots)
+    data = stdout if isinstance(stdout, bytes) else b""
+    lines = data.decode().splitlines()
+    # The native-op path walks every start point too, in operand order;
+    # it used to drop everything after paths[0].
+    assert "/mnt/table1/rows.jsonl" in lines
+    assert "/mnt/notes.txt" in lines
+    assert lines.index("/mnt/table1/rows.jsonl") < lines.index(
+        "/mnt/notes.txt")

--- a/python/tests/core/redis/conftest.py
+++ b/python/tests/core/redis/conftest.py
@@ -22,11 +22,16 @@ from mirage.cache.index import RAMIndexCacheStore
 from mirage.resource.redis.store import RedisStore
 
 REDIS_URL = os.environ.get("REDIS_URL", "")
-pytestmark = pytest.mark.skipif(not REDIS_URL, reason="REDIS_URL not set")
 
 
 @pytest_asyncio.fixture()
 async def store():
+    # The env gate lives here because a `pytestmark` in a conftest is a
+    # no-op (pytest only honors it in test modules): every module in this
+    # directory goes through this fixture, so it skips rather than
+    # erroring out of RedisStore's URL parse on machines without redis.
+    if not REDIS_URL:
+        pytest.skip("REDIS_URL not set")
     s = RedisStore(url=REDIS_URL, key_prefix="test:core:")
     await s.clear()
     await s.add_dir("/")

--- a/python/tests/resource/dev/test_dev.py
+++ b/python/tests/resource/dev/test_dev.py
@@ -1,0 +1,105 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.resource.dev.dev import _ZERO_CHUNK_SIZE, DevStore, _DevFiles
+
+
+def test_contains_dev_names_with_or_without_slash():
+    files = _DevFiles()
+    assert "/null" in files
+    assert "null" in files
+    assert "/zero" in files
+    assert "zero" in files
+    assert "/other" not in files
+
+
+def test_null_reads_empty_and_zero_reads_zeros():
+    files = _DevFiles()
+    assert files["/null"] == b""
+    assert files["/zero"] == b"\x00" * _ZERO_CHUNK_SIZE
+    with pytest.raises(KeyError):
+        files["/missing"]
+
+
+def test_set_on_active_device_is_discarded():
+    files = _DevFiles()
+    files["/null"] = b"overwrite"
+    assert files["/null"] == b""
+    assert files["/zero"] == b"\x00" * _ZERO_CHUNK_SIZE
+
+
+def test_delete_tombstones_a_synthetic_device():
+    files = _DevFiles()
+    del files["/null"]
+    assert "/null" not in files
+    assert list(files.keys()) == ["/zero"]
+    assert len(files) == 1
+    with pytest.raises(KeyError):
+        files["/null"]
+    with pytest.raises(KeyError):
+        del files["/null"]
+
+
+def test_set_after_delete_stores_real_bytes():
+    files = _DevFiles()
+    del files["/null"]
+    files["/null"] = b"recreated"
+    assert "/null" in files
+    assert files["/null"] == b"recreated"
+    assert list(files.keys()) == ["/zero", "/null"]
+    assert len(files) == 2
+
+
+def test_delete_of_recreated_file_removes_it_again():
+    files = _DevFiles()
+    del files["/null"]
+    files["/null"] = b"recreated"
+    del files["/null"]
+    assert "/null" not in files
+    assert list(files.keys()) == ["/zero"]
+
+
+def test_non_device_names_store_for_real():
+    files = _DevFiles()
+    files["/custom"] = b"bytes"
+    assert "/custom" in files
+    assert files["/custom"] == b"bytes"
+    assert list(files.keys()) == ["/null", "/zero", "/custom"]
+    del files["/custom"]
+    assert "/custom" not in files
+
+
+def test_pop_mirrors_delete_semantics():
+    files = _DevFiles()
+    assert files.pop("/null") == b""
+    assert "/null" not in files
+    assert files.pop("/null", b"gone") == b"gone"
+    files["/null"] = b"real"
+    assert files.pop("/null") == b"real"
+    assert "/null" not in files
+
+
+def test_iterates_synthetic_then_real():
+    files = _DevFiles()
+    assert list(files) == ["/null", "/zero"]
+    assert len(files) == 2
+
+
+def test_dev_store_starts_with_synthetic_files_and_root():
+    store = DevStore()
+    assert list(store.files.keys()) == ["/null", "/zero"]
+    assert "/" in store.dirs
+    assert store.modified == {}

--- a/python/tests/resource/test_registry.py
+++ b/python/tests/resource/test_registry.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -80,10 +81,12 @@ def test_build_r2_uses_r2_config():
     assert isinstance(p, R2Resource)
 
 
+@pytest.mark.skipif(not os.environ.get("REDIS_URL"),
+                    reason="REDIS_URL not set")
 def test_build_redis_takes_raw_kwargs():
     from mirage.resource.redis import RedisResource
     p = build_resource("redis", {
-        "url": "redis://localhost:6379/15",
+        "url": os.environ["REDIS_URL"],
         "key_prefix": "test:",
     })
     assert isinstance(p, RedisResource)

--- a/python/tests/shell/test_dev.py
+++ b/python/tests/shell/test_dev.py
@@ -44,3 +44,45 @@ def test_dev_zero_head(shell):
 def test_dev_null_stat(shell):
     cmd = "if [ -f /dev/null ]; then echo exists; fi"
     assert shell.mirage(cmd) == "exists\n"
+
+
+def test_rm_dev_null_exits_zero_and_removes(shell):
+    exit_code, stdout, stderr = shell.mirage_result("rm /dev/null")
+    assert exit_code == 0
+    assert stdout == ""
+    assert stderr == ""
+    listing = shell.mirage("ls /dev").splitlines()
+    assert "zero" in listing
+    assert "null" not in listing
+    exit_code, _, stderr = shell.mirage_result("cat /dev/null")
+    assert exit_code != 0
+    assert "No such file or directory" in stderr
+
+
+def test_rm_v_dev_null_prints_true_claim(shell):
+    exit_code, stdout, _ = shell.mirage_result("rm -v /dev/null")
+    assert exit_code == 0
+    assert stdout == "removed '/dev/null'\n"
+    assert "null" not in shell.mirage("ls /dev").splitlines()
+
+
+def test_rm_rf_dev_null_removes(shell):
+    assert shell.mirage_exit("rm -rf /dev/null") == 0
+    assert "null" not in shell.mirage("ls /dev").splitlines()
+
+
+def test_redirect_recreates_removed_dev_null_as_regular_file(shell):
+    shell.mirage("rm /dev/null")
+    assert shell.mirage_exit("echo recreated > /dev/null") == 0
+    assert shell.mirage("cat /dev/null") == "recreated\n"
+    cmd = "if [ -f /dev/null ]; then echo regular; fi"
+    assert shell.mirage(cmd) == "regular\n"
+
+
+def test_rm_dev_zero_is_symmetric(shell):
+    assert shell.mirage_exit("rm /dev/zero") == 0
+    listing = shell.mirage("ls /dev").splitlines()
+    assert "null" in listing
+    assert "zero" not in listing
+    assert shell.mirage_exit("echo z > /dev/zero") == 0
+    assert shell.mirage("cat /dev/zero") == "z\n"

--- a/python/tests/utils/test_filetype.py
+++ b/python/tests/utils/test_filetype.py
@@ -12,9 +12,44 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import json
+from pathlib import Path
+
 from mirage.types import FileType
-from mirage.utils.filetype import (filetype_from_mimetype, guess_type,
-                                   mime_type_for)
+from mirage.utils.filetype import (EXTENSION_MAP, IMAGE_TYPE_BY_EXTENSION,
+                                   MIME_BY_EXTENSION, _MIMETYPE_MAP,
+                                   filetype_from_mimetype, guess_type,
+                                   image_type_for_extension, mime_type_for)
+
+_FIXTURE = (Path(__file__).parents[3] / "integ" / "fixtures" / "filetype" /
+            "tables.json")
+
+
+def test_shared_parity_fixture_pins_every_table():
+    # integ/fixtures/filetype/tables.json is the contract: the TypeScript
+    # suite (packages/core/src/utils/filetype.test.ts) asserts the same
+    # tables, so an edit on one side fails the other until the fixture
+    # moves with it.
+    tables = json.loads(_FIXTURE.read_text())
+    assert {k: v.value
+            for k, v in EXTENSION_MAP.items()} == tables["extension_map"]
+    assert MIME_BY_EXTENSION == tables["mime_by_extension"]
+    assert {k: v.value
+            for k, v in _MIMETYPE_MAP.items()} == tables["mimetype_map"]
+    assert ({k: v.value
+             for k, v in IMAGE_TYPE_BY_EXTENSION.items()
+             } == tables["image_type_by_extension"])
+
+
+def test_log_and_gzip_extensions():
+    assert guess_type("build.log") == FileType.TEXT
+    assert guess_type("dump.gzip") == FileType.GZIP
+
+
+def test_image_type_for_extension():
+    assert image_type_for_extension("png") == FileType.IMAGE_PNG
+    assert image_type_for_extension("JPG") == FileType.IMAGE_JPEG
+    assert image_type_for_extension("txt") == FileType.BINARY
 
 
 def test_jpg_extension_maps_to_jpeg():

--- a/python/tests/utils/test_filetype.py
+++ b/python/tests/utils/test_filetype.py
@@ -16,8 +16,8 @@ import json
 from pathlib import Path
 
 from mirage.types import FileType
-from mirage.utils.filetype import (EXTENSION_MAP, IMAGE_TYPE_BY_EXTENSION,
-                                   MIME_BY_EXTENSION, _MIMETYPE_MAP,
+from mirage.utils.filetype import (_MIMETYPE_MAP, EXTENSION_MAP,
+                                   IMAGE_TYPE_BY_EXTENSION, MIME_BY_EXTENSION,
                                    filetype_from_mimetype, guess_type,
                                    image_type_for_extension, mime_type_for)
 
@@ -31,14 +31,19 @@ def test_shared_parity_fixture_pins_every_table():
     # tables, so an edit on one side fails the other until the fixture
     # moves with it.
     tables = json.loads(_FIXTURE.read_text())
-    assert {k: v.value
-            for k, v in EXTENSION_MAP.items()} == tables["extension_map"]
+    assert {
+        k: v.value
+        for k, v in EXTENSION_MAP.items()
+    } == tables["extension_map"]
     assert MIME_BY_EXTENSION == tables["mime_by_extension"]
-    assert {k: v.value
-            for k, v in _MIMETYPE_MAP.items()} == tables["mimetype_map"]
-    assert ({k: v.value
-             for k, v in IMAGE_TYPE_BY_EXTENSION.items()
-             } == tables["image_type_by_extension"])
+    assert {
+        k: v.value
+        for k, v in _MIMETYPE_MAP.items()
+    } == tables["mimetype_map"]
+    assert ({
+        k: v.value
+        for k, v in IMAGE_TYPE_BY_EXTENSION.items()
+    } == tables["image_type_by_extension"])
 
 
 def test_log_and_gzip_extensions():

--- a/typescript/packages/core/src/commands/builtin/constants.ts
+++ b/typescript/packages/core/src/commands/builtin/constants.ts
@@ -36,10 +36,6 @@ export const FILE_MIME_MAP: Readonly<Record<string, string>> = Object.freeze({
   'application/zip': 'application/zip',
   'application/gzip': 'application/gzip',
   'application/pdf': 'application/pdf',
-  parquet: 'application/octet-stream',
-  orc: 'application/octet-stream',
-  feather: 'application/octet-stream',
-  hdf5: 'application/octet-stream',
 })
 
 // od and split both read their counts with xstrtoumax, which skips leading

--- a/typescript/packages/core/src/commands/builtin/dify/find.ts
+++ b/typescript/packages/core/src/commands/builtin/dify/find.ts
@@ -15,6 +15,7 @@
 import { mountPrefixOf } from '../../../utils/key_prefix.ts'
 import type { DifyAccessor } from '../../../accessor/dify.ts'
 import { find as difyFind } from '../../../core/dify/find.ts'
+import { stat as statCore, statLight } from '../../../core/dify/stat.ts'
 import { resolveGlobOf } from '../generic_bind/index.ts'
 import { DIFY_IO } from './io.ts'
 import { materialize, type ByteSource } from '../../../io/types.ts'
@@ -22,6 +23,7 @@ import { ResourceName, type PathSpec } from '../../../types.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { findGeneric } from '../generic/find.ts'
 
 const resolveGlob = resolveGlobOf(DIFY_IO)
@@ -68,8 +70,20 @@ async function findCommand(
   const resolved = paths.length > 0 ? await resolveGlob(accessor, paths, index) : []
   const searchPath = resolved[0]
   const adjustedOpts: CommandOpts = { ...opts, flags: defaultName(opts.flags, texts) }
-  const result = await findGeneric(resolved, texts, adjustedOpts, (root, options) =>
-    difyFind(accessor, root, options, index),
+  // Dify's full stat is a document-detail fetch, so it is only paid when
+  // -mtime needs detail timestamps; everything else rides the index-only
+  // stat (mirrors the Python wrapper).
+  const fl = new FlagView(opts.flags, specOf('find'))
+  const statFn =
+    fl.asStr('mtime') !== undefined
+      ? (spec: PathSpec) => statCore(accessor, spec, index)
+      : (spec: PathSpec) => statLight(accessor, spec, index)
+  const result = await findGeneric(
+    resolved,
+    texts,
+    adjustedOpts,
+    (root, options) => difyFind(accessor, root, options, index),
+    statFn,
   )
   if (result === null || searchPath === undefined) return result
   const [stdout, io] = result

--- a/typescript/packages/core/src/commands/builtin/dify/index.ts
+++ b/typescript/packages/core/src/commands/builtin/dify/index.ts
@@ -13,8 +13,10 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { DifyAccessor } from '../../../accessor/dify.ts'
+import { statLight } from '../../../core/dify/stat.ts'
 import { ResourceName } from '../../../types.ts'
 import type { RegisteredCommand } from '../../config.ts'
+import type { CommandIO } from '../generic_bind/index.ts'
 import { makeGenericCommands } from '../generic_bind/index.ts'
 import { DIFY_FIND } from './find.ts'
 import { DIFY_IO } from './io.ts'
@@ -22,9 +24,14 @@ import { DIFY_SEARCH } from './search.ts'
 
 const DIFY_OVERRIDES = new Set(['find', 'search'])
 
+// ls stats every listed entry, so it keeps the index-only stat instead of
+// paying one document-detail call per row (mirrors _DIFY_LIGHT_STAT_OPS).
+const DIFY_LIGHT_STAT_OPS: CommandIO<DifyAccessor> = { ...DIFY_IO, stat: statLight }
+
 export const DIFY_COMMANDS: readonly RegisteredCommand[] = [
   ...makeGenericCommands<DifyAccessor>(ResourceName.DIFY, DIFY_IO, {
     overrides: DIFY_OVERRIDES,
+    opsOverrides: { ls: DIFY_LIGHT_STAT_OPS },
   }),
   ...DIFY_FIND,
   ...DIFY_SEARCH,

--- a/typescript/packages/core/src/commands/builtin/dify/io.ts
+++ b/typescript/packages/core/src/commands/builtin/dify/io.ts
@@ -19,8 +19,11 @@ import { stat as difyStat } from '../../../core/dify/stat.ts'
 import type { CommandIO } from '../generic_bind/index.ts'
 
 // Dify is read-only, so no write op is wired and the generic byte-mutation
-// commands are intentionally absent. stat is the index-only stat, so ls/find
-// never issue a per-entry document-detail call.
+// commands are intentionally absent. stat is the full document-detail stat;
+// the commands that would multiply that per-entry API call stay cheap
+// through lighter routes instead (ls receives a light-stat adapter from the
+// package factory, the find wrapper threads statLight unless -mtime needs
+// detail timestamps), mirroring the Python wiring.
 export const DIFY_IO: CommandIO<DifyAccessor> = {
   readdir: difyReaddir,
   readBytes: difyRead,

--- a/typescript/packages/core/src/commands/builtin/generic/awk.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/awk.test.ts
@@ -206,11 +206,7 @@ describe('awkGeneric', () => {
   it('propagates a -f read failure that is not absence', async () => {
     const raw = new Error('S3 GET prog.awk failed: 403 Forbidden')
     function stream(): AsyncIterable<Uint8Array> {
-      async function* gen(): AsyncIterable<Uint8Array> {
-        await Promise.resolve()
-        throw raw
-      }
-      return gen()
+      throw raw
     }
     await expect(
       awkGeneric([spec('/data.txt')], [], opts({ f: '/prog.awk' }), stream),

--- a/typescript/packages/core/src/commands/builtin/generic/awk.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/awk.test.ts
@@ -43,7 +43,12 @@ function makeStream(files: Record<string, string>) {
     const content = files[p.virtual]
     async function* gen(): AsyncIterable<Uint8Array> {
       await Promise.resolve()
-      if (content === undefined) throw new Error(`${p.virtual}: no such file`)
+      if (content === undefined) {
+        // Stamped like a real backend's ENOENT; awk rethrows anything else.
+        const err = new Error(p.virtual) as Error & { code: string }
+        err.code = 'ENOENT'
+        throw err
+      }
       yield ENC.encode(content)
     }
     return gen()
@@ -193,6 +198,31 @@ describe('awkGeneric', () => {
     const [stdout, io] = result ?? [null, new IOResult()]
     expect(stdout).toBeNull()
     expect(io.exitCode).toBe(2)
+    expect(DEC.decode(await materialize(io.stderr))).toBe(
+      'awk: /missing.awk: No such file or directory\n',
+    )
+  })
+
+  it('propagates a -f read failure that is not absence', async () => {
+    const raw = new Error('S3 GET prog.awk failed: 403 Forbidden')
+    function stream(): AsyncIterable<Uint8Array> {
+      async function* gen(): AsyncIterable<Uint8Array> {
+        await Promise.resolve()
+        throw raw
+      }
+      return gen()
+    }
+    await expect(
+      awkGeneric([spec('/data.txt')], [], opts({ f: '/prog.awk' }), stream),
+    ).rejects.toThrow('403 Forbidden')
+  })
+
+  it('resolves a relative -f program file against the cwd', async () => {
+    const files = { '/data/prog.awk': '{print $1}\n', '/data/in.txt': 'hey there\n' }
+    const o = { ...opts({ f: 'prog.awk' }), cwd: '/data' } as CommandOpts
+    const result = await awkGeneric([spec('/data/in.txt')], [], o, makeStream(files))
+    const [stdout] = result ?? [null, new IOResult()]
+    expect(DEC.decode(await materialize(stdout))).toBe('hey\n')
   })
 
   it('runs the -f program over multiple data files with continuous NR', async () => {

--- a/typescript/packages/core/src/commands/builtin/generic/awk.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/awk.ts
@@ -20,6 +20,8 @@ import { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { awkStream } from './awk_helper.ts'
 import { USAGE, type AwkFlags } from './awk_types.ts'
+import { isMissingPath } from '../../../utils/errors.ts'
+import { resolvePath } from '../../../utils/path.ts'
 import { resolveSource } from '../utils/stream.ts'
 
 const ENC = new TextEncoder()
@@ -55,17 +57,17 @@ export async function awkGeneric(
       ''
     const pieces: string[] = []
     for (const programFile of f.programFiles) {
-      const programSpec = PathSpec.fromStrPath(programFile, mountKey(programFile, mountPrefix))
+      // A relative -f resolves against the cwd, like the shell classifier
+      // resolves python's PathSpec flag values.
+      const virtual = resolvePath(programFile, opts.cwd)
+      const programSpec = PathSpec.fromStrPath(virtual, mountKey(virtual, mountPrefix))
       try {
         pieces.push(DEC.decode(await materialize(stream(programSpec))).trim())
       } catch (err) {
-        const code = (err as { code?: string }).code
-        const msg =
-          code === 'ENOENT'
-            ? `awk: ${programFile}: No such file or directory`
-            : err instanceof Error
-              ? err.message
-              : String(err)
+        // GNU awk exits 2 when a -f program file cannot be opened;
+        // anything that is not absence keeps propagating.
+        if (!isMissingPath(err)) throw err
+        const msg = `awk: ${programFile}: No such file or directory`
         return [null, new IOResult({ exitCode: 2, stderr: ENC.encode(`${msg}\n`) })]
       }
     }

--- a/typescript/packages/core/src/commands/builtin/generic/checksum.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/checksum.test.ts
@@ -150,6 +150,53 @@ describe('checksum --check', () => {
     expect(code).toBe(1)
   })
 
+  it('--status silences no-file-verified but keeps its exit 1', async () => {
+    const [out, err, code] = await runCheck(
+      { '/sums.txt': '5aabc  /gone.txt\n' },
+      { ignore_missing: true, status: true },
+    )
+    expect(out).toBe('')
+    expect(err).toBe('')
+    expect(code).toBe(1)
+  })
+
+  it('--status keeps the no-properly-formatted fatal', async () => {
+    const [out, err, code] = await runCheck({ '/sums.txt': 'junk\n' }, { status: true })
+    expect(out).toBe('')
+    expect(err).toBe('md5sum: /sums.txt: no properly formatted checksum lines found\n')
+    expect(code).toBe(1)
+  })
+
+  it('a malformed line plus an ignored skip is no-file-verified', async () => {
+    // A parsed line whose target --ignore-missing skips must not read as
+    // "no properly formatted checksum lines found".
+    const [out, err, code] = await runCheck(
+      { '/sums.txt': 'junk\n5aabc  /gone.txt\n' },
+      { ignore_missing: true },
+    )
+    expect(out).toBe('')
+    expect(err).toBe(
+      'md5sum: WARNING: 1 line is improperly formatted\n' +
+        'md5sum: /sums.txt: no file was verified\n',
+    )
+    expect(code).toBe(1)
+  })
+
+  it('--ignore-missing with only a mismatch reports both diagnostics', async () => {
+    // GNU: zero OK lines under --ignore-missing is "no file was verified"
+    // even when a mismatch was read and reported.
+    const [out, err, code] = await runCheck(
+      { '/sums.txt': '5aface  /a.txt\n', '/a.txt': 'cafe' },
+      { ignore_missing: true },
+    )
+    expect(out).toBe('/a.txt: FAILED\n')
+    expect(err).toBe(
+      'md5sum: WARNING: 1 computed checksum did NOT match\n' +
+        'md5sum: /sums.txt: no file was verified\n',
+    )
+    expect(code).toBe(1)
+  })
+
   it('--status keeps the strerror lines and drops the summaries', async () => {
     const [out, err, code] = await runCheck(
       { '/sums.txt': '5aabc  /ok.txt\n5aabc  /miss.txt\n', '/ok.txt': 'abc' },

--- a/typescript/packages/core/src/commands/builtin/generic/checksum.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/checksum.test.ts
@@ -1,0 +1,175 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { stripSlash } from '../../../utils/slash.ts'
+import { describe, expect, it } from 'vitest'
+import { IOResult, materialize } from '../../../io/types.ts'
+import { PathSpec } from '../../../types.ts'
+import type { CommandOpts } from '../../config.ts'
+import { checksumGeneric } from './checksum.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+function spec(path: string): PathSpec {
+  return new PathSpec({
+    resourcePath: stripSlash(path),
+    virtual: path,
+    directory: path,
+    resolved: true,
+    rawPath: path,
+  })
+}
+
+function opts(flags: Record<string, string | boolean | number | string[]>, cwd = '/'): CommandOpts {
+  return { stdin: null, flags, filetypeFns: null, cwd, resource: {} } as CommandOpts
+}
+
+function makeStream(files: Record<string, string>) {
+  return function stream(p: PathSpec): AsyncIterable<Uint8Array> {
+    const content = files[p.virtual]
+    async function* gen(): AsyncIterable<Uint8Array> {
+      await Promise.resolve()
+      if (content === undefined) {
+        const err = new Error(p.virtual) as Error & { code: string }
+        err.code = 'ENOENT'
+        throw err
+      }
+      yield ENC.encode(content)
+    }
+    return gen()
+  }
+}
+
+// Content-addressed fake: the digest of a body is '5a' + the body's text,
+// which parseCheckLine accepts as hex when bodies are hex-safe.
+const hasher = (bytes: Uint8Array): Promise<string> => Promise.resolve(`5a${DEC.decode(bytes)}`)
+
+async function runCheck(
+  files: Record<string, string>,
+  flags: Record<string, string | boolean | number | string[]> = {},
+  cwd = '/',
+): Promise<[string, string, number]> {
+  const result = await checksumGeneric(
+    [spec('/sums.txt')],
+    opts({ check: true, ...flags }, cwd),
+    makeStream(files),
+    hasher,
+    'md5sum',
+  )
+  const [out, io] = result ?? [null, new IOResult()]
+  return [
+    out === null ? '' : DEC.decode(await materialize(out)),
+    DEC.decode(await materialize(io.stderr)),
+    io.exitCode,
+  ]
+}
+
+// GNU coreutils 9.7, pinned on debian:stable-slim: the per-file strerror
+// lines and the WARNING block are stderr, FAILED lines are stdout, and
+// --status silences everything except the strerror lines.
+describe('checksum --check', () => {
+  it('reports a missing recorded file on both channels and exits 1', async () => {
+    const [out, err, code] = await runCheck({
+      '/sums.txt': '5aabc  /ok.txt\n5aabc  /miss.txt\n',
+      '/ok.txt': 'abc',
+    })
+    expect(out).toBe('/ok.txt: OK\n/miss.txt: FAILED open or read\n')
+    expect(err).toBe(
+      'md5sum: /miss.txt: No such file or directory\n' +
+        'md5sum: WARNING: 1 listed file could not be read\n',
+    )
+    expect(code).toBe(1)
+  })
+
+  it('resolves a relative recorded name against the cwd', async () => {
+    const [out, err, code] = await runCheck(
+      { '/sums.txt': '5aabc  f.txt\n', '/data/f.txt': 'abc' },
+      {},
+      '/data',
+    )
+    expect(out).toBe('f.txt: OK\n')
+    expect(err).toBe('')
+    expect(code).toBe(0)
+  })
+
+  it('propagates a read failure that is not a filesystem error', async () => {
+    const raw = new Error('S3 GET f failed: 403 Forbidden')
+    function stream(p: PathSpec): AsyncIterable<Uint8Array> {
+      async function* gen(): AsyncIterable<Uint8Array> {
+        await Promise.resolve()
+        if (p.virtual === '/sums.txt') {
+          yield ENC.encode('5aabc  /f.txt\n')
+          return
+        }
+        throw raw
+      }
+      return gen()
+    }
+    await expect(
+      checksumGeneric([spec('/sums.txt')], opts({ check: true }), stream, hasher, 'md5sum'),
+    ).rejects.toThrow('403 Forbidden')
+  })
+
+  it('counts mismatches into the NOT-match warning', async () => {
+    const [out, err, code] = await runCheck({
+      '/sums.txt': '5aface  /a.txt\n5aface  /b.txt\n',
+      '/a.txt': 'face',
+      '/b.txt': 'cafe',
+    })
+    expect(out).toBe('/a.txt: OK\n/b.txt: FAILED\n')
+    expect(err).toBe('md5sum: WARNING: 1 computed checksum did NOT match\n')
+    expect(code).toBe(1)
+  })
+
+  it('fails alone when no line is properly formatted', async () => {
+    const [out, err, code] = await runCheck({ '/sums.txt': 'junk\nmore junk\n' })
+    expect(out).toBe('')
+    expect(err).toBe('md5sum: /sums.txt: no properly formatted checksum lines found\n')
+    expect(code).toBe(1)
+  })
+
+  it('reports nothing verified under --ignore-missing when all are missing', async () => {
+    const [out, err, code] = await runCheck(
+      { '/sums.txt': '5aabc  /gone.txt\n' },
+      { ignore_missing: true },
+    )
+    expect(out).toBe('')
+    expect(err).toBe('md5sum: /sums.txt: no file was verified\n')
+    expect(code).toBe(1)
+  })
+
+  it('--status keeps the strerror lines and drops the summaries', async () => {
+    const [out, err, code] = await runCheck(
+      { '/sums.txt': '5aabc  /ok.txt\n5aabc  /miss.txt\n', '/ok.txt': 'abc' },
+      { status: true },
+    )
+    expect(out).toBe('')
+    expect(err).toBe('md5sum: /miss.txt: No such file or directory\n')
+    expect(code).toBe(1)
+  })
+
+  it('--warn adds per-line diagnostics and the summary prints regardless', async () => {
+    const [out, err, code] = await runCheck(
+      { '/sums.txt': 'bad line\n5aabc  /ok.txt\n', '/ok.txt': 'abc' },
+      { warn: true },
+    )
+    expect(out).toBe('/ok.txt: OK\n')
+    expect(err).toBe(
+      'md5sum: /sums.txt: 1: improperly formatted MD5 checksum line\n' +
+        'md5sum: WARNING: 1 line is improperly formatted\n',
+    )
+    expect(code).toBe(0)
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/checksum.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/checksum.ts
@@ -18,6 +18,8 @@ import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { fsStrerror, isMissingPath, isWalkError } from '../../../utils/errors.ts'
+import { resolvePath } from '../../../utils/path.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { operandsIo, readOperands } from '../utils/operands.ts'
 
@@ -65,6 +67,17 @@ function makePathSpec(virtual: string, mountPrefix: string): PathSpec {
   })
 }
 
+// The recorded name resolves against the command's cwd, exactly like GNU
+// resolves it against the process cwd (a relative `f.txt` in the sums
+// file names a sibling of wherever `-c` runs, not of the sums file).
+function checkTarget(filename: string, cwd: string, mountPrefix: string): PathSpec {
+  return makePathSpec(resolvePath(filename, cwd), mountPrefix)
+}
+
+function countNoun(count: number, singular: string, plural: string): string {
+  return count === 1 ? singular : `${String(count)} ${plural}`
+}
+
 async function checkFile(
   stream: Stream,
   p: PathSpec,
@@ -75,39 +88,81 @@ async function checkFile(
   const fl = new FlagView(opts.flags, specOf(name))
   const data = DEC.decode(await materialize(stream(p)))
   const mountPrefix = mountPrefixOf(p.virtual, p.resourcePath)
+  const checkLabel = p.rawPath !== '' ? p.rawPath : p.virtual
   const output: string[] = []
   const errors: string[] = []
-  let failed = false
+  let verified = 0
+  let mismatched = 0
+  let readFailures = 0
   let malformed = 0
+  let lineno = 0
   for (const line of data.split('\n')) {
+    lineno += 1
     if (line.trim() === '') continue
     const parsed = parseCheckLine(line, name)
     if (parsed === null) {
       malformed += 1
+      if (fl.asBool('warn')) {
+        errors.push(
+          `${name}: ${checkLabel}: ${String(lineno)}: improperly formatted ` +
+            `${algorithmName(name)} checksum line`,
+        )
+      }
       continue
     }
     const [expected, filename] = parsed
     let digest: string
     try {
-      digest = await hashStream(stream(makePathSpec(filename, mountPrefix)), hasher)
+      digest = await hashStream(stream(checkTarget(filename, opts.cwd, mountPrefix)), hasher)
     } catch (error) {
-      if (fl.asBool('ignore_missing') && isMissingError(error)) continue
+      if (!isWalkError(error)) throw error
+      // GNU --ignore-missing skips only absence; a permission or
+      // transport-shaped failure still reports and fails the check.
+      if (fl.asBool('ignore_missing') && isMissingPath(error)) continue
+      const strerror = fsStrerror(error) ?? (error instanceof Error ? error.message : String(error))
+      errors.push(`${name}: ${filename}: ${strerror}`)
       if (!fl.asBool('status')) output.push(`${filename}: FAILED open or read`)
-      failed = true
+      readFailures += 1
       continue
     }
     if (digest === expected) {
+      verified += 1
       if (!fl.asBool('status') && !fl.asBool('quiet')) output.push(`${filename}: OK`)
     } else {
       if (!fl.asBool('status')) output.push(`${filename}: FAILED`)
-      failed = true
+      mismatched += 1
     }
   }
-  if (malformed > 0 && fl.asBool('warn')) {
-    const count = malformed === 1 ? '1 line is' : `${String(malformed)} lines are`
-    errors.push(`WARNING: ${count} improperly formatted`)
+  // GNU's terminal diagnostics and WARNING block, in its order: the two
+  // fatal shapes come alone, the summaries print even without --warn, and
+  // --status silences the summaries but not the per-file strerror lines
+  // (pinned against coreutils 9.7).
+  if (verified === 0 && mismatched === 0 && readFailures === 0 && malformed > 0) {
+    errors.push(`${name}: ${checkLabel}: no properly formatted checksum lines found`)
+    return [null, ENC.encode(`${errors.join('\n')}\n`), 1]
   }
-  if (malformed > 0 && fl.asBool('strict')) failed = true
+  if (fl.asBool('ignore_missing') && verified === 0 && mismatched === 0 && readFailures === 0) {
+    errors.push(`${name}: ${checkLabel}: no file was verified`)
+    return [null, ENC.encode(`${errors.join('\n')}\n`), 1]
+  }
+  if (!fl.asBool('status')) {
+    if (malformed > 0) {
+      errors.push(
+        `${name}: WARNING: ${countNoun(malformed, '1 line is', 'lines are')} improperly formatted`,
+      )
+    }
+    if (readFailures > 0) {
+      errors.push(
+        `${name}: WARNING: ${countNoun(readFailures, '1 listed file', 'listed files')} could not be read`,
+      )
+    }
+    if (mismatched > 0) {
+      errors.push(
+        `${name}: WARNING: ${countNoun(mismatched, '1 computed checksum', 'computed checksums')} did NOT match`,
+      )
+    }
+  }
+  const failed = mismatched > 0 || readFailures > 0 || (fl.asBool('strict') && malformed > 0)
   const stdout = output.length > 0 ? ENC.encode(`${output.join('\n')}\n`) : null
   const stderr = errors.length > 0 ? ENC.encode(`${errors.join('\n')}\n`) : null
   return [stdout, stderr, failed ? 1 : 0]
@@ -119,11 +174,6 @@ function parseCheckLine(line: string, name: string): [string, string] | null {
   const match = /^([0-9a-fA-F]+) [ *](.*)$/.exec(line)
   if (match === null) return null
   return [match[1]?.toLowerCase() ?? '', match[2] ?? '']
-}
-
-function isMissingError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null || !('code' in error)) return false
-  return (error as { code?: unknown }).code === 'ENOENT'
 }
 
 export async function checksumGeneric(

--- a/typescript/packages/core/src/commands/builtin/generic/checksum.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/checksum.ts
@@ -96,6 +96,7 @@ async function checkFile(
   let readFailures = 0
   let malformed = 0
   let lineno = 0
+  let parsedAny = false
   for (const line of data.split('\n')) {
     lineno += 1
     if (line.trim() === '') continue
@@ -110,6 +111,7 @@ async function checkFile(
       }
       continue
     }
+    parsedAny = true
     const [expected, filename] = parsed
     let digest: string
     try {
@@ -133,18 +135,17 @@ async function checkFile(
       mismatched += 1
     }
   }
-  // GNU's terminal diagnostics and WARNING block, in its order: the two
-  // fatal shapes come alone, the summaries print even without --warn, and
-  // --status silences the summaries but not the per-file strerror lines
-  // (pinned against coreutils 9.7).
-  if (verified === 0 && mismatched === 0 && readFailures === 0 && malformed > 0) {
+  // GNU's terminal diagnostics and WARNING block, in its order (pinned
+  // against coreutils 9.7): a file with no properly formatted line is
+  // fatal on its own, even under --status. "No file was verified" means
+  // --ignore-missing left zero OK lines — mismatches included — and
+  // follows the summaries; --status silences it (and the summaries, but
+  // not the per-file strerror lines) while its exit 1 stands.
+  if (!parsedAny) {
     errors.push(`${name}: ${checkLabel}: no properly formatted checksum lines found`)
     return [null, ENC.encode(`${errors.join('\n')}\n`), 1]
   }
-  if (fl.asBool('ignore_missing') && verified === 0 && mismatched === 0 && readFailures === 0) {
-    errors.push(`${name}: ${checkLabel}: no file was verified`)
-    return [null, ENC.encode(`${errors.join('\n')}\n`), 1]
-  }
+  const nothingVerified = fl.asBool('ignore_missing') && verified === 0
   if (!fl.asBool('status')) {
     if (malformed > 0) {
       errors.push(
@@ -161,8 +162,12 @@ async function checkFile(
         `${name}: WARNING: ${countNoun(mismatched, '1 computed checksum', 'computed checksums')} did NOT match`,
       )
     }
+    if (nothingVerified) {
+      errors.push(`${name}: ${checkLabel}: no file was verified`)
+    }
   }
-  const failed = mismatched > 0 || readFailures > 0 || (fl.asBool('strict') && malformed > 0)
+  const failed =
+    mismatched > 0 || readFailures > 0 || nothingVerified || (fl.asBool('strict') && malformed > 0)
   const stdout = output.length > 0 ? ENC.encode(`${output.join('\n')}\n`) : null
   const stderr = errors.length > 0 ? ENC.encode(`${errors.join('\n')}\n`) : null
   return [stdout, stderr, failed ? 1 : 0]

--- a/typescript/packages/core/src/commands/builtin/generic/find.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.test.ts
@@ -60,6 +60,16 @@ describe('generic command find', () => {
     expect(DEC.decode(result?.[0] as Uint8Array)).toBe('/found.txt\n')
   })
 
+  it('prints start points in operand order without a cross-root sort', async () => {
+    // GNU findutils 4.10.0 (debian:stable-slim): each operand's rows print
+    // before the next operand's, even when a later root sorts earlier.
+    const perRoot = (root: PathSpec): Promise<string[]> =>
+      Promise.resolve(root.virtual === '/sub' ? ['/sub/z.txt'] : ['/a.txt'])
+    const result = await findGeneric([spec('/sub'), spec('/')], [], makeOpts(), perRoot)
+    expect(result?.[1].exitCode).toBe(0)
+    expect(DEC.decode(result?.[0] as Uint8Array)).toBe('/sub/z.txt\n/a.txt\n')
+  })
+
   // GNU findutils 4.10.0, pinned on debian:stable-slim:
   //   find <file>             -> <file>   find <file> -type d -> (empty)
   //   find <file> -type f     -> <file>   find <file> -type l -> (empty)

--- a/typescript/packages/core/src/commands/builtin/generic/find.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.ts
@@ -507,7 +507,8 @@ export async function findGeneric(
     withLinks.sort()
     matches.push(...respellRaw(withLinks, root.virtual, root.rawPath))
   }
-  matches.sort()
+  // Start points print in operand order (GNU); each root's rows were
+  // sorted above, and a global sort here would interleave them.
   const out: ByteSource = ENC.encode(matches.length ? matches.join('\n') + '\n' : '')
   if (missing.length > 0) {
     return [out, new IOResult({ stderr: ENC.encode(missing.join('\n') + '\n'), exitCode: 1 })]

--- a/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
@@ -386,7 +386,12 @@ describe('link operands on backends with different readdir shapes', () => {
     targetStat: () => Promise.resolve(null),
   }
 
-  const missing = (p: PathSpec): Promise<never> => Promise.reject(new Error(`ENOENT: ${p.virtual}`))
+  const missing = (p: PathSpec): Promise<never> => {
+    // Stamped like a real backend's ENOENT; bare errors now propagate.
+    const err = new Error(p.virtual) as Error & { code: string }
+    err.code = 'ENOENT'
+    return Promise.reject(err)
+  }
 
   it('reports the link when readdir throws', async () => {
     const [out] = (await lsGeneric(
@@ -408,5 +413,46 @@ describe('link operands on backends with different readdir shapes', () => {
       missing,
     )) as [Uint8Array, unknown]
     expect(new TextDecoder().decode(out)).toContain('flink -> /data/symx/real.txt')
+  })
+})
+
+describe('honest per-entry errors', () => {
+  function enoent(p: string): Error {
+    const e = new Error(p) as Error & { code: string }
+    e.code = 'ENOENT'
+    return e
+  }
+
+  function statFailingEntries(err: Error) {
+    return (p: PathSpec): Promise<FileStat> => (key(p) === '/' ? stat(p) : Promise.reject(err))
+  }
+
+  it('warns per entry and ratchets the exit code on a stamped fs error', async () => {
+    const result = await lsGeneric(
+      [spec('/')],
+      opts({}),
+      readdir,
+      statFailingEntries(enoent('/apple.txt')),
+    )
+    expect(result?.[1].exitCode).toBe(LS_MINOR_PROBLEM)
+    const stderr = DEC.decode(result?.[1].stderr as Uint8Array)
+    expect(stderr).toContain("ls: cannot access '/apple.txt': No such file or directory")
+  })
+
+  it('propagates an unstamped backend error instead of laundering it', async () => {
+    // An error with no POSIX code (auth failure, transport prose) must not
+    // become a GNU-shaped 'cannot access' line.
+    const raw = new Error('S3 GET apple.txt failed: 403 Forbidden')
+    await expect(
+      lsGeneric([spec('/')], opts({}), readdir, statFailingEntries(raw)),
+    ).rejects.toThrow('403 Forbidden')
+  })
+
+  it('-d propagates an unstamped stat error', async () => {
+    const raw = new Error('rate limited')
+    const failing = (): Promise<FileStat> => Promise.reject(raw)
+    await expect(lsGeneric([spec('/x')], opts({ d: true }), readdir, failing)).rejects.toThrow(
+      'rate limited',
+    )
   })
 })

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -20,9 +20,9 @@ import { FileStat, FileType, PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import type { LinkView } from '../../../ops/types.ts'
 import { formatLsLong } from '../utils/formatting.ts'
-import { gnuStrerror } from '../../../utils/errors.ts'
+import { gnuStrerror, isWalkError } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
-import { respellOne } from '../../../utils/path.ts'
+import { CycleError, respellOne } from '../../../utils/path.ts'
 import { formatRecords } from '../utils/output.ts'
 
 type Readdir = (p: PathSpec) => Promise<string[]>
@@ -148,7 +148,8 @@ async function fileEntry(stat: Stat, path: PathSpec): Promise<FileStat | null> {
   try {
     const s = await stat(path)
     return s.type !== FileType.DIRECTORY ? asOperand(s, path) : null
-  } catch {
+  } catch (err) {
+    if (!isWalkError(err)) throw err
     return null
   }
 }
@@ -183,6 +184,7 @@ async function listDir(
     const entry = entries[i]
     if (outcome === undefined || entry === undefined) continue
     if (outcome.status === 'rejected') {
+      if (!isWalkError(outcome.reason)) throw outcome.reason
       // An entry below an operand is never a command-line arg.
       warnings.push({
         message: `ls: cannot access '${entry}': ${errText(outcome.reason)}`,
@@ -220,14 +222,16 @@ async function derefEntry(
   let target: string
   try {
     target = links.resolve(child)
-  } catch {
+  } catch (err) {
+    if (!(err instanceof CycleError)) throw err
     return null
   }
   const spec = childSpec(target, mountPrefixOf(directory.virtual, directory.resourcePath))
   try {
     const s = await stat(spec)
     return s.with({ name: link.name })
-  } catch {
+  } catch (err) {
+    if (!isWalkError(err)) throw err
     return null
   }
 }
@@ -254,6 +258,7 @@ async function probeOperand(
   try {
     stats = await listDir(readdir, stat, path, opts.all, warnings, opts.links, opts.deref, stat)
   } catch (err) {
+    if (!isWalkError(err)) throw err
     const row = await fileEntry(stat, path)
     if (row !== null) return { path, row, groups: [] }
     const link = linkRow(path, opts.links)
@@ -305,7 +310,8 @@ async function operandKey(operand: Operand, sortBy: SortBy, stat: Stat): Promise
   }
   try {
     return asOperand(await stat(operand.path), operand.path)
-  } catch {
+  } catch (err) {
+    if (!isWalkError(err)) throw err
     // The stat only supplies a sort key; an operand that cannot be statted
     // sorts as if it had none rather than failing the listing.
     return new FileStat({ name: operand.path.rawPath, type: FileType.DIRECTORY })
@@ -382,6 +388,7 @@ export async function lsGeneric(
         // GNU ls -d prints the operand as given.
         collected.push(asOperand(await stat(p), p))
       } catch (err) {
+        if (!isWalkError(err)) throw err
         warnings.push({
           message: `ls: cannot access '${p.rawPath}': ${errText(err)}`,
           serious: true,

--- a/typescript/packages/core/src/commands/builtin/generic/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/rg.ts
@@ -17,7 +17,7 @@ import { cacheAwareStream } from '../../../cache/read_through.ts'
 import { exitOnEmpty } from '../../../io/stream.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { FileType, PathSpec, type FileStat } from '../../../types.ts'
-import { fsStrerror, isFsError } from '../../../utils/errors.ts'
+import { fsStrerror, isFsError, isWalkError } from '../../../utils/errors.ts'
 import { respellRaw } from '../../../utils/path.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
@@ -152,11 +152,13 @@ export async function rgGeneric(
   try {
     const s = await stat(first)
     isDir = s.type === FileType.DIRECTORY
-  } catch {
+  } catch (err) {
+    if (!isWalkError(err)) throw err
     try {
       await readdir(first)
       isDir = true
-    } catch {
+    } catch (probeErr) {
+      if (!isWalkError(probeErr)) throw probeErr
       // not readable
     }
   }

--- a/typescript/packages/core/src/commands/builtin/generic/tree.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tree.test.ts
@@ -166,7 +166,11 @@ describe('treeGeneric operand that is not a directory', () => {
   // renders the same marker with exit 2 (a permission error, not absence).
   it('still walks a directory it cannot list', async () => {
     const dirStat = new FileStat({ name: 'locked', type: FileType.DIRECTORY })
-    const failing = (): Promise<string[]> => Promise.reject(new Error('EACCES'))
+    const failing = (): Promise<string[]> => {
+      const err = new Error('/locked') as Error & { code: string }
+      err.code = 'EACCES'
+      return Promise.reject(err)
+    }
     const [out, io] = (await treeGeneric(
       [spec('/locked')],
       optsWith(dirStat),

--- a/typescript/packages/core/src/commands/builtin/generic/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tree.ts
@@ -18,6 +18,7 @@ import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { FileType, PathSpec, type FileStat } from '../../../types.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
+import { isWalkError } from '../../../utils/errors.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { fnmatch } from '../../../utils/fnmatch.ts'
 import { formatRecords } from '../utils/output.ts'
@@ -45,7 +46,8 @@ async function walkTree(
   let entries: string[]
   try {
     entries = await readdir(path)
-  } catch {
+  } catch (err) {
+    if (!isWalkError(err)) throw err
     return { dirs, files, failed: true }
   }
   entries.sort()
@@ -65,7 +67,8 @@ async function walkTree(
     try {
       const s = await stat(sub)
       isDir = s.type === FileType.DIRECTORY
-    } catch {
+    } catch (err) {
+      if (!isWalkError(err)) throw err
       continue
     }
     if (treeOpts.dirsOnly && !isDir) continue

--- a/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
@@ -51,6 +51,9 @@ function withReadCache<A extends Accessor>(ops: CommandIO<A>): CommandIO<A> {
 export interface MakeGenericCommandsOptions<A extends Accessor = Accessor> {
   overrides?: ReadonlySet<string>
   provisionOverrides?: Record<string, ProvisionFn<A>>
+  // Per-command adapters that replace the shared adapter when one command
+  // needs a cheaper backend operation (mirrors the Python ops_overrides).
+  opsOverrides?: Record<string, CommandIO<A>>
 }
 
 export function makeGenericCommands<A extends Accessor = Accessor>(
@@ -60,25 +63,26 @@ export function makeGenericCommands<A extends Accessor = Accessor>(
 ): RegisteredCommand[] {
   const skip = options.overrides ?? new Set<string>()
   const provOver = options.provisionOverrides ?? {}
-  const opsBase = ops as CommandIO
+  const opsOver = options.opsOverrides ?? {}
   const commands: RegisteredCommand[] = []
   for (const b of BUILDERS) {
     if (skip.has(b.name)) continue
+    const baseOps = (opsOver[b.name] ?? ops) as CommandIO
     // A backend missing an op a command cannot run without (cp/mv/tee/
     // gunzip/...) doesn't get the command registered, rather than getting
     // one that crashes when invoked.
-    if (!supports(opsBase, b.requirements ?? [])) continue
+    if (!supports(baseOps, b.requirements ?? [])) continue
     const cmdOps =
-      b.read === true ? withReadCache(opsBase) : b.write === true ? opsBase : withStatCache(opsBase)
+      b.read === true ? withReadCache(baseOps) : b.write === true ? baseOps : withStatCache(baseOps)
     const fn: CommandFn = (accessor, paths, texts, opts) =>
       b.fn(cmdOps, accessor, paths, texts, opts)
     const provision =
       b.name in provOver
         ? ((provOver[b.name] ?? null) as ProvisionFn | null)
         : b.provision !== undefined
-          ? b.provision(opsBase.stat)
-          : defaultProvision(b.name, opsBase.stat, resolveGlobOf(opsBase), opsBase.readdir)
-    const aggregate = ops.local !== false ? (b.aggregate ?? null) : null
+          ? b.provision(baseOps.stat)
+          : defaultProvision(b.name, baseOps.stat, resolveGlobOf(baseOps), baseOps.readdir)
+    const aggregate = baseOps.local !== false ? (b.aggregate ?? null) : null
     commands.push(
       ...command({
         name: b.name,

--- a/typescript/packages/core/src/core/box/stat.ts
+++ b/typescript/packages/core/src/core/box/stat.ts
@@ -20,21 +20,7 @@ import { getFolderInfo, type BoxItem } from './api.ts'
 import { readdir as coreReaddir, resourceTypeFor } from './readdir.ts'
 import { pathParts, resolveItem } from './resolve.ts'
 import { enoent } from '../../utils/errors.ts'
-
-function guessType(name: string): FileType {
-  const lower = name.toLowerCase()
-  if (lower.endsWith('.json')) return FileType.JSON
-  if (lower.endsWith('.csv')) return FileType.CSV
-  if (lower.endsWith('.png')) return FileType.IMAGE_PNG
-  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return FileType.IMAGE_JPEG
-  if (lower.endsWith('.gif')) return FileType.IMAGE_GIF
-  if (lower.endsWith('.zip')) return FileType.ZIP
-  if (lower.endsWith('.gz') || lower.endsWith('.gzip')) return FileType.GZIP
-  if (lower.endsWith('.pdf')) return FileType.PDF
-  if (lower.endsWith('.txt') || lower.endsWith('.md') || lower.endsWith('.log'))
-    return FileType.TEXT
-  return FileType.BINARY
-}
+import { guessType } from '../../utils/filetype.ts'
 
 function statFromItem(item: BoxItem): FileStat {
   const vfsName = item.name

--- a/typescript/packages/core/src/core/dify/_client.ts
+++ b/typescript/packages/core/src/core/dify/_client.ts
@@ -134,6 +134,13 @@ export async function listAllDocuments(accessor: DifyAccessor): Promise<Record<s
   }
 }
 
+export function getDocumentDetail(
+  accessor: DifyAccessor,
+  documentId: string,
+): Promise<Record<string, unknown>> {
+  return difyGet(accessor, `/datasets/${accessor.config.datasetId}/documents/${documentId}`)
+}
+
 export async function* iterSegmentPages(
   accessor: DifyAccessor,
   documentId: string,

--- a/typescript/packages/core/src/core/dify/stat.test.ts
+++ b/typescript/packages/core/src/core/dify/stat.test.ts
@@ -1,0 +1,141 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './_client.ts'
+
+vi.mock('./_client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
+  return { ...actual, listAllDocuments: vi.fn(), getDocumentDetail: vi.fn() }
+})
+
+import type { DifyAccessor } from '../../accessor/dify.ts'
+import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
+import { FileType, PathSpec } from '../../types.ts'
+import { mountKey } from '../../utils/key_prefix.ts'
+import * as clientMod from './_client.ts'
+import { stat, statLight } from './stat.ts'
+
+const ACCESSOR = { config: { slugMetadataName: 'slug' } } as DifyAccessor
+
+function document(
+  documentId: string,
+  name: string,
+  slug: string,
+  size = 123,
+): Record<string, unknown> {
+  return {
+    id: documentId,
+    name,
+    doc_metadata: [{ name: 'slug', value: slug }],
+    enabled: true,
+    indexing_status: 'completed',
+    archived: false,
+    tokens: 9,
+    data_source_type: 'upload_file',
+    data_source_detail_dict: { upload_file: { size } },
+    created_at: 1716282000,
+  }
+}
+
+function pathAt(virtual: string): PathSpec {
+  return new PathSpec({
+    resourcePath: mountKey(virtual, '/knowledge'),
+    virtual,
+    directory: virtual,
+  })
+}
+
+describe('dify stat', () => {
+  beforeEach(() => {
+    vi.mocked(clientMod.listAllDocuments).mockReset()
+    vi.mocked(clientMod.getDocumentDetail).mockReset()
+    vi.mocked(clientMod.listAllDocuments).mockResolvedValue([
+      document('doc-1', 'Quickstart', 'guides/quickstart'),
+    ])
+    vi.mocked(clientMod.getDocumentDetail).mockRejectedValue(
+      new Error('unexpected document-detail call'),
+    )
+  })
+
+  it('statLight uses the index entry without a detail call', async () => {
+    const index = new RAMIndexCacheStore()
+
+    const item = await statLight(ACCESSOR, pathAt('/knowledge/guides/quickstart'), index)
+
+    expect(item.name).toBe('quickstart')
+    expect(item.type).toBe(FileType.TEXT)
+    expect(item.size).toBeNull()
+    expect(item.extra.source_size).toBe(123)
+    expect(item.modified).toBe('2024-05-21T09:00:00.000Z')
+    expect(item.extra.slug).toBe('guides/quickstart')
+    expect(clientMod.getDocumentDetail).not.toHaveBeenCalled()
+  })
+
+  it('statLight returns a directory without a detail call', async () => {
+    const index = new RAMIndexCacheStore()
+
+    const item = await statLight(ACCESSOR, pathAt('/knowledge/guides'), index)
+
+    expect(item.name).toBe('guides')
+    expect(item.type).toBe(FileType.DIRECTORY)
+    expect(item.extra).toEqual({ children_count: 0 })
+    expect(clientMod.getDocumentDetail).not.toHaveBeenCalled()
+  })
+
+  it('stat returns a directory without a detail call', async () => {
+    const index = new RAMIndexCacheStore()
+
+    const item = await stat(ACCESSOR, pathAt('/knowledge/guides'), index)
+
+    expect(item.name).toBe('guides')
+    expect(item.type).toBe(FileType.DIRECTORY)
+    expect(item.extra).toEqual({ children_count: 0 })
+    expect(clientMod.getDocumentDetail).not.toHaveBeenCalled()
+  })
+
+  it('stat fetches document detail and fills the refreshed fields', async () => {
+    const index = new RAMIndexCacheStore()
+    vi.mocked(clientMod.getDocumentDetail).mockResolvedValue({
+      updated_at: 1716282000,
+      tokens: 21,
+      indexing_status: 'completed',
+      data_source_detail_dict: { upload_file: { size: 456 } },
+    })
+
+    const item = await stat(ACCESSOR, pathAt('/knowledge/guides/quickstart'), index)
+
+    expect(clientMod.getDocumentDetail).toHaveBeenCalledWith(ACCESSOR, 'doc-1')
+    expect(item.name).toBe('quickstart')
+    expect(item.type).toBe(FileType.TEXT)
+    expect(item.size).toBeNull()
+    expect(item.extra.document_id).toBe('doc-1')
+    expect(item.extra.source_size).toBe(456)
+    expect(item.extra.tokens).toBe(21)
+    expect(item.extra.indexing_status).toBe('completed')
+    expect(item.modified).toBe('2024-05-21T09:00:00Z')
+  })
+
+  it('stat falls back to the entry size when the detail has none', async () => {
+    const index = new RAMIndexCacheStore()
+    vi.mocked(clientMod.getDocumentDetail).mockResolvedValue({ updated_at: 1716282000 })
+
+    const item = await stat(ACCESSOR, pathAt('/knowledge/guides/quickstart'), index)
+
+    expect(item.extra.source_size).toBe(123)
+    expect(item.extra.tokens).toBe(9)
+    expect(item.extra.indexing_status).toBe('completed')
+    expect(item.modified).toBe('2024-05-21T09:00:00Z')
+  })
+})

--- a/typescript/packages/core/src/core/dify/stat.ts
+++ b/typescript/packages/core/src/core/dify/stat.ts
@@ -74,10 +74,7 @@ export async function stat(
   }
   if (resolved.entry === null) throw enoent(spec.virtual)
   const detail = await getDocumentDetail(accessor, resolved.entry.id)
-  let sourceSize = extractDocumentSize(detail)
-  if (sourceSize === null) {
-    sourceSize = resolved.entry.size
-  }
+  const sourceSize = extractDocumentSize(detail) ?? resolved.entry.size
   const extra: Record<string, unknown> = { ...resolved.entry.extra }
   extra.document_id = resolved.entry.id
   // size stays null: the API reports the uploaded source file's size (e.g.
@@ -104,14 +101,14 @@ export async function stat(
   })
 }
 
-// Mirrors the Python timestamp_to_zulu: epoch seconds render with second
-// precision and a literal Z, unlike tree.ts's timestampToIso (+millis).
+// Mirrors the Python timestamp_to_zulu over its real domain (the API
+// sends epoch seconds or nothing): second precision and a literal Z,
+// unlike tree.ts's timestampToIso (+millis); strings pass through.
 function timestampToZulu(value: unknown): string | null {
-  if (value === null || value === undefined) return null
   if (typeof value === 'number') {
     return new Date(value * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z')
   }
-  return String(value)
+  return typeof value === 'string' ? value : null
 }
 
 function statName(virtualKey: string, mountPrefix: string): string {

--- a/typescript/packages/core/src/core/dify/stat.ts
+++ b/typescript/packages/core/src/core/dify/stat.ts
@@ -17,15 +17,17 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
 import { rstripSlash } from '../../utils/slash.ts'
+import { getDocumentDetail } from './_client.ts'
+import { extractDocumentSize } from './tree.ts'
 import { resolvePath } from './path.ts'
 
-// Index-only stat: never fetches document detail, so `ls`/`ls -l`/`find`
-// stay cheap (one listing per mount, no per-entry API call). size stays
-// null because the entry size is the uploaded source file (e.g. the
-// original PDF), not the rendered segment text this mount serves
-// (FileStat.size must be render-derived or null, see the CLAUDE.md FUSE
-// rules). The source size remains in extra.source_size.
-export async function stat(
+// Index-only stat: never fetches document detail, so `ls` and the plain
+// `find` walk stay cheap (one listing per mount, no per-entry API call).
+// size stays null because the entry size is the uploaded source file
+// (e.g. the original PDF), not the rendered segment text this mount
+// serves (FileStat.size must be render-derived or null, see the
+// CLAUDE.md FUSE rules). The source size remains in extra.source_size.
+export async function statLight(
   accessor: DifyAccessor,
   path: PathSpec | string,
   index?: IndexCacheStore,
@@ -54,6 +56,62 @@ export async function stat(
     revision: null,
     extra,
   })
+}
+
+export async function stat(
+  accessor: DifyAccessor,
+  path: PathSpec | string,
+  index?: IndexCacheStore,
+): Promise<FileStat> {
+  const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
+  const resolved = await resolvePath(accessor, spec, index)
+  if (resolved.isDir) {
+    return new FileStat({
+      name: statName(resolved.virtualKey, resolved.mountPrefix),
+      type: FileType.DIRECTORY,
+      extra: { children_count: 0 },
+    })
+  }
+  if (resolved.entry === null) throw enoent(spec.virtual)
+  const detail = await getDocumentDetail(accessor, resolved.entry.id)
+  let sourceSize = extractDocumentSize(detail)
+  if (sourceSize === null) {
+    sourceSize = resolved.entry.size
+  }
+  const extra: Record<string, unknown> = { ...resolved.entry.extra }
+  extra.document_id = resolved.entry.id
+  // size stays null: the API reports the uploaded source file's size (e.g.
+  // the original PDF), not the rendered segment text this mount serves
+  // (FileStat.size must be render-derived or null, see the CLAUDE.md FUSE
+  // rules). The source size remains in extra.
+  if (sourceSize !== null) {
+    extra.source_size = sourceSize
+  }
+  if ('tokens' in detail) {
+    extra.tokens = detail.tokens
+  }
+  if ('indexing_status' in detail) {
+    extra.indexing_status = detail.indexing_status
+  }
+  return new FileStat({
+    name: resolved.entry.name,
+    type: FileType.TEXT,
+    size: null,
+    modified: timestampToZulu(detail.updated_at),
+    fingerprint: null,
+    revision: null,
+    extra,
+  })
+}
+
+// Mirrors the Python timestamp_to_zulu: epoch seconds render with second
+// precision and a literal Z, unlike tree.ts's timestampToIso (+millis).
+function timestampToZulu(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'number') {
+    return new Date(value * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z')
+  }
+  return String(value)
 }
 
 function statName(virtualKey: string, mountPrefix: string): string {

--- a/typescript/packages/core/src/core/dropbox/stat.ts
+++ b/typescript/packages/core/src/core/dropbox/stat.ts
@@ -21,21 +21,7 @@ import { getMetadata, type DropboxEntry } from './api.ts'
 import { dropboxPathOf } from './paths.ts'
 import { readdir as coreReaddir } from './readdir.ts'
 import { enoent } from '../../utils/errors.ts'
-
-function guessType(name: string): FileType {
-  const lower = name.toLowerCase()
-  if (lower.endsWith('.json')) return FileType.JSON
-  if (lower.endsWith('.csv')) return FileType.CSV
-  if (lower.endsWith('.png')) return FileType.IMAGE_PNG
-  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return FileType.IMAGE_JPEG
-  if (lower.endsWith('.gif')) return FileType.IMAGE_GIF
-  if (lower.endsWith('.zip')) return FileType.ZIP
-  if (lower.endsWith('.gz') || lower.endsWith('.gzip')) return FileType.GZIP
-  if (lower.endsWith('.pdf')) return FileType.PDF
-  if (lower.endsWith('.txt') || lower.endsWith('.md') || lower.endsWith('.log'))
-    return FileType.TEXT
-  return FileType.BINARY
-}
+import { guessType } from '../../utils/filetype.ts'
 
 function statFromEntry(entry: DropboxEntry): FileStat {
   const modified = entry.server_modified ?? entry.client_modified ?? ''

--- a/typescript/packages/core/src/core/gdrive/stat.ts
+++ b/typescript/packages/core/src/core/gdrive/stat.ts
@@ -19,28 +19,8 @@ import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { DIRECTORY_RESOURCE_TYPES, readdir as coreReaddir } from './readdir.ts'
 import { enoent } from '../../utils/errors.ts'
 import { FOLDER_MIME, MIME_TO_EXT, getFile } from '../google/drive.ts'
+import { guessType } from '../../utils/filetype.ts'
 import { resolveKey } from './resolve.ts'
-
-function guessType(name: string): FileType {
-  const lower = name.toLowerCase()
-  if (
-    lower.endsWith('.json') ||
-    lower.endsWith('.gdoc.json') ||
-    lower.endsWith('.gsheet.json') ||
-    lower.endsWith('.gslide.json')
-  )
-    return FileType.JSON
-  if (lower.endsWith('.csv')) return FileType.CSV
-  if (lower.endsWith('.png')) return FileType.IMAGE_PNG
-  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return FileType.IMAGE_JPEG
-  if (lower.endsWith('.gif')) return FileType.IMAGE_GIF
-  if (lower.endsWith('.zip')) return FileType.ZIP
-  if (lower.endsWith('.gz') || lower.endsWith('.gzip')) return FileType.GZIP
-  if (lower.endsWith('.pdf')) return FileType.PDF
-  if (lower.endsWith('.txt') || lower.endsWith('.md') || lower.endsWith('.log'))
-    return FileType.TEXT
-  return FileType.BINARY
-}
 
 const MIME_TO_RT: Readonly<Record<string, string>> = {
   'application/vnd.google-apps.document': 'gdrive/gdoc',

--- a/typescript/packages/core/src/core/gmail/stat.ts
+++ b/typescript/packages/core/src/core/gmail/stat.ts
@@ -19,22 +19,7 @@ import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { readdir as coreReaddir } from './readdir.ts'
 import { listLabels } from './labels.ts'
 import { enoent } from '../../utils/errors.ts'
-
-function guessType(name: string): FileType {
-  const lower = name.toLowerCase()
-  if (lower.endsWith('.json') || lower.endsWith('.gmail.json')) return FileType.JSON
-  if (lower.endsWith('.csv')) return FileType.CSV
-  if (lower.endsWith('.png')) return FileType.IMAGE_PNG
-  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return FileType.IMAGE_JPEG
-  if (lower.endsWith('.gif')) return FileType.IMAGE_GIF
-  if (lower.endsWith('.zip')) return FileType.ZIP
-  if (lower.endsWith('.gz') || lower.endsWith('.gzip')) return FileType.GZIP
-  if (lower.endsWith('.pdf')) return FileType.PDF
-  if (lower.endsWith('.txt') || lower.endsWith('.md') || lower.endsWith('.log')) {
-    return FileType.TEXT
-  }
-  return FileType.BINARY
-}
+import { guessType } from '../../utils/filetype.ts'
 
 export async function stat(
   accessor: GmailAccessor,

--- a/typescript/packages/core/src/core/lancedb/stat.ts
+++ b/typescript/packages/core/src/core/lancedb/stat.ts
@@ -15,6 +15,7 @@
 import type { LanceDBAccessor } from '../../accessor/lancedb.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
+import { imageTypeForExtension } from '../../utils/filetype.ts'
 import { rstripSlash } from '../../utils/slash.ts'
 import { read } from './read.ts'
 import { ScopeLevel, detectScope } from './scope.ts'
@@ -23,13 +24,6 @@ function notFound(p: string): Error {
   const err = new Error(p) as Error & { code?: string }
   err.code = 'ENOENT'
   return err
-}
-
-const IMAGE_TYPES: Record<string, FileType> = {
-  png: FileType.IMAGE_PNG,
-  jpg: FileType.IMAGE_JPEG,
-  jpeg: FileType.IMAGE_JPEG,
-  gif: FileType.IMAGE_GIF,
 }
 
 function nameOf(spec: PathSpec): string {
@@ -58,7 +52,7 @@ export async function stat(
     return new FileStat({ name: nameOf(spec), type: FileType.DIRECTORY })
   }
 
-  const fileType = scope.blob ? (IMAGE_TYPES[config.blobExt] ?? FileType.BINARY) : FileType.TEXT
+  const fileType = scope.blob ? imageTypeForExtension(config.blobExt) : FileType.TEXT
   // The row-dir readdir seeds exact card sizes; blob entries and a cold
   // index fall back to rendering the row, so the size is exact either way.
   if (index !== undefined) {

--- a/typescript/packages/core/src/core/qdrant/stat.ts
+++ b/typescript/packages/core/src/core/qdrant/stat.ts
@@ -16,16 +16,10 @@ import type { QdrantAccessor } from '../../accessor/qdrant.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
+import { imageTypeForExtension } from '../../utils/filetype.ts'
 import { rstripSlash } from '../../utils/slash.ts'
 import { read } from './read.ts'
 import { ScopeLevel, detectScope } from './scope.ts'
-
-const IMAGE_TYPES: Record<string, FileType> = {
-  png: FileType.IMAGE_PNG,
-  jpg: FileType.IMAGE_JPEG,
-  jpeg: FileType.IMAGE_JPEG,
-  gif: FileType.IMAGE_GIF,
-}
 
 function nameOf(spec: PathSpec): string {
   const stripped = rstripSlash(spec.virtual)
@@ -52,8 +46,7 @@ export async function stat(
     return new FileStat({ name: nameOf(spec), type: FileType.DIRECTORY })
   }
 
-  const fileType =
-    scope.kind === 'blob' ? (IMAGE_TYPES[config.blobExt] ?? FileType.BINARY) : FileType.TEXT
+  const fileType = scope.kind === 'blob' ? imageTypeForExtension(config.blobExt) : FileType.TEXT
   // The row-dir readdir seeds exact rendered sizes; a cold index falls back
   // to rendering the row, so the size is exact either way.
   if (index !== undefined) {

--- a/typescript/packages/core/src/resource/dev/dev.test.ts
+++ b/typescript/packages/core/src/resource/dev/dev.test.ts
@@ -37,6 +37,14 @@ function call(
   return registry.call(name, ResourceName.RAM, dev.accessor, PathSpec.fromStrPath(path), args)
 }
 
+async function makeWs(): Promise<Workspace> {
+  const parser = await getTestParser()
+  const ops = new OpsRegistry()
+  const data = new RAMResource()
+  ops.registerResource(data)
+  return new Workspace({ '/data': data }, { mode: MountMode.WRITE, ops, shellParser: parser })
+}
+
 describe('DevResource', () => {
   it('reports kind = ram (matching Python parity)', () => {
     expect(new DevResource().kind).toBe(ResourceName.RAM)
@@ -87,14 +95,6 @@ describe('DevResource', () => {
 })
 
 describe('dev file removal (GNU rm /dev/null semantics)', () => {
-  async function makeWs(): Promise<Workspace> {
-    const parser = await getTestParser()
-    const ops = new OpsRegistry()
-    const data = new RAMResource()
-    ops.registerResource(data)
-    return new Workspace({ '/data': data }, { mode: MountMode.WRITE, ops, shellParser: parser })
-  }
-
   it('rm /dev/null exits 0 and the path is gone', async () => {
     const ws = await makeWs()
     const rm = await ws.execute('rm /dev/null')

--- a/typescript/packages/core/src/resource/dev/dev.test.ts
+++ b/typescript/packages/core/src/resource/dev/dev.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from 'vitest'
 import { OpsRegistry } from '../../ops/registry.ts'
 import { MountMode, PathSpec, ResourceName } from '../../types.ts'
+import { getTestParser } from '../../workspace/fixtures/workspace_fixture.ts'
 import { Workspace } from '../../workspace/workspace.ts'
 import { RAMResource } from '../ram/ram.ts'
 import { DevResource } from './dev.ts'
@@ -82,6 +83,76 @@ describe('DevResource', () => {
     const { dev, registry } = setupOps()
     const entries = (await call(registry, 'readdir', dev, '/')) as string[]
     expect(entries.sort()).toEqual(['/null', '/zero'])
+  })
+})
+
+describe('dev file removal (GNU rm /dev/null semantics)', () => {
+  async function makeWs(): Promise<Workspace> {
+    const parser = await getTestParser()
+    const ops = new OpsRegistry()
+    const data = new RAMResource()
+    ops.registerResource(data)
+    return new Workspace({ '/data': data }, { mode: MountMode.WRITE, ops, shellParser: parser })
+  }
+
+  it('rm /dev/null exits 0 and the path is gone', async () => {
+    const ws = await makeWs()
+    const rm = await ws.execute('rm /dev/null')
+    expect(rm.exitCode).toBe(0)
+    expect(rm.stdoutText).toBe('')
+    expect(new TextDecoder().decode(rm.stderr)).toBe('')
+    const ls = await ws.execute('ls /dev')
+    expect(ls.stdoutText.split('\n')).toContain('zero')
+    expect(ls.stdoutText.split('\n')).not.toContain('null')
+    const cat = await ws.execute('cat /dev/null')
+    expect(cat.exitCode).not.toBe(0)
+    expect(new TextDecoder().decode(cat.stderr)).toMatch(/No such file or directory/)
+    await ws.close()
+  })
+
+  it('rm -v /dev/null prints a true removed claim', async () => {
+    const ws = await makeWs()
+    const rm = await ws.execute('rm -v /dev/null')
+    expect(rm.exitCode).toBe(0)
+    expect(rm.stdoutText).toBe("removed '/dev/null'\n")
+    const ls = await ws.execute('ls /dev')
+    expect(ls.stdoutText.split('\n')).not.toContain('null')
+    await ws.close()
+  })
+
+  it('rm -rf /dev/null removes the file too', async () => {
+    const ws = await makeWs()
+    const rm = await ws.execute('rm -rf /dev/null')
+    expect(rm.exitCode).toBe(0)
+    const ls = await ws.execute('ls /dev')
+    expect(ls.stdoutText.split('\n')).not.toContain('null')
+    await ws.close()
+  })
+
+  it('a redirect recreates a removed /dev/null as a regular file', async () => {
+    const ws = await makeWs()
+    await ws.execute('rm /dev/null')
+    const write = await ws.execute('echo recreated > /dev/null')
+    expect(write.exitCode).toBe(0)
+    const cat = await ws.execute('cat /dev/null')
+    expect(cat.stdoutText).toBe('recreated\n')
+    const test = await ws.execute('if [ -f /dev/null ]; then echo regular; fi')
+    expect(test.stdoutText).toBe('regular\n')
+    await ws.close()
+  })
+
+  it('rm /dev/zero is symmetric', async () => {
+    const ws = await makeWs()
+    const rm = await ws.execute('rm /dev/zero')
+    expect(rm.exitCode).toBe(0)
+    const ls = await ws.execute('ls /dev')
+    expect(ls.stdoutText.split('\n')).toContain('null')
+    expect(ls.stdoutText.split('\n')).not.toContain('zero')
+    const write = await ws.execute('echo z > /dev/zero')
+    expect(write.exitCode).toBe(0)
+    const cat = await ws.execute('cat /dev/zero')
+    expect(cat.stdoutText).toBe('z\n')
+    await ws.close()
   })
 })
 

--- a/typescript/packages/core/src/resource/dev/store.test.ts
+++ b/typescript/packages/core/src/resource/dev/store.test.ts
@@ -45,12 +45,54 @@ describe('DevFiles', () => {
     expect(f.get('/missing')).toBeUndefined()
   })
 
-  it('silently drops set/delete/clear', () => {
+  it('discards writes to an active synthetic device', () => {
     const f = new DevFiles()
     f.set('/null', new TextEncoder().encode('overwrite'))
     expect(f.get('/null')?.byteLength).toBe(0)
+    expect(f.get('/zero')?.byteLength).toBe(1 << 20)
+  })
+
+  it('delete tombstones a synthetic device', () => {
+    const f = new DevFiles()
+    expect(f.delete('/null')).toBe(true)
+    expect(f.has('/null')).toBe(false)
+    expect(f.get('/null')).toBeUndefined()
+    expect([...f.keys()]).toEqual(['/zero'])
+    expect(f.size).toBe(1)
     expect(f.delete('/null')).toBe(false)
+  })
+
+  it('set after delete stores real bytes (rm-then-redirect recreation)', () => {
+    const f = new DevFiles()
+    expect(f.delete('/null')).toBe(true)
+    f.set('/null', new TextEncoder().encode('recreated'))
     expect(f.has('/null')).toBe(true)
+    expect(new TextDecoder().decode(f.get('/null'))).toBe('recreated')
+    expect([...f.keys()]).toEqual(['/zero', '/null'])
+    expect(f.size).toBe(2)
+  })
+
+  it('delete of a recreated real file removes it again', () => {
+    const f = new DevFiles()
+    f.delete('/null')
+    f.set('/null', new TextEncoder().encode('recreated'))
+    expect(f.delete('/null')).toBe(true)
+    expect(f.has('/null')).toBe(false)
+    expect([...f.keys()]).toEqual(['/zero'])
+  })
+
+  it('stores non-device names for real', () => {
+    const f = new DevFiles()
+    f.set('/custom', new TextEncoder().encode('bytes'))
+    expect(f.has('/custom')).toBe(true)
+    expect(new TextDecoder().decode(f.get('/custom'))).toBe('bytes')
+    expect([...f.keys()]).toEqual(['/null', '/zero', '/custom'])
+    expect(f.delete('/custom')).toBe(true)
+    expect(f.has('/custom')).toBe(false)
+  })
+
+  it('clear stays a no-op', () => {
+    const f = new DevFiles()
     f.clear()
     expect(f.has('/null')).toBe(true)
     expect(f.has('/zero')).toBe(true)

--- a/typescript/packages/core/src/resource/dev/store.ts
+++ b/typescript/packages/core/src/resource/dev/store.ts
@@ -22,23 +22,52 @@ function strip(key: string): string {
   return stripSlash(key)
 }
 
+// Real backing store plus a synthetic /null, /zero overlay. The synthetic
+// device names read as empty/zeros and swallow writes until they are
+// deleted (GNU: `rm /dev/null` succeeds and the path is gone). A deleted
+// name is tombstoned; the next write stores real bytes, which is GNU's
+// rm-then-redirect recreation as a regular file.
 export class DevFiles extends Map<string, Uint8Array> {
+  private readonly tombstones = new Set<string>()
+
+  private syntheticActive(name: string): boolean {
+    return DEV_NAMES.has(name) && !this.tombstones.has(name) && !super.has('/' + name)
+  }
+
+  private syntheticBytes(name: string): Uint8Array {
+    return name === 'null' ? new Uint8Array(0) : new Uint8Array(ZERO_CHUNK_SIZE)
+  }
+
   override has(key: string): boolean {
-    return DEV_NAMES.has(strip(key))
+    return super.has(key) || this.syntheticActive(strip(key))
   }
 
   override get(key: string): Uint8Array | undefined {
+    if (super.has(key)) return super.get(key)
     const name = strip(key)
-    if (name === 'null') return new Uint8Array(0)
-    if (name === 'zero') return new Uint8Array(ZERO_CHUNK_SIZE)
+    if (this.syntheticActive(name)) return this.syntheticBytes(name)
     return undefined
   }
 
-  override set(_key: string, _value: Uint8Array): this {
+  override set(key: string, value: Uint8Array): this {
+    const name = strip(key)
+    if (this.syntheticActive(name)) return this
+    super.set(key, value)
+    this.tombstones.delete(name)
     return this
   }
 
-  override delete(_key: string): boolean {
+  override delete(key: string): boolean {
+    const name = strip(key)
+    if (super.has(key)) {
+      super.delete(key)
+      if (DEV_NAMES.has(name)) this.tombstones.add(name)
+      return true
+    }
+    if (this.syntheticActive(name)) {
+      this.tombstones.add(name)
+      return true
+    }
     return false
   }
 
@@ -47,22 +76,26 @@ export class DevFiles extends Map<string, Uint8Array> {
   }
 
   override get size(): number {
-    return DEV_NAMES.size
+    let synthetic = 0
+    for (const name of ['null', 'zero']) {
+      if (this.syntheticActive(name)) synthetic += 1
+    }
+    return synthetic + super.size
   }
 
   override *keys(): MapIterator<string> {
-    yield '/null'
-    yield '/zero'
+    for (const [k] of this.entries()) yield k
   }
 
   override *values(): MapIterator<Uint8Array> {
-    yield new Uint8Array(0)
-    yield new Uint8Array(ZERO_CHUNK_SIZE)
+    for (const [, v] of this.entries()) yield v
   }
 
   override *entries(): MapIterator<[string, Uint8Array]> {
-    yield ['/null', new Uint8Array(0)]
-    yield ['/zero', new Uint8Array(ZERO_CHUNK_SIZE)]
+    for (const name of ['null', 'zero']) {
+      if (this.syntheticActive(name)) yield ['/' + name, this.syntheticBytes(name)]
+    }
+    yield* super.entries()
   }
 
   override [Symbol.iterator](): MapIterator<[string, Uint8Array]> {

--- a/typescript/packages/core/src/utils/errors.ts
+++ b/typescript/packages/core/src/utils/errors.ts
@@ -223,6 +223,16 @@ export function isFsError(err: unknown): boolean {
   return typeof code === 'string' && gnuStrerror(code) !== null
 }
 
+// The per-entry swallow set for walk-and-warn commands (ls, tree, rg):
+// every stamped filesystem code plus the unstamped no-mount refusal.
+// Mirrors Python's `except (OSError, ValueError)`, where ValueError is
+// the no-mount spelling. Anything else — auth failures, transport
+// errors, backend bugs — must propagate instead of vanishing from a
+// listing or being laundered into a GNU-shaped 'cannot access' line.
+export function isWalkError(err: unknown): boolean {
+  return isFsError(err) || (err as { noMount?: unknown }).noMount === true
+}
+
 // Re-spell a reported path the way its operand was typed. Backends name paths
 // in virtual space, but GNU quotes the operand as the user wrote it:
 // `cd /data && mkdir -p f.txt/sub` reports 'f.txt', not '/data/f.txt'. The path

--- a/typescript/packages/core/src/utils/filetype.test.ts
+++ b/typescript/packages/core/src/utils/filetype.test.ts
@@ -56,10 +56,7 @@ describe('shared parity fixture', () => {
   // integ/fixtures/filetype/tables.json is the contract: the python suite
   // (tests/utils/test_filetype.py) asserts the same tables, so an edit on
   // one side fails the other until the fixture moves with it.
-  const tables = JSON.parse(readFileSync(FIXTURE, 'utf8')) as Record<
-    string,
-    Record<string, string>
-  >
+  const tables = JSON.parse(readFileSync(FIXTURE, 'utf8')) as Record<string, Record<string, string>>
 
   it('pins the extension table', () => {
     expect({ ...EXTENSION_MAP }).toEqual(tables.extension_map)

--- a/typescript/packages/core/src/utils/filetype.test.ts
+++ b/typescript/packages/core/src/utils/filetype.test.ts
@@ -12,10 +12,25 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, it } from 'vitest'
 
 import { FileType } from '../types.ts'
-import { guessType, mimeTypeFor } from './filetype.ts'
+import {
+  EXTENSION_MAP,
+  IMAGE_TYPE_BY_EXTENSION,
+  MIMETYPE_MAP,
+  MIME_BY_EXTENSION,
+  guessType,
+  imageTypeForExtension,
+  mimeTypeFor,
+} from './filetype.ts'
+
+const FIXTURE = fileURLToPath(
+  new URL('../../../../../integ/fixtures/filetype/tables.json', import.meta.url),
+)
 
 describe('guessType', () => {
   it('maps extensions to their own types (jpg is JPEG, not PNG)', () => {
@@ -23,7 +38,40 @@ describe('guessType', () => {
     expect(guessType('photo.jpeg')).toBe(FileType.IMAGE_JPEG)
     expect(guessType('image.png')).toBe(FileType.IMAGE_PNG)
     expect(guessType('data.jsonl')).toBe(FileType.JSON)
+    expect(guessType('build.log')).toBe(FileType.TEXT)
+    expect(guessType('dump.gzip')).toBe(FileType.GZIP)
     expect(guessType('unknown.blob')).toBe(FileType.BINARY)
+  })
+})
+
+describe('imageTypeForExtension', () => {
+  it('types bare image extensions and defaults to BINARY', () => {
+    expect(imageTypeForExtension('png')).toBe(FileType.IMAGE_PNG)
+    expect(imageTypeForExtension('JPG')).toBe(FileType.IMAGE_JPEG)
+    expect(imageTypeForExtension('txt')).toBe(FileType.BINARY)
+  })
+})
+
+describe('shared parity fixture', () => {
+  // integ/fixtures/filetype/tables.json is the contract: the python suite
+  // (tests/utils/test_filetype.py) asserts the same tables, so an edit on
+  // one side fails the other until the fixture moves with it.
+  const tables = JSON.parse(readFileSync(FIXTURE, 'utf8')) as Record<
+    string,
+    Record<string, string>
+  >
+
+  it('pins the extension table', () => {
+    expect({ ...EXTENSION_MAP }).toEqual(tables.extension_map)
+  })
+
+  it('pins the mime tables', () => {
+    expect({ ...MIME_BY_EXTENSION }).toEqual(tables.mime_by_extension)
+    expect({ ...MIMETYPE_MAP }).toEqual(tables.mimetype_map)
+  })
+
+  it('pins the image extension table', () => {
+    expect({ ...IMAGE_TYPE_BY_EXTENSION }).toEqual(tables.image_type_by_extension)
   })
 })
 

--- a/typescript/packages/core/src/utils/filetype.ts
+++ b/typescript/packages/core/src/utils/filetype.ts
@@ -14,13 +14,14 @@
 
 import { FileType } from '../types.ts'
 
-const EXTENSION_MAP: Readonly<Record<string, FileType>> = Object.freeze({
+export const EXTENSION_MAP: Readonly<Record<string, FileType>> = Object.freeze({
   json: FileType.JSON,
   jsonl: FileType.JSON,
   csv: FileType.CSV,
   tsv: FileType.CSV,
   txt: FileType.TEXT,
   md: FileType.TEXT,
+  log: FileType.TEXT,
   py: FileType.TEXT,
   js: FileType.TEXT,
   ts: FileType.TEXT,
@@ -33,6 +34,7 @@ const EXTENSION_MAP: Readonly<Record<string, FileType>> = Object.freeze({
   gif: FileType.IMAGE_GIF,
   zip: FileType.ZIP,
   gz: FileType.GZIP,
+  gzip: FileType.GZIP,
   pdf: FileType.PDF,
 })
 
@@ -48,7 +50,7 @@ export function guessType(path: string): FileType {
 // TypeScript implementations must guess identically for serialized
 // bytes to match. Anything else is application/octet-stream, which
 // every client treats as "download me".
-const MIME_BY_EXTENSION: Readonly<Record<string, string>> = Object.freeze({
+export const MIME_BY_EXTENSION: Readonly<Record<string, string>> = Object.freeze({
   csv: 'text/csv',
   gif: 'image/gif',
   gz: 'application/gzip',
@@ -76,7 +78,7 @@ export function mimeTypeFor(filename: string): string {
   return MIME_BY_EXTENSION[filename.slice(dot + 1).toLowerCase()] ?? OCTET_STREAM
 }
 
-const MIMETYPE_MAP: Readonly<Record<string, FileType>> = Object.freeze({
+export const MIMETYPE_MAP: Readonly<Record<string, FileType>> = Object.freeze({
   'application/pdf': FileType.PDF,
   'application/zip': FileType.ZIP,
   'application/gzip': FileType.GZIP,
@@ -95,4 +97,16 @@ export function filetypeFromMimetype(mime: string): FileType {
   if (mapped !== undefined) return mapped
   if (mime.startsWith('text/')) return FileType.TEXT
   return FileType.BINARY
+}
+
+export const IMAGE_TYPE_BY_EXTENSION: Readonly<Record<string, FileType>> = Object.freeze({
+  png: FileType.IMAGE_PNG,
+  jpg: FileType.IMAGE_JPEG,
+  jpeg: FileType.IMAGE_JPEG,
+  gif: FileType.IMAGE_GIF,
+})
+
+/** FileType for a bare image extension ('png'), BINARY for anything else. */
+export function imageTypeForExtension(ext: string): FileType {
+  return IMAGE_TYPE_BY_EXTENSION[ext.toLowerCase()] ?? FileType.BINARY
 }

--- a/typescript/packages/node/src/core/email/stat.ts
+++ b/typescript/packages/node/src/core/email/stat.ts
@@ -18,28 +18,13 @@ import {
   FileType,
   PathSpec,
   enoent,
+  guessType,
   mountKey,
   mountPrefixOf,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../accessor/email.ts'
 import { listFolders } from './folders.ts'
 import { readdir } from './readdir.ts'
-
-function guessType(name: string): FileType {
-  const lower = name.toLowerCase()
-  if (lower.endsWith('.json') || lower.endsWith('.email.json')) return FileType.JSON
-  if (lower.endsWith('.csv')) return FileType.CSV
-  if (lower.endsWith('.png')) return FileType.IMAGE_PNG
-  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return FileType.IMAGE_JPEG
-  if (lower.endsWith('.gif')) return FileType.IMAGE_GIF
-  if (lower.endsWith('.zip')) return FileType.ZIP
-  if (lower.endsWith('.gz') || lower.endsWith('.gzip')) return FileType.GZIP
-  if (lower.endsWith('.pdf')) return FileType.PDF
-  if (lower.endsWith('.txt') || lower.endsWith('.md') || lower.endsWith('.log')) {
-    return FileType.TEXT
-  }
-  return FileType.BINARY
-}
 
 export async function stat(
   accessor: EmailAccessor,


### PR DESCRIPTION
# fix(parity): close out Block A — find multi-root walk, honest error classes, one filetype table, dify stat depth, /dev/null removal (#609)

Finishes the Block A items (5–8) of the parity cleanup that #706 started. Four independent fixes, one commit each.

## 1. `find` walks every start point (T1-A)

Python's generic `find` read `paths[0]` and silently dropped the remaining operands on all 12 backends that wire a native find op (disk, ram, redis, s3, ssh, gdrive, gridfs, hf, nextcloud, notion, onedrive, sharepoint) and the four bespoke wrappers (github, chroma, dify, history). `find /a /b -name '*.txt'` returned only `/a`'s matches; a missing root discarded every other root's rows along with the diagnostic.

`generic_find` now owns the per-operand loop (the same structure as TS `findGeneric`), so both builder branches and all wrappers inherit it. GNU semantics pinned on findutils 4.10.0 (debian:stable-slim):

- operands walk **in order**, duplicates walk twice, no dedupe;
- a missing operand names itself (`find: 'X': No such file or directory`), the rest still walk, partial stdout survives, exit 1;
- the per-root `-path` tree is stamped into a local, so the shared `FindArgs` stays unprefixed.

TypeScript already looped but re-sorted **across** roots at the end, interleaving operands against GNU order — the cross-root sort is gone (per-root sort stays).

New `integ/unix/find/roots.json` (4 cases, 22/18 targets, both hosts): operand order (self-provisioned subtree — shared directories accumulate per-target state), duplicate roots, missing middle operand with partial output.

## 2. Honest error classes in the read/walk family (T1-G)

TS `ls` (7 sites), `tree`, `rg`, `checksum -c`, and `awk -f` caught **every** error class where Python narrows to `(OSError, ValueError)` / `FileNotFoundError` — an S3 403 or rate-limit vanished from listings or was laundered into a GNU-shaped `cannot access` line. New `isWalkError` (= `isFsError` + the `noMount` stamp, the TS twin of Python's `(OSError, ValueError)`) narrows all of them; anything unstamped propagates. Python tightened the other way: `grep`/`rg` per-entry warnings catch `WALK_ERRORS` instead of `Exception`, existence probes in `builders/common` catch `MISS_ERRORS`. (The discord/slack push-down fallbacks keep their broad catch — that's a designed degrade path with explicit 403 handling.)

`checksum -c` was also structurally dishonest in both languages and is now GNU-complete (coreutils 9.7 pins, all wordings docker-verified):

- **py crash fixed:** a relative recorded name reached backend readers as a bare `str` and died on `.virtual` — recorded names now resolve against the **cwd** (like GNU) into real PathSpecs, both languages (`awk -f` gets the same cwd fix in TS);
- stderr now carries GNU's per-file strerror lines (kept under `--status`), the prefixed `WARNING:` block in GNU's order, `--warn` per-line diagnostics, and the `no properly formatted checksum lines found` / `no file was verified` fatals with their exit 1;
- two tier2 integ pins move to the GNU behavior (`no file was verified` exit 1; warn/strict on an all-malformed file);
- codex round (docker-pinned): `no properly formatted checksum lines found` keys on the parsed-line count and still prints under `--status`; `no file was verified` fires whenever `--ignore-missing` leaves zero OK lines (mismatches included), follows the WARNING block, and `--status` silences its text while the exit 1 stands.

## 3. One filetype table (T1-H)

Five private TS `guessType` if-chains (box/gdrive/dropbox/gmail/email) drifted from the shared table Python already uses — 8 typed extensions (`jsonl tsv py js ts yaml yml toml`) read as BINARY, so the same file statted differently per language. Python gmail/email guessed through stdlib `mimetypes`, whose platform tables are non-deterministic (`.ts` → `video/mp2t`, `.gz` → unknown). All seven sites now use the shared table; `log`→TEXT and `gzip`→GZIP (the private copies' two extra keys) join it on both sides; the qdrant/lancedb image maps fold into a shared `image_type_for_extension`; `FILE_MIME_MAP` drops four keys unreachable since #651.

`integ/fixtures/filetype/tables.json` pins every table and both unit suites assert equality against it, so one side can no longer drift alone (the himalaya `mime_parity.json` pattern).

## 4. T1-O leftovers: dify stat depth + `/dev/null` removal

- **dify:** TS had ported only `stat_light` — no detail fetch, so `document_id`, refreshed `tokens`/`indexing_status`, detail-derived `source_size`, and the `updated_at` mtime were missing vs Python. TS now mirrors Python's two-stat design, including the cost containment: a new `opsOverrides` on the generic-command factory (the TS twin of Python's `ops_overrides`) pins `ls` to the light stat, and `find` upgrades to the heavy stat only under `-mtime`. `df_prov_ls`'s `net=0` pin stays green.
- **`/dev/null`:** `rm /dev/null` raised an uncaught `KeyError('/null')` in Python and silently no-opped in TS while `rm -v` printed a false `removed` claim. Both stores are now a synthetic overlay (null/zero) with tombstones over a real backing map — pinned root-on-Linux semantics: `rm /dev/null` succeeds and the path is genuinely gone, a later redirect recreates it as a regular file, writes to a live `/dev/null` still vanish.

## Verification

- GNU pins: findutils 4.10.0 + coreutils 9.7 on debian:stable-slim (multi-root order/dup/missing, the full `-c` stderr surface, `rm /dev/null`).
- Unit: vitest green across packages (core 6867, node 2093, browser 182; the agents `pi/extension` suite fails only on local node 22.8's undici import — CI runs 22-latest/24); pytest green except env-only exclusions on this machine (fuse: no macFUSE; the redis tests need `REDIS_URL` and pass against a throwaway redis — their skip-guard was a no-op `pytestmark` in a conftest and is fixed here: they now skip cleanly without `REDIS_URL`).
- Integ: full `--target ram --target disk` green on both hosts (4547 cases each, incl. the new roots.json and the re-pinned tier2), dify target 71/71 on both hosts (incl. the new `df_stat_mtime`).
- `pnpm -r typecheck` clean, pre-commit all hooks pass, both spec trees regenerate to zero drift, cross-language spec parity 93/93.

Part of #609 (Block A of the parity plan; #706 shipped items 1/2/4, this closes 5–8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
