### PR TITLE
fix(archive): tar and zip archive a directory, and -C re-bases the operands after it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,63 @@ agent discovers state, the CLI is how it acts.
   `file` would promise `type -p` a path that does not exist). `which` prints the
   bare name, never a fabricated path.
 
+## Mount boundaries
+
+A mount root is not an ordinary directory, and a mount nested inside
+another mount's tree is invisible to the backend that owns the parent:
+the child's keys live in a different resource, so the parent's `readdir`
+never lists it. Two mechanisms follow from that, and they are separate.
+
+- **`MountView` is how a command sees the boundaries** (`ops/types.py`,
+  `ops/types.ts`), and it is offered the way `LinkView` is: a command
+  opts in by naming a `mounts` parameter, `execute_cmd`/`executeCmd`
+  delivers it only to handlers that do, and there is no list of
+  boundary-aware commands anywhere. It carries `descendants` (mount
+  roots strictly under a path), `is_root`, and `root_of`.
+  A traversal command that renders **lines** does not need it: the
+  executor's fan-out (`workspace/executor/fanout.py`) already reruns
+  find/du/tree/grep -r per mount and concatenates the output. A command
+  whose output is one **binary object** cannot be merged that way, which
+  is why `tar` reads the boundaries itself.
+- **Crossing into a descendant mount is refused, not attempted.** `tar`
+  and `zip` both keep the mountpoint as a directory entry and drop its
+  contents with GNU's own `--one-file-system` wording (`<name>/: file is on a different filesystem; not dumped`; Info-ZIP has no message of
+  its own for this, so zip borrows the wording under its own
+  `zip warning:` prefix). This is deliberate: descending would archive
+  by accident exactly what the mount-root refusal below forbids on
+  purpose.
+- **`MountRootPolicy` refuses a mount root in a source slot** for `tar`,
+  `zip` and `cp`, on top of the POSIX EBUSY rules it already enforces
+  for `rm`/`rmdir`/`mv`/`mkdir`/`touch`/`ln`. Real tar and cp allow it;
+  mirage does not, because the mount table is the deployment's
+  configuration and reading a whole backend into one object is neither
+  what the operand looks like it costs nor something an agent should be
+  able to do to data it was given a view of. Only **positional** operands
+  are tested, which is why `CommandContext` carries `operands` beside
+  `paths`: `tar -xf a.tar -C /mnt` extracts INTO a mount and must stay
+  legal, while `tar -cf a.tar /mnt` must not. `positional_scopes` /
+  `positionalScopes` (`executor/command/routing`) is what tells the two
+  apart, since classification turns every path-shaped word into a
+  PathSpec whether it filled an operand slot or a flag's value.
+
+## An option that chdirs: `operand_base`
+
+`tar -C` is not a flag the command reads once, it is a chdir for the path
+operands typed **after** it, and it is cumulative (`-C d1 x -C ../d2 y`
+reads `d1/x` and `d1/../d2/y`). That is a property of the line, so it is
+declared in the spec (`CommandSpec.operand_base` / `operandBase`, tar's
+only) and resolved by the one component that walks the line
+positionally: `parse_command` / `parseCommand` tracks the base as it
+scans and reports it per word as `word_bases` / `wordBases`, which
+`classify_parts` then resolves each operand against. Doing it anywhere
+later is too late: the classifier has already produced absolute
+PathSpecs, and an operand resolved against the wrong base makes the
+router see a phantom cross-mount span (which is what
+`tar -czf /work/out.tgz -C /work/check my_paper` used to fail as).
+Only path operands and the option's own value move; every other
+path-valued flag keeps resolving against the session cwd, which is what
+GNU does with `-f`.
+
 ## Symlinks
 
 Symlinks are **namespace state, not backend state**. The `Namespace` node table
@@ -301,6 +358,64 @@ Invoke the venv's `pre-commit` binary directly (not via `uv --directory python r
   were reported as directories, so `find -type f` missed them). Do not
   reintroduce name-based classification in a backend; if stat misclassifies an
   entry, fix that backend's stat.
+- **An archiver walks a directory operand; it does not read it.** `tar`
+  and `zip` decide every member first (`plan_create` / `planCreate` in
+  `generic/tar/create.*`, `plan_zip` / `planZip` in
+  `generic/zip_cmd.*`) and only then write, which is what lets an
+  exclusion prune a whole subtree and keeps the ordering stable. Both
+  plans are built on **one traversal**, `scan_operand` / `scanOperand`
+  (`generic/archive/walk.*`), which merges three sources no single one
+  can see: the backend walk (reusing find's `walk_find` / `walkFind`, so
+  an archiver classifies an entry through `stat` exactly as find does,
+  never by name), the namespace's symlinks, and the mount table. It
+  reports paths, never names, because naming is exactly where the two
+  formats disagree; the two things they disagree about in the traversal
+  itself are parameters (`dereference`, `recurse`), so **a third
+  archiver adds a caller, not a second walk**. Members are named from
+  `PathSpec.raw_path`, so `tar -C d x` stores `x`, not `d/x`.
+  **A directory is its own member**, with GNU's trailing slash and no
+  content, which is the only record an empty directory leaves and the
+  reason extraction has to `mkdir` for one. **A symlink is a symlink
+  member** (`SYMTYPE`, target in `linkname`), never a file of its
+  target's bytes, unless `-h` says to follow it.
+  Two deliberate divergences from GNU, both documented in place:
+  siblings are sorted rather than emitted in readdir order (the same
+  choice `du` makes, for the same reason), and a descendant mount is
+  never crossed (see "Mount boundaries"). Everything else is pinned
+  against GNU tar 1.35 on `debian:stable-slim`: the leading-slash
+  warning, `Cowardly refusing to create an empty archive` (exit 2), a
+  per-operand `Cannot stat` plus one trailer (exit 2, and the other
+  operands still archive), a `-C` it cannot enter (exit 2, no archive
+  written), and `archive cannot contain itself; not dumped` (exit 0).
+  A backend error must never reach the user as itself: an unreadable
+  operand is reported in virtual path space with tar's wording, because
+  the raw `IsADirectoryError` leaked the host path behind a disk mount.
+- **`zip` is Info-ZIP, which inverts tar's two defaults.** A directory
+  operand contributes only its own entry unless `-r` says to descend,
+  and a symlink is *followed* unless `-y` says to store the link, where
+  tar always descends and always stores unless `-h`. Both are just the
+  `recurse` / `dereference` arguments to the shared scan. The rest is
+  pinned against Info-ZIP 3.0 on `debian:stable-slim`: a leading slash
+  is stripped **in silence** (tar warns, zip does not), `-j` junks to
+  the basename and drops directory entries entirely, `-x` is
+  **anchored** on the whole stored name (`d/sub/*` matches, `sub/*` does
+  not) where tar's `--exclude` is unanchored, an unreachable operand is
+  `\tzip warning: name not matched: <name>` and does not stop the run,
+  and a run that matched nothing prints `zip error: Nothing to do!`,
+  exits **12**, and writes no archive. `-q` silences the warnings but
+  never that error. Two deliberate divergences: `-x` takes one pattern
+  per occurrence (mirage's spec has no variadic option value, and
+  `-x a -x b` says the same thing), and the `adding:` line carries no
+  `(deflated N%)` suffix, since the ratio depends on the compressor and
+  would differ between the two languages.
+- **The TypeScript `walkFind` answers in mount-relative keys; the Python
+  `walk_find` answers in virtual paths.** TS's stands in for a backend's
+  native find op, so a caller that needs virtual paths (tar does, to
+  name members and compare against mount prefixes) lifts them with
+  `mountPrefixOf` the way `findGeneric` does. That lift lives once, in
+  `generic_bind/archive_io.*`, which is where both archivers get their
+  walk. This asymmetry is real and has bitten once: a unit test on an
+  unprefixed mount cannot see it, so cover a prefixed mount too.
 - **`du` has one backend contract: `size` and `entries`.** Each backend exposes `core/<backend>/du/size.py` (recursive byte total for one path) and `core/<backend>/du/entries.py` (per-file breakdown), wired as `du_size` / `du_entries` on the adapter. `entries` returns `(entries, total)` where entries are **leaf files only, in mount-relative path space, with no summary row**; the generic lifts them onto virtual paths (`to_virtual`, via `mount_prefix_of`) and re-spells them as the operand was typed (`respell_raw`). A backend that returns backend-key paths, or appends its own roll-up row, makes two mounts holding the same filename render identical lines. Do not reintroduce a second shape; the old flat-list `du_multi` contract is gone.
 - **`du` prints a line per directory, derived not walked.** GNU prints one line per directory with its recursive total, post-order (children before parents), plus one per file under `-a`. Backends only ever report leaf files, so the generic derives the directory rows by summing each leaf into every ancestor (`rollup`, same name both languages), then emits post-order with siblings sorted. Two deliberate divergences: GNU orders siblings by `readdir` (filesystem-dependent), mirage sorts them; and an empty directory is invisible to mirage because no leaf points at it. Sizes are bytes, not GNU's 1 KiB blocks, since an object store has no block size. `--max-depth` prunes only what is printed, never the walk, because every printed total still covers the whole subtree. Verify changes with the differential harness against `debian:stable-slim`: paths, exit codes and stderr must match GNU exactly.
 - **`du` usage errors exit 1, not 2.** `du` is absent from `USAGE_EXIT`, which is correct: GNU du exits 1 for `-s` with `-a` ("cannot both summarize and show all entries"), `-s` with `--max-depth` ("warning: summarizing conflicts with --max-depth=N"), and a bad depth ("invalid maximum depth 'x'"). All three are raised by `parse_flags` / `parseDuFlags` *before* any I/O, mirroring GNU's option-parse order: the depth is parsed as the option is read, so a bad depth wins over the conflict checks. An unreadable operand is not a usage error: GNU names it (`du: cannot access 'x': No such file or directory`), prints every other operand, and exits 1, and still prints `0 total` under `-c` when every operand failed. With no operand at all, du measures the working directory; it never says "missing operand".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ never lists it. Two mechanisms follow from that, and they are separate.
   `zip warning:` prefix). This is deliberate: descending would archive
   by accident exactly what the mount-root refusal below forbids on
   purpose.
-- **`MountRootPolicy` refuses a mount root in a source slot** for `tar`,
+- **`MountRootPolicy` refuses a mount root in a source slot** for `tar -c`,
   `zip` and `cp`, on top of the POSIX EBUSY rules it already enforces
   for `rm`/`rmdir`/`mv`/`mkdir`/`touch`/`ln`. Real tar and cp allow it;
   mirage does not, because the mount table is the deployment's
@@ -134,7 +134,12 @@ never lists it. Two mechanisms follow from that, and they are separate.
   legal, while `tar -cf a.tar /mnt` must not. `positional_scopes` /
   `positionalScopes` (`executor/command/routing`) is what tells the two
   apart, since classification turns every path-shaped word into a
-  PathSpec whether it filled an operand slot or a flag's value.
+  PathSpec whether it filled an operand slot or a flag's value. Mode
+  matters too: only `tar -c` reads its operands from the filesystem, so
+  `is_create_mode` / `isCreateMode` gates the refusal. Under `-t` and
+  `-x` an operand is a member selector matched inside the archive, and
+  refusing one that happens to spell a mount root would deny an
+  ordinary listing.
 
 ## An option that chdirs: `operand_base`
 
@@ -205,8 +210,15 @@ they bite:
 Follow policy is two symmetric tables in `workspace/route/constants.py`, both
 read off the raw command line (operand rewriting happens before flag parsing):
 `NO_FOLLOW_COMMANDS` lists commands that lstat (`rm`, `mv`, `ln`, `readlink`,
-`rmdir`, `unlink`, `stat`, `file`, `du`, `find`), with `DEREFERENCE_FLAGS`
-naming the flag that turns following back on (`-L`). `find` states its policy as
+`rmdir`, `unlink`, `stat`, `file`, `du`, `find`, `tar`, `zip`), with
+`DEREFERENCE_FLAGS` naming the flag that turns following back on (`-L`).
+`tar` and `zip` are in that list for a different reason and deliberately carry
+no `DEREFERENCE_FLAGS` entry: they dereference too, but their planner has to be
+the one doing it. Rewriting the operand in the router hands the planner a
+target it can no longer tell was reached through a link, so `tar` stored a
+regular file where GNU stores a symlink member, and neither archiver could
+apply its own cross-mount refusal or ELOOP wording. `tar -h` and `zip -y` are
+read by `scan_operand` instead. `find` states its policy as
 a leading `-P`/`-H`/`-L` option instead, last one wins, so it lives in
 `LAST_WINS_LINK_OPTIONS`;
 `NO_FOLLOW_FLAGS` is the mirror, for a following command that a flag makes lstat
@@ -378,6 +390,15 @@ Invoke the venv's `pre-commit` binary directly (not via `uv --directory python r
   reason extraction has to `mkdir` for one. **A symlink is a symlink
   member** (`SYMTYPE`, target in `linkname`), never a file of its
   target's bytes, unless `-h` says to follow it.
+  **Two links to one target are not a loop**, and both are archived; the
+  only loop is one `resolve` refuses to resolve, since the namespace
+  already walks the chain under a hop limit and raises `CycleError` at
+  the end of it. That arrives as a fatal `Problem` carrying GNU's
+  `Too many levels of symbolic links`, reported per member with the
+  directory entry kept, rather than as an exception that aborts the
+  plan. **Every `-C` is checked, not just the last**: GNU chdirs at each
+  one and fails at the first it cannot enter, so the option accumulates
+  (`multiple=True`) and the planner walks the list.
   Two deliberate divergences from GNU, both documented in place:
   siblings are sorted rather than emitted in readdir order (the same
   choice `du` makes, for the same reason), and a descendant mount is

--- a/integ/unix/arch/tar.json
+++ b/integ/unix/arch/tar.json
@@ -434,6 +434,108 @@
       "flags": [
         "r"
       ]
+    },
+    {
+      "id": "arch_tar_stores_a_symlink_operand_as_a_link",
+      "seq": 910085,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/sl && echo alpha > /data/sl/a.txt && ln -s /data/sl/a.txt /data/sl/l && tar -cf /data/sl.tar -C /data/sl l && tar -xf /data/sl.tar -C /data/sl/out 2>/dev/null; readlink /data/sl/l",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/sl/a.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c",
+        "C"
+      ]
+    },
+    {
+      "id": "arch_tar_two_links_to_one_target_are_not_a_loop",
+      "seq": 910086,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tl && echo beta > /data/tl/b.txt && ln -s /data/tl/b.txt /data/tl/one && ln -s /data/tl/b.txt /data/tl/two && tar -chf /data/tl.tar -C /data/tl . 2>/dev/null; tar -chf /data/tl2.tar -C /data tl && tar -tf /data/tl2.tar",
+      "expect": {
+        "exit": 0,
+        "stdout": "tl/\ntl/b.txt\ntl/one\ntl/two\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c",
+        "h",
+        "C"
+      ]
+    },
+    {
+      "id": "arch_tar_reports_a_symlink_cycle_per_member",
+      "seq": 910087,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/cy && ln -s /data/cy/b /data/cy/a && ln -s /data/cy/a /data/cy/b && tar -chf /data/cy.tar -C /data cy; echo exit=$?; tar -tf /data/cy.tar",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=2\ncy/\n",
+        "stderr": "tar: cy/a: Cannot stat: Too many levels of symbolic links\ntar: cy/b: Cannot stat: Too many levels of symbolic links\ntar: Exiting with failure status due to previous errors\n"
+      },
+      "flags": [
+        "c",
+        "h",
+        "C"
+      ]
+    },
+    {
+      "id": "arch_tar_fails_at_the_first_unenterable_c",
+      "seq": 910088,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/cgood && echo y > /data/cgood/y.txt && tar -cf /data/cc.tar -C /data/cmissing x -C /data/cgood y.txt; echo exit=$?; ls /data/cc.tar",
+      "expect": {
+        "exit": 2,
+        "stdout": "exit=2\n",
+        "stderr": "tar: /data/cmissing: Cannot open: No such file or directory\ntar: Error is not recoverable: exiting now\nls: cannot access '/data/cc.tar': No such file or directory\n"
+      },
+      "flags": [
+        "c",
+        "C"
+      ]
+    },
+    {
+      "id": "arch_tar_listing_is_not_a_mount_root_source",
+      "seq": 910089,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/ml && echo m > /data/ml/m.txt && tar -cf /data/ml.tar -C /data ml && tar -tf /data/ml.tar data; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "ml/\nml/m.txt\nexit=0\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c",
+        "C"
+      ]
     }
   ]
 }

--- a/integ/unix/arch/tar.json
+++ b/integ/unix/arch/tar.json
@@ -31,7 +31,7 @@
       "expect": {
         "exit": 0,
         "stdout": "data/arch/g.txt\n",
-        "stderr": ""
+        "stderr": "tar: Removing leading `/' from member names\n"
       }
     },
     {
@@ -133,7 +133,7 @@
       "expect": {
         "exit": 0,
         "stdout": "data/arch/g.txt\n",
-        "stderr": ""
+        "stderr": "tar: Removing leading `/' from member names\n"
       }
     },
     {
@@ -149,7 +149,7 @@
       "expect": {
         "exit": 0,
         "stdout": "data/otar/g.txt\notar-data\n",
-        "stderr": ""
+        "stderr": "tar: Removing leading `/' from member names\n"
       }
     },
     {
@@ -165,7 +165,7 @@
       "expect": {
         "exit": 0,
         "stdout": "data/otar2/h.txt\n",
-        "stderr": ""
+        "stderr": "tar: Removing leading `/' from member names\n"
       }
     },
     {
@@ -181,7 +181,7 @@
       "expect": {
         "exit": 0,
         "stdout": "three\n",
-        "stderr": ""
+        "stderr": "tar: Removing leading `/' from member names\n"
       }
     },
     {
@@ -197,7 +197,7 @@
       "expect": {
         "exit": 0,
         "stdout": "data/otar4/j.txt\n",
-        "stderr": ""
+        "stderr": "tar: Removing leading `/' from member names\n"
       }
     },
     {
@@ -231,6 +231,209 @@
         "stdout": "",
         "stderr": "tar: invalid option -- 'Q'\nTry 'tar --help' for more information."
       }
+    },
+    {
+      "id": "arch_tar_create_directory",
+      "seq": 910063,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tdir/sub && echo aa | tee /data/tdir/a.txt > /dev/null && echo bb | tee /data/tdir/sub/b.txt > /dev/null && tar -c -v -f /data/tdir.tar -C /data tdir && tar -t -f /data/tdir.tar",
+      "expect": {
+        "exit": 0,
+        "stdout": "tdir/\ntdir/a.txt\ntdir/sub/\ntdir/sub/b.txt\ntdir/\ntdir/a.txt\ntdir/sub/\ntdir/sub/b.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c",
+        "C",
+        "v",
+        "t"
+      ]
+    },
+    {
+      "id": "arch_tar_dash_c_bases_the_operand",
+      "seq": 910064,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tcin/paper && echo p | tee /data/tcin/paper/p.txt > /dev/null && tar -c -z -f /data/tc.tgz -C /data/tcin paper && tar -t -z -f /data/tc.tgz",
+      "expect": {
+        "exit": 0,
+        "stdout": "paper/\npaper/p.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c",
+        "C",
+        "z",
+        "t"
+      ]
+    },
+    {
+      "id": "arch_tar_directory_round_trips_through_extract",
+      "seq": 910065,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/trt/sub && echo rt | tee /data/trt/sub/r.txt > /dev/null && tar -c -f /data/trt.tar -C /data trt && tar -x -f /data/trt.tar -C /data/trtout && cat /data/trtout/trt/sub/r.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "rt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c",
+        "x",
+        "C"
+      ]
+    },
+    {
+      "id": "arch_tar_exclude_prunes_the_subtree",
+      "seq": 910066,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tex/sub && echo a | tee /data/tex/a.txt > /dev/null && echo b | tee /data/tex/sub/b.txt > /dev/null && tar -c -f /data/tex.tar --exclude sub -C /data tex && tar -t -f /data/tex.tar",
+      "expect": {
+        "exit": 0,
+        "stdout": "tex/\ntex/a.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c",
+        "C",
+        "t",
+        "exclude"
+      ]
+    },
+    {
+      "id": "arch_tar_missing_operand_exits_two",
+      "seq": 910067,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tmiss && tar -c -f /data/tmiss.tar -C /data/tmiss nope.txt",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "tar: nope.txt: Cannot stat: No such file or directory\ntar: Exiting with failure status due to previous errors\n"
+      },
+      "flags": [
+        "c",
+        "C"
+      ]
+    },
+    {
+      "id": "arch_tar_refuses_an_empty_archive",
+      "seq": 910068,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "tar -c -f /data/tempty.tar",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "tar: Cowardly refusing to create an empty archive\nTry 'tar --help' for more information.\n"
+      },
+      "flags": [
+        "c"
+      ]
+    },
+    {
+      "id": "arch_tar_refuses_a_directory_it_cannot_enter",
+      "seq": 910069,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "tar -c -f /data/tnodir.tar -C /data/tnodir a.txt",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "tar: /data/tnodir: Cannot open: No such file or directory\ntar: Error is not recoverable: exiting now\n"
+      },
+      "flags": [
+        "c",
+        "C"
+      ]
+    },
+    {
+      "id": "arch_tar_refuses_a_mount_root_operand",
+      "seq": 910070,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "tar -c -f /data/tmount.tar /data",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "tar: /data: Cannot open: Device or resource busy\ntar: Error is not recoverable: exiting now\n"
+      },
+      "flags": [
+        "c"
+      ]
+    },
+    {
+      "id": "arch_zip_refuses_a_mount_root_operand",
+      "seq": 910071,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "zip -r /data/zmount.zip /data",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "zip: cannot read '/data': Device or resource busy\n"
+      },
+      "flags": [
+        "r"
+      ]
+    },
+    {
+      "id": "arch_cp_refuses_a_mount_root_source",
+      "seq": 910072,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/cpdst && cp -r /data /data/cpdst",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "cp: cannot copy '/data': Device or resource busy\n"
+      },
+      "flags": [
+        "r"
+      ]
     }
   ]
 }

--- a/integ/unix/arch/zip.json
+++ b/integ/unix/arch/zip.json
@@ -33,6 +33,228 @@
         "stdout": "gz-data\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "arch_zip_recurses_a_directory",
+      "seq": 910073,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/zdir/sub && echo one > /data/zdir/a.txt && echo two > /data/zdir/sub/b.txt && zip -r /data/zr.zip /data/zdir && unzip -l /data/zr.zip",
+      "expect": {
+        "exit": 0,
+        "stdout": "  adding: data/zdir/\n  adding: data/zdir/a.txt\n  adding: data/zdir/sub/\n  adding: data/zdir/sub/b.txt\n  Length      Name\n---------  ----\n        0  data/zdir/\n        4  data/zdir/a.txt\n        0  data/zdir/sub/\n        4  data/zdir/sub/b.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "r"
+      ]
+    },
+    {
+      "id": "arch_zip_without_r_stores_only_the_directory",
+      "seq": 910074,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/znor && echo one > /data/znor/a.txt && zip /data/znor.zip /data/znor && unzip -l /data/znor.zip",
+      "expect": {
+        "exit": 0,
+        "stdout": "  adding: data/znor/\n  Length      Name\n---------  ----\n        0  data/znor/\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "arch_zip_keeps_an_empty_directory",
+      "seq": 910075,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/zempty/hollow && echo one > /data/zempty/a.txt && zip -q -r /data/ze.zip /data/zempty && mkdir -p /data/zeout && unzip -q -d /data/zeout /data/ze.zip && find /data/zeout -type d | sort",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/zeout\n/data/zeout/data\n/data/zeout/data/zempty\n/data/zeout/data/zempty/hollow\n",
+        "stderr": ""
+      },
+      "flags": [
+        "r"
+      ]
+    },
+    {
+      "id": "arch_zip_round_trips_a_tree",
+      "seq": 910076,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/zrt/sub && echo alpha > /data/zrt/a.txt && echo beta > /data/zrt/sub/b.txt && zip -q -r /data/zrt.zip /data/zrt && mkdir -p /data/zrtout && unzip -q -d /data/zrtout /data/zrt.zip && cat /data/zrtout/data/zrt/a.txt /data/zrtout/data/zrt/sub/b.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "alpha\nbeta\n",
+        "stderr": ""
+      },
+      "flags": [
+        "r"
+      ]
+    },
+    {
+      "id": "arch_zip_junks_paths_and_drops_directories",
+      "seq": 910077,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/zjunk/sub && echo one > /data/zjunk/a.txt && echo two > /data/zjunk/sub/b.txt && zip -r -j /data/zj.zip /data/zjunk && unzip -l /data/zj.zip",
+      "expect": {
+        "exit": 0,
+        "stdout": "  adding: a.txt\n  adding: b.txt\n  Length      Name\n---------  ----\n        4  a.txt\n        4  b.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "r",
+        "j"
+      ]
+    },
+    {
+      "id": "arch_zip_excludes_a_subtree",
+      "seq": 910078,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/zx/sub && echo one > /data/zx/a.txt && echo two > /data/zx/sub/b.txt && zip -r /data/zx.zip /data/zx -x 'data/zx/sub/*'",
+      "expect": {
+        "exit": 0,
+        "stdout": "  adding: data/zx/\n  adding: data/zx/a.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "r",
+        "x"
+      ]
+    },
+    {
+      "id": "arch_zip_warns_on_a_name_it_cannot_match",
+      "seq": 910079,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/zmiss && echo one > /data/zmiss/a.txt && zip /data/zm.zip /data/zmiss/a.txt /data/zmiss/nope.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "  adding: data/zmiss/a.txt\n",
+        "stderr": "\tzip warning: name not matched: /data/zmiss/nope.txt\n"
+      }
+    },
+    {
+      "id": "arch_zip_refuses_an_empty_archive",
+      "seq": 910080,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "zip /data/znothing.zip /data/no-such-file; echo exit=$?; ls /data/znothing.zip",
+      "expect": {
+        "exit": 2,
+        "stdout": "exit=12\n",
+        "stderr": "\tzip warning: name not matched: /data/no-such-file\n\nzip error: Nothing to do! (/data/znothing.zip)\nls: cannot access '/data/znothing.zip': No such file or directory\n"
+      }
+    },
+    {
+      "id": "arch_zip_quiet_keeps_the_fatal_error",
+      "seq": 910081,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "zip -q /data/zq.zip /data/no-such-file",
+      "expect": {
+        "exit": 12,
+        "stdout": "",
+        "stderr": "\nzip error: Nothing to do! (/data/zq.zip)\n"
+      },
+      "flags": [
+        "q"
+      ]
+    },
+    {
+      "id": "arch_zip_leaves_itself_out",
+      "seq": 910082,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/zself && echo one > /data/zself/a.txt && zip -q -r /data/zself/self.zip /data/zself && unzip -l /data/zself/self.zip",
+      "expect": {
+        "exit": 0,
+        "stdout": "  Length      Name\n---------  ----\n        0  data/zself/\n        4  data/zself/a.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "r"
+      ]
+    },
+    {
+      "id": "arch_zip_follows_a_symlink_by_default",
+      "seq": 910083,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/zsym && echo linked > /data/zsym/a.txt && ln -s /data/zsym/a.txt /data/zsym/l.txt && zip -q -r /data/zsym.zip /data/zsym && unzip -p /data/zsym.zip 'data/zsym/l.txt'",
+      "expect": {
+        "exit": 0,
+        "stdout": "linked\n",
+        "stderr": ""
+      },
+      "flags": [
+        "r"
+      ]
+    },
+    {
+      "id": "arch_zip_y_stores_the_link_target_instead",
+      "seq": 910084,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/zsy && echo linked > /data/zsy/a.txt && ln -s /data/zsy/a.txt /data/zsy/l.txt && zip -q -r -y /data/zsy.zip /data/zsy && unzip -p /data/zsy.zip 'data/zsy/l.txt'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/zsy/a.txt",
+        "stderr": ""
+      },
+      "flags": [
+        "r",
+        "y"
+      ]
     }
   ]
 }

--- a/python/mirage/commands/builtin/generic/archive/types.py
+++ b/python/mirage/commands/builtin/generic/archive/types.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+from mirage.types import PathSpec
+
+# What a member is, which is the whole of what an archive records beyond
+# its name: a regular file carries bytes, a directory carries none and
+# ends in a slash, a symlink carries its target string instead.
+MemberKind: TypeAlias = Literal["file", "dir", "link"]
+
+
+@dataclass(frozen=True, slots=True)
+class Entry:
+    """One thing found under an operand, before it is named or filtered.
+
+    ``name_path`` and ``read`` are two different paths whenever a link is
+    being followed: the member keeps the link's own name while its bytes
+    come from the target.
+
+    Args:
+        name_path (str): absolute virtual path the member is named
+            after, before it is respelled and stripped.
+        kind (MemberKind): file, dir, or link.
+        target (str): a symlink's target, verbatim as stored.
+        read (PathSpec | None): where a file's bytes come from.
+    """
+
+    name_path: str
+    kind: MemberKind
+    target: str = ""
+    read: PathSpec | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Problem:
+    """One thing the scan could not archive, in the order it was met.
+
+    Args:
+        path (str): the absolute virtual path it happened at.
+        reason (str): why, empty when ``fatal`` says the path could not
+            be stat'd at all and each archiver has its own wording.
+        fatal (bool): whether the path was unreachable rather than
+            merely skipped, which is what decides the exit code.
+    """
+
+    path: str
+    reason: str = ""
+    fatal: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Scan:
+    """What one operand contributed, in virtual path space.
+
+    Nothing here is named yet: naming is where the two archive formats
+    part company (tar warns about a leading slash, zip strips it in
+    silence and can junk the path entirely), so the scan reports paths
+    and the caller spells them.
+
+    Args:
+        entries (tuple[Entry, ...]): the operand and its descendants.
+        crossings (tuple[str, ...]): virtual path of each descendant
+            mount whose contents the walk refused to cross into.
+        problems (tuple[Problem, ...]): what was skipped and why, in
+            walk order.
+        missing (bool): whether the operand itself was unreachable, in
+            which case it contributed no entries.
+    """
+
+    entries: tuple[Entry, ...] = ()
+    crossings: tuple[str, ...] = ()
+    problems: tuple[Problem, ...] = ()
+    missing: bool = False

--- a/python/mirage/commands/builtin/generic/archive/walk.py
+++ b/python/mirage/commands/builtin/generic/archive/walk.py
@@ -1,0 +1,259 @@
+from collections.abc import Awaitable, Callable
+
+from mirage.commands.builtin.generic.archive.types import (Entry, MemberKind,
+                                                           Problem, Scan)
+from mirage.ops.types import LinkView, MountView
+from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
+from mirage.utils.key_prefix import mount_key
+
+# A mount boundary is a filesystem boundary, so both archivers stop at
+# one and say so in GNU tar's --one-file-system wording. Descending would
+# archive by accident exactly what the mount-root refusal forbids on
+# purpose.
+OTHER_FILESYSTEM = "file is on a different filesystem; not dumped"
+# Following a link back to something already followed on this operand.
+LOOP_SKIP = "symbolic link loop; not dumped"
+
+StatFn = Callable[[PathSpec], Awaitable[FileStat]]
+WalkFn = Callable[[PathSpec, str], Awaitable[list[str]]]
+DirProbe = Callable[[PathSpec], Awaitable[bool]]
+
+
+def link_target(stat: FileStat) -> str:
+    target = stat.extra.get(LINK_TARGET_KEY)
+    return target if isinstance(target, str) else ""
+
+
+def child_spec(virtual: str, root: PathSpec) -> PathSpec:
+    """A PathSpec for a walked descendant of one operand.
+
+    The walk reports absolute virtual paths; reading their bytes needs
+    the backend key too, which is the virtual path with this mount's
+    prefix removed.
+
+    Args:
+        virtual (str): the descendant's absolute virtual path.
+        root (PathSpec): the operand it was walked from.
+    """
+    cut = len(root.virtual.rstrip("/")) - len(root.resource_path.strip("/"))
+    prefix = root.virtual[:cut].rstrip("/")
+    return PathSpec(virtual=virtual,
+                    directory=virtual[:virtual.rfind("/") + 1] or "/",
+                    resource_path=mount_key(virtual, prefix),
+                    raw_path=virtual)
+
+
+def same_mount(mounts: MountView | None, one: str, other: str) -> bool:
+    """Whether two virtual paths are served by the same mount.
+
+    Args:
+        mounts (MountView | None): where the mount boundaries are;
+            None (outside a workspace) means there is only one mount.
+        one (str): a virtual path.
+        other (str): another virtual path.
+    """
+    if mounts is None:
+        return True
+    return mounts.root_of(one) == mounts.root_of(other)
+
+
+async def subtree(
+    root: PathSpec,
+    base: str,
+    name_base: str,
+    walk: WalkFn,
+    links: LinkView | None,
+    mounts: MountView | None,
+) -> tuple[list[Entry], list[str]]:
+    """Every entry under one directory, named under ``name_base``.
+
+    Three sources have to be merged because no single one can see them
+    all: the backend walk (files and directories), the namespace (its
+    symlinks, which no backend readdir reports), and the mount table (a
+    nested mount, whose keys live in another resource entirely).
+
+    ``base`` and ``name_base`` differ only when a link is being followed:
+    the walk runs over the target while the members keep the link's own
+    name.
+
+    Args:
+        root (PathSpec): the operand, for backend keys.
+        base (str): absolute virtual path actually walked.
+        name_base (str): absolute virtual path the members are named
+            under.
+        walk (WalkFn): subtree listing, by find type.
+        links (LinkView | None): the namespace's symlink facts.
+        mounts (MountView | None): where the mount boundaries are.
+
+    Returns:
+        tuple: the entries, and the virtual path of each mount root that
+        stopped the walk.
+    """
+    walked = child_spec(base, root) if base != root.virtual else root
+    found: dict[str, tuple[MemberKind, str]] = {}
+    for virtual in await walk(walked, "d"):
+        if virtual.rstrip("/") != base:
+            found[virtual.rstrip("/")] = ("dir", "")
+    for virtual in await walk(walked, "f"):
+        found[virtual.rstrip("/")] = ("file", "")
+    if links is not None:
+        for virtual, stat in links.subtree(base):
+            found[virtual.rstrip("/")] = ("link", link_target(stat))
+    crossings = mounts.descendants(base) if mounts is not None else []
+    for crossing in crossings:
+        # The mountpoint itself is still an entry, exactly as GNU's
+        # --one-file-system keeps the directory and drops its contents.
+        found[crossing.rstrip("/")] = ("dir", "")
+    below = [c.rstrip("/") + "/" for c in crossings]
+    entries: list[Entry] = []
+    for virtual, (kind, target) in found.items():
+        if any(virtual.startswith(c) for c in below):
+            continue
+        named = name_base.rstrip("/") + virtual[len(base.rstrip("/")):]
+        entries.append(
+            Entry(name_path=named,
+                  kind=kind,
+                  target=target,
+                  read=child_spec(virtual, root) if kind == "file" else None))
+    entries.sort(key=lambda entry: entry.name_path)
+    return entries, [c.rstrip("/") for c in crossings]
+
+
+async def follow(
+    virtual: str,
+    root: PathSpec,
+    stat: StatFn,
+    walk: WalkFn,
+    links: LinkView | None,
+    mounts: MountView | None,
+    seen: set[str],
+    recurse: bool,
+) -> tuple[list[Entry], list[str], bool]:
+    """What dereferencing puts in the archive in place of one symlink.
+
+    The member keeps the link's own name and takes the target's content,
+    which is what dereferencing means. Two cases stay out of reach and
+    are reported rather than guessed at: a target on another mount
+    (whose bytes this backend cannot read, the same boundary a nested
+    mount draws) and a target already followed on this operand, which is
+    a loop.
+
+    Args:
+        virtual (str): the link's absolute virtual path.
+        root (PathSpec): the operand, for backend keys.
+        stat (StatFn): backend stat.
+        walk (WalkFn): subtree listing, by find type.
+        links (LinkView | None): the namespace's symlink facts.
+        mounts (MountView | None): where the mount boundaries are.
+        seen (set[str]): targets already followed under this operand.
+        recurse (bool): whether a target directory contributes its
+            contents as well as itself.
+
+    Returns:
+        tuple: the entries, why anything was skipped, and whether the
+        link could not be stat'd at all.
+    """
+    if links is None:
+        return [], [], False
+    target = links.resolve(virtual)
+    if not same_mount(mounts, virtual, target):
+        return [], [OTHER_FILESYSTEM], False
+    if target in seen:
+        return [], [LOOP_SKIP], False
+    seen.add(target)
+    spec = child_spec(target, root)
+    try:
+        target_stat = await stat(spec)
+    except (FileNotFoundError, ValueError):
+        return [], [], True
+    if target_stat.type != FileType.DIRECTORY:
+        return [Entry(name_path=virtual, kind="file", read=spec)], [], False
+    if not recurse:
+        return [Entry(name_path=virtual, kind="dir")], [], False
+    entries, crossings = await subtree(root, target, virtual, walk, links,
+                                       mounts)
+    reasons = [OTHER_FILESYSTEM] * len(crossings)
+    return [Entry(name_path=virtual, kind="dir"), *entries], reasons, False
+
+
+async def scan_operand(
+    path: PathSpec,
+    *,
+    stat: StatFn,
+    walk: WalkFn,
+    links: LinkView | None = None,
+    mounts: MountView | None = None,
+    dereference: bool = False,
+    recurse: bool = True,
+) -> Scan:
+    """Everything one operand contributes to an archive.
+
+    This is the whole of what tar and zip share: which paths go in, what
+    each one is, and which of them could not be reached. The two formats
+    disagree about the defaults, not the traversal, so both are
+    parameters: tar stores a symlink unless ``-h`` says to follow it and
+    always descends, zip follows unless ``-y`` says otherwise and only
+    descends under ``-r``.
+
+    Args:
+        path (PathSpec): the operand, glob-resolved and already re-based
+            by any directory option.
+        stat (StatFn): backend stat, raising when nothing is there.
+        walk (WalkFn): subtree listing, by find type.
+        links (LinkView | None): the namespace's symlink facts.
+        mounts (MountView | None): where the mount boundaries are.
+        dereference (bool): archive what a symlink points at rather than
+            the link.
+        recurse (bool): whether a directory contributes its contents as
+            well as itself.
+    """
+    base = path.virtual.rstrip("/") or "/"
+    entries: list[Entry] = []
+    crossings: list[str] = []
+    problems: list[Problem] = []
+    seen: set[str] = set()
+    link_stat = links.stat_at(path.virtual) if links is not None else None
+    if link_stat is not None and not dereference:
+        entries.append(
+            Entry(name_path=base, kind="link", target=link_target(link_stat)))
+    elif link_stat is not None:
+        followed, why, fatal = await follow(base, path, stat, walk, links,
+                                            mounts, seen, recurse)
+        if fatal:
+            return Scan(problems=(Problem(path=base, fatal=True), ),
+                        missing=True)
+        entries.extend(followed)
+        problems.extend(Problem(path=base, reason=reason) for reason in why)
+    else:
+        try:
+            root_stat = await stat(path)
+        except (FileNotFoundError, ValueError):
+            return Scan(problems=(Problem(path=base, fatal=True), ),
+                        missing=True)
+        if root_stat.type != FileType.DIRECTORY:
+            entries.append(Entry(name_path=base, kind="file", read=path))
+        else:
+            entries.append(Entry(name_path=base, kind="dir"))
+            if recurse:
+                below, crossings = await subtree(path, base, base, walk, links,
+                                                 mounts)
+                entries.extend(below)
+    if dereference and links is not None:
+        expanded: list[Entry] = []
+        for entry in entries:
+            if entry.kind != "link":
+                expanded.append(entry)
+                continue
+            followed, why, fatal = await follow(entry.name_path, path, stat,
+                                                walk, links, mounts, seen,
+                                                recurse)
+            if fatal:
+                problems.append(Problem(path=entry.name_path, fatal=True))
+                continue
+            expanded.extend(followed)
+            problems.extend(
+                Problem(path=entry.name_path, reason=reason) for reason in why)
+        entries = expanded
+    return Scan(entries=tuple(entries),
+                crossings=tuple(crossings),
+                problems=tuple(problems))

--- a/python/mirage/commands/builtin/generic/archive/walk.py
+++ b/python/mirage/commands/builtin/generic/archive/walk.py
@@ -5,14 +5,18 @@ from mirage.commands.builtin.generic.archive.types import (Entry, MemberKind,
 from mirage.ops.types import LinkView, MountView
 from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
+from mirage.utils.path import CycleError
 
 # A mount boundary is a filesystem boundary, so both archivers stop at
 # one and say so in GNU tar's --one-file-system wording. Descending would
 # archive by accident exactly what the mount-root refusal forbids on
 # purpose.
 OTHER_FILESYSTEM = "file is on a different filesystem; not dumped"
-# Following a link back to something already followed on this operand.
-LOOP_SKIP = "symbolic link loop; not dumped"
+# Why a path could not be reached, in GNU's strerror wording. Both ride
+# on a fatal Problem; tar prints them after "Cannot stat: " and Info-ZIP
+# words every unreachable name the same way, so it ignores the reason.
+NO_SUCH = "No such file or directory"
+TOO_MANY_LEVELS = "Too many levels of symbolic links"
 
 StatFn = Callable[[PathSpec], Awaitable[FileStat]]
 WalkFn = Callable[[PathSpec, str], Awaitable[list[str]]]
@@ -126,17 +130,15 @@ async def follow(
     walk: WalkFn,
     links: LinkView | None,
     mounts: MountView | None,
-    seen: set[str],
     recurse: bool,
-) -> tuple[list[Entry], list[str], bool]:
+) -> tuple[list[Entry], list[str], str]:
     """What dereferencing puts in the archive in place of one symlink.
 
     The member keeps the link's own name and takes the target's content,
-    which is what dereferencing means. Two cases stay out of reach and
-    are reported rather than guessed at: a target on another mount
-    (whose bytes this backend cannot read, the same boundary a nested
-    mount draws) and a target already followed on this operand, which is
-    a loop.
+    which is what dereferencing means. Two links resolving to the same
+    file are not a loop and both are archived; a real loop is whatever
+    ``resolve`` refuses to resolve, since the namespace already walks
+    the chain under a hop limit and raises ELOOP at the end of it.
 
     Args:
         virtual (str): the link's absolute virtual path.
@@ -145,35 +147,34 @@ async def follow(
         walk (WalkFn): subtree listing, by find type.
         links (LinkView | None): the namespace's symlink facts.
         mounts (MountView | None): where the mount boundaries are.
-        seen (set[str]): targets already followed under this operand.
         recurse (bool): whether a target directory contributes its
             contents as well as itself.
 
     Returns:
-        tuple: the entries, why anything was skipped, and whether the
-        link could not be stat'd at all.
+        tuple: the entries, why anything was skipped, and why the link
+        was unreachable at all (empty when it was reached).
     """
     if links is None:
-        return [], [], False
-    target = links.resolve(virtual)
+        return [], [], ""
+    try:
+        target = links.resolve(virtual)
+    except CycleError:
+        return [], [], TOO_MANY_LEVELS
     if not same_mount(mounts, virtual, target):
-        return [], [OTHER_FILESYSTEM], False
-    if target in seen:
-        return [], [LOOP_SKIP], False
-    seen.add(target)
+        return [], [OTHER_FILESYSTEM], ""
     spec = child_spec(target, root)
     try:
         target_stat = await stat(spec)
     except (FileNotFoundError, ValueError):
-        return [], [], True
+        return [], [], NO_SUCH
     if target_stat.type != FileType.DIRECTORY:
-        return [Entry(name_path=virtual, kind="file", read=spec)], [], False
+        return [Entry(name_path=virtual, kind="file", read=spec)], [], ""
     if not recurse:
-        return [Entry(name_path=virtual, kind="dir")], [], False
+        return [Entry(name_path=virtual, kind="dir")], [], ""
     entries, crossings = await subtree(root, target, virtual, walk, links,
                                        mounts)
     reasons = [OTHER_FILESYSTEM] * len(crossings)
-    return [Entry(name_path=virtual, kind="dir"), *entries], reasons, False
+    return [Entry(name_path=virtual, kind="dir"), *entries], reasons, ""
 
 
 async def scan_operand(
@@ -211,16 +212,17 @@ async def scan_operand(
     entries: list[Entry] = []
     crossings: list[str] = []
     problems: list[Problem] = []
-    seen: set[str] = set()
     link_stat = links.stat_at(path.virtual) if links is not None else None
     if link_stat is not None and not dereference:
         entries.append(
             Entry(name_path=base, kind="link", target=link_target(link_stat)))
     elif link_stat is not None:
-        followed, why, fatal = await follow(base, path, stat, walk, links,
-                                            mounts, seen, recurse)
-        if fatal:
-            return Scan(problems=(Problem(path=base, fatal=True), ),
+        followed, why, unreachable = await follow(base, path, stat, walk,
+                                                  links, mounts, recurse)
+        if unreachable:
+            return Scan(problems=(Problem(path=base,
+                                          reason=unreachable,
+                                          fatal=True), ),
                         missing=True)
         entries.extend(followed)
         problems.extend(Problem(path=base, reason=reason) for reason in why)
@@ -228,7 +230,9 @@ async def scan_operand(
         try:
             root_stat = await stat(path)
         except (FileNotFoundError, ValueError):
-            return Scan(problems=(Problem(path=base, fatal=True), ),
+            return Scan(problems=(Problem(path=base,
+                                          reason=NO_SUCH,
+                                          fatal=True), ),
                         missing=True)
         if root_stat.type != FileType.DIRECTORY:
             entries.append(Entry(name_path=base, kind="file", read=path))
@@ -244,11 +248,14 @@ async def scan_operand(
             if entry.kind != "link":
                 expanded.append(entry)
                 continue
-            followed, why, fatal = await follow(entry.name_path, path, stat,
-                                                walk, links, mounts, seen,
-                                                recurse)
-            if fatal:
-                problems.append(Problem(path=entry.name_path, fatal=True))
+            followed, why, unreachable = await follow(entry.name_path, path,
+                                                      stat, walk, links,
+                                                      mounts, recurse)
+            if unreachable:
+                problems.append(
+                    Problem(path=entry.name_path,
+                            reason=unreachable,
+                            fatal=True))
                 continue
             expanded.extend(followed)
             problems.extend(

--- a/python/mirage/commands/builtin/generic/tar/__init__.py
+++ b/python/mirage/commands/builtin/generic/tar/__init__.py
@@ -1,14 +1,23 @@
 from mirage.commands.builtin.generic.tar.constants import (READ_MODES,
                                                            WRITE_MODES)
+from mirage.commands.builtin.generic.tar.create import (excluded, member_name,
+                                                        plan_create, pruned)
 from mirage.commands.builtin.generic.tar.tar import tar
 from mirage.commands.builtin.generic.tar.types import (CompressionSuffix,
+                                                       CreateResult, Member,
                                                        ReadMode, WriteMode)
 
 __all__ = [
     "CompressionSuffix",
+    "CreateResult",
+    "Member",
     "READ_MODES",
     "ReadMode",
     "WRITE_MODES",
     "WriteMode",
+    "excluded",
+    "member_name",
+    "plan_create",
+    "pruned",
     "tar",
 ]

--- a/python/mirage/commands/builtin/generic/tar/create.py
+++ b/python/mirage/commands/builtin/generic/tar/create.py
@@ -1,0 +1,202 @@
+from mirage.commands.builtin.generic.archive.types import MemberKind
+from mirage.commands.builtin.generic.archive.walk import (OTHER_FILESYSTEM,
+                                                          DirProbe, StatFn,
+                                                          WalkFn, scan_operand)
+from mirage.commands.builtin.generic.tar.types import CreateResult, Member
+from mirage.ops.types import LinkView, MountView
+from mirage.types import PathSpec
+from mirage.utils.fnmatch import fnmatch
+from mirage.utils.path import respell_one
+
+# Every diagnostic below is GNU tar 1.35's own wording, pinned on
+# debian:stable-slim; only the hint line is mirage's, for the reason
+# usage.old_option_error gives (mirage's tar serves no --usage).
+USAGE_HINT = "Try 'tar --help' for more information."
+EMPTY_ARCHIVE = "tar: Cowardly refusing to create an empty archive"
+FATAL_TRAILER = "tar: Error is not recoverable: exiting now"
+ERROR_TRAILER = "tar: Exiting with failure status due to previous errors"
+LEADING_SLASH = "tar: Removing leading `/' from member names"
+SELF_DUMP = "archive cannot contain itself; not dumped"
+# The exit GNU gives an operand it could not read, and a -C it could not
+# enter. Both are fatal for the whole run, not per-operand.
+CREATE_ERROR_EXIT = 2
+
+
+def _refusal(notices: list[str]) -> CreateResult:
+    return CreateResult(members=(),
+                        notices=tuple(notices),
+                        exit_code=CREATE_ERROR_EXIT,
+                        write=False)
+
+
+def excluded(name: str, pattern: str) -> bool:
+    """Whether GNU's ``--exclude`` pattern matches this member name.
+
+    GNU's exclusion is unanchored: the pattern is tried against the whole
+    name and against every suffix that starts at a path component, so
+    ``a.txt``, ``d/a.txt`` and ``sub/b.txt`` all match entries under
+    ``d``. Wildcards cross slashes (``*/b.txt`` matches ``d/sub/b.txt``),
+    which is tar's default for exclusion patterns. A directory's
+    trailing slash is not part of what the pattern sees. Info-ZIP's
+    ``-x`` is the anchored counterpart, which is why the two are not
+    shared.
+
+    Args:
+        name (str): the member name, with or without a trailing slash.
+        pattern (str): the raw ``--exclude`` value.
+    """
+    bare = name.rstrip("/")
+    if fnmatch(bare, pattern):
+        return True
+    cut = bare.find("/")
+    while cut != -1:
+        if fnmatch(bare[cut + 1:], pattern):
+            return True
+        cut = bare.find("/", cut + 1)
+    return False
+
+
+def pruned(names: list[str], pattern: str | None) -> list[str]:
+    """Drop excluded names and everything beneath an excluded directory.
+
+    GNU does not walk into a directory it excluded, so ``--exclude sub``
+    takes ``d/sub/`` and ``d/sub/b.txt`` together. Matching each name in
+    isolation would keep the children of a pruned directory.
+
+    Args:
+        names (list[str]): member names in walk order.
+        pattern (str | None): the raw ``--exclude`` value, or None.
+    """
+    if pattern is None:
+        return names
+    kept: list[str] = []
+    cut_dirs: list[str] = []
+    for name in names:
+        if any(name.startswith(cut) for cut in cut_dirs):
+            continue
+        if excluded(name, pattern):
+            if name.endswith("/"):
+                cut_dirs.append(name)
+            continue
+        kept.append(name)
+    return kept
+
+
+def member_name(spelled: str, kind: MemberKind) -> str:
+    """The name tar records for a path spelled as the operand was typed.
+
+    A leading slash is stripped (tar refuses to store absolute names, and
+    says so once per run), and a directory carries the trailing slash
+    that tells an extractor it holds no content.
+
+    Args:
+        spelled (str): the path as the operand spelled it.
+        kind (MemberKind): what the entry is.
+    """
+    name = spelled.lstrip("/")
+    if kind == "dir" and name and not name.endswith("/"):
+        return name + "/"
+    return name
+
+
+async def plan_create(
+    paths: list[PathSpec],
+    *,
+    archive: PathSpec,
+    exclude: str | None,
+    dereference: bool,
+    stat: StatFn,
+    walk: WalkFn,
+    is_dir: DirProbe,
+    directory: PathSpec | None = None,
+    links: LinkView | None = None,
+    mounts: MountView | None = None,
+) -> CreateResult:
+    """Decide every member of a new archive, before writing any of it.
+
+    One pass per operand, in the order they were typed, each
+    contributing itself and then its subtree. GNU walks a directory
+    operand rather than refusing it, and mirage now does too; the one
+    deliberate divergence is ordering, since GNU emits siblings in
+    readdir order (filesystem-dependent) and this sorts them, the same
+    choice ``du`` already documents.
+
+    Args:
+        paths (list[PathSpec]): the operands, glob-resolved and already
+            re-based by any ``-C``.
+        archive (PathSpec): the ``-f`` target, so it can be left out of
+            itself.
+        exclude (str | None): the raw ``--exclude`` value.
+        dereference (bool): ``-h``, archive what a symlink points at.
+        stat (StatFn): backend stat, raising when nothing is there.
+        walk (WalkFn): subtree listing, by find type.
+        is_dir (DirProbe): whether ``directory`` can be entered.
+        directory (PathSpec | None): the ``-C`` the operands were based
+            on, checked here because GNU chdirs before reading anything.
+        links (LinkView | None): the namespace's symlink facts.
+        mounts (MountView | None): where the mount boundaries are.
+    """
+    if not paths:
+        return _refusal([EMPTY_ARCHIVE, USAGE_HINT])
+    if directory is not None and not await is_dir(directory):
+        # GNU chdirs before reading a single operand, so a -C it cannot
+        # enter is fatal for the whole run and no archive is written.
+        return _refusal([
+            f"tar: {directory.raw_path}: Cannot open: "
+            "No such file or directory", FATAL_TRAILER
+        ])
+    members: list[Member] = []
+    notices: list[str] = []
+    absolute_seen = False
+    exit_code = 0
+    for path in paths:
+        raw = path.raw_path
+        base = path.virtual.rstrip("/") or "/"
+        scan = await scan_operand(path,
+                                  stat=stat,
+                                  walk=walk,
+                                  links=links,
+                                  mounts=mounts,
+                                  dereference=dereference,
+                                  recurse=True)
+        for problem in scan.problems:
+            shown = respell_one(problem.path, base, raw)
+            if not problem.fatal:
+                notices.append(f"tar: {shown}: {problem.reason}")
+                continue
+            notices.append(f"tar: {shown}: Cannot stat: "
+                           "No such file or directory")
+            exit_code = CREATE_ERROR_EXIT
+        if scan.missing:
+            continue
+        for crossing in scan.crossings:
+            shown = member_name(respell_one(crossing, base, raw), "dir")
+            notices.append(f"tar: {shown}: {OTHER_FILESYSTEM}")
+        # Every descendant is spelled under the operand's own base, so
+        # the operand alone decides whether this run stored an absolute
+        # name and owes GNU's one-per-run warning.
+        absolute_seen = absolute_seen or raw.startswith("/")
+        named = [(member_name(respell_one(entry.name_path, base, raw),
+                              entry.kind), entry) for entry in scan.entries]
+        keep = set(pruned([name for name, _ in named], exclude))
+        for name, entry in named:
+            if name not in keep:
+                continue
+            read = entry.read
+            if read is not None and read.virtual == archive.virtual:
+                notices.append(f"tar: {name}: {SELF_DUMP}")
+                continue
+            members.append(
+                Member(name=name,
+                       kind=entry.kind,
+                       path=entry.read,
+                       target=entry.target))
+    if absolute_seen:
+        notices.insert(0, LEADING_SLASH)
+    if exit_code:
+        # GNU closes a run that failed an operand with one trailer, after
+        # everything it did manage to name.
+        notices.append(ERROR_TRAILER)
+    return CreateResult(members=tuple(members),
+                        notices=tuple(notices),
+                        exit_code=exit_code)

--- a/python/mirage/commands/builtin/generic/tar/create.py
+++ b/python/mirage/commands/builtin/generic/tar/create.py
@@ -108,7 +108,7 @@ async def plan_create(
     stat: StatFn,
     walk: WalkFn,
     is_dir: DirProbe,
-    directory: PathSpec | None = None,
+    directories: list[PathSpec] | None = None,
     links: LinkView | None = None,
     mounts: MountView | None = None,
 ) -> CreateResult:
@@ -130,21 +130,25 @@ async def plan_create(
         dereference (bool): ``-h``, archive what a symlink points at.
         stat (StatFn): backend stat, raising when nothing is there.
         walk (WalkFn): subtree listing, by find type.
-        is_dir (DirProbe): whether ``directory`` can be entered.
-        directory (PathSpec | None): the ``-C`` the operands were based
-            on, checked here because GNU chdirs before reading anything.
+        is_dir (DirProbe): whether a ``-C`` can be entered.
+        directories (list[PathSpec] | None): every ``-C`` the operands
+            were based on, in order, checked here because GNU chdirs at
+            each one before reading anything.
         links (LinkView | None): the namespace's symlink facts.
         mounts (MountView | None): where the mount boundaries are.
     """
     if not paths:
         return _refusal([EMPTY_ARCHIVE, USAGE_HINT])
-    if directory is not None and not await is_dir(directory):
-        # GNU chdirs before reading a single operand, so a -C it cannot
-        # enter is fatal for the whole run and no archive is written.
-        return _refusal([
-            f"tar: {directory.raw_path}: Cannot open: "
-            "No such file or directory", FATAL_TRAILER
-        ])
+    for directory in directories or []:
+        # GNU chdirs at each -C in turn, before reading a single
+        # operand, so the FIRST one it cannot enter is fatal for the
+        # whole run and no members are written. Checking only the last
+        # would archive the operands that followed a bad earlier one.
+        if not await is_dir(directory):
+            return _refusal([
+                f"tar: {directory.raw_path}: Cannot open: "
+                "No such file or directory", FATAL_TRAILER
+            ])
     members: list[Member] = []
     notices: list[str] = []
     absolute_seen = False
@@ -164,8 +168,7 @@ async def plan_create(
             if not problem.fatal:
                 notices.append(f"tar: {shown}: {problem.reason}")
                 continue
-            notices.append(f"tar: {shown}: Cannot stat: "
-                           "No such file or directory")
+            notices.append(f"tar: {shown}: Cannot stat: {problem.reason}")
             exit_code = CREATE_ERROR_EXIT
         if scan.missing:
             continue

--- a/python/mirage/commands/builtin/generic/tar/tar.py
+++ b/python/mirage/commands/builtin/generic/tar/tar.py
@@ -2,18 +2,17 @@ import io
 import tarfile
 from collections.abc import Awaitable, Callable
 
+from mirage.commands.builtin.generic.archive.walk import (DirProbe, StatFn,
+                                                          WalkFn)
 from mirage.commands.builtin.generic.tar.constants import (READ_MODES,
                                                            WRITE_MODES)
+from mirage.commands.builtin.generic.tar.create import plan_create
 from mirage.commands.builtin.generic.tar.types import (CompressionSuffix,
+                                                       CreateResult, Member,
                                                        ReadMode, WriteMode)
 from mirage.io.types import ByteSource, IOResult
+from mirage.ops.types import LinkView, MountView
 from mirage.types import PathSpec
-from mirage.utils.fnmatch import fnmatch
-
-
-def _excluded(name: str, pattern: str) -> bool:
-    base = name.split("/")[-1]
-    return fnmatch(name, pattern) or fnmatch(base, pattern)
 
 
 def _compression_suffix(z: bool, j: bool, J: bool) -> CompressionSuffix:
@@ -34,11 +33,33 @@ def _read_mode(suffix: CompressionSuffix) -> ReadMode:
     return READ_MODES[suffix]
 
 
+def _stderr(lines: list[str]) -> bytes:
+    return ("\n".join(lines) + "\n").encode() if lines else b""
+
+
+def _info(member: Member, size: int) -> tarfile.TarInfo:
+    """The header for one member, typed the way its kind demands.
+
+    Args:
+        member (Member): the planned entry.
+        size (int): byte length of the content, 0 for a dir or a link.
+    """
+    info = tarfile.TarInfo(name=member.name)
+    info.size = size
+    if member.kind == "dir":
+        info.type = tarfile.DIRTYPE
+        info.mode = 0o755
+    elif member.kind == "link":
+        info.type = tarfile.SYMTYPE
+        info.linkname = member.target
+        info.mode = 0o777
+    return info
+
+
 async def _create_archive(
-    paths: list[PathSpec],
+    plan: CreateResult,
     archive_path: PathSpec,
     mode_suffix: CompressionSuffix,
-    exclude: str | None,
     verbose: bool,
     read_bytes: Callable[..., Awaitable[bytes]],
     write_bytes: Callable[..., Awaitable[None]],
@@ -46,19 +67,18 @@ async def _create_archive(
     buf = io.BytesIO()
     names: list[str] = []
     with tarfile.open(fileobj=buf, mode=_write_mode(mode_suffix)) as tf:
-        for p in paths:
-            name = p.virtual.lstrip("/")
-            if exclude and _excluded(name, exclude):
-                continue
-            data = await read_bytes(p)
-            info = tarfile.TarInfo(name=name)
-            info.size = len(data)
-            tf.addfile(info, io.BytesIO(data))
-            names.append(name)
+        for member in plan.members:
+            data = b""
+            if member.path is not None:
+                data = await read_bytes(member.path)
+            tf.addfile(_info(member, len(data)), io.BytesIO(data))
+            names.append(member.name)
     archive = buf.getvalue()
     await write_bytes(archive_path, archive)
     stdout = ("\n".join(names) + "\n").encode() if verbose and names else None
-    return stdout, IOResult(writes={archive_path.mount_path: archive})
+    return stdout, IOResult(writes={archive_path.mount_path: archive},
+                            stderr=_stderr(list(plan.notices)),
+                            exit_code=plan.exit_code)
 
 
 async def _list_archive(
@@ -69,7 +89,10 @@ async def _list_archive(
     data = await read_bytes(archive_path)
     with tarfile.open(fileobj=io.BytesIO(data),
                       mode=_read_mode(mode_suffix)) as tf:
-        names = tf.getnames()
+        names = [
+            member.name + "/" if member.isdir() else member.name
+            for member in tf.getmembers()
+        ]
     return ("\n".join(names) + "\n").encode(), IOResult()
 
 
@@ -89,18 +112,29 @@ async def _extract_archive(
     with tarfile.open(fileobj=io.BytesIO(data),
                       mode=_read_mode(mode_suffix)) as tf:
         for member in tf.getmembers():
-            if not member.isfile():
+            # A symlink member has no bytes to write and no namespace to
+            # write into from here (links are workspace state, not the
+            # backend's), so extraction skips it rather than dropping an
+            # empty file where a link belongs.
+            if not member.isfile() and not member.isdir():
+                continue
+            name_parts = member.name.rstrip("/").split("/")
+            if strip_n > 0:
+                name_parts = name_parts[strip_n:]
+            if not name_parts or name_parts == [""]:
+                continue
+            out_path = dest_path.rstrip("/") + "/" + "/".join(name_parts)
+            if member.isdir():
+                # A directory member is the only record an empty
+                # directory leaves, so it has to be recreated even
+                # though nothing is written inside it.
+                await mkdir_fn(PathSpec.from_str_path(out_path), parents=True)
+                names.append(member.name.rstrip("/") + "/")
                 continue
             extracted = tf.extractfile(member)
             if not extracted:
                 continue
             content = extracted.read()
-            name_parts = member.name.split("/")
-            if strip_n > 0:
-                name_parts = name_parts[strip_n:]
-            if not name_parts:
-                continue
-            out_path = dest_path.rstrip("/") + "/" + "/".join(name_parts)
             parent = out_path.rsplit("/", 1)[0] or "/"
             if parent != "/":
                 await mkdir_fn(PathSpec.from_str_path(parent), parents=True)
@@ -117,6 +151,9 @@ async def tar(
     read_bytes: Callable[..., Awaitable[bytes]],
     write_bytes: Callable[..., Awaitable[None]],
     mkdir_fn: Callable[..., Awaitable[None]],
+    stat: StatFn,
+    walk: WalkFn,
+    is_dir: DirProbe,
     c: bool = False,
     x: bool = False,
     t: bool = False,
@@ -124,10 +161,13 @@ async def tar(
     j: bool = False,
     J: bool = False,
     v: bool = False,
+    h: bool = False,
     f: PathSpec | None = None,
     C: PathSpec | None = None,
     strip_components: str | None = None,
     exclude: str | None = None,
+    links: LinkView | None = None,
+    mounts: MountView | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     archive = f if f else None
     dest_path = C.mount_path if C else "/"
@@ -136,8 +176,21 @@ async def tar(
     if c:
         if archive is None:
             raise ValueError("tar: -f is required")
-        return await _create_archive(paths, archive, mode_suffix, exclude, v,
-                                     read_bytes, write_bytes)
+        plan = await plan_create(paths,
+                                 archive=archive,
+                                 exclude=exclude,
+                                 dereference=h,
+                                 stat=stat,
+                                 walk=walk,
+                                 is_dir=is_dir,
+                                 directory=C,
+                                 links=links,
+                                 mounts=mounts)
+        if not plan.write:
+            return None, IOResult(exit_code=plan.exit_code,
+                                  stderr=_stderr(list(plan.notices)))
+        return await _create_archive(plan, archive, mode_suffix, v, read_bytes,
+                                     write_bytes)
     if t:
         if archive is None:
             raise ValueError("tar: -f is required")

--- a/python/mirage/commands/builtin/generic/tar/tar.py
+++ b/python/mirage/commands/builtin/generic/tar/tar.py
@@ -163,14 +163,15 @@ async def tar(
     v: bool = False,
     h: bool = False,
     f: PathSpec | None = None,
-    C: PathSpec | None = None,
+    C: list[PathSpec] | None = None,
     strip_components: str | None = None,
     exclude: str | None = None,
     links: LinkView | None = None,
     mounts: MountView | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     archive = f if f else None
-    dest_path = C.mount_path if C else "/"
+    # Only the last -C is a destination; create checks every one.
+    dest_path = C[-1].mount_path if C else "/"
     mode_suffix = _compression_suffix(z, j, J)
     strip_n = int(strip_components) if strip_components else 0
     if c:
@@ -183,7 +184,7 @@ async def tar(
                                  stat=stat,
                                  walk=walk,
                                  is_dir=is_dir,
-                                 directory=C,
+                                 directories=C or [],
                                  links=links,
                                  mounts=mounts)
         if not plan.write:

--- a/python/mirage/commands/builtin/generic/tar/types.py
+++ b/python/mirage/commands/builtin/generic/tar/types.py
@@ -1,5 +1,54 @@
+from dataclasses import dataclass
 from typing import Literal, TypeAlias
+
+from mirage.commands.builtin.generic.archive.types import MemberKind
+from mirage.types import PathSpec
 
 CompressionSuffix: TypeAlias = Literal["", ":gz", ":bz2", ":xz"]
 WriteMode: TypeAlias = Literal["w", "w:gz", "w:bz2", "w:xz"]
 ReadMode: TypeAlias = Literal["r", "r:gz", "r:bz2", "r:xz"]
+
+
+@dataclass(frozen=True, slots=True)
+class Member:
+    """One entry the create pass decided to put in the archive.
+
+    Choosing every member before writing any of them is what lets an
+    exclusion prune a whole subtree and the ordering stay stable; the
+    writer is then a straight loop with no policy left in it.
+
+    Args:
+        name (str): the archive member name, spelled as the operand was
+            typed. A directory carries GNU's trailing slash.
+        kind (MemberKind): file, dir, or link.
+        path (PathSpec | None): where a file's bytes come from; None for
+            a directory or a symlink, neither of which has content.
+        target (str): a symlink's target, verbatim as stored; empty for
+            every other kind.
+    """
+
+    name: str
+    kind: MemberKind
+    path: PathSpec | None = None
+    target: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class CreateResult:
+    """What one ``tar -c`` pass decided, before anything is written.
+
+    Args:
+        members (tuple[Member, ...]): the entries to write, in order.
+        notices (tuple[str, ...]): stderr lines, each already carrying
+            its ``tar: `` prefix and no trailing newline.
+        exit_code (int): 0, or 2 when an operand could not be read.
+        write (bool): whether to write an archive at all. False for the
+            two refusals GNU makes before reading anything (no operands,
+            and a ``-C`` it cannot enter), which leave no file behind;
+            an operand it merely failed to stat still writes the rest.
+    """
+
+    members: tuple[Member, ...]
+    notices: tuple[str, ...]
+    exit_code: int
+    write: bool = True

--- a/python/mirage/commands/builtin/generic/unzip.py
+++ b/python/mirage/commands/builtin/generic/unzip.py
@@ -128,17 +128,23 @@ async def unzip(
         writes: dict[str, ByteSource] = {}
         output_lines: list[str] = []
         for info in selected:
+            entry_name = info.filename.lstrip("/")
+            out_path = dest.rstrip("/") + "/" + entry_name.rstrip("/")
+            report_path = (mount_prefix +
+                           out_path) if mount_prefix else out_path
             if info.is_dir():
+                # A directory entry is the only record an empty
+                # directory leaves, so it has to be recreated even
+                # though nothing is written inside it.
+                await mkdir_fn(PathSpec.from_str_path(out_path), parents=True)
+                if not q:
+                    output_lines.append(f"   creating: {report_path}/")
                 continue
             content = zf.read(info)
-            entry_name = info.filename.lstrip("/")
-            out_path = dest.rstrip("/") + "/" + entry_name
             parent = out_path.rsplit("/", 1)[0] or "/"
             if parent != "/":
                 await mkdir_fn(PathSpec.from_str_path(parent), parents=True)
             await write_bytes(PathSpec.from_str_path(out_path), content)
-            report_path = (mount_prefix +
-                           out_path) if mount_prefix else out_path
             writes[out_path] = content
             if not q:
                 output_lines.append(f"  inflating: {report_path}")

--- a/python/mirage/commands/builtin/generic/zip_cmd.py
+++ b/python/mirage/commands/builtin/generic/zip_cmd.py
@@ -2,9 +2,208 @@ import io
 import posixpath
 import zipfile
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
+from mirage.commands.builtin.generic.archive.types import MemberKind
+from mirage.commands.builtin.generic.archive.walk import (OTHER_FILESYSTEM,
+                                                          StatFn, WalkFn,
+                                                          scan_operand)
 from mirage.io.types import ByteSource, IOResult
+from mirage.ops.types import LinkView, MountView
 from mirage.types import PathSpec
+from mirage.utils.fnmatch import fnmatch
+from mirage.utils.path import respell_one
+
+# Info-ZIP 3.0's wording, pinned on debian:stable-slim. A warning is
+# indented with a tab and -q silences it; the "Nothing to do!" error is
+# not a warning and survives -q. Exit 12 is Info-ZIP's ZE_NONE.
+WARNING_PREFIX = "\tzip warning: "
+# What Info-ZIP calls a path it could not reach. It does not distinguish
+# absent from unreadable, and a dangling symlink under the default
+# follow prints exactly this too.
+NOT_MATCHED = "name not matched: "
+NOTHING_TO_DO_EXIT = 12
+# Info-ZIP has no mount boundaries to describe, so this borrows GNU
+# tar's --one-file-system wording rather than inventing a second one.
+CROSSING_REASON = OTHER_FILESYSTEM
+# Unix mode bits in the high half of external_attr, which is where
+# Info-ZIP puts them and where a symlink entry is told from a file.
+DIR_MODE = 0o40755 << 16 | 0x10
+FILE_MODE = 0o100644 << 16
+LINK_MODE = 0o120777 << 16
+
+
+@dataclass(frozen=True, slots=True)
+class ZipMember:
+    """One entry the plan decided to store.
+
+    Args:
+        name (str): the archive entry name; a directory carries the
+            trailing slash Info-ZIP stores it with.
+        kind (MemberKind): file, dir, or link.
+        path (PathSpec | None): where a file's bytes come from.
+        target (str): a symlink's target, which is its content.
+    """
+
+    name: str
+    kind: MemberKind
+    path: PathSpec | None = None
+    target: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ZipPlan:
+    """What one ``zip`` run decided, before anything is written.
+
+    Args:
+        members (tuple[ZipMember, ...]): the entries to store, in order.
+        warnings (tuple[str, ...]): stderr lines without their prefix.
+        write (bool): whether to write an archive at all. Info-ZIP
+            leaves no file behind when nothing matched.
+    """
+
+    members: tuple[ZipMember, ...]
+    warnings: tuple[str, ...]
+    write: bool
+
+
+def member_name(spelled: str, kind: MemberKind, junk: bool) -> str:
+    """The entry name Info-ZIP stores for a path as the operand typed it.
+
+    A leading slash is stripped in silence (unlike tar, which warns), a
+    directory carries a trailing slash, and ``-j`` throws the directory
+    part away entirely.
+
+    Args:
+        spelled (str): the path as the operand spelled it.
+        kind (MemberKind): what the entry is.
+        junk (bool): ``-j``, store the basename only.
+    """
+    name = spelled.lstrip("/")
+    if junk:
+        name = posixpath.basename(name.rstrip("/"))
+    if kind == "dir" and name and not name.endswith("/"):
+        return name + "/"
+    return name
+
+
+def excluded(name: str, patterns: list[str]) -> bool:
+    """Whether an Info-ZIP ``-x`` pattern matches this entry name.
+
+    Info-ZIP matches the whole stored name, anchored, with wildcards
+    crossing slashes: ``d/sub/*`` takes ``d/sub/`` and everything under
+    it, ``*.txt`` takes every ``.txt`` at any depth, and a bare
+    ``b.txt`` matches nothing below the top. That is the opposite of
+    GNU tar's unanchored ``--exclude``, which is why the two have
+    separate matchers.
+
+    Args:
+        name (str): the stored entry name, directories slash-terminated.
+        patterns (list[str]): the raw ``-x`` values.
+    """
+    return any(fnmatch(name, pattern) for pattern in patterns)
+
+
+async def plan_zip(
+    paths: list[PathSpec],
+    *,
+    archive: PathSpec,
+    stat: StatFn,
+    walk: WalkFn,
+    recurse: bool,
+    junk: bool,
+    store_links: bool,
+    exclude: list[str],
+    links: LinkView | None = None,
+    mounts: MountView | None = None,
+) -> ZipPlan:
+    """Decide every entry of a new archive, before writing any of it.
+
+    Info-ZIP's defaults are tar's inverted twice over: a directory
+    operand contributes only itself unless ``-r`` says to descend, and a
+    symlink is followed unless ``-y`` says to store the link. Both are
+    parameters of the shared scan, so the traversal is the same one
+    ``tar -c`` uses.
+
+    Args:
+        paths (list[PathSpec]): the file operands, glob-resolved.
+        archive (PathSpec): the archive being written, so it is left out
+            of itself the way Info-ZIP silently leaves it out.
+        stat (StatFn): backend stat, raising when nothing is there.
+        walk (WalkFn): subtree listing, by find type.
+        recurse (bool): ``-r``.
+        junk (bool): ``-j``.
+        store_links (bool): ``-y``, store a symlink as a symlink.
+        exclude (list[str]): the raw ``-x`` values.
+        links (LinkView | None): the namespace's symlink facts.
+        mounts (MountView | None): where the mount boundaries are.
+    """
+    members: list[ZipMember] = []
+    warnings: list[str] = []
+    for path in paths:
+        raw = path.raw_path
+        base = path.virtual.rstrip("/") or "/"
+        scan = await scan_operand(path,
+                                  stat=stat,
+                                  walk=walk,
+                                  links=links,
+                                  mounts=mounts,
+                                  dereference=not store_links,
+                                  recurse=recurse)
+        for problem in scan.problems:
+            shown = respell_one(problem.path, base, raw)
+            if problem.fatal:
+                warnings.append(NOT_MATCHED + shown)
+            else:
+                warnings.append(f"{shown}: {problem.reason}")
+        if scan.missing:
+            continue
+        for crossing in scan.crossings:
+            shown = respell_one(crossing, base, raw)
+            warnings.append(f"{shown}: {CROSSING_REASON}")
+        for entry in scan.entries:
+            name = member_name(respell_one(entry.name_path, base, raw),
+                               entry.kind, junk)
+            if not name or excluded(name, exclude):
+                continue
+            # -j has no directory to name, so Info-ZIP drops directory
+            # entries under it entirely rather than storing bare slashes.
+            if junk and entry.kind == "dir":
+                continue
+            read = entry.read
+            if read is not None and read.virtual == archive.virtual:
+                # Info-ZIP never stores the archive it is writing, and
+                # says nothing about it.
+                continue
+            members.append(
+                ZipMember(name=name,
+                          kind=entry.kind,
+                          path=entry.read,
+                          target=entry.target))
+    return ZipPlan(members=tuple(members),
+                   warnings=tuple(warnings),
+                   write=bool(members))
+
+
+def _info(member: ZipMember, size: int) -> zipfile.ZipInfo:
+    info = zipfile.ZipInfo(filename=member.name)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.create_system = 3
+    info.file_size = size
+    if member.kind == "dir":
+        info.external_attr = DIR_MODE
+        info.compress_type = zipfile.ZIP_STORED
+    elif member.kind == "link":
+        info.external_attr = LINK_MODE
+    else:
+        info.external_attr = FILE_MODE
+    return info
+
+
+def _stderr(warnings: tuple[str, ...], quiet: bool) -> bytes:
+    if quiet:
+        return b""
+    return "".join(WARNING_PREFIX + line + "\n" for line in warnings).encode()
 
 
 async def zip_cmd(
@@ -12,29 +211,52 @@ async def zip_cmd(
     *,
     read_bytes: Callable[..., Awaitable[bytes]],
     write_bytes: Callable[..., Awaitable[None]],
+    stat: StatFn,
+    walk: WalkFn,
     r: bool = False,
     j: bool = False,
     q: bool = False,
+    y: bool = False,
+    x: list[str] | None = None,
+    links: LinkView | None = None,
+    mounts: MountView | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
-    if len(paths) < 2:
+    if not paths:
         raise ValueError("zip: usage: zip archive.zip file1 [file2 ...]")
     archive_path = paths[0]
-    file_paths = paths[1:]
+    plan = await plan_zip(paths[1:],
+                          archive=archive_path,
+                          stat=stat,
+                          walk=walk,
+                          recurse=r,
+                          junk=j,
+                          store_links=y,
+                          exclude=x or [],
+                          links=links,
+                          mounts=mounts)
+    if not plan.write:
+        # Info-ZIP writes no archive when nothing matched, and the error
+        # is not a warning: -q does not silence it.
+        nothing = f"\nzip error: Nothing to do! ({archive_path.raw_path})\n"
+        return None, IOResult(exit_code=NOTHING_TO_DO_EXIT,
+                              stderr=_stderr(plan.warnings, q) +
+                              nothing.encode())
     buf = io.BytesIO()
     output_lines: list[str] = []
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for p in file_paths:
-            data = await read_bytes(p)
-            arcname = posixpath.basename(
-                p.virtual) if j else p.virtual.lstrip("/")
-            zf.writestr(arcname, data)
-            if not q:
-                output_lines.append(f"  adding: {arcname}")
+        for member in plan.members:
+            data = b""
+            if member.kind == "link":
+                data = member.target.encode()
+            elif member.path is not None:
+                data = await read_bytes(member.path)
+            zf.writestr(_info(member, len(data)), data)
+            output_lines.append(f"  adding: {member.name}")
     archive = buf.getvalue()
     await write_bytes(archive_path, archive)
-    stdout = ("\n".join(output_lines) +
-              "\n").encode() if output_lines else None
-    return stdout, IOResult(writes={archive_path.mount_path: archive})
+    stdout = ("\n".join(output_lines) + "\n").encode() if not q else None
+    return stdout, IOResult(writes={archive_path.mount_path: archive},
+                            stderr=_stderr(plan.warnings, q))
 
 
-__all__ = ["zip_cmd"]
+__all__ = ["plan_zip", "zip_cmd"]

--- a/python/mirage/commands/builtin/generic_bind/archive_io.py
+++ b/python/mirage/commands/builtin/generic_bind/archive_io.py
@@ -1,0 +1,90 @@
+import logging
+from functools import partial
+
+from mirage.accessor.base import Accessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.archive.walk import DirProbe, WalkFn
+from mirage.commands.builtin.generic.find import parse_find_args, walk_find
+from mirage.commands.builtin.generic_bind.adapter import CommandIO, OperationFn
+from mirage.types import FileType, PathSpec
+
+logger = logging.getLogger(__name__)
+
+
+async def _walk(readdir: OperationFn, stat: OperationFn,
+                index: IndexCacheStore, path: PathSpec,
+                find_type: str) -> list[str]:
+    """One subtree listing, filtered to files or to directories.
+
+    Reuses find's walk so an archiver classifies an entry exactly the
+    way find does (through stat, never by name). The two calls a
+    directory operand makes share one readdir cache, so the second is
+    answered from the index instead of the backend.
+
+    Args:
+        readdir (OperationFn): backend readdir.
+        stat (OperationFn): backend stat.
+        index (IndexCacheStore): the per-call cache index.
+        path (PathSpec): the operand to walk.
+        find_type (str): "d" or "f".
+    """
+    return await walk_find(path,
+                           readdir=readdir,
+                           stat=stat,
+                           index=index,
+                           args=parse_find_args((), type=find_type))
+
+
+async def _is_dir(stat: OperationFn, readdir: OperationFn, path: PathSpec,
+                  index: IndexCacheStore) -> bool:
+    """Whether a path is a directory an archiver could chdir into.
+
+    Two channels, because a stat miss alone is not absence: on a prefix
+    store a directory is the set of keys under it and nothing answers
+    stat for it, so a readdir that returns anything is the second and
+    deciding opinion.
+
+    Args:
+        stat (OperationFn): backend stat.
+        readdir (OperationFn): backend readdir.
+        path (PathSpec): the candidate directory.
+        index (IndexCacheStore): the per-call cache index.
+    """
+    try:
+        return (await stat(path, index)).type == FileType.DIRECTORY
+    except (FileNotFoundError, ValueError):
+        logger.debug("archive: %s does not stat; asking readdir", path.virtual)
+    try:
+        return bool(await readdir(path, index))
+    except (FileNotFoundError, ValueError) as exc:
+        logger.debug("archive: %s is not a directory on either channel: %r",
+                     path.virtual, exc)
+        return False
+
+
+def walk_of(ops: CommandIO, accessor: Accessor,
+            index: IndexCacheStore) -> WalkFn:
+    """The subtree listing tar and zip both walk with.
+
+    Args:
+        ops (CommandIO): the bound backend operations.
+        accessor (Accessor): the mount's accessor.
+        index (IndexCacheStore): the per-call cache index.
+    """
+    return partial(_walk, partial(ops.readdir, accessor),
+                   partial(ops.stat, accessor), index)
+
+
+def is_dir_of(ops: CommandIO, accessor: Accessor,
+              index: IndexCacheStore) -> DirProbe:
+    """The directory probe tar's ``-C`` check uses.
+
+    Args:
+        ops (CommandIO): the bound backend operations.
+        accessor (Accessor): the mount's accessor.
+        index (IndexCacheStore): the per-call cache index.
+    """
+    return partial(_is_dir,
+                   partial(ops.stat, accessor),
+                   partial(ops.readdir, accessor),
+                   index=index)

--- a/python/mirage/commands/builtin/generic_bind/builders/tar.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/tar.py
@@ -41,7 +41,7 @@ async def tar(
     v: bool = False,
     h: bool = False,
     f: PathSpec | None = None,
-    C: PathSpec | None = None,
+    C: list[PathSpec] | None = None,
     strip_components: str | None = None,
     exclude: str | None = None,
     index: IndexCacheStore = NULL_INDEX,

--- a/python/mirage/commands/builtin/generic_bind/builders/tar.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/tar.py
@@ -19,7 +19,10 @@ from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.commands.builtin.generic.tar import tar as generic_tar
 from mirage.commands.builtin.generic_bind.adapter import (Builder, CommandIO,
                                                           Operation, bound_op)
+from mirage.commands.builtin.generic_bind.archive_io import is_dir_of, walk_of
+from mirage.commands.spec.types import FlagValue
 from mirage.io.types import ByteSource, IOResult
+from mirage.ops.types import LinkView, MountView
 from mirage.types import PathSpec
 
 
@@ -36,12 +39,15 @@ async def tar(
     j: bool = False,
     J: bool = False,
     v: bool = False,
+    h: bool = False,
     f: PathSpec | None = None,
     C: PathSpec | None = None,
     strip_components: str | None = None,
     exclude: str | None = None,
     index: IndexCacheStore = NULL_INDEX,
-    **flags,
+    links: LinkView | None = None,
+    mounts: MountView | None = None,
+    **flags: FlagValue,
 ) -> tuple[ByteSource | None, IOResult]:
     if not ops.is_mounted(accessor):
         raise ValueError("tar: missing operand")
@@ -53,6 +59,9 @@ async def tar(
                                                  accessor),
                              mkdir_fn=partial(ops.require(Operation.MKDIR),
                                               accessor),
+                             stat=bound_op(ops.stat, accessor, index),
+                             walk=walk_of(ops, accessor, index),
+                             is_dir=is_dir_of(ops, accessor, index),
                              c=c,
                              x=x,
                              t=t,
@@ -60,10 +69,13 @@ async def tar(
                              j=j,
                              J=J,
                              v=v,
+                             h=h,
                              f=f,
                              C=C,
                              strip_components=strip_components,
-                             exclude=exclude)
+                             exclude=exclude,
+                             links=links,
+                             mounts=mounts)
 
 
 BUILDER = Builder('tar',

--- a/python/mirage/commands/builtin/generic_bind/builders/zip_cmd.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/zip_cmd.py
@@ -19,7 +19,10 @@ from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.commands.builtin.generic.zip_cmd import zip_cmd as generic_zip
 from mirage.commands.builtin.generic_bind.adapter import (Builder, CommandIO,
                                                           Operation, bound_op)
+from mirage.commands.builtin.generic_bind.archive_io import walk_of
+from mirage.commands.spec.types import FlagValue
 from mirage.io.types import ByteSource, IOResult
+from mirage.ops.types import LinkView, MountView
 from mirage.types import PathSpec
 
 
@@ -32,10 +35,14 @@ async def zip_cmd(
     r: bool = False,
     j: bool = False,
     q: bool = False,
+    y: bool = False,
+    x: list[str] | None = None,
     index: IndexCacheStore = NULL_INDEX,
-    **flags,
+    links: LinkView | None = None,
+    mounts: MountView | None = None,
+    **flags: FlagValue,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not ops.is_mounted(accessor) or len(paths) < 2:
+    if not ops.is_mounted(accessor) or not paths:
         raise ValueError("zip: usage: zip archive.zip file1 [file2 ...]")
     paths = await ops.resolve_glob(accessor, paths, index)
     return await generic_zip(paths,
@@ -43,9 +50,15 @@ async def zip_cmd(
                                                  index),
                              write_bytes=partial(ops.require(Operation.WRITE),
                                                  accessor),
+                             stat=partial(ops.stat, accessor, index=index),
+                             walk=walk_of(ops, accessor, index),
                              r=r,
                              j=j,
-                             q=q)
+                             q=q,
+                             y=y,
+                             x=x,
+                             links=links,
+                             mounts=mounts)
 
 
 BUILDER = Builder('zip',

--- a/python/mirage/commands/spec/builtin_specs/archive.py
+++ b/python/mirage/commands/spec/builtin_specs/archive.py
@@ -25,6 +25,8 @@ SPECS: dict[str, CommandSpec] = {
             Option(short="-j"),
             Option(short="-J"),
             Option(short="-v"),
+            # -h archives what a symlink points at instead of the link.
+            Option(short="-h"),
             Option(short="-f", type="path"),
             Option(short="-C", type="path"),
             Option(long="--strip-components", type="str"),
@@ -33,6 +35,9 @@ SPECS: dict[str, CommandSpec] = {
         rest=Operand(type="path"),
         # `tar xzf a.tgz` is the spelling everyone types.
         old_option_style=True,
+        # -C is a chdir for the operands after it, not a flag the command
+        # reads once: `tar -cf a.tar -C d x` archives d/x as `x`.
+        operand_base="-C",
     ),
     'gzip':
     CommandSpec(
@@ -69,6 +74,13 @@ SPECS: dict[str, CommandSpec] = {
             Option(short="-r"),
             Option(short="-j"),
             Option(short="-q"),
+            # -y stores a symlink as a symlink; without it zip archives
+            # what the link points at, which is tar's -h inverted.
+            Option(short="-y"),
+            # Info-ZIP reads -x as a variadic list of patterns; mirage
+            # takes one per occurrence, since its spec has no variadic
+            # option value and `-x a -x b` says the same thing.
+            Option(short="-x", type="str", multiple=True),
         ),
         rest=Operand(type="path"),
     ),

--- a/python/mirage/commands/spec/builtin_specs/archive.py
+++ b/python/mirage/commands/spec/builtin_specs/archive.py
@@ -28,7 +28,10 @@ SPECS: dict[str, CommandSpec] = {
             # -h archives what a symlink points at instead of the link.
             Option(short="-h"),
             Option(short="-f", type="path"),
-            Option(short="-C", type="path"),
+            # Every occurrence is kept, in order: GNU chdirs at each
+            # one and fails at the first it cannot enter, so the
+            # planner has to see them all, not just the last.
+            Option(short="-C", type="path", multiple=True),
             Option(long="--strip-components", type="str"),
             Option(long="--exclude", type="str"),
         ),

--- a/python/mirage/commands/spec/compile.py
+++ b/python/mirage/commands/spec/compile.py
@@ -79,6 +79,9 @@ class CompiledSpec:
         numeric_dest (str | None): canonical spelling fed by the
             ``-<digits>`` shorthand, when one option declares it.
         rest_kind (ValueType | None): kind of the rest operand.
+        base_dest (str | None): canonical spelling of the option that
+            re-bases the path operands after it (``CommandSpec.
+            operand_base``, tar's -C).
     """
 
     bool_spellings: frozenset[str] = frozenset()
@@ -102,6 +105,7 @@ class CompiledSpec:
     defaults: dict[str, str] = field(default_factory=dict)
     numeric_dest: str | None = None
     rest_kind: ValueType | None = None
+    base_dest: str | None = None
 
     def dest_of(self, spelling: str) -> str:
         """Canonical spelling for a typed spelling.
@@ -262,6 +266,16 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
                 long_value_spellings.add(opt.long)
                 kind_of[opt.long] = opt.type
 
+    base_dest: str | None = None
+    if spec.operand_base is not None:
+        base_dest = dest.get(spec.operand_base)
+        if base_dest is None:
+            raise ValueError(f"operand_base {spec.operand_base!r} is not a "
+                             "declared option")
+        if kind_by_dest.get(base_dest) != "path" or base_dest in pair_dests:
+            raise ValueError(f"operand_base {spec.operand_base!r} must be a "
+                             "single-token path option")
+
     # Longest first so an attached match can never be stolen by a
     # shorter spelling that happens to prefix it (-name vs -n).
     value_spellings.sort(key=len, reverse=True)
@@ -289,4 +303,5 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
         defaults=defaults,
         numeric_dest=numeric_dest,
         rest_kind=spec.rest.type if spec.rest is not None else None,
+        base_dest=base_dest,
     )

--- a/python/mirage/commands/spec/parser.py
+++ b/python/mirage/commands/spec/parser.py
@@ -81,7 +81,13 @@ def _rebase(
     if cs.base_dest is None or cs.dest_of(spelling) != cs.base_dest:
         return base
     moved = resolve_path(value, base)
-    flags[cs.base_dest] = moved
+    bag = flags.get(cs.base_dest)
+    if isinstance(bag, list) and bag:
+        # An accumulating option already appended the raw value; the
+        # resolved one replaces it so nothing resolves it twice.
+        bag[-1] = moved
+    else:
+        flags[cs.base_dest] = moved
     return moved
 
 

--- a/python/mirage/commands/spec/parser.py
+++ b/python/mirage/commands/spec/parser.py
@@ -52,6 +52,39 @@ def _set_value_flag(
         flags[name] = value
 
 
+def _rebase(
+    flags: dict[str, ParsedFlagValue],
+    cs: CompiledSpec,
+    spelling: str,
+    value: str,
+    base: str,
+) -> str:
+    """Fold one option occurrence into the operand base directory.
+
+    Called after every value-flag record. Only the spec's declared
+    ``operand_base`` option moves the base, and it moves it the way a
+    chdir does: relative to wherever the previous occurrence left it, so
+    ``-C d1 ... -C ../d2`` lands in ``d1/../d2``. The resolved absolute
+    path replaces the raw value in the flag bag, so the later path-flag
+    pass has nothing left to resolve.
+
+    Args:
+        flags (dict): parsed flag bag, updated in place.
+        cs (CompiledSpec): compiled spec tables.
+        spelling (str): dashed spelling as typed.
+        value (str): the flag's value.
+        base (str): the base directory in effect before this occurrence.
+
+    Returns:
+        str: the base directory in effect after this occurrence.
+    """
+    if cs.base_dest is None or cs.dest_of(spelling) != cs.base_dest:
+        return base
+    moved = resolve_path(value, base)
+    flags[cs.base_dest] = moved
+    return moved
+
+
 def _set_bool_flag(
     flags: dict[str, ParsedFlagValue],
     cs: CompiledSpec,
@@ -157,6 +190,13 @@ def parse_command(
         # the shape heuristic and a path-shaped one (`tar sub/a.tgz`)
         # would reach dispatch resolved and unreadable as letters.
         word_kinds[0] = "str"
+    # The directory the next path operand resolves against, and where it
+    # was for each word already read. It only ever moves for a spec that
+    # declares operand_base, so every other command records None
+    # throughout and the classifier keeps using the session cwd.
+    base = cwd
+    word_bases: list[str | None] = [None] * len(argv)
+    raw_bases: list[str] = []
     warnings: list[str] = []
     invalid_options: list[str] = []
     ambiguous_options: list[tuple[str, tuple[str, ...]]] = []
@@ -181,6 +221,7 @@ def parse_command(
         if end_of_flags:
             raw_args.append(tok)
             raw_indices.append(orig_indices[i])
+            raw_bases.append(base)
             i += 1
             continue
 
@@ -221,6 +262,9 @@ def parse_command(
                   and i + 1 < len(filtered_argv)):
                 _set_value_flag(flags, cs, etok, filtered_argv[i + 1])
                 word_kinds[orig_indices[i + 1]] = cs.kind_of[etok]
+                if cs.dest_of(etok) == cs.base_dest:
+                    word_bases[orig_indices[i + 1]] = base
+                base = _rebase(flags, cs, etok, filtered_argv[i + 1], base)
                 i += 2
             elif is_pair:
                 if eq == -1:
@@ -235,12 +279,14 @@ def parse_command(
                 if eq != -1 and (spelling in cs.long_value_spellings
                                  or spelling in cs.long_optional_spellings):
                     _set_value_flag(flags, cs, spelling, tok[eq + 1:])
+                    base = _rebase(flags, cs, spelling, tok[eq + 1:], base)
                 elif etok in cs.long_value_spellings:
                     # Declared value flag at end of line with no argument.
                     needs_value_options.append(etok)
                 elif lenient_dash_operands:
                     raw_args.append(tok)
                     raw_indices.append(orig_indices[i])
+                    raw_bases.append(base)
                 else:
                     invalid_options.append(tok)
                     option_error_kinds.append("invalid")
@@ -256,6 +302,7 @@ def parse_command(
             for vf in cs.attach_spellings:
                 if tok.startswith(vf) and len(tok) > len(vf):
                     _set_value_flag(flags, cs, vf, tok[len(vf):])
+                    base = _rebase(flags, cs, vf, tok[len(vf):], base)
                     i += 1
                     matched_optional = True
                     break
@@ -266,11 +313,15 @@ def parse_command(
                 if tok == vf and i + 1 < len(filtered_argv):
                     _set_value_flag(flags, cs, vf, filtered_argv[i + 1])
                     word_kinds[orig_indices[i + 1]] = cs.kind_of[vf]
+                    if cs.dest_of(vf) == cs.base_dest:
+                        word_bases[orig_indices[i + 1]] = base
+                    base = _rebase(flags, cs, vf, filtered_argv[i + 1], base)
                     i += 2
                     matched_value = True
                     break
                 if tok.startswith(vf) and len(tok) > len(vf):
                     _set_value_flag(flags, cs, vf, tok[len(vf):])
+                    base = _rebase(flags, cs, vf, tok[len(vf):], base)
                     i += 1
                     matched_value = True
                     break
@@ -300,6 +351,7 @@ def parse_command(
                     for name in cluster_bools:
                         _set_bool_flag(flags, cs, name)
                     _set_value_flag(flags, cs, vflag, attached)
+                    base = _rebase(flags, cs, vflag, attached, base)
                     i += 1
                     continue
                 if i + 1 < len(filtered_argv):
@@ -307,12 +359,17 @@ def parse_command(
                         _set_bool_flag(flags, cs, name)
                     _set_value_flag(flags, cs, vflag, filtered_argv[i + 1])
                     word_kinds[orig_indices[i + 1]] = cs.kind_of[vflag]
+                    if cs.dest_of(vflag) == cs.base_dest:
+                        word_bases[orig_indices[i + 1]] = base
+                    base = _rebase(flags, cs, vflag, filtered_argv[i + 1],
+                                   base)
                     i += 2
                     continue
 
             if lenient_dash_operands or NUMERIC_SHORT.match(tok):
                 raw_args.append(tok)
                 raw_indices.append(orig_indices[i])
+                raw_bases.append(base)
             elif tok in cs.value_spellings or (mixed is not None
                                                and mixed[2] is None):
                 # A declared value flag (alone or ending a cluster) with no
@@ -338,6 +395,7 @@ def parse_command(
 
         raw_args.append(tok)
         raw_indices.append(orig_indices[i])
+        raw_bases.append(base)
         i += 1
 
     # Declared defaults land as if typed, before choices/required checks
@@ -421,8 +479,13 @@ def parse_command(
         else:
             kind = overflow_kind
         if kind == "path":
-            classified.append((resolve_path(arg, cwd), "path"))
+            # Against the base an operand_base option left in effect at
+            # this position, which is the session cwd for every command
+            # that declares none.
+            classified.append((resolve_path(arg, raw_bases[j]), "path"))
             raw_operands.append((arg, "path"))
+            if raw_bases[j] != cwd:
+                word_bases[raw_indices[j]] = raw_bases[j]
         else:
             classified.append((arg, kind))
             raw_operands.append((arg, kind))
@@ -469,6 +532,7 @@ def parse_command(
         text_flag_values=text_flag_values,
         warnings=warnings,
         word_kinds=word_kinds,
+        word_bases=word_bases,
         invalid_options=invalid_options,
         ambiguous_options=ambiguous_options,
         option_error_kinds=option_error_kinds,

--- a/python/mirage/commands/spec/types.py
+++ b/python/mirage/commands/spec/types.py
@@ -189,6 +189,13 @@ class CommandSpec:
     # (`tar xzf a.tgz`). Expanded by expand_old_style before any other
     # scanning; see oldstyle.py for the rules and why only tar has it.
     old_option_style: bool = False
+    # The spelling of an option that changes directory for the path
+    # operands typed AFTER it (tar's -C). Positional and cumulative, the
+    # way a real chdir is: `tar -cf a.tar -C d1 x -C ../d2 y` reads d1/x
+    # and d1/../d2/y. Only path operands and the option's own value move;
+    # every other path-valued flag keeps resolving against the session
+    # cwd, which is what GNU does with -f.
+    operand_base: str | None = None
 
 
 class FlagView:
@@ -310,6 +317,11 @@ class ParsedArgs:
     text_flag_values: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     word_kinds: list[ValueType | None] = field(default_factory=list)
+    # Per-position base directory, aligned with word_kinds: the absolute
+    # path a word resolves against when an operand_base option (tar's -C)
+    # moved it, and None when the session cwd still applies. Only a spec
+    # declaring operand_base ever fills this.
+    word_bases: list[str | None] = field(default_factory=list)
     # GNU-shaped option errors, reported (never raised) by the parser:
     # undeclared options ('--bogus' or the offending cluster char 'Y'),
     # abbreviated longs matching several options (typed prefix, matched

--- a/python/mirage/ops/types.py
+++ b/python/mirage/ops/types.py
@@ -28,6 +28,12 @@ StatPath = Callable[[str], Awaitable["FileStat | None"]]
 # (GIT_DISCOVERY_ACROSS_FILESYSTEM); crossing it would probe an
 # unrelated backend.
 MountRoot = Callable[[str], str]
+# The mount roots strictly under a virtual path, in prefix order,
+# without their trailing slash.
+MountDescendants = Callable[[str], list[str]]
+# Whether a virtual path IS a mount's root, rather than a directory the
+# backend holds.
+MountIsRoot = Callable[[str], bool]
 # lstat for one path: the link's own stat, None when not a link.
 LinkStat = Callable[[str], "FileStat | None"]
 # Stat rows for the links directly under a directory, for listings.
@@ -42,6 +48,35 @@ LinkResolve = Callable[[str], str]
 LinkExists = Callable[[str], Awaitable[bool]]
 # The stat of what a link points at, None when it dangles or loops.
 LinkTargetStat = Callable[[str], Awaitable["FileStat | None"]]
+
+
+@dataclass(frozen=True)
+class MountView:
+    """Where the mount boundaries are, as one injected object.
+
+    A command runs bound to one backend, and that backend cannot see a
+    mount nested inside its own tree: the child's keys live in another
+    resource entirely, so the parent's ``readdir`` never lists it. A
+    walker that must account for the whole subtree therefore has to be
+    told, the same way ``LinkView`` tells it about symlinks.
+
+    Traversal commands that render lines (find, du, grep -r) get this
+    for free from the executor's fan-out, which reruns them per mount
+    and concatenates the output. A command whose output is one binary
+    object (tar, zip) cannot be merged that way, so it reads the
+    boundaries here and says what it did with them.
+
+    A command opts in by naming a ``mounts`` parameter, which is what
+    makes the dispatcher hand it one.
+    """
+
+    # Mount roots strictly under a path (a walker: tar, zip).
+    descendants: MountDescendants
+    # Whether a path is a mount root itself.
+    is_root: MountIsRoot
+    # The mount serving a path, so a walker can tell "still mine" from
+    # "another backend" before it tries to read something it cannot.
+    root_of: MountRoot
 
 
 @dataclass(frozen=True)

--- a/python/mirage/policy/builtin/mount_root.py
+++ b/python/mirage/policy/builtin/mount_root.py
@@ -37,6 +37,38 @@ def has_symlink_flag(argv: tuple[str, ...]) -> bool:
     return False
 
 
+def is_create_mode(argv: tuple[str, ...]) -> bool:
+    """Whether a tar line reads the filesystem rather than an archive.
+
+    Only ``-c`` makes tar's operands source paths. Under ``-t`` and
+    ``-x`` they are member selectors matched against names inside the
+    archive, so a selector that happens to spell a mount root is not a
+    mount at all and refusing it would deny an ordinary listing.
+
+    Scanned raw for the same reason :func:`has_symlink_flag` is: the
+    policy fires before flag parsing. Only the first word may be GNU's
+    dashless option cluster (``tar cf a.tar d``), so a later bare word
+    is an operand and cannot turn the mode on.
+
+    Args:
+        argv (tuple[str, ...]): raw argv after the command name.
+    """
+    for i, tok in enumerate(argv):
+        if not isinstance(tok, str):
+            continue
+        if tok == "--create":
+            return True
+        if tok.startswith("--"):
+            continue
+        if tok.startswith("-"):
+            if "c" in tok[1:]:
+                return True
+            continue
+        if i == 0 and "c" in tok:
+            return True
+    return False
+
+
 def has_parents_flag(argv: tuple[str, ...]) -> bool:
     """Spot mkdir's -p/--parents by raw token scan.
 
@@ -139,7 +171,10 @@ class MountRootPolicy(Policy):
                 return Deny(f"ln: failed to create {kind} "
                             f"'{ctx.paths[-1].virtual}': File exists\n")
         elif cmd == "tar":
-            root = first_root(ctx.registry, ctx.operands)
+            # Only -c reads the filesystem; -t and -x match their
+            # operands against names inside the archive.
+            root = (first_root(ctx.registry, ctx.operands)
+                    if is_create_mode(ctx.argv) else None)
             if root is not None:
                 return Deny(
                     f"tar: {root.raw_path}: Cannot open: "

--- a/python/mirage/policy/builtin/mount_root.py
+++ b/python/mirage/policy/builtin/mount_root.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import Sequence
+
 from mirage.policy.base import Policy
-from mirage.policy.types import Action, CommandContext, Deny
+from mirage.policy.types import Action, CommandContext, Deny, MountRootQuery
+from mirage.types import PathSpec
 
 
 def has_symlink_flag(argv: tuple[str, ...]) -> bool:
@@ -53,17 +56,47 @@ def has_parents_flag(argv: tuple[str, ...]) -> bool:
     return False
 
 
-class MountRootPolicy(Policy):
-    """The built-in POSIX rule: a mount root is busy, not a directory.
+def first_root(query: MountRootQuery,
+               paths: Sequence[PathSpec]) -> PathSpec | None:
+    """The first of these paths that is a mount root, if any.
 
-    Mirrors the kernel's refusal to unlink or replace a mountpoint
-    (EBUSY on Linux), with each command's own GNU message. Fires before
-    mount resolution and cross-mount routing so the refusal is the same
-    however the operands span mounts, and before runtime placement so a
-    routed command is refused identically. MountRegistry seeds it as
-    the first policy (mount-root semantics belong to the mount layer),
-    so its exact GNU messages win over user policies by order, not by
-    privilege.
+    Args:
+        query (MountRootQuery): the mount-root oracle.
+        paths (Sequence[PathSpec]): paths to test, in operand order.
+    """
+    for path in paths:
+        if query.is_mount_root(path.virtual):
+            return path
+    return None
+
+
+class MountRootPolicy(Policy):
+    """The built-in rule: a mount root is not an ordinary directory.
+
+    Two rules, one boundary. The first mirrors the kernel's refusal to
+    unlink or replace a mountpoint (EBUSY on Linux), with each command's
+    own GNU message: rm, rmdir, mv, mkdir, touch and ln.
+
+    The second is mirage's own, and is a deliberate divergence: an
+    archiver or a recursive copy pointed at a mount root would read an
+    entire backend into one object. Real tar and cp allow it because a
+    mountpoint there is just another directory; here the mount table is
+    the deployment's configuration, and consuming a whole mount is
+    neither what the operand looks like it costs nor something an agent
+    should be able to do to data it was merely given a view of. The
+    refusal names the boundary in each tool's own voice rather than
+    inventing a mirage error, so a caller sees a filesystem answer.
+
+    Only positional operands are tested. tar's ``-C`` and unzip's ``-d``
+    are destinations to extract INTO, which is ordinary use of a mount,
+    so reading them here would refuse the safe direction as well.
+
+    Fires before mount resolution and cross-mount routing so the refusal
+    is the same however the operands span mounts, and before runtime
+    placement so a routed command is refused identically. MountRegistry
+    seeds it as the first policy (mount-root semantics belong to the
+    mount layer), so its exact messages win over user policies by order,
+    not by privilege.
     """
 
     async def pre_command(self, ctx: CommandContext) -> Action | None:
@@ -105,4 +138,25 @@ class MountRootPolicy(Policy):
                         if has_symlink_flag(ctx.argv) else "link")
                 return Deny(f"ln: failed to create {kind} "
                             f"'{ctx.paths[-1].virtual}': File exists\n")
+        elif cmd == "tar":
+            root = first_root(ctx.registry, ctx.operands)
+            if root is not None:
+                return Deny(
+                    f"tar: {root.raw_path}: Cannot open: "
+                    f"Device or resource busy\n"
+                    f"tar: Error is not recoverable: exiting now\n", 2)
+        elif cmd == "zip":
+            # The first operand is the archive being written, not a
+            # source; only what follows it is read.
+            root = first_root(ctx.registry, ctx.operands[1:])
+            if root is not None:
+                return Deny(f"zip: cannot read '{root.raw_path}': "
+                            f"Device or resource busy\n")
+        elif cmd == "cp":
+            # The last operand is the destination, and copying INTO a
+            # mount is ordinary; only the sources are refused.
+            root = first_root(ctx.registry, ctx.operands[:-1])
+            if root is not None:
+                return Deny(f"cp: cannot copy '{root.raw_path}': "
+                            f"Device or resource busy\n")
         return None

--- a/python/mirage/policy/types.py
+++ b/python/mirage/policy/types.py
@@ -81,7 +81,14 @@ class CommandContext:
 
     Args:
         command (str): the command name.
-        paths (tuple[PathSpec, ...]): positional path operands.
+        paths (tuple[PathSpec, ...]): every path the line names, the
+            positional operands first and then the values of any
+            path-valued flags. What a path-pattern guard matches on.
+        operands (tuple[PathSpec, ...]): the positional operands alone.
+            A rule that reads a slot by position (mv's source, ln's
+            target, tar's files) has to use this: with the flag values
+            mixed in, ``tar -xf a.tar -C /mnt`` would read the ``-C``
+            destination as a file being archived.
         argv (tuple[str, ...]): raw argv after the command name; the
             hook fires before flag parsing, so shorthand flags are raw
             tokens.
@@ -94,6 +101,7 @@ class CommandContext:
     argv: tuple[str, ...]
     cwd: str
     registry: MountRootQuery
+    operands: tuple[PathSpec, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/python/mirage/workspace/executor/command/routing.py
+++ b/python/mirage/workspace/executor/command/routing.py
@@ -86,6 +86,39 @@ def path_flag_scopes(cmd_name: str, argv: list[str],
     ]
 
 
+def positional_scopes(cmd_name: str, argv: list[str], cwd: str,
+                      words: list[str | PathSpec]) -> list[PathSpec]:
+    """The path operands a line names positionally, flag values left out.
+
+    Classification turns every path-shaped word into a PathSpec,
+    including the value of a path-valued flag, so the classified word
+    list cannot tell ``tar -xf a.tar -C /mnt`` (extract INTO a mount)
+    from ``tar -cf a.tar /mnt`` (archive a whole mount). Only the spec
+    knows which slot a word filled, so this asks it and keeps the
+    classified spec for each surviving operand, whose ``raw_path`` is
+    what a message should name.
+
+    Args:
+        cmd_name (str): command name.
+        argv (list[str]): the words after the command name, as typed.
+        cwd (str): working directory the line was typed under.
+        words (list[str | PathSpec]): the same words, classified.
+    """
+    spec = SPECS.get(cmd_name)
+    if spec is None:
+        return [p for p in words if isinstance(p, PathSpec)]
+    parsed = parse_command(spec, argv, cwd)
+    by_virtual = {p.virtual: p for p in words if isinstance(p, PathSpec)}
+    return [
+        by_virtual.get(
+            value,
+            PathSpec(virtual=value,
+                     directory=value,
+                     resource_path="",
+                     raw_path=value)) for value in parsed.paths()
+    ]
+
+
 def merge_scopes(positional: list[PathSpec],
                  flag_scopes: list[PathSpec]) -> list[PathSpec]:
     """Combine positional and path-flag scopes, keeping operand order.

--- a/python/mirage/workspace/executor/command/run.py
+++ b/python/mirage/workspace/executor/command/run.py
@@ -22,7 +22,7 @@ from mirage.commands.spec.types import FlagValue
 from mirage.io import IOResult
 from mirage.io.stream import materialize, wrap_cachable_streams
 from mirage.io.types import ByteSource
-from mirage.ops.types import LinkView
+from mirage.ops.types import LinkView, MountView
 from mirage.runtime.base import Runtime
 from mirage.runtime.policy import PolicyDecision
 from mirage.runtime.table import VFSRuntime
@@ -140,6 +140,19 @@ def link_view(namespace: Namespace | None,
                                                   dispatch))
 
 
+def mount_roots_below(registry: MountRegistry, virtual: str) -> list[str]:
+    """Mount roots strictly under a path, without the trailing slash.
+
+    Args:
+        registry (MountRegistry): registry holding the mount table.
+        virtual (str): absolute virtual path to scan beneath.
+    """
+    return [
+        m.prefix.rstrip("/") or "/"
+        for m in registry.descendant_mounts(virtual)
+    ]
+
+
 def mount_root_of(registry: MountRegistry, virtual: str) -> str:
     """The mount prefix serving a virtual path, "/" when none does.
 
@@ -157,6 +170,23 @@ def mount_root_of(registry: MountRegistry, virtual: str) -> str:
         return registry.mount_for(virtual).prefix
     except ValueError:
         return "/"
+
+
+def mount_view(registry: MountRegistry) -> MountView:
+    """The mount-boundary facts on offer to every command.
+
+    Which commands receive it is decided at dispatch by whether the
+    handler names a ``mounts`` parameter, the same opt-in ``links``
+    uses, so there is no list of boundary-aware commands to keep in
+    step.
+
+    Args:
+        registry (MountRegistry): registry holding the mount table.
+    """
+    return MountView(descendants=functools.partial(mount_roots_below,
+                                                   registry),
+                     is_root=registry.is_mount_root,
+                     root_of=functools.partial(mount_root_of, registry))
 
 
 async def drop_service_caches(registry: MountRegistry,
@@ -321,6 +351,7 @@ async def run_on_mount(
             stat_overlay=stat_overlay,
             links=links,
             stat_path=stat_path,
+            mounts=mount_view(registry),
         )
     except UsageError as exc:
         # Command-owned usage errors (extra operands, missing patterns)

--- a/python/mirage/workspace/expand/argv.py
+++ b/python/mirage/workspace/expand/argv.py
@@ -26,6 +26,7 @@ from mirage.workspace.expand.classify import classify_parts
 from mirage.workspace.expand.globs import resolve_globs
 from mirage.workspace.expand.parts import expand_parts
 from mirage.workspace.expand.spec_hints import (spec_for_command,
+                                                spec_word_bases,
                                                 spec_word_kinds)
 from mirage.workspace.mount import MountRegistry
 from mirage.workspace.route import WordPolicy, route, word_policy
@@ -105,16 +106,22 @@ async def expand_argv(
 
     policy = word_policy(route(name, session, registry))
     word_kinds: list[ValueType | None] | None = None
+    word_bases: list[str | None] | None = None
     if policy is WordPolicy.MOUNT:
         spec = spec_for_command(name, registry, session.cwd)
         if spec:
             extra: list[ValueType | None] = ["str"] * (consumed - 1)
             word_kinds = extra + spec_word_kinds(spec, expanded[consumed:])
+            bases = spec_word_bases(spec, expanded[consumed:], session.cwd)
+            if bases is not None:
+                head: list[str | None] = [None] * (consumed - 1)
+                word_bases = head + bases
 
     classified = classify_parts(expanded,
                                 registry,
                                 session.cwd,
-                                word_kinds=word_kinds)
+                                word_kinds=word_kinds,
+                                word_bases=word_bases)
     # set -f: glob words become literal paths for every consumer,
     # including backend pushdown, so `cat *.txt` looks up a file
     # literally named `*.txt` like bash with noglob.

--- a/python/mirage/workspace/expand/classify/parts.py
+++ b/python/mirage/workspace/expand/classify/parts.py
@@ -24,13 +24,16 @@ def classify_parts(
     registry: MountRegistry,
     cwd: str,
     word_kinds: list[ValueType | None] | None = None,
+    word_bases: list[str | None] | None = None,
 ) -> list[str | PathSpec]:
     """Classify a list of expanded words.
 
     First element (command name) is never classified as a path.
     word_kinds (from CommandSpec, aligned with parts[1:]) decides per
     position: TEXT skips classification, PATH classifies even bare
-    filenames, None falls back to the shape heuristics.
+    filenames, None falls back to the shape heuristics. word_bases, also
+    aligned with parts[1:], names the directory a word resolves against
+    when a chdir option (tar's -C) moved it; None there means the cwd.
     """
     if not parts:
         return []
@@ -38,10 +41,13 @@ def classify_parts(
     for i, w in enumerate(parts[1:]):
         kind = (word_kinds[i]
                 if word_kinds is not None and i < len(word_kinds) else None)
+        base = (word_bases[i]
+                if word_bases is not None and i < len(word_bases) else None)
+        here = base if base is not None else cwd
         if kind is not None and kind != "path":
             result.append(w)
         elif kind == "path":
-            result.append(classify_bare_path(w, registry, cwd))
+            result.append(classify_bare_path(w, registry, here))
         else:
-            result.append(classify_word(w, registry, cwd))
+            result.append(classify_word(w, registry, here))
     return result

--- a/python/mirage/workspace/expand/spec_hints.py
+++ b/python/mirage/workspace/expand/spec_hints.py
@@ -67,3 +67,26 @@ def spec_word_kinds(
     # nothing to override here: leaving them None sent `find \( ... \)`
     # back to the shape heuristic, which read "(" as the bare path "/(".
     return list(parse_command(spec, argv, cwd="/").word_kinds)
+
+
+def spec_word_bases(
+    spec: CommandSpec,
+    argv: list[str],
+    cwd: str,
+) -> list[str | None] | None:
+    """Per-position base directories for a spec that declares one.
+
+    tar's -C is a chdir for the operands typed after it, so those words
+    are not relative to the session cwd at all. The parser already walks
+    the line positionally, so it is what says where each word stood;
+    this asks it, and only for the one command family that can answer
+    (None everywhere else, so 92 of 93 specs pay nothing).
+
+    Args:
+        spec (CommandSpec): command specification.
+        argv (list[str]): command arguments (without command name).
+        cwd (str): the working directory the line was typed under.
+    """
+    if spec.operand_base is None:
+        return None
+    return list(parse_command(spec, argv, cwd=cwd).word_bases)

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -31,7 +31,7 @@ from mirage.observe.context import (push_mount_prefix, push_revisions,
                                     reset_revisions, with_mount_prefix,
                                     with_revisions)
 from mirage.ops.registry import RegisteredOp
-from mirage.ops.types import LinkView, StatOverlay, StatPath
+from mirage.ops.types import LinkView, MountView, StatOverlay, StatPath
 from mirage.policy import resolve_limit
 from mirage.resource.base import BaseResource
 from mirage.runtime.base import Runtime
@@ -446,6 +446,7 @@ class MountEntry:
         stat_overlay: StatOverlay | None = None,
         links: LinkView | None = None,
         stat_path: StatPath | None = None,
+        mounts: MountView | None = None,
     ) -> tuple[ByteSource | None, IOResult]:
         """Execute a command on this mount's resource.
 
@@ -465,7 +466,10 @@ class MountEntry:
             links (LinkView | None): the namespace's symlink facts.
             stat_path (StatPath | None): dispatcher-backed stat of one
                 path, for a traversal command's start point.
-                All three reach only the handlers that name them as a
+            mounts (MountView | None): where the mount boundaries are,
+                for a walker whose output cannot be fanned out and
+                concatenated (tar, zip).
+                All four reach only the handlers that name them as a
                 parameter, so no list of command names is kept here.
         """
         extension = get_extension(paths[0].virtual) if paths else None
@@ -533,6 +537,7 @@ class MountEntry:
             "stat_overlay": stat_overlay,
             "links": links,
             "stat_path": stat_path,
+            "mounts": mounts,
         }
         offered = {k: v for k, v in offered.items() if v is not None}
         if runtime is not None:

--- a/python/mirage/workspace/names.py
+++ b/python/mirage/workspace/names.py
@@ -70,9 +70,17 @@ JOB_BUILTINS = frozenset({"wait", "fg", "kill", "jobs", "ps"})
 # `stat` is here because GNU stat lstats, but it takes -L to dereference
 # after all, which route's `dereferences` reads back out of the command
 # line; `file`, `du` and `find` are the same shape.
+#
+# `tar` and `zip` are here for a different reason and deliberately carry
+# no DEREFERENCE_FLAGS entry: they dereference too, but their planner
+# has to be the one doing it. Rewriting the operand up here would hand
+# the planner a target it can no longer tell was reached through a link,
+# so `tar` could not store a symlink member at all and neither archiver
+# could apply its own cross-mount refusal or ELOOP wording. tar's -h and
+# zip's -y are read by the planner instead.
 NO_FOLLOW_COMMANDS = frozenset({
     "rm", "mv", "ln", "readlink", "rmdir", "unlink", "stat", "file", "du",
-    "find"
+    "find", "tar", "zip"
 })
 
 SHELL_NAMES = frozenset(str(b) for b in ShellBuiltin) | UNSUPPORTED_BUILTINS

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -27,7 +27,8 @@ from mirage.shell.xtrace import trace_command
 from mirage.types import PathSpec, Producer, word_text
 from mirage.utils.path import CycleError
 from mirage.workspace.executor.command import handle_command
-from mirage.workspace.executor.command.routing import path_flag_scopes
+from mirage.workspace.executor.command.routing import (path_flag_scopes,
+                                                       positional_scopes)
 from mirage.workspace.executor.control import BreakSignal, ContinueSignal
 from mirage.workspace.expand import expand_node
 from mirage.workspace.expand.argv import Argv, expand_argv
@@ -283,6 +284,9 @@ async def _run_argv(
         deny = await registry.policies.pre_command(
             CommandContext(command=name,
                            paths=tuple(scopes),
+                           operands=tuple(
+                               positional_scopes(name, args, session.cwd,
+                                                 operands)),
                            argv=tuple(args),
                            cwd=session.cwd,
                            registry=registry))

--- a/python/tests/commands/builtin/generic/archive/test_walk.py
+++ b/python/tests/commands/builtin/generic/archive/test_walk.py
@@ -1,0 +1,193 @@
+import pytest
+
+from mirage.commands.builtin.generic.archive.walk import (LOOP_SKIP,
+                                                          OTHER_FILESYSTEM,
+                                                          child_spec,
+                                                          same_mount,
+                                                          scan_operand)
+from mirage.ops.types import LinkView, MountView
+from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
+from mirage.utils.key_prefix import mount_key
+
+
+def _spec(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(resource_path=mount_key(path, prefix),
+                    virtual=path,
+                    directory=path,
+                    resolved=True)
+
+
+class _Tree:
+
+    def __init__(self, files: dict[str, bytes], dirs: tuple[str, ...] = ()):
+        self.files = dict(files)
+        self.dirs = set(dirs)
+
+    async def stat(self, path):
+        key = path.virtual.rstrip("/") or "/"
+        if key in self.dirs:
+            return FileStat(name=key, type=FileType.DIRECTORY)
+        if key in self.files:
+            return FileStat(name=key,
+                            type=FileType.TEXT,
+                            size=len(self.files[key]))
+        raise FileNotFoundError(key)
+
+    async def walk(self, path, find_type):
+        base = path.virtual.rstrip("/") or "/"
+        pool = self.dirs if find_type == "d" else self.files
+        return sorted(p for p in pool
+                      if p == base or p.startswith(base.rstrip("/") + "/"))
+
+
+def _links(entries: dict[str, str]) -> LinkView:
+
+    def stat_of(path):
+        target = entries[path]
+        return FileStat(name=path,
+                        type=FileType.SYMLINK,
+                        size=len(target),
+                        extra={LINK_TARGET_KEY: target})
+
+    async def target_stat(path):
+        return None
+
+    async def exists(path):
+        return path in entries
+
+    return LinkView(
+        stat_at=lambda p: stat_of(p) if p in entries else None,
+        children=lambda p: [],
+        subtree=lambda p: [(k, stat_of(k)) for k in sorted(entries)
+                           if k.startswith(p.rstrip("/") + "/")],
+        resolve=lambda p: entries.get(p, p),
+        exists=exists,
+        target_stat=target_stat,
+    )
+
+
+def _mounts(descendants: tuple[str, ...] = (),
+            roots: tuple[str, ...] = ()) -> MountView:
+
+    def root_of(path):
+        for root in sorted(roots, key=len, reverse=True):
+            if path == root or path.startswith(root.rstrip("/") + "/"):
+                return root
+        return "/"
+
+    return MountView(
+        descendants=lambda p:
+        [d for d in descendants if d.startswith(p.rstrip("/") + "/")],
+        is_root=lambda p: p.rstrip("/") in {r.rstrip("/")
+                                            for r in roots},
+        root_of=root_of,
+    )
+
+
+async def _scan(tree: _Tree, path: PathSpec, **kwargs):
+    return await scan_operand(path, stat=tree.stat, walk=tree.walk, **kwargs)
+
+
+def test_child_spec_strips_the_mount_prefix_from_the_backend_key():
+    root = _spec("/data/d", "/data")
+    child = child_spec("/data/d/a.txt", root)
+    assert child.virtual == "/data/d/a.txt"
+    assert child.resource_path == "d/a.txt"
+
+
+def test_same_mount_is_true_without_a_mount_view():
+    assert same_mount(None, "/a", "/b")
+    mounts = _mounts(roots=("/", "/m"))
+    assert same_mount(mounts, "/a", "/b")
+    assert not same_mount(mounts, "/a", "/m/x")
+
+
+@pytest.mark.asyncio
+async def test_recurse_false_stops_at_the_directory_itself():
+    tree = _Tree({"/d/a.txt": b"a"}, dirs=("/d", "/d/sub"))
+    scan = await _scan(tree, _spec("/d"), recurse=False)
+    assert [e.name_path for e in scan.entries] == ["/d"]
+    assert scan.entries[0].kind == "dir"
+
+
+@pytest.mark.asyncio
+async def test_recurse_true_reports_the_whole_subtree_sorted():
+    tree = _Tree({
+        "/d/a.txt": b"a",
+        "/d/sub/b.txt": b"b"
+    },
+                 dirs=("/d", "/d/sub"))
+    scan = await _scan(tree, _spec("/d"), recurse=True)
+    assert [e.name_path for e in scan.entries
+            ] == ["/d", "/d/a.txt", "/d/sub", "/d/sub/b.txt"]
+
+
+@pytest.mark.asyncio
+async def test_a_missing_operand_is_one_fatal_problem_and_no_entries():
+    tree = _Tree({})
+    scan = await _scan(tree, _spec("/nope"))
+    assert scan.missing
+    assert not scan.entries
+    assert [(p.path, p.fatal) for p in scan.problems] == [("/nope", True)]
+
+
+@pytest.mark.asyncio
+async def test_a_link_is_stored_or_followed_by_the_dereference_flag():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    links = _links({"/d/link.txt": "/d/a.txt"})
+    stored = await _scan(tree,
+                         _spec("/d"),
+                         links=links,
+                         dereference=False,
+                         recurse=True)
+    kinds = {e.name_path: e.kind for e in stored.entries}
+    assert kinds["/d/link.txt"] == "link"
+    followed = await _scan(tree,
+                           _spec("/d"),
+                           links=links,
+                           dereference=True,
+                           recurse=True)
+    kinds = {e.name_path: e.kind for e in followed.entries}
+    assert kinds["/d/link.txt"] == "file"
+
+
+@pytest.mark.asyncio
+async def test_following_a_link_twice_reports_a_loop_once():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    links = _links({"/d/one": "/d/a.txt", "/d/two": "/d/a.txt"})
+    scan = await _scan(tree,
+                       _spec("/d"),
+                       links=links,
+                       dereference=True,
+                       recurse=True)
+    assert [p.reason for p in scan.problems] == [LOOP_SKIP]
+    assert "/d/two" not in {e.name_path for e in scan.entries}
+
+
+@pytest.mark.asyncio
+async def test_a_nested_mount_is_reported_and_its_contents_dropped():
+    tree = _Tree({
+        "/d/a.txt": b"a",
+        "/d/nested/deep.txt": b"deep"
+    },
+                 dirs=("/d", "/d/nested"))
+    mounts = _mounts(descendants=("/d/nested", ), roots=("/", "/d/nested"))
+    scan = await _scan(tree, _spec("/d"), mounts=mounts, recurse=True)
+    assert scan.crossings == ("/d/nested", )
+    names = [e.name_path for e in scan.entries]
+    assert names == ["/d", "/d/a.txt", "/d/nested"]
+
+
+@pytest.mark.asyncio
+async def test_a_link_across_a_mount_is_refused_not_followed():
+    tree = _Tree({"/d/a.txt": b"a"}, dirs=("/d", ))
+    links = _links({"/d/away": "/m/x.txt"})
+    mounts = _mounts(roots=("/", "/m"))
+    scan = await _scan(tree,
+                       _spec("/d"),
+                       links=links,
+                       mounts=mounts,
+                       dereference=True,
+                       recurse=True)
+    assert [(p.path, p.reason)
+            for p in scan.problems] == [("/d/away", OTHER_FILESYSTEM)]

--- a/python/tests/commands/builtin/generic/archive/test_walk.py
+++ b/python/tests/commands/builtin/generic/archive/test_walk.py
@@ -1,13 +1,12 @@
+from dataclasses import replace
+
 import pytest
 
-from mirage.commands.builtin.generic.archive.walk import (LOOP_SKIP,
-                                                          OTHER_FILESYSTEM,
-                                                          child_spec,
-                                                          same_mount,
-                                                          scan_operand)
+from mirage.commands.builtin.generic.archive import walk as aw
 from mirage.ops.types import LinkView, MountView
 from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
+from mirage.utils.path import CycleError
 
 
 def _spec(path: str, prefix: str = "") -> PathSpec:
@@ -66,6 +65,16 @@ def _links(entries: dict[str, str]) -> LinkView:
     )
 
 
+def _cycle(entries: dict[str, str]) -> LinkView:
+    """A LinkView whose resolve raises ELOOP, as the namespace does."""
+    view = _links(entries)
+
+    def resolve(path):
+        raise CycleError(path)
+
+    return replace(view, resolve=resolve)
+
+
 def _mounts(descendants: tuple[str, ...] = (),
             roots: tuple[str, ...] = ()) -> MountView:
 
@@ -85,21 +94,24 @@ def _mounts(descendants: tuple[str, ...] = (),
 
 
 async def _scan(tree: _Tree, path: PathSpec, **kwargs):
-    return await scan_operand(path, stat=tree.stat, walk=tree.walk, **kwargs)
+    return await aw.scan_operand(path,
+                                 stat=tree.stat,
+                                 walk=tree.walk,
+                                 **kwargs)
 
 
 def test_child_spec_strips_the_mount_prefix_from_the_backend_key():
     root = _spec("/data/d", "/data")
-    child = child_spec("/data/d/a.txt", root)
+    child = aw.child_spec("/data/d/a.txt", root)
     assert child.virtual == "/data/d/a.txt"
     assert child.resource_path == "d/a.txt"
 
 
 def test_same_mount_is_true_without_a_mount_view():
-    assert same_mount(None, "/a", "/b")
+    assert aw.same_mount(None, "/a", "/b")
     mounts = _mounts(roots=("/", "/m"))
-    assert same_mount(mounts, "/a", "/b")
-    assert not same_mount(mounts, "/a", "/m/x")
+    assert aw.same_mount(mounts, "/a", "/b")
+    assert not aw.same_mount(mounts, "/a", "/m/x")
 
 
 @pytest.mark.asyncio
@@ -152,7 +164,8 @@ async def test_a_link_is_stored_or_followed_by_the_dereference_flag():
 
 
 @pytest.mark.asyncio
-async def test_following_a_link_twice_reports_a_loop_once():
+async def test_two_links_to_one_target_are_both_archived():
+    """Not a loop: GNU tar -h and Info-ZIP both store the two names."""
     tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
     links = _links({"/d/one": "/d/a.txt", "/d/two": "/d/a.txt"})
     scan = await _scan(tree,
@@ -160,8 +173,38 @@ async def test_following_a_link_twice_reports_a_loop_once():
                        links=links,
                        dereference=True,
                        recurse=True)
-    assert [p.reason for p in scan.problems] == [LOOP_SKIP]
-    assert "/d/two" not in {e.name_path for e in scan.entries}
+    assert not scan.problems
+    names = {e.name_path for e in scan.entries}
+    assert {"/d/one", "/d/two"} <= names
+
+
+@pytest.mark.asyncio
+async def test_a_real_cycle_is_one_fatal_problem_per_member():
+    tree = _Tree({}, dirs=("/d", ))
+    links = _cycle({"/d/a": "/d/b", "/d/b": "/d/a"})
+    scan = await _scan(tree,
+                       _spec("/d"),
+                       links=links,
+                       dereference=True,
+                       recurse=True)
+    assert [(p.path, p.reason, p.fatal) for p in scan.problems] == [
+        ("/d/a", aw.TOO_MANY_LEVELS, True),
+        ("/d/b", aw.TOO_MANY_LEVELS, True),
+    ]
+    # GNU keeps the directory entry and exits 2; it does not abort.
+    assert [e.name_path for e in scan.entries] == ["/d"]
+
+
+@pytest.mark.asyncio
+async def test_a_dangling_link_is_fatal_with_the_enoent_wording():
+    tree = _Tree({}, dirs=("/d", ))
+    links = _links({"/d/bad": "/d/nowhere"})
+    scan = await _scan(tree,
+                       _spec("/d"),
+                       links=links,
+                       dereference=True,
+                       recurse=True)
+    assert [(p.reason, p.fatal) for p in scan.problems] == [(aw.NO_SUCH, True)]
 
 
 @pytest.mark.asyncio
@@ -190,4 +233,4 @@ async def test_a_link_across_a_mount_is_refused_not_followed():
                        dereference=True,
                        recurse=True)
     assert [(p.path, p.reason)
-            for p in scan.problems] == [("/d/away", OTHER_FILESYSTEM)]
+            for p in scan.problems] == [("/d/away", aw.OTHER_FILESYSTEM)]

--- a/python/tests/commands/builtin/generic/test_phase_z.py
+++ b/python/tests/commands/builtin/generic/test_phase_z.py
@@ -3,10 +3,8 @@ import pytest
 from mirage.commands.builtin.generic.diff import diff
 from mirage.commands.builtin.generic.jq import jq
 from mirage.commands.builtin.generic.patch import patch
-from mirage.commands.builtin.generic.tar import tar
 from mirage.commands.builtin.generic.tsort import tsort
 from mirage.commands.builtin.generic.unzip import unzip
-from mirage.commands.builtin.generic.zip_cmd import zip_cmd
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -131,40 +129,6 @@ async def test_jq_no_input():
 
 
 @pytest.mark.asyncio
-async def test_zip_basic():
-    rb, wb, _, _, store = _make_backend({
-        "f1.txt": b"hello",
-        "f2.txt": b"world"
-    })
-    out, io = await zip_cmd(
-        [_spec("out.zip"), _spec("f1.txt"),
-         _spec("f2.txt")],
-        read_bytes=rb,
-        write_bytes=wb)
-    assert b"adding" in out
-    assert "out.zip" in store
-    archive = store["out.zip"]
-    assert archive.startswith(b"PK")
-
-
-@pytest.mark.asyncio
-async def test_zip_quiet():
-    rb, wb, _, _, _ = _make_backend({"f.txt": b"x"})
-    out, _ = await zip_cmd([_spec("o.zip"), _spec("f.txt")],
-                           read_bytes=rb,
-                           write_bytes=wb,
-                           q=True)
-    assert out is None
-
-
-@pytest.mark.asyncio
-async def test_zip_too_few_paths():
-    rb, wb, _, _, _ = _make_backend({})
-    with pytest.raises(ValueError, match="usage"):
-        await zip_cmd([_spec("only.zip")], read_bytes=rb, write_bytes=wb)
-
-
-@pytest.mark.asyncio
 async def test_unzip_extracts():
     import io as _io
     import zipfile
@@ -228,63 +192,6 @@ async def test_unzip_pipe_mode():
                          mkdir_fn=mk,
                          p=True)
     assert out == b"hello"
-
-
-@pytest.mark.asyncio
-async def test_tar_create_and_list():
-    rb, wb, _, mk, store = _make_backend({"a.txt": b"alpha", "b.txt": b"beta"})
-    _, io_res = await tar([_spec("a.txt"), _spec("b.txt")],
-                          read_bytes=rb,
-                          write_bytes=wb,
-                          mkdir_fn=mk,
-                          c=True,
-                          f=_spec("out.tar"))
-    assert "/out.tar" in io_res.writes
-    out, _ = await tar([],
-                       read_bytes=rb,
-                       write_bytes=wb,
-                       mkdir_fn=mk,
-                       t=True,
-                       f=_spec("out.tar"))
-    assert b"a.txt" in out
-    assert b"b.txt" in out
-
-
-@pytest.mark.asyncio
-async def test_tar_extract():
-    rb, wb, _, mk, _ = _make_backend({"x.txt": b"data"})
-    await tar([_spec("x.txt")],
-              read_bytes=rb,
-              write_bytes=wb,
-              mkdir_fn=mk,
-              c=True,
-              f=_spec("a.tar"))
-    _, io_res = await tar([],
-                          read_bytes=rb,
-                          write_bytes=wb,
-                          mkdir_fn=mk,
-                          x=True,
-                          f=_spec("a.tar"),
-                          C=_spec("/out"))
-    assert any("x.txt" in p for p in io_res.writes)
-
-
-@pytest.mark.asyncio
-async def test_tar_requires_mode():
-    rb, wb, _, mk, _ = _make_backend({})
-    with pytest.raises(ValueError, match="-c, -x, or -t"):
-        await tar([], read_bytes=rb, write_bytes=wb, mkdir_fn=mk)
-
-
-@pytest.mark.asyncio
-async def test_tar_requires_f():
-    rb, wb, _, mk, _ = _make_backend({"a.txt": b"x"})
-    with pytest.raises(ValueError, match="-f is required"):
-        await tar([_spec("a.txt")],
-                  read_bytes=rb,
-                  write_bytes=wb,
-                  mkdir_fn=mk,
-                  c=True)
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/generic/test_tar.py
+++ b/python/tests/commands/builtin/generic/test_tar.py
@@ -1,0 +1,377 @@
+import io
+import tarfile
+
+import pytest
+
+from mirage.commands.builtin.generic.tar import (excluded, member_name, pruned,
+                                                 tar)
+from mirage.ops.types import LinkView, MountView
+from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
+from mirage.utils.key_prefix import mount_key
+
+
+def _spec(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(resource_path=mount_key(path, prefix),
+                    virtual=path,
+                    directory=path,
+                    resolved=True)
+
+
+def _raw(path: str, raw: str, prefix: str = "") -> PathSpec:
+    return PathSpec(resource_path=mount_key(path, prefix),
+                    virtual=path,
+                    directory=path,
+                    resolved=True,
+                    raw_path=raw)
+
+
+class _Tree:
+    """A tiny in-memory backend: files by path, directories derived."""
+
+    def __init__(self, files: dict[str, bytes], dirs: tuple[str, ...] = ()):
+        self.files = dict(files)
+        self.dirs = set(dirs)
+        for path in files:
+            parent = path.rsplit("/", 1)[0]
+            while parent:
+                self.dirs.add(parent)
+                parent = parent.rsplit("/", 1)[0] if "/" in parent else ""
+
+    async def read_bytes(self, path):
+        key = path.virtual if isinstance(path, PathSpec) else path
+        if key not in self.files:
+            raise FileNotFoundError(key)
+        return self.files[key]
+
+    async def write_bytes(self, path, data):
+        self.files[path.virtual] = data
+
+    async def mkdir(self, path, parents=False):
+        self.dirs.add(path.virtual.rstrip("/"))
+
+    async def stat(self, path):
+        key = path.virtual.rstrip("/") or "/"
+        if key in self.dirs:
+            return FileStat(name=key, type=FileType.DIRECTORY)
+        if key in self.files:
+            return FileStat(name=key,
+                            type=FileType.TEXT,
+                            size=len(self.files[key]))
+        raise FileNotFoundError(key)
+
+    async def walk(self, path, find_type):
+        base = path.virtual.rstrip("/") or "/"
+        pool = self.dirs if find_type == "d" else self.files
+        return sorted(p for p in pool
+                      if p == base or p.startswith(base.rstrip("/") + "/"))
+
+    async def is_dir(self, path):
+        return (path.virtual.rstrip("/") or "/") in self.dirs
+
+
+def _links(entries: dict[str, str]) -> LinkView:
+
+    def stat_of(path):
+        target = entries[path]
+        return FileStat(name=path,
+                        type=FileType.SYMLINK,
+                        size=len(target),
+                        extra={LINK_TARGET_KEY: target})
+
+    async def target_stat(path):
+        return None
+
+    async def exists(path):
+        return path in entries
+
+    return LinkView(
+        stat_at=lambda p: stat_of(p) if p in entries else None,
+        children=lambda p: [],
+        subtree=lambda p: [(k, stat_of(k)) for k in sorted(entries)
+                           if k.startswith(p.rstrip("/") + "/")],
+        resolve=lambda p: entries.get(p, p),
+        exists=exists,
+        target_stat=target_stat,
+    )
+
+
+def _mounts(descendants: tuple[str, ...] = (),
+            roots: tuple[str, ...] = ()) -> MountView:
+
+    def root_of(path):
+        for root in sorted(roots, key=len, reverse=True):
+            if path == root or path.startswith(root.rstrip("/") + "/"):
+                return root
+        return "/"
+
+    return MountView(
+        descendants=lambda p:
+        [d for d in descendants if d.startswith(p.rstrip("/") + "/")],
+        is_root=lambda p: p.rstrip("/") in {r.rstrip("/")
+                                            for r in roots},
+        root_of=root_of,
+    )
+
+
+async def _create(tree: _Tree, paths, **flags):
+    return await tar(paths,
+                     read_bytes=tree.read_bytes,
+                     write_bytes=tree.write_bytes,
+                     mkdir_fn=tree.mkdir,
+                     stat=tree.stat,
+                     walk=tree.walk,
+                     is_dir=tree.is_dir,
+                     **flags)
+
+
+def _names(archive: bytes) -> list[str]:
+    with tarfile.open(fileobj=io.BytesIO(archive)) as tf:
+        return [
+            member.name + "/" if member.isdir() else member.name
+            for member in tf.getmembers()
+        ]
+
+
+def test_excluded_matches_whole_name_and_every_component_suffix():
+    assert excluded("d/a.txt", "d/a.txt")
+    assert excluded("d/a.txt", "a.txt")
+    assert excluded("d/sub/b.txt", "sub/b.txt")
+    assert excluded("d/sub/b.txt", "*/b.txt")
+    assert excluded("d/sub/", "sub")
+    assert not excluded("d/a.txt", "b.txt")
+    # The pattern is anchored at a component boundary, not mid-name.
+    assert not excluded("d/abc.txt", "bc.txt")
+
+
+def test_pruned_takes_the_children_of_an_excluded_directory():
+    names = ["d/", "d/a.txt", "d/sub/", "d/sub/b.txt"]
+    assert pruned(names, "sub") == ["d/", "d/a.txt"]
+    assert pruned(names, "sub/b.txt") == ["d/", "d/a.txt", "d/sub/"]
+    assert pruned(names, None) == names
+
+
+def test_member_name_strips_the_leading_slash_and_marks_directories():
+    assert member_name("/data/d/a.txt", "file") == "data/d/a.txt"
+    assert member_name("/data/d", "dir") == "data/d/"
+    assert member_name("d/", "dir") == "d/"
+    assert member_name("link", "link") == "link"
+
+
+@pytest.mark.asyncio
+async def test_create_walks_a_directory_operand():
+    tree = _Tree({
+        "/d/a.txt": b"alpha",
+        "/d/sub/b.txt": b"beta"
+    },
+                 dirs=("/d", "/d/sub", "/d/empty"))
+    out, io_res = await _create(tree, [_raw("/d", "d")],
+                                c=True,
+                                v=True,
+                                f=_spec("/out.tar"))
+    assert io_res.exit_code == 0
+    assert out.decode().split() == [
+        "d/", "d/a.txt", "d/empty/", "d/sub/", "d/sub/b.txt"
+    ]
+    assert _names(io_res.writes["/out.tar"]) == [
+        "d/", "d/a.txt", "d/empty/", "d/sub/", "d/sub/b.txt"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_keeps_an_empty_directory_as_its_own_member():
+    tree = _Tree({"/d/a.txt": b"x"}, dirs=("/d", "/d/empty"))
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              f=_spec("/out.tar"))
+    assert "d/empty/" in _names(io_res.writes["/out.tar"])
+
+
+@pytest.mark.asyncio
+async def test_create_names_members_as_the_operand_was_typed():
+    tree = _Tree({"/base/d/a.txt": b"x"}, dirs=("/base", "/base/d"))
+    _, io_res = await _create(tree, [_raw("/base/d", "d")],
+                              c=True,
+                              f=_spec("/out.tar"))
+    assert _names(io_res.writes["/out.tar"]) == ["d/", "d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_create_warns_once_about_a_stripped_leading_slash():
+    tree = _Tree({"/d/a.txt": b"x"}, dirs=("/d", ))
+    _, io_res = await _create(tree, [_spec("/d")], c=True, f=_spec("/out.tar"))
+    assert io_res.stderr.decode().count("Removing leading") == 1
+    assert _names(io_res.writes["/out.tar"]) == ["d/", "d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_create_reports_a_missing_operand_and_exits_two():
+    tree = _Tree({"/d/a.txt": b"x"}, dirs=("/d", ))
+    _, io_res = await _create(
+        tree, [_raw("/nope", "nope"), _raw("/d", "d")],
+        c=True,
+        f=_spec("/out.tar"))
+    assert io_res.exit_code == 2
+    err = io_res.stderr.decode()
+    assert "tar: nope: Cannot stat: No such file or directory" in err
+    assert "Exiting with failure status due to previous errors" in err
+    # GNU still archives every operand it could read.
+    assert "d/a.txt" in _names(io_res.writes["/out.tar"])
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_an_empty_archive():
+    tree = _Tree({})
+    out, io_res = await _create(tree, [], c=True, f=_spec("/out.tar"))
+    assert out is None
+    assert io_res.exit_code == 2
+    assert "Cowardly refusing" in io_res.stderr.decode()
+    assert not io_res.writes
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_a_directory_it_cannot_enter():
+    tree = _Tree({"/d/a.txt": b"x"}, dirs=("/d", ))
+    _, io_res = await _create(tree, [_raw("/nodir/a.txt", "a.txt")],
+                              c=True,
+                              f=_spec("/out.tar"),
+                              C=_raw("/nodir", "nodir"))
+    assert io_res.exit_code == 2
+    err = io_res.stderr.decode()
+    assert "tar: nodir: Cannot open: No such file or directory" in err
+    assert "Error is not recoverable: exiting now" in err
+    assert not io_res.writes
+
+
+@pytest.mark.asyncio
+async def test_create_prunes_an_excluded_subtree():
+    tree = _Tree({
+        "/d/a.txt": b"a",
+        "/d/sub/b.txt": b"b"
+    },
+                 dirs=("/d", "/d/sub"))
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              f=_spec("/out.tar"),
+                              exclude="sub")
+    assert _names(io_res.writes["/out.tar"]) == ["d/", "d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_create_stores_a_symlink_as_a_symlink():
+    tree = _Tree({"/d/a.txt": b"a"}, dirs=("/d", ))
+    links = _links({"/d/link.txt": "a.txt"})
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              f=_spec("/out.tar"),
+                              links=links)
+    with tarfile.open(fileobj=io.BytesIO(io_res.writes["/out.tar"])) as tf:
+        link = tf.getmember("d/link.txt")
+    assert link.issym()
+    assert link.linkname == "a.txt"
+
+
+@pytest.mark.asyncio
+async def test_dereference_stores_the_target_content_under_the_link_name():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    links = _links({"/d/link.txt": "/d/a.txt"})
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              h=True,
+                              f=_spec("/out.tar"),
+                              links=links)
+    with tarfile.open(fileobj=io.BytesIO(io_res.writes["/out.tar"])) as tf:
+        member = tf.getmember("d/link.txt")
+        assert not member.issym()
+        assert tf.extractfile(member).read() == b"alpha"
+
+
+@pytest.mark.asyncio
+async def test_dereference_reports_a_dangling_link_and_exits_two():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    links = _links({"/d/bad": "/d/nope"})
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              h=True,
+                              f=_spec("/out.tar"),
+                              links=links)
+    assert io_res.exit_code == 2
+    assert "tar: d/bad: Cannot stat" in io_res.stderr.decode()
+
+
+@pytest.mark.asyncio
+async def test_create_stops_at_a_nested_mount_and_says_so():
+    tree = _Tree({"/d/a.txt": b"a"}, dirs=("/d", "/d/nested"))
+    mounts = _mounts(descendants=("/d/nested", ), roots=("/", "/d/nested"))
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              f=_spec("/out.tar"),
+                              mounts=mounts)
+    assert io_res.exit_code == 0
+    assert ("tar: d/nested/: file is on a different filesystem; not dumped"
+            in io_res.stderr.decode())
+    # The mountpoint stays an entry; only its contents are left out.
+    assert _names(io_res.writes["/out.tar"]) == ["d/", "d/a.txt", "d/nested/"]
+
+
+@pytest.mark.asyncio
+async def test_create_leaves_the_archive_out_of_itself():
+    tree = _Tree({"/d/a.txt": b"a", "/d/old.tar": b"stale"}, dirs=("/d", ))
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              f=_spec("/d/old.tar"))
+    assert "archive cannot contain itself" in io_res.stderr.decode()
+    assert _names(io_res.writes["/d/old.tar"]) == ["d/", "d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_round_trip_plain_files():
+    tree = _Tree({"/a.txt": b"alpha", "/b.txt": b"beta"})
+    _, io_res = await _create(
+        tree, [_spec("/a.txt"), _spec("/b.txt")], c=True, f=_spec("/out.tar"))
+    assert "/out.tar" in io_res.writes
+    out, _ = await _create(tree, [], t=True, f=_spec("/out.tar"))
+    assert out.decode().split() == ["a.txt", "b.txt"]
+
+
+@pytest.mark.asyncio
+async def test_extract_recreates_directories_including_empty_ones():
+    tree = _Tree({"/d/a.txt": b"x"}, dirs=("/d", "/d/empty"))
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              f=_spec("/out.tar"))
+    tree.files["/out.tar"] = io_res.writes["/out.tar"]
+    _, io_res = await _create(tree, [],
+                              x=True,
+                              f=_spec("/out.tar"),
+                              C=_spec("/out"))
+    assert any("d/a.txt" in path for path in io_res.writes)
+    assert "/out/d/empty" in tree.dirs
+
+
+@pytest.mark.asyncio
+async def test_extract_strips_leading_components():
+    tree = _Tree({"/deep/d/a.txt": b"x"}, dirs=("/deep", "/deep/d"))
+    _, io_res = await _create(tree, [_spec("/deep/d")],
+                              c=True,
+                              f=_spec("/out.tar"))
+    tree.files["/out.tar"] = io_res.writes["/out.tar"]
+    _, io_res = await _create(tree, [],
+                              x=True,
+                              f=_spec("/out.tar"),
+                              strip_components="2",
+                              C=_spec("/out"))
+    assert "/out/a.txt" in io_res.writes
+
+
+@pytest.mark.asyncio
+async def test_requires_a_mode():
+    tree = _Tree({})
+    with pytest.raises(ValueError, match="-c, -x, or -t"):
+        await _create(tree, [])
+
+
+@pytest.mark.asyncio
+async def test_requires_an_archive():
+    tree = _Tree({"/a.txt": b"x"})
+    with pytest.raises(ValueError, match="-f is required"):
+        await _create(tree, [_spec("/a.txt")], c=True)

--- a/python/tests/commands/builtin/generic/test_tar.py
+++ b/python/tests/commands/builtin/generic/test_tar.py
@@ -1,5 +1,6 @@
 import io
 import tarfile
+from dataclasses import replace
 
 import pytest
 
@@ -8,6 +9,7 @@ from mirage.commands.builtin.generic.tar import (excluded, member_name, pruned,
 from mirage.ops.types import LinkView, MountView
 from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
+from mirage.utils.path import CycleError
 
 
 def _spec(path: str, prefix: str = "") -> PathSpec:
@@ -93,6 +95,15 @@ def _links(entries: dict[str, str]) -> LinkView:
         exists=exists,
         target_stat=target_stat,
     )
+
+
+def _cycle(entries: dict[str, str]) -> LinkView:
+    """A LinkView whose resolve raises ELOOP, as the namespace does."""
+
+    def resolve(path):
+        raise CycleError(path)
+
+    return replace(_links(entries), resolve=resolve)
 
 
 def _mounts(descendants: tuple[str, ...] = (),
@@ -234,7 +245,7 @@ async def test_create_refuses_a_directory_it_cannot_enter():
     _, io_res = await _create(tree, [_raw("/nodir/a.txt", "a.txt")],
                               c=True,
                               f=_spec("/out.tar"),
-                              C=_raw("/nodir", "nodir"))
+                              C=[_raw("/nodir", "nodir")])
     assert io_res.exit_code == 2
     err = io_res.stderr.decode()
     assert "tar: nodir: Cannot open: No such file or directory" in err
@@ -343,7 +354,7 @@ async def test_extract_recreates_directories_including_empty_ones():
     _, io_res = await _create(tree, [],
                               x=True,
                               f=_spec("/out.tar"),
-                              C=_spec("/out"))
+                              C=[_spec("/out")])
     assert any("d/a.txt" in path for path in io_res.writes)
     assert "/out/d/empty" in tree.dirs
 
@@ -359,7 +370,7 @@ async def test_extract_strips_leading_components():
                               x=True,
                               f=_spec("/out.tar"),
                               strip_components="2",
-                              C=_spec("/out"))
+                              C=[_spec("/out")])
     assert "/out/a.txt" in io_res.writes
 
 
@@ -375,3 +386,73 @@ async def test_requires_an_archive():
     tree = _Tree({"/a.txt": b"x"})
     with pytest.raises(ValueError, match="-f is required"):
         await _create(tree, [_spec("/a.txt")], c=True)
+
+
+@pytest.mark.asyncio
+async def test_create_fails_at_the_first_unenterable_c_not_the_last():
+    """GNU chdirs at each -C, so a bad early one stops the whole run.
+
+    Checking only the parsed flag's final value archived the operands
+    that followed the bad one and named the wrong subject.
+    """
+    tree = _Tree({"/good/y.txt": b"y"}, dirs=("/good", ))
+    _, io_res = await _create(
+        tree, [_raw("/good/y.txt", "y.txt")],
+        c=True,
+        f=_spec("/out.tar"),
+        C=[_raw("/missing", "missing"),
+           _raw("/good", "good")])
+    assert io_res.exit_code == 2
+    err = io_res.stderr.decode()
+    assert "tar: missing: Cannot open: No such file or directory" in err
+    assert "Error is not recoverable" in err
+    assert not io_res.writes
+
+
+@pytest.mark.asyncio
+async def test_two_links_to_one_target_are_not_a_loop():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    links = _links({"/d/one": "/d/a.txt", "/d/two": "/d/a.txt"})
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              h=True,
+                              f=_spec("/out.tar"),
+                              links=links)
+    assert io_res.exit_code == 0
+    assert io_res.stderr == b""
+    assert _names(
+        io_res.writes["/out.tar"]) == ["d/", "d/a.txt", "d/one", "d/two"]
+
+
+@pytest.mark.asyncio
+async def test_a_symlink_cycle_is_reported_per_member_and_keeps_the_directory(
+):
+    tree = _Tree({}, dirs=("/d", ))
+    links = _cycle({"/d/a": "/d/b", "/d/b": "/d/a"})
+    _, io_res = await _create(tree, [_raw("/d", "d")],
+                              c=True,
+                              h=True,
+                              f=_spec("/out.tar"),
+                              links=links)
+    assert io_res.exit_code == 2
+    err = io_res.stderr.decode()
+    assert "tar: d/a: Cannot stat: Too many levels of symbolic links" in err
+    assert "tar: d/b: Cannot stat: Too many levels of symbolic links" in err
+    # GNU keeps the directory entry rather than aborting the archive.
+    assert _names(io_res.writes["/out.tar"]) == ["d/"]
+
+
+@pytest.mark.asyncio
+async def test_a_symlink_operand_is_stored_as_a_symlink():
+    """The router must not dereference it before the planner sees it."""
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    links = _links({"/link": "/d/a.txt"})
+    _, io_res = await _create(tree, [_raw("/link", "link")],
+                              c=True,
+                              f=_spec("/out.tar"),
+                              links=links)
+    with tarfile.open(fileobj=io.BytesIO(io_res.writes["/out.tar"])) as tf:
+        member = tf.getmember("link")
+    assert member.issym()
+    assert member.size == 0
+    assert member.linkname == "/d/a.txt"

--- a/python/tests/commands/builtin/generic/test_zip_cmd.py
+++ b/python/tests/commands/builtin/generic/test_zip_cmd.py
@@ -1,0 +1,305 @@
+import io
+import zipfile
+
+import pytest
+
+from mirage.commands.builtin.generic.zip_cmd import (excluded, member_name,
+                                                     zip_cmd)
+from mirage.ops.types import LinkView, MountView
+from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
+from mirage.utils.key_prefix import mount_key
+
+
+def _spec(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(resource_path=mount_key(path, prefix),
+                    virtual=path,
+                    directory=path,
+                    resolved=True)
+
+
+def _raw(path: str, raw: str, prefix: str = "") -> PathSpec:
+    return PathSpec(resource_path=mount_key(path, prefix),
+                    virtual=path,
+                    directory=path,
+                    resolved=True,
+                    raw_path=raw)
+
+
+class _Tree:
+    """A tiny in-memory backend: files by path, directories derived."""
+
+    def __init__(self, files: dict[str, bytes], dirs: tuple[str, ...] = ()):
+        self.files = dict(files)
+        self.dirs = set(dirs)
+        for path in files:
+            parent = path.rsplit("/", 1)[0]
+            while parent:
+                self.dirs.add(parent)
+                parent = parent.rsplit("/", 1)[0] if "/" in parent else ""
+
+    async def read_bytes(self, path):
+        key = path.virtual if isinstance(path, PathSpec) else path
+        if key not in self.files:
+            raise FileNotFoundError(key)
+        return self.files[key]
+
+    async def write_bytes(self, path, data):
+        self.files[path.virtual] = data
+
+    async def stat(self, path):
+        key = path.virtual.rstrip("/") or "/"
+        if key in self.dirs:
+            return FileStat(name=key, type=FileType.DIRECTORY)
+        if key in self.files:
+            return FileStat(name=key,
+                            type=FileType.TEXT,
+                            size=len(self.files[key]))
+        raise FileNotFoundError(key)
+
+    async def walk(self, path, find_type):
+        base = path.virtual.rstrip("/") or "/"
+        pool = self.dirs if find_type == "d" else self.files
+        return sorted(p for p in pool
+                      if p == base or p.startswith(base.rstrip("/") + "/"))
+
+
+def _links(entries: dict[str, str]) -> LinkView:
+
+    def stat_of(path):
+        target = entries[path]
+        return FileStat(name=path,
+                        type=FileType.SYMLINK,
+                        size=len(target),
+                        extra={LINK_TARGET_KEY: target})
+
+    async def target_stat(path):
+        return None
+
+    async def exists(path):
+        return path in entries
+
+    return LinkView(
+        stat_at=lambda p: stat_of(p) if p in entries else None,
+        children=lambda p: [],
+        subtree=lambda p: [(k, stat_of(k)) for k in sorted(entries)
+                           if k.startswith(p.rstrip("/") + "/")],
+        resolve=lambda p: entries.get(p, p),
+        exists=exists,
+        target_stat=target_stat,
+    )
+
+
+def _mounts(descendants: tuple[str, ...] = (),
+            roots: tuple[str, ...] = ()) -> MountView:
+
+    def root_of(path):
+        for root in sorted(roots, key=len, reverse=True):
+            if path == root or path.startswith(root.rstrip("/") + "/"):
+                return root
+        return "/"
+
+    return MountView(
+        descendants=lambda p:
+        [d for d in descendants if d.startswith(p.rstrip("/") + "/")],
+        is_root=lambda p: p.rstrip("/") in {r.rstrip("/")
+                                            for r in roots},
+        root_of=root_of,
+    )
+
+
+async def _zip(tree: _Tree, paths, **flags):
+    return await zip_cmd(paths,
+                         read_bytes=tree.read_bytes,
+                         write_bytes=tree.write_bytes,
+                         stat=tree.stat,
+                         walk=tree.walk,
+                         **flags)
+
+
+def _entries(archive: bytes) -> list[str]:
+    with zipfile.ZipFile(io.BytesIO(archive)) as zf:
+        return [info.filename for info in zf.infolist()]
+
+
+def test_member_name_strips_the_leading_slash_and_marks_directories():
+    assert member_name("/d/a.txt", "file", False) == "d/a.txt"
+    assert member_name("/d", "dir", False) == "d/"
+    assert member_name("/d/sub/b.txt", "file", True) == "b.txt"
+    assert member_name("link", "link", False) == "link"
+
+
+def test_excluded_is_anchored_unlike_tars_exclude():
+    assert excluded("d/sub/b.txt", ["d/sub/*"])
+    assert excluded("d/sub/", ["d/sub/*"])
+    assert excluded("d/a.txt", ["*.txt"])
+    assert excluded("d/sub/b.txt", ["*/b.txt"])
+    # Info-ZIP matches the whole stored name, so a bare component misses.
+    assert not excluded("d/sub/b.txt", ["b.txt"])
+    assert not excluded("d/sub/b.txt", ["sub/*"])
+
+
+@pytest.mark.asyncio
+async def test_recurses_a_directory_operand_under_r():
+    tree = _Tree({
+        "/d/a.txt": b"alpha",
+        "/d/sub/b.txt": b"beta"
+    },
+                 dirs=("/d", "/d/sub", "/d/empty"))
+    out, io_res = await _zip(
+        tree, [_spec("/out.zip"), _raw("/d", "d")], r=True)
+    assert io_res.exit_code == 0
+    assert _entries(io_res.writes["/out.zip"]) == [
+        "d/", "d/a.txt", "d/empty/", "d/sub/", "d/sub/b.txt"
+    ]
+    assert out.decode().startswith("  adding: d/\n")
+
+
+@pytest.mark.asyncio
+async def test_without_r_a_directory_stores_only_itself():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    _, io_res = await _zip(tree, [_spec("/out.zip"), _raw("/d", "d")])
+    assert _entries(io_res.writes["/out.zip"]) == ["d/"]
+
+
+@pytest.mark.asyncio
+async def test_directory_entries_carry_no_content():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    _, io_res = await _zip(tree, [_spec("/out.zip"), _raw("/d", "d")], r=True)
+    with zipfile.ZipFile(io.BytesIO(io_res.writes["/out.zip"])) as zf:
+        info = zf.getinfo("d/")
+    assert info.is_dir()
+    assert info.file_size == 0
+
+
+@pytest.mark.asyncio
+async def test_junk_paths_drops_directories_and_keeps_basenames():
+    tree = _Tree({
+        "/d/a.txt": b"alpha",
+        "/d/sub/b.txt": b"beta"
+    },
+                 dirs=("/d", "/d/sub"))
+    _, io_res = await _zip(
+        tree, [_spec("/out.zip"), _raw("/d", "d")], r=True, j=True)
+    assert _entries(io_res.writes["/out.zip"]) == ["a.txt", "b.txt"]
+
+
+@pytest.mark.asyncio
+async def test_exclude_pattern_prunes_by_stored_name():
+    tree = _Tree({
+        "/d/a.txt": b"alpha",
+        "/d/sub/b.txt": b"beta"
+    },
+                 dirs=("/d", "/d/sub"))
+    _, io_res = await _zip(
+        tree, [_spec("/out.zip"), _raw("/d", "d")], r=True, x=["d/sub/*"])
+    assert _entries(io_res.writes["/out.zip"]) == ["d/", "d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_follows_a_symlink_by_default():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    links = _links({"/d/link.txt": "/d/a.txt"})
+    _, io_res = await _zip(
+        tree, [_spec("/out.zip"), _raw("/d", "d")], r=True, links=links)
+    with zipfile.ZipFile(io.BytesIO(io_res.writes["/out.zip"])) as zf:
+        assert zf.read("d/link.txt") == b"alpha"
+
+
+@pytest.mark.asyncio
+async def test_y_stores_a_symlink_as_a_symlink():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    links = _links({"/d/link.txt": "a.txt"})
+    _, io_res = await _zip(
+        tree, [_spec("/out.zip"), _raw("/d", "d")],
+        r=True,
+        y=True,
+        links=links)
+    with zipfile.ZipFile(io.BytesIO(io_res.writes["/out.zip"])) as zf:
+        info = zf.getinfo("d/link.txt")
+        assert zf.read(info) == b"a.txt"
+    assert info.external_attr >> 16 == 0o120777
+
+
+@pytest.mark.asyncio
+async def test_warns_on_a_name_it_cannot_match_but_still_archives_the_rest():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", ))
+    _, io_res = await _zip(tree, [
+        _spec("/out.zip"),
+        _raw("/d/a.txt", "d/a.txt"),
+        _raw("/nope", "nope")
+    ])
+    assert io_res.exit_code == 0
+    assert io_res.stderr.decode() == "\tzip warning: name not matched: nope\n"
+    assert _entries(io_res.writes["/out.zip"]) == ["d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_nothing_to_do_writes_no_archive_and_exits_twelve():
+    tree = _Tree({})
+    out, io_res = await _zip(
+        tree, [_raw("/out.zip", "out.zip"),
+               _raw("/nope", "nope")])
+    assert out is None
+    assert io_res.exit_code == 12
+    assert not io_res.writes
+    err = io_res.stderr.decode()
+    assert err.startswith("\tzip warning: name not matched: nope\n")
+    assert err.endswith("\nzip error: Nothing to do! (out.zip)\n")
+
+
+@pytest.mark.asyncio
+async def test_quiet_silences_the_warning_but_not_the_fatal_error():
+    tree = _Tree({})
+    _, io_res = await _zip(
+        tree, [_raw("/out.zip", "out.zip"),
+               _raw("/nope", "nope")], q=True)
+    assert io_res.stderr.decode() == "\nzip error: Nothing to do! (out.zip)\n"
+
+
+@pytest.mark.asyncio
+async def test_quiet_prints_no_adding_lines():
+    tree = _Tree({"/a.txt": b"alpha"})
+    out, io_res = await _zip(
+        tree, [_spec("/out.zip"), _raw("/a.txt", "a.txt")], q=True)
+    assert out is None
+    assert _entries(io_res.writes["/out.zip"]) == ["a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_stops_at_a_nested_mount_and_says_so():
+    tree = _Tree({"/d/a.txt": b"alpha"}, dirs=("/d", "/d/nested"))
+    mounts = _mounts(descendants=("/d/nested", ), roots=("/", "/d/nested"))
+    _, io_res = await _zip(
+        tree, [_spec("/out.zip"), _raw("/d", "d")], r=True, mounts=mounts)
+    assert io_res.exit_code == 0
+    assert ("\tzip warning: d/nested: file is on a different filesystem; "
+            "not dumped\n" in io_res.stderr.decode())
+    # The mountpoint stays an entry; only its contents are left out.
+    assert _entries(
+        io_res.writes["/out.zip"]) == ["d/", "d/a.txt", "d/nested/"]
+
+
+@pytest.mark.asyncio
+async def test_leaves_the_archive_out_of_itself():
+    tree = _Tree({"/d/a.txt": b"alpha", "/d/old.zip": b"stale"}, dirs=("/d", ))
+    _, io_res = await _zip(
+        tree, [_spec("/d/old.zip"), _raw("/d", "d")], r=True)
+    assert _entries(io_res.writes["/d/old.zip"]) == ["d/", "d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_names_members_on_a_prefixed_mount():
+    tree = _Tree({"/data/d/a.txt": b"alpha"}, dirs=("/data", "/data/d"))
+    await _zip(
+        tree,
+        [_spec("/data/out.zip", "/data"),
+         _raw("/data/d", "/data/d", "/data")],
+        r=True)
+    assert _entries(tree.files["/data/out.zip"]) == ["data/d/", "data/d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_requires_an_archive_operand():
+    tree = _Tree({})
+    with pytest.raises(ValueError, match="usage"):
+        await _zip(tree, [])

--- a/python/tests/commands/spec/test_parser.py
+++ b/python/tests/commands/spec/test_parser.py
@@ -637,7 +637,7 @@ def test_tar_old_style_two_value_letters_bind_in_letter_order():
     parsed = parse_command(SPECS["tar"], ["xfC", "/data/a.tgz", "/data/out"],
                            "/")
     assert parsed.flags["-f"] == "/data/a.tgz"
-    assert parsed.flags["-C"] == "/data/out"
+    assert parsed.flags["-C"] == ["/data/out"]
 
 
 def test_tar_old_style_value_letter_before_bool_letter():
@@ -670,7 +670,7 @@ def test_tar_old_style_still_accepts_long_options_after_the_cluster():
         ["xzf", "/data/a.tgz", "--strip-components", "1", "-C", "/data/out"],
         "/")
     assert parsed.flags["--strip-components"] == "1"
-    assert parsed.flags["-C"] == "/data/out"
+    assert parsed.flags["-C"] == ["/data/out"]
 
 
 def test_old_option_style_is_off_for_every_other_command():
@@ -688,7 +688,7 @@ def test_operand_base_rebases_the_operands_typed_after_it():
         cwd="/home")
     assert parsed.paths() == ["/work/check/my_paper"]
     assert parsed.flags["-f"] == "/home/out.tgz"
-    assert parsed.flags["-C"] == "/work/check"
+    assert parsed.flags["-C"] == ["/work/check"]
 
 
 def test_operand_base_is_cumulative_like_a_real_chdir():
@@ -696,7 +696,8 @@ def test_operand_base_is_cumulative_like_a_real_chdir():
         SPECS["tar"], ["-cf", "a.tar", "-C", "d1", "x", "-C", "../d2", "y"],
         cwd="/work")
     assert parsed.paths() == ["/work/d1/x", "/work/d2/y"]
-    assert parsed.flags["-C"] == "/work/d2"
+    # Every occurrence is kept in order: GNU chdirs at each one.
+    assert parsed.flags["-C"] == ["/work/d1", "/work/d2"]
 
 
 def test_operand_base_only_moves_what_follows_it():

--- a/python/tests/commands/spec/test_parser.py
+++ b/python/tests/commands/spec/test_parser.py
@@ -678,3 +678,41 @@ def test_old_option_style_is_off_for_every_other_command():
     parsed = parse_command(SPECS["gzip"], ["dkf"], "/")
     assert parsed.paths() == ["/dkf"]
     assert parsed.old_option_needs_value is None
+
+
+def test_operand_base_rebases_the_operands_typed_after_it():
+    # GNU tar's -C is a chdir for the operands that follow it, so the
+    # archive (-f) stays relative to the session cwd while the files move.
+    parsed = parse_command(
+        SPECS["tar"], ["-czf", "out.tgz", "-C", "/work/check", "my_paper"],
+        cwd="/home")
+    assert parsed.paths() == ["/work/check/my_paper"]
+    assert parsed.flags["-f"] == "/home/out.tgz"
+    assert parsed.flags["-C"] == "/work/check"
+
+
+def test_operand_base_is_cumulative_like_a_real_chdir():
+    parsed = parse_command(
+        SPECS["tar"], ["-cf", "a.tar", "-C", "d1", "x", "-C", "../d2", "y"],
+        cwd="/work")
+    assert parsed.paths() == ["/work/d1/x", "/work/d2/y"]
+    assert parsed.flags["-C"] == "/work/d2"
+
+
+def test_operand_base_only_moves_what_follows_it():
+    parsed = parse_command(
+        SPECS["tar"], ["-cf", "a.tar", "top.txt", "-C", "/work/e", "e.txt"],
+        cwd="/work")
+    assert parsed.paths() == ["/work/top.txt", "/work/e/e.txt"]
+
+
+def test_operand_base_survives_the_old_style_cluster():
+    parsed = parse_command(SPECS["tar"], ["czf", "a.tgz", "-C", "sub", "x"],
+                           cwd="/work")
+    assert parsed.paths() == ["/work/sub/x"]
+    assert parsed.word_bases[-1] == "/work/sub"
+
+
+def test_word_bases_are_empty_without_an_operand_base():
+    parsed = parse_command(SPECS["cat"], ["a.txt"], cwd="/work")
+    assert parsed.word_bases == [None]

--- a/python/tests/commands/test_no_dead_flag_params.py
+++ b/python/tests/commands/test_no_dead_flag_params.py
@@ -48,6 +48,7 @@ DISPATCHER_PARAMS = frozenset({
     "stat_overlay",
     "links",
     "stat_path",
+    "mounts",
     "prefix",
     "command",
 })

--- a/python/tests/policy/builtin/test_mount_root.py
+++ b/python/tests/policy/builtin/test_mount_root.py
@@ -38,12 +38,15 @@ def _path(virtual: str, raw: str | None = None) -> PathSpec:
 def _ctx(command: str,
          paths: list[PathSpec],
          argv: list[str] | None = None,
-         registry: MountRegistry | None = None) -> CommandContext:
-    return CommandContext(command=command,
-                          paths=tuple(paths),
-                          argv=tuple(argv or []),
-                          cwd="/",
-                          registry=registry or _registry())
+         registry: MountRegistry | None = None,
+         operands: list[PathSpec] | None = None) -> CommandContext:
+    return CommandContext(
+        command=command,
+        paths=tuple(paths),
+        operands=tuple(paths if operands is None else operands),
+        argv=tuple(argv or []),
+        cwd="/",
+        registry=registry or _registry())
 
 
 @pytest.mark.parametrize("cmd,needle", [
@@ -114,3 +117,57 @@ def test_has_parents_flag_spots_the_shorthand_cluster():
     assert has_parents_flag(("-pv", ))
     assert not has_parents_flag(("--print", ))
     assert not has_parents_flag(("x", "-r"))
+
+
+@pytest.mark.parametrize("cmd,needle", [
+    ("tar", "tar: /data: Cannot open: Device or resource busy"),
+    ("zip", "zip: cannot read '/data': Device or resource busy"),
+    ("cp", "cp: cannot copy '/data': Device or resource busy"),
+])
+@pytest.mark.asyncio
+async def test_whole_mount_archivers_refused(cmd, needle):
+    # zip's first operand is the archive it writes, cp's last is the
+    # destination, so each line puts the mount root in a source slot.
+    operands = {
+        "tar": [_path("/data")],
+        "zip": [_path("/out.zip"), _path("/data")],
+        "cp": [_path("/data"), _path("/dst")],
+    }[cmd]
+    deny = await MountRootPolicy().pre_command(_ctx(cmd, operands))
+    assert deny is not None
+    assert needle in deny.message
+
+
+@pytest.mark.asyncio
+async def test_tar_refusal_names_the_operand_as_typed_and_exits_two():
+    deny = await MountRootPolicy().pre_command(
+        _ctx("tar", [_path("/data", raw=".")]))
+    assert deny is not None
+    assert "tar: .: Cannot open" in deny.message
+    assert "Error is not recoverable" in deny.message
+    assert deny.exit_code == 2
+
+
+@pytest.mark.asyncio
+async def test_extracting_into_a_mount_root_is_allowed():
+    # `-C /data` is a path-valued flag, so it reaches paths but never
+    # operands; refusing it would block the safe direction.
+    deny = await MountRootPolicy().pre_command(
+        _ctx("tar",
+             [_path("/archive.tar"), _path("/data")],
+             operands=[_path("/archive.tar")]))
+    assert deny is None
+
+
+@pytest.mark.asyncio
+async def test_copying_into_a_mount_root_is_allowed():
+    deny = await MountRootPolicy().pre_command(
+        _ctx("cp", [_path("/src/a.txt"), _path("/data")]))
+    assert deny is None
+
+
+@pytest.mark.asyncio
+async def test_zip_archive_slot_is_not_a_source():
+    deny = await MountRootPolicy().pre_command(
+        _ctx("zip", [_path("/data"), _path("/src/a.txt")]))
+    assert deny is None

--- a/python/tests/policy/builtin/test_mount_root.py
+++ b/python/tests/policy/builtin/test_mount_root.py
@@ -133,7 +133,8 @@ async def test_whole_mount_archivers_refused(cmd, needle):
         "zip": [_path("/out.zip"), _path("/data")],
         "cp": [_path("/data"), _path("/dst")],
     }[cmd]
-    deny = await MountRootPolicy().pre_command(_ctx(cmd, operands))
+    argv = ["-cf", "/out.tar"] if cmd == "tar" else []
+    deny = await MountRootPolicy().pre_command(_ctx(cmd, operands, argv=argv))
     assert deny is not None
     assert needle in deny.message
 
@@ -141,7 +142,7 @@ async def test_whole_mount_archivers_refused(cmd, needle):
 @pytest.mark.asyncio
 async def test_tar_refusal_names_the_operand_as_typed_and_exits_two():
     deny = await MountRootPolicy().pre_command(
-        _ctx("tar", [_path("/data", raw=".")]))
+        _ctx("tar", [_path("/data", raw=".")], argv=["-cf", "/out.tar"]))
     assert deny is not None
     assert "tar: .: Cannot open" in deny.message
     assert "Error is not recoverable" in deny.message
@@ -171,3 +172,25 @@ async def test_zip_archive_slot_is_not_a_source():
     deny = await MountRootPolicy().pre_command(
         _ctx("zip", [_path("/data"), _path("/src/a.txt")]))
     assert deny is None
+
+
+@pytest.mark.parametrize("argv,denied", [
+    (["-cf", "/a.tar"], True),
+    (["--create", "-f", "/a.tar"], True),
+    (["cf", "/a.tar"], True),
+    (["-tf", "/a.tar"], False),
+    (["-xf", "/a.tar"], False),
+    (["xzf", "/a.tar"], False),
+    (["-xf", "/a.tar", "-C", "/cache"], False),
+])
+@pytest.mark.asyncio
+async def test_only_tar_create_reads_its_operands_from_the_filesystem(
+        argv, denied):
+    """Under -t and -x an operand names a member, not a path.
+
+    A selector that happens to spell a mount root is not a mount, so
+    refusing it would deny an ordinary listing or extraction.
+    """
+    deny = await MountRootPolicy().pre_command(
+        _ctx("tar", [_path("/data")], argv=argv))
+    assert (deny is not None) is denied

--- a/scripts/check_spec_parity.py
+++ b/scripts/check_spec_parity.py
@@ -222,12 +222,14 @@ def describe(diff: str, py: dict[str, Any], ts: dict[str, Any],
         return (f"    {diff}: python={py['_meta'].get(key)!r} "
                 f"typescript={ts['_meta'].get(key)!r}")
     if diff == "options":
+        # An option that declares only one spelling carries only that
+        # key, since the dumps omit anything left at its default.
         py_by_name = {
-            o["long"] or o["short"]: o
+            o.get("long") or o.get("short"): o
             for o in py.get("options", [])
         }
         ts_by_name = {
-            o["long"] or o["short"]: o
+            o.get("long") or o.get("short"): o
             for o in ts.get("options", [])
         }
         lines = [f"    {diff}:"]

--- a/scripts/gen_specs.py
+++ b/scripts/gen_specs.py
@@ -17,13 +17,14 @@ import json
 import logging
 import pkgutil
 import sys
-from dataclasses import asdict
+from dataclasses import MISSING, Field, asdict, fields
 from pathlib import Path
 from typing import Any
 
 import mirage.commands.builtin
 from mirage.commands.config import RegisteredCommand
 from mirage.commands.spec import SPECS
+from mirage.commands.spec.types import CommandSpec, Operand, Option
 from mirage.resource.registry import REGISTRY
 
 logger = logging.getLogger(__name__)
@@ -122,8 +123,55 @@ def _default(o: object) -> object:
     raise TypeError(f"unserializable: {type(o)}")
 
 
+def _default_of(f: Field) -> Any:
+    if f.default_factory is not MISSING:
+        return f.default_factory()
+    return f.default
+
+
+def _prune(payload: dict[str, Any], cls: type) -> dict[str, Any]:
+    """``payload`` without the fields ``cls`` would have defaulted anyway.
+
+    A spec dump is a cross-language contract, and restating every
+    default in all 93 files buries the handful of facts each command
+    actually declares. The defaults come from the dataclass rather than
+    a second table, so a field added to a spec type cannot fall out of
+    step with this. ``type`` survives even at its default, because what
+    a token *is* is the first thing a reader looks for.
+
+    The typescript side prunes against a default-constructed instance
+    for the same reason; the two must drop exactly the same keys or the
+    parity gate reports every command.
+
+    Args:
+        payload (dict[str, Any]): one ``asdict`` level, every key
+            present.
+        cls (type): the dataclass the payload came from.
+    """
+    kept: dict[str, Any] = {}
+    for f in fields(cls):
+        value = payload[f.name]
+        if f.name != "type" and value == _default_of(f):
+            continue
+        kept[f.name] = value
+    return kept
+
+
+def _spec_payload(spec: Any) -> dict[str, Any]:
+    payload = _prune(asdict(spec), CommandSpec)
+    if "options" in payload:
+        payload["options"] = [_prune(o, Option) for o in payload["options"]]
+    if "positional" in payload:
+        payload["positional"] = [
+            _prune(p, Operand) for p in payload["positional"]
+        ]
+    if payload.get("rest") is not None:
+        payload["rest"] = _prune(payload["rest"], Operand)
+    return payload
+
+
 def _emit_one(name: str, spec: Any, rcs: list[RegisteredCommand]) -> None:
-    payload = asdict(spec)
+    payload = _spec_payload(spec)
     payload["_meta"] = _meta_for(rcs)
     path = OUT / f"{name}.json"
     path.write_text(

--- a/spec/python/general/awk.json
+++ b/spec/python/general/awk.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/awk.json
+++ b/spec/python/general/awk.json
@@ -254,56 +254,20 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     }
   ],
   "positional": [
@@ -311,13 +275,10 @@
       "provided_by": [
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/base64.json
+++ b/spec/python/general/base64.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/base64.json
+++ b/spec/python/general/base64.json
@@ -254,79 +254,30 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--decode",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-D",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--wrap",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-garbage",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/basename.json
+++ b/spec/python/general/basename.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/basename.json
+++ b/spec/python/general/basename.json
@@ -254,62 +254,24 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--multiple",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/bash.json
+++ b/spec/python/general/bash.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/bash.json
+++ b/spec/python/general/bash.json
@@ -8,181 +8,64 @@
     "resources": []
   },
   "description": "Run a command string through Mirage's shell. Only `-c` is meaningful; other flags are accepted and ignored. `bash` and `sh` are aliases.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read commands from the next argument and execute them.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read commands from stdin instead of from an argument.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Login shell. Mirage does not source profile files.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Interactive flag. Mirage shells are non-interactive.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Exit on first error.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Treat unset variables as errors.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Print commands as they execute.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Login shell.",
       "long": "--login",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Skip rc files.",
       "long": "--norc",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Skip profile files.",
       "long": "--noprofile",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) POSIX-conformant mode.",
       "long": "--posix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/bc.json
+++ b/spec/python/general/bc.json
@@ -15,46 +15,19 @@
     "resources": []
   },
   "description": "Arbitrary precision calculator language.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Load the standard math library.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Suppress the welcome banner.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/bc.json
+++ b/spec/python/general/bc.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/cat.json
+++ b/spec/python/general/cat.json
@@ -261,167 +261,56 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-nonblank",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-ends",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-tabs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-nonprinting",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-all",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--squeeze-blank",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/cat.json
+++ b/spec/python/general/cat.json
@@ -265,6 +265,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/chgrp.json
+++ b/spec/python/general/chgrp.json
@@ -7,83 +7,30 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/chgrp.json
+++ b/spec/python/general/chgrp.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/chmod.json
+++ b/spec/python/general/chmod.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/chmod.json
+++ b/spec/python/general/chmod.json
@@ -7,68 +7,26 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/chown.json
+++ b/spec/python/general/chown.json
@@ -7,83 +7,30 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/chown.json
+++ b/spec/python/general/chown.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/cmp.json
+++ b/spec/python/general/cmp.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/cmp.json
+++ b/spec/python/general/cmp.json
@@ -254,99 +254,34 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/column.json
+++ b/spec/python/general/column.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/column.json
+++ b/spec/python/general/column.json
@@ -254,62 +254,21 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/comm.json
+++ b/spec/python/general/comm.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/comm.json
+++ b/spec/python/general/comm.json
@@ -254,144 +254,47 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-2",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-3",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--nocheck-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output-delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--total",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/cp.json
+++ b/spec/python/general/cp.json
@@ -100,212 +100,76 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--recursive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--archive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--force",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--interactive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-clobber",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--update",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--backup",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strip-trailing-slashes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/cp.json
+++ b/spec/python/general/cp.json
@@ -104,6 +104,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/csplit.json
+++ b/spec/python/general/csplit.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/csplit.json
+++ b/spec/python/general/csplit.json
@@ -107,143 +107,52 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--prefix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--digits",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix-format",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--keep-files",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--silent",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suppress-matched",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--elide-empty-files",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/curl.json
+++ b/spec/python/general/curl.json
@@ -15,166 +15,60 @@
     "resources": []
   },
   "description": "Transfer data from or to a server.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Add a custom header to the request.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set the User-Agent header.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Specify the HTTP request method.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-X",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Send the given data as the request body.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Submit a multipart/form-data field.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Write response body to the given file.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Follow HTTP redirects.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Fail with exit 22 on an HTTP error status.",
       "long": "--fail",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run silently with no progress or messages.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Show errors even when silent.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/curl.json
+++ b/spec/python/general/curl.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/cut.json
+++ b/spec/python/general/cut.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/cut.json
+++ b/spec/python/general/cut.json
@@ -254,212 +254,69 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--fields",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--characters",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-partial",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--complement",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--only-delimited",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-O",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output-delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--whitespace-delimited",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/date.json
+++ b/spec/python/general/date.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/date.json
+++ b/spec/python/general/date.json
@@ -15,78 +15,31 @@
     "resources": []
   },
   "description": "Print or set the system date and time.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Display the time described by the given date string.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Use Coordinated Universal Time (UTC).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Output date in ISO 8601 format.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Output date in RFC 5322 email format.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/df.json
+++ b/spec/python/general/df.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/df.json
+++ b/spec/python/general/df.json
@@ -7,137 +7,41 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-B",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/diff.json
+++ b/spec/python/general/diff.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/diff.json
+++ b/spec/python/general/diff.json
@@ -254,129 +254,42 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/dirname.json
+++ b/spec/python/general/dirname.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/dirname.json
+++ b/spec/python/general/dirname.json
@@ -254,32 +254,14 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/du.json
+++ b/spec/python/general/du.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/du.json
+++ b/spec/python/general/du.json
@@ -254,122 +254,38 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--max-depth",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/echo.json
+++ b/spec/python/general/echo.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/echo.json
+++ b/spec/python/general/echo.json
@@ -7,47 +7,17 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/expand.json
+++ b/spec/python/general/expand.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/expand.json
+++ b/spec/python/general/expand.json
@@ -254,47 +254,19 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tabs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--initial",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/expr.json
+++ b/spec/python/general/expr.json
@@ -15,15 +15,7 @@
     "resources": []
   },
   "description": "Evaluate expressions.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/expr.json
+++ b/spec/python/general/expr.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/python/general/file.json
+++ b/spec/python/general/file.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/file.json
+++ b/spec/python/general/file.json
@@ -254,77 +254,25 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/find.json
+++ b/spec/python/general/find.json
@@ -261,365 +261,113 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
   "ignore_tokens": [
     "(",
     ")"
   ],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-name",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-type",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-maxdepth",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-size",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-mtime",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-iname",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-path",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-mindepth",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-print",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-print0",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-delete",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-depth",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-prune",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-ls",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-empty",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-or",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-and",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-not",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/find.json
+++ b/spec/python/general/find.json
@@ -268,6 +268,7 @@
     ")"
   ],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/fmt.json
+++ b/spec/python/general/fmt.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/fmt.json
+++ b/spec/python/general/fmt.json
@@ -254,122 +254,44 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--width",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--goal",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-g",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--crown-margin",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--prefix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--split-only",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tagged-paragraph",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--uniform-spacing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/fold.json
+++ b/spec/python/general/fold.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/fold.json
+++ b/spec/python/general/fold.json
@@ -254,77 +254,29 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--width",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--spaces",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--characters",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/grep.json
+++ b/spec/python/general/grep.json
@@ -265,6 +265,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/grep.json
+++ b/spec/python/general/grep.json
@@ -261,386 +261,110 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-G",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-B",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--color",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--colour",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--line-buffered",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -649,13 +373,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/gunzip.json
+++ b/spec/python/general/gunzip.json
@@ -107,77 +107,25 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/gunzip.json
+++ b/spec/python/general/gunzip.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/gzip.json
+++ b/spec/python/general/gzip.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/gzip.json
+++ b/spec/python/general/gzip.json
@@ -107,212 +107,61 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-2",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-3",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-4",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-5",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-6",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-7",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-8",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-9",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/head.json
+++ b/spec/python/general/head.json
@@ -265,6 +265,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/head.json
+++ b/spec/python/general/head.json
@@ -261,107 +261,39 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--lines",
-      "multiple": false,
       "numeric_shorthand": true,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--silent",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/history.json
+++ b/spec/python/general/history.json
@@ -17,136 +17,49 @@
     ]
   },
   "description": "Show command history for the session.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Clear the command history.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Delete the entry at the given position; negative counts back from the end.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Append the args to the history as a single entry without executing them.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Print the args without storing them.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Append: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Write: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read-new: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/history.json
+++ b/spec/python/general/history.json
@@ -20,6 +20,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/iconv.json
+++ b/spec/python/general/iconv.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/iconv.json
+++ b/spec/python/general/iconv.json
@@ -107,77 +107,25 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/join.json
+++ b/spec/python/general/join.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/join.json
+++ b/spec/python/general/join.json
@@ -254,219 +254,68 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-2",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-case",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--nocheck-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--header",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/jq.json
+++ b/spec/python/general/jq.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/jq.json
+++ b/spec/python/general/jq.json
@@ -254,371 +254,142 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Use null as the single input value",
       "long": "--null-input",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read each line as a string instead of JSON",
       "long": "--raw-input",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read all inputs into one array",
       "long": "--slurp",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Compact instead of pretty-printed output",
       "long": "--compact-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Output strings without quotes or escapes",
       "long": "--raw-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Implies -r and writes NUL after each output",
       "long": "--raw-output0",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Implies -r and writes no trailing newline",
       "long": "--join-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Escape non-ASCII characters in output",
       "long": "--ascii-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Sort object keys on output",
       "long": "--sort-keys",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set the exit status from the last output",
       "long": "--exit-status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Indent with tabs",
       "long": "--tab",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Indent with n spaces (max 7)",
       "long": "--indent",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "int",
-      "value_optional": false
+      "type": "int"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Disable colored output (already the default)",
       "long": "--monochrome-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-M",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Accepted for compatibility; output is one buffer",
       "long": "--unbuffered",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read the filter from a file",
       "long": "--from-file",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read each input as its [path, leaf] events",
       "long": "--stream",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read and write RS-delimited JSON text sequences",
       "long": "--seq",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a string value",
       "long": "--arg",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a JSON value",
       "long": "--argjson",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a file's contents",
       "long": "--rawfile",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a file's documents, as an array",
       "long": "--slurpfile",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read the remaining operands as positional string values",
       "long": "--args",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read the remaining operands as positional JSON values",
       "long": "--jsonargs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Show this help and exit",
       "long": "--help",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -626,12 +397,10 @@
       "provided_by": [
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
     "text_when": [
       "--args",
       "--jsonargs"

--- a/spec/python/general/js.json
+++ b/spec/python/general/js.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/js.json
+++ b/spec/python/general/js.json
@@ -15,46 +15,20 @@
     "resources": []
   },
   "description": "Run JavaScript on a sandboxed quickjs engine.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Evaluate the next argument as a script.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run as an ES module (top-level import/export/await); .mjs files select this automatically.",
       "long": "--module",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/ln.json
+++ b/spec/python/general/ln.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/ln.json
+++ b/spec/python/general/ln.json
@@ -107,77 +107,25 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/look.json
+++ b/spec/python/general/look.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/look.json
+++ b/spec/python/general/look.json
@@ -254,39 +254,18 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/ls.json
+++ b/spec/python/general/ls.json
@@ -265,6 +265,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/ls.json
+++ b/spec/python/general/ls.json
@@ -261,212 +261,62 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--color",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/md5.json
+++ b/spec/python/general/md5.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/python/general/md5.json
+++ b/spec/python/general/md5.json
@@ -254,16 +254,7 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/md5sum.json
+++ b/spec/python/general/md5sum.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/md5sum.json
+++ b/spec/python/general/md5sum.json
@@ -254,167 +254,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/mkdir.json
+++ b/spec/python/general/mkdir.json
@@ -107,77 +107,30 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--parents",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--mode",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--context",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-Z",
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/mkdir.json
+++ b/spec/python/general/mkdir.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/mktemp.json
+++ b/spec/python/general/mktemp.json
@@ -107,124 +107,43 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tmpdir",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "path",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--dry-run",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/mktemp.json
+++ b/spec/python/general/mktemp.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/mv.json
+++ b/spec/python/general/mv.json
@@ -100,197 +100,70 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--force",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--interactive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-clobber",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--update",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--backup",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--exchange",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-copy",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strip-trailing-slashes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/mv.json
+++ b/spec/python/general/mv.json
@@ -104,6 +104,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/nl.json
+++ b/spec/python/general/nl.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/nl.json
+++ b/spec/python/general/nl.json
@@ -254,182 +254,64 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--body-numbering",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--section-delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--footer-numbering",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--header-numbering",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--join-blank-lines",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-format",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-renumber",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--starting-line-number",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--line-increment",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-width",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/node.json
+++ b/spec/python/general/node.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/node.json
+++ b/spec/python/general/node.json
@@ -15,46 +15,20 @@
     "resources": []
   },
   "description": "Run JavaScript on a sandboxed quickjs engine.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Evaluate the next argument as a script.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run as an ES module (top-level import/export/await); .mjs files select this automatically.",
       "long": "--module",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/numfmt.json
+++ b/spec/python/general/numfmt.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/numfmt.json
+++ b/spec/python/general/numfmt.json
@@ -254,77 +254,25 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--to",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--from",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--grouping",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/od.json
+++ b/spec/python/general/od.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/od.json
+++ b/spec/python/general/od.json
@@ -254,77 +254,30 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--address-radix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--skip-bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--read-bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-N",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--format",
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/paste.json
+++ b/spec/python/general/paste.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/paste.json
+++ b/spec/python/general/paste.json
@@ -254,62 +254,24 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--delimiters",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--serial",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/patch.json
+++ b/spec/python/general/patch.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/patch.json
+++ b/spec/python/general/patch.json
@@ -107,84 +107,30 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-N",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/printf.json
+++ b/spec/python/general/printf.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [
     {

--- a/spec/python/general/printf.json
+++ b/spec/python/general/printf.json
@@ -7,22 +7,12 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/pwd.json
+++ b/spec/python/general/pwd.json
@@ -7,47 +7,17 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/pwd.json
+++ b/spec/python/general/pwd.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/python.json
+++ b/spec/python/general/python.json
@@ -14,32 +14,13 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/python.json
+++ b/spec/python/general/python.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/python3.json
+++ b/spec/python/general/python3.json
@@ -14,32 +14,13 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/python3.json
+++ b/spec/python/general/python3.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/readlink.json
+++ b/spec/python/general/readlink.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/readlink.json
+++ b/spec/python/general/readlink.json
@@ -254,77 +254,25 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/realpath.json
+++ b/spec/python/general/realpath.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/realpath.json
+++ b/spec/python/general/realpath.json
@@ -254,47 +254,17 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/rev.json
+++ b/spec/python/general/rev.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/python/general/rev.json
+++ b/spec/python/general/rev.json
@@ -254,16 +254,7 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/rg.json
+++ b/spec/python/general/rg.json
@@ -265,6 +265,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/rg.json
+++ b/spec/python/general/rg.json
@@ -261,309 +261,87 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-B",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--hidden",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--type",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--glob",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--color",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
@@ -574,13 +352,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/rm.json
+++ b/spec/python/general/rm.json
@@ -128,167 +128,49 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--preserve-root",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-preserve-root",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--one-file-system",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/rm.json
+++ b/spec/python/general/rm.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/rmdir.json
+++ b/spec/python/general/rmdir.json
@@ -100,32 +100,13 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/rmdir.json
+++ b/spec/python/general/rmdir.json
@@ -104,6 +104,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/search.json
+++ b/spec/python/general/search.json
@@ -41,6 +41,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/search.json
+++ b/spec/python/general/search.json
@@ -37,68 +37,26 @@
       "qdrant"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--method",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--top-k",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--threshold",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/sed.json
+++ b/spec/python/general/sed.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/sed.json
+++ b/spec/python/general/sed.json
@@ -254,101 +254,32 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -357,13 +288,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/seq.json
+++ b/spec/python/general/seq.json
@@ -15,73 +15,32 @@
     "resources": []
   },
   "description": "Print a sequence of numbers.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Use the given string as separator between numbers.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Pad numbers with zeros to equal width.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Format each number with a printf-style format string.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/seq.json
+++ b/spec/python/general/seq.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/sha1sum.json
+++ b/spec/python/general/sha1sum.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/sha1sum.json
+++ b/spec/python/general/sha1sum.json
@@ -254,167 +254,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/sha256sum.json
+++ b/spec/python/general/sha256sum.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/sha256sum.json
+++ b/spec/python/general/sha256sum.json
@@ -254,167 +254,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/sha384sum.json
+++ b/spec/python/general/sha384sum.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/sha384sum.json
+++ b/spec/python/general/sha384sum.json
@@ -254,167 +254,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/sha512sum.json
+++ b/spec/python/general/sha512sum.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/sha512sum.json
+++ b/spec/python/general/sha512sum.json
@@ -254,167 +254,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/shuf.json
+++ b/spec/python/general/shuf.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/shuf.json
+++ b/spec/python/general/shuf.json
@@ -254,107 +254,39 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--head-count",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--echo",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--repeat",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--input-range",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/sleep.json
+++ b/spec/python/general/sleep.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/python/general/sleep.json
+++ b/spec/python/general/sleep.json
@@ -8,15 +8,7 @@
     "resources": []
   },
   "description": "Delay for a specified amount of time.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/sort.json
+++ b/spec/python/general/sort.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/sort.json
+++ b/spec/python/general/sort.json
@@ -254,302 +254,104 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--reverse",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--numeric-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--unique",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-case",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--key",
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--field-separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--human-numeric-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--version-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-V",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--stable",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--month-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-M",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-leading-blanks",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--dictionary-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--general-numeric-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-g",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-nonprinting",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--merge",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/split.json
+++ b/spec/python/general/split.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/split.json
+++ b/spec/python/general/split.json
@@ -107,144 +107,55 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--lines",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--numeric-suffixes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--hex-suffixes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix-length",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--additional-suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/stat.json
+++ b/spec/python/general/stat.json
@@ -265,6 +265,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/stat.json
+++ b/spec/python/general/stat.json
@@ -261,62 +261,21 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/strings.json
+++ b/spec/python/general/strings.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/strings.json
+++ b/spec/python/general/strings.json
@@ -254,32 +254,13 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/tac.json
+++ b/spec/python/general/tac.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/tac.json
+++ b/spec/python/general/tac.json
@@ -254,62 +254,24 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--before",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--regex",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/tail.json
+++ b/spec/python/general/tail.json
@@ -265,6 +265,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/tail.json
+++ b/spec/python/general/tail.json
@@ -261,92 +261,31 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
       "numeric_shorthand": true,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--follow",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/tar.json
+++ b/spec/python/general/tar.json
@@ -107,197 +107,59 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
   "old_option_style": true,
   "operand_base": "-C",
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-J",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strip-components",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--exclude",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/tar.json
+++ b/spec/python/general/tar.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": true,
+  "operand_base": "-C",
   "options": [
     {
       "choices": [],
@@ -213,6 +214,21 @@
       "pair": false,
       "required": false,
       "short": "-v",
+      "short_value": true,
+      "type": "bool",
+      "value_optional": false
+    },
+    {
+      "choices": [],
+      "count": false,
+      "default": null,
+      "description": null,
+      "long": null,
+      "multiple": false,
+      "numeric_shorthand": false,
+      "pair": false,
+      "required": false,
+      "short": "-h",
       "short_value": true,
       "type": "bool",
       "value_optional": false

--- a/spec/python/general/tar.json
+++ b/spec/python/general/tar.json
@@ -147,6 +147,7 @@
       "type": "path"
     },
     {
+      "multiple": true,
       "short": "-C",
       "type": "path"
     },

--- a/spec/python/general/tee.json
+++ b/spec/python/general/tee.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/tee.json
+++ b/spec/python/general/tee.json
@@ -107,56 +107,20 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--append",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-interrupts",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
       "choices": [
@@ -165,24 +129,12 @@
         "exit",
         "exit-nopipe"
       ],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output-error",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/touch.json
+++ b/spec/python/general/touch.json
@@ -107,62 +107,21 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/touch.json
+++ b/spec/python/general/touch.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/tr.json
+++ b/spec/python/general/tr.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/tr.json
+++ b/spec/python/general/tr.json
@@ -254,99 +254,38 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--delete",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--squeeze-repeats",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--complement",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--truncate-set1",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/tree.json
+++ b/spec/python/general/tree.json
@@ -265,6 +265,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/tree.json
+++ b/spec/python/general/tree.json
@@ -261,92 +261,29 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/truncate.json
+++ b/spec/python/general/truncate.json
@@ -90,6 +90,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/truncate.json
+++ b/spec/python/general/truncate.json
@@ -86,32 +86,14 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--size",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/tsort.json
+++ b/spec/python/general/tsort.json
@@ -254,18 +254,9 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/tsort.json
+++ b/spec/python/general/tsort.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [
     {

--- a/spec/python/general/unexpand.json
+++ b/spec/python/general/unexpand.json
@@ -254,62 +254,23 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tabs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--all",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--first-only",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/unexpand.json
+++ b/spec/python/general/unexpand.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/uniq.json
+++ b/spec/python/general/uniq.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/uniq.json
+++ b/spec/python/general/uniq.json
@@ -254,189 +254,68 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--count",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--repeated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-D",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--all-repeated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--group",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--unique",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--skip-fields",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--skip-chars",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-case",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check-chars",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/unlink.json
+++ b/spec/python/general/unlink.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/python/general/unlink.json
+++ b/spec/python/general/unlink.json
@@ -107,16 +107,7 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/unzip.json
+++ b/spec/python/general/unzip.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/unzip.json
+++ b/spec/python/general/unzip.json
@@ -107,113 +107,38 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/python/general/wc.json
+++ b/spec/python/general/wc.json
@@ -265,6 +265,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/wc.json
+++ b/spec/python/general/wc.json
@@ -261,107 +261,38 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--lines",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--words",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--chars",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--max-line-length",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--total",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/wget.json
+++ b/spec/python/general/wget.json
@@ -15,67 +15,29 @@
     "resources": []
   },
   "description": "Retrieve files from the web.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Write the downloaded content to the given file.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-O",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run quietly with no output.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Check that the URL exists without downloading it.",
       "long": "--spider",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/wget.json
+++ b/spec/python/general/wget.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/xxd.json
+++ b/spec/python/general/xxd.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/xxd.json
+++ b/spec/python/general/xxd.json
@@ -254,129 +254,42 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-g",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/python/general/zcat.json
+++ b/spec/python/general/zcat.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/python/general/zcat.json
+++ b/spec/python/general/zcat.json
@@ -254,16 +254,7 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/zgrep.json
+++ b/spec/python/general/zgrep.json
@@ -258,6 +258,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/python/general/zgrep.json
+++ b/spec/python/general/zgrep.json
@@ -254,251 +254,72 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-G",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -507,13 +328,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/python/general/zip.json
+++ b/spec/python/general/zip.json
@@ -111,6 +111,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],
@@ -155,6 +156,36 @@
       "short": "-q",
       "short_value": true,
       "type": "bool",
+      "value_optional": false
+    },
+    {
+      "choices": [],
+      "count": false,
+      "default": null,
+      "description": null,
+      "long": null,
+      "multiple": false,
+      "numeric_shorthand": false,
+      "pair": false,
+      "required": false,
+      "short": "-y",
+      "short_value": true,
+      "type": "bool",
+      "value_optional": false
+    },
+    {
+      "choices": [],
+      "count": false,
+      "default": null,
+      "description": null,
+      "long": null,
+      "multiple": true,
+      "numeric_shorthand": false,
+      "pair": false,
+      "required": false,
+      "short": "-x",
+      "short_value": true,
+      "type": "str",
       "value_optional": false
     }
   ],

--- a/spec/python/general/zip.json
+++ b/spec/python/general/zip.json
@@ -107,92 +107,30 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-y",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/awk.json
+++ b/spec/typescript/browser/general/awk.json
@@ -212,56 +212,20 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     }
   ],
   "positional": [
@@ -269,13 +233,10 @@
       "provided_by": [
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/awk.json
+++ b/spec/typescript/browser/general/awk.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/base64.json
+++ b/spec/typescript/browser/general/base64.json
@@ -212,79 +212,30 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--decode",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-D",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--wrap",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-garbage",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/base64.json
+++ b/spec/typescript/browser/general/base64.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/basename.json
+++ b/spec/typescript/browser/general/basename.json
@@ -212,62 +212,24 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--multiple",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/basename.json
+++ b/spec/typescript/browser/general/basename.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/bash.json
+++ b/spec/typescript/browser/general/bash.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/bash.json
+++ b/spec/typescript/browser/general/bash.json
@@ -8,181 +8,64 @@
     "resources": []
   },
   "description": "Run a command string through Mirage's shell. Only `-c` is meaningful; other flags are accepted and ignored. `bash` and `sh` are aliases.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read commands from the next argument and execute them.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read commands from stdin instead of from an argument.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Login shell. Mirage does not source profile files.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Interactive flag. Mirage shells are non-interactive.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Exit on first error.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Treat unset variables as errors.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Print commands as they execute.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Login shell.",
       "long": "--login",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Skip rc files.",
       "long": "--norc",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Skip profile files.",
       "long": "--noprofile",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) POSIX-conformant mode.",
       "long": "--posix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/bc.json
+++ b/spec/typescript/browser/general/bc.json
@@ -15,46 +15,19 @@
     "resources": []
   },
   "description": "Arbitrary precision calculator language.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Load the standard math library.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Suppress the welcome banner.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/bc.json
+++ b/spec/typescript/browser/general/bc.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/cat.json
+++ b/spec/typescript/browser/general/cat.json
@@ -223,6 +223,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/cat.json
+++ b/spec/typescript/browser/general/cat.json
@@ -219,167 +219,56 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-nonblank",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-ends",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-tabs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-nonprinting",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-all",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--squeeze-blank",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/chgrp.json
+++ b/spec/typescript/browser/general/chgrp.json
@@ -7,83 +7,30 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/chgrp.json
+++ b/spec/typescript/browser/general/chgrp.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/chmod.json
+++ b/spec/typescript/browser/general/chmod.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/chmod.json
+++ b/spec/typescript/browser/general/chmod.json
@@ -7,68 +7,26 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/chown.json
+++ b/spec/typescript/browser/general/chown.json
@@ -7,83 +7,30 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/chown.json
+++ b/spec/typescript/browser/general/chown.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/cmp.json
+++ b/spec/typescript/browser/general/cmp.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/cmp.json
+++ b/spec/typescript/browser/general/cmp.json
@@ -212,99 +212,34 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/column.json
+++ b/spec/typescript/browser/general/column.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/column.json
+++ b/spec/typescript/browser/general/column.json
@@ -212,62 +212,21 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/comm.json
+++ b/spec/typescript/browser/general/comm.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/comm.json
+++ b/spec/typescript/browser/general/comm.json
@@ -212,144 +212,47 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-2",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-3",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--nocheck-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output-delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--total",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/cp.json
+++ b/spec/typescript/browser/general/cp.json
@@ -72,212 +72,76 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--recursive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--archive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--force",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--interactive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-clobber",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--update",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--backup",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strip-trailing-slashes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/cp.json
+++ b/spec/typescript/browser/general/cp.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/csplit.json
+++ b/spec/typescript/browser/general/csplit.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/csplit.json
+++ b/spec/typescript/browser/general/csplit.json
@@ -72,143 +72,52 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--prefix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--digits",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix-format",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--keep-files",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--silent",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suppress-matched",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--elide-empty-files",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/curl.json
+++ b/spec/typescript/browser/general/curl.json
@@ -15,166 +15,60 @@
     "resources": []
   },
   "description": "Transfer data from or to a server.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Add a custom header to the request.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set the User-Agent header.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Specify the HTTP request method.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-X",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Send the given data as the request body.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Submit a multipart/form-data field.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Write response body to the given file.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Follow HTTP redirects.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Fail with exit 22 on an HTTP error status.",
       "long": "--fail",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run silently with no progress or messages.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Show errors even when silent.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/curl.json
+++ b/spec/typescript/browser/general/curl.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/cut.json
+++ b/spec/typescript/browser/general/cut.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/cut.json
+++ b/spec/typescript/browser/general/cut.json
@@ -212,212 +212,69 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--fields",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--characters",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-partial",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--complement",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--only-delimited",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-O",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output-delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--whitespace-delimited",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/date.json
+++ b/spec/typescript/browser/general/date.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/date.json
+++ b/spec/typescript/browser/general/date.json
@@ -15,78 +15,31 @@
     "resources": []
   },
   "description": "Print or set the system date and time.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Display the time described by the given date string.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Use Coordinated Universal Time (UTC).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Output date in ISO 8601 format.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Output date in RFC 5322 email format.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/df.json
+++ b/spec/typescript/browser/general/df.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/df.json
+++ b/spec/typescript/browser/general/df.json
@@ -7,137 +7,41 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-B",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/diff.json
+++ b/spec/typescript/browser/general/diff.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/diff.json
+++ b/spec/typescript/browser/general/diff.json
@@ -212,129 +212,42 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/dirname.json
+++ b/spec/typescript/browser/general/dirname.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/dirname.json
+++ b/spec/typescript/browser/general/dirname.json
@@ -212,32 +212,14 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/du.json
+++ b/spec/typescript/browser/general/du.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/du.json
+++ b/spec/typescript/browser/general/du.json
@@ -212,122 +212,38 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--max-depth",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/echo.json
+++ b/spec/typescript/browser/general/echo.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/echo.json
+++ b/spec/typescript/browser/general/echo.json
@@ -7,47 +7,17 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/expand.json
+++ b/spec/typescript/browser/general/expand.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/expand.json
+++ b/spec/typescript/browser/general/expand.json
@@ -212,47 +212,19 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tabs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--initial",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/expr.json
+++ b/spec/typescript/browser/general/expr.json
@@ -15,15 +15,7 @@
     "resources": []
   },
   "description": "Evaluate expressions.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/expr.json
+++ b/spec/typescript/browser/general/expr.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/browser/general/file.json
+++ b/spec/typescript/browser/general/file.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/file.json
+++ b/spec/typescript/browser/general/file.json
@@ -212,77 +212,25 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/find.json
+++ b/spec/typescript/browser/general/find.json
@@ -226,6 +226,7 @@
     ")"
   ],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/find.json
+++ b/spec/typescript/browser/general/find.json
@@ -219,365 +219,113 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
   "ignore_tokens": [
     "(",
     ")"
   ],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-name",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-type",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-maxdepth",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-size",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-mtime",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-iname",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-path",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-mindepth",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-print",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-print0",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-delete",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-depth",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-prune",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-ls",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-empty",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-or",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-and",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-not",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/fmt.json
+++ b/spec/typescript/browser/general/fmt.json
@@ -212,122 +212,44 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--width",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--goal",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-g",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--crown-margin",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--prefix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--split-only",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tagged-paragraph",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--uniform-spacing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/fmt.json
+++ b/spec/typescript/browser/general/fmt.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/fold.json
+++ b/spec/typescript/browser/general/fold.json
@@ -212,77 +212,29 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--width",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--spaces",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--characters",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/fold.json
+++ b/spec/typescript/browser/general/fold.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/grep.json
+++ b/spec/typescript/browser/general/grep.json
@@ -223,6 +223,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/grep.json
+++ b/spec/typescript/browser/general/grep.json
@@ -219,386 +219,110 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-G",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-B",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--color",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--colour",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--line-buffered",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -607,13 +331,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/gunzip.json
+++ b/spec/typescript/browser/general/gunzip.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/gunzip.json
+++ b/spec/typescript/browser/general/gunzip.json
@@ -72,77 +72,25 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/gzip.json
+++ b/spec/typescript/browser/general/gzip.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/gzip.json
+++ b/spec/typescript/browser/general/gzip.json
@@ -72,212 +72,61 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-2",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-3",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-4",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-5",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-6",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-7",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-8",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-9",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/head.json
+++ b/spec/typescript/browser/general/head.json
@@ -223,6 +223,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/head.json
+++ b/spec/typescript/browser/general/head.json
@@ -219,107 +219,39 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--lines",
-      "multiple": false,
       "numeric_shorthand": true,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--silent",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/history.json
+++ b/spec/typescript/browser/general/history.json
@@ -17,136 +17,49 @@
     ]
   },
   "description": "Show command history for the session.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Clear the command history.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Delete the entry at the given position; negative counts back from the end.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Append the args to the history as a single entry without executing them.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Print the args without storing them.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Append: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Write: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read-new: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/history.json
+++ b/spec/typescript/browser/general/history.json
@@ -20,6 +20,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/iconv.json
+++ b/spec/typescript/browser/general/iconv.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/iconv.json
+++ b/spec/typescript/browser/general/iconv.json
@@ -72,77 +72,25 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/join.json
+++ b/spec/typescript/browser/general/join.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/join.json
+++ b/spec/typescript/browser/general/join.json
@@ -212,219 +212,68 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-2",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-case",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--nocheck-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--header",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/jq.json
+++ b/spec/typescript/browser/general/jq.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/jq.json
+++ b/spec/typescript/browser/general/jq.json
@@ -212,371 +212,142 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Use null as the single input value",
       "long": "--null-input",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read each line as a string instead of JSON",
       "long": "--raw-input",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read all inputs into one array",
       "long": "--slurp",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Compact instead of pretty-printed output",
       "long": "--compact-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Output strings without quotes or escapes",
       "long": "--raw-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Implies -r and writes NUL after each output",
       "long": "--raw-output0",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Implies -r and writes no trailing newline",
       "long": "--join-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Escape non-ASCII characters in output",
       "long": "--ascii-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Sort object keys on output",
       "long": "--sort-keys",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set the exit status from the last output",
       "long": "--exit-status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Indent with tabs",
       "long": "--tab",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Indent with n spaces (max 7)",
       "long": "--indent",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "int",
-      "value_optional": false
+      "type": "int"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Disable colored output (already the default)",
       "long": "--monochrome-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-M",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Accepted for compatibility; output is one buffer",
       "long": "--unbuffered",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read the filter from a file",
       "long": "--from-file",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read each input as its [path, leaf] events",
       "long": "--stream",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read and write RS-delimited JSON text sequences",
       "long": "--seq",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a string value",
       "long": "--arg",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a JSON value",
       "long": "--argjson",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a file's contents",
       "long": "--rawfile",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a file's documents, as an array",
       "long": "--slurpfile",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read the remaining operands as positional string values",
       "long": "--args",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read the remaining operands as positional JSON values",
       "long": "--jsonargs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Show this help and exit",
       "long": "--help",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -584,12 +355,10 @@
       "provided_by": [
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
     "text_when": [
       "--args",
       "--jsonargs"

--- a/spec/typescript/browser/general/js.json
+++ b/spec/typescript/browser/general/js.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/js.json
+++ b/spec/typescript/browser/general/js.json
@@ -15,46 +15,20 @@
     "resources": []
   },
   "description": "Run JavaScript on a sandboxed quickjs engine.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Evaluate the next argument as a script.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run as an ES module (top-level import/export/await); .mjs files select this automatically.",
       "long": "--module",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/ln.json
+++ b/spec/typescript/browser/general/ln.json
@@ -72,77 +72,25 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/ln.json
+++ b/spec/typescript/browser/general/ln.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/look.json
+++ b/spec/typescript/browser/general/look.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/look.json
+++ b/spec/typescript/browser/general/look.json
@@ -212,39 +212,18 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/ls.json
+++ b/spec/typescript/browser/general/ls.json
@@ -223,6 +223,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/ls.json
+++ b/spec/typescript/browser/general/ls.json
@@ -219,212 +219,62 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--color",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/md5.json
+++ b/spec/typescript/browser/general/md5.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/browser/general/md5.json
+++ b/spec/typescript/browser/general/md5.json
@@ -212,16 +212,7 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/md5sum.json
+++ b/spec/typescript/browser/general/md5sum.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/md5sum.json
+++ b/spec/typescript/browser/general/md5sum.json
@@ -212,167 +212,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/mkdir.json
+++ b/spec/typescript/browser/general/mkdir.json
@@ -72,77 +72,30 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--parents",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--mode",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--context",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-Z",
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/mkdir.json
+++ b/spec/typescript/browser/general/mkdir.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/mktemp.json
+++ b/spec/typescript/browser/general/mktemp.json
@@ -72,124 +72,43 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tmpdir",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "path",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--dry-run",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/mktemp.json
+++ b/spec/typescript/browser/general/mktemp.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/mv.json
+++ b/spec/typescript/browser/general/mv.json
@@ -72,197 +72,70 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--force",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--interactive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-clobber",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--update",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--backup",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--exchange",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-copy",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strip-trailing-slashes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/mv.json
+++ b/spec/typescript/browser/general/mv.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/nl.json
+++ b/spec/typescript/browser/general/nl.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/nl.json
+++ b/spec/typescript/browser/general/nl.json
@@ -212,182 +212,64 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--body-numbering",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--section-delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--footer-numbering",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--header-numbering",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--join-blank-lines",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-format",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-renumber",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--starting-line-number",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--line-increment",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-width",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/node.json
+++ b/spec/typescript/browser/general/node.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/node.json
+++ b/spec/typescript/browser/general/node.json
@@ -15,46 +15,20 @@
     "resources": []
   },
   "description": "Run JavaScript on a sandboxed quickjs engine.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Evaluate the next argument as a script.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run as an ES module (top-level import/export/await); .mjs files select this automatically.",
       "long": "--module",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/numfmt.json
+++ b/spec/typescript/browser/general/numfmt.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/numfmt.json
+++ b/spec/typescript/browser/general/numfmt.json
@@ -212,77 +212,25 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--to",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--from",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--grouping",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/od.json
+++ b/spec/typescript/browser/general/od.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/od.json
+++ b/spec/typescript/browser/general/od.json
@@ -212,77 +212,30 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--address-radix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--skip-bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--read-bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-N",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--format",
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/paste.json
+++ b/spec/typescript/browser/general/paste.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/paste.json
+++ b/spec/typescript/browser/general/paste.json
@@ -212,62 +212,24 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--delimiters",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--serial",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/patch.json
+++ b/spec/typescript/browser/general/patch.json
@@ -72,84 +72,30 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-N",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/patch.json
+++ b/spec/typescript/browser/general/patch.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/printf.json
+++ b/spec/typescript/browser/general/printf.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [
     {

--- a/spec/typescript/browser/general/printf.json
+++ b/spec/typescript/browser/general/printf.json
@@ -7,22 +7,12 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/pwd.json
+++ b/spec/typescript/browser/general/pwd.json
@@ -7,47 +7,17 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/pwd.json
+++ b/spec/typescript/browser/general/pwd.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/python.json
+++ b/spec/typescript/browser/general/python.json
@@ -14,32 +14,13 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/python.json
+++ b/spec/typescript/browser/general/python.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/python3.json
+++ b/spec/typescript/browser/general/python3.json
@@ -14,32 +14,13 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/python3.json
+++ b/spec/typescript/browser/general/python3.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/readlink.json
+++ b/spec/typescript/browser/general/readlink.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/readlink.json
+++ b/spec/typescript/browser/general/readlink.json
@@ -212,77 +212,25 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/realpath.json
+++ b/spec/typescript/browser/general/realpath.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/realpath.json
+++ b/spec/typescript/browser/general/realpath.json
@@ -212,47 +212,17 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/rev.json
+++ b/spec/typescript/browser/general/rev.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/browser/general/rev.json
+++ b/spec/typescript/browser/general/rev.json
@@ -212,16 +212,7 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/rg.json
+++ b/spec/typescript/browser/general/rg.json
@@ -223,6 +223,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/rg.json
+++ b/spec/typescript/browser/general/rg.json
@@ -219,309 +219,87 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-B",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--hidden",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--type",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--glob",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--color",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
@@ -532,13 +310,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/rm.json
+++ b/spec/typescript/browser/general/rm.json
@@ -93,167 +93,49 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--preserve-root",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-preserve-root",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--one-file-system",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/rm.json
+++ b/spec/typescript/browser/general/rm.json
@@ -97,6 +97,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/rmdir.json
+++ b/spec/typescript/browser/general/rmdir.json
@@ -72,32 +72,13 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/rmdir.json
+++ b/spec/typescript/browser/general/rmdir.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/search.json
+++ b/spec/typescript/browser/general/search.json
@@ -41,6 +41,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/search.json
+++ b/spec/typescript/browser/general/search.json
@@ -37,68 +37,26 @@
       "qdrant"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--method",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--top-k",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--threshold",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/sed.json
+++ b/spec/typescript/browser/general/sed.json
@@ -212,101 +212,32 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -315,13 +246,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/sed.json
+++ b/spec/typescript/browser/general/sed.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/seq.json
+++ b/spec/typescript/browser/general/seq.json
@@ -15,73 +15,32 @@
     "resources": []
   },
   "description": "Print a sequence of numbers.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Use the given string as separator between numbers.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Pad numbers with zeros to equal width.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Format each number with a printf-style format string.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/seq.json
+++ b/spec/typescript/browser/general/seq.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/sha1sum.json
+++ b/spec/typescript/browser/general/sha1sum.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/sha1sum.json
+++ b/spec/typescript/browser/general/sha1sum.json
@@ -212,167 +212,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/sha256sum.json
+++ b/spec/typescript/browser/general/sha256sum.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/sha256sum.json
+++ b/spec/typescript/browser/general/sha256sum.json
@@ -212,167 +212,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/sha384sum.json
+++ b/spec/typescript/browser/general/sha384sum.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/sha384sum.json
+++ b/spec/typescript/browser/general/sha384sum.json
@@ -212,167 +212,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/sha512sum.json
+++ b/spec/typescript/browser/general/sha512sum.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/sha512sum.json
+++ b/spec/typescript/browser/general/sha512sum.json
@@ -212,167 +212,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/shuf.json
+++ b/spec/typescript/browser/general/shuf.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/shuf.json
+++ b/spec/typescript/browser/general/shuf.json
@@ -212,107 +212,39 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--head-count",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--echo",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--repeat",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--input-range",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/sleep.json
+++ b/spec/typescript/browser/general/sleep.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/browser/general/sleep.json
+++ b/spec/typescript/browser/general/sleep.json
@@ -8,15 +8,7 @@
     "resources": []
   },
   "description": "Delay for a specified amount of time.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/sort.json
+++ b/spec/typescript/browser/general/sort.json
@@ -212,302 +212,104 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--reverse",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--numeric-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--unique",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-case",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--key",
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--field-separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--human-numeric-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--version-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-V",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--stable",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--month-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-M",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-leading-blanks",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--dictionary-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--general-numeric-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-g",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-nonprinting",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--merge",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/sort.json
+++ b/spec/typescript/browser/general/sort.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/split.json
+++ b/spec/typescript/browser/general/split.json
@@ -72,144 +72,55 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--lines",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--numeric-suffixes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--hex-suffixes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix-length",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--additional-suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/split.json
+++ b/spec/typescript/browser/general/split.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/stat.json
+++ b/spec/typescript/browser/general/stat.json
@@ -219,62 +219,21 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/stat.json
+++ b/spec/typescript/browser/general/stat.json
@@ -223,6 +223,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/strings.json
+++ b/spec/typescript/browser/general/strings.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/strings.json
+++ b/spec/typescript/browser/general/strings.json
@@ -212,32 +212,13 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/tac.json
+++ b/spec/typescript/browser/general/tac.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/tac.json
+++ b/spec/typescript/browser/general/tac.json
@@ -212,62 +212,24 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--before",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--regex",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/tail.json
+++ b/spec/typescript/browser/general/tail.json
@@ -219,92 +219,31 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
       "numeric_shorthand": true,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--follow",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/tail.json
+++ b/spec/typescript/browser/general/tail.json
@@ -223,6 +223,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/tar.json
+++ b/spec/typescript/browser/general/tar.json
@@ -112,6 +112,7 @@
       "type": "path"
     },
     {
+      "multiple": true,
       "short": "-C",
       "type": "path"
     },

--- a/spec/typescript/browser/general/tar.json
+++ b/spec/typescript/browser/general/tar.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": true,
+  "operand_base": "-C",
   "options": [
     {
       "choices": [],
@@ -178,6 +179,21 @@
       "pair": false,
       "required": false,
       "short": "-v",
+      "short_value": true,
+      "type": "bool",
+      "value_optional": false
+    },
+    {
+      "choices": [],
+      "count": false,
+      "default": null,
+      "description": null,
+      "long": null,
+      "multiple": false,
+      "numeric_shorthand": false,
+      "pair": false,
+      "required": false,
+      "short": "-h",
       "short_value": true,
       "type": "bool",
       "value_optional": false

--- a/spec/typescript/browser/general/tar.json
+++ b/spec/typescript/browser/general/tar.json
@@ -72,197 +72,59 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
   "old_option_style": true,
   "operand_base": "-C",
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-J",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strip-components",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--exclude",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/tee.json
+++ b/spec/typescript/browser/general/tee.json
@@ -72,56 +72,20 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--append",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-interrupts",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
       "choices": [
@@ -130,24 +94,12 @@
         "exit",
         "exit-nopipe"
       ],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output-error",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/tee.json
+++ b/spec/typescript/browser/general/tee.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/touch.json
+++ b/spec/typescript/browser/general/touch.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/touch.json
+++ b/spec/typescript/browser/general/touch.json
@@ -72,62 +72,21 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/tr.json
+++ b/spec/typescript/browser/general/tr.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/tr.json
+++ b/spec/typescript/browser/general/tr.json
@@ -212,99 +212,38 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--delete",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--squeeze-repeats",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--complement",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--truncate-set1",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/tree.json
+++ b/spec/typescript/browser/general/tree.json
@@ -219,92 +219,29 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/tree.json
+++ b/spec/typescript/browser/general/tree.json
@@ -223,6 +223,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/truncate.json
+++ b/spec/typescript/browser/general/truncate.json
@@ -58,32 +58,14 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--size",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/truncate.json
+++ b/spec/typescript/browser/general/truncate.json
@@ -62,6 +62,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/tsort.json
+++ b/spec/typescript/browser/general/tsort.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [
     {

--- a/spec/typescript/browser/general/tsort.json
+++ b/spec/typescript/browser/general/tsort.json
@@ -212,18 +212,9 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/unexpand.json
+++ b/spec/typescript/browser/general/unexpand.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/unexpand.json
+++ b/spec/typescript/browser/general/unexpand.json
@@ -212,62 +212,23 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tabs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--all",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--first-only",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/uniq.json
+++ b/spec/typescript/browser/general/uniq.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/uniq.json
+++ b/spec/typescript/browser/general/uniq.json
@@ -212,189 +212,68 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--count",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--repeated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-D",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--all-repeated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--group",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--unique",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--skip-fields",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--skip-chars",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-case",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check-chars",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/unlink.json
+++ b/spec/typescript/browser/general/unlink.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/browser/general/unlink.json
+++ b/spec/typescript/browser/general/unlink.json
@@ -72,16 +72,7 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/unzip.json
+++ b/spec/typescript/browser/general/unzip.json
@@ -72,113 +72,38 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/unzip.json
+++ b/spec/typescript/browser/general/unzip.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/wc.json
+++ b/spec/typescript/browser/general/wc.json
@@ -219,107 +219,38 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--lines",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--words",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--chars",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--max-line-length",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--total",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/wc.json
+++ b/spec/typescript/browser/general/wc.json
@@ -223,6 +223,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/wget.json
+++ b/spec/typescript/browser/general/wget.json
@@ -15,67 +15,29 @@
     "resources": []
   },
   "description": "Retrieve files from the web.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Write the downloaded content to the given file.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-O",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run quietly with no output.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Check that the URL exists without downloading it.",
       "long": "--spider",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/wget.json
+++ b/spec/typescript/browser/general/wget.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/xxd.json
+++ b/spec/typescript/browser/general/xxd.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/xxd.json
+++ b/spec/typescript/browser/general/xxd.json
@@ -212,129 +212,42 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-g",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/browser/general/zcat.json
+++ b/spec/typescript/browser/general/zcat.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/browser/general/zcat.json
+++ b/spec/typescript/browser/general/zcat.json
@@ -212,16 +212,7 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/zgrep.json
+++ b/spec/typescript/browser/general/zgrep.json
@@ -216,6 +216,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/browser/general/zgrep.json
+++ b/spec/typescript/browser/general/zgrep.json
@@ -212,251 +212,72 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-G",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -465,13 +286,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/browser/general/zip.json
+++ b/spec/typescript/browser/general/zip.json
@@ -76,6 +76,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],
@@ -120,6 +121,36 @@
       "short": "-q",
       "short_value": true,
       "type": "bool",
+      "value_optional": false
+    },
+    {
+      "choices": [],
+      "count": false,
+      "default": null,
+      "description": null,
+      "long": null,
+      "multiple": false,
+      "numeric_shorthand": false,
+      "pair": false,
+      "required": false,
+      "short": "-y",
+      "short_value": true,
+      "type": "bool",
+      "value_optional": false
+    },
+    {
+      "choices": [],
+      "count": false,
+      "default": null,
+      "description": null,
+      "long": null,
+      "multiple": true,
+      "numeric_shorthand": false,
+      "pair": false,
+      "required": false,
+      "short": "-x",
+      "short_value": true,
+      "type": "str",
       "value_optional": false
     }
   ],

--- a/spec/typescript/browser/general/zip.json
+++ b/spec/typescript/browser/general/zip.json
@@ -72,92 +72,30 @@
       "sharepoint"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-y",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/awk.json
+++ b/spec/typescript/node/general/awk.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/awk.json
+++ b/spec/typescript/node/general/awk.json
@@ -275,56 +275,20 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     }
   ],
   "positional": [
@@ -332,13 +296,10 @@
       "provided_by": [
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/base64.json
+++ b/spec/typescript/node/general/base64.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/base64.json
+++ b/spec/typescript/node/general/base64.json
@@ -275,79 +275,30 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--decode",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-D",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--wrap",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-garbage",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/basename.json
+++ b/spec/typescript/node/general/basename.json
@@ -275,62 +275,24 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--multiple",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/basename.json
+++ b/spec/typescript/node/general/basename.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/bash.json
+++ b/spec/typescript/node/general/bash.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/bash.json
+++ b/spec/typescript/node/general/bash.json
@@ -8,181 +8,64 @@
     "resources": []
   },
   "description": "Run a command string through Mirage's shell. Only `-c` is meaningful; other flags are accepted and ignored. `bash` and `sh` are aliases.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read commands from the next argument and execute them.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read commands from stdin instead of from an argument.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Login shell. Mirage does not source profile files.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Interactive flag. Mirage shells are non-interactive.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Exit on first error.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Treat unset variables as errors.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Print commands as they execute.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Login shell.",
       "long": "--login",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Skip rc files.",
       "long": "--norc",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) Skip profile files.",
       "long": "--noprofile",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "(Ignored) POSIX-conformant mode.",
       "long": "--posix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/bc.json
+++ b/spec/typescript/node/general/bc.json
@@ -15,46 +15,19 @@
     "resources": []
   },
   "description": "Arbitrary precision calculator language.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Load the standard math library.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Suppress the welcome banner.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/bc.json
+++ b/spec/typescript/node/general/bc.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/cat.json
+++ b/spec/typescript/node/general/cat.json
@@ -286,6 +286,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/cat.json
+++ b/spec/typescript/node/general/cat.json
@@ -282,167 +282,56 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-nonblank",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-ends",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-tabs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-nonprinting",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--show-all",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--squeeze-blank",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/chgrp.json
+++ b/spec/typescript/node/general/chgrp.json
@@ -7,83 +7,30 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/chgrp.json
+++ b/spec/typescript/node/general/chgrp.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/chmod.json
+++ b/spec/typescript/node/general/chmod.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/chmod.json
+++ b/spec/typescript/node/general/chmod.json
@@ -7,68 +7,26 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/chown.json
+++ b/spec/typescript/node/general/chown.json
@@ -7,83 +7,30 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/chown.json
+++ b/spec/typescript/node/general/chown.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/cmp.json
+++ b/spec/typescript/node/general/cmp.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/cmp.json
+++ b/spec/typescript/node/general/cmp.json
@@ -275,99 +275,34 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/column.json
+++ b/spec/typescript/node/general/column.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/column.json
+++ b/spec/typescript/node/general/column.json
@@ -275,62 +275,21 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/comm.json
+++ b/spec/typescript/node/general/comm.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/comm.json
+++ b/spec/typescript/node/general/comm.json
@@ -275,144 +275,47 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-2",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-3",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--nocheck-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output-delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--total",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/cp.json
+++ b/spec/typescript/node/general/cp.json
@@ -100,212 +100,76 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--recursive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--archive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--force",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--interactive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-clobber",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--update",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--backup",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strip-trailing-slashes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/cp.json
+++ b/spec/typescript/node/general/cp.json
@@ -104,6 +104,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/csplit.json
+++ b/spec/typescript/node/general/csplit.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/csplit.json
+++ b/spec/typescript/node/general/csplit.json
@@ -128,143 +128,52 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--prefix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--digits",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix-format",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--keep-files",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--silent",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suppress-matched",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--elide-empty-files",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/curl.json
+++ b/spec/typescript/node/general/curl.json
@@ -15,166 +15,60 @@
     "resources": []
   },
   "description": "Transfer data from or to a server.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Add a custom header to the request.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set the User-Agent header.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Specify the HTTP request method.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-X",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Send the given data as the request body.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Submit a multipart/form-data field.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Write response body to the given file.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Follow HTTP redirects.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Fail with exit 22 on an HTTP error status.",
       "long": "--fail",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run silently with no progress or messages.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Show errors even when silent.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/curl.json
+++ b/spec/typescript/node/general/curl.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/cut.json
+++ b/spec/typescript/node/general/cut.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/cut.json
+++ b/spec/typescript/node/general/cut.json
@@ -275,212 +275,69 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--fields",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--characters",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-partial",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--complement",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--only-delimited",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-O",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output-delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--whitespace-delimited",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/date.json
+++ b/spec/typescript/node/general/date.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/date.json
+++ b/spec/typescript/node/general/date.json
@@ -15,78 +15,31 @@
     "resources": []
   },
   "description": "Print or set the system date and time.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Display the time described by the given date string.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Use Coordinated Universal Time (UTC).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Output date in ISO 8601 format.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Output date in RFC 5322 email format.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/df.json
+++ b/spec/typescript/node/general/df.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/df.json
+++ b/spec/typescript/node/general/df.json
@@ -7,137 +7,41 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-B",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/diff.json
+++ b/spec/typescript/node/general/diff.json
@@ -275,129 +275,42 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/diff.json
+++ b/spec/typescript/node/general/diff.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/dirname.json
+++ b/spec/typescript/node/general/dirname.json
@@ -275,32 +275,14 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/dirname.json
+++ b/spec/typescript/node/general/dirname.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/du.json
+++ b/spec/typescript/node/general/du.json
@@ -275,122 +275,38 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--max-depth",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/du.json
+++ b/spec/typescript/node/general/du.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/echo.json
+++ b/spec/typescript/node/general/echo.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/echo.json
+++ b/spec/typescript/node/general/echo.json
@@ -7,47 +7,17 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/expand.json
+++ b/spec/typescript/node/general/expand.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/expand.json
+++ b/spec/typescript/node/general/expand.json
@@ -275,47 +275,19 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tabs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--initial",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/expr.json
+++ b/spec/typescript/node/general/expr.json
@@ -15,15 +15,7 @@
     "resources": []
   },
   "description": "Evaluate expressions.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/expr.json
+++ b/spec/typescript/node/general/expr.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/node/general/file.json
+++ b/spec/typescript/node/general/file.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/file.json
+++ b/spec/typescript/node/general/file.json
@@ -275,77 +275,25 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/find.json
+++ b/spec/typescript/node/general/find.json
@@ -282,365 +282,113 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
   "ignore_tokens": [
     "(",
     ")"
   ],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-name",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-type",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-maxdepth",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-size",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-mtime",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-iname",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-path",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-mindepth",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-print",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-print0",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-delete",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-depth",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-prune",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-ls",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-empty",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-or",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-and",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-not",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/find.json
+++ b/spec/typescript/node/general/find.json
@@ -289,6 +289,7 @@
     ")"
   ],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/fmt.json
+++ b/spec/typescript/node/general/fmt.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/fmt.json
+++ b/spec/typescript/node/general/fmt.json
@@ -275,122 +275,44 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--width",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--goal",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-g",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--crown-margin",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--prefix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--split-only",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tagged-paragraph",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--uniform-spacing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/fold.json
+++ b/spec/typescript/node/general/fold.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/fold.json
+++ b/spec/typescript/node/general/fold.json
@@ -275,77 +275,29 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--width",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--spaces",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--characters",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/grep.json
+++ b/spec/typescript/node/general/grep.json
@@ -286,6 +286,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/grep.json
+++ b/spec/typescript/node/general/grep.json
@@ -282,386 +282,110 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-G",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-B",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--color",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--colour",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--line-buffered",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -670,13 +394,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/gunzip.json
+++ b/spec/typescript/node/general/gunzip.json
@@ -128,77 +128,25 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/gunzip.json
+++ b/spec/typescript/node/general/gunzip.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/gzip.json
+++ b/spec/typescript/node/general/gzip.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/gzip.json
+++ b/spec/typescript/node/general/gzip.json
@@ -128,212 +128,61 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-2",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-3",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-4",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-5",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-6",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-7",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-8",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-9",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/head.json
+++ b/spec/typescript/node/general/head.json
@@ -286,6 +286,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/head.json
+++ b/spec/typescript/node/general/head.json
@@ -282,107 +282,39 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--lines",
-      "multiple": false,
       "numeric_shorthand": true,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--silent",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/history.json
+++ b/spec/typescript/node/general/history.json
@@ -17,136 +17,49 @@
     ]
   },
   "description": "Show command history for the session.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Clear the command history.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Delete the entry at the given position; negative counts back from the end.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Append the args to the history as a single entry without executing them.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Print the args without storing them.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Append: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Write: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read-new: no-op (file and store are the same).",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/history.json
+++ b/spec/typescript/node/general/history.json
@@ -20,6 +20,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/iconv.json
+++ b/spec/typescript/node/general/iconv.json
@@ -128,77 +128,25 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/iconv.json
+++ b/spec/typescript/node/general/iconv.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/join.json
+++ b/spec/typescript/node/general/join.json
@@ -275,219 +275,68 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-2",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-case",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--nocheck-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--header",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/join.json
+++ b/spec/typescript/node/general/join.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/jq.json
+++ b/spec/typescript/node/general/jq.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/jq.json
+++ b/spec/typescript/node/general/jq.json
@@ -275,371 +275,142 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Use null as the single input value",
       "long": "--null-input",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read each line as a string instead of JSON",
       "long": "--raw-input",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read all inputs into one array",
       "long": "--slurp",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Compact instead of pretty-printed output",
       "long": "--compact-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Output strings without quotes or escapes",
       "long": "--raw-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Implies -r and writes NUL after each output",
       "long": "--raw-output0",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Implies -r and writes no trailing newline",
       "long": "--join-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Escape non-ASCII characters in output",
       "long": "--ascii-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Sort object keys on output",
       "long": "--sort-keys",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set the exit status from the last output",
       "long": "--exit-status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Indent with tabs",
       "long": "--tab",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Indent with n spaces (max 7)",
       "long": "--indent",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "int",
-      "value_optional": false
+      "type": "int"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Disable colored output (already the default)",
       "long": "--monochrome-output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-M",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Accepted for compatibility; output is one buffer",
       "long": "--unbuffered",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read the filter from a file",
       "long": "--from-file",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read each input as its [path, leaf] events",
       "long": "--stream",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read and write RS-delimited JSON text sequences",
       "long": "--seq",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a string value",
       "long": "--arg",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a JSON value",
       "long": "--argjson",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a file's contents",
       "long": "--rawfile",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Set $name to a file's documents, as an array",
       "long": "--slurpfile",
-      "multiple": false,
-      "numeric_shorthand": false,
       "pair": true,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read the remaining operands as positional string values",
       "long": "--args",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Read the remaining operands as positional JSON values",
       "long": "--jsonargs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Show this help and exit",
       "long": "--help",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -647,12 +418,10 @@
       "provided_by": [
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
     "text_when": [
       "--args",
       "--jsonargs"

--- a/spec/typescript/node/general/js.json
+++ b/spec/typescript/node/general/js.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/js.json
+++ b/spec/typescript/node/general/js.json
@@ -15,46 +15,20 @@
     "resources": []
   },
   "description": "Run JavaScript on a sandboxed quickjs engine.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Evaluate the next argument as a script.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run as an ES module (top-level import/export/await); .mjs files select this automatically.",
       "long": "--module",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/ln.json
+++ b/spec/typescript/node/general/ln.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/ln.json
+++ b/spec/typescript/node/general/ln.json
@@ -128,77 +128,25 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/look.json
+++ b/spec/typescript/node/general/look.json
@@ -275,39 +275,18 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/look.json
+++ b/spec/typescript/node/general/look.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/ls.json
+++ b/spec/typescript/node/general/ls.json
@@ -286,6 +286,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/ls.json
+++ b/spec/typescript/node/general/ls.json
@@ -282,212 +282,62 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-1",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--color",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/md5.json
+++ b/spec/typescript/node/general/md5.json
@@ -275,16 +275,7 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/md5.json
+++ b/spec/typescript/node/general/md5.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/node/general/md5sum.json
+++ b/spec/typescript/node/general/md5sum.json
@@ -275,167 +275,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/md5sum.json
+++ b/spec/typescript/node/general/md5sum.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/mkdir.json
+++ b/spec/typescript/node/general/mkdir.json
@@ -128,77 +128,30 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--parents",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--mode",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--context",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-Z",
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/mkdir.json
+++ b/spec/typescript/node/general/mkdir.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/mktemp.json
+++ b/spec/typescript/node/general/mktemp.json
@@ -128,124 +128,43 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tmpdir",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "path",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--dry-run",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/mktemp.json
+++ b/spec/typescript/node/general/mktemp.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/mv.json
+++ b/spec/typescript/node/general/mv.json
@@ -100,197 +100,70 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--force",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--interactive",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-clobber",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--verbose",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--update",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--backup",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
       "short_value": false,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-S",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-target-directory",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-T",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--exchange",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-copy",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strip-trailing-slashes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/mv.json
+++ b/spec/typescript/node/general/mv.json
@@ -104,6 +104,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/nl.json
+++ b/spec/typescript/node/general/nl.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/nl.json
+++ b/spec/typescript/node/general/nl.json
@@ -275,182 +275,64 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--body-numbering",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--section-delimiter",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--footer-numbering",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--header-numbering",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--join-blank-lines",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-format",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-renumber",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--starting-line-number",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--line-increment",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-width",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number-separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/node.json
+++ b/spec/typescript/node/general/node.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/node.json
+++ b/spec/typescript/node/general/node.json
@@ -15,46 +15,20 @@
     "resources": []
   },
   "description": "Run JavaScript on a sandboxed quickjs engine.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Evaluate the next argument as a script.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run as an ES module (top-level import/export/await); .mjs files select this automatically.",
       "long": "--module",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/numfmt.json
+++ b/spec/typescript/node/general/numfmt.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/numfmt.json
+++ b/spec/typescript/node/general/numfmt.json
@@ -275,77 +275,25 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--to",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--from",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--grouping",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/od.json
+++ b/spec/typescript/node/general/od.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/od.json
+++ b/spec/typescript/node/general/od.json
@@ -275,77 +275,30 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--address-radix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--skip-bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--read-bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-N",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--format",
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/paste.json
+++ b/spec/typescript/node/general/paste.json
@@ -275,62 +275,24 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--delimiters",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--serial",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/paste.json
+++ b/spec/typescript/node/general/paste.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/patch.json
+++ b/spec/typescript/node/general/patch.json
@@ -128,84 +128,30 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-N",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/patch.json
+++ b/spec/typescript/node/general/patch.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/printf.json
+++ b/spec/typescript/node/general/printf.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [
     {

--- a/spec/typescript/node/general/printf.json
+++ b/spec/typescript/node/general/printf.json
@@ -7,22 +7,12 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/pwd.json
+++ b/spec/typescript/node/general/pwd.json
@@ -7,47 +7,17 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/pwd.json
+++ b/spec/typescript/node/general/pwd.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/python.json
+++ b/spec/typescript/node/general/python.json
@@ -14,32 +14,13 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/python.json
+++ b/spec/typescript/node/general/python.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/python3.json
+++ b/spec/typescript/node/general/python3.json
@@ -14,32 +14,13 @@
     "has_write": false,
     "resources": []
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/python3.json
+++ b/spec/typescript/node/general/python3.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/readlink.json
+++ b/spec/typescript/node/general/readlink.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/readlink.json
+++ b/spec/typescript/node/general/readlink.json
@@ -275,77 +275,25 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/realpath.json
+++ b/spec/typescript/node/general/realpath.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/realpath.json
+++ b/spec/typescript/node/general/realpath.json
@@ -275,47 +275,17 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/rev.json
+++ b/spec/typescript/node/general/rev.json
@@ -275,16 +275,7 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/rev.json
+++ b/spec/typescript/node/general/rev.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/node/general/rg.json
+++ b/spec/typescript/node/general/rg.json
@@ -286,6 +286,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/rg.json
+++ b/spec/typescript/node/general/rg.json
@@ -282,309 +282,87 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-A",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-B",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--hidden",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--type",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--glob",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--color",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
@@ -595,13 +373,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/rm.json
+++ b/spec/typescript/node/general/rm.json
@@ -153,6 +153,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/rm.json
+++ b/spec/typescript/node/general/rm.json
@@ -149,167 +149,49 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-R",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--preserve-root",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--no-preserve-root",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--one-file-system",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/rmdir.json
+++ b/spec/typescript/node/general/rmdir.json
@@ -100,32 +100,13 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/rmdir.json
+++ b/spec/typescript/node/general/rmdir.json
@@ -104,6 +104,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/search.json
+++ b/spec/typescript/node/general/search.json
@@ -41,6 +41,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/search.json
+++ b/spec/typescript/node/general/search.json
@@ -37,68 +37,26 @@
       "qdrant"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--method",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--top-k",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--threshold",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/sed.json
+++ b/spec/typescript/node/general/sed.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/sed.json
+++ b/spec/typescript/node/general/sed.json
@@ -275,101 +275,32 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -378,13 +309,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/seq.json
+++ b/spec/typescript/node/general/seq.json
@@ -15,73 +15,32 @@
     "resources": []
   },
   "description": "Print a sequence of numbers.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Use the given string as separator between numbers.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Pad numbers with zeros to equal width.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Format each number with a printf-style format string.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/seq.json
+++ b/spec/typescript/node/general/seq.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/sha1sum.json
+++ b/spec/typescript/node/general/sha1sum.json
@@ -275,167 +275,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/sha1sum.json
+++ b/spec/typescript/node/general/sha1sum.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/sha256sum.json
+++ b/spec/typescript/node/general/sha256sum.json
@@ -275,167 +275,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/sha256sum.json
+++ b/spec/typescript/node/general/sha256sum.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/sha384sum.json
+++ b/spec/typescript/node/general/sha384sum.json
@@ -275,167 +275,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/sha384sum.json
+++ b/spec/typescript/node/general/sha384sum.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/sha512sum.json
+++ b/spec/typescript/node/general/sha512sum.json
@@ -275,167 +275,54 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--binary",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--text",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tag",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--warn",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strict",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-missing",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--status",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--quiet",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/sha512sum.json
+++ b/spec/typescript/node/general/sha512sum.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/shuf.json
+++ b/spec/typescript/node/general/shuf.json
@@ -275,107 +275,39 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--head-count",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--echo",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--repeat",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--input-range",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/shuf.json
+++ b/spec/typescript/node/general/shuf.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/sleep.json
+++ b/spec/typescript/node/general/sleep.json
@@ -11,6 +11,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/node/general/sleep.json
+++ b/spec/typescript/node/general/sleep.json
@@ -8,15 +8,7 @@
     "resources": []
   },
   "description": "Delay for a specified amount of time.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/sort.json
+++ b/spec/typescript/node/general/sort.json
@@ -275,302 +275,104 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--reverse",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--numeric-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--unique",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-case",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--key",
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-k",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--field-separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--human-numeric-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--version-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-V",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--stable",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--month-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-M",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-leading-blanks",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--dictionary-order",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--general-numeric-sort",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-g",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-nonprinting",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--merge",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/sort.json
+++ b/spec/typescript/node/general/sort.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/split.json
+++ b/spec/typescript/node/general/split.json
@@ -128,144 +128,55 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--lines",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--number",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--numeric-suffixes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--hex-suffixes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--suffix-length",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--additional-suffix",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/split.json
+++ b/spec/typescript/node/general/split.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/stat.json
+++ b/spec/typescript/node/general/stat.json
@@ -286,6 +286,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/stat.json
+++ b/spec/typescript/node/general/stat.json
@@ -282,62 +282,21 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/strings.json
+++ b/spec/typescript/node/general/strings.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/strings.json
+++ b/spec/typescript/node/general/strings.json
@@ -275,32 +275,13 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/tac.json
+++ b/spec/typescript/node/general/tac.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/tac.json
+++ b/spec/typescript/node/general/tac.json
@@ -275,62 +275,24 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--before",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-b",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--regex",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--separator",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/tail.json
+++ b/spec/typescript/node/general/tail.json
@@ -286,6 +286,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/tail.json
+++ b/spec/typescript/node/general/tail.json
@@ -282,92 +282,31 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
       "numeric_shorthand": true,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--follow",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/tar.json
+++ b/spec/typescript/node/general/tar.json
@@ -128,197 +128,59 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
   "old_option_style": true,
   "operand_base": "-C",
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-J",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--strip-components",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--exclude",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/tar.json
+++ b/spec/typescript/node/general/tar.json
@@ -168,6 +168,7 @@
       "type": "path"
     },
     {
+      "multiple": true,
       "short": "-C",
       "type": "path"
     },

--- a/spec/typescript/node/general/tar.json
+++ b/spec/typescript/node/general/tar.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": true,
+  "operand_base": "-C",
   "options": [
     {
       "choices": [],
@@ -234,6 +235,21 @@
       "pair": false,
       "required": false,
       "short": "-v",
+      "short_value": true,
+      "type": "bool",
+      "value_optional": false
+    },
+    {
+      "choices": [],
+      "count": false,
+      "default": null,
+      "description": null,
+      "long": null,
+      "multiple": false,
+      "numeric_shorthand": false,
+      "pair": false,
+      "required": false,
+      "short": "-h",
       "short_value": true,
       "type": "bool",
       "value_optional": false

--- a/spec/typescript/node/general/tee.json
+++ b/spec/typescript/node/general/tee.json
@@ -128,56 +128,20 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--append",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-interrupts",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
       "choices": [
@@ -186,24 +150,12 @@
         "exit",
         "exit-nopipe"
       ],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--output-error",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/tee.json
+++ b/spec/typescript/node/general/tee.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/touch.json
+++ b/spec/typescript/node/general/touch.json
@@ -128,62 +128,21 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/touch.json
+++ b/spec/typescript/node/general/touch.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/tr.json
+++ b/spec/typescript/node/general/tr.json
@@ -275,99 +275,38 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--delete",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--squeeze-repeats",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--complement",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-C",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--truncate-set1",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/tr.json
+++ b/spec/typescript/node/general/tr.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/tree.json
+++ b/spec/typescript/node/general/tree.json
@@ -286,6 +286,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/tree.json
+++ b/spec/typescript/node/general/tree.json
@@ -282,92 +282,29 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-I",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-P",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/truncate.json
+++ b/spec/typescript/node/general/truncate.json
@@ -90,6 +90,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/truncate.json
+++ b/spec/typescript/node/general/truncate.json
@@ -86,32 +86,14 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--size",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/tsort.json
+++ b/spec/typescript/node/general/tsort.json
@@ -275,18 +275,9 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/tsort.json
+++ b/spec/typescript/node/general/tsort.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [
     {

--- a/spec/typescript/node/general/unexpand.json
+++ b/spec/typescript/node/general/unexpand.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/unexpand.json
+++ b/spec/typescript/node/general/unexpand.json
@@ -275,62 +275,23 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--tabs",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--all",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-a",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--first-only",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/uniq.json
+++ b/spec/typescript/node/general/uniq.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/uniq.json
+++ b/spec/typescript/node/general/uniq.json
@@ -275,189 +275,68 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--count",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--repeated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-D",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--all-repeated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--group",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
       "type": "str",
       "value_optional": true
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--unique",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--skip-fields",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--skip-chars",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--ignore-case",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--check-chars",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--zero-terminated",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-z",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/unlink.json
+++ b/spec/typescript/node/general/unlink.json
@@ -128,16 +128,7 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/unlink.json
+++ b/spec/typescript/node/general/unlink.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/node/general/unzip.json
+++ b/spec/typescript/node/general/unzip.json
@@ -128,113 +128,38 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-d",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-t",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/unzip.json
+++ b/spec/typescript/node/general/unzip.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/wc.json
+++ b/spec/typescript/node/general/wc.json
@@ -286,6 +286,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/wc.json
+++ b/spec/typescript/node/general/wc.json
@@ -282,107 +282,38 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--lines",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--words",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--bytes",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--chars",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--max-line-length",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-L",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
       "long": "--total",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/wget.json
+++ b/spec/typescript/node/general/wget.json
@@ -15,67 +15,29 @@
     "resources": []
   },
   "description": "Retrieve files from the web.",
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Write the downloaded content to the given file.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-O",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Run quietly with no output.",
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
       "description": "Check that the URL exists without downloading it.",
       "long": "--spider",
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
-      "short": null,
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/wget.json
+++ b/spec/typescript/node/general/wget.json
@@ -18,6 +18,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/xxd.json
+++ b/spec/typescript/node/general/xxd.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/xxd.json
+++ b/spec/typescript/node/general/xxd.json
@@ -275,129 +275,42 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-p",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-s",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-g",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-u",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     },
     {
-      "provided_by": [],
-      "text_when": [],
       "type": "path"
     }
-  ],
-  "rest": null
+  ]
 }

--- a/spec/typescript/node/general/zcat.json
+++ b/spec/typescript/node/general/zcat.json
@@ -275,16 +275,7 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
-  "options": [],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/zcat.json
+++ b/spec/typescript/node/general/zcat.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [],
   "positional": [],
   "rest": {

--- a/spec/typescript/node/general/zgrep.json
+++ b/spec/typescript/node/general/zgrep.json
@@ -275,251 +275,72 @@
       "trello"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-i",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-c",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-l",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-n",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-v",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-e",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-f",
-      "short_value": true,
-      "type": "path",
-      "value_optional": false
+      "type": "path"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-E",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-G",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-F",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-H",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-h",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-m",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-o",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-w",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     }
   ],
   "positional": [
@@ -528,13 +349,10 @@
         "-e",
         "-f"
       ],
-      "text_when": [],
       "type": "str"
     }
   ],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/spec/typescript/node/general/zgrep.json
+++ b/spec/typescript/node/general/zgrep.json
@@ -279,6 +279,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],

--- a/spec/typescript/node/general/zip.json
+++ b/spec/typescript/node/general/zip.json
@@ -132,6 +132,7 @@
   "epilog": null,
   "ignore_tokens": [],
   "old_option_style": false,
+  "operand_base": null,
   "options": [
     {
       "choices": [],
@@ -176,6 +177,36 @@
       "short": "-q",
       "short_value": true,
       "type": "bool",
+      "value_optional": false
+    },
+    {
+      "choices": [],
+      "count": false,
+      "default": null,
+      "description": null,
+      "long": null,
+      "multiple": false,
+      "numeric_shorthand": false,
+      "pair": false,
+      "required": false,
+      "short": "-y",
+      "short_value": true,
+      "type": "bool",
+      "value_optional": false
+    },
+    {
+      "choices": [],
+      "count": false,
+      "default": null,
+      "description": null,
+      "long": null,
+      "multiple": true,
+      "numeric_shorthand": false,
+      "pair": false,
+      "required": false,
+      "short": "-x",
+      "short_value": true,
+      "type": "str",
       "value_optional": false
     }
   ],

--- a/spec/typescript/node/general/zip.json
+++ b/spec/typescript/node/general/zip.json
@@ -128,92 +128,30 @@
       "ssh"
     ]
   },
-  "description": null,
-  "epilog": null,
-  "ignore_tokens": [],
-  "old_option_style": false,
-  "operand_base": null,
   "options": [
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-r",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-j",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-q",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
-      "multiple": false,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-y",
-      "short_value": true,
-      "type": "bool",
-      "value_optional": false
+      "type": "bool"
     },
     {
-      "choices": [],
-      "count": false,
-      "default": null,
-      "description": null,
-      "long": null,
       "multiple": true,
-      "numeric_shorthand": false,
-      "pair": false,
-      "required": false,
       "short": "-x",
-      "short_value": true,
-      "type": "str",
-      "value_optional": false
+      "type": "str"
     }
   ],
-  "positional": [],
   "rest": {
-    "provided_by": [],
-    "text_when": [],
     "type": "path"
   }
 }

--- a/typescript/packages/core/src/commands/builtin/generic/archive/types.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/archive/types.ts
@@ -1,0 +1,54 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { PathSpec } from '../../../../types.ts'
+
+// What a member is, which is the whole of what an archive records beyond
+// its name: a regular file carries bytes, a directory carries none and
+// ends in a slash, a symlink carries its target string instead.
+export type MemberKind = 'file' | 'dir' | 'link'
+
+// One thing found under an operand, before it is named or filtered.
+// `namePath` and `read` are two different paths whenever a link is being
+// followed: the member keeps the link's own name while its bytes come
+// from the target.
+export interface Entry {
+  namePath: string
+  kind: MemberKind
+  target?: string
+  read?: PathSpec | null
+}
+
+// One thing the scan could not archive, in the order it was met.
+// `reason` is empty when `fatal` says the path could not be stat'd at
+// all, since each archiver words that case itself.
+export interface Problem {
+  path: string
+  reason?: string
+  fatal?: boolean
+}
+
+// What one operand contributed, in virtual path space.
+//
+// Nothing here is named yet: naming is where the two archive formats
+// part company (tar warns about a leading slash, zip strips it in
+// silence and can junk the path entirely), so the scan reports paths and
+// the caller spells them. `missing` says the operand itself was
+// unreachable, in which case it contributed no entries.
+export interface Scan {
+  entries: Entry[]
+  crossings: string[]
+  problems: Problem[]
+  missing: boolean
+}

--- a/typescript/packages/core/src/commands/builtin/generic/archive/walk.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/archive/walk.ts
@@ -1,0 +1,228 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { LinkView, MountView } from '../../../../ops/types.ts'
+import { type FileStat, FileType, LINK_TARGET_KEY, PathSpec } from '../../../../types.ts'
+import { mountKey } from '../../../../utils/key_prefix.ts'
+import { rstripSlash } from '../../../../utils/slash.ts'
+import type { Entry, MemberKind, Problem, Scan } from './types.ts'
+
+// A mount boundary is a filesystem boundary, so both archivers stop at
+// one and say so in GNU tar's --one-file-system wording. Descending
+// would archive by accident exactly what the mount-root refusal forbids
+// on purpose.
+export const OTHER_FILESYSTEM = 'file is on a different filesystem; not dumped'
+// Following a link back to something already followed on this operand.
+const LOOP_SKIP = 'symbolic link loop; not dumped'
+
+export type StatFn = (path: PathSpec) => Promise<FileStat>
+export type WalkFn = (path: PathSpec, findType: string) => Promise<string[]>
+export type DirProbe = (path: PathSpec) => Promise<boolean>
+
+// What the shared scan needs from the mount it runs on, plus the two
+// knobs the formats disagree about.
+export interface ScanDeps {
+  stat: StatFn
+  walk: WalkFn
+  links?: LinkView | null
+  mounts?: MountView | null
+  // Archive what a symlink points at rather than the link. tar sets
+  // this from -h, zip from the absence of -y.
+  dereference: boolean
+  // Whether a directory contributes its contents as well as itself.
+  // Always true for tar, only under -r for zip.
+  recurse: boolean
+}
+
+function linkTarget(stat: FileStat): string {
+  const target = stat.extra[LINK_TARGET_KEY]
+  return typeof target === 'string' ? target : ''
+}
+
+// A PathSpec for a walked descendant of one operand. The walk reports
+// absolute virtual paths; reading their bytes needs the backend key too,
+// which is the virtual path with this mount's prefix removed.
+function childSpec(virtual: string, root: PathSpec): PathSpec {
+  const cut = rstripSlash(root.virtual).length - root.resourcePath.replace(/^\/+|\/+$/g, '').length
+  const prefix = rstripSlash(root.virtual.slice(0, cut))
+  const slash = virtual.lastIndexOf('/')
+  return new PathSpec({
+    virtual,
+    directory: slash >= 0 ? virtual.slice(0, slash + 1) : '/',
+    resourcePath: mountKey(virtual, prefix),
+    rawPath: virtual,
+  })
+}
+
+// Whether two virtual paths are served by the same mount. Outside a
+// workspace (no MountView) there is only one mount.
+function sameMount(mounts: MountView | null, one: string, other: string): boolean {
+  if (mounts === null) return true
+  return mounts.rootOf(one) === mounts.rootOf(other)
+}
+
+// Every entry under one directory, named under `nameBase`.
+//
+// Three sources have to be merged because no single one can see them
+// all: the backend walk (files and directories), the namespace (its
+// symlinks, which no backend readdir reports), and the mount table (a
+// nested mount, whose keys live in another resource entirely).
+//
+// `base` and `nameBase` differ only when a link is being followed: the
+// walk runs over the target while the members keep the link's own name.
+async function subtree(
+  root: PathSpec,
+  base: string,
+  nameBase: string,
+  deps: ScanDeps,
+): Promise<[Entry[], string[]]> {
+  const walked = base !== root.virtual ? childSpec(base, root) : root
+  const found = new Map<string, [MemberKind, string]>()
+  for (const virtual of await deps.walk(walked, 'd')) {
+    if (rstripSlash(virtual) !== base) found.set(rstripSlash(virtual), ['dir', ''])
+  }
+  for (const virtual of await deps.walk(walked, 'f')) {
+    found.set(rstripSlash(virtual), ['file', ''])
+  }
+  const links = deps.links ?? null
+  if (links !== null) {
+    for (const [virtual, stat] of links.subtree(base)) {
+      found.set(rstripSlash(virtual), ['link', linkTarget(stat)])
+    }
+  }
+  const mounts = deps.mounts ?? null
+  const crossings = mounts !== null ? mounts.descendants(base) : []
+  for (const crossing of crossings) {
+    // The mountpoint itself is still an entry, exactly as GNU's
+    // --one-file-system keeps the directory and drops its contents.
+    found.set(rstripSlash(crossing), ['dir', ''])
+  }
+  const below = crossings.map((c) => `${rstripSlash(c)}/`)
+  const entries: Entry[] = []
+  for (const [virtual, [kind, target]] of found) {
+    if (below.some((c) => virtual.startsWith(c))) continue
+    const named = rstripSlash(nameBase) + virtual.slice(rstripSlash(base).length)
+    entries.push({
+      namePath: named,
+      kind,
+      target,
+      read: kind === 'file' ? childSpec(virtual, root) : null,
+    })
+  }
+  entries.sort((a, b) => (a.namePath < b.namePath ? -1 : a.namePath > b.namePath ? 1 : 0))
+  return [entries, crossings.map((c) => rstripSlash(c))]
+}
+
+// What dereferencing puts in the archive in place of one symlink.
+//
+// The member keeps the link's own name and takes the target's content,
+// which is what dereferencing means. Two cases stay out of reach and are
+// reported rather than guessed at: a target on another mount (whose
+// bytes this backend cannot read, the same boundary a nested mount
+// draws) and a target already followed on this operand, which is a loop.
+// The third return value says the link could not be stat'd at all.
+async function follow(
+  virtual: string,
+  root: PathSpec,
+  deps: ScanDeps,
+  seen: Set<string>,
+): Promise<[Entry[], string[], boolean]> {
+  const links = deps.links ?? null
+  if (links === null) return [[], [], false]
+  const target = links.resolve(virtual)
+  if (!sameMount(deps.mounts ?? null, virtual, target)) return [[], [OTHER_FILESYSTEM], false]
+  if (seen.has(target)) return [[], [LOOP_SKIP], false]
+  seen.add(target)
+  const spec = childSpec(target, root)
+  let targetStat: FileStat
+  try {
+    targetStat = await deps.stat(spec)
+  } catch {
+    return [[], [], true]
+  }
+  if (targetStat.type !== FileType.DIRECTORY) {
+    return [[{ namePath: virtual, kind: 'file', read: spec }], [], false]
+  }
+  if (!deps.recurse) return [[{ namePath: virtual, kind: 'dir' }], [], false]
+  const [entries, crossings] = await subtree(root, target, virtual, deps)
+  return [
+    [{ namePath: virtual, kind: 'dir' }, ...entries],
+    crossings.map(() => OTHER_FILESYSTEM),
+    false,
+  ]
+}
+
+/**
+ * Everything one operand contributes to an archive.
+ *
+ * This is the whole of what tar and zip share: which paths go in, what each
+ * one is, and which of them could not be reached. The two formats disagree
+ * about the defaults, not the traversal, so both are parameters: tar stores a
+ * symlink unless `-h` says to follow it and always descends, zip follows
+ * unless `-y` says otherwise and only descends under `-r`.
+ */
+export async function scanOperand(path: PathSpec, deps: ScanDeps): Promise<Scan> {
+  const base = rstripSlash(path.virtual) || '/'
+  let entries: Entry[] = []
+  let crossings: string[] = []
+  const problems: Problem[] = []
+  const seen = new Set<string>()
+  const links = deps.links ?? null
+  const linkStat = links !== null ? links.statAt(path.virtual) : null
+  if (linkStat !== null && !deps.dereference) {
+    entries.push({ namePath: base, kind: 'link', target: linkTarget(linkStat) })
+  } else if (linkStat !== null) {
+    const [followed, why, fatal] = await follow(base, path, deps, seen)
+    if (fatal) {
+      return { entries: [], crossings: [], problems: [{ path: base, fatal: true }], missing: true }
+    }
+    entries.push(...followed)
+    problems.push(...why.map((reason) => ({ path: base, reason })))
+  } else {
+    let rootStat: FileStat
+    try {
+      rootStat = await deps.stat(path)
+    } catch {
+      return { entries: [], crossings: [], problems: [{ path: base, fatal: true }], missing: true }
+    }
+    if (rootStat.type !== FileType.DIRECTORY) {
+      entries.push({ namePath: base, kind: 'file', read: path })
+    } else {
+      entries.push({ namePath: base, kind: 'dir' })
+      if (deps.recurse) {
+        const [below, found] = await subtree(path, base, base, deps)
+        entries.push(...below)
+        crossings = found
+      }
+    }
+  }
+  if (deps.dereference && links !== null) {
+    const expanded: Entry[] = []
+    for (const entry of entries) {
+      if (entry.kind !== 'link') {
+        expanded.push(entry)
+        continue
+      }
+      const [followed, why, fatal] = await follow(entry.namePath, path, deps, seen)
+      if (fatal) {
+        problems.push({ path: entry.namePath, fatal: true })
+        continue
+      }
+      expanded.push(...followed)
+      problems.push(...why.map((reason) => ({ path: entry.namePath, reason })))
+    }
+    entries = expanded
+  }
+  return { entries, crossings, problems, missing: false }
+}

--- a/typescript/packages/core/src/commands/builtin/generic/archive/walk.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/archive/walk.ts
@@ -15,6 +15,7 @@
 import type { LinkView, MountView } from '../../../../ops/types.ts'
 import { type FileStat, FileType, LINK_TARGET_KEY, PathSpec } from '../../../../types.ts'
 import { mountKey } from '../../../../utils/key_prefix.ts'
+import { CycleError } from '../../../../utils/path.ts'
 import { rstripSlash, stripSlash } from '../../../../utils/slash.ts'
 import type { Entry, MemberKind, Problem, Scan } from './types.ts'
 
@@ -23,8 +24,11 @@ import type { Entry, MemberKind, Problem, Scan } from './types.ts'
 // would archive by accident exactly what the mount-root refusal forbids
 // on purpose.
 export const OTHER_FILESYSTEM = 'file is on a different filesystem; not dumped'
-// Following a link back to something already followed on this operand.
-const LOOP_SKIP = 'symbolic link loop; not dumped'
+// Why a path could not be reached, in GNU's strerror wording. Both ride
+// on a fatal Problem; tar prints them after "Cannot stat: " and Info-ZIP
+// words every unreachable name the same way, so it ignores the reason.
+const NO_SUCH = 'No such file or directory'
+const TOO_MANY_LEVELS = 'Too many levels of symbolic links'
 
 export type StatFn = (path: PathSpec) => Promise<FileStat>
 export type WalkFn = (path: PathSpec, findType: string) => Promise<string[]>
@@ -127,39 +131,42 @@ async function subtree(
 // What dereferencing puts in the archive in place of one symlink.
 //
 // The member keeps the link's own name and takes the target's content,
-// which is what dereferencing means. Two cases stay out of reach and are
-// reported rather than guessed at: a target on another mount (whose
-// bytes this backend cannot read, the same boundary a nested mount
-// draws) and a target already followed on this operand, which is a loop.
-// The third return value says the link could not be stat'd at all.
+// which is what dereferencing means. Two links resolving to the same
+// file are not a loop and both are archived; a real loop is whatever
+// `resolve` refuses to resolve, since the namespace already walks the
+// chain under a hop limit and raises ELOOP at the end of it. The third
+// return value is why the link was unreachable, empty when it was not.
 async function follow(
   virtual: string,
   root: PathSpec,
   deps: ScanDeps,
-  seen: Set<string>,
-): Promise<[Entry[], string[], boolean]> {
+): Promise<[Entry[], string[], string]> {
   const links = deps.links ?? null
-  if (links === null) return [[], [], false]
-  const target = links.resolve(virtual)
-  if (!sameMount(deps.mounts ?? null, virtual, target)) return [[], [OTHER_FILESYSTEM], false]
-  if (seen.has(target)) return [[], [LOOP_SKIP], false]
-  seen.add(target)
+  if (links === null) return [[], [], '']
+  let target: string
+  try {
+    target = links.resolve(virtual)
+  } catch (e) {
+    if (!(e instanceof CycleError)) throw e
+    return [[], [], TOO_MANY_LEVELS]
+  }
+  if (!sameMount(deps.mounts ?? null, virtual, target)) return [[], [OTHER_FILESYSTEM], '']
   const spec = childSpec(target, root)
   let targetStat: FileStat
   try {
     targetStat = await deps.stat(spec)
   } catch {
-    return [[], [], true]
+    return [[], [], NO_SUCH]
   }
   if (targetStat.type !== FileType.DIRECTORY) {
-    return [[{ namePath: virtual, kind: 'file', read: spec }], [], false]
+    return [[{ namePath: virtual, kind: 'file', read: spec }], [], '']
   }
-  if (!deps.recurse) return [[{ namePath: virtual, kind: 'dir' }], [], false]
+  if (!deps.recurse) return [[{ namePath: virtual, kind: 'dir' }], [], '']
   const [entries, crossings] = await subtree(root, target, virtual, deps)
   return [
     [{ namePath: virtual, kind: 'dir' }, ...entries],
     crossings.map(() => OTHER_FILESYSTEM),
-    false,
+    '',
   ]
 }
 
@@ -177,15 +184,19 @@ export async function scanOperand(path: PathSpec, deps: ScanDeps): Promise<Scan>
   let entries: Entry[] = []
   let crossings: string[] = []
   const problems: Problem[] = []
-  const seen = new Set<string>()
   const links = deps.links ?? null
   const linkStat = links !== null ? links.statAt(path.virtual) : null
   if (linkStat !== null && !deps.dereference) {
     entries.push({ namePath: base, kind: 'link', target: linkTarget(linkStat) })
   } else if (linkStat !== null) {
-    const [followed, why, fatal] = await follow(base, path, deps, seen)
-    if (fatal) {
-      return { entries: [], crossings: [], problems: [{ path: base, fatal: true }], missing: true }
+    const [followed, why, unreachable] = await follow(base, path, deps)
+    if (unreachable !== '') {
+      return {
+        entries: [],
+        crossings: [],
+        problems: [{ path: base, reason: unreachable, fatal: true }],
+        missing: true,
+      }
     }
     entries.push(...followed)
     problems.push(...why.map((reason) => ({ path: base, reason })))
@@ -194,7 +205,12 @@ export async function scanOperand(path: PathSpec, deps: ScanDeps): Promise<Scan>
     try {
       rootStat = await deps.stat(path)
     } catch {
-      return { entries: [], crossings: [], problems: [{ path: base, fatal: true }], missing: true }
+      return {
+        entries: [],
+        crossings: [],
+        problems: [{ path: base, reason: NO_SUCH, fatal: true }],
+        missing: true,
+      }
     }
     if (rootStat.type !== FileType.DIRECTORY) {
       entries.push({ namePath: base, kind: 'file', read: path })
@@ -214,9 +230,9 @@ export async function scanOperand(path: PathSpec, deps: ScanDeps): Promise<Scan>
         expanded.push(entry)
         continue
       }
-      const [followed, why, fatal] = await follow(entry.namePath, path, deps, seen)
-      if (fatal) {
-        problems.push({ path: entry.namePath, fatal: true })
+      const [followed, why, unreachable] = await follow(entry.namePath, path, deps)
+      if (unreachable !== '') {
+        problems.push({ path: entry.namePath, reason: unreachable, fatal: true })
         continue
       }
       expanded.push(...followed)

--- a/typescript/packages/core/src/commands/builtin/generic/archive/walk.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/archive/walk.ts
@@ -15,7 +15,7 @@
 import type { LinkView, MountView } from '../../../../ops/types.ts'
 import { type FileStat, FileType, LINK_TARGET_KEY, PathSpec } from '../../../../types.ts'
 import { mountKey } from '../../../../utils/key_prefix.ts'
-import { rstripSlash } from '../../../../utils/slash.ts'
+import { rstripSlash, stripSlash } from '../../../../utils/slash.ts'
 import type { Entry, MemberKind, Problem, Scan } from './types.ts'
 
 // A mount boundary is a filesystem boundary, so both archivers stop at
@@ -54,7 +54,7 @@ function linkTarget(stat: FileStat): string {
 // absolute virtual paths; reading their bytes needs the backend key too,
 // which is the virtual path with this mount's prefix removed.
 function childSpec(virtual: string, root: PathSpec): PathSpec {
-  const cut = rstripSlash(root.virtual).length - root.resourcePath.replace(/^\/+|\/+$/g, '').length
+  const cut = rstripSlash(root.virtual).length - stripSlash(root.resourcePath).length
   const prefix = rstripSlash(root.virtual.slice(0, cut))
   const slash = virtual.lastIndexOf('/')
   return new PathSpec({

--- a/typescript/packages/core/src/commands/builtin/generic/tar.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar.ts
@@ -20,12 +20,25 @@ import { PathSpec } from '../../../types.ts'
 import { gzip, gunzip, getCompressionCodec } from '../../../utils/compress.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { readTar, writeTar, type TarEntry } from '../tar_helper.ts'
-import { lstripSlash, rstripSlash, stripSlash } from '../../../utils/slash.ts'
-import { fnmatch } from '../../../utils/fnmatch.ts'
+import { rstripSlash } from '../../../utils/slash.ts'
 import { COMPRESSION_SIGNATURES } from './tar/constants.ts'
-import type { Compression, CompressionKind } from './tar/types.ts'
+import { planCreate, type DirProbe, type StatFn, type WalkFn } from './tar/create.ts'
+import type { Compression, CompressionKind, CreateResult } from './tar/types.ts'
 
 const ENC = new TextEncoder()
+
+// What tar needs from the mount it runs on. `stat` and `walk` are what
+// make a directory operand archivable at all; `isDir` answers on two
+// channels so a prefix-store directory (no object of its own) is not
+// mistaken for an absent one.
+export interface TarDeps {
+  stream: (p: PathSpec) => AsyncIterable<Uint8Array>
+  write: (p: PathSpec, data: Uint8Array) => Promise<void>
+  mkdir: (p: PathSpec, parents?: boolean) => Promise<void>
+  stat: StatFn
+  walk: WalkFn
+  isDir: DirProbe
+}
 
 function makePathSpec(virtual: string, prefix: string): PathSpec {
   return new PathSpec({
@@ -74,12 +87,51 @@ async function decompress(data: Uint8Array, kind: Compression): Promise<Uint8Arr
   return codec.decompress(data)
 }
 
+function stderrOf(lines: readonly string[]): Uint8Array | null {
+  return lines.length > 0 ? ENC.encode(`${lines.join('\n')}\n`) : null
+}
+
+async function writeArchive(
+  plan: CreateResult,
+  archivePath: string,
+  mountPrefix: string,
+  compression: Compression,
+  verbose: boolean,
+  deps: TarDeps,
+): Promise<CommandFnResult> {
+  const entries: TarEntry[] = []
+  const names: string[] = []
+  for (const member of plan.members) {
+    const data =
+      member.path !== null ? await materialize(deps.stream(member.path)) : new Uint8Array(0)
+    entries.push({
+      name: member.name,
+      data,
+      isFile: member.kind === 'file',
+      isDir: member.kind === 'dir',
+      linkname: member.kind === 'link' ? member.target : '',
+    })
+    names.push(member.name)
+  }
+  const raw = writeTar(entries)
+  const archive = await compress(raw, compression)
+  await deps.write(makePathSpec(archivePath, mountPrefix), archive)
+  const stderr = stderrOf(plan.notices)
+  const stdout = verbose && names.length > 0 ? ENC.encode(`${names.join('\n')}\n`) : null
+  return [
+    stdout,
+    new IOResult({
+      writes: { [archivePath]: archive },
+      exitCode: plan.exitCode,
+      ...(stderr !== null ? { stderr } : {}),
+    }),
+  ]
+}
+
 export async function tarGeneric(
   paths: PathSpec[],
   opts: CommandOpts,
-  stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
-  write: (p: PathSpec, data: Uint8Array) => Promise<void>,
-  mkdir: (p: PathSpec) => Promise<void>,
+  deps: TarDeps,
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('tar'))
   const create = fl.asBool('c')
@@ -111,35 +163,40 @@ export async function tarGeneric(
     if (archivePath === null) {
       return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('tar: -f is required\n') })]
     }
-    const filtered =
-      exclude !== null
-        ? paths.filter((p) => {
-            const name = p.virtual.split('/').pop() ?? ''
-            return !fnmatch(name, exclude)
-          })
-        : paths
-    const entries: TarEntry[] = []
-    for (const p of filtered) {
-      const data = await materialize(stream(p))
-      const name = lstripSlash(p.virtual)
-      entries.push({ name, data, isFile: true })
-      if (verbose) verboseLines.push(name)
+    const plan = await planCreate(paths, {
+      archive: makePathSpec(archivePath, mountPrefix),
+      exclude,
+      dereference: fl.asBool('h'),
+      stat: deps.stat,
+      walk: deps.walk,
+      isDir: deps.isDir,
+      directory: CFlag !== null ? makePathSpec(CFlag, mountPrefix) : null,
+      links: opts.links ?? null,
+      mounts: opts.mounts ?? null,
+    })
+    if (!plan.write) {
+      const stderr = stderrOf(plan.notices)
+      return [
+        null,
+        new IOResult({
+          exitCode: plan.exitCode,
+          ...(stderr !== null ? { stderr } : {}),
+        }),
+      ]
     }
-    const raw = writeTar(entries)
-    const archive = await compress(raw, compression)
-    await write(makePathSpec(archivePath, mountPrefix), archive)
-    const stdout = verbose ? ENC.encode(verboseLines.join('\n') + '\n') : null
-    return [stdout, new IOResult({ writes: { [archivePath]: archive } })]
+    return writeArchive(plan, archivePath, mountPrefix, compression, verbose, deps)
   }
 
   if (list) {
     if (archivePath === null) {
       return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('tar: -f is required\n') })]
     }
-    const raw = await materialize(stream(makePathSpec(archivePath, mountPrefix)))
+    const raw = await materialize(deps.stream(makePathSpec(archivePath, mountPrefix)))
     const data = await decompress(raw, compression)
     const entries = readTar(data)
-    const out: ByteSource = ENC.encode(entries.map((e) => e.name).join('\n') + '\n')
+    const out: ByteSource = ENC.encode(
+      entries.map((e) => (e.isDir === true ? `${rstripSlash(e.name)}/` : e.name)).join('\n') + '\n',
+    )
     return [out, new IOResult()]
   }
 
@@ -147,25 +204,31 @@ export async function tarGeneric(
     if (archivePath === null) {
       return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('tar: -f is required\n') })]
     }
-    const raw = await materialize(stream(makePathSpec(archivePath, mountPrefix)))
+    const raw = await materialize(deps.stream(makePathSpec(archivePath, mountPrefix)))
     const data = await decompress(raw, compression)
     const writes: Record<string, Uint8Array> = {}
     for (const entry of readTar(data)) {
-      if (!entry.isFile) continue
-      const nameParts = entry.name.split('/')
+      // A symlink member has no bytes to write and no namespace to write
+      // into from here (links are workspace state, not the backend's),
+      // so extraction skips it rather than dropping an empty file where
+      // a link belongs.
+      const isDir = entry.isDir === true
+      if (!entry.isFile && !isDir) continue
+      const nameParts = rstripSlash(entry.name).split('/')
       const stripped = stripN > 0 ? nameParts.slice(stripN) : nameParts
-      if (stripped.length === 0) continue
-      const outPath = rstripSlash(destPath) + '/' + stripped.join('/')
-      const parts = stripSlash(outPath).split('/')
-      for (let pi = 1; pi < parts.length; pi++) {
-        const d = '/' + parts.slice(0, pi).join('/')
-        try {
-          await mkdir(makePathSpec(d, mountPrefix))
-        } catch {
-          // already exists
-        }
+      if (stripped.length === 0 || (stripped.length === 1 && stripped[0] === '')) continue
+      const outPath = `${rstripSlash(destPath)}/${stripped.join('/')}`
+      if (isDir) {
+        // A directory member is the only record an empty directory
+        // leaves, so it has to be recreated even though nothing is
+        // written inside it.
+        await deps.mkdir(makePathSpec(outPath, mountPrefix), true)
+        if (verbose) verboseLines.push(`${rstripSlash(entry.name)}/`)
+        continue
       }
-      await write(makePathSpec(outPath, mountPrefix), entry.data)
+      const parent = outPath.slice(0, outPath.lastIndexOf('/')) || '/'
+      if (parent !== '/') await deps.mkdir(makePathSpec(parent, mountPrefix), true)
+      await deps.write(makePathSpec(outPath, mountPrefix), entry.data)
       writes[outPath] = entry.data
       if (verbose) verboseLines.push(entry.name)
     }

--- a/typescript/packages/core/src/commands/builtin/generic/tar.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar.ts
@@ -151,7 +151,9 @@ export async function tarGeneric(
     ]
   }
   const fFlag = fl.asStr('f') ?? null
-  const CFlag = fl.asStr('C') ?? null
+  const CFlags = fl.asList('C')
+  // Only the last -C is a destination; create checks every one.
+  const CFlag = CFlags.length > 0 ? (CFlags[CFlags.length - 1] ?? null) : null
   const stripN = fl.asInt('strip_components') ?? 0
   const exclude = fl.asStr('exclude') ?? null
   const mountPrefix = opts.mountPrefix ?? ''
@@ -170,7 +172,7 @@ export async function tarGeneric(
       stat: deps.stat,
       walk: deps.walk,
       isDir: deps.isDir,
-      directory: CFlag !== null ? makePathSpec(CFlag, mountPrefix) : null,
+      directories: CFlags.map((c) => makePathSpec(c, mountPrefix)),
       links: opts.links ?? null,
       mounts: opts.mounts ?? null,
     })

--- a/typescript/packages/core/src/commands/builtin/generic/tar/create.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar/create.ts
@@ -49,9 +49,9 @@ export interface CreateDeps {
   stat: StatFn
   walk: WalkFn
   isDir: DirProbe
-  // The `-C` the operands were based on, checked inside the plan
-  // because GNU chdirs before reading anything.
-  directory?: PathSpec | null
+  // Every `-C` the operands were based on, in order, checked inside
+  // the plan because GNU chdirs at each one before reading anything.
+  directories?: readonly PathSpec[]
   links?: LinkView | null
   mounts?: MountView | null
 }
@@ -122,14 +122,17 @@ export async function planCreate(
   deps: CreateDeps,
 ): Promise<CreateResult> {
   if (paths.length === 0) return refusal([EMPTY_ARCHIVE, USAGE_HINT])
-  const directory = deps.directory ?? null
-  if (directory !== null && !(await deps.isDir(directory))) {
-    // GNU chdirs before reading a single operand, so a -C it cannot
-    // enter is fatal for the whole run and no archive is written.
-    return refusal([
-      `tar: ${directory.rawPath}: Cannot open: No such file or directory`,
-      FATAL_TRAILER,
-    ])
+  for (const directory of deps.directories ?? []) {
+    // GNU chdirs at each -C in turn, before reading a single operand,
+    // so the FIRST one it cannot enter is fatal for the whole run and
+    // no members are written. Checking only the last would archive the
+    // operands that followed a bad earlier one.
+    if (!(await deps.isDir(directory))) {
+      return refusal([
+        `tar: ${directory.rawPath}: Cannot open: No such file or directory`,
+        FATAL_TRAILER,
+      ])
+    }
   }
   const members: Member[] = []
   const notices: string[] = []
@@ -152,7 +155,7 @@ export async function planCreate(
         notices.push(`tar: ${shown}: ${problem.reason ?? ''}`)
         continue
       }
-      notices.push(`tar: ${shown}: Cannot stat: No such file or directory`)
+      notices.push(`tar: ${shown}: Cannot stat: ${problem.reason ?? ''}`)
       exitCode = CREATE_ERROR_EXIT
     }
     if (scan.missing) continue

--- a/typescript/packages/core/src/commands/builtin/generic/tar/create.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar/create.ts
@@ -1,0 +1,191 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { LinkView, MountView } from '../../../../ops/types.ts'
+import type { PathSpec } from '../../../../types.ts'
+import { fnmatch } from '../../../../utils/fnmatch.ts'
+import { respellOne } from '../../../../utils/path.ts'
+import { lstripSlash, rstripSlash } from '../../../../utils/slash.ts'
+import type { MemberKind } from '../archive/types.ts'
+import {
+  OTHER_FILESYSTEM,
+  scanOperand,
+  type DirProbe,
+  type StatFn,
+  type WalkFn,
+} from '../archive/walk.ts'
+import type { CreateResult, Member } from './types.ts'
+
+// Every diagnostic below is GNU tar 1.35's own wording, pinned on
+// debian:stable-slim; only the hint line is mirage's, for the reason
+// usage.oldOptionError gives (mirage's tar serves no --usage).
+const USAGE_HINT = "Try 'tar --help' for more information."
+const EMPTY_ARCHIVE = 'tar: Cowardly refusing to create an empty archive'
+const FATAL_TRAILER = 'tar: Error is not recoverable: exiting now'
+const ERROR_TRAILER = 'tar: Exiting with failure status due to previous errors'
+const LEADING_SLASH = "tar: Removing leading `/' from member names"
+const SELF_DUMP = 'archive cannot contain itself; not dumped'
+// The exit GNU gives an operand it could not read, and a -C it could not
+// enter. Both are fatal for the whole run, not per-operand.
+const CREATE_ERROR_EXIT = 2
+
+export type { DirProbe, StatFn, WalkFn }
+
+export interface CreateDeps {
+  archive: PathSpec
+  exclude: string | null
+  dereference: boolean
+  stat: StatFn
+  walk: WalkFn
+  isDir: DirProbe
+  // The `-C` the operands were based on, checked inside the plan
+  // because GNU chdirs before reading anything.
+  directory?: PathSpec | null
+  links?: LinkView | null
+  mounts?: MountView | null
+}
+
+function refusal(notices: string[]): CreateResult {
+  return { members: [], notices, exitCode: CREATE_ERROR_EXIT, write: false }
+}
+
+// Whether GNU's `--exclude` pattern matches this member name. GNU's
+// exclusion is unanchored: the pattern is tried against the whole name
+// and against every suffix that starts at a path component, so `a.txt`,
+// `d/a.txt` and `sub/b.txt` all match entries under `d`. Wildcards cross
+// slashes (`*/b.txt` matches `d/sub/b.txt`), which is tar's default for
+// exclusion patterns. A directory's trailing slash is not part of what
+// the pattern sees. Info-ZIP's `-x` is the anchored counterpart, which
+// is why the two are not shared.
+function excluded(name: string, pattern: string): boolean {
+  const bare = rstripSlash(name)
+  if (fnmatch(bare, pattern)) return true
+  let cut = bare.indexOf('/')
+  while (cut !== -1) {
+    if (fnmatch(bare.slice(cut + 1), pattern)) return true
+    cut = bare.indexOf('/', cut + 1)
+  }
+  return false
+}
+
+// Drop excluded names and everything beneath an excluded directory. GNU
+// does not walk into a directory it excluded, so `--exclude sub` takes
+// `d/sub/` and `d/sub/b.txt` together; matching each name in isolation
+// would keep the children of a pruned directory.
+function pruned(names: readonly string[], pattern: string | null): string[] {
+  if (pattern === null) return [...names]
+  const kept: string[] = []
+  const cutDirs: string[] = []
+  for (const name of names) {
+    if (cutDirs.some((cut) => name.startsWith(cut))) continue
+    if (excluded(name, pattern)) {
+      if (name.endsWith('/')) cutDirs.push(name)
+      continue
+    }
+    kept.push(name)
+  }
+  return kept
+}
+
+// The name tar records for a path spelled as the operand was typed. A
+// leading slash is stripped (tar refuses to store absolute names, and
+// says so once per run), and a directory carries the trailing slash that
+// tells an extractor it holds no content.
+function memberName(spelled: string, kind: MemberKind): string {
+  const name = lstripSlash(spelled)
+  if (kind === 'dir' && name !== '' && !name.endsWith('/')) return `${name}/`
+  return name
+}
+
+/**
+ * Decide every member of a new archive, before writing any of it.
+ *
+ * One pass per operand, in the order they were typed, each contributing
+ * itself and then its subtree. GNU walks a directory operand rather than
+ * refusing it, and mirage now does too; the one deliberate divergence is
+ * ordering, since GNU emits siblings in readdir order (filesystem-dependent)
+ * and this sorts them, the same choice `du` already documents.
+ */
+export async function planCreate(
+  paths: readonly PathSpec[],
+  deps: CreateDeps,
+): Promise<CreateResult> {
+  if (paths.length === 0) return refusal([EMPTY_ARCHIVE, USAGE_HINT])
+  const directory = deps.directory ?? null
+  if (directory !== null && !(await deps.isDir(directory))) {
+    // GNU chdirs before reading a single operand, so a -C it cannot
+    // enter is fatal for the whole run and no archive is written.
+    return refusal([
+      `tar: ${directory.rawPath}: Cannot open: No such file or directory`,
+      FATAL_TRAILER,
+    ])
+  }
+  const members: Member[] = []
+  const notices: string[] = []
+  let absoluteSeen = false
+  let exitCode = 0
+  for (const path of paths) {
+    const raw = path.rawPath
+    const base = rstripSlash(path.virtual) || '/'
+    const scan = await scanOperand(path, {
+      stat: deps.stat,
+      walk: deps.walk,
+      links: deps.links ?? null,
+      mounts: deps.mounts ?? null,
+      dereference: deps.dereference,
+      recurse: true,
+    })
+    for (const problem of scan.problems) {
+      const shown = respellOne(problem.path, base, raw)
+      if (problem.fatal !== true) {
+        notices.push(`tar: ${shown}: ${problem.reason ?? ''}`)
+        continue
+      }
+      notices.push(`tar: ${shown}: Cannot stat: No such file or directory`)
+      exitCode = CREATE_ERROR_EXIT
+    }
+    if (scan.missing) continue
+    for (const crossing of scan.crossings) {
+      const shown = memberName(respellOne(crossing, base, raw), 'dir')
+      notices.push(`tar: ${shown}: ${OTHER_FILESYSTEM}`)
+    }
+    // Every descendant is spelled under the operand's own base, so the
+    // operand alone decides whether this run stored an absolute name and
+    // owes GNU's one-per-run warning.
+    absoluteSeen = absoluteSeen || raw.startsWith('/')
+    const named = scan.entries.map(
+      (entry) => [memberName(respellOne(entry.namePath, base, raw), entry.kind), entry] as const,
+    )
+    const keep = new Set(
+      pruned(
+        named.map(([name]) => name),
+        deps.exclude,
+      ),
+    )
+    for (const [name, entry] of named) {
+      if (!keep.has(name)) continue
+      const read = entry.read ?? null
+      if (read !== null && read.virtual === deps.archive.virtual) {
+        notices.push(`tar: ${name}: ${SELF_DUMP}`)
+        continue
+      }
+      members.push({ name, kind: entry.kind, path: read, target: entry.target ?? '' })
+    }
+  }
+  if (absoluteSeen) notices.unshift(LEADING_SLASH)
+  // GNU closes a run that failed an operand with one trailer, after
+  // everything it did manage to name.
+  if (exitCode !== 0) notices.push(ERROR_TRAILER)
+  return { members, notices, exitCode, write: true }
+}

--- a/typescript/packages/core/src/commands/builtin/generic/tar/types.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar/types.ts
@@ -12,5 +12,32 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { PathSpec } from '../../../../types.ts'
+import type { MemberKind } from '../archive/types.ts'
+
 export type CompressionKind = 'gzip' | 'bzip2' | 'xz'
 export type Compression = CompressionKind | null
+
+// One entry the create pass decided to put in the archive. Choosing
+// every member before writing any of them is what lets an exclusion
+// prune a whole subtree and the ordering stay stable; the writer is then
+// a straight loop with no policy left in it.
+export interface Member {
+  name: string
+  kind: MemberKind
+  path: PathSpec | null
+  target: string
+}
+
+// What one `tar -c` pass decided, before anything is written. Notices
+// each carry their own `tar: ` prefix and no trailing newline.
+export interface CreateResult {
+  members: Member[]
+  notices: string[]
+  exitCode: number
+  // Whether to write an archive at all. False for the two refusals GNU
+  // makes before reading anything (no operands, and a `-C` it cannot
+  // enter), which leave no file behind; an operand it merely failed to
+  // stat still writes the rest.
+  write: boolean
+}

--- a/typescript/packages/core/src/commands/builtin/generic/unzip.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/unzip.ts
@@ -253,12 +253,19 @@ export async function unzipGeneric(
   const writes: Record<string, Uint8Array> = {}
   const outputLines: string[] = []
   for (const e of selected) {
-    if (e.name.endsWith('/')) continue
     const entryName = lstripSlash(e.name)
-    const outPath = rstripSlash(dest) + '/' + entryName
+    const outPath = rstripSlash(dest) + '/' + rstripSlash(entryName)
+    const reportPath = mountPrefix !== '' ? mountPrefix + outPath : outPath
+    if (e.name.endsWith('/')) {
+      // A directory entry is the only record an empty directory leaves,
+      // so it has to be recreated even though nothing is written inside
+      // it.
+      await mkdir(makePathSpec(outPath), true)
+      if (!quiet) outputLines.push(`   creating: ${reportPath}/`)
+      continue
+    }
     await ensureParents(mkdir, outPath)
     await write(makePathSpec(outPath), e.data)
-    const reportPath = mountPrefix !== '' ? mountPrefix + outPath : outPath
     writes[outPath] = e.data
     if (!quiet) outputLines.push(`  inflating: ${reportPath}`)
   }

--- a/typescript/packages/core/src/commands/builtin/generic/zip_cmd.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/zip_cmd.ts
@@ -18,8 +18,11 @@ import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import { deflateRaw } from '../../../utils/compress.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
-import { lstripSlash } from '../../../utils/slash.ts'
-import { gnuBasename } from '../../../utils/path.ts'
+import { fnmatch } from '../../../utils/fnmatch.ts'
+import { lstripSlash, rstripSlash } from '../../../utils/slash.ts'
+import { gnuBasename, respellOne } from '../../../utils/path.ts'
+import type { MemberKind } from './archive/types.ts'
+import { OTHER_FILESYSTEM, scanOperand, type StatFn, type WalkFn } from './archive/walk.ts'
 
 const ENC = new TextEncoder()
 
@@ -61,7 +64,26 @@ interface ZipItem {
   compressed: Uint8Array
   crc: number
   method: number
+  // Unix mode bits in the high half of external_attr, which is where
+  // Info-ZIP puts them and where a symlink entry is told from a file.
+  externalAttr: number
   localOffset: number
+}
+
+// One entry the plan decided to store, before its bytes are read.
+interface ZipMember {
+  name: string
+  kind: MemberKind
+  path: PathSpec | null
+  target: string
+}
+
+// What one `zip` run decided. `write` is false when nothing matched, in
+// which case Info-ZIP leaves no archive behind at all.
+interface ZipPlan {
+  members: ZipMember[]
+  warnings: string[]
+  write: boolean
 }
 
 function concat(chunks: readonly Uint8Array[]): Uint8Array {
@@ -104,7 +126,8 @@ function buildZip(items: ZipItem[]): Uint8Array {
     const nameBytes = ENC.encode(item.name)
     const central = new Uint8Array(46 + nameBytes.byteLength)
     writeU32LE(central, 0, 0x02014b50)
-    writeU16LE(central, 4, 20)
+    // Unix in the high byte, so the mode bits below are read as such.
+    writeU16LE(central, 4, (3 << 8) | 20)
     writeU16LE(central, 6, 20)
     writeU16LE(central, 8, 0)
     writeU16LE(central, 10, item.method)
@@ -118,7 +141,7 @@ function buildZip(items: ZipItem[]): Uint8Array {
     writeU16LE(central, 32, 0)
     writeU16LE(central, 34, 0)
     writeU16LE(central, 36, 0)
-    writeU32LE(central, 38, 0)
+    writeU32LE(central, 38, item.externalAttr)
     writeU32LE(central, 42, item.localOffset)
     central.set(nameBytes, 46)
     parts.push(central)
@@ -138,14 +161,118 @@ function buildZip(items: ZipItem[]): Uint8Array {
   return concat(parts)
 }
 
+// Info-ZIP 3.0's wording, pinned on debian:stable-slim. A warning is
+// indented with a tab and -q silences it; the "Nothing to do!" error is
+// not a warning and survives -q. Exit 12 is Info-ZIP's ZE_NONE.
+const WARNING_PREFIX = '\tzip warning: '
+// What Info-ZIP calls a path it could not reach. It does not distinguish
+// absent from unreadable, and a dangling symlink under the default
+// follow prints exactly this too.
+const NOT_MATCHED = 'name not matched: '
+const NOTHING_TO_DO_EXIT = 12
+// Unix mode bits in the high half of external_attr.
+const DIR_MODE = ((0o40755 << 16) | 0x10) >>> 0
+const FILE_MODE = (0o100644 << 16) >>> 0
+const LINK_MODE = (0o120777 << 16) >>> 0
+
+// What zip needs from the mount it runs on. `stat` and `walk` are what
+// make a directory operand archivable at all.
+export interface ZipDeps {
+  stream: (p: PathSpec) => AsyncIterable<Uint8Array>
+  write: (p: PathSpec, data: Uint8Array) => Promise<void>
+  stat: StatFn
+  walk: WalkFn
+}
+
+// The entry name Info-ZIP stores for a path as the operand typed it. A
+// leading slash is stripped in silence (unlike tar, which warns), a
+// directory carries a trailing slash, and `-j` throws the directory part
+// away entirely.
+function memberName(spelled: string, kind: MemberKind, junk: boolean): string {
+  let name = lstripSlash(spelled)
+  if (junk) name = gnuBasename(rstripSlash(name))
+  if (kind === 'dir' && name !== '' && !name.endsWith('/')) return `${name}/`
+  return name
+}
+
+// Whether an Info-ZIP `-x` pattern matches this entry name. Info-ZIP
+// matches the whole stored name, anchored, with wildcards crossing
+// slashes: `d/sub/*` takes `d/sub/` and everything under it, `*.txt`
+// takes every `.txt` at any depth, and a bare `b.txt` matches nothing
+// below the top. That is the opposite of GNU tar's unanchored
+// `--exclude`, which is why the two have separate matchers.
+function excluded(name: string, patterns: readonly string[]): boolean {
+  return patterns.some((pattern) => fnmatch(name, pattern))
+}
+
+/**
+ * Decide every entry of a new archive, before writing any of it.
+ *
+ * Info-ZIP's defaults are tar's inverted twice over: a directory operand
+ * contributes only itself unless `-r` says to descend, and a symlink is
+ * followed unless `-y` says to store the link. Both are parameters of the
+ * shared scan, so the traversal is the same one `tar -c` uses.
+ */
+async function planZip(
+  paths: readonly PathSpec[],
+  archive: PathSpec,
+  deps: ZipDeps,
+  opts: CommandOpts,
+): Promise<ZipPlan> {
+  const fl = new FlagView(opts.flags, specOf('zip'))
+  const recurse = fl.asBool('r')
+  const junk = fl.asBool('j')
+  const exclude = fl.asList('x')
+  const members: ZipMember[] = []
+  const warnings: string[] = []
+  for (const path of paths) {
+    const raw = path.rawPath
+    const base = rstripSlash(path.virtual) || '/'
+    const scan = await scanOperand(path, {
+      stat: deps.stat,
+      walk: deps.walk,
+      links: opts.links ?? null,
+      mounts: opts.mounts ?? null,
+      dereference: !fl.asBool('y'),
+      recurse,
+    })
+    for (const problem of scan.problems) {
+      const shown = respellOne(problem.path, base, raw)
+      if (problem.fatal === true) warnings.push(NOT_MATCHED + shown)
+      else warnings.push(`${shown}: ${problem.reason ?? ''}`)
+    }
+    if (scan.missing) continue
+    for (const crossing of scan.crossings) {
+      warnings.push(`${respellOne(crossing, base, raw)}: ${OTHER_FILESYSTEM}`)
+    }
+    for (const entry of scan.entries) {
+      const name = memberName(respellOne(entry.namePath, base, raw), entry.kind, junk)
+      if (name === '' || excluded(name, exclude)) continue
+      // -j has no directory to name, so Info-ZIP drops directory entries
+      // under it entirely rather than storing bare slashes.
+      if (junk && entry.kind === 'dir') continue
+      const read = entry.read ?? null
+      // Info-ZIP never stores the archive it is writing, and says
+      // nothing about it.
+      if (read !== null && read.virtual === archive.virtual) continue
+      members.push({ name, kind: entry.kind, path: read, target: entry.target ?? '' })
+    }
+  }
+  return { members, warnings, write: members.length > 0 }
+}
+
+function warningText(warnings: readonly string[], quiet: boolean): string {
+  if (quiet) return ''
+  return warnings.map((line) => WARNING_PREFIX + line + '\n').join('')
+}
+
 export async function zipGeneric(
   paths: PathSpec[],
   opts: CommandOpts,
-  stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
-  write: (p: PathSpec, data: Uint8Array) => Promise<void>,
+  deps: ZipDeps,
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('zip'))
-  if (paths.length < 2) {
+  if (paths.length === 0) {
     return [
       null,
       new IOResult({
@@ -155,32 +282,51 @@ export async function zipGeneric(
     ]
   }
   const archivePath = paths[0]
-  const filePaths = paths.slice(1)
   if (archivePath === undefined) return [null, new IOResult()]
-  const junkPaths = fl.asBool('j')
   const quiet = fl.asBool('q')
+  const plan = await planZip(paths.slice(1), archivePath, deps, opts)
+  if (!plan.write) {
+    // Info-ZIP writes no archive when nothing matched, and the error is
+    // not a warning: -q does not silence it.
+    const message =
+      warningText(plan.warnings, quiet) + `\nzip error: Nothing to do! (${archivePath.rawPath})\n`
+    return [null, new IOResult({ exitCode: NOTHING_TO_DO_EXIT, stderr: ENC.encode(message) })]
+  }
 
   const items: ZipItem[] = []
   const outputLines: string[] = []
-  for (const p of filePaths) {
-    const raw = await materialize(stream(p))
-    const data = new Uint8Array(raw.byteLength)
-    data.set(raw)
-    const arcname = junkPaths ? gnuBasename(p.virtual) : lstripSlash(p.virtual)
-    const compressed = await deflateRaw(data)
+  for (const member of plan.members) {
+    let data = new Uint8Array(0)
+    if (member.kind === 'link') {
+      data = ENC.encode(member.target)
+    } else if (member.path !== null) {
+      const raw = await materialize(deps.stream(member.path))
+      data = new Uint8Array(raw.byteLength)
+      data.set(raw)
+    }
+    const stored = member.kind === 'dir'
+    const compressed = stored ? data : await deflateRaw(data)
     items.push({
-      name: arcname,
+      name: member.name,
       data,
       compressed,
       crc: crc32(data),
-      method: 8,
+      method: stored ? 0 : 8,
+      externalAttr:
+        member.kind === 'dir' ? DIR_MODE : member.kind === 'link' ? LINK_MODE : FILE_MODE,
       localOffset: 0,
     })
-    if (!quiet) outputLines.push(`  adding: ${arcname}`)
+    outputLines.push(`  adding: ${member.name}`)
   }
   const archive = buildZip(items)
-  await write(archivePath, archive)
+  await deps.write(archivePath, archive)
   const stdout: ByteSource | null =
-    outputLines.length > 0 ? ENC.encode(outputLines.join('\n') + '\n') : null
-  return [stdout, new IOResult({ writes: { [archivePath.mountPath]: archive } })]
+    !quiet && outputLines.length > 0 ? ENC.encode(outputLines.join('\n') + '\n') : null
+  return [
+    stdout,
+    new IOResult({
+      writes: { [archivePath.mountPath]: archive },
+      stderr: ENC.encode(warningText(plan.warnings, quiet)),
+    }),
+  ]
 }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/archive_io.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/archive_io.ts
@@ -1,0 +1,53 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { Accessor } from '../../../accessor/base.ts'
+import type { IndexCacheStore } from '../../../cache/index/store.ts'
+import { walkFind } from '../../../core/generic/find.ts'
+import { mountPrefixOf } from '../../../utils/key_prefix.ts'
+import type { WalkFn } from '../generic/archive/walk.ts'
+import type { CommandIO } from './adapter.ts'
+
+/**
+ * The subtree listing tar and zip both walk with.
+ *
+ * Reuses find's walk so an archiver classifies an entry exactly the way find
+ * does (through stat, never by name). The two calls a directory operand makes
+ * share one readdir cache, so the second is answered from the index instead of
+ * the backend.
+ *
+ * walkFind stands in for a backend's native find op, so it answers in
+ * mount-relative keys; both archivers name members from virtual paths, so they
+ * are lifted back here the way findGeneric lifts them.
+ */
+export function walkOf(
+  ops: CommandIO,
+  accessor: Accessor,
+  index: IndexCacheStore | undefined,
+): WalkFn {
+  return async (p, findType) => {
+    const prefix = mountPrefixOf(p.virtual, p.resourcePath)
+    const keys = await walkFind(
+      p,
+      {
+        readdir: (spec, i) => ops.readdir(accessor, spec, i),
+        stat: (spec, i) => ops.stat(accessor, spec, i),
+      },
+      { type: findType },
+      index,
+    )
+    if (prefix === '') return keys
+    return keys.map((key) => (key === '/' ? prefix : prefix + key))
+  }
+}

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/tar.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/tar.ts
@@ -12,8 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { type FileStat, FileType, type PathSpec } from '../../../../types.ts'
 import { tarGeneric } from '../../generic/tar.ts'
 import { type Builder, resolveGlobOf } from '../adapter.ts'
+import { walkOf } from '../archive_io.ts'
 
 export const TAR_BUILDER: Builder = {
   name: 'tar',
@@ -26,12 +28,29 @@ export const TAR_BUILDER: Builder = {
       throw new Error('tar: backend provides no write op')
     }
     const resolved = paths.length > 0 ? await resolveGlobOf(ops)(accessor, paths, idx) : []
-    return tarGeneric(
-      resolved,
-      opts,
-      (p) => ops.readStream(accessor, p, idx),
-      (p, data) => write(accessor, p, data),
-      (p) => mkdir(accessor, p),
-    )
+    const stat = async (p: PathSpec): Promise<FileStat> => ops.stat(accessor, p, idx)
+    return tarGeneric(resolved, opts, {
+      stream: (p) => ops.readStream(accessor, p, idx),
+      write: (p, data) => write(accessor, p, data),
+      mkdir: (p, parents) => mkdir(accessor, p, parents),
+      stat,
+      walk: walkOf(ops, accessor, idx),
+      // Two channels, because a stat miss alone is not absence: on a
+      // prefix store a directory is the set of keys under it and
+      // nothing answers stat for it, so a readdir that returns anything
+      // is the second and deciding opinion.
+      isDir: async (p) => {
+        try {
+          return (await stat(p)).type === FileType.DIRECTORY
+        } catch {
+          // Not an object of its own; ask the listing instead.
+        }
+        try {
+          return (await ops.readdir(accessor, p, idx)).length > 0
+        } catch {
+          return false
+        }
+      },
+    })
   },
 }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/zip_cmd.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/zip_cmd.ts
@@ -12,8 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { FileStat, PathSpec } from '../../../../types.ts'
 import { zipGeneric } from '../../generic/zip_cmd.ts'
 import { type Builder, resolveGlobOf } from '../adapter.ts'
+import { walkOf } from '../archive_io.ts'
 
 export const ZIP_BUILDER: Builder = {
   name: 'zip',
@@ -26,11 +28,11 @@ export const ZIP_BUILDER: Builder = {
       throw new Error('zip: backend provides no write op')
     }
     const resolved = paths.length > 0 ? await resolveGlobOf(ops)(accessor, paths, idx) : []
-    return zipGeneric(
-      resolved,
-      opts,
-      (p) => ops.readStream(accessor, p, idx),
-      (p, d) => write(accessor, p, d),
-    )
+    return zipGeneric(resolved, opts, {
+      stream: (p) => ops.readStream(accessor, p, idx),
+      write: (p, data) => write(accessor, p, data),
+      stat: async (p: PathSpec): Promise<FileStat> => ops.stat(accessor, p, idx),
+      walk: walkOf(ops, accessor, idx),
+    })
   },
 }

--- a/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
@@ -25,6 +25,18 @@ const RAM_UNZIP = RAM_COMMANDS.filter((c) => c.name === 'unzip' && c.filetype ==
 const ENC = new TextEncoder()
 const DEC = new TextDecoder()
 
+// An operand carrying the spelling the user typed, which is what the
+// member names are built from.
+function dirSpec(virtual: string, raw: string): PathSpec {
+  return new PathSpec({
+    virtual,
+    directory: virtual,
+    resourcePath: virtual.replace(/^\/+/, ''),
+    resolved: true,
+    rawPath: raw,
+  })
+}
+
 interface CmdResult {
   out: Uint8Array
   writes: Record<string, Uint8Array>
@@ -38,6 +50,7 @@ async function runCmd(
   paths: PathSpec[],
   flags: Record<string, string | boolean | number | string[]>,
   texts: string[] = [],
+  mountPrefix = '',
 ): Promise<CmdResult> {
   const cmd = reg[0]
   if (cmd === undefined) throw new Error('not registered')
@@ -47,6 +60,7 @@ async function runCmd(
     filetypeFns: null,
     cwd: '/',
     resource,
+    mountPrefix,
   })
   if (result === null) {
     return { out: new Uint8Array(), writes: {}, exitCode: 0, stderr: new Uint8Array() }
@@ -97,6 +111,179 @@ describe('tar', () => {
     await runCmd(RAM_TAR, resource, [], { x: true, f: '/archive.tar', C: '/' })
     expect(resource.store.files.has('/a.txt')).toBe(true)
     expect(DEC.decode(resource.store.files.get('/a.txt'))).toBe('content_a')
+  })
+
+  it('walks a directory operand instead of failing on it', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.dirs.add('/d/sub')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    resource.store.files.set('/d/sub/b.txt', ENC.encode('beta'))
+    const { exitCode, out } = await runCmd(RAM_TAR, resource, [dirSpec('/d', 'd')], {
+      c: true,
+      v: true,
+      f: '/out.tar',
+    })
+    expect(exitCode).toBe(0)
+    expect(DEC.decode(out).trim().split('\n')).toEqual(['d/', 'd/a.txt', 'd/sub/', 'd/sub/b.txt'])
+    const listed = await runCmd(RAM_TAR, resource, [], { t: true, f: '/out.tar' })
+    expect(DEC.decode(listed.out).trim().split('\n')).toEqual([
+      'd/',
+      'd/a.txt',
+      'd/sub/',
+      'd/sub/b.txt',
+    ])
+  })
+
+  it('names members as the operand was typed, so -C survives a round trip', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/base')
+    resource.store.dirs.add('/base/d')
+    resource.store.files.set('/base/d/a.txt', ENC.encode('alpha'))
+    await runCmd(RAM_TAR, resource, [dirSpec('/base/d', 'd')], { c: true, f: '/out.tar' })
+    const listed = await runCmd(RAM_TAR, resource, [], { t: true, f: '/out.tar' })
+    expect(DEC.decode(listed.out).trim().split('\n')).toEqual(['d/', 'd/a.txt'])
+  })
+
+  it('warns once about a stripped leading slash', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const { stderr } = await runCmd(RAM_TAR, resource, [dirSpec('/d', '/d')], {
+      c: true,
+      f: '/out.tar',
+    })
+    const text = DEC.decode(stderr)
+    expect(text).toContain('Removing leading')
+    expect(text.split('Removing leading').length - 1).toBe(1)
+  })
+
+  it("reports a missing operand in tar's own words and exits 2", async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const { exitCode, stderr } = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/nope', 'nope'), dirSpec('/d', 'd')],
+      { c: true, f: '/out.tar' },
+    )
+    expect(exitCode).toBe(2)
+    const text = DEC.decode(stderr)
+    expect(text).toContain('tar: nope: Cannot stat: No such file or directory')
+    expect(text).toContain('Exiting with failure status due to previous errors')
+  })
+
+  it('refuses to create an empty archive', async () => {
+    const resource = new RAMResource()
+    const { exitCode, stderr, writes } = await runCmd(RAM_TAR, resource, [], {
+      c: true,
+      f: '/out.tar',
+    })
+    expect(exitCode).toBe(2)
+    expect(DEC.decode(stderr)).toContain('Cowardly refusing to create an empty archive')
+    expect(Object.keys(writes)).toHaveLength(0)
+  })
+
+  it('refuses a -C it cannot enter', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const { exitCode, stderr, writes } = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/nodir/a.txt', 'a.txt')],
+      { c: true, f: '/out.tar', C: '/nodir' },
+    )
+    expect(exitCode).toBe(2)
+    const text = DEC.decode(stderr)
+    expect(text).toContain('tar: /nodir: Cannot open: No such file or directory')
+    expect(text).toContain('Error is not recoverable: exiting now')
+    expect(Object.keys(writes)).toHaveLength(0)
+  })
+
+  it('--exclude prunes the whole subtree, and matches mid-path like GNU', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.dirs.add('/d/sub')
+    resource.store.files.set('/d/a.txt', ENC.encode('a'))
+    resource.store.files.set('/d/sub/b.txt', ENC.encode('b'))
+    const pruned = await runCmd(RAM_TAR, resource, [dirSpec('/d', 'd')], {
+      c: true,
+      f: '/out.tar',
+      exclude: 'sub',
+    })
+    expect(pruned.exitCode).toBe(0)
+    const listed = await runCmd(RAM_TAR, resource, [], { t: true, f: '/out.tar' })
+    expect(DEC.decode(listed.out).trim().split('\n')).toEqual(['d/', 'd/a.txt'])
+
+    const one = await runCmd(RAM_TAR, resource, [dirSpec('/d', 'd')], {
+      c: true,
+      f: '/two.tar',
+      exclude: 'sub/b.txt',
+    })
+    expect(one.exitCode).toBe(0)
+    const listedTwo = await runCmd(RAM_TAR, resource, [], { t: true, f: '/two.tar' })
+    expect(DEC.decode(listedTwo.out).trim().split('\n')).toEqual(['d/', 'd/a.txt', 'd/sub/'])
+  })
+
+  it('round-trips an empty directory through create and extract', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.dirs.add('/d/empty')
+    resource.store.files.set('/d/a.txt', ENC.encode('a'))
+    await runCmd(RAM_TAR, resource, [dirSpec('/d', 'd')], { c: true, f: '/out.tar' })
+    const listed = await runCmd(RAM_TAR, resource, [], { t: true, f: '/out.tar' })
+    expect(DEC.decode(listed.out)).toContain('d/empty/')
+    await runCmd(RAM_TAR, resource, [], { x: true, f: '/out.tar', C: '/out' })
+    expect(resource.store.dirs.has('/out/d/empty')).toBe(true)
+  })
+
+  it('names members from virtual paths on a prefixed mount', async () => {
+    // The walk answers in mount-relative keys, the way a backend's own
+    // find op does; a mount behind a prefix is the only place where
+    // forgetting to lift them back shows up.
+    const resource = new RAMResource()
+    resource.store.dirs.add('/tdir')
+    resource.store.dirs.add('/tdir/sub')
+    resource.store.files.set('/tdir/a.txt', ENC.encode('aa'))
+    resource.store.files.set('/tdir/sub/b.txt', ENC.encode('bb'))
+    const operand = new PathSpec({
+      virtual: '/data/tdir',
+      directory: '/data/tdir',
+      resourcePath: 'tdir',
+      resolved: true,
+      rawPath: 'tdir',
+    })
+    const { out, exitCode } = await runCmd(
+      RAM_TAR,
+      resource,
+      [operand],
+      { c: true, v: true, f: '/tdir.tar' },
+      [],
+      '/data',
+    )
+    expect(exitCode).toBe(0)
+    expect(DEC.decode(out).trim().split('\n')).toEqual([
+      'tdir/',
+      'tdir/a.txt',
+      'tdir/sub/',
+      'tdir/sub/b.txt',
+    ])
+  })
+
+  it('leaves the archive out of itself', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('a'))
+    resource.store.files.set('/d/old.tar', ENC.encode('stale'))
+    const { stderr } = await runCmd(RAM_TAR, resource, [dirSpec('/d', 'd')], {
+      c: true,
+      f: '/d/old.tar',
+    })
+    expect(DEC.decode(stderr)).toContain('archive cannot contain itself')
+    const listed = await runCmd(RAM_TAR, resource, [], { t: true, f: '/d/old.tar' })
+    expect(DEC.decode(listed.out).trim().split('\n')).toEqual(['d/', 'd/a.txt'])
   })
 })
 
@@ -160,6 +347,147 @@ describe('zip / unzip', () => {
       { q: true },
     )
     expect(out.byteLength).toBe(0)
+  })
+
+  it('zip -r walks a directory operand instead of failing on it', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.dirs.add('/d/sub')
+    resource.store.dirs.add('/d/empty')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    resource.store.files.set('/d/sub/b.txt', ENC.encode('beta'))
+    const { out, exitCode } = await runCmd(
+      RAM_ZIP,
+      resource,
+      [PathSpec.fromStrPath('/out.zip'), dirSpec('/d', 'd')],
+      { r: true },
+    )
+    expect(exitCode).toBe(0)
+    expect(DEC.decode(out)).toBe(
+      '  adding: d/\n  adding: d/a.txt\n  adding: d/empty/\n  adding: d/sub/\n  adding: d/sub/b.txt\n',
+    )
+  })
+
+  it('zip without -r stores the directory entry and nothing under it', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const { out } = await runCmd(
+      RAM_ZIP,
+      resource,
+      [PathSpec.fromStrPath('/out.zip'), dirSpec('/d', 'd')],
+      {},
+    )
+    expect(DEC.decode(out)).toBe('  adding: d/\n')
+  })
+
+  it('zip -r then unzip restores an empty directory', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.dirs.add('/d/empty')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    await runCmd(RAM_ZIP, resource, [PathSpec.fromStrPath('/out.zip'), dirSpec('/d', 'd')], {
+      r: true,
+      q: true,
+    })
+    resource.store.dirs.delete('/d/empty')
+    resource.store.files.delete('/d/a.txt')
+    await runCmd(RAM_UNZIP, resource, [PathSpec.fromStrPath('/out.zip')], { d: '/', q: true })
+    expect(resource.store.dirs.has('/d/empty')).toBe(true)
+    expect(DEC.decode(resource.store.files.get('/d/a.txt'))).toBe('alpha')
+  })
+
+  it('zip -r -j drops directory entries entirely', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.dirs.add('/d/sub')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    resource.store.files.set('/d/sub/b.txt', ENC.encode('beta'))
+    const { out } = await runCmd(
+      RAM_ZIP,
+      resource,
+      [PathSpec.fromStrPath('/out.zip'), dirSpec('/d', 'd')],
+      { r: true, j: true },
+    )
+    expect(DEC.decode(out)).toBe('  adding: a.txt\n  adding: b.txt\n')
+  })
+
+  it('zip -x is anchored on the whole stored name', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.dirs.add('/d/sub')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    resource.store.files.set('/d/sub/b.txt', ENC.encode('beta'))
+    const { out } = await runCmd(
+      RAM_ZIP,
+      resource,
+      [PathSpec.fromStrPath('/out.zip'), dirSpec('/d', 'd')],
+      { r: true, x: ['d/sub/*'] },
+    )
+    expect(DEC.decode(out)).toBe('  adding: d/\n  adding: d/a.txt\n')
+  })
+
+  it("warns in Info-ZIP's words on a name it cannot match, and archives the rest", async () => {
+    const resource = new RAMResource()
+    resource.store.files.set('/a.txt', ENC.encode('alpha'))
+    const { exitCode, stderr } = await runCmd(
+      RAM_ZIP,
+      resource,
+      [PathSpec.fromStrPath('/out.zip'), dirSpec('/a.txt', 'a.txt'), dirSpec('/nope', 'nope')],
+      {},
+    )
+    expect(exitCode).toBe(0)
+    expect(DEC.decode(stderr)).toBe('\tzip warning: name not matched: nope\n')
+    expect(resource.store.files.has('/out.zip')).toBe(true)
+  })
+
+  it('writes no archive and exits 12 when nothing matched', async () => {
+    const resource = new RAMResource()
+    const { exitCode, stderr } = await runCmd(
+      RAM_ZIP,
+      resource,
+      [dirSpec('/out.zip', 'out.zip'), dirSpec('/nope', 'nope')],
+      {},
+    )
+    expect(exitCode).toBe(12)
+    expect(resource.store.files.has('/out.zip')).toBe(false)
+    expect(DEC.decode(stderr)).toBe(
+      '\tzip warning: name not matched: nope\n\nzip error: Nothing to do! (out.zip)\n',
+    )
+  })
+
+  it('-q silences the warning but never the fatal error', async () => {
+    const resource = new RAMResource()
+    const { exitCode, stderr } = await runCmd(
+      RAM_ZIP,
+      resource,
+      [dirSpec('/out.zip', 'out.zip'), dirSpec('/nope', 'nope')],
+      { q: true },
+    )
+    expect(exitCode).toBe(12)
+    expect(DEC.decode(stderr)).toBe('\nzip error: Nothing to do! (out.zip)\n')
+  })
+
+  it('names members from virtual paths on a prefixed mount', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const operand = new PathSpec({
+      virtual: '/data/d',
+      directory: '/data/d',
+      resourcePath: 'd',
+      resolved: true,
+      rawPath: '/data/d',
+    })
+    const archive = new PathSpec({
+      virtual: '/data/out.zip',
+      directory: '/data',
+      resourcePath: 'out.zip',
+      resolved: true,
+      rawPath: '/data/out.zip',
+    })
+    const { out } = await runCmd(RAM_ZIP, resource, [archive, operand], { r: true }, [], '/data')
+    expect(DEC.decode(out)).toBe('  adding: data/d/\n  adding: data/d/a.txt\n')
   })
 })
 

--- a/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
@@ -18,7 +18,7 @@ import type { RegisteredCommand } from '../../config.ts'
 import { materialize } from '../../../io/types.ts'
 import { RAMResource } from '../../../resource/ram/ram.ts'
 import type { LinkView } from '../../../ops/types.ts'
-import { FileType, LINK_TARGET_KEY, PathSpec, type FileStat } from '../../../types.ts'
+import { FileStat, FileType, LINK_TARGET_KEY, PathSpec } from '../../../types.ts'
 import { CycleError } from '../../../utils/path.ts'
 const RAM_TAR = RAM_COMMANDS.filter((c) => c.name === 'tar' && c.filetype == null)
 const RAM_ZIP = RAM_COMMANDS.filter((c) => c.name === 'zip' && c.filetype == null)
@@ -42,12 +42,12 @@ function dirSpec(virtual: string, raw: string): PathSpec {
 // The namespace's symlink facts, as the dispatcher would offer them.
 function linkView(entries: Record<string, string>, cycles = false): LinkView {
   const statOf = (path: string): FileStat =>
-    ({
+    new FileStat({
       name: path,
       type: FileType.SYMLINK,
       size: (entries[path] ?? '').length,
       extra: { [LINK_TARGET_KEY]: entries[path] ?? '' },
-    }) as FileStat
+    })
   return {
     statAt: (p) => (p in entries ? statOf(p) : null),
     children: () => [],

--- a/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
@@ -17,7 +17,9 @@ import { describe, expect, it } from 'vitest'
 import type { RegisteredCommand } from '../../config.ts'
 import { materialize } from '../../../io/types.ts'
 import { RAMResource } from '../../../resource/ram/ram.ts'
-import { PathSpec } from '../../../types.ts'
+import type { LinkView } from '../../../ops/types.ts'
+import { FileType, LINK_TARGET_KEY, PathSpec, type FileStat } from '../../../types.ts'
+import { CycleError } from '../../../utils/path.ts'
 const RAM_TAR = RAM_COMMANDS.filter((c) => c.name === 'tar' && c.filetype == null)
 const RAM_ZIP = RAM_COMMANDS.filter((c) => c.name === 'zip' && c.filetype == null)
 const RAM_UNZIP = RAM_COMMANDS.filter((c) => c.name === 'unzip' && c.filetype == null)
@@ -37,6 +39,38 @@ function dirSpec(virtual: string, raw: string): PathSpec {
   })
 }
 
+// The namespace's symlink facts, as the dispatcher would offer them.
+function linkView(entries: Record<string, string>, cycles = false): LinkView {
+  const statOf = (path: string): FileStat =>
+    ({
+      name: path,
+      type: FileType.SYMLINK,
+      size: (entries[path] ?? '').length,
+      extra: { [LINK_TARGET_KEY]: entries[path] ?? '' },
+    }) as FileStat
+  return {
+    statAt: (p) => (p in entries ? statOf(p) : null),
+    children: () => [],
+    subtree: (dir) =>
+      Object.keys(entries)
+        .sort()
+        .filter((k) => k.startsWith(rstrip(dir) + '/'))
+        .map((k) => [k, statOf(k)] as [string, FileStat]),
+    resolve: (p) => {
+      // The namespace walks the chain under a hop limit and raises
+      // ELOOP at the end of it; a real cycle never returns a target.
+      if (cycles) throw new CycleError(p)
+      return entries[p] ?? p
+    },
+    exists: (p) => Promise.resolve(p in entries),
+    targetStat: () => Promise.resolve(null),
+  }
+}
+
+function rstrip(s: string): string {
+  return s.endsWith('/') ? s.slice(0, -1) : s
+}
+
 interface CmdResult {
   out: Uint8Array
   writes: Record<string, Uint8Array>
@@ -51,6 +85,7 @@ async function runCmd(
   flags: Record<string, string | boolean | number | string[]>,
   texts: string[] = [],
   mountPrefix = '',
+  links: LinkView | null = null,
 ): Promise<CmdResult> {
   const cmd = reg[0]
   if (cmd === undefined) throw new Error('not registered')
@@ -61,6 +96,7 @@ async function runCmd(
     cwd: '/',
     resource,
     mountPrefix,
+    ...(links !== null ? { links } : {}),
   })
   if (result === null) {
     return { out: new Uint8Array(), writes: {}, exitCode: 0, stderr: new Uint8Array() }
@@ -634,5 +670,83 @@ describe('unzip members', () => {
     expect(resource.store.files.has('/ext/docProps/app.xml')).toBe(false)
     expect(r.exitCode).toBe(11)
     expect(DEC.decode(r.stderr)).toBe(`${CAUTION}NOSUCHFILE.xml\n`)
+  })
+})
+
+describe('archive planner regressions', () => {
+  it('two links to one target are not a loop', async () => {
+    // GNU tar -h and Info-ZIP both store the two names.
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const links = linkView({ '/d/one': '/d/a.txt', '/d/two': '/d/a.txt' })
+    const { out, exitCode, stderr } = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/d', 'd')],
+      { c: true, h: true, v: true, f: '/out.tar' },
+      [],
+      '',
+      links,
+    )
+    expect(exitCode).toBe(0)
+    expect(DEC.decode(stderr)).toBe('')
+    expect(DEC.decode(out).trim().split('\n')).toEqual(['d/', 'd/a.txt', 'd/one', 'd/two'])
+  })
+
+  it('a real cycle is one fatal problem per member and keeps the directory', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    const links = linkView({ '/d/a': '/d/b', '/d/b': '/d/a' }, true)
+    const { exitCode, stderr } = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/d', 'd')],
+      { c: true, h: true, f: '/out.tar' },
+      [],
+      '',
+      links,
+    )
+    expect(exitCode).toBe(2)
+    const text = DEC.decode(stderr)
+    expect(text).toContain('tar: d/a: Cannot stat: Too many levels of symbolic links')
+    expect(text).toContain('tar: d/b: Cannot stat: Too many levels of symbolic links')
+  })
+
+  it('stores a symlink operand as a symlink rather than its target', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const links = linkView({ '/link': '/d/a.txt' })
+    const { out } = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/link', 'link')],
+      { c: true, v: true, f: '/out.tar' },
+      [],
+      '',
+      links,
+    )
+    expect(DEC.decode(out).trim()).toBe('link')
+    const { out: listed } = await runCmd(RAM_TAR, resource, [], { t: true, f: '/out.tar' })
+    expect(DEC.decode(listed).trim()).toBe('link')
+  })
+
+  it('fails at the first unenterable -C, not the last', async () => {
+    // GNU chdirs at each -C, so a bad early one stops the whole run.
+    const resource = new RAMResource()
+    resource.store.dirs.add('/good')
+    resource.store.files.set('/good/y.txt', ENC.encode('y'))
+    const { exitCode, stderr } = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/good/y.txt', 'y.txt')],
+      { c: true, f: '/out.tar', C: ['/missing', '/good'] },
+    )
+    expect(exitCode).toBe(2)
+    const text = DEC.decode(stderr)
+    expect(text).toContain('tar: /missing: Cannot open: No such file or directory')
+    expect(text).toContain('Error is not recoverable')
+    expect(resource.store.files.has('/out.tar')).toBe(false)
   })
 })

--- a/typescript/packages/core/src/commands/builtin/tar_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/tar_helper.ts
@@ -16,10 +16,19 @@ const BLOCK_SIZE = 512
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
 
+// A ustar typeflag byte, restricted to the three kinds mirage records.
+const REGTYPE = 0x30
+const SYMTYPE = 0x32
+const DIRTYPE = 0x35
+
 export interface TarEntry {
   name: string
   data: Uint8Array
   isFile: boolean
+  // Directories carry no content and a trailing slash; a symlink carries
+  // its target in the header's linkname field instead of any content.
+  isDir?: boolean
+  linkname?: string
 }
 
 function writeOctalField(buf: Uint8Array, offset: number, length: number, value: number): void {
@@ -41,18 +50,24 @@ function computeChecksum(header: Uint8Array): number {
   return sum
 }
 
-function buildHeader(name: string, size: number): Uint8Array {
+function buildHeader(entry: TarEntry, size: number): Uint8Array {
   const header = new Uint8Array(BLOCK_SIZE)
   header.fill(0)
+  const isDir = entry.isDir === true
+  const isLink = entry.linkname !== undefined && entry.linkname !== ''
+  // A directory member is spelled with a trailing slash; that slash is
+  // what tells every extractor it holds no content.
+  const name = isDir && !entry.name.endsWith('/') ? `${entry.name}/` : entry.name
   writeStringField(header, 0, 100, name)
-  writeOctalField(header, 100, 8, 0o644) // mode
+  writeOctalField(header, 100, 8, isDir ? 0o755 : isLink ? 0o777 : 0o644)
   writeOctalField(header, 108, 8, 0) // uid
   writeOctalField(header, 116, 8, 0) // gid
   writeOctalField(header, 124, 12, size)
   writeOctalField(header, 136, 12, Math.floor(Date.now() / 1000))
   // checksum placeholder: spaces
   for (let i = 148; i < 156; i++) header[i] = 0x20
-  header[156] = 0x30 // '0' regular file
+  header[156] = isDir ? DIRTYPE : isLink ? SYMTYPE : REGTYPE
+  if (isLink) writeStringField(header, 157, 100, entry.linkname ?? '')
   writeStringField(header, 257, 6, 'ustar\0')
   writeStringField(header, 263, 2, '00')
   const checksum = computeChecksum(header)
@@ -82,9 +97,13 @@ function readStringField(buf: Uint8Array, offset: number, length: number): strin
 export function writeTar(entries: readonly TarEntry[]): Uint8Array {
   const blocks: Uint8Array[] = []
   for (const entry of entries) {
-    blocks.push(buildHeader(entry.name, entry.data.byteLength))
-    blocks.push(entry.data)
-    const padding = (BLOCK_SIZE - (entry.data.byteLength % BLOCK_SIZE)) % BLOCK_SIZE
+    // A directory and a symlink record their identity in the header and
+    // occupy no data blocks, whatever the caller put in `data`.
+    const carries = entry.isDir !== true && (entry.linkname ?? '') === ''
+    const data = carries ? entry.data : new Uint8Array(0)
+    blocks.push(buildHeader(entry, data.byteLength))
+    if (data.byteLength > 0) blocks.push(data)
+    const padding = (BLOCK_SIZE - (data.byteLength % BLOCK_SIZE)) % BLOCK_SIZE
     if (padding > 0) blocks.push(new Uint8Array(padding))
   }
   blocks.push(new Uint8Array(BLOCK_SIZE * 2))
@@ -107,10 +126,20 @@ export function readTar(data: Uint8Array): TarEntry[] {
     const name = readStringField(header, 0, 100)
     const size = readOctalField(header, 124, 12)
     const typeflag = header[156]
-    const isFile = typeflag === 0 || typeflag === 0x30
+    const isFile = typeflag === 0 || typeflag === REGTYPE
+    // A trailing slash marks a directory even on an archive written
+    // before ustar typeflags (GNU tar has always spelled it that way).
+    const isDir = typeflag === DIRTYPE || name.endsWith('/')
+    const linkname = typeflag === SYMTYPE ? readStringField(header, 157, 100) : ''
     offset += BLOCK_SIZE
     const fileData = data.subarray(offset, offset + size)
-    entries.push({ name, data: new Uint8Array(fileData), isFile })
+    entries.push({
+      name,
+      data: new Uint8Array(fileData),
+      isFile: isFile && !isDir,
+      isDir,
+      linkname,
+    })
     const padded = Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE
     offset += padded
   }

--- a/typescript/packages/core/src/commands/config.ts
+++ b/typescript/packages/core/src/commands/config.ts
@@ -18,7 +18,7 @@ import { IOResult, type ByteSource } from '../io/types.ts'
 import type { Resource } from '../resource/base.ts'
 import type { Limit, PathSpec } from '../types.ts'
 import type { Runtime } from '../runtime/base.ts'
-import type { LinkView, StatOverlay, StatPath } from '../ops/types.ts'
+import type { LinkView, MountView, StatOverlay, StatPath } from '../ops/types.ts'
 import { VERSION } from '../version.ts'
 import type { AggregateResult } from './builtin/aggregators.ts'
 import { renderHelp } from './spec/help.ts'
@@ -71,6 +71,10 @@ export interface CommandOpts {
   // point: only a directory has a subtree to walk, and a start point the
   // router resolved into another mount answers there, not on this mount.
   statPath?: StatPath
+  // Where the mount boundaries are, for a walker whose output cannot be
+  // fanned out and concatenated (tar, zip). A nested mount's keys live
+  // in another resource, so this backend's readdir cannot see it.
+  mounts?: MountView
   signal?: AbortSignal
   timeoutSeconds?: number
 }

--- a/typescript/packages/core/src/commands/spec/builtin_specs/archive.ts
+++ b/typescript/packages/core/src/commands/spec/builtin_specs/archive.ts
@@ -54,7 +54,10 @@ export const SPECS: Record<string, CommandSpec> = {
       // -h archives what a symlink points at instead of the link.
       new Option({ short: '-h' }),
       new Option({ short: '-f', type: 'path' }),
-      new Option({ short: '-C', type: 'path' }),
+      // Every occurrence is kept, in order: GNU chdirs at each one and
+      // fails at the first it cannot enter, so the planner has to see
+      // them all, not just the last.
+      new Option({ short: '-C', type: 'path', multiple: true }),
       new Option({ long: '--strip-components', type: 'str' }),
       new Option({ long: '--exclude', type: 'str' }),
     ],

--- a/typescript/packages/core/src/commands/spec/builtin_specs/archive.ts
+++ b/typescript/packages/core/src/commands/spec/builtin_specs/archive.ts
@@ -51,6 +51,8 @@ export const SPECS: Record<string, CommandSpec> = {
       new Option({ short: '-j' }),
       new Option({ short: '-J' }),
       new Option({ short: '-v' }),
+      // -h archives what a symlink points at instead of the link.
+      new Option({ short: '-h' }),
       new Option({ short: '-f', type: 'path' }),
       new Option({ short: '-C', type: 'path' }),
       new Option({ long: '--strip-components', type: 'str' }),
@@ -59,6 +61,9 @@ export const SPECS: Record<string, CommandSpec> = {
     rest: new Operand({ type: 'path' }),
     // `tar xzf a.tgz` is the spelling everyone types.
     oldOptionStyle: true,
+    // -C is a chdir for the operands after it, not a flag the command
+    // reads once: `tar -cf a.tar -C d x` archives d/x as `x`.
+    operandBase: '-C',
   }),
   unzip: new CommandSpec({
     options: [
@@ -81,6 +86,13 @@ export const SPECS: Record<string, CommandSpec> = {
       new Option({ short: '-r' }),
       new Option({ short: '-j' }),
       new Option({ short: '-q' }),
+      // -y stores a symlink as a symlink; without it zip archives what
+      // the link points at, which is tar's -h inverted.
+      new Option({ short: '-y' }),
+      // Info-ZIP reads -x as a variadic list of patterns; mirage takes
+      // one per occurrence, since its spec has no variadic option value
+      // and `-x a -x b` says the same thing.
+      new Option({ short: '-x', type: 'str', multiple: true }),
     ],
     rest: new Operand({ type: 'path' }),
   }),

--- a/typescript/packages/core/src/commands/spec/compile.ts
+++ b/typescript/packages/core/src/commands/spec/compile.ts
@@ -85,6 +85,9 @@ export class CompiledSpec {
   readonly numericDest: string | null
   /** Kind of the rest operand. */
   readonly restKind: ValueType | null
+  // Canonical spelling of the option that re-bases the path operands
+  // after it (CommandSpec.operandBase, tar's -C).
+  readonly baseDest: string | null
 
   constructor(fields: {
     boolSpellings: ReadonlySet<string>
@@ -108,6 +111,7 @@ export class CompiledSpec {
     defaults: ReadonlyMap<string, string>
     numericDest: string | null
     restKind: ValueType | null
+    baseDest: string | null
   }) {
     this.boolSpellings = fields.boolSpellings
     this.valueSpellings = fields.valueSpellings
@@ -130,6 +134,7 @@ export class CompiledSpec {
     this.defaults = fields.defaults
     this.numericDest = fields.numericDest
     this.restKind = fields.restKind
+    this.baseDest = fields.baseDest
   }
 
   /** Canonical spelling for a typed spelling. */
@@ -261,6 +266,17 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     }
   }
 
+  let baseDest: string | null = null
+  if (spec.operandBase !== null) {
+    baseDest = dest.get(spec.operandBase) ?? null
+    if (baseDest === null) {
+      throw new Error(`operandBase '${spec.operandBase}' is not a declared option`)
+    }
+    if (kindByDest.get(baseDest) !== 'path' || pairDests.has(baseDest)) {
+      throw new Error(`operandBase '${spec.operandBase}' must be a single-token path option`)
+    }
+  }
+
   // Longest first so an attached match can never be stolen by a shorter
   // spelling that happens to prefix it (-name vs -n).
   valueSpellings.sort((a, b) => b.length - a.length)
@@ -288,6 +304,7 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     defaults,
     numericDest,
     restKind: spec.rest !== null ? spec.rest.type : null,
+    baseDest,
   })
   CACHE.set(spec, compiled)
   return compiled

--- a/typescript/packages/core/src/commands/spec/parser.test.ts
+++ b/typescript/packages/core/src/commands/spec/parser.test.ts
@@ -950,3 +950,56 @@ describe("parseCommand — tar's old option style", () => {
     expect(p.oldOptionNeedsValue).toBeNull()
   })
 })
+
+describe('operandBase (tar -C)', () => {
+  it('re-bases the operands typed after it, leaving -f on the cwd', () => {
+    // GNU tar's -C is a chdir for the operands that follow it, so the
+    // archive stays relative to the session cwd while the files move.
+    const parsed = parseCommand(
+      specOf('tar'),
+      ['-czf', 'out.tgz', '-C', '/work/check', 'my_paper'],
+      '/home',
+    )
+    expect(parsed.args.filter(([, k]) => k === 'path').map(([v]) => v)).toEqual([
+      '/work/check/my_paper',
+    ])
+    expect(parsed.flags['-f']).toBe('/home/out.tgz')
+    expect(parsed.flags['-C']).toBe('/work/check')
+  })
+
+  it('is cumulative like a real chdir', () => {
+    const parsed = parseCommand(
+      specOf('tar'),
+      ['-cf', 'a.tar', '-C', 'd1', 'x', '-C', '../d2', 'y'],
+      '/work',
+    )
+    expect(parsed.args.filter(([, k]) => k === 'path').map(([v]) => v)).toEqual([
+      '/work/d1/x',
+      '/work/d2/y',
+    ])
+    expect(parsed.flags['-C']).toBe('/work/d2')
+  })
+
+  it('only moves what follows it', () => {
+    const parsed = parseCommand(
+      specOf('tar'),
+      ['-cf', 'a.tar', 'top.txt', '-C', '/work/e', 'e.txt'],
+      '/work',
+    )
+    expect(parsed.args.filter(([, k]) => k === 'path').map(([v]) => v)).toEqual([
+      '/work/top.txt',
+      '/work/e/e.txt',
+    ])
+  })
+
+  it('survives the old-style cluster', () => {
+    const parsed = parseCommand(specOf('tar'), ['czf', 'a.tgz', '-C', 'sub', 'x'], '/work')
+    expect(parsed.args.filter(([, k]) => k === 'path').map(([v]) => v)).toEqual(['/work/sub/x'])
+    expect(parsed.wordBases.at(-1)).toBe('/work/sub')
+  })
+
+  it('records no bases for a spec that declares none', () => {
+    const parsed = parseCommand(specOf('cat'), ['a.txt'], '/work')
+    expect(parsed.wordBases).toEqual([null])
+  })
+})

--- a/typescript/packages/core/src/commands/spec/parser.test.ts
+++ b/typescript/packages/core/src/commands/spec/parser.test.ts
@@ -908,7 +908,7 @@ describe("parseCommand — tar's old option style", () => {
   it('binds two value letters in letter order', () => {
     const p = parseCommand(specOf('tar'), ['xfC', '/data/a.tgz', '/data/out'], '/')
     expect(p.flags['-f']).toBe('/data/a.tgz')
-    expect(p.flags['-C']).toBe('/data/out')
+    expect(p.flags['-C']).toEqual(['/data/out'])
   })
 
   it('keeps a bool letter that follows a value letter', () => {
@@ -940,7 +940,7 @@ describe("parseCommand — tar's old option style", () => {
       '/',
     )
     expect(p.flags['--strip-components']).toBe('1')
-    expect(p.flags['-C']).toBe('/data/out')
+    expect(p.flags['-C']).toEqual(['/data/out'])
   })
 
   it('is off for every other command', () => {
@@ -964,7 +964,7 @@ describe('operandBase (tar -C)', () => {
       '/work/check/my_paper',
     ])
     expect(parsed.flags['-f']).toBe('/home/out.tgz')
-    expect(parsed.flags['-C']).toBe('/work/check')
+    expect(parsed.flags['-C']).toEqual(['/work/check'])
   })
 
   it('is cumulative like a real chdir', () => {
@@ -977,7 +977,8 @@ describe('operandBase (tar -C)', () => {
       '/work/d1/x',
       '/work/d2/y',
     ])
-    expect(parsed.flags['-C']).toBe('/work/d2')
+    // Every occurrence is kept in order: GNU chdirs at each one.
+    expect(parsed.flags['-C']).toEqual(['/work/d1', '/work/d2'])
   })
 
   it('only moves what follows it', () => {

--- a/typescript/packages/core/src/commands/spec/parser.ts
+++ b/typescript/packages/core/src/commands/spec/parser.ts
@@ -42,6 +42,25 @@ function setValueFlag(
   }
 }
 
+// Fold one option occurrence into the operand base directory. Called
+// after every value-flag record. Only the spec's declared operandBase
+// option moves the base, and it moves it the way a chdir does: relative
+// to wherever the previous occurrence left it, so `-C d1 ... -C ../d2`
+// lands in d1/../d2. The resolved absolute path replaces the raw value
+// in the flag bag, so the later path-flag pass has nothing left to do.
+function rebase(
+  flags: Record<string, string | boolean | number | string[]>,
+  cs: CompiledSpec,
+  spelling: string,
+  value: string,
+  base: string,
+): string {
+  if (cs.baseDest === null || cs.destOf(spelling) !== cs.baseDest) return base
+  const moved = resolvePath(value, base)
+  flags[cs.baseDest] = moved
+  return moved
+}
+
 // Record a boolean flag occurrence under its canonical dest. A count flag
 // accumulates occurrences into a number (`-vvv` and `-v -v -v` both land
 // as 3); every other boolean flag is sticky true.
@@ -139,6 +158,13 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
     // dispatch resolved and unreadable as letters.
     wordKinds[0] = 'str'
   }
+  // The directory the next path operand resolves against, and where it
+  // was for each word already read. It only ever moves for a spec that
+  // declares operandBase, so every other command records null throughout
+  // and the classifier keeps using the session cwd.
+  let base = cwd
+  const wordBases: (string | null)[] = new Array<string | null>(argv.length).fill(null)
+  const rawBases: string[] = []
   const warnings: string[] = []
   const invalidOptions: string[] = []
   const ambiguousOptions: [string, readonly string[]][] = []
@@ -169,6 +195,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
     if (endOfFlags) {
       rawArgs.push(tok)
       rawIndices.push(origIndices[i] ?? -1)
+      rawBases.push(base)
       i += 1
       continue
     }
@@ -211,6 +238,8 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
       } else if (!isPair && cs.longValueSpellings.has(etok) && i + 1 < filteredArgv.length) {
         setValueFlag(flags, cs, etok, filteredArgv[i + 1] ?? '')
         wordKinds[origIndices[i + 1] ?? -1] = cs.kindOf.get(etok) ?? null
+        if (cs.destOf(etok) === cs.baseDest) wordBases[origIndices[i + 1] ?? -1] = base
+        base = rebase(flags, cs, etok, filteredArgv[i + 1] ?? '', base)
         i += 2
       } else if (isPair) {
         if (eqPos === -1) {
@@ -228,12 +257,14 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
           (cs.longValueSpellings.has(spelling) || cs.longOptionalSpellings.has(spelling))
         ) {
           setValueFlag(flags, cs, spelling, tok.slice(eqPos + 1))
+          base = rebase(flags, cs, spelling, tok.slice(eqPos + 1), base)
         } else if (cs.longValueSpellings.has(etok)) {
           // Declared value flag at end of line with no argument.
           needsValueOptions.push(etok)
         } else if (lenientDashOperands) {
           rawArgs.push(tok)
           rawIndices.push(origIndices[i] ?? -1)
+          rawBases.push(base)
         } else {
           invalidOptions.push(tok)
           optionErrorKinds.push('invalid')
@@ -253,6 +284,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
       for (const vf of cs.attachSpellings) {
         if (tok.startsWith(vf) && tok.length > vf.length) {
           setValueFlag(flags, cs, vf, tok.slice(vf.length))
+          base = rebase(flags, cs, vf, tok.slice(vf.length), base)
           i += 1
           matchedOptional = true
           break
@@ -264,12 +296,15 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
         if (tok === vf && i + 1 < filteredArgv.length) {
           setValueFlag(flags, cs, vf, filteredArgv[i + 1] ?? '')
           wordKinds[origIndices[i + 1] ?? -1] = cs.kindOf.get(vf) ?? null
+          if (cs.destOf(vf) === cs.baseDest) wordBases[origIndices[i + 1] ?? -1] = base
+          base = rebase(flags, cs, vf, filteredArgv[i + 1] ?? '', base)
           i += 2
           matchedValue = true
           break
         }
         if (tok.startsWith(vf) && tok.length > vf.length) {
           setValueFlag(flags, cs, vf, tok.slice(vf.length))
+          base = rebase(flags, cs, vf, tok.slice(vf.length), base)
           i += 1
           matchedValue = true
           break
@@ -301,6 +336,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
         if (mixed.attached !== null) {
           for (const name of mixed.bools) setBoolFlag(flags, cs, name)
           setValueFlag(flags, cs, mixed.valueFlag, mixed.attached)
+          base = rebase(flags, cs, mixed.valueFlag, mixed.attached, base)
           i += 1
           continue
         }
@@ -308,6 +344,10 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
           for (const name of mixed.bools) setBoolFlag(flags, cs, name)
           setValueFlag(flags, cs, mixed.valueFlag, filteredArgv[i + 1] ?? '')
           wordKinds[origIndices[i + 1] ?? -1] = cs.kindOf.get(mixed.valueFlag) ?? null
+          if (cs.destOf(mixed.valueFlag) === cs.baseDest) {
+            wordBases[origIndices[i + 1] ?? -1] = base
+          }
+          base = rebase(flags, cs, mixed.valueFlag, filteredArgv[i + 1] ?? '', base)
           i += 2
           continue
         }
@@ -316,6 +356,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
       if (lenientDashOperands || NUMERIC_SHORT.test(tok)) {
         rawArgs.push(tok)
         rawIndices.push(origIndices[i] ?? -1)
+        rawBases.push(base)
       } else if (cs.valueSpellings.includes(tok)) {
         // A declared value flag with no argument left on the line.
         needsValueOptions.push(tok.slice(1))
@@ -340,6 +381,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
 
     rawArgs.push(tok)
     rawIndices.push(origIndices[i] ?? -1)
+    rawBases.push(base)
     i += 1
   }
 
@@ -417,8 +459,14 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
       kind = overflowKind
     }
     if (kind === 'path') {
-      classified.push([resolvePath(arg, cwd), 'path'])
+      // Against the base an operandBase option left in effect at this
+      // position, which is the session cwd for every command that
+      // declares none.
+      const here = rawBases[j] ?? cwd
+      classified.push([resolvePath(arg, here), 'path'])
       rawOperands.push([arg, 'path'])
+      const baseIdx = rawIndices[j]
+      if (here !== cwd && baseIdx !== undefined && baseIdx >= 0) wordBases[baseIdx] = here
     } else {
       classified.push([arg, kind])
       rawOperands.push([arg, kind])
@@ -476,6 +524,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
     missingRequiredOptions,
     oldOptionNeedsValue: old !== null ? old.needsValue : null,
     wordKinds,
+    wordBases,
   })
 }
 

--- a/typescript/packages/core/src/commands/spec/parser.ts
+++ b/typescript/packages/core/src/commands/spec/parser.ts
@@ -57,7 +57,14 @@ function rebase(
 ): string {
   if (cs.baseDest === null || cs.destOf(spelling) !== cs.baseDest) return base
   const moved = resolvePath(value, base)
-  flags[cs.baseDest] = moved
+  const bag = flags[cs.baseDest]
+  if (Array.isArray(bag) && bag.length > 0) {
+    // An accumulating option already appended the raw value; the
+    // resolved one replaces it so nothing resolves it twice.
+    bag[bag.length - 1] = moved
+  } else {
+    flags[cs.baseDest] = moved
+  }
   return moved
 }
 

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -207,6 +207,7 @@ export interface CommandSpecInit {
   description?: string | null
   epilog?: string | null
   oldOptionStyle?: boolean
+  operandBase?: string | null
 }
 
 export class CommandSpec {
@@ -221,6 +222,13 @@ export class CommandSpec {
   // (`tar xzf a.tgz`). Expanded by expandOldStyle before any other
   // scanning; see oldstyle.ts for the rules and why only tar has it.
   readonly oldOptionStyle: boolean
+  // The spelling of an option that changes directory for the path
+  // operands typed AFTER it (tar's -C). Positional and cumulative, the
+  // way a real chdir is: `tar -cf a.tar -C d1 x -C ../d2 y` reads d1/x
+  // and d1/../d2/y. Only path operands and the option's own value move;
+  // every other path-valued flag keeps resolving against the session
+  // cwd, which is what GNU does with -f.
+  readonly operandBase: string | null
 
   constructor(init: CommandSpecInit = {}) {
     this.options = init.options ?? []
@@ -230,6 +238,7 @@ export class CommandSpec {
     this.description = init.description ?? null
     this.epilog = init.epilog ?? null
     this.oldOptionStyle = init.oldOptionStyle ?? false
+    this.operandBase = init.operandBase ?? null
     // A subclass (CLISpec) still has its own fields to assign, so only
     // freeze here when constructed directly; subclasses freeze themselves.
     if (new.target === CommandSpec) Object.freeze(this)
@@ -245,6 +254,7 @@ export interface ParsedArgsInit {
   textFlagValues?: string[]
   warnings?: string[]
   wordKinds?: (ValueType | null)[]
+  wordBases?: (string | null)[]
   invalidOptions?: string[]
   ambiguousOptions?: [string, readonly string[]][]
   optionErrorKinds?: string[]
@@ -265,6 +275,11 @@ export class ParsedArgs {
   readonly textFlagValues: string[]
   readonly warnings: string[]
   readonly wordKinds: (ValueType | null)[]
+  // Per-position base directory, aligned with wordKinds: the absolute
+  // path a word resolves against when an operandBase option (tar's -C)
+  // moved it, and null when the session cwd still applies. Only a spec
+  // declaring operandBase ever fills this.
+  readonly wordBases: (string | null)[]
   // GNU-shaped option errors, reported (never thrown) by the parser:
   // undeclared options ('--bogus' or the offending cluster char 'Y'),
   // abbreviated longs matching several options (typed prefix, matched
@@ -303,6 +318,7 @@ export class ParsedArgs {
     this.textFlagValues = init.textFlagValues ?? []
     this.warnings = init.warnings ?? []
     this.wordKinds = init.wordKinds ?? []
+    this.wordBases = init.wordBases ?? []
     this.invalidOptions = init.invalidOptions ?? []
     this.ambiguousOptions = init.ambiguousOptions ?? []
     this.optionErrorKinds = init.optionErrorKinds ?? []

--- a/typescript/packages/core/src/ops/types.ts
+++ b/typescript/packages/core/src/ops/types.ts
@@ -28,6 +28,29 @@ export type StatPath = (path: string) => Promise<FileStat | null>
 // backend.
 export type MountRoot = (path: string) => string
 
+// Where the mount boundaries are, as one injected object.
+//
+// A command runs bound to one backend, and that backend cannot see a
+// mount nested inside its own tree: the child's keys live in another
+// resource entirely, so the parent's `readdir` never lists it. A walker
+// that must account for the whole subtree therefore has to be told, the
+// same way `LinkView` tells it about symlinks.
+//
+// Traversal commands that render lines (find, du, grep -r) get this for
+// free from the executor's fan-out, which reruns them per mount and
+// concatenates the output. A command whose output is one binary object
+// (tar, zip) cannot be merged that way, so it reads the boundaries here
+// and says what it did with them.
+export interface MountView {
+  // Mount roots strictly under a path (a walker: tar, zip).
+  descendants(path: string): string[]
+  // Whether a path is a mount root itself.
+  isRoot(path: string): boolean
+  // The mount serving a path, so a walker can tell "still mine" from
+  // "another backend" before it tries to read something it cannot.
+  rootOf(path: string): string
+}
+
 // The symlink facts a command may consult, as one injected object.
 //
 // Symlinks live in the workspace namespace and no backend can see them,

--- a/typescript/packages/core/src/policy/builtin/mount_root.test.ts
+++ b/typescript/packages/core/src/policy/builtin/mount_root.test.ts
@@ -39,8 +39,9 @@ function ctx(
   paths: PathSpec[],
   argv: string[] = [],
   reg: MountRegistry = registry(),
+  operands?: PathSpec[],
 ): CommandContext {
-  return { command, paths, argv, cwd: '/', registry: reg }
+  return { command, paths, operands: operands ?? paths, argv, cwd: '/', registry: reg }
 }
 
 describe('MountRootPolicy', () => {
@@ -103,5 +104,50 @@ describe('MountRootPolicy', () => {
     expect(hasParentsFlag(['-pv'])).toBe(true)
     expect(hasParentsFlag(['--print'])).toBe(false)
     expect(hasParentsFlag(['x', '-r'])).toBe(false)
+  })
+})
+
+describe('MountRootPolicy: whole-mount archivers', () => {
+  it.each([
+    ['tar', 'tar: /data: Cannot open: Device or resource busy'],
+    ['zip', "zip: cannot read '/data': Device or resource busy"],
+    ['cp', "cp: cannot copy '/data': Device or resource busy"],
+  ])('refuses %s with a mount root in a source slot', (cmd, needle) => {
+    // zip's first operand is the archive it writes, cp's last is the
+    // destination, so each line puts the mount root in a source slot.
+    const operands: Record<string, PathSpec[]> = {
+      tar: [path('/data')],
+      zip: [path('/out.zip'), path('/data')],
+      cp: [path('/data'), path('/dst')],
+    }
+    const deny = new MountRootPolicy().preCommand(ctx(cmd, operands[cmd] ?? []))
+    expect(deny).not.toBeNull()
+    expect(deny && 'message' in deny ? deny.message : '').toContain(needle)
+  })
+
+  it("names tar's operand as typed and exits 2", () => {
+    const deny = new MountRootPolicy().preCommand(ctx('tar', [path('/data', '.')]))
+    expect(deny && 'message' in deny ? deny.message : '').toContain('tar: .: Cannot open')
+    expect(deny && 'message' in deny ? deny.message : '').toContain('Error is not recoverable')
+    expect(deny && 'exitCode' in deny ? deny.exitCode : 0).toBe(2)
+  })
+
+  it('allows extracting into a mount root', () => {
+    // `-C /data` is a path-valued flag, so it reaches paths but never
+    // operands; refusing it would block the safe direction.
+    const deny = new MountRootPolicy().preCommand(
+      ctx('tar', [path('/archive.tar'), path('/data')], [], registry(), [path('/archive.tar')]),
+    )
+    expect(deny).toBeNull()
+  })
+
+  it('allows copying into a mount root', () => {
+    const deny = new MountRootPolicy().preCommand(ctx('cp', [path('/src/a.txt'), path('/data')]))
+    expect(deny).toBeNull()
+  })
+
+  it("does not read zip's archive slot as a source", () => {
+    const deny = new MountRootPolicy().preCommand(ctx('zip', [path('/data'), path('/src/a.txt')]))
+    expect(deny).toBeNull()
   })
 })

--- a/typescript/packages/core/src/policy/builtin/mount_root.test.ts
+++ b/typescript/packages/core/src/policy/builtin/mount_root.test.ts
@@ -120,16 +120,34 @@ describe('MountRootPolicy: whole-mount archivers', () => {
       zip: [path('/out.zip'), path('/data')],
       cp: [path('/data'), path('/dst')],
     }
-    const deny = new MountRootPolicy().preCommand(ctx(cmd, operands[cmd] ?? []))
+    const argv = cmd === 'tar' ? ['-cf', '/out.tar'] : []
+    const deny = new MountRootPolicy().preCommand(ctx(cmd, operands[cmd] ?? [], argv))
     expect(deny).not.toBeNull()
     expect(deny && 'message' in deny ? deny.message : '').toContain(needle)
   })
 
   it("names tar's operand as typed and exits 2", () => {
-    const deny = new MountRootPolicy().preCommand(ctx('tar', [path('/data', '.')]))
+    const deny = new MountRootPolicy().preCommand(
+      ctx('tar', [path('/data', '.')], ['-cf', '/out.tar']),
+    )
     expect(deny && 'message' in deny ? deny.message : '').toContain('tar: .: Cannot open')
     expect(deny && 'message' in deny ? deny.message : '').toContain('Error is not recoverable')
     expect(deny && 'exitCode' in deny ? deny.exitCode : 0).toBe(2)
+  })
+
+  it.each([
+    [['-cf', '/a.tar'], true],
+    [['--create', '-f', '/a.tar'], true],
+    [['cf', '/a.tar'], true],
+    [['-tf', '/a.tar'], false],
+    [['-xf', '/a.tar'], false],
+    [['xzf', '/a.tar'], false],
+    [['-xf', '/a.tar', '-C', '/cache'], false],
+  ])('only tar create reads its operands from the filesystem: %s', (argv, denied) => {
+    // Under -t and -x an operand names a member, not a path, so a
+    // selector spelling a mount root must not deny the listing.
+    const deny = new MountRootPolicy().preCommand(ctx('tar', [path('/data')], argv))
+    expect(deny !== null).toBe(denied)
   })
 
   it('allows extracting into a mount root', () => {

--- a/typescript/packages/core/src/policy/builtin/mount_root.ts
+++ b/typescript/packages/core/src/policy/builtin/mount_root.ts
@@ -14,6 +14,7 @@
 
 import type { Policy } from '../base.ts'
 import type { Action, CommandContext, Deny } from '../types.ts'
+import type { PathSpec } from '../../types.ts'
 
 /**
  * Spot ln's -s/--symbolic by raw token scan. Same reason as
@@ -44,20 +45,46 @@ export function hasParentsFlag(argv: readonly string[]): boolean {
   return false
 }
 
-function deny(message: string): Deny {
-  return { kind: 'deny', message, exitCode: 1 }
+function deny(message: string, exitCode = 1): Deny {
+  return { kind: 'deny', message, exitCode }
+}
+
+// The first of these paths that is a mount root, if any.
+function firstRoot(
+  isRoot: (virtual: string) => boolean,
+  paths: readonly PathSpec[],
+): PathSpec | null {
+  for (const path of paths) {
+    if (isRoot(path.virtual)) return path
+  }
+  return null
 }
 
 /**
- * The built-in POSIX rule: a mount root is busy, not a directory.
- * Mirrors the kernel's refusal to unlink or replace a mountpoint
- * (EBUSY on Linux), with each command's own GNU message. Fires before
- * mount resolution and cross-mount routing so the refusal is the same
- * however the operands span mounts, and before runtime placement so a
- * routed command is refused identically. MountRegistry seeds it as the
- * first policy (mount-root semantics belong to the mount layer), so
- * its exact GNU messages win over user policies by order, not by
- * privilege.
+ * The built-in rule: a mount root is not an ordinary directory.
+ *
+ * Two rules, one boundary. The first mirrors the kernel's refusal to unlink
+ * or replace a mountpoint (EBUSY on Linux), with each command's own GNU
+ * message: rm, rmdir, mv, mkdir, touch and ln.
+ *
+ * The second is mirage's own, and is a deliberate divergence: an archiver or
+ * a recursive copy pointed at a mount root would read an entire backend into
+ * one object. Real tar and cp allow it because a mountpoint there is just
+ * another directory; here the mount table is the deployment's configuration,
+ * and consuming a whole mount is neither what the operand looks like it costs
+ * nor something an agent should be able to do to data it was merely given a
+ * view of. The refusal names the boundary in each tool's own voice rather
+ * than inventing a mirage error, so a caller sees a filesystem answer.
+ *
+ * Only positional operands are tested. tar's `-C` and unzip's `-d` are
+ * destinations to extract INTO, which is ordinary use of a mount, so reading
+ * them here would refuse the safe direction as well.
+ *
+ * Fires before mount resolution and cross-mount routing so the refusal is the
+ * same however the operands span mounts, and before runtime placement so a
+ * routed command is refused identically. MountRegistry seeds it as the first
+ * policy (mount-root semantics belong to the mount layer), so its exact
+ * messages win over user policies by order, not by privilege.
  */
 export class MountRootPolicy implements Policy {
   preCommand(ctx: CommandContext): Action | null {
@@ -113,6 +140,40 @@ export class MountRootPolicy implements Policy {
       if (last !== undefined && isRoot(last.virtual)) {
         const kind = hasSymlinkFlag(ctx.argv) ? 'symbolic link' : 'link'
         return deny(`ln: failed to create ${kind} '${last.virtual}': File exists\n`)
+      }
+      return null
+    }
+
+    const operands = ctx.operands ?? ctx.paths
+
+    if (cmd === 'tar') {
+      const root = firstRoot(isRoot, operands)
+      if (root !== null) {
+        return deny(
+          `tar: ${root.rawPath}: Cannot open: Device or resource busy\n` +
+            `tar: Error is not recoverable: exiting now\n`,
+          2,
+        )
+      }
+      return null
+    }
+
+    if (cmd === 'zip') {
+      // The first operand is the archive being written, not a source;
+      // only what follows it is read.
+      const root = firstRoot(isRoot, operands.slice(1))
+      if (root !== null) {
+        return deny(`zip: cannot read '${root.rawPath}': Device or resource busy\n`)
+      }
+      return null
+    }
+
+    if (cmd === 'cp') {
+      // The last operand is the destination, and copying INTO a mount is
+      // ordinary; only the sources are refused.
+      const root = firstRoot(isRoot, operands.slice(0, -1))
+      if (root !== null) {
+        return deny(`cp: cannot copy '${root.rawPath}': Device or resource busy\n`)
       }
       return null
     }

--- a/typescript/packages/core/src/policy/builtin/mount_root.ts
+++ b/typescript/packages/core/src/policy/builtin/mount_root.ts
@@ -45,6 +45,32 @@ export function hasParentsFlag(argv: readonly string[]): boolean {
   return false
 }
 
+/**
+ * Whether a tar line reads the filesystem rather than an archive.
+ *
+ * Only `-c` makes tar's operands source paths. Under `-t` and `-x` they are
+ * member selectors matched against names inside the archive, so a selector
+ * that happens to spell a mount root is not a mount at all and refusing it
+ * would deny an ordinary listing.
+ *
+ * Scanned raw for the same reason hasSymlinkFlag is: the policy fires before
+ * flag parsing. Only the first word may be GNU's dashless option cluster
+ * (`tar cf a.tar d`), so a later bare word is an operand and cannot turn the
+ * mode on.
+ */
+function isCreateMode(argv: readonly string[]): boolean {
+  for (const [i, tok] of argv.entries()) {
+    if (tok === '--create') return true
+    if (tok.startsWith('--')) continue
+    if (tok.startsWith('-')) {
+      if (tok.slice(1).includes('c')) return true
+      continue
+    }
+    if (i === 0 && tok.includes('c')) return true
+  }
+  return false
+}
+
 function deny(message: string, exitCode = 1): Deny {
   return { kind: 'deny', message, exitCode }
 }
@@ -147,7 +173,9 @@ export class MountRootPolicy implements Policy {
     const operands = ctx.operands ?? ctx.paths
 
     if (cmd === 'tar') {
-      const root = firstRoot(isRoot, operands)
+      // Only -c reads the filesystem; -t and -x match their operands
+      // against names inside the archive.
+      const root = isCreateMode(ctx.argv) ? firstRoot(isRoot, operands) : null
       if (root !== null) {
         return deny(
           `tar: ${root.rawPath}: Cannot open: Device or resource busy\n` +

--- a/typescript/packages/core/src/policy/types.ts
+++ b/typescript/packages/core/src/policy/types.ts
@@ -62,7 +62,18 @@ export interface GuardSpec {
 /** Facts about one classified command, as preCommand hooks see it. */
 export interface CommandContext {
   command: string
+  /**
+   * Every path the line names: the positional operands first, then the
+   * values of any path-valued flags. What a path-pattern guard matches on.
+   */
   paths: readonly PathSpec[]
+  /**
+   * The positional operands alone. A rule that reads a slot by position
+   * (mv's source, ln's target, tar's files) has to use this: with the flag
+   * values mixed in, `tar -xf a.tar -C /mnt` would read the `-C`
+   * destination as a file being archived.
+   */
+  operands?: readonly PathSpec[]
   /** Raw argv after the command name; hooks fire before flag parsing. */
   argv: readonly string[]
   cwd: string

--- a/typescript/packages/core/src/workspace/executor/command/routing.ts
+++ b/typescript/packages/core/src/workspace/executor/command/routing.ts
@@ -83,6 +83,40 @@ export function pathFlagScopes(cmdName: string, argv: string[], cwd: string): Pa
   )
 }
 
+/**
+ * The path operands a line names positionally, flag values left out.
+ *
+ * Classification turns every path-shaped word into a PathSpec, including the
+ * value of a path-valued flag, so the classified word list cannot tell
+ * `tar -xf a.tar -C /mnt` (extract INTO a mount) from `tar -cf a.tar /mnt`
+ * (archive a whole mount). Only the spec knows which slot a word filled, so
+ * this asks it and keeps the classified spec for each surviving operand,
+ * whose `rawPath` is what a message should name.
+ */
+export function positionalScopes(
+  cmdName: string,
+  argv: string[],
+  cwd: string,
+  words: readonly (string | PathSpec)[],
+): PathSpec[] {
+  const spec = SPECS[cmdName]
+  if (spec === undefined) {
+    return words.filter((p): p is PathSpec => p instanceof PathSpec)
+  }
+  const parsed = parseCommand(spec, argv, cwd)
+  const byVirtual = new Map<string, PathSpec>()
+  for (const word of words) {
+    if (word instanceof PathSpec) byVirtual.set(word.virtual, word)
+  }
+  return parsed.args
+    .filter(([, kind]) => kind === 'path')
+    .map(
+      ([value]) =>
+        byVirtual.get(value) ??
+        new PathSpec({ virtual: value, directory: value, resourcePath: '', rawPath: value }),
+    )
+}
+
 /** Combine positional and path-flag scopes, keeping operand order. */
 export function mergeScopes(positional: PathSpec[], flagScopes: PathSpec[]): PathSpec[] {
   const merged = [...positional]

--- a/typescript/packages/core/src/workspace/executor/command/run.ts
+++ b/typescript/packages/core/src/workspace/executor/command/run.ts
@@ -19,7 +19,7 @@ import { assertMountAllowed, MountNotAllowedError } from '../../../context/sessi
 import type { PathSpec } from '../../../types.ts'
 import type { FileStat, ResourceName } from '../../../types.ts'
 import type { MountEntry } from '../../mount/mount.ts'
-import type { LinkView, StatOverlay, StatPath } from '../../../ops/types.ts'
+import type { LinkView, MountView, StatOverlay, StatPath } from '../../../ops/types.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
 import { linkTargetStat, pathExists, pathStat } from '../builtins/links.ts'
 import { mergeOverlayStat } from '../../mount/namespace/overlay.ts'
@@ -126,6 +126,21 @@ function namespaceStatOverlay(namespace: Namespace, virtual: string, stat: FileS
  */
 export function mountRootOf(registry: MountRegistry, virtual: string): string {
   return registry.mountFor(virtual)?.prefix ?? '/'
+}
+
+/**
+ * The mount-boundary facts on offer to every command.
+ *
+ * A command that does not read `mounts` off its context simply ignores it, so
+ * there is no list of boundary-aware commands to keep in step.
+ */
+function mountView(registry: MountRegistry): MountView {
+  return {
+    descendants: (path: string) =>
+      registry.descendantMounts(path).map((m) => rstripSlash(m.prefix) || '/'),
+    isRoot: (path: string) => registry.isMountRoot(path),
+    rootOf: (path: string) => mountRootOf(registry, path),
+  }
 }
 
 /**
@@ -262,6 +277,7 @@ export async function runOnMount(
       ...(statOverlay !== null ? { statOverlay } : {}),
       ...(links !== null ? { links } : {}),
       statPath,
+      mounts: mountView(registry),
       ...(session.abortSignal !== null ? { signal: session.abortSignal } : {}),
       limitOverride,
     })

--- a/typescript/packages/core/src/workspace/expand/argv.ts
+++ b/typescript/packages/core/src/workspace/expand/argv.ts
@@ -22,7 +22,7 @@ import { resolveGlobs } from './globs.ts'
 import { type ExecuteFn } from './node.ts'
 import { expandParts } from './parts.ts'
 import { type ValueType } from '../../commands/spec/types.ts'
-import { specForCommand, specWordKinds } from './spec_hints.ts'
+import { specForCommand, specWordBases, specWordKinds } from './spec_hints.ts'
 import type { TSNodeLike } from '../../shell/types.ts'
 
 /**
@@ -88,15 +88,20 @@ export async function expandArgv(
 
   const policy = wordPolicy(route(name, session, registry))
   let wordKinds: (ValueType | null)[] | null = null
+  let wordBases: (string | null)[] | null = null
   if (policy === WordPolicy.MOUNT) {
     const spec = specForCommand(name, registry, session.cwd)
     if (spec !== null) {
       const extra: (ValueType | null)[] = new Array<ValueType | null>(consumed - 1).fill('str')
       wordKinds = [...extra, ...specWordKinds(spec, expanded.slice(consumed))]
+      const bases = specWordBases(spec, expanded.slice(consumed), session.cwd)
+      if (bases !== null) {
+        wordBases = [...new Array<string | null>(consumed - 1).fill(null), ...bases]
+      }
     }
   }
 
-  let classified = classifyParts(expanded, registry, session.cwd, wordKinds)
+  let classified = classifyParts(expanded, registry, session.cwd, wordKinds, wordBases)
   // set -f: glob words become literal paths for every consumer,
   // including backend pushdown, so `cat *.txt` looks up a file
   // literally named `*.txt` like bash with noglob.

--- a/typescript/packages/core/src/workspace/expand/classify/parts.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/parts.ts
@@ -22,12 +22,15 @@ import { classifyBarePath } from './path.ts'
 // is never classified as a path. wordKinds (from CommandSpec, aligned
 // with parts[1:]) decides per position: TEXT skips classification,
 // PATH classifies even bare filenames, null falls back to the shape
-// heuristics.
+// heuristics. wordBases, also aligned with parts[1:], names the
+// directory a word resolves against when a chdir option (tar's -C)
+// moved it; null there means the cwd.
 export function classifyParts(
   parts: string[],
   registry: MountRegistry,
   cwd: string,
   wordKinds: readonly (ValueType | null)[] | null = null,
+  wordBases: readonly (string | null)[] | null = null,
 ): (string | PathSpec)[] {
   if (parts.length === 0) return []
   const result: (string | PathSpec)[] = [parts[0] ?? '']
@@ -35,12 +38,14 @@ export function classifyParts(
     const w = parts[i]
     if (w === undefined) continue
     const kind = wordKinds !== null ? (wordKinds[i - 1] ?? null) : null
+    const base = wordBases !== null ? (wordBases[i - 1] ?? null) : null
+    const here = base ?? cwd
     if (kind !== null && kind !== 'path') {
       result.push(w)
     } else if (kind === 'path') {
-      result.push(classifyBarePath(w, registry, cwd))
+      result.push(classifyBarePath(w, registry, here))
     } else {
-      result.push(classifyWord(w, registry, cwd))
+      result.push(classifyWord(w, registry, here))
     }
   }
   return result

--- a/typescript/packages/core/src/workspace/expand/spec_hints.ts
+++ b/typescript/packages/core/src/workspace/expand/spec_hints.ts
@@ -49,3 +49,18 @@ export function specWordKinds(spec: CommandSpec, argv: readonly string[]): (Valu
   }
   return kinds
 }
+
+// Per-position base directories for a spec that declares one. tar's -C
+// is a chdir for the operands typed after it, so those words are not
+// relative to the session cwd at all. The parser already walks the line
+// positionally, so it is what says where each word stood; this asks it,
+// and only for the one command family that can answer (null everywhere
+// else, so 92 of 93 specs pay nothing).
+export function specWordBases(
+  spec: CommandSpec,
+  argv: readonly string[],
+  cwd: string,
+): (string | null)[] | null {
+  if (spec.operandBase === null) return null
+  return [...parseCommand(spec, [...argv], cwd).wordBases]
+}

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -22,7 +22,7 @@ import type {
   RegisteredCommand,
 } from '../../commands/config.ts'
 import type { OpKwargs } from '../../ops/registry.ts'
-import type { LinkView, StatOverlay, StatPath } from '../../ops/types.ts'
+import type { LinkView, MountView, StatOverlay, StatPath } from '../../ops/types.ts'
 
 const NOOP_ACCESSOR = new NOOPAccessor()
 import { getExtension } from '../../commands/resolve.ts'
@@ -392,6 +392,7 @@ export class MountEntry {
       statOverlay?: StatOverlay
       links?: LinkView
       statPath?: StatPath
+      mounts?: MountView
       signal?: AbortSignal
       limitOverride?: Limit | null
     } = {},
@@ -447,6 +448,7 @@ export class MountEntry {
       ...(opts.statOverlay !== undefined ? { statOverlay: opts.statOverlay } : {}),
       ...(opts.links !== undefined ? { links: opts.links } : {}),
       ...(opts.statPath !== undefined ? { statPath: opts.statPath } : {}),
+      ...(opts.mounts !== undefined ? { mounts: opts.mounts } : {}),
     }
 
     return runWithMountPrefix(mountPrefix, () =>

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -37,7 +37,7 @@ import { expandArgv } from '../expand/argv.ts'
 import { type ExecuteFn, expandNode } from '../expand/node.ts'
 import type { TSNodeLike } from '../../shell/types.ts'
 import { handleCommand } from '../executor/command.ts'
-import { pathFlagScopes } from '../executor/command/routing.ts'
+import { pathFlagScopes, positionalScopes } from '../executor/command/routing.ts'
 import { runWithTimeout } from '../../commands/builtin/utils/limit.ts'
 import { resolveLimit } from '../../policy/index.ts'
 import { BreakSignal, ContinueSignal } from '../executor/control.ts'
@@ -421,6 +421,7 @@ async function runArgv(
     const deny = await registry.policies.preCommand({
       command: name,
       paths: scopes,
+      operands: positionalScopes(name, args, session.cwd, operands),
       argv: args,
       cwd: session.cwd,
       registry,

--- a/typescript/packages/core/src/workspace/route/constants.ts
+++ b/typescript/packages/core/src/workspace/route/constants.ts
@@ -66,6 +66,14 @@ export const JOB_BUILTINS: ReadonlySet<string> = new Set(['wait', 'fg', 'kill', 
 // `stat`, `file` and `du` are here because GNU lstats for all three,
 // but each takes -L to dereference after all, which `dereferences`
 // reads back out of the command line.
+//
+// `tar` and `zip` are here for a different reason and deliberately
+// carry no DEREFERENCE_FLAGS entry: they dereference too, but their
+// planner has to be the one doing it. Rewriting the operand up here
+// would hand the planner a target it can no longer tell was reached
+// through a link, so `tar` could not store a symlink member at all and
+// neither archiver could apply its own cross-mount refusal or ELOOP
+// wording. tar's -h and zip's -y are read by the planner instead.
 export const NO_FOLLOW_COMMANDS: ReadonlySet<string> = new Set([
   'rm',
   'mv',
@@ -77,6 +85,8 @@ export const NO_FOLLOW_COMMANDS: ReadonlySet<string> = new Set([
   'file',
   'du',
   'find',
+  'tar',
+  'zip',
 ])
 
 // Per-command flags that turn a no-follow command back into a

--- a/typescript/scripts/gen-specs.ts
+++ b/typescript/scripts/gen-specs.ts
@@ -22,6 +22,8 @@ import * as Node from '@struktoai/mirage-node'
 
 import type { CommandSpec, Operand, Option, RegisteredCommand } from '@struktoai/mirage-core'
 
+const { CommandSpec: SpecClass, Operand: OperandClass, Option: OptionClass } = Core
+
 const __dirname = resolve(fileURLToPath(import.meta.url), '..')
 const SPEC_ROOT = resolve(__dirname, '..', '..', 'spec', 'typescript')
 const PACKAGES = resolve(__dirname, '..', 'packages')
@@ -143,11 +145,36 @@ function metaFor(rcs: RegisteredCommand[]): Record<string, unknown> {
   }
 }
 
-function serializeOperand(op: Operand): Record<string, unknown> {
+// A spec dump is a cross-language contract, and restating every default
+// in all 93 files buries the handful of facts each command actually
+// declares. Anything equal to what a default-constructed instance would
+// have carried is dropped, so the defaults come from the class rather
+// than a table that could drift from it. `type` survives even at its
+// default, because what a token *is* is the first thing a reader looks
+// for. Python's `_prune` does the same against its dataclass fields; the
+// two must drop exactly the same keys or the parity gate reports every
+// command.
+function prune(
+  full: Record<string, unknown>,
+  defaults: Record<string, unknown>,
+): Record<string, unknown> {
+  const kept: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(full)) {
+    if (key !== 'type' && JSON.stringify(value) === JSON.stringify(defaults[key])) continue
+    kept[key] = value
+  }
+  return kept
+}
+
+function operandFields(op: Operand): Record<string, unknown> {
   return { provided_by: [...op.providedBy], text_when: [...op.textWhen], type: op.type }
 }
 
-function serializeOption(o: Option): Record<string, unknown> {
+function serializeOperand(op: Operand): Record<string, unknown> {
+  return prune(operandFields(op), operandFields(new OperandClass({})))
+}
+
+function optionFields(o: Option): Record<string, unknown> {
   return {
     choices: o.choices,
     count: o.count,
@@ -165,9 +192,12 @@ function serializeOption(o: Option): Record<string, unknown> {
   }
 }
 
-function serializeSpec(spec: CommandSpec, rcs: RegisteredCommand[]): Record<string, unknown> {
+function serializeOption(o: Option): Record<string, unknown> {
+  return prune(optionFields(o), optionFields(new OptionClass({})))
+}
+
+function specFields(spec: CommandSpec): Record<string, unknown> {
   return {
-    _meta: metaFor(rcs),
     description: spec.description,
     epilog: spec.epilog,
     ignore_tokens: [...spec.ignoreTokens].sort(),
@@ -176,6 +206,13 @@ function serializeSpec(spec: CommandSpec, rcs: RegisteredCommand[]): Record<stri
     options: spec.options.map(serializeOption),
     positional: spec.positional.map(serializeOperand),
     rest: spec.rest === null ? null : serializeOperand(spec.rest),
+  }
+}
+
+function serializeSpec(spec: CommandSpec, rcs: RegisteredCommand[]): Record<string, unknown> {
+  return {
+    ...prune(specFields(spec), specFields(new SpecClass({}))),
+    _meta: metaFor(rcs),
   }
 }
 

--- a/typescript/scripts/gen-specs.ts
+++ b/typescript/scripts/gen-specs.ts
@@ -172,6 +172,7 @@ function serializeSpec(spec: CommandSpec, rcs: RegisteredCommand[]): Record<stri
     epilog: spec.epilog,
     ignore_tokens: [...spec.ignoreTokens].sort(),
     old_option_style: spec.oldOptionStyle,
+    operand_base: spec.operandBase,
     options: spec.options.map(serializeOption),
     positional: spec.positional.map(serializeOperand),
     rest: spec.rest === null ? null : serializeOperand(spec.rest),


### PR DESCRIPTION
Two reported `tar` bugs, plus the identical defect in `zip`.

## Bug 1: `tar -c` could not archive a directory

`tar -cf dir.tar d` exited 1 with `tar: <hostpath>/d: Is a directory`. Every operand went straight to `read_bytes`, with no isdir check and no recursion, so `tar -czf archive.tar.gz somedir/` (the most common tar invocation there is) could not work. Two further leaks in that one error: it printed the **host** path, breaking the sandbox illusion, and `Is a directory` is not something tar says.

`zip -r <dir>` had exactly the same defect (`zip: /data/d: No such file or directory`), since `zip_cmd` also read every operand with `read_bytes`.

Both now walk. Create is a two-phase pass in each: decide every member, then write. That ordering is what lets an exclusion prune a whole subtree and keeps the ordering stable, and it is why the two refusals that produce no archive can happen before anything is written.

An unreadable operand is now reported in virtual path space with the archiver's own wording, so a backend's raw `IsADirectoryError` can no longer reach the user.

## Bug 2: `tar -C` was ignored

`tar -czf /work/out1.tar.gz -C /work/check my_paper` failed as `tar: paths span multiple mounts (/, /work/), cross-mount not supported`, and `-C /work check/my_paper` said `No such file or directory` immediately after `ls -ld` had printed the directory. Same defect class as `unzip -p` in #725.

Fixed one layer lower than that one. `-C` is not a flag the command reads once, it is a chdir for the operands typed **after** it, and it is cumulative. That is a property of the line, so it is declared in the spec (`CommandSpec.operand_base`, tar's only) and resolved by the one component that walks the line positionally: the parser tracks the base as it scans and reports it per word, and the classifier resolves each operand against it. Doing it any later is too late, because the classifier has already produced absolute PathSpecs and the router sees a phantom mount span. `-f` still resolves against the session cwd, which is what GNU does.

## One traversal, two archivers

`scan_operand` / `scanOperand` (`generic/archive/walk.*`) is the whole of what tar and zip share. It merges three sources no single one can see:

- the backend walk, reusing find's `walk_find` / `walkFind`, so an entry is classified through `stat` and never by name;
- the namespace's symlinks, which no backend `readdir` reports;
- the mount table, since a nested mount's keys live in another resource entirely.

It reports **paths, never names**, because naming is exactly where the two formats part company. The two things they disagree about in the traversal itself are parameters, so a third archiver adds a caller rather than a second walk:

| | descends | symlink |
|---|---|---|
| `tar` | always | stored, unless `-h` |
| `zip` | only under `-r` | followed, unless `-y` |

A directory is its own member in both, so an empty one survives a round trip, and `tar -x` / `unzip` now `mkdir` for one.

## Mount boundaries

`MountView` is how a command sees them, offered the way `LinkView` is: name a `mounts` parameter, nothing else. A traversal that renders **lines** never needs it, because the executor's fan-out already reruns per mount and concatenates; one that emits a single **binary object** cannot be merged that way, which is why the archivers read the table themselves.

A descendant mount is not crossed. The mountpoint stays an entry and its contents are dropped with GNU's `--one-file-system` wording, because descending would archive by accident exactly what `MountRootPolicy` now refuses on purpose: a mount root in a **source** slot for `tar -c`, `zip` and `cp`. Only positional operands are tested, so `tar -xf a.tar -C /mnt` stays legal while `tar -cf a.tar /mnt` does not, and only create mode counts, so a `-t`/`-x` member selector is never treated as a path.

One consequence worth flagging: `cd /work && tar -czf ../x.tgz .` is now refused, since `.` resolves to the mount root.

## Semantics, pinned not guessed

Everything below was probed against GNU tar 1.35 and Info-ZIP 3.0 on `debian:stable-slim`.

tar: the leading-slash warning, `Cowardly refusing to create an empty archive` (exit 2), a per-operand `Cannot stat` plus one trailer (exit 2, the other operands still archive), a `-C` it cannot enter (exit 2, no archive written), `archive cannot contain itself; not dumped` (exit 0).

zip, whose defaults are tar's inverted twice over: a leading slash is stripped **in silence**, `-j` junks to the basename and drops directory entries entirely, `-x` is **anchored** on the whole stored name (`d/sub/*` matches, `sub/*` does not) where tar's `--exclude` is unanchored, an unreachable operand is `zip warning: name not matched:` and does not stop the run, and a run that matched nothing prints `zip error: Nothing to do!`, exits **12**, and writes no archive. `-q` silences the warnings but never that error.

Deliberate divergences, documented in place: siblings are sorted rather than emitted in readdir order (the same choice `du` already makes); `zip -x` takes one pattern per occurrence, since the spec has no variadic option value and `-x a -x b` says the same thing; and the `adding:` line carries no `(deflated N%)` suffix, since the ratio depends on the compressor and would differ between the two languages.

## Verified

- pre-commit clean and idempotent across two consecutive `--all-files` passes; spec drift none; spec parity 93/93.
- TS core 7005, node 2272, browser 182.
- Full Python suite: exit 0, no failures.
- integ, both languages, exact parity: ram 2328 / disk 2293 / redis 2186 each, 0 failures (plus opfs 2188, TS only). 13 new zip cases and 15 new tar cases.

The integ run earned its place: it caught a TS-only bug the unit tests could not. `walkFind` answers in mount-relative keys (it stands in for a backend find op) while Python's `walk_find` answers in virtual paths, so members came out mangled on any prefixed mount. The unit harness mounts at root, which is exactly why it could not see it; there is now a prefixed-mount test in both languages that fails without the lift.

---

## Second commit: the spec dumps state what a command declares

Unrelated to the archive fix, but the same files pushed me into it. Both generators emitted every field of every dataclass, so `truncate`, which declares one thing, spent 27 lines of spec body restating 21 defaults that read identically in all 93 files:

```json
{ "description": null, "epilog": null, "ignore_tokens": [],
  "old_option_style": false, "operand_base": null,
  "options": [ { "choices": [], "count": false, "default": null,
    "description": null, "long": "--size", "multiple": false,
    "numeric_shorthand": false, "pair": false, "required": false,
    "short": "-s", "short_value": true, "type": "str",
    "value_optional": false } ],
  "positional": [], "rest": { "provided_by": [], "text_when": [], "type": "path" } }
```

is now

```json
{ "options": [ { "long": "--size", "short": "-s", "type": "str" } ],
  "rest": { "type": "path" } }
```

`type` survives even at its default, because what a token is is the first thing a reader looks for. Defaults come from the dataclass fields in Python and from a default-constructed instance in TypeScript, not from a table either side could let drift.

This **narrows** the parity gate's blast radius rather than widening it. When `operand_base` was missing from `gen-specs.ts` earlier in this PR, Python emitted the key in all 93 files and TypeScript in none, so parity reported ~95 divergences to sift through. The same bug now reports one, on `tar`, the only command that sets it.

279 files, 22,113 lines of restated defaults gone. Regeneration verified idempotent; parity green.

---

## Fourth commit: the five findings from the Codex review

All five were real. Each was reproduced against a live workspace before anything changed, then pinned against GNU tar 1.35 and Info-ZIP 3.0 on `debian:stable-slim`.

**A symlink operand never reached the planner as a link.** `tar` and `zip` were absent from `NO_FOLLOW_COMMANDS`, so the router rewrote the operand through the link table first: `tar -cf o.tar link` stored a regular file holding the target's 6 bytes where GNU stores `lrwxrwxrwx link -> d/a.txt` at size 0. It also skipped the planner's cross-mount refusal, since by then there was no link left to refuse. Both archivers now lstat, and deliberately carry no `DEREFERENCE_FLAGS` entry: `-h` and `-y` are the planner's to read.

**Only the last `-C` was checked.** `tar -cf m.tar -C missing x -C good y.txt` reported `x: Cannot stat` and still wrote an archive holding `y.txt`, where GNU chdirs at each `-C` and dies at the first it cannot enter. The option accumulates now and the planner walks the list, so the first bad one is fatal and no members are written. Extraction still uses the last.

**Two links to one target were called a loop, and a real loop was not caught at all.** These turned out to be the same mistake: an operand-wide `seen` set doing detection that `namespace.follow` already does properly under a hop limit. Deleting it archives both names, as GNU and Info-ZIP do; catching the `CycleError` that `resolve` raises turns a genuine cycle into one fatal problem per member with GNU's `Too many levels of symbolic links`, keeping the directory entry and exiting 2 rather than throwing out of the planner for a bare exit 1.

**The mount-root refusal denied member selectors.** Under `-t` and `-x` an operand names something inside the archive, so `tar -tf a.tar data` was refused as busy when `data` happened to spell a mount. Gated on create mode now, GNU's dashless first word included.

One of my own tests asserted the loop bug rather than catching it. It is replaced.

Five integ cases cover all of it end to end in both languages. Counts after: ram 2328 / disk 2293 / redis 2186 each, plus opfs 2188, zero failures, exact parity. Full Python suite exit 0; TS core 7005, node 2272.

Unrelated gap the new coverage surfaced, pinned as observed rather than wished for: mirage's `tar -t` ignores member selectors and lists the whole archive, where GNU filters and says `Not found in archive`. Worth its own issue.
