### PR TITLE
feat(workspace): merge mount structure into the door's readdir and stat (R1)

### DIFF
--- a/integ/bash/history/view.json
+++ b/integ/bash/history/view.json
@@ -61,7 +61,7 @@
       "command": "ls /",
       "expect": {
         "exit": 0,
-        "stdout": "data\ndev",
+        "stdout": "data\ndev\n",
         "stderr": ""
       }
     },
@@ -74,7 +74,7 @@
       "command": "ls -a /",
       "expect": {
         "exit": 0,
-        "stdout": ".bash_history\ndata\ndev",
+        "stdout": ".bash_history\ndata\ndev\n",
         "stderr": ""
       }
     }

--- a/python/mirage/commands/builtin/generic/ls.py
+++ b/python/mirage/commands/builtin/generic/ls.py
@@ -323,9 +323,11 @@ async def probe_operand(
         index (IndexCacheStore): listing cache.
         links (LinkView | None): the namespace's symlink facts.
         child_mounts (ChildMounts | None): session-filtered child-mount
-            names. Withheld under ``-R``: the walk cannot descend into
-            another mount's backend, so the recursive listing is the
-            cross-mount fan-out's to assemble, one mount at a time.
+            names. Under ``-R`` a backend-served listing withholds the
+            merge and a child-mount root is never descended (the walk
+            cannot read another mount's backend, so the cross-mount
+            fan-out assembles those groups); a directory only the
+            namespace serves still renders its own group from it.
     """
     warnings: list[LsWarning] = []
     structure_only = False
@@ -338,8 +340,7 @@ async def probe_operand(
         link_row = _link_row(path, links)
         if link_row is not None:
             return Operand(path, link_row, []), warnings
-        if (recursive or child_mounts is None
-                or not child_mounts(path.virtual)):
+        if child_mounts is None or not child_mounts(path.virtual):
             warnings.append(
                 LsWarning(
                     f"ls: cannot access '{path.raw_path}': "
@@ -348,7 +349,10 @@ async def probe_operand(
         # No backend serves it, but the namespace owes it children (a
         # nested mount, a link's ancestors), so the door lists it as a
         # directory and ls must agree: the merge below renders those
-        # rows from an empty backend listing.
+        # rows from an empty backend listing. Under -R this group still
+        # renders; only descent into a child-mount root is withheld,
+        # because that listing is another backend's and the cross-mount
+        # fan-out assembles it.
         names = []
         structure_only = True
 
@@ -371,7 +375,8 @@ async def probe_operand(
         index=index,
         links=links,
         deref=deref,
-        child_mounts=None if recursive else child_mounts)
+        child_mounts=child_mounts if structure_only else
+        (None if recursive else child_mounts))
     warnings.extend(entry_ws)
     entries = sort_stats(entries, sort_by, reverse)
     groups: list[tuple[PathSpec, list[FileStat]]] = [(path, entries)]
@@ -379,8 +384,13 @@ async def probe_operand(
         for entry in entries:
             if entry.type != FileType.DIRECTORY:
                 continue
-            child, child_ws = await probe_operand(_child_spec(
-                path, entry.name),
+            child_path = _child_spec(path, entry.name)
+            if structure_only and (child_mounts is None
+                                   or not child_mounts(child_path.virtual)):
+                # A child-mount root: its listing is another backend's,
+                # so the cross-mount fan-out renders that group.
+                continue
+            child, child_ws = await probe_operand(child_path,
                                                   readdir=readdir,
                                                   stat=stat,
                                                   all_files=all_files,
@@ -390,7 +400,8 @@ async def probe_operand(
                                                   command_line_arg=False,
                                                   index=index,
                                                   links=links,
-                                                  deref=deref)
+                                                  deref=deref,
+                                                  child_mounts=child_mounts)
             groups.extend(child.groups)
             warnings.extend(child_ws)
     return Operand(path, None, groups), warnings
@@ -439,6 +450,12 @@ async def walk(
         try:
             listed = await stat(path, index)
         except (OSError, ValueError) as exc:
+            if child_mounts is not None and child_mounts(path.virtual):
+                # No backend serves it, but the namespace owes it
+                # children, so the door stats it as a directory and -d
+                # must print the same row.
+                return WalkResult(
+                    [FileStat(name=path.raw_path, type=FileType.DIRECTORY)])
             detail = fs_strerror(exc) or exc
             return WalkResult(warnings=[
                 LsWarning(f"ls: cannot access '{path.raw_path}': {detail}",
@@ -557,7 +574,8 @@ async def ls(
                                 list_dir=True,
                                 index=index,
                                 links=links,
-                                deref=deref)
+                                deref=deref,
+                                child_mounts=child_mounts)
             rows.extend(result.entries)
             warnings.extend(result.warnings)
         if len(rows) > 1:

--- a/python/mirage/commands/builtin/generic/ls.py
+++ b/python/mirage/commands/builtin/generic/ls.py
@@ -6,7 +6,7 @@ from mirage.commands.builtin.utils.formatting import format_ls_long
 from mirage.commands.builtin.utils.output import (format_optional_records,
                                                   format_records)
 from mirage.io.types import IOResult
-from mirage.ops.types import LinkView
+from mirage.ops.types import ChildMounts, LinkView
 from mirage.types import FileStat, FileType, LsSortBy, PathSpec
 from mirage.utils.errors import fs_strerror
 from mirage.utils.key_prefix import rekey
@@ -228,6 +228,7 @@ async def _stat_entries(
     index: IndexCacheStore,
     links: LinkView | None = None,
     deref: bool = False,
+    child_mounts: ChildMounts | None = None,
 ) -> tuple[list[FileStat], list[LsWarning]]:
     """Stat every name in a directory, plus the symlinks living there.
 
@@ -245,6 +246,10 @@ async def _stat_entries(
             name instead of the link row. A dereferenced directory link
             then carries FileType.DIRECTORY, which is what makes -R
             descend it.
+        child_mounts (ChildMounts | None): session-filtered child-mount
+            names under a directory. A nested mount is namespace
+            structure the backend readdir cannot name, merged here like
+            a link row.
     """
     stats: list[FileStat] = []
     warnings: list[LsWarning] = []
@@ -273,9 +278,18 @@ async def _stat_entries(
             continue
         if not all_files and link.name.startswith("."):
             continue
+        seen.add(link.name)
         resolved = (await _deref_entry(path, link, links, stat, index)
                     if deref and links is not None else None)
         stats.append(resolved if resolved is not None else link)
+    for name in (child_mounts(path.virtual)
+                 if child_mounts is not None else []):
+        if name in seen:
+            continue
+        if not all_files and name.startswith("."):
+            continue
+        seen.add(name)
+        stats.append(FileStat(name=name, type=FileType.DIRECTORY))
     return stats, warnings
 
 
@@ -292,6 +306,7 @@ async def probe_operand(
     index: IndexCacheStore = NULL_INDEX,
     links: LinkView | None = None,
     deref: bool = False,
+    child_mounts: ChildMounts | None = None,
 ) -> tuple[Operand, list[LsWarning]]:
     """List one operand and report whether it turned out to be a directory.
 
@@ -307,6 +322,10 @@ async def probe_operand(
             a failure to a minor problem (exit 1).
         index (IndexCacheStore): listing cache.
         links (LinkView | None): the namespace's symlink facts.
+        child_mounts (ChildMounts | None): session-filtered child-mount
+            names. Withheld under ``-R``: the walk cannot descend into
+            another mount's backend, so the recursive listing is the
+            cross-mount fan-out's to assemble, one mount at a time.
     """
     warnings: list[LsWarning] = []
     try:
@@ -335,13 +354,15 @@ async def probe_operand(
         if link_row is not None:
             return Operand(path, link_row, []), warnings
 
-    entries, entry_ws = await _stat_entries(path,
-                                            names,
-                                            stat=stat,
-                                            all_files=all_files,
-                                            index=index,
-                                            links=links,
-                                            deref=deref)
+    entries, entry_ws = await _stat_entries(
+        path,
+        names,
+        stat=stat,
+        all_files=all_files,
+        index=index,
+        links=links,
+        deref=deref,
+        child_mounts=None if recursive else child_mounts)
     warnings.extend(entry_ws)
     entries = sort_stats(entries, sort_by, reverse)
     groups: list[tuple[PathSpec, list[FileStat]]] = [(path, entries)]
@@ -380,6 +401,7 @@ async def walk(
     index: IndexCacheStore = NULL_INDEX,
     links: LinkView | None = None,
     deref: bool = False,
+    child_mounts: ChildMounts | None = None,
 ) -> WalkResult:
     """Flat listing for one operand: a directory's entries, or the operand
     itself when it is not one. ``recursive`` flattens the whole subtree in
@@ -398,6 +420,8 @@ async def walk(
             a failure to a minor problem (exit 1).
         index (IndexCacheStore): listing cache.
         links (LinkView | None): the namespace's symlink facts.
+        child_mounts (ChildMounts | None): session-filtered child-mount
+            names to merge into a directory listing.
     """
     if list_dir:
         link_row = _link_row(path, links)
@@ -425,7 +449,8 @@ async def walk(
                                             command_line_arg=command_line_arg,
                                             index=index,
                                             links=links,
-                                            deref=deref)
+                                            deref=deref,
+                                            child_mounts=child_mounts)
     if operand.row is not None:
         return WalkResult([operand.row], warnings)
     entries = [e for _, group in operand.groups for e in group]
@@ -507,6 +532,7 @@ async def ls(
     index: IndexCacheStore = NULL_INDEX,
     links: LinkView | None = None,
     deref: bool = False,
+    child_mounts: ChildMounts | None = None,
 ) -> tuple[bytes, IOResult]:
     results: list[str] = []
     warnings: list[LsWarning] = []
@@ -546,7 +572,8 @@ async def ls(
                                             recursive=recursive,
                                             index=index,
                                             links=links,
-                                            deref=deref)
+                                            deref=deref,
+                                            child_mounts=child_mounts)
         warnings.extend(p_ws)
         operands.append(operand)
     if len(operands) > 1:

--- a/python/mirage/commands/builtin/generic/ls.py
+++ b/python/mirage/commands/builtin/generic/ls.py
@@ -328,6 +328,7 @@ async def probe_operand(
             cross-mount fan-out's to assemble, one mount at a time.
     """
     warnings: list[LsWarning] = []
+    structure_only = False
     try:
         names = await readdir(path, index)
     except (OSError, ValueError) as exc:
@@ -337,13 +338,21 @@ async def probe_operand(
         link_row = _link_row(path, links)
         if link_row is not None:
             return Operand(path, link_row, []), warnings
-        warnings.append(
-            LsWarning(
-                f"ls: cannot access '{path.raw_path}': "
-                f"{fs_strerror(exc) or exc}", command_line_arg))
-        return Operand(path, None, []), warnings
+        if (recursive or child_mounts is None
+                or not child_mounts(path.virtual)):
+            warnings.append(
+                LsWarning(
+                    f"ls: cannot access '{path.raw_path}': "
+                    f"{fs_strerror(exc) or exc}", command_line_arg))
+            return Operand(path, None, []), warnings
+        # No backend serves it, but the namespace owes it children (a
+        # nested mount, a link's ancestors), so the door lists it as a
+        # directory and ls must agree: the merge below renders those
+        # rows from an empty backend listing.
+        names = []
+        structure_only = True
 
-    if not names:
+    if not names and not structure_only:
         row = await _file_entry(path, stat, index)
         if row is not None:
             return Operand(path, row, []), warnings

--- a/python/mirage/commands/builtin/generic_bind/builders/ls.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/ls.py
@@ -20,7 +20,7 @@ from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.builtin.generic_bind.adapter import (Builder, CommandIO,
                                                           overlaid_stat)
 from mirage.io.types import ByteSource, IOResult
-from mirage.ops.types import LinkView, StatOverlay
+from mirage.ops.types import ChildMounts, LinkView, StatOverlay
 from mirage.types import LsSortBy, PathSpec
 
 
@@ -46,6 +46,7 @@ async def ls(
     cwd: PathSpec | str = "/",
     stat_overlay: StatOverlay | None = None,
     links: LinkView | None = None,
+    child_mounts: ChildMounts | None = None,
     **kwargs,
 ) -> tuple[ByteSource | None, IOResult]:
     if not ops.is_mounted(accessor):
@@ -81,6 +82,7 @@ async def ls(
         index=index,
         links=links,
         deref=L,
+        child_mounts=child_mounts,
     )
 
 

--- a/python/mirage/context/__init__.py
+++ b/python/mirage/context/__init__.py
@@ -14,7 +14,7 @@
 
 from mirage.context.session_context import (assert_mount_allowed,
                                             effective_mount_mode,
-                                            get_current_session,
+                                            get_current_session, mount_allowed,
                                             reset_current_session,
                                             set_current_session)
 
@@ -22,6 +22,7 @@ __all__ = [
     "assert_mount_allowed",
     "effective_mount_mode",
     "get_current_session",
+    "mount_allowed",
     "reset_current_session",
     "set_current_session",
 ]

--- a/python/mirage/context/session_context.py
+++ b/python/mirage/context/session_context.py
@@ -62,6 +62,20 @@ def _session_mode(mount_prefix: str) -> "MountMode | None":
     return sess.mount_modes.get(_norm_prefix(mount_prefix))
 
 
+def mount_allowed(mount_prefix: str) -> bool:
+    """Whether the current session may touch this mount at all.
+
+    The non-raising twin of ``assert_mount_allowed``, for enumeration:
+    structure merges and fan-outs filter names through it, so a scoped
+    session never learns that an ungranted mount exists. True when no
+    session is bound or the session is unrestricted.
+
+    Args:
+        mount_prefix (str): the mount's prefix, e.g. ``/s3``.
+    """
+    return _session_mode(mount_prefix) is not None
+
+
 def assert_mount_allowed(mount_prefix: str) -> None:
     """Raise PermissionError if the current session may not touch this mount.
 

--- a/python/mirage/fuse/core.py
+++ b/python/mirage/fuse/core.py
@@ -73,12 +73,6 @@ class MountCore:
         self._session = session
         self._now = time.time_ns()
         self._root = root_prefix.rstrip("/")
-        # When scoped to a single mount, the root maps onto that mount and
-        # there are no virtual intermediate directories to synthesize.
-        if self._root:
-            self._prefixes: list[str] = []
-        else:
-            self._prefixes = self._ops.mount_prefixes()
         self._handles: dict[int, Handle] = {}
         # Prefetched content for size-unknown files: path -> (data, expiry).
         self._prefetch: dict[str, tuple[bytes, float]] = {}
@@ -242,24 +236,6 @@ class MountCore:
         entry["st_mode"] = stat.S_IFLNK | 0o777
         return entry
 
-    def _is_virtual_dir(self, path: str) -> bool:
-        normalized = path.rstrip("/") + "/"
-        for p in self._prefixes:
-            if p.startswith(normalized) or p.rstrip("/") == path.rstrip("/"):
-                return True
-        return False
-
-    def _virtual_children(self, path: str) -> list[str]:
-        normalized = path.rstrip("/") + "/" if path != "/" else "/"
-        children = set()
-        for p in self._prefixes:
-            if p.startswith(normalized) and p != normalized:
-                rest = p[len(normalized):]
-                child = rest.split("/")[0]
-                if child:
-                    children.add(child)
-        return sorted(children)
-
     def drain_ops(self) -> list[dict[str, Any]]:
         records = [asdict(r) for r in self._ops.records]
         self._ops.records.clear()
@@ -355,8 +331,6 @@ class MountCore:
         target = self.link_target(path)
         if target is not None:
             return self.link_stat(target)
-        if self._is_virtual_dir(path):
-            return self.dir_stat()
         s = self._run(self._ops.stat(self.resolve(path)))
         if s.type == FileType.DIRECTORY:
             return self._apply_stat_attrs(self.dir_stat(), s)
@@ -385,21 +359,16 @@ class MountCore:
         Raises:
             FileNotFoundError: no such directory and nothing virtual there.
         """
-        names = set(self._virtual_children(path))
-        links = self._ops.links
-        if links is not None:
-            for link_name in links.links_under(self.resolve(path)):
-                if link_name and not is_macos_metadata(link_name):
-                    names.add(link_name)
-        try:
-            entries = self._run(self._ops.readdir(self.resolve(path)))
-            for e in entries:
-                part = e.rstrip("/").rsplit("/", 1)[-1]
-                if part and not is_macos_metadata(part):
-                    names.add(part)
-        except (FileNotFoundError, ValueError, NotADirectoryError):
-            if not names:
-                raise
+        # The ops facade merges namespace structure (child mounts and
+        # symlinks) into readdir and answers structure-only directories
+        # itself, so the core only normalizes entry shapes and drops
+        # macOS metadata names.
+        names = set()
+        entries = self._run(self._ops.readdir(self.resolve(path)))
+        for e in entries:
+            part = e.rstrip("/").rsplit("/", 1)[-1]
+            if part and not is_macos_metadata(part):
+                names.add(part)
         return [".", ".."] + sorted(names)
 
     def read(self, path: str, size: int, offset: int, fh: int | None) -> bytes:

--- a/python/mirage/ops/config.py
+++ b/python/mirage/ops/config.py
@@ -63,12 +63,8 @@ class NamespaceLinks(Protocol):
         """
         ...
 
-    def links_under(self, directory: str) -> dict[str, str]:
-        """Link basename to target for entries directly under a directory.
-
-        Args:
-            directory (str): absolute virtual directory path.
-        """
+    def symlink_targets(self) -> dict[str, str]:
+        """Every link path to its stored target, the whole table."""
         ...
 
     def link_stat_at(self, path: str) -> FileStat | None:

--- a/python/mirage/ops/namespace_view.py
+++ b/python/mirage/ops/namespace_view.py
@@ -17,11 +17,7 @@ from collections.abc import Iterable
 from mirage.context import mount_allowed
 from mirage.ops.config import NamespaceLinks
 from mirage.types import FileStat, FileType
-
-
-def _norm_dir(path: str) -> str:
-    stripped = path.strip("/")
-    return "/" + stripped + "/" if stripped else "/"
+from mirage.utils.path import norm_dir
 
 
 def child_mount_names(prefixes: Iterable[str], parent: str) -> list[str]:
@@ -37,10 +33,10 @@ def child_mount_names(prefixes: Iterable[str], parent: str) -> list[str]:
         prefixes (Iterable[str]): the mount prefixes to derive from.
         parent (str): directory whose child mounts to enumerate.
     """
-    norm = _norm_dir(parent)
+    norm = norm_dir(parent)
     out: set[str] = set()
     for prefix in prefixes:
-        p = _norm_dir(prefix)
+        p = norm_dir(prefix)
         if p == norm or not p.startswith(norm):
             continue
         name = p[len(norm):].split("/", 1)[0]
@@ -66,7 +62,7 @@ def _link_allowed(prefixes: Iterable[str], link: str) -> bool:
     """
     owner = ""
     for prefix in prefixes:
-        p = _norm_dir(prefix)
+        p = norm_dir(prefix)
         if (link + "/").startswith(p) and len(p) > len(owner):
             owner = p
     return owner == "" or mount_allowed(owner)
@@ -91,7 +87,7 @@ def _link_names(prefixes: Iterable[str], links: NamespaceLinks | None,
     """
     if links is None:
         return []
-    norm = _norm_dir(parent)
+    norm = norm_dir(parent)
     out: set[str] = set()
     for link in links.symlink_targets():
         if not link.startswith(norm):
@@ -102,7 +98,7 @@ def _link_names(prefixes: Iterable[str], links: NamespaceLinks | None,
     return sorted(out)
 
 
-def structure_names(prefixes: Iterable[str], links: NamespaceLinks | None,
+def namespace_names(prefixes: Iterable[str], links: NamespaceLinks | None,
                     parent: str) -> list[str]:
     """Every child segment the namespace owes ``parent``: mounts + links.
 
@@ -141,7 +137,7 @@ def merge_readdir(entries: list[str], prefixes: Iterable[str],
     present = {e.rstrip("/").rsplit("/", 1)[-1] for e in entries}
     base = parent.rstrip("/")
     merged = list(entries)
-    for name in structure_names(prefixes, links, parent):
+    for name in namespace_names(prefixes, links, parent):
         if name in present:
             continue
         present.add(name)
@@ -149,7 +145,7 @@ def merge_readdir(entries: list[str], prefixes: Iterable[str],
     return merged
 
 
-def structure_listing(prefixes: Iterable[str], links: NamespaceLinks | None,
+def namespace_listing(prefixes: Iterable[str], links: NamespaceLinks | None,
                       parent: str) -> list[str] | None:
     """A listing for a directory that exists only as namespace structure.
 
@@ -163,12 +159,12 @@ def structure_listing(prefixes: Iterable[str], links: NamespaceLinks | None,
         links (NamespaceLinks | None): the namespace symlink table.
         parent (str): the directory that was listed, as a virtual path.
     """
-    if not structure_names(prefixes, links, parent):
+    if not namespace_names(prefixes, links, parent):
         return None
     return merge_readdir([], prefixes, links, parent)
 
 
-def structure_stat(prefixes: Iterable[str], links: NamespaceLinks | None,
+def namespace_stat(prefixes: Iterable[str], links: NamespaceLinks | None,
                    path: str) -> FileStat | None:
     """A directory stat for a path that exists only as namespace structure.
 
@@ -181,7 +177,7 @@ def structure_stat(prefixes: Iterable[str], links: NamespaceLinks | None,
         links (NamespaceLinks | None): the namespace symlink table.
         path (str): the path that was statted, as a virtual path.
     """
-    if structure_listing(prefixes, links, path) is None:
+    if namespace_listing(prefixes, links, path) is None:
         return None
     name = path.rstrip("/").rsplit("/", 1)[-1] or "/"
     return FileStat(name=name, type=FileType.DIRECTORY)

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -21,7 +21,8 @@ from mirage.accessor.base import Accessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.utils.limit import apply_op_limit
 from mirage.commands.resolve import COMPOUND_EXTENSIONS
-from mirage.context import assert_mount_allowed, effective_mount_mode
+from mirage.context import (assert_mount_allowed, effective_mount_mode,
+                            mount_allowed)
 from mirage.observe import OpRecord
 from mirage.observe.context import push_mount_prefix
 from mirage.ops.config import (NO_FOLLOW_OPS, STAMP_WRITE_OPS, NamespaceLinks,
@@ -222,6 +223,32 @@ class Ops:
             return structure_stat(self.mount_prefixes(), self._links, path)
         return None
 
+    async def _gated_structure(self, op: str, path: str, write: bool,
+                               fallback: "list[str] | FileStat"):
+        """Gate a namespace-served answer exactly like a backend one.
+
+        Mirrors the workspace dispatcher: no owning prefix (the gates
+        see ""), but admission still fires so a policy that bounds
+        readdir or stat by path covers the synthetic answer too.
+
+        Args:
+            op (str): the op name.
+            path (str): the virtual path being answered.
+            write (bool): whether the op is a write for policy admission.
+            fallback (list[str] | FileStat): the structure answer.
+        """
+        if self._policies is None:
+            return fallback
+        scope = PathSpec(virtual=path,
+                         directory=path.rsplit("/", 1)[0] or "/",
+                         resource_path="")
+        await pre_ops_gate(self._policies, op, scope, write, "")
+        bound = await post_ops_gate(self._policies, op, scope, write, "",
+                                    fallback)
+        if bound is not None:
+            return await apply_op_limit(fallback, bound)
+        return fallback
+
     async def _call(self,
                     op: str,
                     path: str,
@@ -235,24 +262,22 @@ class Ops:
             resource_type, rel_path, accessor, index, mode = self._resolve(
                 path)
         except ValueError:
-            # Mirrors the workspace dispatcher: no owning prefix (the
-            # gates see ""), but admission still fires so a policy that
-            # bounds readdir or stat by path covers the synthetic
-            # answer too.
             fallback = self._structure_result(op, path)
             if fallback is None:
                 raise
-            if self._policies is not None:
-                scope = PathSpec(virtual=path,
-                                 directory=path.rsplit("/", 1)[0] or "/",
-                                 resource_path="")
-                await pre_ops_gate(self._policies, op, scope, write, "")
-                bound = await post_ops_gate(self._policies, op, scope, write,
-                                            "", fallback)
-                if bound is not None:
-                    fallback = await apply_op_limit(fallback, bound)
-            return fallback
+            return await self._gated_structure(op, path, write, fallback)
         mount_prefix = self._mount_prefix(path)
+        if not mount_allowed(mount_prefix):
+            # The mount is real but ungranted, and the namespace may
+            # still owe the session a directory here: a granted mount
+            # below it already put this path's name in a listing, so
+            # walking down to the grant must answer. The names are
+            # session-filtered, so nothing of the mount's own content
+            # leaks; a path the structure does not owe falls through to
+            # the canonical denial below.
+            fallback = self._structure_result(op, path)
+            if fallback is not None:
+                return await self._gated_structure(op, path, write, fallback)
         assert_mount_allowed(mount_prefix)
         if write and effective_mount_mode(mount_prefix,
                                           mode) == MountMode.READ:

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -235,9 +235,22 @@ class Ops:
             resource_type, rel_path, accessor, index, mode = self._resolve(
                 path)
         except ValueError:
+            # Mirrors the workspace dispatcher: no owning prefix (the
+            # gates see ""), but admission still fires so a policy that
+            # bounds readdir or stat by path covers the synthetic
+            # answer too.
             fallback = self._structure_result(op, path)
             if fallback is None:
                 raise
+            if self._policies is not None:
+                scope = PathSpec(virtual=path,
+                                 directory=path.rsplit("/", 1)[0] or "/",
+                                 resource_path="")
+                await pre_ops_gate(self._policies, op, scope, write, "")
+                bound = await post_ops_gate(self._policies, op, scope, write,
+                                            "", fallback)
+                if bound is not None:
+                    fallback = await apply_op_limit(fallback, bound)
             return fallback
         mount_prefix = self._mount_prefix(path)
         assert_mount_allowed(mount_prefix)

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -27,6 +27,8 @@ from mirage.observe.context import push_mount_prefix
 from mirage.ops.config import (NO_FOLLOW_OPS, STAMP_WRITE_OPS, NamespaceLinks,
                                OpsMount)
 from mirage.ops.registry import OpsRegistry, RegisteredOp
+from mirage.ops.structure import (merge_readdir, structure_listing,
+                                  structure_stat)
 from mirage.ops.types import StatOverlay
 from mirage.policy import Policies, post_ops_gate, pre_ops_gate
 from mirage.types import FileStat, MountMode, PathSpec
@@ -201,6 +203,25 @@ class Ops:
         if self._on_write is not None:
             await self._on_write(path, observed)
 
+    def _structure_result(self, op: str,
+                          path: str) -> "list[str] | FileStat | None":
+        """The namespace's own answer for a path no backend serves.
+
+        Mirrors the workspace dispatcher: a directory that exists only
+        because a mount or a link sits below it still lists and stats,
+        so FUSE and programmatic callers agree with the shell. None for
+        any other op, or when the namespace knows nothing at ``path``.
+
+        Args:
+            op (str): the op name.
+            path (str): the virtual path being answered.
+        """
+        if op == "readdir":
+            return structure_listing(self.mount_prefixes(), self._links, path)
+        if op == "stat":
+            return structure_stat(self.mount_prefixes(), self._links, path)
+        return None
+
     async def _call(self,
                     op: str,
                     path: str,
@@ -210,7 +231,14 @@ class Ops:
         start = int(time.monotonic() * 1000)
         if self._links is not None and op not in NO_FOLLOW_OPS:
             path = self._links.follow(path)
-        resource_type, rel_path, accessor, index, mode = self._resolve(path)
+        try:
+            resource_type, rel_path, accessor, index, mode = self._resolve(
+                path)
+        except ValueError:
+            fallback = self._structure_result(op, path)
+            if fallback is None:
+                raise
+            return fallback
         mount_prefix = self._mount_prefix(path)
         assert_mount_allowed(mount_prefix)
         if write and effective_mount_mode(mount_prefix,
@@ -234,8 +262,15 @@ class Ops:
                                                filetype=filetype,
                                                index=index,
                                                **kwargs)
+        except FileNotFoundError:
+            result = self._structure_result(op, path)
+            if result is None:
+                raise
         finally:
             push_mount_prefix(prev_prefix)
+        if op == "readdir":
+            result = merge_readdir(result, self.mount_prefixes(), self._links,
+                                   path)
         if isinstance(result, (bytes, bytearray)):
             nbytes = len(result)
         else:

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -27,9 +27,9 @@ from mirage.observe import OpRecord
 from mirage.observe.context import push_mount_prefix
 from mirage.ops.config import (NO_FOLLOW_OPS, STAMP_WRITE_OPS, NamespaceLinks,
                                OpsMount)
+from mirage.ops.namespace_view import (merge_readdir, namespace_listing,
+                                       namespace_stat)
 from mirage.ops.registry import OpsRegistry, RegisteredOp
-from mirage.ops.structure import (merge_readdir, structure_listing,
-                                  structure_stat)
 from mirage.ops.types import StatOverlay
 from mirage.policy import Policies, post_ops_gate, pre_ops_gate
 from mirage.types import FileStat, MountMode, PathSpec
@@ -204,7 +204,7 @@ class Ops:
         if self._on_write is not None:
             await self._on_write(path, observed)
 
-    def _structure_result(self, op: str,
+    def _namespace_result(self, op: str,
                           path: str) -> "list[str] | FileStat | None":
         """The namespace's own answer for a path no backend serves.
 
@@ -218,12 +218,12 @@ class Ops:
             path (str): the virtual path being answered.
         """
         if op == "readdir":
-            return structure_listing(self.mount_prefixes(), self._links, path)
+            return namespace_listing(self.mount_prefixes(), self._links, path)
         if op == "stat":
-            return structure_stat(self.mount_prefixes(), self._links, path)
+            return namespace_stat(self.mount_prefixes(), self._links, path)
         return None
 
-    async def _gated_structure(self, op: str, path: str, write: bool,
+    async def _gated_namespace(self, op: str, path: str, write: bool,
                                fallback: "list[str] | FileStat"):
         """Gate a namespace-served answer exactly like a backend one.
 
@@ -235,7 +235,7 @@ class Ops:
             op (str): the op name.
             path (str): the virtual path being answered.
             write (bool): whether the op is a write for policy admission.
-            fallback (list[str] | FileStat): the structure answer.
+            fallback (list[str] | FileStat): the namespace's answer.
         """
         if self._policies is None:
             return fallback
@@ -262,10 +262,10 @@ class Ops:
             resource_type, rel_path, accessor, index, mode = self._resolve(
                 path)
         except ValueError:
-            fallback = self._structure_result(op, path)
+            fallback = self._namespace_result(op, path)
             if fallback is None:
                 raise
-            return await self._gated_structure(op, path, write, fallback)
+            return await self._gated_namespace(op, path, write, fallback)
         mount_prefix = self._mount_prefix(path)
         if not mount_allowed(mount_prefix):
             # The mount is real but ungranted, and the namespace may
@@ -275,9 +275,9 @@ class Ops:
             # session-filtered, so nothing of the mount's own content
             # leaks; a path the structure does not owe falls through to
             # the canonical denial below.
-            fallback = self._structure_result(op, path)
+            fallback = self._namespace_result(op, path)
             if fallback is not None:
-                return await self._gated_structure(op, path, write, fallback)
+                return await self._gated_namespace(op, path, write, fallback)
         assert_mount_allowed(mount_prefix)
         if write and effective_mount_mode(mount_prefix,
                                           mode) == MountMode.READ:
@@ -301,7 +301,7 @@ class Ops:
                                                index=index,
                                                **kwargs)
         except FileNotFoundError:
-            result = self._structure_result(op, path)
+            result = self._namespace_result(op, path)
             if result is None:
                 raise
         finally:

--- a/python/mirage/ops/structure.py
+++ b/python/mirage/ops/structure.py
@@ -51,9 +51,47 @@ def child_mount_names(prefixes: Iterable[str], parent: str) -> list[str]:
 
 
 def _link_names(links: NamespaceLinks | None, parent: str) -> list[str]:
+    """Immediate child segments owed to links at or below ``parent``.
+
+    Derived from every link path, not just direct children, exactly as
+    mount prefixes are: ``ln`` allows a link below a directory chain no
+    backend serves, and without its ancestors synthesized the link
+    lists at its own parent yet is unreachable from a walk above it.
+
+    Args:
+        links (NamespaceLinks | None): the namespace symlink table.
+        parent (str): directory whose child segments to enumerate.
+    """
     if links is None:
         return []
-    return [name for name in links.links_under(parent) if name]
+    norm = _norm_dir(parent)
+    out: set[str] = set()
+    for link in links.symlink_targets():
+        if not link.startswith(norm):
+            continue
+        name = link[len(norm):].split("/", 1)[0]
+        if name:
+            out.add(name)
+    return sorted(out)
+
+
+def structure_names(prefixes: Iterable[str], links: NamespaceLinks | None,
+                    parent: str) -> list[str]:
+    """Every child segment the namespace owes ``parent``: mounts + links.
+
+    The one union both consumers derive from: the door merges these
+    names into its readdir and the ``child_mounts`` fact offers them to
+    listing commands, so the shell and the ops surface cannot disagree
+    about what a directory holds.
+
+    Args:
+        prefixes (Iterable[str]): the mount prefixes to derive from.
+        links (NamespaceLinks | None): the namespace symlink table.
+        parent (str): directory whose child segments to enumerate.
+    """
+    return sorted(
+        set(child_mount_names(prefixes, parent))
+        | set(_link_names(links, parent)))
 
 
 def merge_readdir(entries: list[str], prefixes: Iterable[str],
@@ -76,8 +114,7 @@ def merge_readdir(entries: list[str], prefixes: Iterable[str],
     present = {e.rstrip("/").rsplit("/", 1)[-1] for e in entries}
     base = parent.rstrip("/")
     merged = list(entries)
-    for name in child_mount_names(prefixes, parent) + _link_names(
-            links, parent):
+    for name in structure_names(prefixes, links, parent):
         if name in present:
             continue
         present.add(name)
@@ -99,8 +136,7 @@ def structure_listing(prefixes: Iterable[str], links: NamespaceLinks | None,
         links (NamespaceLinks | None): the namespace symlink table.
         parent (str): the directory that was listed, as a virtual path.
     """
-    if not child_mount_names(prefixes, parent) and not _link_names(
-            links, parent):
+    if not structure_names(prefixes, links, parent):
         return None
     return merge_readdir([], prefixes, links, parent)
 

--- a/python/mirage/ops/structure.py
+++ b/python/mirage/ops/structure.py
@@ -1,0 +1,124 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import Iterable
+
+from mirage.context import mount_allowed
+from mirage.ops.config import NamespaceLinks
+from mirage.types import FileStat, FileType
+
+
+def _norm_dir(path: str) -> str:
+    stripped = path.strip("/")
+    return "/" + stripped + "/" if stripped else "/"
+
+
+def child_mount_names(prefixes: Iterable[str], parent: str) -> list[str]:
+    """Immediate child segments of mounts strictly under ``parent``.
+
+    Session-filtered: a child name appears only when some mount whose
+    prefix runs through it is visible to the current session, so a
+    scoped session never learns an ungranted mount's name from a
+    listing. Hidden names (leading dot) are included; presentation
+    filtering is the consumer's job, exactly as for backend entries.
+
+    Args:
+        prefixes (Iterable[str]): the mount prefixes to derive from.
+        parent (str): directory whose child mounts to enumerate.
+    """
+    norm = _norm_dir(parent)
+    out: set[str] = set()
+    for prefix in prefixes:
+        p = _norm_dir(prefix)
+        if p == norm or not p.startswith(norm):
+            continue
+        name = p[len(norm):].split("/", 1)[0]
+        if not name or not mount_allowed(p):
+            continue
+        out.add(name)
+    return sorted(out)
+
+
+def _link_names(links: NamespaceLinks | None, parent: str) -> list[str]:
+    if links is None:
+        return []
+    return [name for name in links.links_under(parent) if name]
+
+
+def merge_readdir(entries: list[str], prefixes: Iterable[str],
+                  links: NamespaceLinks | None, parent: str) -> list[str]:
+    """Merge namespace structure into a backend readdir listing.
+
+    Child mounts and symlinks are namespace state no backend can see,
+    so a listing that stops at one backend misses both. Merged names are
+    appended as virtual paths (the shape RAM-style backends already
+    emit); deduplication is by final path segment because backends
+    disagree on entry shape (bare names, trailing-slash names, full
+    paths).
+
+    Args:
+        entries (list[str]): the backend's own listing.
+        prefixes (Iterable[str]): the mount prefixes to derive from.
+        links (NamespaceLinks | None): the namespace symlink table.
+        parent (str): the directory that was listed, as a virtual path.
+    """
+    present = {e.rstrip("/").rsplit("/", 1)[-1] for e in entries}
+    base = parent.rstrip("/")
+    merged = list(entries)
+    for name in child_mount_names(prefixes, parent) + _link_names(
+            links, parent):
+        if name in present:
+            continue
+        present.add(name)
+        merged.append(f"{base}/{name}")
+    return merged
+
+
+def structure_listing(prefixes: Iterable[str], links: NamespaceLinks | None,
+                      parent: str) -> list[str] | None:
+    """A listing for a directory that exists only as namespace structure.
+
+    ``/data/x`` exists when a mount sits at ``/data/x/y`` or a link
+    lives directly under it, even though the ``/data`` backend holds
+    nothing at ``/x``. None when the namespace knows nothing there
+    either, so a caller re-raises the backend's miss.
+
+    Args:
+        prefixes (Iterable[str]): the mount prefixes to derive from.
+        links (NamespaceLinks | None): the namespace symlink table.
+        parent (str): the directory that was listed, as a virtual path.
+    """
+    if not child_mount_names(prefixes, parent) and not _link_names(
+            links, parent):
+        return None
+    return merge_readdir([], prefixes, links, parent)
+
+
+def structure_stat(prefixes: Iterable[str], links: NamespaceLinks | None,
+                   path: str) -> FileStat | None:
+    """A directory stat for a path that exists only as namespace structure.
+
+    The listing and the stat must agree: a directory ``readdir`` can
+    serve (because a mount or a link sits below it) must stat as a
+    directory, or ``os.walk`` and ``Path.is_dir`` break on it.
+
+    Args:
+        prefixes (Iterable[str]): the mount prefixes to derive from.
+        links (NamespaceLinks | None): the namespace symlink table.
+        path (str): the path that was statted, as a virtual path.
+    """
+    if structure_listing(prefixes, links, path) is None:
+        return None
+    name = path.rstrip("/").rsplit("/", 1)[-1] or "/"
+    return FileStat(name=name, type=FileType.DIRECTORY)

--- a/python/mirage/ops/structure.py
+++ b/python/mirage/ops/structure.py
@@ -50,15 +50,42 @@ def child_mount_names(prefixes: Iterable[str], parent: str) -> list[str]:
     return sorted(out)
 
 
-def _link_names(links: NamespaceLinks | None, parent: str) -> list[str]:
+def _link_allowed(prefixes: Iterable[str], link: str) -> bool:
+    """Whether the current session may see the link at ``link``.
+
+    A link is namespace state, but its path lies on some mount's turf:
+    the longest mount prefix above it owns it, the same longest-match
+    rule dispatch resolves the path by. A scoped session that may not
+    touch that mount must not learn the link's name from a listing,
+    exactly as ``child_mount_names`` hides the mount itself. A link
+    above every mount is bare namespace structure and stays visible.
+
+    Args:
+        prefixes (Iterable[str]): the mount prefixes to derive from.
+        link (str): the link's virtual path.
+    """
+    owner = ""
+    for prefix in prefixes:
+        p = _norm_dir(prefix)
+        if (link + "/").startswith(p) and len(p) > len(owner):
+            owner = p
+    return owner == "" or mount_allowed(owner)
+
+
+def _link_names(prefixes: Iterable[str], links: NamespaceLinks | None,
+                parent: str) -> list[str]:
     """Immediate child segments owed to links at or below ``parent``.
 
     Derived from every link path, not just direct children, exactly as
     mount prefixes are: ``ln`` allows a link below a directory chain no
     backend serves, and without its ancestors synthesized the link
     lists at its own parent yet is unreachable from a walk above it.
+    Session-filtered through ``_link_allowed``: a link below an
+    ungranted mount would otherwise leak that mount's name into a
+    listing ``child_mount_names`` had already filtered.
 
     Args:
+        prefixes (Iterable[str]): the mount prefixes to derive from.
         links (NamespaceLinks | None): the namespace symlink table.
         parent (str): directory whose child segments to enumerate.
     """
@@ -70,7 +97,7 @@ def _link_names(links: NamespaceLinks | None, parent: str) -> list[str]:
         if not link.startswith(norm):
             continue
         name = link[len(norm):].split("/", 1)[0]
-        if name:
+        if name and _link_allowed(prefixes, link):
             out.add(name)
     return sorted(out)
 
@@ -91,7 +118,7 @@ def structure_names(prefixes: Iterable[str], links: NamespaceLinks | None,
     """
     return sorted(
         set(child_mount_names(prefixes, parent))
-        | set(_link_names(links, parent)))
+        | set(_link_names(prefixes, links, parent)))
 
 
 def merge_readdir(entries: list[str], prefixes: Iterable[str],

--- a/python/mirage/ops/types.py
+++ b/python/mirage/ops/types.py
@@ -42,6 +42,12 @@ LinkResolve = Callable[[str], str]
 LinkExists = Callable[[str], Awaitable[bool]]
 # The stat of what a link points at, None when it dangles or loops.
 LinkTargetStat = Callable[[str], Awaitable["FileStat | None"]]
+# Immediate child-mount names under a directory, session-filtered. The
+# other half of namespace structure beside links: a nested mount is
+# invisible to the parent mount's backend, so a listing command is
+# handed the names from above, the same names the door merges into its
+# own readdir.
+ChildMounts = Callable[[str], list[str]]
 
 
 @dataclass(frozen=True)

--- a/python/mirage/runtime/wasm/vfs.py
+++ b/python/mirage/runtime/wasm/vfs.py
@@ -261,6 +261,13 @@ class WasmVFS:
         return sorted(entries.items())
 
     def _readdir_root(self) -> list[tuple[str, int]]:
+        """Merge the build directory's root listing with the core's.
+
+        The core's readdir already carries mount structure (the door
+        merges child mounts and links), so no prefix synthesis happens
+        here; mount entries arrive kind-unknown and guests stat lazily,
+        which the door also answers for structure-only directories.
+        """
         entries: dict[str, int] = {}
         if self._build is not None:
             for name, kind in self._build.readdir("/"):
@@ -268,7 +275,4 @@ class WasmVFS:
         if self._core is not None:
             for name, kind in self._readdir_core("/"):
                 entries.setdefault(name, kind)
-            for prefix in self._prefixes():
-                top = prefix.lstrip("/").split("/", 1)[0]
-                entries[top] = FT_DIR
         return sorted(entries.items())

--- a/python/mirage/utils/path.py
+++ b/python/mirage/utils/path.py
@@ -56,6 +56,21 @@ def norm(path: str) -> str:
     return "/" + path.strip("/")
 
 
+def norm_dir(path: str) -> str:
+    """Normalize a virtual path to its trailing-slash directory form.
+
+    Args:
+        path: A virtual path string.
+
+    Returns:
+        The path with one leading and one trailing slash
+        (``"foo/bar"`` -> ``"/foo/bar/"``, ``""`` -> ``"/"``), the form
+        prefix comparisons need so ``/a/`` cannot match ``/ab``.
+    """
+    stripped = path.strip("/")
+    return "/" + stripped + "/" if stripped else "/"
+
+
 def parent(path: str) -> str:
     """Return the parent directory of a normalized virtual key.
 

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -21,6 +21,8 @@ from mirage.commands.builtin.utils.limit import apply_op_limit
 from mirage.io import IOResult
 from mirage.observe.record import OpRecord
 from mirage.ops.config import NO_FOLLOW_OPS, STAMP_WRITE_OPS
+from mirage.ops.structure import (merge_readdir, structure_listing,
+                                  structure_stat)
 from mirage.policy import post_ops_gate, pre_ops_gate
 from mirage.types import ConsistencyPolicy, FileStat, PathSpec
 from mirage.utils.key_prefix import mount_key
@@ -64,13 +66,43 @@ class Dispatcher:
     def reconciler(self) -> Reconciler:
         return self._reconciler
 
+    def _structure_result(self, op: str,
+                          virtual: str) -> list[str] | FileStat | None:
+        """The namespace's own answer for a path no backend serves.
+
+        Child mounts and symlinks are structure the door owns, so a
+        directory that exists only because a mount or link sits below it
+        still lists and stats. None for any other op, or when the
+        namespace knows nothing at ``virtual``.
+
+        Args:
+            op (str): the dispatched op name.
+            virtual (str): the virtual path being answered.
+        """
+        prefixes = [m.prefix for m in self._namespace.registry.mounts()]
+        if op == "readdir":
+            return structure_listing(prefixes, self._namespace, virtual)
+        if op == "stat":
+            return structure_stat(prefixes, self._namespace, virtual)
+        return None
+
     async def dispatch(self, op: str, path: PathSpec,
                        **kwargs: Any) -> tuple[Any, IOResult]:
         if op not in NO_FOLLOW_OPS:
             followed = self._namespace.follow(path.virtual)
             if followed != path.virtual:
                 path = PathSpec.from_str_path(followed)
-        mount = self._namespace.mount_for(path.virtual)
+        try:
+            mount = self._namespace.mount_for(path.virtual)
+        except ValueError:
+            # No mount serves the path, but the namespace may still know
+            # a directory there (a deeper mount, a link). No mount means
+            # no admission gate to key on and no cache to keep straight;
+            # the merged names are session-filtered individually.
+            fallback = self._structure_result(op, path.virtual)
+            if fallback is None:
+                raise
+            return fallback, IOResult()
         assert_mount_allowed(mount.prefix)
         # Admission policies fire at the door, before the warm-cache
         # early return below: a cached read must be refused exactly
@@ -103,8 +135,14 @@ class Dispatcher:
         try:
             result = await mount.execute_op(op, path.virtual, **kwargs)
         except FileNotFoundError:
-            await self._reconciler.on_op_missing(op, path.virtual)
-            raise
+            result = self._structure_result(op, path.virtual)
+            if result is None:
+                await self._reconciler.on_op_missing(op, path.virtual)
+                raise
+        if op == "readdir":
+            result = merge_readdir(
+                result, [m.prefix for m in self._namespace.registry.mounts()],
+                self._namespace, path.virtual)
         if op == "stat" and isinstance(result, FileStat):
             result = merge_overlay_stat(self._namespace.meta_for(path.virtual),
                                         result)

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -22,8 +22,8 @@ from mirage.context import mount_allowed
 from mirage.io import IOResult
 from mirage.observe.record import OpRecord
 from mirage.ops.config import NO_FOLLOW_OPS, STAMP_WRITE_OPS
-from mirage.ops.structure import (merge_readdir, structure_listing,
-                                  structure_stat)
+from mirage.ops.namespace_view import (merge_readdir, namespace_listing,
+                                       namespace_stat)
 from mirage.policy import post_ops_gate, pre_ops_gate
 from mirage.types import ConsistencyPolicy, FileStat, PathSpec
 from mirage.utils.key_prefix import mount_key
@@ -67,7 +67,7 @@ class Dispatcher:
     def reconciler(self) -> Reconciler:
         return self._reconciler
 
-    def _structure_result(self, op: str,
+    def _namespace_result(self, op: str,
                           virtual: str) -> list[str] | FileStat | None:
         """The namespace's own answer for a path no backend serves.
 
@@ -82,12 +82,12 @@ class Dispatcher:
         """
         prefixes = [m.prefix for m in self._namespace.registry.mounts()]
         if op == "readdir":
-            return structure_listing(prefixes, self._namespace, virtual)
+            return namespace_listing(prefixes, self._namespace, virtual)
         if op == "stat":
-            return structure_stat(prefixes, self._namespace, virtual)
+            return namespace_stat(prefixes, self._namespace, virtual)
         return None
 
-    async def _gated_structure(self, op: str, path: PathSpec,
+    async def _gated_namespace(self, op: str, path: PathSpec,
                                fallback: "list[str] | FileStat") -> Any:
         """Gate a namespace-served answer exactly like a backend one.
 
@@ -98,7 +98,7 @@ class Dispatcher:
         Args:
             op (str): the dispatched op name.
             path (PathSpec): the op's path scope.
-            fallback (list[str] | FileStat): the structure answer.
+            fallback (list[str] | FileStat): the namespace's answer.
         """
         policies = self._namespace.registry.policies
         write = op in _POLICY_WRITE_OPS
@@ -121,10 +121,10 @@ class Dispatcher:
             # a directory there (a deeper mount, a link). No mount means
             # no cache to keep straight. The merged names are
             # session-filtered individually.
-            fallback = self._structure_result(op, path.virtual)
+            fallback = self._namespace_result(op, path.virtual)
             if fallback is None:
                 raise
-            return await self._gated_structure(op, path, fallback), IOResult()
+            return await self._gated_namespace(op, path, fallback), IOResult()
         if not mount_allowed(mount.prefix):
             # The mount is real but ungranted, and the namespace may
             # still owe the session a directory here: a granted mount
@@ -133,9 +133,9 @@ class Dispatcher:
             # session-filtered, so nothing of the mount's own content
             # leaks; a path the structure does not owe falls through to
             # the canonical denial below.
-            fallback = self._structure_result(op, path.virtual)
+            fallback = self._namespace_result(op, path.virtual)
             if fallback is not None:
-                return await self._gated_structure(op, path,
+                return await self._gated_namespace(op, path,
                                                    fallback), IOResult()
         assert_mount_allowed(mount.prefix)
         # Admission policies fire at the door, before the warm-cache
@@ -169,7 +169,7 @@ class Dispatcher:
         try:
             result = await mount.execute_op(op, path.virtual, **kwargs)
         except FileNotFoundError:
-            result = self._structure_result(op, path.virtual)
+            result = self._namespace_result(op, path.virtual)
             if result is None:
                 await self._reconciler.on_op_missing(op, path.virtual)
                 raise

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -18,6 +18,7 @@ from typing import Any
 from mirage.cache.file import io as cache_io
 from mirage.cache.manager import CacheManager
 from mirage.commands.builtin.utils.limit import apply_op_limit
+from mirage.context import mount_allowed
 from mirage.io import IOResult
 from mirage.observe.record import OpRecord
 from mirage.ops.config import NO_FOLLOW_OPS, STAMP_WRITE_OPS
@@ -86,6 +87,27 @@ class Dispatcher:
             return structure_stat(prefixes, self._namespace, virtual)
         return None
 
+    async def _gated_structure(self, op: str, path: PathSpec,
+                               fallback: "list[str] | FileStat") -> Any:
+        """Gate a namespace-served answer exactly like a backend one.
+
+        The answer has no owning prefix (the gates see ""), but
+        admission still fires: a policy that bounds readdir or stat by
+        path must cover the synthetic answer too.
+
+        Args:
+            op (str): the dispatched op name.
+            path (PathSpec): the op's path scope.
+            fallback (list[str] | FileStat): the structure answer.
+        """
+        policies = self._namespace.registry.policies
+        write = op in _POLICY_WRITE_OPS
+        await pre_ops_gate(policies, op, path, write, "")
+        bound = await post_ops_gate(policies, op, path, write, "", fallback)
+        if bound is not None:
+            return await apply_op_limit(fallback, bound)
+        return fallback
+
     async def dispatch(self, op: str, path: PathSpec,
                        **kwargs: Any) -> tuple[Any, IOResult]:
         if op not in NO_FOLLOW_OPS:
@@ -97,21 +119,24 @@ class Dispatcher:
         except ValueError:
             # No mount serves the path, but the namespace may still know
             # a directory there (a deeper mount, a link). No mount means
-            # no cache to keep straight and no owning prefix (the gates
-            # see ""), but admission still fires: a policy that bounds
-            # readdir or stat by path must cover the synthetic answer
-            # too. The merged names are session-filtered individually.
+            # no cache to keep straight. The merged names are
+            # session-filtered individually.
             fallback = self._structure_result(op, path.virtual)
             if fallback is None:
                 raise
-            policies = self._namespace.registry.policies
-            write = op in _POLICY_WRITE_OPS
-            await pre_ops_gate(policies, op, path, write, "")
-            bound = await post_ops_gate(policies, op, path, write, "",
-                                        fallback)
-            if bound is not None:
-                fallback = await apply_op_limit(fallback, bound)
-            return fallback, IOResult()
+            return await self._gated_structure(op, path, fallback), IOResult()
+        if not mount_allowed(mount.prefix):
+            # The mount is real but ungranted, and the namespace may
+            # still owe the session a directory here: a granted mount
+            # below it already put this path's name in a listing, so
+            # walking down to the grant must answer. The names are
+            # session-filtered, so nothing of the mount's own content
+            # leaks; a path the structure does not owe falls through to
+            # the canonical denial below.
+            fallback = self._structure_result(op, path.virtual)
+            if fallback is not None:
+                return await self._gated_structure(op, path,
+                                                   fallback), IOResult()
         assert_mount_allowed(mount.prefix)
         # Admission policies fire at the door, before the warm-cache
         # early return below: a cached read must be refused exactly

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -97,11 +97,20 @@ class Dispatcher:
         except ValueError:
             # No mount serves the path, but the namespace may still know
             # a directory there (a deeper mount, a link). No mount means
-            # no admission gate to key on and no cache to keep straight;
-            # the merged names are session-filtered individually.
+            # no cache to keep straight and no owning prefix (the gates
+            # see ""), but admission still fires: a policy that bounds
+            # readdir or stat by path must cover the synthetic answer
+            # too. The merged names are session-filtered individually.
             fallback = self._structure_result(op, path.virtual)
             if fallback is None:
                 raise
+            policies = self._namespace.registry.policies
+            write = op in _POLICY_WRITE_OPS
+            await pre_ops_gate(policies, op, path, write, "")
+            bound = await post_ops_gate(policies, op, path, write, "",
+                                        fallback)
+            if bound is not None:
+                fallback = await apply_op_limit(fallback, bound)
             return fallback, IOResult()
         assert_mount_allowed(mount.prefix)
         # Admission policies fire at the door, before the warm-cache

--- a/python/mirage/workspace/executor/builtins/metadata.py
+++ b/python/mirage/workspace/executor/builtins/metadata.py
@@ -317,6 +317,7 @@ async def _apply_attrs(
 
 
 async def _walk_stats(
+    namespace: Namespace,
     dispatch: Callable[..., Any],
     root: PathSpec,
     root_stat: FileStat,
@@ -325,11 +326,14 @@ async def _walk_stats(
 
     Each entry's stat is captured during the walk because chmod's
     symbolic clauses (``u+x``) build on the entry's own current mode.
-    Symlinks never appear: they are namespace state, so no backend
-    readdir reports one, which is exactly GNU chmod -R's rule of
-    changing neither a traversed link nor its referent.
+    Symlinks are skipped by name: the door's readdir reports them (they
+    are namespace structure), GNU chmod -R changes neither a traversed
+    link nor its referent, and the skip must come before the stat
+    because stat follows a link and would descend through a directory
+    link.
 
     Args:
+        namespace (Namespace): addressing authority (link table).
         dispatch (Callable): op dispatcher.
         root (PathSpec): subtree root (already link-resolved).
         root_stat (FileStat): the root's stat, already read.
@@ -340,6 +344,8 @@ async def _walk_stats(
         directory = queue.pop(0)
         children, _ = await dispatch("readdir", directory)
         for child_virtual in children:
+            if namespace.is_link(child_virtual):
+                continue
             child = PathSpec.from_str_path(child_virtual)
             child_stat, _ = await dispatch("stat", child)
             entries.append((child, child_stat))
@@ -367,7 +373,7 @@ async def _walk_owned(
         root (PathSpec): subtree root.
         root_stat (FileStat): the root's stat, already read.
     """
-    walked = await _walk_stats(dispatch, root, root_stat)
+    walked = await _walk_stats(namespace, dispatch, root, root_stat)
     links = [path for path, _stat in namespace.link_stats_below(root.virtual)]
     return [path for path, _stat in walked], links
 
@@ -409,7 +415,7 @@ async def handle_chmod(
             continue
         resolved, stat = found
         if recursive:
-            entries = await _walk_stats(dispatch, resolved, stat)
+            entries = await _walk_stats(namespace, dispatch, resolved, stat)
         else:
             entries = [(resolved, stat)]
         for path, path_stat in entries:

--- a/python/mirage/workspace/executor/command/command.py
+++ b/python/mirage/workspace/executor/command/command.py
@@ -42,6 +42,7 @@ from mirage.workspace.executor.command.routing import (CWD_DEFAULT_RAW,
                                                        path_flag_scopes)
 from mirage.workspace.executor.command.run import (drop_service_caches,
                                                    exec_node, mount_root_of,
+                                                   registry_child_mounts,
                                                    run_on_mount,
                                                    scalar_find_flags)
 from mirage.workspace.executor.command.types import ExecuteNodeFn
@@ -323,10 +324,23 @@ async def handle_command(
         for w in parse_warnings).encode() if parse_warnings else b"")
 
     if _should_fan_out(cmd_name, paths, flag_kwargs, registry):
-        stdout, io, node = await _fan_out_traversal(cmd_name, paths, texts,
-                                                    flag_kwargs, registry,
-                                                    mount, session.cwd,
-                                                    cmd_str, stdin)
+        # The one fact threaded into the fan-out's per-mount runs: a
+        # start point only the namespace serves (a nested mount's
+        # ancestor) has no backend listing, so without it the primary
+        # run reports the operand missing. Links and stat overlays are
+        # still dropped here, a known seam of the fan-out.
+        child_mounts = functools.partial(registry_child_mounts, registry,
+                                         namespace)
+        stdout, io, node = await _fan_out_traversal(cmd_name,
+                                                    paths,
+                                                    texts,
+                                                    flag_kwargs,
+                                                    registry,
+                                                    mount,
+                                                    session.cwd,
+                                                    cmd_str,
+                                                    stdin,
+                                                    child_mounts=child_mounts)
         if warn_bytes:
             existing = await materialize(io.stderr) if io.stderr else b""
             io.stderr = warn_bytes + existing

--- a/python/mirage/workspace/executor/command/run.py
+++ b/python/mirage/workspace/executor/command/run.py
@@ -15,13 +15,13 @@
 import functools
 from typing import Any
 
-from mirage.commands.builtin.generic.ls import LS_FAILURE
 from mirage.commands.builtin.utils.limit import CommandTimeoutError
 from mirage.commands.errors import UsageError
 from mirage.commands.spec.types import FlagValue
 from mirage.io import IOResult
 from mirage.io.stream import materialize, wrap_cachable_streams
 from mirage.io.types import ByteSource
+from mirage.ops.structure import child_mount_names
 from mirage.ops.types import LinkView
 from mirage.runtime.base import Runtime
 from mirage.runtime.policy import PolicyDecision
@@ -113,6 +113,21 @@ def scalar_find_flags(
         k: (v[-1] if isinstance(v, list) and v else v)
         for k, v in flag_kwargs.items()
     }
+
+
+def registry_child_mounts(registry: MountRegistry, parent: str) -> list[str]:
+    """Session-filtered child-mount names under ``parent``.
+
+    The ``child_mounts`` fact offered to listing commands: the same
+    names the door merges into its own readdir, derived from the same
+    prefixes, so the shell and the ops surface cannot disagree about
+    which mounts a directory holds.
+
+    Args:
+        registry (MountRegistry): registry holding the mount table.
+        parent (str): directory whose child mounts to enumerate.
+    """
+    return child_mount_names([m.prefix for m in registry.mounts()], parent)
 
 
 def link_view(namespace: Namespace | None,
@@ -298,6 +313,7 @@ async def run_on_mount(
     links = link_view(namespace, dispatch)
     stat_path = (functools.partial(path_stat, dispatch)
                  if dispatch is not None else None)
+    child_mounts = functools.partial(registry_child_mounts, registry)
 
     line_runtime, denial = line_runtime_for(cmd_name, registry,
                                             routing_decision)
@@ -321,6 +337,7 @@ async def run_on_mount(
             stat_overlay=stat_overlay,
             links=links,
             stat_path=stat_path,
+            child_mounts=child_mounts,
         )
     except UsageError as exc:
         # Command-owned usage errors (extra operands, missing patterns)
@@ -340,13 +357,6 @@ async def run_on_mount(
         return None, IOResult(exit_code=1,
                               stderr=format_fs_error(cmd_name, exc, paths))
 
-    # A minor problem (exit 1: an entry below the operand could not be
-    # stat'd) still lists the directory, so the mount and link rows belong
-    # in that output; only a failed operand (exit 2) has nothing to augment.
-    if cmd_name == "ls" and io.exit_code != LS_FAILURE:
-        stdout = await inject_child_mounts(stdout, registry, paths,
-                                           flag_kwargs, session.cwd)
-
     if cmd_name == "find":
         stdout, action_err = await _apply_find_actions(stdout, flag_kwargs,
                                                        registry, session.cwd)
@@ -362,70 +372,3 @@ async def run_on_mount(
         io.writes = {prefix + k: v for k, v in io.writes.items()}
         io.cache = [prefix + p for p in io.cache]
     return wrap_cachable_streams(stdout, io)
-
-
-def listed_names(existing: str, long_form: bool) -> set[str]:
-    """Names already rendered in an ls listing, for injection dedup.
-
-    Long rows come in two shapes: the degraded ``mode\t-\t-\tname``
-    form used for entries with neither size nor mtime, and the full GNU
-    row whose name is the ninth whitespace-separated field. Splitting on
-    tabs alone reads a full row as a single field, so a name would never
-    match and an injected row could duplicate an entry the backend
-    already listed.
-
-    Args:
-        existing (str): the backend's rendered ls output.
-        long_form (bool): whether -l rows are being parsed.
-    """
-    names: set[str] = set()
-    for line in existing.split("\n"):
-        if line == "":
-            continue
-        if not long_form:
-            names.add(line.rstrip("/*@|="))
-        elif "\t" in line:
-            names.add(line.split("\t")[-1])
-        else:
-            parts = line.split(maxsplit=8)
-            if len(parts) == 9:
-                names.add(parts[8])
-    names.discard("")
-    return names
-
-
-async def inject_child_mounts(
-    stdout: ByteSource | None,
-    registry: MountRegistry,
-    paths: list[PathSpec],
-    flag_kwargs: dict[str, FlagValue],
-    cwd: str,
-) -> ByteSource | None:
-    if flag_kwargs.get("d") is True or flag_kwargs.get("R") is True:
-        return stdout
-    if len(paths) > 1:
-        return stdout
-    listed = paths[0].virtual if paths else cwd
-    include_hidden = (flag_kwargs.get("a") is True
-                      or flag_kwargs.get("A") is True)
-    child_names = registry.child_mount_names(listed, include_hidden)
-    if not child_names:
-        return stdout
-
-    existing_bytes = await materialize(stdout) if stdout is not None else b""
-    existing = existing_bytes.decode("utf-8")
-    long_form = flag_kwargs.get("args_l") is True
-    classify = flag_kwargs.get("F") is True
-    present = listed_names(existing, long_form)
-    extras: list[str] = []
-    for name in child_names:
-        if name in present:
-            continue
-        if long_form:
-            extras.append(f"d\t-\t-\t{name}")
-        else:
-            extras.append(f"{name}/" if classify else name)
-    if not extras:
-        return stdout
-    sep = "" if existing == "" or existing.endswith("\n") else "\n"
-    return (existing + sep + "\n".join(extras)).encode("utf-8")

--- a/python/mirage/workspace/executor/command/run.py
+++ b/python/mirage/workspace/executor/command/run.py
@@ -22,7 +22,7 @@ from mirage.io import IOResult
 from mirage.io.stream import materialize, wrap_cachable_streams
 from mirage.io.types import ByteSource
 from mirage.ops.config import NamespaceLinks
-from mirage.ops.structure import structure_names
+from mirage.ops.namespace_view import namespace_names
 from mirage.ops.types import LinkView, MountView
 from mirage.runtime.base import Runtime
 from mirage.runtime.policy import PolicyDecision
@@ -131,7 +131,7 @@ def registry_child_mounts(registry: MountRegistry,
         links (NamespaceLinks | None): the namespace symlink table.
         parent (str): directory whose child segments to enumerate.
     """
-    return structure_names([m.prefix for m in registry.mounts()], links,
+    return namespace_names([m.prefix for m in registry.mounts()], links,
                            parent)
 
 

--- a/python/mirage/workspace/executor/command/run.py
+++ b/python/mirage/workspace/executor/command/run.py
@@ -21,7 +21,8 @@ from mirage.commands.spec.types import FlagValue
 from mirage.io import IOResult
 from mirage.io.stream import materialize, wrap_cachable_streams
 from mirage.io.types import ByteSource
-from mirage.ops.structure import child_mount_names
+from mirage.ops.config import NamespaceLinks
+from mirage.ops.structure import structure_names
 from mirage.ops.types import LinkView
 from mirage.runtime.base import Runtime
 from mirage.runtime.policy import PolicyDecision
@@ -115,19 +116,23 @@ def scalar_find_flags(
     }
 
 
-def registry_child_mounts(registry: MountRegistry, parent: str) -> list[str]:
-    """Session-filtered child-mount names under ``parent``.
+def registry_child_mounts(registry: MountRegistry,
+                          links: NamespaceLinks | None,
+                          parent: str) -> list[str]:
+    """Child names the namespace owes ``parent``: mounts and links.
 
     The ``child_mounts`` fact offered to listing commands: the same
     names the door merges into its own readdir, derived from the same
-    prefixes, so the shell and the ops surface cannot disagree about
-    which mounts a directory holds.
+    tables (mount names session-filtered), so the shell and the ops
+    surface cannot disagree about what a directory holds.
 
     Args:
         registry (MountRegistry): registry holding the mount table.
-        parent (str): directory whose child mounts to enumerate.
+        links (NamespaceLinks | None): the namespace symlink table.
+        parent (str): directory whose child segments to enumerate.
     """
-    return child_mount_names([m.prefix for m in registry.mounts()], parent)
+    return structure_names([m.prefix for m in registry.mounts()], links,
+                           parent)
 
 
 def link_view(namespace: Namespace | None,
@@ -313,7 +318,8 @@ async def run_on_mount(
     links = link_view(namespace, dispatch)
     stat_path = (functools.partial(path_stat, dispatch)
                  if dispatch is not None else None)
-    child_mounts = functools.partial(registry_child_mounts, registry)
+    child_mounts = functools.partial(registry_child_mounts, registry,
+                                     namespace)
 
     line_runtime, denial = line_runtime_for(cmd_name, registry,
                                             routing_decision)

--- a/python/mirage/workspace/executor/fanout.py
+++ b/python/mirage/workspace/executor/fanout.py
@@ -16,6 +16,7 @@ from mirage.commands.builtin.find_eval import FindEntry, keep
 from mirage.commands.builtin.find_parse import parse_find_expression
 from mirage.commands.errors import FindParseError
 from mirage.commands.spec.types import FlagValue
+from mirage.context import mount_allowed
 from mirage.io import IOResult
 from mirage.io.stream import materialize
 from mirage.io.types import ByteSource
@@ -30,6 +31,25 @@ _TRAVERSAL_CMDS = frozenset({"find", "tree", "du"})
 
 def _path_segments(path: str) -> list[str]:
     return [s for s in path.strip("/").split("/") if s]
+
+
+def _allowed_descendants(registry: MountRegistry,
+                         path: str) -> list[MountEntry]:
+    """Descendant mounts the current session may see.
+
+    A fan-out rooted above a session boundary must not walk into an
+    ungranted mount: enumerating it through the raw registry is exactly
+    how `grep -r x /` leaked a walled-off mount's contents. The filter
+    matches the door's structure merge, so the fan-out stays an
+    unobservable optimization.
+
+    Args:
+        registry (MountRegistry): registry holding the mount table.
+        path (str): parent path to scan beneath.
+    """
+    return [
+        m for m in registry.descendant_mounts(path) if mount_allowed(m.prefix)
+    ]
 
 
 def _depth_flag_value(raw: FlagValue | None) -> int | None:
@@ -59,7 +79,7 @@ def _should_fan_out(
     if not paths:
         return False
     target = paths[0].virtual
-    if not registry.descendant_mounts(target):
+    if not _allowed_descendants(registry, target):
         return False
     if cmd_name in _TRAVERSAL_CMDS:
         return True
@@ -269,8 +289,13 @@ async def _fan_out_traversal(
     mirage's per-mount find doesn't emit the path argument itself.
     """
     target_path = paths[0].virtual
-    descendants = registry.descendant_mounts(target_path)
-    descendant_prefixes = [m.prefix.rstrip("/") for m in descendants]
+    descendants = _allowed_descendants(registry, target_path)
+    # The shadow filter keeps the raw list on purpose: a mount the
+    # session cannot see still shadows the primary backend's keys under
+    # its prefix, the walk just never descends into it.
+    descendant_prefixes = [
+        m.prefix.rstrip("/") for m in registry.descendant_mounts(target_path)
+    ]
 
     all_stdout: list[bytes] = []
     merged_io = IOResult()

--- a/python/mirage/workspace/executor/fanout.py
+++ b/python/mirage/workspace/executor/fanout.py
@@ -20,6 +20,7 @@ from mirage.context import mount_allowed
 from mirage.io import IOResult
 from mirage.io.stream import materialize
 from mirage.io.types import ByteSource
+from mirage.ops.types import ChildMounts
 from mirage.types import PathSpec, Producer
 from mirage.utils.path import respell_one
 from mirage.workspace.executor.find_action_dispatch import _apply_find_actions
@@ -280,6 +281,7 @@ async def _fan_out_traversal(
     cwd: str,
     cmd_str: str,
     stdin: ByteSource | None,
+    child_mounts: ChildMounts | None = None,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     """Run a traversal command across the parent mount + descendant mounts.
 
@@ -341,7 +343,8 @@ async def _fan_out_traversal(
                                              sub_texts,
                                              sub_flags,
                                              stdin=stdin,
-                                             cwd=cwd)
+                                             cwd=cwd,
+                                             child_mounts=child_mounts)
 
         if mount is not primary_mount and io.exit_code == 127:
             # A descendant that does not serve this command contributes

--- a/python/mirage/workspace/executor/fanout.py
+++ b/python/mirage/workspace/executor/fanout.py
@@ -79,7 +79,12 @@ def _should_fan_out(
     if not paths:
         return False
     target = paths[0].virtual
-    if not _allowed_descendants(registry, target):
+    # Gated on the raw registry, not the session view: with every
+    # descendant ungranted, single-mount dispatch would serve the parent
+    # backend's keys shadowed under a hidden mount's prefix, and only
+    # the fan-out's shadow filter drops those. Execution still runs the
+    # allowed descendants only.
+    if not registry.descendant_mounts(target):
         return False
     if cmd_name in _TRAVERSAL_CMDS:
         return True

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -31,7 +31,7 @@ from mirage.observe.context import (push_mount_prefix, push_revisions,
                                     reset_revisions, with_mount_prefix,
                                     with_revisions)
 from mirage.ops.registry import RegisteredOp
-from mirage.ops.types import LinkView, StatOverlay, StatPath
+from mirage.ops.types import ChildMounts, LinkView, StatOverlay, StatPath
 from mirage.policy import resolve_limit
 from mirage.resource.base import BaseResource
 from mirage.runtime.base import Runtime
@@ -446,6 +446,7 @@ class MountEntry:
         stat_overlay: StatOverlay | None = None,
         links: LinkView | None = None,
         stat_path: StatPath | None = None,
+        child_mounts: ChildMounts | None = None,
     ) -> tuple[ByteSource | None, IOResult]:
         """Execute a command on this mount's resource.
 
@@ -465,7 +466,9 @@ class MountEntry:
             links (LinkView | None): the namespace's symlink facts.
             stat_path (StatPath | None): dispatcher-backed stat of one
                 path, for a traversal command's start point.
-                All three reach only the handlers that name them as a
+            child_mounts (ChildMounts | None): session-filtered child
+                mount names under a directory, for listing commands.
+                All four reach only the handlers that name them as a
                 parameter, so no list of command names is kept here.
         """
         extension = get_extension(paths[0].virtual) if paths else None
@@ -533,6 +536,7 @@ class MountEntry:
             "stat_overlay": stat_overlay,
             "links": links,
             "stat_path": stat_path,
+            "child_mounts": child_mounts,
         }
         offered = {k: v for k, v in offered.items() if v is not None}
         if runtime is not None:

--- a/python/mirage/workspace/mount/namespace/namespace.py
+++ b/python/mirage/workspace/mount/namespace/namespace.py
@@ -404,24 +404,6 @@ class Namespace:
             return path
         return resolve_symlinks(path, targets)
 
-    def links_under(self, directory: str) -> dict[str, str]:
-        """Links living directly under a directory.
-
-        Args:
-            directory (str): absolute virtual directory path.
-
-        Returns:
-            dict[str, str]: link basename to target, for entries whose
-            parent is exactly ``directory``.
-        """
-        base = directory.rstrip("/") + "/"
-        out: dict[str, str] = {}
-        for path, meta in self._nodes.items():
-            if (meta.target is not None and path.startswith(base)
-                    and "/" not in path[len(base):]):
-                out[path[len(base):]] = meta.target
-        return out
-
     def link_stat_at(self, path: str) -> FileStat | None:
         """lstat a path: the link's own stat, or None when not a link.
 

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -251,40 +251,6 @@ class MountRegistry:
         out.sort(key=lambda m: m.prefix)
         return out
 
-    def child_mount_names(
-        self,
-        parent_path: str,
-        include_hidden: bool = False,
-    ) -> list[str]:
-        """Names of immediate child mounts under parent_path.
-
-        Args:
-            parent_path (str): directory whose child mounts to enumerate.
-            include_hidden (bool): include names starting with '.'.
-        """
-        stripped = parent_path.strip("/")
-        norm = "/" + stripped + "/" if stripped else "/"
-        seen: set[str] = set()
-        out: list[str] = []
-        for m in self._mounts:
-            if m.prefix == norm:
-                continue
-            if not m.prefix.startswith(norm):
-                continue
-            rest = m.prefix[len(norm):]
-            slash = rest.find("/")
-            name = rest if slash == -1 else rest[:slash]
-            if name == "":
-                continue
-            if not include_hidden and name.startswith("."):
-                continue
-            if name in seen:
-                continue
-            seen.add(name)
-            out.append(name)
-        out.sort()
-        return out
-
     def mount_for(self, path: str) -> MountEntry:
         """Find the mount that handles this path."""
         norm = "/" + path.strip("/")

--- a/python/tests/commands/builtin/generic/test_ls.py
+++ b/python/tests/commands/builtin/generic/test_ls.py
@@ -727,6 +727,53 @@ async def test_link_operand_on_a_backend_whose_readdir_raises():
 
 
 @pytest.mark.asyncio
+async def test_structure_only_directory_lists_its_children():
+    """A directory no backend serves still lists when the namespace owes
+    it children (a nested mount, a link's ancestors): the door already
+    names it in the parent listing, so ls must agree instead of
+    reporting it missing."""
+
+    async def readdir(p, index=None):
+        raise FileNotFoundError(p.virtual)
+
+    async def stat(p, index=None):
+        raise FileNotFoundError(p.virtual)
+
+    def child_mounts(parent: str) -> list[str]:
+        return ["deep"] if parent == "/ghost" else []
+
+    out, io = await ls([PathSpec.from_str_path("/ghost")],
+                       readdir=readdir,
+                       stat=stat,
+                       child_mounts=child_mounts)
+    assert io.exit_code == 0
+    assert out.decode() == "deep\n"
+
+
+@pytest.mark.asyncio
+async def test_structure_only_directory_stays_missing_under_recursive():
+    """-R withholds child_mounts (the fan-out owns cross-mount
+    assembly), so the rescue must not fire there either."""
+
+    async def readdir(p, index=None):
+        raise FileNotFoundError(p.virtual)
+
+    async def stat(p, index=None):
+        raise FileNotFoundError(p.virtual)
+
+    def child_mounts(parent: str) -> list[str]:
+        return ["deep"] if parent == "/ghost" else []
+
+    out, io = await ls([PathSpec.from_str_path("/ghost")],
+                       readdir=readdir,
+                       stat=stat,
+                       recursive=True,
+                       child_mounts=child_mounts)
+    assert io.exit_code == LS_FAILURE
+    assert b"cannot access '/ghost'" in io.stderr
+
+
+@pytest.mark.asyncio
 async def test_link_operand_on_a_backend_whose_readdir_returns_empty():
     """Backends without real directories (s3, nextcloud) answer readdir
     on a link with an empty list rather than raising, which rendered the

--- a/python/tests/commands/builtin/generic/test_ls.py
+++ b/python/tests/commands/builtin/generic/test_ls.py
@@ -751,9 +751,10 @@ async def test_structure_only_directory_lists_its_children():
 
 
 @pytest.mark.asyncio
-async def test_structure_only_directory_stays_missing_under_recursive():
-    """-R withholds child_mounts (the fan-out owns cross-mount
-    assembly), so the rescue must not fire there either."""
+async def test_structure_only_directory_renders_group_under_recursive():
+    """Under -R the group still renders from the namespace fact; only
+    descent into the child-mount root is withheld, because that listing
+    is another backend's and the cross-mount fan-out assembles it."""
 
     async def readdir(p, index=None):
         raise FileNotFoundError(p.virtual)
@@ -769,8 +770,59 @@ async def test_structure_only_directory_stays_missing_under_recursive():
                        stat=stat,
                        recursive=True,
                        child_mounts=child_mounts)
-    assert io.exit_code == LS_FAILURE
-    assert b"cannot access '/ghost'" in io.stderr
+    assert io.exit_code == 0
+    assert out.decode() == "/ghost:\ndeep\n"
+
+
+@pytest.mark.asyncio
+async def test_structure_only_chain_descends_under_recursive():
+    """A structure chain (a link's ancestors) continues below the first
+    level, so -R descends it: only a child-mount root stops the walk."""
+
+    async def readdir(p, index=None):
+        raise FileNotFoundError(p.virtual)
+
+    async def stat(p, index=None):
+        raise FileNotFoundError(p.virtual)
+
+    def child_mounts(parent: str) -> list[str]:
+        if parent == "/ghost":
+            return ["deep"]
+        if parent == "/ghost/deep":
+            return ["lnk"]
+        return []
+
+    out, io = await ls([PathSpec.from_str_path("/ghost")],
+                       readdir=readdir,
+                       stat=stat,
+                       recursive=True,
+                       child_mounts=child_mounts)
+    assert io.exit_code == 0
+    assert out.decode() == "/ghost:\ndeep\n\n/ghost/deep:\nlnk\n"
+
+
+@pytest.mark.asyncio
+async def test_list_dir_itself_on_structure_only_directory():
+    """-d stats the operand itself; the namespace fact is what says the
+    directory exists, so the row must come from it when no backend
+    does."""
+
+    async def readdir(p, index=None):
+        raise FileNotFoundError(p.virtual)
+
+    async def stat(p, index=None):
+        raise FileNotFoundError(p.virtual)
+
+    def child_mounts(parent: str) -> list[str]:
+        return ["deep"] if parent == "/ghost" else []
+
+    out, io = await ls([PathSpec.from_str_path("/ghost")],
+                       readdir=readdir,
+                       stat=stat,
+                       list_dir=True,
+                       child_mounts=child_mounts)
+    assert io.exit_code == 0
+    assert out.decode() == "/ghost\n"
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/ram/test_bare_cwd_operand.py
+++ b/python/tests/commands/builtin/ram/test_bare_cwd_operand.py
@@ -87,5 +87,6 @@ async def test_ls_bare_still_lists_the_cwd(workspace):
     io = await seeded.execute("ls", cwd="/")
     assert io.exit_code == 0
     out = (io.stdout or b"").decode()
-    assert out.startswith("a.txt\nsub")
-    assert "dev" in out
+    # The dev mount is a row like any other now, so it sorts into the
+    # listing instead of trailing it the way the old stdout patch did.
+    assert out.startswith("a.txt\ndev\nsub")

--- a/python/tests/commands/test_no_dead_flag_params.py
+++ b/python/tests/commands/test_no_dead_flag_params.py
@@ -48,6 +48,7 @@ DISPATCHER_PARAMS = frozenset({
     "stat_overlay",
     "links",
     "stat_path",
+    "child_mounts",
     "prefix",
     "command",
 })

--- a/python/tests/context/test_session_context.py
+++ b/python/tests/context/test_session_context.py
@@ -15,8 +15,8 @@
 import pytest
 
 from mirage.context import (assert_mount_allowed, effective_mount_mode,
-                            get_current_session, reset_current_session,
-                            set_current_session)
+                            get_current_session, mount_allowed,
+                            reset_current_session, set_current_session)
 from mirage.types import MountMode, weaker_mode
 from mirage.workspace.session import Session
 
@@ -85,3 +85,13 @@ def test_prefix_normalization(bound_session):
 
 def test_missing_grant_defaults_effective_to_read(bound_session):
     assert effective_mount_mode("/other", MountMode.EXEC) == MountMode.READ
+
+
+def test_mount_allowed_is_the_non_raising_twin(bound_session):
+    assert mount_allowed("/ro") is True
+    assert mount_allowed("/ro/") is True
+    assert mount_allowed("/other") is False
+
+
+def test_mount_allowed_without_session_permits_everything():
+    assert mount_allowed("/anything") is True

--- a/python/tests/ops/test_namespace_view.py
+++ b/python/tests/ops/test_namespace_view.py
@@ -15,9 +15,9 @@
 import pytest
 
 from mirage.context import reset_current_session, set_current_session
-from mirage.ops.structure import (child_mount_names, merge_readdir,
-                                  structure_listing, structure_names,
-                                  structure_stat)
+from mirage.ops.namespace_view import (child_mount_names, merge_readdir,
+                                       namespace_listing, namespace_names,
+                                       namespace_stat)
 from mirage.types import FileType, MountMode
 from mirage.workspace.session import Session
 
@@ -84,10 +84,10 @@ def test_merge_readdir_without_links_or_mounts_is_identity():
 
 
 def test_structure_listing_answers_only_when_something_is_below():
-    assert structure_listing(PREFIXES, None, "/base/ghost") is None
-    assert structure_listing(PREFIXES, None, "/base") == ["/base/inner"]
+    assert namespace_listing(PREFIXES, None, "/base/ghost") is None
+    assert namespace_listing(PREFIXES, None, "/base") == ["/base/inner"]
     links = _Links({"/base/ghost/lnk": "/base"})
-    assert structure_listing(PREFIXES, links,
+    assert namespace_listing(PREFIXES, links,
                              "/base/ghost") == ["/base/ghost/lnk"]
 
 
@@ -96,29 +96,29 @@ def test_link_ancestors_synthesize_like_mount_prefixes():
     # ancestor of the link must list and stat, or the link is reachable
     # by exact path yet invisible to any walk from above.
     links = _Links({"/ghost/deep/lnk": "/base"})
-    assert structure_listing([], links, "/") == ["/ghost"]
-    assert structure_listing([], links, "/ghost") == ["/ghost/deep"]
-    assert structure_listing([], links, "/ghost/deep") == ["/ghost/deep/lnk"]
-    st = structure_stat([], links, "/ghost")
+    assert namespace_listing([], links, "/") == ["/ghost"]
+    assert namespace_listing([], links, "/ghost") == ["/ghost/deep"]
+    assert namespace_listing([], links, "/ghost/deep") == ["/ghost/deep/lnk"]
+    st = namespace_stat([], links, "/ghost")
     assert st is not None and st.type is FileType.DIRECTORY
     # The link itself is not structure: its stat is the lstat surface's.
-    assert structure_stat([], links, "/ghost/deep/lnk") is None
+    assert namespace_stat([], links, "/ghost/deep/lnk") is None
 
 
 def test_structure_stat_agrees_with_the_listing():
-    st = structure_stat(PREFIXES, None, "/base")
+    st = namespace_stat(PREFIXES, None, "/base")
     assert st is not None and st.type is FileType.DIRECTORY
     assert st.name == "base"
-    assert structure_stat(PREFIXES, None, "/base/ghost") is None
+    assert namespace_stat(PREFIXES, None, "/base/ghost") is None
 
 
 def test_structure_answers_hide_ungranted_mounts(scoped_session):
     # /top exists only because an ungranted mount sits below it: to
     # this session the namespace must deny knowing anything there.
-    assert structure_listing(["/top/secret/"], None, "/top") is None
-    assert structure_stat(["/top/secret/"], None, "/top") is None
+    assert namespace_listing(["/top/secret/"], None, "/top") is None
+    assert namespace_stat(["/top/secret/"], None, "/top") is None
     # The granted mount keeps answering through the same session.
-    assert structure_stat(PREFIXES, None, "/base") is not None
+    assert namespace_stat(PREFIXES, None, "/base") is not None
 
 
 def test_link_names_filter_by_owning_mount(scoped_session):
@@ -127,8 +127,8 @@ def test_link_names_filter_by_owning_mount(scoped_session):
     # inside the granted mount keeps answering. Ownership is
     # longest-match, the same rule dispatch resolves the path by.
     links = _Links({"/other/leak": "/tgt", "/base/inner/ok": "/tgt"})
-    assert structure_names(PREFIXES, links, "/") == ["base"]
-    assert structure_listing(PREFIXES, links,
+    assert namespace_names(PREFIXES, links, "/") == ["base"]
+    assert namespace_listing(PREFIXES, links,
                              "/base/inner") == ["/base/inner/ok"]
 
 
@@ -137,5 +137,5 @@ def test_link_above_every_mount_stays_visible(scoped_session):
     # mount, so a scoped session still sees the chain (it may have
     # created the link itself at a structure-only path).
     links = _Links({"/ghost/deep/lnk": "/base/inner"})
-    assert structure_listing(["/base/inner/"], links,
+    assert namespace_listing(["/base/inner/"], links,
                              "/") == ["/base", "/ghost"]

--- a/python/tests/ops/test_ops.py
+++ b/python/tests/ops/test_ops.py
@@ -16,6 +16,7 @@ import pytest
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.context import reset_current_session, set_current_session
 from mirage.ops import Ops
 from mirage.ops.config import OpsMount
 from mirage.policy import (Action, Deny, OpsContext, Policies, Policy,
@@ -23,6 +24,7 @@ from mirage.policy import (Action, Deny, OpsContext, Policies, Policy,
 from mirage.resource.ram import RAMResource
 from mirage.resource.ram.store import RAMStore
 from mirage.types import FileType, MountMode
+from mirage.workspace.session import Session
 
 from .conftest import _ram_registered_ops, make_ops, run
 
@@ -288,3 +290,57 @@ class TestStructureFallbackGates:
     def test_the_synthetic_answer_serves_when_no_policy_objects(self):
         ops = _structure_only_ops(Policies())
         assert run(ops.readdir("/data/inner")) == ["/data/inner/deep"]
+
+
+def _granted_child_ops() -> Ops:
+    """An Ops with a real mount at /data and a nested one at
+    /data/inner/deep, for sessions granted only the deep one."""
+    mounts = [
+        OpsMount(
+            prefix="/data/",
+            resource_type="ram",
+            accessor=RAMAccessor(RAMStore()),
+            index=RAMIndexCacheStore(),
+            mode=MountMode.WRITE,
+            ops=_ram_registered_ops(),
+        ),
+        OpsMount(
+            prefix="/data/inner/deep/",
+            resource_type="ram",
+            accessor=RAMAccessor(RAMStore()),
+            index=RAMIndexCacheStore(),
+            mode=MountMode.WRITE,
+            ops=_ram_registered_ops(),
+        ),
+    ]
+    return Ops(mounts, policies=Policies())
+
+
+@pytest.fixture
+def deep_scoped_session():
+    """Bind a session granted only /data/inner/deep."""
+    session = Session(session_id="agent",
+                      mount_modes={"/data/inner/deep": MountMode.EXEC})
+    token = set_current_session(session)
+    yield session
+    reset_current_session(token)
+
+
+class TestUngrantedParentStructure:
+
+    def test_walking_down_to_the_grant_answers(self, deep_scoped_session):
+        # /data is real but ungranted; the granted mount below it
+        # already put "data" in the root listing, so readdir and stat
+        # must answer with the granted structure and nothing else.
+        ops = _granted_child_ops()
+        assert run(ops.readdir("/data")) == ["/data/inner"]
+        st = run(ops.stat("/data"))
+        assert st.type is FileType.DIRECTORY
+
+    def test_paths_the_structure_does_not_owe_still_deny(
+            self, deep_scoped_session):
+        ops = _granted_child_ops()
+        with pytest.raises(PermissionError):
+            run(ops.readdir("/data/other"))
+        with pytest.raises(PermissionError):
+            run(ops.write("/data/f.txt", b"x"))

--- a/python/tests/ops/test_ops.py
+++ b/python/tests/ops/test_ops.py
@@ -18,6 +18,8 @@ from mirage.accessor.ram import RAMAccessor
 from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.ops import Ops
 from mirage.ops.config import OpsMount
+from mirage.policy import (Action, Deny, OpsContext, Policies, Policy,
+                           PolicyDenied)
 from mirage.resource.ram import RAMResource
 from mirage.resource.ram.store import RAMStore
 from mirage.types import FileType, MountMode
@@ -244,3 +246,45 @@ class TestOpsViaRegistry:
         assert ops._registry is not None
         fn = ops._registry.resolve("read", "ram")
         assert fn is not None
+
+
+class _SealInner(Policy):
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        if ctx.path.virtual == "/data/inner":
+            return Deny("sealed\n")
+        return None
+
+
+def _structure_only_ops(policies: Policies | None) -> Ops:
+    """An Ops whose only mount sits below the probed path, so resolve
+    misses at /data/inner and the answer is namespace structure."""
+    mounts = [
+        OpsMount(
+            prefix="/data/inner/deep/",
+            resource_type="ram",
+            accessor=RAMAccessor(RAMStore()),
+            index=RAMIndexCacheStore(),
+            mode=MountMode.WRITE,
+            ops=_ram_registered_ops(),
+        )
+    ]
+    return Ops(mounts, policies=policies)
+
+
+class TestStructureFallbackGates:
+
+    def test_the_synthetic_answer_still_clears_admission(self):
+        # Mirrors the dispatcher door: a policy that bounds readdir or
+        # stat by path must cover a structure-only directory too.
+        policies = Policies()
+        policies.add(_SealInner())
+        ops = _structure_only_ops(policies)
+        with pytest.raises(PolicyDenied):
+            run(ops.readdir("/data/inner"))
+        with pytest.raises(PolicyDenied):
+            run(ops.stat("/data/inner"))
+
+    def test_the_synthetic_answer_serves_when_no_policy_objects(self):
+        ops = _structure_only_ops(Policies())
+        assert run(ops.readdir("/data/inner")) == ["/data/inner/deep"]

--- a/python/tests/ops/test_structure.py
+++ b/python/tests/ops/test_structure.py
@@ -1,0 +1,107 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.context import reset_current_session, set_current_session
+from mirage.ops.structure import (child_mount_names, merge_readdir,
+                                  structure_listing, structure_stat)
+from mirage.types import FileType, MountMode
+from mirage.workspace.session import Session
+
+PREFIXES = ["/base/", "/base/inner/", "/base/inner/deep/", "/other/", "/"]
+
+
+class _Links:
+    """A NamespaceLinks double answering a fixed links_under table."""
+
+    def __init__(self, under: dict[str, dict[str, str]]) -> None:
+        self._under = under
+
+    def links_under(self, directory: str) -> dict[str, str]:
+        return self._under.get(directory, {})
+
+
+@pytest.fixture
+def scoped_session():
+    """Bind a session granted only /base/inner (and its descendants)."""
+    session = Session(session_id="agent",
+                      mount_modes={"/base/inner": MountMode.EXEC})
+    token = set_current_session(session)
+    yield session
+    reset_current_session(token)
+
+
+def test_child_mount_names_lists_immediate_segments():
+    assert child_mount_names(PREFIXES, "/base") == ["inner"]
+    assert child_mount_names(PREFIXES, "/base/inner") == ["deep"]
+    assert child_mount_names(PREFIXES, "/") == ["base", "other"]
+
+
+def test_child_mount_names_excludes_the_parent_itself():
+    assert child_mount_names(["/base/"], "/base") == []
+
+
+def test_child_mount_names_keeps_hidden_names():
+    assert child_mount_names(["/.dev/"], "/") == [".dev"]
+
+
+def test_child_mount_names_filters_by_session(scoped_session):
+    # /base/inner is granted, so listing /base still shows the way to
+    # it; /other is not granted, so its name never surfaces.
+    assert child_mount_names(PREFIXES, "/") == ["base"]
+    assert child_mount_names(PREFIXES, "/base") == ["inner"]
+
+
+def test_merge_readdir_appends_mounts_and_links_as_paths():
+    links = _Links({"/base": {"lnk": "/base/inner"}})
+    merged = merge_readdir(["/base/a.txt"], PREFIXES, links, "/base")
+    assert merged == ["/base/a.txt", "/base/inner", "/base/lnk"]
+
+
+def test_merge_readdir_dedupes_on_the_final_segment():
+    # A backend that already lists a shadowed directory (any entry
+    # shape) must not gain a duplicate from the mount table.
+    for spelled in ("inner", "inner/", "/base/inner"):
+        merged = merge_readdir([spelled], PREFIXES, None, "/base")
+        assert merged == [spelled]
+
+
+def test_merge_readdir_without_links_or_mounts_is_identity():
+    assert merge_readdir(["/x/a"], ["/x/"], None, "/x") == ["/x/a"]
+
+
+def test_structure_listing_answers_only_when_something_is_below():
+    assert structure_listing(PREFIXES, None, "/base/ghost") is None
+    assert structure_listing(PREFIXES, None, "/base") == ["/base/inner"]
+    links = _Links({"/base/ghost": {"lnk": "/base"}})
+    assert structure_listing(PREFIXES, links, "/base/ghost") == [
+        "/base/ghost/lnk"
+    ]
+
+
+def test_structure_stat_agrees_with_the_listing():
+    st = structure_stat(PREFIXES, None, "/base")
+    assert st is not None and st.type is FileType.DIRECTORY
+    assert st.name == "base"
+    assert structure_stat(PREFIXES, None, "/base/ghost") is None
+
+
+def test_structure_answers_hide_ungranted_mounts(scoped_session):
+    # /top exists only because an ungranted mount sits below it: to
+    # this session the namespace must deny knowing anything there.
+    assert structure_listing(["/top/secret/"], None, "/top") is None
+    assert structure_stat(["/top/secret/"], None, "/top") is None
+    # The granted mount keeps answering through the same session.
+    assert structure_stat(PREFIXES, None, "/base") is not None

--- a/python/tests/ops/test_structure.py
+++ b/python/tests/ops/test_structure.py
@@ -16,7 +16,8 @@ import pytest
 
 from mirage.context import reset_current_session, set_current_session
 from mirage.ops.structure import (child_mount_names, merge_readdir,
-                                  structure_listing, structure_stat)
+                                  structure_listing, structure_names,
+                                  structure_stat)
 from mirage.types import FileType, MountMode
 from mirage.workspace.session import Session
 
@@ -118,3 +119,23 @@ def test_structure_answers_hide_ungranted_mounts(scoped_session):
     assert structure_stat(["/top/secret/"], None, "/top") is None
     # The granted mount keeps answering through the same session.
     assert structure_stat(PREFIXES, None, "/base") is not None
+
+
+def test_link_names_filter_by_owning_mount(scoped_session):
+    # A link below an ungranted mount must not leak that mount's name
+    # into a listing child_mount_names had already filtered; a link
+    # inside the granted mount keeps answering. Ownership is
+    # longest-match, the same rule dispatch resolves the path by.
+    links = _Links({"/other/leak": "/tgt", "/base/inner/ok": "/tgt"})
+    assert structure_names(PREFIXES, links, "/") == ["base"]
+    assert structure_listing(PREFIXES, links,
+                             "/base/inner") == ["/base/inner/ok"]
+
+
+def test_link_above_every_mount_stays_visible(scoped_session):
+    # No mount owns /ghost/...: the link discloses nothing about any
+    # mount, so a scoped session still sees the chain (it may have
+    # created the link itself at a structure-only path).
+    links = _Links({"/ghost/deep/lnk": "/base/inner"})
+    assert structure_listing(["/base/inner/"], links,
+                             "/") == ["/base", "/ghost"]

--- a/python/tests/ops/test_structure.py
+++ b/python/tests/ops/test_structure.py
@@ -86,9 +86,8 @@ def test_structure_listing_answers_only_when_something_is_below():
     assert structure_listing(PREFIXES, None, "/base/ghost") is None
     assert structure_listing(PREFIXES, None, "/base") == ["/base/inner"]
     links = _Links({"/base/ghost": {"lnk": "/base"}})
-    assert structure_listing(PREFIXES, links, "/base/ghost") == [
-        "/base/ghost/lnk"
-    ]
+    assert structure_listing(PREFIXES, links,
+                             "/base/ghost") == ["/base/ghost/lnk"]
 
 
 def test_structure_stat_agrees_with_the_listing():

--- a/python/tests/ops/test_structure.py
+++ b/python/tests/ops/test_structure.py
@@ -24,13 +24,13 @@ PREFIXES = ["/base/", "/base/inner/", "/base/inner/deep/", "/other/", "/"]
 
 
 class _Links:
-    """A NamespaceLinks double answering a fixed links_under table."""
+    """A NamespaceLinks double answering a fixed link table."""
 
-    def __init__(self, under: dict[str, dict[str, str]]) -> None:
-        self._under = under
+    def __init__(self, targets: dict[str, str]) -> None:
+        self._targets = targets
 
-    def links_under(self, directory: str) -> dict[str, str]:
-        return self._under.get(directory, {})
+    def symlink_targets(self) -> dict[str, str]:
+        return self._targets
 
 
 @pytest.fixture
@@ -65,7 +65,7 @@ def test_child_mount_names_filters_by_session(scoped_session):
 
 
 def test_merge_readdir_appends_mounts_and_links_as_paths():
-    links = _Links({"/base": {"lnk": "/base/inner"}})
+    links = _Links({"/base/lnk": "/base/inner"})
     merged = merge_readdir(["/base/a.txt"], PREFIXES, links, "/base")
     assert merged == ["/base/a.txt", "/base/inner", "/base/lnk"]
 
@@ -85,9 +85,23 @@ def test_merge_readdir_without_links_or_mounts_is_identity():
 def test_structure_listing_answers_only_when_something_is_below():
     assert structure_listing(PREFIXES, None, "/base/ghost") is None
     assert structure_listing(PREFIXES, None, "/base") == ["/base/inner"]
-    links = _Links({"/base/ghost": {"lnk": "/base"}})
+    links = _Links({"/base/ghost/lnk": "/base"})
     assert structure_listing(PREFIXES, links,
                              "/base/ghost") == ["/base/ghost/lnk"]
+
+
+def test_link_ancestors_synthesize_like_mount_prefixes():
+    # ln permits a link below a directory chain no backend serves; every
+    # ancestor of the link must list and stat, or the link is reachable
+    # by exact path yet invisible to any walk from above.
+    links = _Links({"/ghost/deep/lnk": "/base"})
+    assert structure_listing([], links, "/") == ["/ghost"]
+    assert structure_listing([], links, "/ghost") == ["/ghost/deep"]
+    assert structure_listing([], links, "/ghost/deep") == ["/ghost/deep/lnk"]
+    st = structure_stat([], links, "/ghost")
+    assert st is not None and st.type is FileType.DIRECTORY
+    # The link itself is not structure: its stat is the lstat surface's.
+    assert structure_stat([], links, "/ghost/deep/lnk") is None
 
 
 def test_structure_stat_agrees_with_the_listing():

--- a/python/tests/runtime/test_conformance_worlds.py
+++ b/python/tests/runtime/test_conformance_worlds.py
@@ -302,6 +302,32 @@ async def test_door_stats_structure_only_directory():
         await ws.close()
 
 
+@pytest.mark.asyncio
+async def test_link_ancestors_synthesize_on_every_surface():
+    """A link below an absent directory chain is reachable from above.
+
+    ``ln`` permits ``/ghost/deep/lnk`` with no backend serving
+    ``/ghost``; its ancestors synthesize exactly as nested mount
+    prefixes do, so ``ls /`` shows the way in and a guest walk from
+    the root reaches the link.
+    """
+    ws = structure_world("monty")
+    try:
+        assert (await _sh(ws, "ln -s /base/a.txt /ghost/deep/lnk"))[0] == 0
+        st = await ws.ops.stat("/ghost")
+        assert st.type.value == "directory"
+        code, out, _ = await _sh(ws, "ls /")
+        assert code == 0
+        assert "ghost" in out
+        code, out, err = await _sh(
+            ws, "python3 -c \"from pathlib import Path; "
+            "print(sorted(str(p) for p in Path('/ghost').iterdir()))\"")
+        assert code == 0, err
+        assert "/ghost/deep" in out
+    finally:
+        await ws.close()
+
+
 # ── Group 3: a scoped session confines every surface ──
 #
 # Explicit operands and the headless FUSE core are confined today. The

--- a/python/tests/runtime/test_conformance_worlds.py
+++ b/python/tests/runtime/test_conformance_worlds.py
@@ -479,6 +479,62 @@ async def test_fanout_does_not_cross_boundary(line: str, needle: str):
         await ws.close()
 
 
+def shadowed_world(runtime: str) -> Workspace:
+    """A parent backend holding keys shadowed by an ungranted mount.
+
+    ``/base`` (granted to session ``agent``) is seeded with
+    ``inner/leftover.txt`` in its own backend; ``/base/inner`` is a
+    second, ungranted mount that shadows that key in the merged view.
+    The trap: with no *allowed* descendant the fan-out is tempting to
+    skip, and single-mount dispatch then serves the shadowed key that
+    path dispatch itself refuses.
+
+    Args:
+        runtime (str): registry name of the guest runtime to attach.
+    """
+    ws = Workspace(
+        {
+            "/base":
+            _seed({
+                "/a.txt": b"top",
+                "/inner/leftover.txt": b"SHADOWED-xyz",
+            }),
+            "/base/inner":
+            _seed({"/deep.txt": b"needle"}),
+        },
+        mode=MountMode.EXEC,
+        runtimes=[runtime, "vfs"],
+    )
+    ws.create_session("agent", mounts=["/base"])
+    return ws
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line,needle", [
+    ("find /base", "leftover"),
+    ("grep -r SHADOWED /base", "SHADOWED-xyz"),
+])
+async def test_fanout_hides_shadowed_keys_when_no_descendant_is_granted(
+        line: str, needle: str):
+    """Fan-out still engages when every descendant mount is ungranted.
+
+    The parent backend's keys under the hidden mount's prefix are
+    shadowed in the merged view, so the walk must drop them even though
+    there is no granted descendant to descend into.
+
+    Args:
+        line (str): the recursive shell line rooted at the parent.
+        needle (str): the shadowed fact that must not appear.
+    """
+    ws = shadowed_world("monty")
+    try:
+        _, out, _ = await _sh(ws, line, session_id="agent")
+        assert needle not in out
+        assert "inner" not in out
+    finally:
+        await ws.close()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "runtime,line",

--- a/python/tests/runtime/test_conformance_worlds.py
+++ b/python/tests/runtime/test_conformance_worlds.py
@@ -122,7 +122,8 @@ def scoped_world(runtime: str) -> Workspace:
     return ws
 
 
-async def _sh(ws: Workspace, line: str,
+async def _sh(ws: Workspace,
+              line: str,
               session_id: str | None = None) -> tuple[int, str, str]:
     """Run one shell line, returning exit code and decoded streams.
 
@@ -384,8 +385,10 @@ async def test_fanout_does_not_cross_boundary(line: str, needle: str):
 @pytest.mark.parametrize(
     "runtime,line",
     _guest_cases({
-        "monty": "python3 -c \"print(open('/closed/sec.txt').read())\"",
-        "wasi": "python3 -c \"print(open('/closed/sec.txt').read())\"",
+        "monty":
+        "python3 -c \"print(open('/closed/sec.txt').read())\"",
+        "wasi":
+        "python3 -c \"print(open('/closed/sec.txt').read())\"",
         "quickjs":
         "node -e \"const f = std.open('/closed/sec.txt', 'r'); "
         "console.log(f.readAsString())\"",
@@ -431,7 +434,8 @@ async def test_guest_cannot_follow_link_out_of_scope():
     try:
         assert (await _sh(ws, "ln -s /closed /open/esc"))[0] == 0
         code, out, _ = await _sh(
-            ws, "python3 -c \"print(open('/open/esc/sec.txt').read())\"",
+            ws,
+            "python3 -c \"print(open('/open/esc/sec.txt').read())\"",
             session_id="agent")
         assert code != 0
         assert "SECRET-xyz" not in out
@@ -450,13 +454,15 @@ async def test_guest_cannot_follow_link_out_of_scope():
 @pytest.mark.parametrize(
     "runtime,line",
     _guest_cases({
-        "monty": "cd /base && python3 -c \"print(open('a.txt').read())\"",
-        "wasi": "cd /base && python3 -c \"print(open('a.txt').read())\"",
+        "monty":
+        "cd /base && python3 -c \"print(open('a.txt').read())\"",
+        "wasi":
+        "cd /base && python3 -c \"print(open('a.txt').read())\"",
     }),
 )
 @pytest.mark.xfail(reason=CWD, strict=True)
-async def test_guest_resolves_relative_path_against_cwd(runtime: str,
-                                                        line: str):
+async def test_guest_resolves_relative_path_against_cwd(
+        runtime: str, line: str):
     """A guest launched in ``/base`` reads ``a.txt`` relatively.
 
     Args:

--- a/python/tests/runtime/test_conformance_worlds.py
+++ b/python/tests/runtime/test_conformance_worlds.py
@@ -319,6 +319,9 @@ async def test_link_ancestors_synthesize_on_every_surface():
         code, out, _ = await _sh(ws, "ls /")
         assert code == 0
         assert "ghost" in out
+        code, out, _ = await _sh(ws, "ls /ghost")
+        assert code == 0
+        assert "deep" in out
         code, out, err = await _sh(
             ws, "python3 -c \"from pathlib import Path; "
             "print(sorted(str(p) for p in Path('/ghost').iterdir()))\"")

--- a/python/tests/runtime/test_conformance_worlds.py
+++ b/python/tests/runtime/test_conformance_worlds.py
@@ -386,6 +386,75 @@ async def test_scoped_session_hides_name_from_root_listing():
 
 
 @pytest.mark.asyncio
+async def test_scoped_link_below_ungranted_mount_stays_hidden():
+    """A namespace link under an ungranted mount must not leak its name.
+
+    ``child_mount_names`` already hides ``/closed`` itself; a link at
+    ``/closed/leak`` is namespace state above the backend, but its path
+    discloses the same name, so the same grant filters it. The
+    unrestricted view keeps the link.
+    """
+    ws = scoped_world("monty")
+    try:
+        assert (await _sh(ws, "ln -s /closed/sec.txt /closed/leak"))[0] == 0
+        code, out, _ = await _sh(ws, "ls /", session_id="agent")
+        assert code == 0
+        assert "closed" not in out
+        code, out, _ = await _sh(ws, "ls /")
+        assert code == 0
+        assert "closed" in out
+    finally:
+        await ws.close()
+
+
+def granted_child_world(runtime: str) -> Workspace:
+    """An ungranted parent mount with a granted child nested inside.
+
+    ``/base`` (``a.txt``) is not granted to session ``agent``;
+    ``/base/inner`` (``deep.txt``) is. The root listing deliberately
+    shows ``base`` as the traversal path to the grant, so the walk down
+    through ``/base`` must answer with structure and nothing of the
+    parent's own content.
+
+    Args:
+        runtime (str): registry name of the guest runtime to attach.
+    """
+    ws = Workspace(
+        {
+            "/base": _seed({"/a.txt": b"top"}),
+            "/base/inner": _seed({"/deep.txt": b"needle"}),
+        },
+        mode=MountMode.EXEC,
+        runtimes=[runtime, "vfs"],
+    )
+    ws.create_session("agent", mounts=["/base/inner"])
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_scoped_walk_reaches_nested_grant():
+    """An ungranted parent with a granted child serves its structure.
+
+    Refusing ``/base`` strands the session outside its own mount, and
+    serving the backend would leak ungranted content; the answer is
+    the granted structure and nothing else.
+    """
+    ws = granted_child_world("monty")
+    try:
+        sess = ws.get_session("agent")
+        core = MountCore(ws.ops, session=sess)
+        names = core.readdir("/base")
+        assert "inner" in names
+        assert "a.txt" not in names
+        assert core.getattr("/base")["st_mode"] & 0o040000
+        assert "deep.txt" in core.readdir("/base/inner")
+        with pytest.raises(PermissionError):
+            core.getattr("/base/a.txt")
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("line,needle", [
     ("grep -r SECRET /", "SECRET-xyz"),
     ("ls -R /", "sec.txt"),

--- a/python/tests/runtime/test_conformance_worlds.py
+++ b/python/tests/runtime/test_conformance_worlds.py
@@ -1,0 +1,472 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import os
+from pathlib import Path
+
+import pytest
+
+from mirage import MountMode, Workspace
+from mirage.fuse.core import MountCore
+from mirage.io.types import materialize
+from mirage.resource.ram import RAMResource
+from mirage.runtime.js.quickjs import QUICKJS_HOME_ENV
+from mirage.runtime.python.wasi import WASI_HOME_ENV
+
+
+def _wasi_available() -> bool:
+    root = os.environ.get(WASI_HOME_ENV)
+    return bool(root) and (Path(root) / "python.wasm").is_file()
+
+
+def _quickjs_available() -> bool:
+    root = os.environ.get(QUICKJS_HOME_ENV)
+    return bool(root) and (Path(root) / "qjs-wasi.wasm").is_file()
+
+
+wasi_live = pytest.mark.skipif(
+    not _wasi_available(),
+    reason=f"{WASI_HOME_ENV} does not point at a CPython WASI build")
+quickjs_live = pytest.mark.skipif(
+    not _quickjs_available(),
+    reason=f"{QUICKJS_HOME_ENV} does not point at a quickjs WASI build")
+
+# One world, three surfaces, one door. The suite pins the facts a mount
+# tree must present identically through the shell (virtual commands),
+# through a sandboxed guest (its own stdlib), and through a headless
+# FUSE MountCore. A guest and the shell disagreeing about the same
+# mount is the whole bug class the runtime-fs-unify arc exists to
+# close, so the guest surface is verified against the SAME world the
+# shell walks, never against the runtime's own report.
+#
+# Facts broken on main are marked xfail(strict=True) with the R-step
+# that fixes them: the mark comes off as each step lands, and a fact
+# that starts passing early fails loud instead of rotting as a silent
+# xpass. R1 (mount structure into the door: readdir/stat merge child
+# mounts and namespace links behind the session guard, fan-out and the
+# ls fact session-filtered) has landed, which is why the structure and
+# enumeration groups run unmarked. R2 = one guarded door for every op,
+# closing the guest session leaks that remain (the thread-hop drops the
+# session contextvar, so a guest reads and writes unscoped).
+
+R2_GUEST = "R2: the guest thread-hop drops the session, so ops run unscoped"
+CWD = "runtime cwd is not wired: guests resolve no relative paths"
+
+
+def _seed(files: dict[str, bytes]) -> RAMResource:
+    """A RAM resource preloaded with mount-relative files.
+
+    Args:
+        files (dict[str, bytes]): mount-relative path -> content.
+    """
+    r = RAMResource()
+    for name, body in files.items():
+        r._store.files[name] = body
+    return r
+
+
+def structure_world(runtime: str) -> Workspace:
+    """A nested mount plus a namespace symlink, one backend file each.
+
+    ``/base`` holds ``a.txt``; ``/base/inner`` is a second mount holding
+    ``deep.txt``; ``/base/lnk`` is a namespace symlink to ``/base/inner``
+    (created by the caller, since links are namespace state no backend
+    reports). The point: ``inner`` and ``lnk`` are both discoverable
+    only above the backend, so a surface that lists ``/base`` by asking
+    one backend alone misses them.
+
+    Args:
+        runtime (str): registry name of the guest runtime to attach.
+    """
+    return Workspace(
+        {
+            "/base": _seed({"/a.txt": b"top"}),
+            "/base/inner": _seed({"/deep.txt": b"needle"}),
+        },
+        mode=MountMode.EXEC,
+        runtimes=[runtime, "vfs"],
+    )
+
+
+def scoped_world(runtime: str) -> Workspace:
+    """Two mounts, a session granted only the first.
+
+    ``/open`` (``pub.txt``) is granted to session ``agent``; ``/closed``
+    (``sec.txt``) is not. ``/open/esc`` is a namespace symlink into
+    ``/closed``, the cross-mount escape a confined guest must not be
+    able to follow.
+
+    Args:
+        runtime (str): registry name of the guest runtime to attach.
+    """
+    ws = Workspace(
+        {
+            "/open": _seed({"/pub.txt": b"public"}),
+            "/closed": _seed({"/sec.txt": b"SECRET-xyz"}),
+        },
+        mode=MountMode.EXEC,
+        runtimes=[runtime, "vfs"],
+    )
+    ws.create_session("agent", mounts=["/open"])
+    return ws
+
+
+async def _sh(ws: Workspace, line: str,
+              session_id: str | None = None) -> tuple[int, str, str]:
+    """Run one shell line, returning exit code and decoded streams.
+
+    Args:
+        ws (Workspace): the world.
+        line (str): the command line (a shell command or a guest one).
+        session_id (str | None): session to run under, None for default.
+    """
+    kwargs = {"session_id": session_id} if session_id is not None else {}
+    io = await ws.execute(line, **kwargs)
+    out = (await materialize(io.stdout)).decode() if io.stdout else ""
+    err = (await materialize(io.stderr)).decode() if io.stderr else ""
+    return io.exit_code, out, err
+
+
+GUARDS = {"monty": (), "wasi": (wasi_live, ), "quickjs": (quickjs_live, )}
+
+
+def _guest_cases(spellings: dict[str, str]) -> list[object]:
+    """Parametrize a guest line over the runtimes that can express it.
+
+    Args:
+        spellings (dict[str, str]): runtime name -> the guest line in
+            that runtime's idiom. A runtime absent from the dict has no
+            spelling for this fact and is skipped.
+    """
+    out: list[object] = []
+    for runtime, line in spellings.items():
+        out.append(
+            pytest.param(runtime, line, id=runtime, marks=GUARDS[runtime]))
+    return out
+
+
+# ── Group 1: nested mount + namespace link are visible to every surface ──
+#
+# The shell and a headless FUSE readdir both merge structure today; the
+# guest readdir does not, and that gap is the same one that hides a
+# nested mount and a namespace symlink alike.
+
+
+@pytest.mark.asyncio
+async def test_shell_lists_child_mount_and_link():
+    ws = structure_world("monty")
+    try:
+        code, out, _ = await _sh(ws, "ln -s /base/inner /base/lnk")
+        assert code == 0
+        code, out, _ = await _sh(ws, "ls /base")
+        assert code == 0
+        assert "a.txt" in out and "inner" in out and "lnk" in out
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_shell_walk_reaches_nested_descendant():
+    ws = structure_world("monty")
+    try:
+        code, out, _ = await _sh(ws, "grep -r needle /base")
+        assert code == 0
+        assert "/base/inner/deep.txt" in out
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_fuse_readdir_merges_child_mount_and_link():
+    ws = structure_world("monty")
+    try:
+        assert (await _sh(ws, "ln -s /base/inner /base/lnk"))[0] == 0
+        core = MountCore(ws.ops)
+        names = core.readdir("/base")
+        assert "a.txt" in names and "inner" in names and "lnk" in names
+        assert core.getattr("/base/inner")["st_mode"] & 0o040000
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime,line",
+    _guest_cases({
+        "monty":
+        "python3 -c \"from pathlib import Path; "
+        "print(sorted(p.name for p in Path('/base').iterdir()))\"",
+        "wasi":
+        "python3 -c \"import os; print(sorted(os.listdir('/base')))\"",
+        "quickjs":
+        "node -e \"const [n] = os.readdir('/base'); "
+        "console.log(n.sort().join(','))\"",
+    }),
+)
+async def test_guest_lists_child_mount(runtime: str, line: str):
+    """A guest listing ``/base`` must see the nested mount ``inner``.
+
+    Args:
+        runtime (str): guest runtime under test.
+        line (str): the listing line in that runtime's idiom.
+    """
+    ws = structure_world(runtime)
+    try:
+        code, out, err = await _sh(ws, line)
+        assert code == 0, err
+        assert "inner" in out
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime,line",
+    _guest_cases({
+        "monty":
+        "python3 -c \"from pathlib import Path; "
+        "print(sorted(p.name for p in Path('/base').iterdir()))\"",
+        "wasi":
+        "python3 -c \"import os; print(sorted(os.listdir('/base')))\"",
+    }),
+)
+async def test_guest_lists_namespace_link(runtime: str, line: str):
+    """A guest listing ``/base`` must see the namespace symlink ``lnk``.
+
+    Args:
+        runtime (str): guest runtime under test.
+        line (str): the listing line in that runtime's idiom.
+    """
+    ws = structure_world(runtime)
+    try:
+        assert (await _sh(ws, "ln -s /base/inner /base/lnk"))[0] == 0
+        code, out, err = await _sh(ws, line)
+        assert code == 0, err
+        assert "lnk" in out
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_guest_reads_through_link_by_exact_path():
+    """Following a link by exact path already works: the door follows.
+
+    This is the counterpart to the xfail above. Discovery (readdir) is
+    broken, but resolution (follow) is not, which is why the fix is to
+    complete readdir, not to teach the guest about links.
+    """
+    ws = structure_world("monty")
+    try:
+        assert (await _sh(ws, "ln -s /base/inner /base/lnk"))[0] == 0
+        code, out, err = await _sh(
+            ws, "python3 -c \"print(open('/base/lnk/deep.txt').read())\"")
+        assert code == 0, err
+        assert "needle" in out
+    finally:
+        await ws.close()
+
+
+# ── Group 2: a structure-only directory stats as a directory ──
+
+
+@pytest.mark.asyncio
+async def test_door_stats_structure_only_directory():
+    """``stat`` on a pure mount-prefix dir answers directory, not ENOENT.
+
+    ``/base/inner`` exists because a mount sits there; the ``/base``
+    backend holds nothing at that path. os.walk and Path.is_dir both
+    depend on this, so it is the door's to answer.
+    """
+    ws = structure_world("monty")
+    try:
+        st = await ws.ops.stat("/base/inner")
+        assert st.type.value == "directory"
+        code, out, err = await _sh(
+            ws, "python3 -c \"from pathlib import Path; "
+            "print(Path('/base/inner').is_dir())\"")
+        assert code == 0, err
+        assert "True" in out
+    finally:
+        await ws.close()
+
+
+# ── Group 3: a scoped session confines every surface ──
+#
+# Explicit operands and the headless FUSE core are confined today. The
+# fan-out shell commands and the guest are not: they reach an ungranted
+# mount's names, bytes and sizes, and the guest can even write there.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line", [
+    "cat /closed/sec.txt",
+    "ls /closed",
+    "grep -r SECRET /closed",
+    "find /closed",
+    "du /closed",
+])
+async def test_explicit_operand_at_boundary_is_denied(line: str):
+    """A named operand on an ungranted mount is refused out loud.
+
+    Args:
+        line (str): the shell line naming ``/closed`` directly.
+    """
+    ws = scoped_world("monty")
+    try:
+        code, _, err = await _sh(ws, line, session_id="agent")
+        assert code != 0
+        assert "not allowed" in err and "/closed" in err
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_fuse_core_confines_ungranted_mount():
+    ws = scoped_world("monty")
+    try:
+        sess = ws.get_session("agent")
+        core = MountCore(ws.ops, session=sess)
+        with pytest.raises(PermissionError):
+            core.readdir("/closed")
+        with pytest.raises(PermissionError):
+            fh = core.open("/closed/sec.txt")
+            core.read("/closed/sec.txt", 4096, 0, fh)
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_scoped_session_hides_name_from_root_listing():
+    ws = scoped_world("monty")
+    try:
+        code, out, _ = await _sh(ws, "ls /", session_id="agent")
+        assert code == 0
+        assert "open" in out
+        assert "closed" not in out
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line,needle", [
+    ("grep -r SECRET /", "SECRET-xyz"),
+    ("ls -R /", "sec.txt"),
+    ("find /", "/closed/sec.txt"),
+    ("du -a /", "/closed"),
+])
+async def test_fanout_does_not_cross_boundary(line: str, needle: str):
+    """A fan-out from ``/`` must not surface an ungranted mount.
+
+    Args:
+        line (str): the recursive shell line rooted above the boundary.
+        needle (str): the ``/closed`` fact that must not appear.
+    """
+    ws = scoped_world("monty")
+    try:
+        code, out, _ = await _sh(ws, line, session_id="agent")
+        assert needle not in out
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime,line",
+    _guest_cases({
+        "monty": "python3 -c \"print(open('/closed/sec.txt').read())\"",
+        "wasi": "python3 -c \"print(open('/closed/sec.txt').read())\"",
+        "quickjs":
+        "node -e \"const f = std.open('/closed/sec.txt', 'r'); "
+        "console.log(f.readAsString())\"",
+    }),
+)
+@pytest.mark.xfail(reason=R2_GUEST, strict=True)
+async def test_guest_cannot_read_ungranted_mount(runtime: str, line: str):
+    """A confined guest reading ``/closed`` must be refused, not served.
+
+    Args:
+        runtime (str): guest runtime under test.
+        line (str): the read line in that runtime's idiom.
+    """
+    ws = scoped_world(runtime)
+    try:
+        code, out, _ = await _sh(ws, line, session_id="agent")
+        assert code != 0
+        assert "SECRET-xyz" not in out
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason=R2_GUEST, strict=True)
+async def test_guest_cannot_write_ungranted_mount():
+    ws = scoped_world("monty")
+    try:
+        line = ("python3 -c \"from pathlib import Path; "
+                "Path('/closed/planted.txt').write_text('X')\"")
+        await _sh(ws, line, session_id="agent")
+        code, out, _ = await _sh(ws, "ls /closed")
+        assert code == 0
+        assert "planted.txt" not in out
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason=R2_GUEST, strict=True)
+async def test_guest_cannot_follow_link_out_of_scope():
+    """A cross-mount symlink is not an escape hatch from confinement."""
+    ws = scoped_world("monty")
+    try:
+        assert (await _sh(ws, "ln -s /closed /open/esc"))[0] == 0
+        code, out, _ = await _sh(
+            ws, "python3 -c \"print(open('/open/esc/sec.txt').read())\"",
+            session_id="agent")
+        assert code != 0
+        assert "SECRET-xyz" not in out
+    finally:
+        await ws.close()
+
+
+# ── Group 4: a guest resolves relative paths against its cwd (forward) ──
+#
+# The shell has a cwd; the guest never receives it. Relative-path ops
+# in a guest fail today. Pinned as the fact a cwd-carrying door must
+# satisfy, so the wiring lands with a test already waiting for it.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime,line",
+    _guest_cases({
+        "monty": "cd /base && python3 -c \"print(open('a.txt').read())\"",
+        "wasi": "cd /base && python3 -c \"print(open('a.txt').read())\"",
+    }),
+)
+@pytest.mark.xfail(reason=CWD, strict=True)
+async def test_guest_resolves_relative_path_against_cwd(runtime: str,
+                                                        line: str):
+    """A guest launched in ``/base`` reads ``a.txt`` relatively.
+
+    Args:
+        runtime (str): guest runtime under test.
+        line (str): the relative-read line in that runtime's idiom.
+    """
+    ws = structure_world(runtime)
+    try:
+        code, out, err = await _sh(ws, line)
+        assert code == 0, err
+        assert "top" in out
+    finally:
+        await ws.close()

--- a/python/tests/runtime/test_conformance_worlds.py
+++ b/python/tests/runtime/test_conformance_worlds.py
@@ -331,6 +331,32 @@ async def test_link_ancestors_synthesize_on_every_surface():
         await ws.close()
 
 
+@pytest.mark.asyncio
+async def test_namespace_only_ancestor_serves_every_ls_variant():
+    """A mount at ``/ghost/deep`` gives ``/ghost`` no backend, so the
+    door alone says it exists; plain ls, ls -R (whose walk runs through
+    the cross-mount fan-out) and ls -d must all agree instead of
+    reporting the operand missing.
+    """
+    ws = Workspace(
+        {
+            "/base": _seed({"/a.txt": b"top"}),
+            "/ghost/deep": _seed({"/x.txt": b"inside"}),
+        },
+        mode=MountMode.EXEC,
+        runtimes=["monty", "vfs"],
+    )
+    try:
+        code, out, _ = await _sh(ws, "ls -R /ghost")
+        assert code == 0
+        assert "/ghost:" in out and "deep" in out and "x.txt" in out
+        code, out, _ = await _sh(ws, "ls -d /ghost")
+        assert code == 0
+        assert out.strip() == "/ghost"
+    finally:
+        await ws.close()
+
+
 # ── Group 3: a scoped session confines every surface ──
 #
 # Explicit operands and the headless FUSE core are confined today. The

--- a/python/tests/runtime/wasm/test_vfs.py
+++ b/python/tests/runtime/wasm/test_vfs.py
@@ -16,6 +16,7 @@ import errno as host_errno
 
 import pytest
 
+from mirage.ops.structure import merge_readdir
 from mirage.runtime.vfs import RuntimeVFS
 from mirage.runtime.wasm.abi import FT_DIR, FT_REG, FT_UNKNOWN
 from mirage.runtime.wasm.config import WasmFsConfig
@@ -82,7 +83,9 @@ class FakeVFS(RuntimeVFS):
             out += [d + "/" for d in self.dirs if d.startswith(prefix)]
             if not out and path not in self.dirs and path != "/":
                 raise FileNotFoundError(path)
-            return sorted(out)
+            # The real door merges child-mount names into readdir; the
+            # double rides the same helper so it cannot drift from it.
+            return sorted(merge_readdir(out, self.prefixes(), None, path))
         raise NotImplementedError(op)
 
 
@@ -153,10 +156,13 @@ def test_readdir_root_merges_host_bridge_and_mounts(tmp_path):
     (tmp_path / "python.wasm").write_bytes(b"\0asm")
     bridge = FakeVFS(files={"/root.txt": b""}, prefixes=["/data/", "/logs/"])
     fs = WasmVFS(WasmFsConfig(host_root=str(tmp_path)), bridge)
+    # Mount entries arrive through the core readdir (the door merges
+    # them), so their kind is unknown here; guests stat lazily and the
+    # door answers a directory for a structure-only path.
     assert fs.readdir("/") == [
-        ("data", FT_DIR),
+        ("data", FT_UNKNOWN),
         ("lib", FT_DIR),
-        ("logs", FT_DIR),
+        ("logs", FT_UNKNOWN),
         ("python.wasm", FT_REG),
         ("root.txt", FT_UNKNOWN),
     ]

--- a/python/tests/runtime/wasm/test_vfs.py
+++ b/python/tests/runtime/wasm/test_vfs.py
@@ -16,7 +16,7 @@ import errno as host_errno
 
 import pytest
 
-from mirage.ops.structure import merge_readdir
+from mirage.ops.namespace_view import merge_readdir
 from mirage.runtime.vfs import RuntimeVFS
 from mirage.runtime.wasm.abi import FT_DIR, FT_REG, FT_UNKNOWN
 from mirage.runtime.wasm.config import WasmFsConfig

--- a/python/tests/utils/test_path.py
+++ b/python/tests/utils/test_path.py
@@ -16,7 +16,8 @@ import pytest
 
 from mirage.utils.path import (ancestors, drop_trailing_segments, expand_tilde,
                                glob_prefix_match, gnu_basename, gnu_dirname,
-                               norm, parent, resolve_path, respell_one)
+                               norm, norm_dir, parent, resolve_path,
+                               respell_one)
 
 
 def test_norm_strips_and_adds_leading_slash():
@@ -25,6 +26,14 @@ def test_norm_strips_and_adds_leading_slash():
     assert norm("///a///") == "/a"
     assert norm("") == "/"
     assert norm("/") == "/"
+
+
+def test_norm_dir_yields_trailing_slash_form():
+    assert norm_dir("a/b") == "/a/b/"
+    assert norm_dir("/a/b/") == "/a/b/"
+    assert norm_dir("///a///") == "/a/"
+    assert norm_dir("") == "/"
+    assert norm_dir("/") == "/"
 
 
 def test_parent_of_normalized_key():

--- a/python/tests/workspace/executor/command/test_run.py
+++ b/python/tests/workspace/executor/command/test_run.py
@@ -20,43 +20,31 @@ from mirage.types import MountMode, ResourceName
 from mirage.utils.params import accepts_kwarg
 from mirage.workspace import Workspace
 from mirage.workspace.executor.command.run import (drop_service_caches,
-                                                   link_view, listed_names)
-
-_LONG_ROW = "-rw-r--r-- 1 user user 6 Aug  2 18:54 real.txt"
-_DEGRADED_ROW = "d\t-\t-\tsub"
+                                                   link_view,
+                                                   registry_child_mounts)
 
 
-def test_short_form_reads_plain_names():
-    assert listed_names("a.txt\nb.txt\n", False) == {"a.txt", "b.txt"}
+class _FakeMount:
+
+    def __init__(self, prefix: str) -> None:
+        self.prefix = prefix
 
 
-def test_short_form_strips_classify_suffixes():
-    assert listed_names("dir/\nlink@\nexe*\n", False) == {"dir", "link", "exe"}
+class _FakeRegistry:
+    """Enough of MountRegistry for the child_mounts fact to bind against."""
+
+    def __init__(self, prefixes: list[str]) -> None:
+        self._prefixes = prefixes
+
+    def mounts(self) -> list[_FakeMount]:
+        return [_FakeMount(p) for p in self._prefixes]
 
 
-def test_long_form_reads_the_name_out_of_a_full_gnu_row():
-    """The name is the ninth whitespace field; splitting on tabs alone
-    read the whole row as one field, so dedup silently never matched."""
-    assert listed_names(_LONG_ROW, True) == {"real.txt"}
-
-
-def test_long_form_still_reads_the_degraded_tab_row():
-    assert listed_names(_DEGRADED_ROW, True) == {"sub"}
-
-
-def test_long_form_handles_both_row_shapes_at_once():
-    listing = f"{_LONG_ROW}\n{_DEGRADED_ROW}\n"
-    assert listed_names(listing, True) == {"real.txt", "sub"}
-
-
-def test_a_name_containing_spaces_survives():
-    row = "-rw-r--r-- 1 user user 6 Aug  2 18:54 two words.txt"
-    assert listed_names(row, True) == {"two words.txt"}
-
-
-def test_blank_lines_contribute_nothing():
-    assert listed_names("\n\n", True) == set()
-    assert listed_names("\n\n", False) == set()
+def test_registry_child_mounts_derives_from_the_mount_table():
+    reg = _FakeRegistry(["/base/", "/base/inner/", "/dev/"])
+    assert registry_child_mounts(reg, "/base") == ["inner"]
+    assert registry_child_mounts(reg, "/") == ["base", "dev"]
+    assert registry_child_mounts(reg, "/dev") == []
 
 
 class _FakeNamespace:

--- a/python/tests/workspace/executor/command/test_run.py
+++ b/python/tests/workspace/executor/command/test_run.py
@@ -40,11 +40,30 @@ class _FakeRegistry:
         return [_FakeMount(p) for p in self._prefixes]
 
 
+class _FakeLinks:
+
+    def __init__(self, targets: dict[str, str]) -> None:
+        self._targets = targets
+
+    def symlink_targets(self) -> dict[str, str]:
+        return self._targets
+
+
 def test_registry_child_mounts_derives_from_the_mount_table():
     reg = _FakeRegistry(["/base/", "/base/inner/", "/dev/"])
-    assert registry_child_mounts(reg, "/base") == ["inner"]
-    assert registry_child_mounts(reg, "/") == ["base", "dev"]
-    assert registry_child_mounts(reg, "/dev") == []
+    assert registry_child_mounts(reg, None, "/base") == ["inner"]
+    assert registry_child_mounts(reg, None, "/") == ["base", "dev"]
+    assert registry_child_mounts(reg, None, "/dev") == []
+
+
+def test_registry_child_mounts_includes_link_ancestors():
+    # A link below a directory chain no backend serves synthesizes its
+    # ancestors, exactly as a nested mount prefix does, so `ls /` shows
+    # the way to it.
+    reg = _FakeRegistry(["/base/"])
+    links = _FakeLinks({"/ghost/deep/lnk": "/base"})
+    assert registry_child_mounts(reg, links, "/") == ["base", "ghost"]
+    assert registry_child_mounts(reg, links, "/ghost") == ["deep"]
 
 
 class _FakeNamespace:

--- a/python/tests/workspace/mount/namespace/test_namespace.py
+++ b/python/tests/workspace/mount/namespace/test_namespace.py
@@ -114,15 +114,6 @@ def test_follow_identity_without_links(namespace):
 
 
 @pytest.mark.asyncio
-async def test_links_under_returns_direct_children_only(namespace):
-    await namespace.symlink("/data/a", "/t1", 1.0)
-    await namespace.symlink("/data/sub/b", "/t2", 1.0)
-    await namespace.symlink("/other/c", "/t3", 1.0)
-    assert namespace.links_under("/data") == {"a": "/t1"}
-    assert namespace.links_under("/data/sub") == {"b": "/t2"}
-
-
-@pytest.mark.asyncio
 async def test_purge_under_drops_nested_entries(namespace):
     await namespace.symlink("/data/sub/a", "/t1", 1.0)
     await namespace.symlink("/data/sub/deep/b", "/t2", 1.0)
@@ -167,7 +158,6 @@ async def test_overlay_nodes_are_not_links(namespace):
     await namespace.set_attrs("/data/f.txt", mode=0o600)
     assert namespace.symlink_targets() == {}
     assert namespace.has_links() is False
-    assert namespace.links_under("/data") == {}
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/test_dispatcher.py
+++ b/python/tests/workspace/test_dispatcher.py
@@ -109,3 +109,39 @@ async def test_spec_op_twin_holds_on_the_dispatch_door():
     with pytest.raises(PolicyDenied) as excinfo:
         await dispatcher.dispatch("read", _path("/data/locked/a.txt"))
     assert "frozen" in str(excinfo.value)
+
+
+def _structure_only(dispatcher) -> None:
+    """Point the mocks at a path no mount serves but structure knows:
+    mount_for misses, while a mount deeper down makes the namespace
+    answer readdir/stat for its parent."""
+    namespace = dispatcher._namespace
+    namespace.mount_for = MagicMock(side_effect=ValueError("no mount"))
+    deep = MagicMock()
+    deep.prefix = "/data/locked/inner/deep/"
+    namespace.registry.mounts = MagicMock(return_value=[deep])
+    namespace.links_under = MagicMock(return_value={})
+
+
+@pytest.mark.asyncio
+async def test_structure_fallback_still_clears_admission():
+    # A path with no owning mount can still answer readdir/stat from
+    # namespace structure. That synthetic answer must pass the same
+    # gates as a backend one, or "no mount here" is a policy bypass.
+    policies = Policies()
+    policies.add(DenyLocked())
+    dispatcher, _ = _dispatcher(policies)
+    _structure_only(dispatcher)
+    with pytest.raises(PolicyDenied):
+        await dispatcher.dispatch("readdir", _path("/data/locked/inner"))
+    with pytest.raises(PolicyDenied):
+        await dispatcher.dispatch("stat", _path("/data/locked/inner"))
+
+
+@pytest.mark.asyncio
+async def test_structure_fallback_serves_when_no_policy_objects():
+    dispatcher, _ = _dispatcher(Policies())
+    _structure_only(dispatcher)
+    result, _ = await dispatcher.dispatch("readdir",
+                                          _path("/data/locked/inner"))
+    assert result == ["/data/locked/inner/deep"]

--- a/python/tests/workspace/test_dispatcher.py
+++ b/python/tests/workspace/test_dispatcher.py
@@ -16,10 +16,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from mirage.context import reset_current_session, set_current_session
 from mirage.policy import (Action, Deny, GuardSpec, OpsContext, Policies,
                            Policy, PolicyDenied)
-from mirage.types import ConsistencyPolicy, PathSpec
+from mirage.types import ConsistencyPolicy, FileType, MountMode, PathSpec
 from mirage.workspace.dispatcher import Dispatcher
+from mirage.workspace.session import Session
 
 
 class DenyLocked(Policy):
@@ -145,3 +147,68 @@ async def test_structure_fallback_serves_when_no_policy_objects():
     result, _ = await dispatcher.dispatch("readdir",
                                           _path("/data/locked/inner"))
     assert result == ["/data/locked/inner/deep"]
+
+
+@pytest.fixture
+def scoped_session():
+    """Bind a session granted only the deep nested mount."""
+    session = Session(session_id="agent",
+                      mount_modes={"/data/locked/inner/deep": MountMode.EXEC})
+    token = set_current_session(session)
+    yield session
+    reset_current_session(token)
+
+
+def _ungranted_parent(dispatcher) -> None:
+    """Point the mocks at a real but ungranted mount whose subtree holds
+    a granted one: mount_for resolves the parent for every path, while
+    only the deep mount is in the session's grants."""
+    namespace = dispatcher._namespace
+    mount = MagicMock()
+    mount.prefix = "/data/locked/"
+    mount.execute_op = AsyncMock(return_value=b"cold")
+    namespace.mount_for = MagicMock(return_value=mount)
+    deep = MagicMock()
+    deep.prefix = "/data/locked/inner/deep/"
+    namespace.registry.mounts = MagicMock(return_value=[mount, deep])
+    namespace.symlink_targets = MagicMock(return_value={})
+
+
+@pytest.mark.asyncio
+async def test_ungranted_parent_serves_granted_structure(scoped_session):
+    # A granted mount below an ungranted one already put the parent's
+    # name in a listing, so walking down to the grant must answer; the
+    # backend never runs, so nothing of the parent's content leaks.
+    dispatcher, _ = _dispatcher(Policies())
+    _ungranted_parent(dispatcher)
+    result, _ = await dispatcher.dispatch("readdir", _path("/data/locked"))
+    assert result == ["/data/locked/inner"]
+    st, _ = await dispatcher.dispatch("stat", _path("/data/locked"))
+    assert st.type is FileType.DIRECTORY
+    mount = dispatcher._namespace.mount_for.return_value
+    mount.execute_op.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ungranted_parent_structure_still_clears_admission(
+        scoped_session):
+    policies = Policies()
+    policies.add(DenyLocked())
+    dispatcher, _ = _dispatcher(policies)
+    _ungranted_parent(dispatcher)
+    with pytest.raises(PolicyDenied):
+        await dispatcher.dispatch("readdir", _path("/data/locked/inner"))
+
+
+@pytest.mark.asyncio
+async def test_ungranted_mount_without_structure_still_denies(scoped_session):
+    # A path the structure does not owe raises the canonical denial,
+    # and a write can never be served synthetically.
+    dispatcher, _ = _dispatcher(Policies())
+    _ungranted_parent(dispatcher)
+    with pytest.raises(PermissionError):
+        await dispatcher.dispatch("readdir", _path("/data/locked/other"))
+    with pytest.raises(PermissionError):
+        await dispatcher.dispatch("write",
+                                  _path("/data/locked/f.txt"),
+                                  data=b"x")

--- a/python/tests/workspace/test_dispatcher.py
+++ b/python/tests/workspace/test_dispatcher.py
@@ -120,7 +120,7 @@ def _structure_only(dispatcher) -> None:
     deep = MagicMock()
     deep.prefix = "/data/locked/inner/deep/"
     namespace.registry.mounts = MagicMock(return_value=[deep])
-    namespace.links_under = MagicMock(return_value={})
+    namespace.symlink_targets = MagicMock(return_value={})
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
@@ -416,6 +416,41 @@ describe('link operands on backends with different readdir shapes', () => {
   })
 })
 
+describe('structure-only directories', () => {
+  const missing = (p: PathSpec): Promise<never> => {
+    const err = new Error(p.virtual) as Error & { code: string }
+    err.code = 'ENOENT'
+    return Promise.reject(err)
+  }
+  const childMounts = (parent: string): string[] => (parent === '/ghost' ? ['deep'] : [])
+
+  // A directory no backend serves still lists when the namespace owes it
+  // children (a nested mount, a link's ancestors): the door already names
+  // it in the parent listing, so ls must agree instead of reporting it
+  // missing.
+  it('lists namespace children when no backend serves the directory', async () => {
+    const result = await lsGeneric(
+      [PathSpec.fromStrPath('/ghost')],
+      { flags: {}, cwd: '/', childMounts } as never,
+      missing,
+      missing,
+    )
+    expect(result?.[1].exitCode).toBe(LS_OK)
+    expect(DEC.decode(result?.[0] as Uint8Array)).toBe('deep\n')
+  })
+
+  it('-R keeps the missing report (the fan-out owns cross-mount assembly)', async () => {
+    const result = await lsGeneric(
+      [PathSpec.fromStrPath('/ghost')],
+      { flags: { R: true }, cwd: '/', childMounts } as never,
+      missing,
+      missing,
+    )
+    expect(result?.[1].exitCode).toBe(LS_FAILURE)
+    expect(DEC.decode(result?.[1].stderr as Uint8Array)).toContain("cannot access '/ghost'")
+  })
+})
+
 describe('honest per-entry errors', () => {
   function enoent(p: string): Error {
     const e = new Error(p) as Error & { code: string }

--- a/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
@@ -439,15 +439,46 @@ describe('structure-only directories', () => {
     expect(DEC.decode(result?.[0] as Uint8Array)).toBe('deep\n')
   })
 
-  it('-R keeps the missing report (the fan-out owns cross-mount assembly)', async () => {
+  // Under -R the group still renders from the namespace fact; only
+  // descent into the child-mount root is withheld, because that listing
+  // is another backend's and the cross-mount fan-out assembles it.
+  it('-R renders the namespace-only group and leaves descent to fan-out', async () => {
     const result = await lsGeneric(
       [PathSpec.fromStrPath('/ghost')],
       { flags: { R: true }, cwd: '/', childMounts } as never,
       missing,
       missing,
     )
-    expect(result?.[1].exitCode).toBe(LS_FAILURE)
-    expect(DEC.decode(result?.[1].stderr as Uint8Array)).toContain("cannot access '/ghost'")
+    expect(result?.[1].exitCode).toBe(LS_OK)
+    expect(DEC.decode(result?.[0] as Uint8Array)).toBe('/ghost:\ndeep\n')
+  })
+
+  // A structure chain (a link's ancestors) continues below the first
+  // level, so -R descends it: only a child-mount root stops the walk.
+  it('-R descends structure that continues below', async () => {
+    const chain = (parent: string): string[] =>
+      parent === '/ghost' ? ['deep'] : parent === '/ghost/deep' ? ['lnk'] : []
+    const result = await lsGeneric(
+      [PathSpec.fromStrPath('/ghost')],
+      { flags: { R: true }, cwd: '/', childMounts: chain } as never,
+      missing,
+      missing,
+    )
+    expect(result?.[1].exitCode).toBe(LS_OK)
+    expect(DEC.decode(result?.[0] as Uint8Array)).toBe('/ghost:\ndeep\n\n/ghost/deep:\nlnk\n')
+  })
+
+  // -d stats the operand itself; the namespace fact is what says the
+  // directory exists, so the row must come from it when no backend does.
+  it('-d prints the namespace-only directory row', async () => {
+    const result = await lsGeneric(
+      [PathSpec.fromStrPath('/ghost')],
+      { flags: { d: true }, cwd: '/', childMounts } as never,
+      missing,
+      missing,
+    )
+    expect(result?.[1].exitCode).toBe(LS_OK)
+    expect(DEC.decode(result?.[0] as Uint8Array)).toBe('/ghost\n')
   })
 })
 

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -55,9 +55,11 @@ interface WalkOpts {
   // is what makes -R descend it.
   deref: boolean
   // Session-filtered child-mount names: the other half of namespace
-  // structure beside links, merged as directory rows. Withheld under
-  // -R, where the cross-mount fan-out assembles the recursive listing
-  // one mount at a time.
+  // structure beside links, merged as directory rows. Under -R a
+  // backend-served listing withholds the merge and a child-mount root
+  // is never descended (the cross-mount fan-out assembles those
+  // groups); a directory only the namespace serves still renders its
+  // own group from it.
   childMounts: ChildMounts | null
 }
 
@@ -180,8 +182,10 @@ async function listDir(
   deref: boolean,
   stat2: Stat,
   childMounts: ChildMounts | null,
-): Promise<FileStat[]> {
+  recursive: boolean,
+): Promise<{ stats: FileStat[]; structureOnly: boolean }> {
   let entries: string[]
+  let structureOnly = false
   try {
     entries = await readdir(dir)
   } catch (err) {
@@ -189,8 +193,12 @@ async function listDir(
     // No backend serves it, but the namespace owes it children (a
     // nested mount, a link's ancestors), so the door lists it as a
     // directory and ls must agree: the merge below renders those rows
-    // from an empty backend listing.
+    // from an empty backend listing. Under -R this group still renders;
+    // only descent into a child-mount root is withheld, because that
+    // listing is another backend's and the cross-mount fan-out
+    // assembles it.
     entries = []
+    structureOnly = true
   }
   const prefix = mountPrefixOf(dir.virtual, dir.resourcePath)
   const settled = await Promise.allSettled(entries.map((p) => stat(childSpec(p, prefix))))
@@ -217,12 +225,17 @@ async function listDir(
     const resolved = deref && links !== null ? await derefEntry(dir, link, links, stat2) : null
     stats.push(resolved ?? link)
   }
-  for (const name of childMounts?.(dir.virtual) ?? []) {
-    if (seen.has(name)) continue
-    seen.add(name)
-    stats.push(new FileStat({ name, type: FileType.DIRECTORY }))
+  if (!recursive || structureOnly) {
+    for (const name of childMounts?.(dir.virtual) ?? []) {
+      if (seen.has(name)) continue
+      seen.add(name)
+      stats.push(new FileStat({ name, type: FileType.DIRECTORY }))
+    }
   }
-  return all ? stats : stats.filter((s) => !s.name.startsWith('.'))
+  return {
+    stats: all ? stats : stats.filter((s) => !s.name.startsWith('.')),
+    structureOnly,
+  }
 }
 
 // The row for an operand that is itself a symlink, else null.
@@ -277,8 +290,9 @@ async function probeOperand(
   commandLineArg: boolean,
 ): Promise<Operand> {
   let stats: FileStat[]
+  let structureOnly = false
   try {
-    stats = await listDir(
+    const listed = await listDir(
       readdir,
       stat,
       path,
@@ -287,8 +301,11 @@ async function probeOperand(
       opts.links,
       opts.deref,
       stat,
-      opts.recursive ? null : opts.childMounts,
+      opts.childMounts,
+      opts.recursive,
     )
+    stats = listed.stats
+    structureOnly = listed.structureOnly
   } catch (err) {
     if (!isWalkError(err)) throw err
     const row = await fileEntry(stat, path)
@@ -316,6 +333,11 @@ async function probeOperand(
     for (const s of entries) {
       if (s.type !== FileType.DIRECTORY) continue
       const childPath = `${rstripSlash(path.virtual)}/${s.name}`
+      if (structureOnly && (opts.childMounts?.(childPath) ?? []).length === 0) {
+        // A child-mount root: its listing is another backend's, so the
+        // cross-mount fan-out renders that group.
+        continue
+      }
       const child = await probeOperand(
         readdir,
         stat,
@@ -421,6 +443,13 @@ export async function lsGeneric(
         collected.push(asOperand(await stat(p), p))
       } catch (err) {
         if (!isWalkError(err)) throw err
+        if ((opts.childMounts?.(p.virtual) ?? []).length > 0) {
+          // No backend serves it, but the namespace owes it children,
+          // so the door stats it as a directory and -d must print the
+          // same row.
+          collected.push(new FileStat({ name: p.rawPath, type: FileType.DIRECTORY }))
+          continue
+        }
         warnings.push({
           message: `ls: cannot access '${p.rawPath}': ${errText(err)}`,
           serious: true,

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -18,7 +18,7 @@ import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { FileStat, FileType, PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
-import type { LinkView } from '../../../ops/types.ts'
+import type { ChildMounts, LinkView } from '../../../ops/types.ts'
 import { formatLsLong } from '../utils/formatting.ts'
 import { gnuStrerror, isWalkError } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
@@ -54,6 +54,11 @@ interface WalkOpts {
   // dereferenced directory link then carries FileType.DIRECTORY, which
   // is what makes -R descend it.
   deref: boolean
+  // Session-filtered child-mount names: the other half of namespace
+  // structure beside links, merged as directory rows. Withheld under
+  // -R, where the cross-mount fan-out assembles the recursive listing
+  // one mount at a time.
+  childMounts: ChildMounts | null
 }
 
 // One ls operand once its kind is known. `row` is set when the operand is not
@@ -174,6 +179,7 @@ async function listDir(
   links: LinkView | null,
   deref: boolean,
   stat2: Stat,
+  childMounts: ChildMounts | null,
 ): Promise<FileStat[]> {
   const entries = await readdir(dir)
   const prefix = mountPrefixOf(dir.virtual, dir.resourcePath)
@@ -197,8 +203,14 @@ async function listDir(
   const seen = new Set(stats.map((s) => s.name))
   for (const link of links?.children(dir.virtual) ?? []) {
     if (seen.has(link.name)) continue
+    seen.add(link.name)
     const resolved = deref && links !== null ? await derefEntry(dir, link, links, stat2) : null
     stats.push(resolved ?? link)
+  }
+  for (const name of childMounts?.(dir.virtual) ?? []) {
+    if (seen.has(name)) continue
+    seen.add(name)
+    stats.push(new FileStat({ name, type: FileType.DIRECTORY }))
   }
   return all ? stats : stats.filter((s) => !s.name.startsWith('.'))
 }
@@ -256,7 +268,17 @@ async function probeOperand(
 ): Promise<Operand> {
   let stats: FileStat[]
   try {
-    stats = await listDir(readdir, stat, path, opts.all, warnings, opts.links, opts.deref, stat)
+    stats = await listDir(
+      readdir,
+      stat,
+      path,
+      opts.all,
+      warnings,
+      opts.links,
+      opts.deref,
+      stat,
+      opts.recursive ? null : opts.childMounts,
+    )
   } catch (err) {
     if (!isWalkError(err)) throw err
     const row = await fileEntry(stat, path)
@@ -400,7 +422,15 @@ export async function lsGeneric(
     return finish(lines, warnings)
   }
 
-  const walkOpts: WalkOpts = { all, sortBy, reverse, recursive, links, deref }
+  const walkOpts: WalkOpts = {
+    all,
+    sortBy,
+    reverse,
+    recursive,
+    links,
+    deref,
+    childMounts: opts.childMounts ?? null,
+  }
   const probed: Operand[] = []
   for (const p of targets) {
     probed.push(await probeOperand(readdir, stat, p, walkOpts, warnings, true))

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -181,7 +181,17 @@ async function listDir(
   stat2: Stat,
   childMounts: ChildMounts | null,
 ): Promise<FileStat[]> {
-  const entries = await readdir(dir)
+  let entries: string[]
+  try {
+    entries = await readdir(dir)
+  } catch (err) {
+    if (!isWalkError(err) || (childMounts?.(dir.virtual) ?? []).length === 0) throw err
+    // No backend serves it, but the namespace owes it children (a
+    // nested mount, a link's ancestors), so the door lists it as a
+    // directory and ls must agree: the merge below renders those rows
+    // from an empty backend listing.
+    entries = []
+  }
   const prefix = mountPrefixOf(dir.virtual, dir.resourcePath)
   const settled = await Promise.allSettled(entries.map((p) => stat(childSpec(p, prefix))))
   const stats: FileStat[] = []

--- a/typescript/packages/core/src/commands/config.ts
+++ b/typescript/packages/core/src/commands/config.ts
@@ -18,7 +18,7 @@ import { IOResult, type ByteSource } from '../io/types.ts'
 import type { Resource } from '../resource/base.ts'
 import type { Limit, PathSpec } from '../types.ts'
 import type { Runtime } from '../runtime/base.ts'
-import type { LinkView, StatOverlay, StatPath } from '../ops/types.ts'
+import type { ChildMounts, LinkView, StatOverlay, StatPath } from '../ops/types.ts'
 import { VERSION } from '../version.ts'
 import type { AggregateResult } from './builtin/aggregators.ts'
 import { renderHelp } from './spec/help.ts'
@@ -71,6 +71,10 @@ export interface CommandOpts {
   // point: only a directory has a subtree to walk, and a start point the
   // router resolved into another mount answers there, not on this mount.
   statPath?: StatPath
+  // Session-filtered child-mount names under a directory: the other
+  // half of namespace structure beside links, merged into listings the
+  // same way link rows are.
+  childMounts?: ChildMounts
   signal?: AbortSignal
   timeoutSeconds?: number
 }

--- a/typescript/packages/core/src/context/session_context.ts
+++ b/typescript/packages/core/src/context/session_context.ts
@@ -69,6 +69,18 @@ function sessionMode(mountPrefix: string): MountMode | undefined {
 }
 
 /**
+ * Whether the current session may touch this mount at all.
+ *
+ * The non-raising twin of `assertMountAllowed`, for enumeration:
+ * structure merges and fan-outs filter names through it, so a scoped
+ * session never learns that an ungranted mount exists. True when no
+ * session is bound or the session is unrestricted.
+ */
+export function mountAllowed(mountPrefix: string): boolean {
+  return sessionMode(mountPrefix) !== undefined
+}
+
+/**
  * Throw if the current session may not touch this mount. A user-defined
  * root mount is governed like any other: a session must be granted `/`
  * to touch it.

--- a/typescript/packages/core/src/ops/config.ts
+++ b/typescript/packages/core/src/ops/config.ts
@@ -39,8 +39,8 @@ export interface NamespaceLinks {
   isLink(path: string): boolean
   // The stored target for a link path, null when not a link.
   readlink(path: string): string | null
-  // Link basename to target for entries directly under a directory.
-  linksUnder(directory: string): Map<string, string>
+  // Every link path to its stored target, the whole table.
+  symlinkTargets(): Map<string, string>
   // Create or overwrite a symlink entry; target is kept verbatim.
   symlink(link: string, target: string, mtime: number): Promise<void>
   // Drop a node entry; true when one existed.

--- a/typescript/packages/core/src/ops/namespace_view.ts
+++ b/typescript/packages/core/src/ops/namespace_view.ts
@@ -13,14 +13,9 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { mountAllowed } from '../context/session_context.ts'
-import { rstripSlash, stripSlash } from '../utils/slash.ts'
+import { normDir, rstripSlash } from '../utils/slash.ts'
 import { FileStat, FileType } from '../types.ts'
 import type { NamespaceLinks } from './config.ts'
-
-function normDir(path: string): string {
-  const stripped = stripSlash(path)
-  return stripped === '' ? '/' : '/' + stripped + '/'
-}
 
 /**
  * Immediate child segments of mounts strictly under `parent`.
@@ -98,7 +93,7 @@ function linkNames(
  * listing commands, so the shell and the ops surface cannot disagree
  * about what a directory holds.
  */
-export function structureNames(
+export function namespaceNames(
   prefixes: readonly string[],
   links: NamespaceLinks | null,
   parent: string,
@@ -127,7 +122,7 @@ export function mergeReaddir(
   const present = new Set(entries.map((e) => stripEntry(e)))
   const base = rstripSlash(parent)
   const merged = [...entries]
-  for (const name of structureNames(prefixes, links, parent)) {
+  for (const name of namespaceNames(prefixes, links, parent)) {
     if (present.has(name)) continue
     present.add(name)
     merged.push(`${base}/${name}`)
@@ -149,12 +144,12 @@ function stripEntry(entry: string): string {
  * `/x`. Null when the namespace knows nothing there either, so a caller
  * re-throws the backend's miss.
  */
-export function structureListing(
+export function namespaceListing(
   prefixes: readonly string[],
   links: NamespaceLinks | null,
   parent: string,
 ): string[] | null {
-  if (structureNames(prefixes, links, parent).length === 0) {
+  if (namespaceNames(prefixes, links, parent).length === 0) {
     return null
   }
   return mergeReaddir([], prefixes, links, parent)
@@ -167,12 +162,12 @@ export function structureListing(
  * (because a mount or a link sits below it) must stat as a directory,
  * or `os.walk` and `Path.is_dir` break on it.
  */
-export function structureStat(
+export function namespaceStat(
   prefixes: readonly string[],
   links: NamespaceLinks | null,
   path: string,
 ): FileStat | null {
-  if (structureListing(prefixes, links, path) === null) return null
+  if (namespaceListing(prefixes, links, path) === null) return null
   const name = stripEntry(path)
   return new FileStat({ name: name === '' ? '/' : name, type: FileType.DIRECTORY })
 }

--- a/typescript/packages/core/src/ops/structure.ts
+++ b/typescript/packages/core/src/ops/structure.ts
@@ -45,21 +45,47 @@ function childMountNames(prefixes: readonly string[], parent: string): string[] 
 }
 
 /**
+ * Whether the current session may see the link at `link`.
+ *
+ * A link is namespace state, but its path lies on some mount's turf:
+ * the longest mount prefix above it owns it, the same longest-match
+ * rule dispatch resolves the path by. A scoped session that may not
+ * touch that mount must not learn the link's name from a listing,
+ * exactly as `childMountNames` hides the mount itself. A link above
+ * every mount is bare namespace structure and stays visible.
+ */
+function linkAllowed(prefixes: readonly string[], link: string): boolean {
+  let owner = ''
+  for (const prefix of prefixes) {
+    const p = normDir(prefix)
+    if ((link + '/').startsWith(p) && p.length > owner.length) owner = p
+  }
+  return owner === '' || mountAllowed(owner)
+}
+
+/**
  * Immediate child segments owed to links at or below `parent`.
  *
  * Derived from every link path, not just direct children, exactly as
  * mount prefixes are: `ln` allows a link below a directory chain no
  * backend serves, and without its ancestors synthesized the link lists
  * at its own parent yet is unreachable from a walk above it.
+ * Session-filtered through `linkAllowed`: a link below an ungranted
+ * mount would otherwise leak that mount's name into a listing
+ * `childMountNames` had already filtered.
  */
-function linkNames(links: NamespaceLinks | null, parent: string): string[] {
+function linkNames(
+  prefixes: readonly string[],
+  links: NamespaceLinks | null,
+  parent: string,
+): string[] {
   if (links === null) return []
   const norm = normDir(parent)
   const out = new Set<string>()
   for (const link of links.symlinkTargets().keys()) {
     if (!link.startsWith(norm)) continue
     const name = link.slice(norm.length).split('/', 1)[0] ?? ''
-    if (name !== '') out.add(name)
+    if (name !== '' && linkAllowed(prefixes, link)) out.add(name)
   }
   return [...out].sort()
 }
@@ -77,7 +103,9 @@ export function structureNames(
   links: NamespaceLinks | null,
   parent: string,
 ): string[] {
-  return [...new Set([...childMountNames(prefixes, parent), ...linkNames(links, parent)])].sort()
+  return [
+    ...new Set([...childMountNames(prefixes, parent), ...linkNames(prefixes, links, parent)]),
+  ].sort()
 }
 
 /**

--- a/typescript/packages/core/src/ops/structure.ts
+++ b/typescript/packages/core/src/ops/structure.ts
@@ -1,0 +1,119 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mountAllowed } from '../context/session_context.ts'
+import { stripSlash } from '../utils/slash.ts'
+import { FileStat, FileType } from '../types.ts'
+import type { NamespaceLinks } from './config.ts'
+
+function normDir(path: string): string {
+  const stripped = stripSlash(path)
+  return stripped === '' ? '/' : '/' + stripped + '/'
+}
+
+/**
+ * Immediate child segments of mounts strictly under `parent`.
+ *
+ * Session-filtered: a child name appears only when some mount whose
+ * prefix runs through it is visible to the current session, so a scoped
+ * session never learns an ungranted mount's name from a listing. Hidden
+ * names (leading dot) are included; presentation filtering is the
+ * consumer's job, exactly as for backend entries.
+ */
+export function childMountNames(prefixes: readonly string[], parent: string): string[] {
+  const norm = normDir(parent)
+  const out = new Set<string>()
+  for (const prefix of prefixes) {
+    const p = normDir(prefix)
+    if (p === norm || !p.startsWith(norm)) continue
+    const name = p.slice(norm.length).split('/', 1)[0] ?? ''
+    if (name === '' || !mountAllowed(p)) continue
+    out.add(name)
+  }
+  return [...out].sort()
+}
+
+function linkNames(links: NamespaceLinks | null, parent: string): string[] {
+  if (links === null) return []
+  return [...links.linksUnder(parent).keys()].filter((name) => name !== '')
+}
+
+/**
+ * Merge namespace structure into a backend readdir listing.
+ *
+ * Child mounts and symlinks are namespace state no backend can see, so
+ * a listing that stops at one backend misses both. Merged names are
+ * appended as virtual paths (the shape RAM-style backends already
+ * emit); deduplication is by final path segment because backends
+ * disagree on entry shape (bare names, trailing-slash names, full
+ * paths).
+ */
+export function mergeReaddir(
+  entries: readonly string[],
+  prefixes: readonly string[],
+  links: NamespaceLinks | null,
+  parent: string,
+): string[] {
+  const present = new Set(entries.map((e) => stripEntry(e)))
+  const base = parent.replace(/\/+$/, '')
+  const merged = [...entries]
+  for (const name of [...childMountNames(prefixes, parent), ...linkNames(links, parent)]) {
+    if (present.has(name)) continue
+    present.add(name)
+    merged.push(`${base}/${name}`)
+  }
+  return merged
+}
+
+function stripEntry(entry: string): string {
+  const trimmed = entry.replace(/\/+$/, '')
+  const slash = trimmed.lastIndexOf('/')
+  return slash === -1 ? trimmed : trimmed.slice(slash + 1)
+}
+
+/**
+ * A listing for a directory that exists only as namespace structure.
+ *
+ * `/data/x` exists when a mount sits at `/data/x/y` or a link lives
+ * directly under it, even though the `/data` backend holds nothing at
+ * `/x`. Null when the namespace knows nothing there either, so a caller
+ * re-throws the backend's miss.
+ */
+export function structureListing(
+  prefixes: readonly string[],
+  links: NamespaceLinks | null,
+  parent: string,
+): string[] | null {
+  if (childMountNames(prefixes, parent).length === 0 && linkNames(links, parent).length === 0) {
+    return null
+  }
+  return mergeReaddir([], prefixes, links, parent)
+}
+
+/**
+ * A directory stat for a path that exists only as namespace structure.
+ *
+ * The listing and the stat must agree: a directory `readdir` can serve
+ * (because a mount or a link sits below it) must stat as a directory,
+ * or `os.walk` and `Path.is_dir` break on it.
+ */
+export function structureStat(
+  prefixes: readonly string[],
+  links: NamespaceLinks | null,
+  path: string,
+): FileStat | null {
+  if (structureListing(prefixes, links, path) === null) return null
+  const name = stripEntry(path)
+  return new FileStat({ name: name === '' ? '/' : name, type: FileType.DIRECTORY })
+}

--- a/typescript/packages/core/src/ops/structure.ts
+++ b/typescript/packages/core/src/ops/structure.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { mountAllowed } from '../context/session_context.ts'
-import { stripSlash } from '../utils/slash.ts'
+import { rstripSlash, stripSlash } from '../utils/slash.ts'
 import { FileStat, FileType } from '../types.ts'
 import type { NamespaceLinks } from './config.ts'
 
@@ -66,7 +66,7 @@ export function mergeReaddir(
   parent: string,
 ): string[] {
   const present = new Set(entries.map((e) => stripEntry(e)))
-  const base = parent.replace(/\/+$/, '')
+  const base = rstripSlash(parent)
   const merged = [...entries]
   for (const name of [...childMountNames(prefixes, parent), ...linkNames(links, parent)]) {
     if (present.has(name)) continue
@@ -77,7 +77,7 @@ export function mergeReaddir(
 }
 
 function stripEntry(entry: string): string {
-  const trimmed = entry.replace(/\/+$/, '')
+  const trimmed = rstripSlash(entry)
   const slash = trimmed.lastIndexOf('/')
   return slash === -1 ? trimmed : trimmed.slice(slash + 1)
 }

--- a/typescript/packages/core/src/ops/structure.ts
+++ b/typescript/packages/core/src/ops/structure.ts
@@ -31,7 +31,7 @@ function normDir(path: string): string {
  * names (leading dot) are included; presentation filtering is the
  * consumer's job, exactly as for backend entries.
  */
-export function childMountNames(prefixes: readonly string[], parent: string): string[] {
+function childMountNames(prefixes: readonly string[], parent: string): string[] {
   const norm = normDir(parent)
   const out = new Set<string>()
   for (const prefix of prefixes) {
@@ -44,9 +44,40 @@ export function childMountNames(prefixes: readonly string[], parent: string): st
   return [...out].sort()
 }
 
+/**
+ * Immediate child segments owed to links at or below `parent`.
+ *
+ * Derived from every link path, not just direct children, exactly as
+ * mount prefixes are: `ln` allows a link below a directory chain no
+ * backend serves, and without its ancestors synthesized the link lists
+ * at its own parent yet is unreachable from a walk above it.
+ */
 function linkNames(links: NamespaceLinks | null, parent: string): string[] {
   if (links === null) return []
-  return [...links.linksUnder(parent).keys()].filter((name) => name !== '')
+  const norm = normDir(parent)
+  const out = new Set<string>()
+  for (const link of links.symlinkTargets().keys()) {
+    if (!link.startsWith(norm)) continue
+    const name = link.slice(norm.length).split('/', 1)[0] ?? ''
+    if (name !== '') out.add(name)
+  }
+  return [...out].sort()
+}
+
+/**
+ * Every child segment the namespace owes `parent`: mounts + links.
+ *
+ * The one union both consumers derive from: the door merges these
+ * names into its readdir and the `childMounts` fact offers them to
+ * listing commands, so the shell and the ops surface cannot disagree
+ * about what a directory holds.
+ */
+export function structureNames(
+  prefixes: readonly string[],
+  links: NamespaceLinks | null,
+  parent: string,
+): string[] {
+  return [...new Set([...childMountNames(prefixes, parent), ...linkNames(links, parent)])].sort()
 }
 
 /**
@@ -68,7 +99,7 @@ export function mergeReaddir(
   const present = new Set(entries.map((e) => stripEntry(e)))
   const base = rstripSlash(parent)
   const merged = [...entries]
-  for (const name of [...childMountNames(prefixes, parent), ...linkNames(links, parent)]) {
+  for (const name of structureNames(prefixes, links, parent)) {
     if (present.has(name)) continue
     present.add(name)
     merged.push(`${base}/${name}`)
@@ -95,7 +126,7 @@ export function structureListing(
   links: NamespaceLinks | null,
   parent: string,
 ): string[] | null {
-  if (childMountNames(prefixes, parent).length === 0 && linkNames(links, parent).length === 0) {
+  if (structureNames(prefixes, links, parent).length === 0) {
     return null
   }
   return mergeReaddir([], prefixes, links, parent)

--- a/typescript/packages/core/src/ops/types.ts
+++ b/typescript/packages/core/src/ops/types.ts
@@ -28,6 +28,13 @@ export type StatPath = (path: string) => Promise<FileStat | null>
 // backend.
 export type MountRoot = (path: string) => string
 
+// Immediate child-mount names under a directory, session-filtered. The
+// other half of namespace structure beside links: a nested mount is
+// invisible to the parent mount's backend, so a listing command is
+// handed the names from above, the same names the door merges into its
+// own readdir.
+export type ChildMounts = (parent: string) => string[]
+
 // The symlink facts a command may consult, as one injected object.
 //
 // Symlinks live in the workspace namespace and no backend can see them,

--- a/typescript/packages/core/src/runtime/conformance_worlds.test.ts
+++ b/typescript/packages/core/src/runtime/conformance_worlds.test.ts
@@ -1,0 +1,268 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { OpsRegistry } from '../ops/registry.ts'
+import { RAMResource } from '../resource/ram/ram.ts'
+import { FileType, MountMode } from '../types.ts'
+import { getTestParser, stderrStr, stdoutStr } from '../workspace/fixtures/workspace_fixture.ts'
+import { Workspace } from '../workspace/workspace.ts'
+import { MontyRuntime } from './python/monty/index.ts'
+
+// One world, three surfaces, one door: the TS half of the conformance
+// worlds (python/tests/runtime/test_conformance_worlds.py). The suite
+// pins the facts a mount tree must present identically through the
+// shell (virtual commands) and a sandboxed guest (its own stdlib); the
+// FUSE surface lives in @struktoai/mirage-node, whose core routes every
+// op through the same Workspace.dispatch these tests exercise.
+//
+// R1 (mount structure into the door: readdir/stat merge child mounts
+// and namespace links behind the session guard, fan-out and the ls
+// fact session-filtered) has landed, which is why the structure and
+// enumeration groups run unmarked. Facts still broken run as it.fails
+// with the reason beside them, and start passing loud when fixed.
+
+async function structureWorld(): Promise<Workspace> {
+  const parser = await getTestParser()
+  const ops = new OpsRegistry()
+  const base = new RAMResource()
+  const inner = new RAMResource()
+  ops.registerResource(base)
+  ops.registerResource(inner)
+  const ws = new Workspace(
+    {},
+    { mode: MountMode.EXEC, ops, shellParser: parser, runtimes: [new MontyRuntime(), 'vfs'] },
+  )
+  ws.addMount('/base', base, MountMode.WRITE)
+  ws.addMount('/base/inner', inner, MountMode.WRITE)
+  // Seeded through the fs facade, not the shell: a shell line would be
+  // recorded into /.bash_history, which every session may read, and the
+  // scoped-world tests would then find the seed line instead of a leak.
+  await ws.fs.writeFile('/base/a.txt', 'top')
+  await ws.fs.writeFile('/base/inner/deep.txt', 'needle')
+  return ws
+}
+
+async function scopedWorld(): Promise<Workspace> {
+  const parser = await getTestParser()
+  const ops = new OpsRegistry()
+  const open = new RAMResource()
+  const closed = new RAMResource()
+  ops.registerResource(open)
+  ops.registerResource(closed)
+  const ws = new Workspace(
+    {},
+    { mode: MountMode.EXEC, ops, shellParser: parser, runtimes: [new MontyRuntime(), 'vfs'] },
+  )
+  ws.addMount('/open', open, MountMode.WRITE)
+  ws.addMount('/closed', closed, MountMode.WRITE)
+  await ws.fs.writeFile('/open/pub.txt', 'public')
+  await ws.fs.writeFile('/closed/sec.txt', 'SECRET-xyz')
+  ws.createSession('agent', { mounts: ['/open'] })
+  return ws
+}
+
+async function run(
+  ws: Workspace,
+  line: string,
+  sessionId?: string,
+): Promise<[number, string, string]> {
+  const io = await ws.execute(line, sessionId !== undefined ? { sessionId } : undefined)
+  return [io.exitCode, stdoutStr(io), stderrStr(io)]
+}
+
+// ts monty's iterdir yields plain strings where py monty yields Path
+// objects; `str(p)` reads the entry either way.
+const LIST_BASE = `python3 -c "from pathlib import Path; print(sorted(str(p) for p in Path('/base').iterdir()))"`
+
+// ── Group 1: nested mount + namespace link are visible to every surface ──
+
+describe('structure world', () => {
+  it('shell lists the child mount and the namespace link', async () => {
+    const ws = await structureWorld()
+    try {
+      expect((await run(ws, 'ln -s /base/inner /base/lnk'))[0]).toBe(0)
+      const [code, out] = await run(ws, 'ls /base')
+      expect(code).toBe(0)
+      expect(out).toContain('a.txt')
+      expect(out).toContain('inner')
+      expect(out).toContain('lnk')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('shell walk reaches a nested descendant', async () => {
+    const ws = await structureWorld()
+    try {
+      const [code, out] = await run(ws, 'grep -r needle /base')
+      expect(code).toBe(0)
+      expect(out).toContain('/base/inner/deep.txt')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('guest lists the child mount', async () => {
+    const ws = await structureWorld()
+    try {
+      const [code, out, err] = await run(ws, LIST_BASE)
+      expect(code, err).toBe(0)
+      expect(out).toContain('inner')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('guest lists the namespace link', async () => {
+    const ws = await structureWorld()
+    try {
+      expect((await run(ws, 'ln -s /base/inner /base/lnk'))[0]).toBe(0)
+      const [code, out, err] = await run(ws, LIST_BASE)
+      expect(code, err).toBe(0)
+      expect(out).toContain('lnk')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('guest reads through a link by exact path', async () => {
+    const ws = await structureWorld()
+    try {
+      expect((await run(ws, 'ln -s /base/inner /base/lnk'))[0]).toBe(0)
+      const [code, out, err] = await run(
+        ws,
+        `python3 -c "from pathlib import Path; print(Path('/base/lnk/deep.txt').read_text())"`,
+      )
+      expect(code, err).toBe(0)
+      expect(out).toContain('needle')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  // ── Group 2: a structure-only directory stats as a directory ──
+
+  it('the door stats a structure-only directory', async () => {
+    const ws = await structureWorld()
+    try {
+      const stat = await ws.stat('/base/inner')
+      expect((stat as { type: FileType | null }).type).toBe(FileType.DIRECTORY)
+      const [code, out, err] = await run(
+        ws,
+        `python3 -c "from pathlib import Path; print(Path('/base/inner').is_dir())"`,
+      )
+      expect(code, err).toBe(0)
+      expect(out).toContain('True')
+    } finally {
+      await ws.close()
+    }
+  })
+})
+
+// ── Group 3: a scoped session confines every surface ──
+
+describe('scoped world', () => {
+  it.each([
+    'cat /closed/sec.txt',
+    'ls /closed',
+    'grep -r SECRET /closed',
+    'find /closed',
+    'du /closed',
+  ])('an explicit operand at the boundary is denied: %s', async (line) => {
+    const ws = await scopedWorld()
+    try {
+      const [code, , err] = await run(ws, line, 'agent')
+      expect(code).not.toBe(0)
+      expect(err).toContain('not allowed')
+      expect(err).toContain('/closed')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('a scoped session cannot learn an ungranted name from the root listing', async () => {
+    const ws = await scopedWorld()
+    try {
+      const [code, out] = await run(ws, 'ls /', 'agent')
+      expect(code).toBe(0)
+      expect(out).toContain('open')
+      expect(out).not.toContain('closed')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it.each([
+    ['grep -r SECRET /', 'SECRET-xyz'],
+    ['ls -R /', 'sec.txt'],
+    ['find /', '/closed/sec.txt'],
+    ['du -a /', '/closed'],
+  ])('a fan-out from / does not cross the boundary: %s', async (line, needle) => {
+    const ws = await scopedWorld()
+    try {
+      const [, out] = await run(ws, line, 'agent')
+      expect(out).not.toContain(needle)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('a confined guest cannot read an ungranted mount', async () => {
+    const ws = await scopedWorld()
+    try {
+      const [code, out] = await run(
+        ws,
+        `python3 -c "from pathlib import Path; print(Path('/closed/sec.txt').read_text())"`,
+        'agent',
+      )
+      expect(code).not.toBe(0)
+      expect(out).not.toContain('SECRET-xyz')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('a confined guest cannot write an ungranted mount', async () => {
+    const ws = await scopedWorld()
+    try {
+      await run(
+        ws,
+        `python3 -c "from pathlib import Path; Path('/closed/planted.txt').write_text('X')"`,
+        'agent',
+      )
+      const [code, out] = await run(ws, 'ls /closed')
+      expect(code).toBe(0)
+      expect(out).not.toContain('planted.txt')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('a cross-mount link is not an escape hatch from confinement', async () => {
+    const ws = await scopedWorld()
+    try {
+      expect((await run(ws, 'ln -s /closed /open/esc'))[0]).toBe(0)
+      const [code, out] = await run(
+        ws,
+        `python3 -c "from pathlib import Path; print(Path('/open/esc/sec.txt').read_text())"`,
+        'agent',
+      )
+      expect(code).not.toBe(0)
+      expect(out).not.toContain('SECRET-xyz')
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/runtime/conformance_worlds.test.ts
+++ b/typescript/packages/core/src/runtime/conformance_worlds.test.ts
@@ -226,6 +226,24 @@ describe('scoped world', () => {
     }
   })
 
+  it('a link below an ungranted mount stays out of a scoped listing', async () => {
+    // The link's path discloses the same name childMountNames already
+    // filters, so the same grant filters it; the unrestricted view
+    // keeps the link.
+    const ws = await scopedWorld()
+    try {
+      expect((await run(ws, 'ln -s /closed/sec.txt /closed/leak'))[0]).toBe(0)
+      const [code, out] = await run(ws, 'ls /', 'agent')
+      expect(code).toBe(0)
+      expect(out).not.toContain('closed')
+      const [openCode, openOut] = await run(ws, 'ls /')
+      expect(openCode).toBe(0)
+      expect(openOut).toContain('closed')
+    } finally {
+      await ws.close()
+    }
+  })
+
   it.each([
     ['grep -r SECRET /', 'SECRET-xyz'],
     ['ls -R /', 'sec.txt'],

--- a/typescript/packages/core/src/runtime/conformance_worlds.test.ts
+++ b/typescript/packages/core/src/runtime/conformance_worlds.test.ts
@@ -165,6 +165,9 @@ describe('structure world', () => {
       const [code, out] = await run(ws, 'ls /')
       expect(code).toBe(0)
       expect(out).toContain('ghost')
+      const [ghostCode, ghostOut] = await run(ws, 'ls /ghost')
+      expect(ghostCode).toBe(0)
+      expect(ghostOut).toContain('deep')
       // No guest probe here: a ts guest serves only paths under a
       // visible mount, and /ghost (like / itself) is not one — the
       // documented root-anchor divergence from python, whose guests

--- a/typescript/packages/core/src/runtime/conformance_worlds.test.ts
+++ b/typescript/packages/core/src/runtime/conformance_worlds.test.ts
@@ -262,6 +262,42 @@ describe('scoped world', () => {
     }
   })
 
+  it.each([
+    ['find /base', 'leftover'],
+    ['grep -r SHADOWED /base', 'SHADOWED-xyz'],
+  ])('a fan-out hides shadowed keys when no descendant is granted: %s', async (line, needle) => {
+    // The parent backend holds a key under the ungranted mount's
+    // prefix (seeded before that mount exists, so dispatch lands it
+    // in the parent). With no allowed descendant the fan-out must
+    // still engage: skipping it hands the walk to single-mount
+    // dispatch, which serves the shadowed key that path dispatch
+    // itself refuses.
+    const parser = await getTestParser()
+    const ops = new OpsRegistry()
+    const base = new RAMResource()
+    const inner = new RAMResource()
+    ops.registerResource(base)
+    ops.registerResource(inner)
+    const ws = new Workspace(
+      {},
+      { mode: MountMode.EXEC, ops, shellParser: parser, runtimes: [new MontyRuntime(), 'vfs'] },
+    )
+    ws.addMount('/base', base, MountMode.WRITE)
+    await ws.fs.writeFile('/base/a.txt', 'top')
+    await ws.fs.mkdir('/base/inner')
+    await ws.fs.writeFile('/base/inner/leftover.txt', 'SHADOWED-xyz')
+    ws.addMount('/base/inner', inner, MountMode.WRITE)
+    await ws.fs.writeFile('/base/inner/deep.txt', 'needle')
+    ws.createSession('agent', { mounts: ['/base'] })
+    try {
+      const [, out] = await run(ws, line, 'agent')
+      expect(out).not.toContain(needle)
+      expect(out).not.toContain('inner')
+    } finally {
+      await ws.close()
+    }
+  })
+
   it('a confined guest cannot read an ungranted mount', async () => {
     const ws = await scopedWorld()
     try {

--- a/typescript/packages/core/src/runtime/conformance_worlds.test.ts
+++ b/typescript/packages/core/src/runtime/conformance_worlds.test.ts
@@ -177,6 +177,39 @@ describe('structure world', () => {
     }
   })
 
+  it('a namespace-only ancestor serves every ls variant', async () => {
+    // A mount at /ghost/deep gives /ghost no backend, so the door alone
+    // says it exists; plain ls, ls -R (whose walk runs through the
+    // cross-mount fan-out) and ls -d must all agree instead of
+    // reporting the operand missing.
+    const parser = await getTestParser()
+    const ops = new OpsRegistry()
+    const base = new RAMResource()
+    const deep = new RAMResource()
+    ops.registerResource(base)
+    ops.registerResource(deep)
+    const ws = new Workspace(
+      {},
+      { mode: MountMode.EXEC, ops, shellParser: parser, runtimes: [new MontyRuntime(), 'vfs'] },
+    )
+    ws.addMount('/base', base, MountMode.WRITE)
+    ws.addMount('/ghost/deep', deep, MountMode.WRITE)
+    await ws.fs.writeFile('/base/a.txt', 'top')
+    await ws.fs.writeFile('/ghost/deep/x.txt', 'inside')
+    try {
+      const [rCode, rOut] = await run(ws, 'ls -R /ghost')
+      expect(rCode).toBe(0)
+      expect(rOut).toContain('/ghost:')
+      expect(rOut).toContain('deep')
+      expect(rOut).toContain('x.txt')
+      const [dCode, dOut] = await run(ws, 'ls -d /ghost')
+      expect(dCode).toBe(0)
+      expect(dOut.trim()).toBe('/ghost')
+    } finally {
+      await ws.close()
+    }
+  })
+
   // ── Group 2: a structure-only directory stats as a directory ──
 
   it('the door stats a structure-only directory', async () => {

--- a/typescript/packages/core/src/runtime/conformance_worlds.test.ts
+++ b/typescript/packages/core/src/runtime/conformance_worlds.test.ts
@@ -152,6 +152,28 @@ describe('structure world', () => {
     }
   })
 
+  it('link ancestors synthesize on every surface', async () => {
+    // ln permits /ghost/deep/lnk with no backend serving /ghost; its
+    // ancestors synthesize exactly as nested mount prefixes do, so
+    // `ls /` shows the way in and a guest walk from the root reaches
+    // the link.
+    const ws = await structureWorld()
+    try {
+      expect((await run(ws, 'ln -s /base/a.txt /ghost/deep/lnk'))[0]).toBe(0)
+      const stat = await ws.stat('/ghost')
+      expect((stat as { type: FileType | null }).type).toBe(FileType.DIRECTORY)
+      const [code, out] = await run(ws, 'ls /')
+      expect(code).toBe(0)
+      expect(out).toContain('ghost')
+      // No guest probe here: a ts guest serves only paths under a
+      // visible mount, and /ghost (like / itself) is not one — the
+      // documented root-anchor divergence from python, whose guests
+      // fall through to dispatch and do walk the synthesized chain.
+    } finally {
+      await ws.close()
+    }
+  })
+
   // ── Group 2: a structure-only directory stats as a directory ──
 
   it('the door stats a structure-only directory', async () => {

--- a/typescript/packages/core/src/runtime/python/mount.test.ts
+++ b/typescript/packages/core/src/runtime/python/mount.test.ts
@@ -44,14 +44,22 @@ function makeBridge(): {
     if (op === 'READ') return Promise.resolve(files.get(path) ?? new Uint8Array())
     const prefix = path
     const entries: { path: string; size: number; isDir: boolean }[] = []
+    const dirs = new Set<string>()
     for (const [p, content] of files) {
       if (p.startsWith(prefix)) {
         const rest = p.slice(prefix.length)
         if (!rest.includes('/')) {
           entries.push({ path: p, size: content.length, isDir: false })
+        } else {
+          const seg = rest.split('/', 1)[0] ?? ''
+          if (seg !== '') dirs.add(prefix + seg)
         }
       }
     }
+    // The real door merges child mounts and directories into readdir
+    // (R1), so the double reports them too: preload descends through
+    // them exactly as it does against a live workspace.
+    for (const d of dirs) entries.push({ path: d, size: 0, isDir: true })
     return Promise.resolve(entries)
   }
   return { dispatch, calls, files }
@@ -170,8 +178,10 @@ describe('PyodideRuntime mount visibility', () => {
   }, 60_000)
 
   it('a nested prefix stays reachable under its parent mount', async () => {
-    // prefixes() is longest-first; mounting in that order puts /data
-    // over the /data/inner mounted a moment earlier and orphans it.
+    // Only the maximal prefix earns an Emscripten mountpoint; the
+    // nested mount's content arrives through the parent's preload,
+    // which descends the door's merged readdir. Mounting both used to
+    // orphan the child under the parent's mountpoint.
     const { dispatch, files } = makeBridge()
     files.set('/data/outer.txt', new TextEncoder().encode('OUTER'))
     files.set('/data/inner/deep.txt', new TextEncoder().encode('DEEP'))

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -95,6 +95,24 @@ function servable(prefix: string): boolean {
   return mountpointOf(prefix) !== ''
 }
 
+/**
+ * Drop every prefix nested inside another: only the shallowest of a
+ * nested pair earns an Emscripten mountpoint, and its preload descends
+ * into the child through the door's merged readdir.
+ *
+ * Args:
+ *   prefixes: slash-terminated mount prefixes.
+ */
+function maximalPrefixes(prefixes: readonly string[]): string[] {
+  const shallowFirst = [...prefixes].sort((a, b) => a.length - b.length)
+  const out: string[] = []
+  for (const p of shallowFirst) {
+    if (out.some((kept) => p.startsWith(kept))) continue
+    out.push(p)
+  }
+  return out
+}
+
 function runtimeEnv(): Record<string, string> {
   const env: Record<string, string> = {}
   const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
@@ -381,11 +399,12 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
           `root; python will not see it`,
       )
     }
-    // `prefixes()` is longest-first, which is the order routing wants
-    // and the reverse of the order the mount table wants: mounting
-    // /data over an existing /data/inner orphans the child. So unmount
-    // deepest-first and mount shallowest-first.
-    const wanted = new Set(all.filter(servable))
+    // Only maximal prefixes become Emscripten mounts: the bridge routes
+    // every op by full path and the door's readdir lists a nested
+    // mount's name under its parent, so a child mount is served through
+    // the parent's mountpoint. A second Emscripten mount inside the
+    // first would be orphaned when the parent remounts.
+    const wanted = new Set(maximalPrefixes(all.filter(servable)))
     for (const prefix of [...this.mounted].sort((a, b) => b.length - a.length)) {
       if (wanted.has(prefix)) continue
       pyodide.FS.unmount(mountpointOf(prefix))

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -418,7 +418,9 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       await preloadInto(seed, vfs, prefix)
       const mountpoint = mountpointOf(prefix)
       if (this.mounted.has(prefix)) pyodide.FS.unmount(mountpoint)
-      const fs = new MirageFs(pyodide.FS, pyodide.ERRNO_CODES, this.journal, mountpoint)
+      const fs = new MirageFs(pyodide.FS, pyodide.ERRNO_CODES, this.journal, mountpoint, (p) =>
+        vfs.mountOf(p),
+      )
       pyodide.FS.mkdirTree(mountpoint)
       pyodide.FS.mount(fs.type, {}, mountpoint)
       // After the mount, never inside it: Emscripten assigns the root's

--- a/typescript/packages/core/src/runtime/python/vfs/errors.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/errors.test.ts
@@ -28,7 +28,7 @@ class FakeErrnoError extends Error {
 // musl's numbering, which is what pyodide reports and what an errno
 // literal copied from Linux would get wrong (EXDEV is 75 here, and 18
 // is EDOM rather than the cross-device link everyone remembers).
-const CODES: ErrnoCodes = { ENOENT: 44, EPERM: 63, EINVAL: 28, EIO: 29 }
+const CODES: ErrnoCodes = { ENOENT: 44, EPERM: 63, EINVAL: 28, EIO: 29, EXDEV: 75 }
 
 const HOST = { ErrnoError: FakeErrnoError } as unknown as FSHost
 

--- a/typescript/packages/core/src/runtime/python/vfs/errors.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/errors.ts
@@ -20,7 +20,7 @@ import type { ErrnoCodes, FSHost } from './types.ts'
  * call failed names the condition, and the adapter turns the name into
  * whatever number its kernel interface uses.
  */
-export type FsErrorCode = 'ENOENT' | 'EPERM' | 'EINVAL' | 'EIO'
+export type FsErrorCode = 'ENOENT' | 'EPERM' | 'EINVAL' | 'EIO' | 'EXDEV'
 
 /**
  * Build an error naming a POSIX condition, for failures the host sees.

--- a/typescript/packages/core/src/runtime/python/vfs/preload.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/preload.test.ts
@@ -170,4 +170,26 @@ describe('preloadInto', () => {
       /top-level boom/,
     )
   })
+
+  // A nested mount is served through its parent's walk (syncMounts
+  // collapses to maximal prefixes), but it keeps the failure boundary it
+  // had as a top-level prefix: degrading its root LIST failure to an
+  // empty directory would let syncMounts replace a healthy snapshot with
+  // one where the nested mount reads as empty.
+  it('lets a nested mount root LIST failure fail the whole collection', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
+      if (op === 'LIST' && path === '/ram/') {
+        return Promise.resolve([
+          { path: '/ram/ok.txt', size: 1, isDir: false },
+          { path: '/ram/inner', size: 0, isDir: true },
+        ])
+      }
+      if (op === 'READ' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([7]))
+      if (op === 'LIST' && path === '/ram/inner/') return Promise.reject(new Error('inner boom'))
+      return Promise.reject(new Error(`unexpected ${op} ${path}`))
+    })
+    const fs = makeFakeFS()
+    const vfs = new RuntimeVFS(dispatch, () => ['/ram/', '/ram/inner/'])
+    await expect(preloadInto(fs, vfs, '/ram/')).rejects.toThrow(/inner boom/)
+  })
 })

--- a/typescript/packages/core/src/runtime/python/vfs/preload.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/preload.ts
@@ -34,6 +34,15 @@ async function preloadEntry(fs: FSLike, vfs: RuntimeVFS, entry: VFSEntry): Promi
   if (entry.isDir) {
     fs.mkdirTree(entry.path)
     const next = entry.path.endsWith('/') ? entry.path : entry.path + '/'
+    if (vfs.mountOf(entry.path) === next) {
+      // A nested mount served through its parent keeps the failure
+      // boundary it had as a top-level prefix: its root LIST failing
+      // must fail the whole collection, so syncMounts keeps the
+      // previous healthy snapshot instead of replacing it with one
+      // where this subtree reads as empty.
+      await preloadInto(fs, vfs, next)
+      return
+    }
     try {
       await preloadInto(fs, vfs, next)
     } catch (err) {

--- a/typescript/packages/core/src/runtime/python/vfs/preload.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/preload.ts
@@ -26,6 +26,11 @@ export interface FSLike {
 }
 
 async function preloadEntry(fs: FSLike, vfs: RuntimeVFS, entry: VFSEntry): Promise<void> {
+  // A namespace symlink is skipped, not followed: stat reports the
+  // target, so a directory link would copy its whole subtree here and a
+  // cyclic one would never terminate. The guest sees exactly what a
+  // seed can hold, which has never included links.
+  if (entry.isLink === true) return
   if (entry.isDir) {
     fs.mkdirTree(entry.path)
     const next = entry.path.endsWith('/') ? entry.path : entry.path + '/'

--- a/typescript/packages/core/src/runtime/python/vfs/types.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/types.ts
@@ -22,6 +22,7 @@ export interface ErrnoCodes {
   readonly EPERM: number
   readonly EINVAL: number
   readonly EIO: number
+  readonly EXDEV: number
 }
 
 export interface FSNode {

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
@@ -50,7 +50,7 @@ describe('MirageFs', () => {
     const seed = new MirageFsSeed()
     await preloadInto(seed, vfs, prefix)
     const mountpoint = prefix.slice(0, -1)
-    const fs = new MirageFs(py.FS, py.ERRNO_CODES, journal, mountpoint)
+    const fs = new MirageFs(py.FS, py.ERRNO_CODES, journal, mountpoint, (path) => vfs.mountOf(path))
     py.FS.mkdirTree(mountpoint)
     py.FS.mount(fs.type, {}, mountpoint)
     fs.seed(seed)
@@ -228,6 +228,31 @@ except OSError as e:
 `)
     expect(py.globals.get('_res')).toBe('EXDEV')
     expect(journal.takeMutations()).toEqual([])
+  })
+
+  it('refuses a rename across a nested mount boundary inside one mountpoint', async () => {
+    const p = prefix()
+    const nested = `${p}inner/`
+    store.set(`${p}x.txt`, enc.encode('X'))
+    store.set(`${nested}deep.txt`, enc.encode('D'))
+    // The nested prefix is a mirage mount but not an Emscripten one:
+    // syncMounts collapses to maximal prefixes, so one mountpoint serves
+    // both trees and the kernel's own cross-mount check cannot fire.
+    mounts.push(nested)
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+import errno, os
+try:
+    os.rename('${p}x.txt', '${nested}x.txt')
+    _res2 = 'NO ERROR'
+except OSError as e:
+    _res2 = 'EXDEV' if e.errno == errno.EXDEV else f'wrong errno {e.errno}'
+`)
+    expect(py.globals.get('_res2')).toBe('EXDEV')
+    expect(journal.takeMutations()).toEqual([])
+    // The refused source is still readable in place.
+    await py.runPythonAsync(`_kept = open('${p}x.txt').read()`)
+    expect(py.globals.get('_kept')).toBe('X')
   })
 
   it('resolves a relative path against the guest cwd', async () => {

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.ts
@@ -55,6 +55,7 @@ export class MirageFs {
   private readonly errno: ErrnoCodes
   private readonly journal: MutationJournal
   private readonly tree: NodeTree
+  private readonly mountOf: (path: string) => string | null
 
   /**
    * Args:
@@ -62,11 +63,22 @@ export class MirageFs {
    *   errno: Emscripten's errno table (`pyodide.ERRNO_CODES`).
    *   journal: the write-ahead log guest mutations are recorded on.
    *   prefix: the mount prefix this filesystem serves.
+   *   mountOf: the mirage mount owning a path (`RuntimeVFS.mountOf`).
+   *     One mountpoint serves every mirage mount nested under its
+   *     prefix, so this is the only boundary fact left to check ops
+   *     against; Emscripten's own cross-mount checks cannot see it.
    */
-  constructor(host: FSHost, errno: ErrnoCodes, journal: MutationJournal, prefix: string) {
+  constructor(
+    host: FSHost,
+    errno: ErrnoCodes,
+    journal: MutationJournal,
+    prefix: string,
+    mountOf: (path: string) => string | null,
+  ) {
     this.host = host
     this.errno = errno
     this.journal = journal
+    this.mountOf = mountOf
     const nodeOps: NodeOps = {
       getattr: this.getattr.bind(this),
       setattr: this.setattr.bind(this),
@@ -158,8 +170,16 @@ export class MirageFs {
 
   private rename(node: FSNode, newDir: FSNode, newName: string): void {
     const from = this.tree.pathOf(node)
+    const to = this.tree.pathOf(newDir) + '/' + newName
+    // A nested mirage mount is served through this same mountpoint, so
+    // Emscripten's kernel cannot see the boundary; refuse the crossing
+    // here, before the tree moves and the journal records a rename the
+    // post-run replay would reject anyway.
+    if (this.mountOf(from) !== this.mountOf(to)) {
+      throw errnoError(this.host, this.errno, 'EXDEV')
+    }
     this.tree.move(node, newDir, newName)
-    this.journal.markRename(from, this.tree.pathOf(node))
+    this.journal.markRename(from, to)
   }
 
   private unlink(parent: FSNode, name: string): void {

--- a/typescript/packages/core/src/runtime/vfs.ts
+++ b/typescript/packages/core/src/runtime/vfs.ts
@@ -28,6 +28,10 @@ export interface VFSEntry {
   path: string
   size: number
   isDir: boolean
+  // A namespace symlink. Marked so a whole-tree preload can skip it:
+  // stat follows links, so a directory link would otherwise read as a
+  // plain directory and a cyclic one would recurse the walk forever.
+  isLink?: boolean
 }
 
 /** One path's metadata, in the shape every guest encoder needs. */

--- a/typescript/packages/core/src/utils/slash.test.ts
+++ b/typescript/packages/core/src/utils/slash.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { lstripSlash, rstripSlash, stripSlash } from './slash.ts'
+import { lstripSlash, normDir, rstripSlash, stripSlash } from './slash.ts'
 
 const SAMPLES = ['', '/', '//', '///', 'a', '/a', 'a/', '/a/', '//a//', 'a/b/c', '/a/b/c/', 'a//b']
 
@@ -35,5 +35,13 @@ describe('slash helpers match Python str strip and the prior regex', () => {
     expect(lstripSlash('///a')).toBe('a')
     expect(stripSlash('///a///')).toBe('a')
     expect(stripSlash('///')).toBe('')
+  })
+
+  it('normDir yields the trailing-slash directory form', () => {
+    expect(normDir('a/b')).toBe('/a/b/')
+    expect(normDir('/a/b/')).toBe('/a/b/')
+    expect(normDir('///a///')).toBe('/a/')
+    expect(normDir('')).toBe('/')
+    expect(normDir('/')).toBe('/')
   })
 })

--- a/typescript/packages/core/src/utils/slash.ts
+++ b/typescript/packages/core/src/utils/slash.ts
@@ -31,3 +31,10 @@ export function stripSlash(s: string): string {
   while (end > start && s.charCodeAt(end - 1) === 47) end--
   return s.slice(start, end)
 }
+
+// The trailing-slash directory form prefix comparisons need, so '/a/'
+// cannot match '/ab' ('foo/bar' -> '/foo/bar/', '' -> '/').
+export function normDir(s: string): string {
+  const stripped = stripSlash(s)
+  return stripped === '' ? '/' : '/' + stripped + '/'
+}

--- a/typescript/packages/core/src/workspace/bare_cwd_operand.test.ts
+++ b/typescript/packages/core/src/workspace/bare_cwd_operand.test.ts
@@ -89,6 +89,8 @@ describe('bare invocations default to the cwd', () => {
     const ws = await makeWs()
     const io = await ws.execute('ls')
     expect(io.exitCode).toBe(0)
-    expect(stdoutStr(io).startsWith('a.txt\nsub')).toBe(true)
+    // The dev mount is a row like any other now, so it sorts into the
+    // listing instead of trailing it the way the old stdout patch did.
+    expect(stdoutStr(io).startsWith('a.txt\ndev\nsub')).toBe(true)
   })
 })

--- a/typescript/packages/core/src/workspace/bridge_list.test.ts
+++ b/typescript/packages/core/src/workspace/bridge_list.test.ts
@@ -1,0 +1,66 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { OpsRegistry } from '../ops/registry.ts'
+import { RAMResource } from '../resource/ram/ram.ts'
+import type { BridgeDispatchFn } from '../runtime/types.ts'
+import type { VFSEntry } from '../runtime/vfs.ts'
+import { MountMode } from '../types.ts'
+import { Workspace } from './workspace.ts'
+
+function bridgeOn(ws: Workspace): BridgeDispatchFn {
+  return (ws as unknown as { buildWorkspaceBridge(): BridgeDispatchFn }).buildWorkspaceBridge()
+}
+
+function mkWorld(): { ws: Workspace; ops: OpsRegistry; resource: RAMResource } {
+  const resource = new RAMResource()
+  const ops = new OpsRegistry()
+  for (const op of resource.ops()) ops.register(op)
+  const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE, ops })
+  return { ws, ops, resource }
+}
+
+// The bridge LIST is the sandboxed runtimes' directory read: what it
+// swallows, a guest can never see, and what it fails, pyodide's
+// syncMounts treats as the whole tree.
+describe('workspace bridge LIST', () => {
+  it('a dangling link degrades to a zero row instead of failing the listing', async () => {
+    const { ws } = mkWorld()
+    await ws.fs.writeFile('/data/a.txt', 'hi')
+    await ws.namespace.symlink('/data/lnk', '/data/gone', 1)
+    const entries = (await bridgeOn(ws)('LIST', '/data')) as VFSEntry[]
+    const row = entries.find((e) => e.path.endsWith('/lnk'))
+    expect(row).toMatchObject({ size: 0, isDir: false, isLink: true })
+  })
+
+  it('a non-missing stat failure propagates instead of degrading the row', async () => {
+    // Only a genuine missing path (the dangling-link race above) may
+    // read back as a zero row; authorization failures, timeouts, and
+    // backend bugs must surface, or an incomplete listing replaces a
+    // healthy snapshot.
+    const { ws, ops, resource } = mkWorld()
+    await ws.fs.writeFile('/data/a.txt', 'hi')
+    ops.register({
+      name: 'stat',
+      resource: resource.kind,
+      filetype: null,
+      fn: () => {
+        throw new Error('401 Unauthorized')
+      },
+      write: false,
+    })
+    await expect(bridgeOn(ws)('LIST', '/data')).rejects.toThrow('401 Unauthorized')
+  })
+})

--- a/typescript/packages/core/src/workspace/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher.ts
@@ -27,6 +27,8 @@ import type { OpRecord } from '../observe/record.ts'
 import type { OpsRegistry } from '../ops/registry.ts'
 import { type OpKwargs } from '../ops/registry.ts'
 import { NO_FOLLOW_OPS, STAMP_WRITE_OPS } from '../ops/config.ts'
+import { mergeReaddir, structureListing, structureStat } from '../ops/structure.ts'
+import { isMissingPath } from '../utils/errors.ts'
 import { cachesReads, type Resource } from '../resource/base.ts'
 import { ConsistencyPolicy, FileStat, MountMode, PathSpec } from '../types.ts'
 import type { DispatchFn } from './executor/cross_mount.ts'
@@ -76,13 +78,43 @@ export class Dispatcher {
     this.reconciler = new Reconciler(cache, namespace, opsRegistry, consistency)
   }
 
+  /**
+   * The namespace's own answer for a path no backend serves.
+   *
+   * Child mounts and symlinks are structure the door owns, so a
+   * directory that exists only because a mount or link sits below it
+   * still lists and stats. Null for any other op, or when the
+   * namespace knows nothing at `virtual`.
+   */
+  private structureResult(opName: string, virtual: string): string[] | FileStat | null {
+    if (opName === 'readdir') {
+      return structureListing(this.namespace.mountPrefixes(), this.namespace, virtual)
+    }
+    if (opName === 'stat') {
+      return structureStat(this.namespace.mountPrefixes(), this.namespace, virtual)
+    }
+    return null
+  }
+
   dispatch: DispatchFn = async (opName, path, args, kwargs) => {
     let p = path
     if (!NO_FOLLOW_OPS.has(opName)) {
       const followed = this.namespace.follow(path.virtual)
       if (followed !== path.virtual) p = PathSpec.fromStrPath(followed)
     }
-    const [resource, scope, mode] = await this.namespace.resolve(p.virtual, false)
+    let resolved: [Resource, PathSpec, MountMode]
+    try {
+      resolved = await this.namespace.resolve(p.virtual, false)
+    } catch (err) {
+      // No mount serves the path, but the namespace may still know a
+      // directory there (a deeper mount, a link). No mount means no
+      // admission gate to key on and no cache to keep straight; the
+      // merged names are session-filtered individually.
+      const fallback = isMissingPath(err) ? this.structureResult(opName, p.virtual) : null
+      if (fallback === null) throw err
+      return [fallback, new IOResult()]
+    }
+    const [resource, scope, mode] = resolved
     const mount = this.namespace.mountFor(p.virtual)
     const mountPrefix = mount?.prefix ?? '/'
     // Admission policies fire at the door, before the warm-cache early
@@ -168,8 +200,15 @@ export class Dispatcher {
         ),
       )
     } catch (err) {
-      await this.reconciler.onOpMissing(opName, p.virtual, err)
-      throw err
+      const fallback = isMissingPath(err) ? this.structureResult(opName, p.virtual) : null
+      if (fallback === null) {
+        await this.reconciler.onOpMissing(opName, p.virtual, err)
+        throw err
+      }
+      result = fallback
+    }
+    if (opName === 'readdir' && Array.isArray(result)) {
+      result = mergeReaddir(result, this.namespace.mountPrefixes(), this.namespace, p.virtual)
     }
     if (DISPATCH_WRITE_OPS.has(opName)) {
       const observed = STAMP_WRITE_OPS.has(opName) ? Date.now() / 1000 : null

--- a/typescript/packages/core/src/workspace/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher.ts
@@ -27,7 +27,7 @@ import type { OpRecord } from '../observe/record.ts'
 import type { OpsRegistry } from '../ops/registry.ts'
 import { type OpKwargs } from '../ops/registry.ts'
 import { NO_FOLLOW_OPS, STAMP_WRITE_OPS } from '../ops/config.ts'
-import { mergeReaddir, structureListing, structureStat } from '../ops/structure.ts'
+import { mergeReaddir, namespaceListing, namespaceStat } from '../ops/namespace_view.ts'
 import { isMissingPath } from '../utils/errors.ts'
 import { cachesReads, type Resource } from '../resource/base.ts'
 import { ConsistencyPolicy, FileStat, MountMode, PathSpec } from '../types.ts'
@@ -86,12 +86,12 @@ export class Dispatcher {
    * still lists and stats. Null for any other op, or when the
    * namespace knows nothing at `virtual`.
    */
-  private structureResult(opName: string, virtual: string): string[] | FileStat | null {
+  private namespaceResult(opName: string, virtual: string): string[] | FileStat | null {
     if (opName === 'readdir') {
-      return structureListing(this.namespace.mountPrefixes(), this.namespace, virtual)
+      return namespaceListing(this.namespace.mountPrefixes(), this.namespace, virtual)
     }
     if (opName === 'stat') {
-      return structureStat(this.namespace.mountPrefixes(), this.namespace, virtual)
+      return namespaceStat(this.namespace.mountPrefixes(), this.namespace, virtual)
     }
     return null
   }
@@ -117,7 +117,7 @@ export class Dispatcher {
       // session-filtered individually, so nothing of the mount's own
       // content leaks.
       const eligible = isMissingPath(err) || err instanceof MountNotAllowedError
-      const fallback = eligible ? this.structureResult(opName, p.virtual) : null
+      const fallback = eligible ? this.namespaceResult(opName, p.virtual) : null
       if (fallback === null) throw err
       const fallbackWrite = POLICY_WRITE_OPS.has(opName)
       await preOpsGate(this.policies, opName, p, fallbackWrite, '')
@@ -211,7 +211,7 @@ export class Dispatcher {
         ),
       )
     } catch (err) {
-      const fallback = isMissingPath(err) ? this.structureResult(opName, p.virtual) : null
+      const fallback = isMissingPath(err) ? this.namespaceResult(opName, p.virtual) : null
       if (fallback === null) {
         await this.reconciler.onOpMissing(opName, p.virtual, err)
         throw err

--- a/typescript/packages/core/src/workspace/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher.ts
@@ -108,11 +108,17 @@ export class Dispatcher {
     } catch (err) {
       // No mount serves the path, but the namespace may still know a
       // directory there (a deeper mount, a link). No mount means no
-      // admission gate to key on and no cache to keep straight; the
-      // merged names are session-filtered individually.
+      // cache to keep straight and no owning prefix (the gates see ''),
+      // but admission still fires: a policy that bounds readdir or stat
+      // by path must cover the synthetic answer too. The merged names
+      // are session-filtered individually.
       const fallback = isMissingPath(err) ? this.structureResult(opName, p.virtual) : null
       if (fallback === null) throw err
-      return [fallback, new IOResult()]
+      const fallbackWrite = POLICY_WRITE_OPS.has(opName)
+      await preOpsGate(this.policies, opName, p, fallbackWrite, '')
+      const fallbackBound = await postOpsGate(this.policies, opName, p, fallbackWrite, '', fallback)
+      const gated = fallbackBound !== null ? await applyOpLimit(fallback, fallbackBound) : fallback
+      return [gated, new IOResult()]
     }
     const [resource, scope, mode] = resolved
     const mount = this.namespace.mountFor(p.virtual)

--- a/typescript/packages/core/src/workspace/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher.ts
@@ -35,7 +35,7 @@ import type { DispatchFn } from './executor/cross_mount.ts'
 import type { Namespace } from './mount/namespace/namespace.ts'
 import { mergeOverlayStat } from './mount/namespace/overlay.ts'
 import { Reconciler } from './reconcile.ts'
-import { effectiveMountMode } from '../context/session_context.ts'
+import { effectiveMountMode, MountNotAllowedError } from '../context/session_context.ts'
 
 const NOOP_ACCESSOR_INSTANCE = new NOOPAccessor()
 const DISPATCH_READ_OPS = new Set(['read', 'read_bytes'])
@@ -110,9 +110,14 @@ export class Dispatcher {
       // directory there (a deeper mount, a link). No mount means no
       // cache to keep straight and no owning prefix (the gates see ''),
       // but admission still fires: a policy that bounds readdir or stat
-      // by path must cover the synthetic answer too. The merged names
-      // are session-filtered individually.
-      const fallback = isMissingPath(err) ? this.structureResult(opName, p.virtual) : null
+      // by path must cover the synthetic answer too. A real but
+      // ungranted mount is the same case: a granted mount below it
+      // already put this path's name in a listing, so walking down to
+      // the grant must answer, and the merged names are
+      // session-filtered individually, so nothing of the mount's own
+      // content leaks.
+      const eligible = isMissingPath(err) || err instanceof MountNotAllowedError
+      const fallback = eligible ? this.structureResult(opName, p.virtual) : null
       if (fallback === null) throw err
       const fallbackWrite = POLICY_WRITE_OPS.has(opName)
       await preOpsGate(this.policies, opName, p, fallbackWrite, '')

--- a/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
@@ -295,11 +295,13 @@ function joinedError(cmd: string, errors: string[], exitCode: number): Result {
 
 // A subtree as [path, stat] pairs, parents before children. Each entry's
 // stat is captured during the walk because chmod's symbolic clauses (u+x)
-// build on the entry's own current mode. Symlinks never appear: they are
-// namespace state, so no backend readdir reports one, which is exactly
-// GNU chmod -R's rule of changing neither a traversed link nor its
-// referent.
+// build on the entry's own current mode. Symlinks are skipped by name:
+// the door's readdir reports them (they are namespace structure), GNU
+// chmod -R changes neither a traversed link nor its referent, and the
+// skip must come before the stat because stat follows a link and would
+// descend through a directory link.
 async function walkStats(
+  namespace: Namespace,
   dispatch: DispatchFn,
   root: PathSpec,
   rootStat: FileStat,
@@ -311,6 +313,7 @@ async function walkStats(
     if (directory === undefined) break
     const [children] = await dispatch('readdir', directory)
     for (const childVirtual of children as string[]) {
+      if (namespace.isLink(childVirtual)) continue
       const child = PathSpec.fromStrPath(childVirtual)
       const [childStat] = await dispatch('stat', child)
       const stat = childStat as FileStat
@@ -331,7 +334,7 @@ async function walkOwned(
   root: PathSpec,
   rootStat: FileStat,
 ): Promise<{ paths: PathSpec[]; links: string[] }> {
-  const walked = await walkStats(dispatch, root, rootStat)
+  const walked = await walkStats(namespace, dispatch, root, rootStat)
   return {
     paths: walked.map(([path]) => path),
     links: namespace.linkStatsBelow(root.virtual).map(([path]) => path),
@@ -388,7 +391,7 @@ export async function handleChmod(
       throw err
     }
     const entries: [PathSpec, FileStat][] = recursive
-      ? await walkStats(dispatch, resolved, stat)
+      ? await walkStats(namespace, dispatch, resolved, stat)
       : [[resolved, stat]]
     for (const [path, pathStat] of entries) {
       // Backends without a mode default to what ls renders: 755 for

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -23,6 +23,8 @@ import type { JobTable } from '../../shell/job_table.ts'
 import { PathSpec } from '../../types.ts'
 import type { MountEntry } from '../mount/mount.ts'
 import type { Namespace } from '../mount/namespace/namespace.ts'
+import type { ChildMounts } from '../../ops/types.ts'
+import { namespaceNames } from '../../ops/namespace_view.ts'
 import { MountCommandUnsupported, type MountRegistry } from '../mount/registry.ts'
 import { makeStorageKey } from '../mount/storage.ts'
 import { Consumer, JOB_BUILTINS, route } from '../route/index.ts'
@@ -410,6 +412,8 @@ export async function handleCommand(
   }
 
   if (shouldFanOut(cmdName, paths, flagKwargs, registry)) {
+    const fanChildMounts: ChildMounts = (parent: string) =>
+      namespaceNames(registry.mountPrefixes(), namespace ?? null, parent)
     const [fanOut, fanIo, fanNode] = await fanOutTraversal(
       cmdName,
       paths,
@@ -421,6 +425,7 @@ export async function handleCommand(
       cmdStr,
       stdin,
       ensureOpen,
+      fanChildMounts,
     )
     if (warnBytes !== null) {
       const existing = await materialize(fanIo.stderr)

--- a/typescript/packages/core/src/workspace/executor/command/run.ts
+++ b/typescript/packages/core/src/workspace/executor/command/run.ts
@@ -20,7 +20,7 @@ import type { PathSpec } from '../../../types.ts'
 import type { FileStat, ResourceName } from '../../../types.ts'
 import type { MountEntry } from '../../mount/mount.ts'
 import type { ChildMounts, LinkView, StatOverlay, StatPath } from '../../../ops/types.ts'
-import { childMountNames } from '../../../ops/structure.ts'
+import { structureNames } from '../../../ops/structure.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
 import { linkTargetStat, pathExists, pathStat } from '../builtins/links.ts'
 import { mergeOverlayStat } from '../../mount/namespace/overlay.ts'
@@ -244,7 +244,7 @@ export async function runOnMount(
   // links: the same session-filtered names the door merges into its own
   // readdir, offered to listing commands as rows.
   const childMounts: ChildMounts = (parent: string) =>
-    childMountNames(registry.mountPrefixes(), parent)
+    structureNames(registry.mountPrefixes(), namespace ?? null, parent)
 
   const [lineRuntime, denial] = lineRuntimeFor(
     cmdName,

--- a/typescript/packages/core/src/workspace/executor/command/run.ts
+++ b/typescript/packages/core/src/workspace/executor/command/run.ts
@@ -19,7 +19,8 @@ import { assertMountAllowed, MountNotAllowedError } from '../../../context/sessi
 import type { PathSpec } from '../../../types.ts'
 import type { FileStat, ResourceName } from '../../../types.ts'
 import type { MountEntry } from '../../mount/mount.ts'
-import type { LinkView, StatOverlay, StatPath } from '../../../ops/types.ts'
+import type { ChildMounts, LinkView, StatOverlay, StatPath } from '../../../ops/types.ts'
+import { childMountNames } from '../../../ops/structure.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
 import { linkTargetStat, pathExists, pathStat } from '../builtins/links.ts'
 import { mergeOverlayStat } from '../../mount/namespace/overlay.ts'
@@ -28,7 +29,6 @@ import type { Runtime } from '../../../runtime/base.ts'
 import { VFSRuntime } from '../../../runtime/table.ts'
 import type { PolicyDecision } from '../../../runtime/policy/index.ts'
 import type { Session } from '../../session/session.ts'
-import { LS_FAILURE } from '../../../commands/builtin/generic/ls.ts'
 import type { DispatchFn } from '../cross_mount.ts'
 import { applyFindActions } from '../find_action_dispatch.ts'
 import { CommandTimeoutError } from '../../../commands/builtin/utils/limit.ts'
@@ -37,7 +37,6 @@ import { formatFsError } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 
 import type { Flags } from './types.ts'
-import type { FlagValue } from '../../../commands/spec/types.ts'
 
 export interface RunOnMountCtx {
   registry: MountRegistry
@@ -241,6 +240,11 @@ export async function runOnMount(
   // a start point under another mount answers (`find -L` follows a link
   // across mounts before the command ever runs).
   const statPath: StatPath = (path: string) => pathStat(dispatch, path, statOverlay)
+  // Child mounts are the other half of namespace structure beside
+  // links: the same session-filtered names the door merges into its own
+  // readdir, offered to listing commands as rows.
+  const childMounts: ChildMounts = (parent: string) =>
+    childMountNames(registry.mountPrefixes(), parent)
 
   const [lineRuntime, denial] = lineRuntimeFor(
     cmdName,
@@ -262,16 +266,11 @@ export async function runOnMount(
       ...(statOverlay !== null ? { statOverlay } : {}),
       ...(links !== null ? { links } : {}),
       statPath,
+      childMounts,
       ...(session.abortSignal !== null ? { signal: session.abortSignal } : {}),
       limitOverride,
     })
     let stdout = initialStdout
-    // A minor problem (exit 1: an entry below the operand could not be
-    // stat'd) still lists the directory, so the mount and link rows belong in
-    // that output; only a failed operand (exit 2) has nothing to augment.
-    if (cmdName === 'ls' && io.exitCode !== LS_FAILURE) {
-      stdout = await injectChildMounts(stdout, registry, paths, flags, session.cwd)
-    }
     if (cmdName === 'find') {
       const [newStdout, actionErr] = await applyFindActions(stdout, flags, registry, session.cwd)
       stdout = newStdout
@@ -342,59 +341,4 @@ function linkView(
     exists: (path: string) => pathExists(dispatch, path),
     targetStat: (path: string) => linkTargetStat(namespace, dispatch, path, overlay),
   }
-}
-
-// Names already rendered in an ls listing, for injection dedup.
-//
-// Long rows come in two shapes: the degraded `mode\t-\t-\tname` form
-// used for entries with neither size nor mtime, and the full GNU row
-// whose name is the ninth whitespace-separated field. Splitting on tabs
-// alone reads a full row as a single field, so a name would never match
-// and an injected row could duplicate an entry the backend already
-// listed.
-function listedNames(existing: string, longForm: boolean): Set<string> {
-  const names = new Set<string>()
-  for (const line of existing.split('\n')) {
-    if (line === '') continue
-    if (!longForm) {
-      names.add(line.replace(/[/*@|=]$/, ''))
-    } else if (line.includes('\t')) {
-      names.add(line.split('\t').pop() ?? '')
-    } else {
-      const parts = line.split(/\s+/)
-      if (parts.length >= 9) names.add(parts.slice(8).join(' '))
-    }
-  }
-  names.delete('')
-  return names
-}
-
-async function injectChildMounts(
-  stdout: ByteSource | null,
-  registry: MountRegistry,
-  paths: readonly PathSpec[],
-  flagKwargs: Record<string, FlagValue>,
-  cwd: string,
-): Promise<ByteSource | null> {
-  if (flagKwargs.d === true || flagKwargs.R === true) return stdout
-  if (paths.length > 1) return stdout
-  const listed = paths.length === 1 && paths[0] !== undefined ? paths[0].virtual : cwd
-  const includeHidden = flagKwargs.a === true || flagKwargs.A === true
-  const childNames = registry.childMountNames(listed, includeHidden)
-  if (childNames.length === 0) return stdout
-
-  const existing = stdout === null ? '' : new TextDecoder().decode(await materialize(stdout))
-  const long = flagKwargs.args_l === true
-  const classify = flagKwargs.F === true
-  const present = listedNames(existing, long)
-  const extras: string[] = []
-  for (const n of childNames) {
-    if (present.has(n)) continue
-    if (long) extras.push(`d\t-\t-\t${n}`)
-    else extras.push(classify ? `${n}/` : n)
-  }
-  if (extras.length === 0) return stdout
-  const sep = existing === '' || existing.endsWith('\n') ? '' : '\n'
-  const combined = existing + sep + extras.join('\n')
-  return new TextEncoder().encode(combined)
 }

--- a/typescript/packages/core/src/workspace/executor/command/run.ts
+++ b/typescript/packages/core/src/workspace/executor/command/run.ts
@@ -20,7 +20,7 @@ import type { PathSpec } from '../../../types.ts'
 import type { FileStat, ResourceName } from '../../../types.ts'
 import type { MountEntry } from '../../mount/mount.ts'
 import type { ChildMounts, LinkView, MountView, StatOverlay, StatPath } from '../../../ops/types.ts'
-import { structureNames } from '../../../ops/structure.ts'
+import { namespaceNames } from '../../../ops/namespace_view.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
 import { linkTargetStat, pathExists, pathStat } from '../builtins/links.ts'
 import { mergeOverlayStat } from '../../mount/namespace/overlay.ts'
@@ -259,7 +259,7 @@ export async function runOnMount(
   // links: the same session-filtered names the door merges into its own
   // readdir, offered to listing commands as rows.
   const childMounts: ChildMounts = (parent: string) =>
-    structureNames(registry.mountPrefixes(), namespace ?? null, parent)
+    namespaceNames(registry.mountPrefixes(), namespace ?? null, parent)
 
   const [lineRuntime, denial] = lineRuntimeFor(
     cmdName,

--- a/typescript/packages/core/src/workspace/executor/fanout.ts
+++ b/typescript/packages/core/src/workspace/executor/fanout.ts
@@ -59,7 +59,12 @@ export function shouldFanOut(
   registry: MountRegistry,
 ): boolean {
   if (paths.length === 0 || paths[0] === undefined) return false
-  if (allowedDescendants(registry, paths[0].virtual).length === 0) return false
+  // Gated on the raw registry, not the session view: with every
+  // descendant ungranted, single-mount dispatch would serve the parent
+  // backend's keys shadowed under a hidden mount's prefix, and only the
+  // fan-out's shadow filter drops those. Execution still runs the
+  // allowed descendants only.
+  if (registry.descendantMounts(paths[0].virtual).length === 0) return false
   if (TRAVERSAL_CMDS.has(cmdName)) return true
   if (cmdName === 'grep') {
     return flagKwargs.r === true || flagKwargs.R === true || flagKwargs.recursive === true

--- a/typescript/packages/core/src/workspace/executor/fanout.ts
+++ b/typescript/packages/core/src/workspace/executor/fanout.ts
@@ -30,6 +30,7 @@ import {
   type FindExpr,
 } from '../../commands/builtin/findParse.ts'
 import type { FlagValue } from '../../commands/spec/types.ts'
+import type { ChildMounts } from '../../ops/types.ts'
 
 type Result = [ByteSource | null, IOResult, ExecutionNode]
 
@@ -213,6 +214,7 @@ export async function fanOutTraversal(
   cmdStr: string,
   stdin: ByteSource | null,
   ensureOpen: ((resource: Resource) => Promise<void>) | undefined,
+  childMounts: ChildMounts | null = null,
 ): Promise<Result> {
   const targetPath = paths[0]?.virtual ?? cwd
   const descendants = allowedDescendants(registry, targetPath)
@@ -266,9 +268,15 @@ export async function fanOutTraversal(
     if (ensureOpen !== undefined) {
       await ensureOpen(mount.resource)
     }
+    // The one fact threaded into the per-mount runs: a start point only
+    // the namespace serves (a nested mount's ancestor) has no backend
+    // listing, so without it the primary run reports the operand
+    // missing. Links and stat overlays are still dropped here, a known
+    // seam of the fan-out.
     const [stdout0, io] = await mount.executeCmd(cmdName, subPaths, subTexts, subFlags, {
       stdin,
       cwd,
+      ...(childMounts !== null ? { childMounts } : {}),
     })
     let stdout: ByteSource | null = stdout0
     if (mount !== primaryMount && io.exitCode === 127) {

--- a/typescript/packages/core/src/workspace/executor/fanout.ts
+++ b/typescript/packages/core/src/workspace/executor/fanout.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { mountAllowed } from '../../context/session_context.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import { type ByteSource, IOResult, materialize } from '../../io/types.ts'
 import type { Resource } from '../../resource/base.ts'
@@ -38,6 +39,19 @@ function pathSegments(path: string): string[] {
   return path.split('/').filter((s) => s !== '')
 }
 
+/**
+ * Descendant mounts the current session may see.
+ *
+ * A fan-out rooted above a session boundary must not walk into an
+ * ungranted mount: enumerating it through the raw registry is exactly
+ * how `grep -r x /` leaked a walled-off mount's contents. The filter
+ * matches the door's structure merge, so the fan-out stays an
+ * unobservable optimization.
+ */
+function allowedDescendants(registry: MountRegistry, path: string): MountEntry[] {
+  return registry.descendantMounts(path).filter((m) => mountAllowed(m.prefix))
+}
+
 export function shouldFanOut(
   cmdName: string,
   paths: readonly PathSpec[],
@@ -45,7 +59,7 @@ export function shouldFanOut(
   registry: MountRegistry,
 ): boolean {
   if (paths.length === 0 || paths[0] === undefined) return false
-  if (registry.descendantMounts(paths[0].virtual).length === 0) return false
+  if (allowedDescendants(registry, paths[0].virtual).length === 0) return false
   if (TRAVERSAL_CMDS.has(cmdName)) return true
   if (cmdName === 'grep') {
     return flagKwargs.r === true || flagKwargs.R === true || flagKwargs.recursive === true
@@ -196,8 +210,11 @@ export async function fanOutTraversal(
   ensureOpen: ((resource: Resource) => Promise<void>) | undefined,
 ): Promise<Result> {
   const targetPath = paths[0]?.virtual ?? cwd
-  const descendants = registry.descendantMounts(targetPath)
-  const descendantPrefixes = descendants.map((m) => rstripSlash(m.prefix))
+  const descendants = allowedDescendants(registry, targetPath)
+  // The shadow filter keeps the raw list on purpose: a mount the
+  // session cannot see still shadows the primary backend's keys under
+  // its prefix, the walk just never descends into it.
+  const descendantPrefixes = registry.descendantMounts(targetPath).map((m) => rstripSlash(m.prefix))
 
   const allStdout: Uint8Array[] = []
   let mergedIo = new IOResult()

--- a/typescript/packages/core/src/workspace/fs.test.ts
+++ b/typescript/packages/core/src/workspace/fs.test.ts
@@ -18,8 +18,9 @@ import type { Policy } from '../policy/base.ts'
 import { PolicyDenied } from '../policy/errors.ts'
 import { Policies } from '../policy/policies.ts'
 import type { Action, OpsContext, OpsResultContext } from '../policy/types.ts'
+import { MountNotAllowedError } from '../context/session_context.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
-import { Limit, MountMode } from '../types.ts'
+import { FileType, Limit, MountMode } from '../types.ts'
 import { enoent, enotdir } from '../utils/errors.ts'
 import { WorkspaceFS } from './fs.ts'
 import { Workspace } from './workspace.ts'
@@ -264,5 +265,36 @@ describe('WorkspaceFS structure fallback still clears admission', () => {
   it('the synthetic answer serves when no policy objects', async () => {
     const fs = mkStructureFS(new Policies())
     expect(await fs.readdir('/data/inner')).toEqual(['/data/inner/deep'])
+  })
+})
+
+describe('WorkspaceFS structure below an ungranted mount', () => {
+  function mkUngrantedFS(prefixes: string[]): WorkspaceFS {
+    return new WorkspaceFS(
+      () => Promise.reject(new MountNotAllowedError('agent', '/data')),
+      new OpsRegistry(),
+      null,
+      null,
+      null,
+      new Policies(),
+      () => '',
+      () => prefixes,
+    )
+  }
+
+  it('serves the granted structure instead of the denial', async () => {
+    // The resolver rejects because the owning mount is ungranted, but a
+    // granted mount below the path already put its name in a listing,
+    // so walking down to the grant must answer.
+    const fs = mkUngrantedFS(['/data/inner/deep/'])
+    expect(await fs.readdir('/data/inner')).toEqual(['/data/inner/deep'])
+    const st = await fs.stat('/data/inner')
+    expect(st.type).toBe(FileType.DIRECTORY)
+  })
+
+  it('a path the structure does not owe keeps the canonical denial', async () => {
+    const fs = mkUngrantedFS([])
+    await expect(fs.readdir('/data/inner')).rejects.toThrow(MountNotAllowedError)
+    await expect(fs.stat('/data/inner')).rejects.toThrow(MountNotAllowedError)
   })
 })

--- a/typescript/packages/core/src/workspace/fs.test.ts
+++ b/typescript/packages/core/src/workspace/fs.test.ts
@@ -16,10 +16,12 @@ import { describe, expect, it } from 'vitest'
 import { OpsRegistry } from '../ops/registry.ts'
 import type { Policy } from '../policy/base.ts'
 import { PolicyDenied } from '../policy/errors.ts'
+import { Policies } from '../policy/policies.ts'
 import type { Action, OpsContext, OpsResultContext } from '../policy/types.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { Limit, MountMode } from '../types.ts'
-import { enotdir } from '../utils/errors.ts'
+import { enoent, enotdir } from '../utils/errors.ts'
+import { WorkspaceFS } from './fs.ts'
 import { Workspace } from './workspace.ts'
 
 const DEC = new TextDecoder()
@@ -223,5 +225,44 @@ describe('WorkspaceFS policy door', () => {
     const ws = mkGuarded()
     await expect(ws.fs.writeFile('/data/locked/f.txt', 'hi')).rejects.toThrow(PolicyDenied)
     expect(await ws.fs.exists('/data/locked/f.txt')).toBe(false)
+  })
+})
+
+// The resolver-miss structure fallback (a directory that exists only
+// because a mount sits below it) answers with no owning mount, so the
+// gates fire with prefix '' — skipping them would make "no mount here"
+// a policy bypass.
+describe('WorkspaceFS structure fallback still clears admission', () => {
+  class SealInner implements Policy {
+    preOps(ctx: OpsContext): Action | null {
+      if (ctx.path.virtual === '/data/inner') return { kind: 'deny', message: 'sealed\n' }
+      return null
+    }
+  }
+
+  function mkStructureFS(policies: Policies): WorkspaceFS {
+    return new WorkspaceFS(
+      () => Promise.reject(enoent('/data/inner')),
+      new OpsRegistry(),
+      null,
+      null,
+      null,
+      policies,
+      () => '',
+      () => ['/data/inner/deep/'],
+    )
+  }
+
+  it('a policy deny covers the synthetic readdir and stat', async () => {
+    const policies = new Policies()
+    policies.add(new SealInner())
+    const fs = mkStructureFS(policies)
+    await expect(fs.readdir('/data/inner')).rejects.toThrow(PolicyDenied)
+    await expect(fs.stat('/data/inner')).rejects.toThrow(PolicyDenied)
+  })
+
+  it('the synthetic answer serves when no policy objects', async () => {
+    const fs = mkStructureFS(new Policies())
+    expect(await fs.readdir('/data/inner')).toEqual(['/data/inner/deep'])
   })
 })

--- a/typescript/packages/core/src/workspace/fs.test.ts
+++ b/typescript/packages/core/src/workspace/fs.test.ts
@@ -297,4 +297,33 @@ describe('WorkspaceFS structure below an ungranted mount', () => {
     await expect(fs.readdir('/data/inner')).rejects.toThrow(MountNotAllowedError)
     await expect(fs.stat('/data/inner')).rejects.toThrow(MountNotAllowedError)
   })
+
+  it("gates the fallback with the synthetic '' prefix, not the ungranted mount's", async () => {
+    // prefixOf still resolves the real ungranted '/data/' here, but the
+    // namespace's own answer has no owning mount: the gates must see ''
+    // exactly as the dispatcher and both Python doors report it, or a
+    // mount-scoped policy diverges between ws.readdir and ws.dispatch.
+    const seen: string[] = []
+    class RecordPrefix implements Policy {
+      preOps(ctx: OpsContext): Action | null {
+        seen.push(ctx.prefix)
+        return null
+      }
+    }
+    const policies = new Policies()
+    policies.add(new RecordPrefix())
+    const fs = new WorkspaceFS(
+      () => Promise.reject(new MountNotAllowedError('agent', '/data')),
+      new OpsRegistry(),
+      null,
+      null,
+      null,
+      policies,
+      () => '/data/',
+      () => ['/data/inner/deep/'],
+    )
+    expect(await fs.readdir('/data/inner')).toEqual(['/data/inner/deep'])
+    await fs.stat('/data/inner')
+    expect(seen).toEqual(['', ''])
+  })
 })

--- a/typescript/packages/core/src/workspace/fs.ts
+++ b/typescript/packages/core/src/workspace/fs.ts
@@ -17,6 +17,7 @@ import { applyOpLimit } from '../commands/builtin/utils/limit.ts'
 import { getExtension } from '../commands/resolve.ts'
 import { OpRecord } from '../observe/record.ts'
 import { NO_FOLLOW_OPS, type NamespaceLinks } from '../ops/config.ts'
+import { mergeReaddir, structureListing, structureStat } from '../ops/structure.ts'
 import type { StatOverlay } from '../ops/types.ts'
 import type { OpKwargs, OpsRegistry } from '../ops/registry.ts'
 import { type Policies, postOpsGate, preOpsGate } from '../policy/policies.ts'
@@ -48,6 +49,12 @@ export class WorkspaceFS {
   // direct construction in tests.
   private readonly policies: Policies | null
   private readonly prefixOf: PrefixOf | null
+  // Live view of the workspace mount prefixes, for the structure merge:
+  // this facade is a second door beside the dispatcher until they
+  // collapse (R2), so both must answer readdir and stat with the same
+  // namespace structure. Null means no structure to merge (direct
+  // construction in tests).
+  private readonly prefixes: (() => string[]) | null
 
   constructor(
     resolver: Resolver,
@@ -57,6 +64,7 @@ export class WorkspaceFS {
     statOverlay: StatOverlay | null = null,
     policies: Policies | null = null,
     prefixOf: PrefixOf | null = null,
+    prefixes: (() => string[]) | null = null,
   ) {
     this.resolver = resolver
     this.ops = ops
@@ -65,6 +73,20 @@ export class WorkspaceFS {
     this.statOverlay = statOverlay
     this.policies = policies
     this.prefixOf = prefixOf
+    this.prefixes = prefixes
+  }
+
+  /**
+   * The namespace's own answer for a path no backend serves, mirroring
+   * the dispatcher: a directory that exists only because a mount or a
+   * link sits below it still lists and stats. Null for any other op,
+   * or when the namespace knows nothing at `path`.
+   */
+  private structureResult(op: string, path: string): string[] | FileStat | null {
+    if (this.prefixes === null) return null
+    if (op === 'readdir') return structureListing(this.prefixes(), this.links, path)
+    if (op === 'stat') return structureStat(this.prefixes(), this.links, path)
+    return null
   }
 
   private follow(op: string, path: string): string {
@@ -168,17 +190,35 @@ export class WorkspaceFS {
   async readdir(path: string): Promise<string[]> {
     const start = Date.now()
     path = this.follow('readdir', path)
-    const [resource, pathSpec] = await this.resolver(path)
+    let resolved: [Resource, PathSpec, MountMode]
+    try {
+      resolved = await this.resolver(path)
+    } catch (err) {
+      const fallback = isMissingPath(err) ? this.structureResult('readdir', path) : null
+      if (fallback === null) throw err
+      return fallback as string[]
+    }
+    const [resource, pathSpec] = resolved
     const kwargs = resource.index !== undefined ? { index: resource.index } : {}
     await this.firePreOps('readdir', path, pathSpec, false)
-    const result = (await this.ops.call(
-      'readdir',
-      resource.kind,
-      resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-      pathSpec,
-      [],
-      kwargs,
-    )) as string[] | null
+    let result: string[] | null
+    try {
+      result = (await this.ops.call(
+        'readdir',
+        resource.kind,
+        resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+        pathSpec,
+        [],
+        kwargs,
+      )) as string[] | null
+    } catch (err) {
+      const fallback = isMissingPath(err) ? this.structureResult('readdir', path) : null
+      if (fallback === null) throw err
+      result = fallback as string[]
+    }
+    if (this.prefixes !== null) {
+      result = mergeReaddir(result ?? [], this.prefixes(), this.links, path)
+    }
     await this.record('readdir', path, resource.kind, 0, start)
     return (
       ((await this.firePostOps('readdir', path, pathSpec, false, result)) as string[] | null) ?? []
@@ -188,17 +228,32 @@ export class WorkspaceFS {
   async stat(path: string): Promise<FileStat> {
     const start = Date.now()
     path = this.follow('stat', path)
-    const [resource, pathSpec] = await this.resolver(path)
+    let resolved: [Resource, PathSpec, MountMode]
+    try {
+      resolved = await this.resolver(path)
+    } catch (err) {
+      const fallback = isMissingPath(err) ? this.structureResult('stat', path) : null
+      if (fallback === null) throw err
+      return fallback as FileStat
+    }
+    const [resource, pathSpec] = resolved
     const kwargs = resource.index !== undefined ? { index: resource.index } : {}
     await this.firePreOps('stat', path, pathSpec, false)
-    let result = (await this.ops.call(
-      'stat',
-      resource.kind,
-      resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-      pathSpec,
-      [],
-      kwargs,
-    )) as FileStat
+    let result: FileStat
+    try {
+      result = (await this.ops.call(
+        'stat',
+        resource.kind,
+        resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+        pathSpec,
+        [],
+        kwargs,
+      )) as FileStat
+    } catch (err) {
+      const fallback = isMissingPath(err) ? this.structureResult('stat', path) : null
+      if (fallback === null) throw err
+      result = fallback as FileStat
+    }
     await this.record('stat', path, resource.kind, 0, start)
     result = (await this.firePostOps('stat', path, pathSpec, false, result)) as FileStat
     if (this.statOverlay !== null) return this.statOverlay(path, result)

--- a/typescript/packages/core/src/workspace/fs.ts
+++ b/typescript/packages/core/src/workspace/fs.ts
@@ -15,6 +15,7 @@
 import { NOOPAccessor } from '../accessor/base.ts'
 import { applyOpLimit } from '../commands/builtin/utils/limit.ts'
 import { getExtension } from '../commands/resolve.ts'
+import { MountNotAllowedError } from '../context/session_context.ts'
 import { OpRecord } from '../observe/record.ts'
 import { NO_FOLLOW_OPS, type NamespaceLinks } from '../ops/config.ts'
 import { mergeReaddir, structureListing, structureStat } from '../ops/structure.ts'
@@ -194,10 +195,13 @@ export class WorkspaceFS {
     try {
       resolved = await this.resolver(path)
     } catch (err) {
-      // No mount serves the path; mirror the dispatcher and fire the
-      // gates anyway (prefixOf answers '' here) so a policy that bounds
-      // readdir by path covers the synthetic answer too.
-      const fallback = isMissingPath(err) ? this.structureResult('readdir', path) : null
+      // No mount serves the path, or a real mount is ungranted; mirror
+      // the dispatcher and fire the gates anyway (prefixOf answers ''
+      // here) so a policy that bounds readdir by path covers the
+      // synthetic answer too. The merged names are session-filtered,
+      // so an ungranted mount's own content never leaks.
+      const eligible = isMissingPath(err) || err instanceof MountNotAllowedError
+      const fallback = eligible ? this.structureResult('readdir', path) : null
       if (fallback === null) throw err
       const pathSpec = PathSpec.fromStrPath(path)
       await this.firePreOps('readdir', path, pathSpec, false)
@@ -241,7 +245,8 @@ export class WorkspaceFS {
       resolved = await this.resolver(path)
     } catch (err) {
       // Same gate routing as the readdir resolver miss above.
-      const fallback = isMissingPath(err) ? this.structureResult('stat', path) : null
+      const eligible = isMissingPath(err) || err instanceof MountNotAllowedError
+      const fallback = eligible ? this.structureResult('stat', path) : null
       if (fallback === null) throw err
       const pathSpec = PathSpec.fromStrPath(path)
       await this.firePreOps('stat', path, pathSpec, false)

--- a/typescript/packages/core/src/workspace/fs.ts
+++ b/typescript/packages/core/src/workspace/fs.ts
@@ -95,15 +95,19 @@ export class WorkspaceFS {
     return this.links.follow(path)
   }
 
+  // `prefix` overrides the mount attribution; the structure fallbacks
+  // pass '' ("no owning mount"), matching how the dispatcher and both
+  // Python doors gate the same synthetic answer.
   private async firePreOps(
     op: string,
     path: string,
     pathSpec: PathSpec,
     write: boolean,
+    prefix?: string,
   ): Promise<void> {
     if (this.policies === null) return
-    const prefix = this.prefixOf !== null ? this.prefixOf(path) : ''
-    await preOpsGate(this.policies, op, pathSpec, write, prefix)
+    const p = prefix ?? (this.prefixOf !== null ? this.prefixOf(path) : '')
+    await preOpsGate(this.policies, op, pathSpec, write, p)
   }
 
   // Bookkeeping precedes this gate: a denied result is still a completed
@@ -115,10 +119,11 @@ export class WorkspaceFS {
     pathSpec: PathSpec,
     write: boolean,
     result: unknown,
+    prefix?: string,
   ): Promise<unknown> {
     if (this.policies === null) return result
-    const prefix = this.prefixOf !== null ? this.prefixOf(path) : ''
-    const bound = await postOpsGate(this.policies, op, pathSpec, write, prefix, result)
+    const p = prefix ?? (this.prefixOf !== null ? this.prefixOf(path) : '')
+    const bound = await postOpsGate(this.policies, op, pathSpec, write, p, result)
     if (bound !== null) return applyOpLimit(result, bound)
     return result
   }
@@ -196,18 +201,21 @@ export class WorkspaceFS {
       resolved = await this.resolver(path)
     } catch (err) {
       // No mount serves the path, or a real mount is ungranted; mirror
-      // the dispatcher and fire the gates anyway (prefixOf answers ''
-      // here) so a policy that bounds readdir by path covers the
-      // synthetic answer too. The merged names are session-filtered,
-      // so an ungranted mount's own content never leaks.
+      // the dispatcher and fire the gates anyway, with the synthetic ''
+      // prefix (a grant-miss resolves to the real ungranted prefix,
+      // which must not attribute the namespace's own answer), so a
+      // policy that bounds readdir by path covers the synthetic answer
+      // too. The merged names are session-filtered, so an ungranted
+      // mount's own content never leaks.
       const eligible = isMissingPath(err) || err instanceof MountNotAllowedError
       const fallback = eligible ? this.structureResult('readdir', path) : null
       if (fallback === null) throw err
       const pathSpec = PathSpec.fromStrPath(path)
-      await this.firePreOps('readdir', path, pathSpec, false)
+      await this.firePreOps('readdir', path, pathSpec, false, '')
       return (
-        ((await this.firePostOps('readdir', path, pathSpec, false, fallback)) as string[] | null) ??
-        []
+        ((await this.firePostOps('readdir', path, pathSpec, false, fallback, '')) as
+          | string[]
+          | null) ?? []
       )
     }
     const [resource, pathSpec] = resolved
@@ -249,8 +257,8 @@ export class WorkspaceFS {
       const fallback = eligible ? this.structureResult('stat', path) : null
       if (fallback === null) throw err
       const pathSpec = PathSpec.fromStrPath(path)
-      await this.firePreOps('stat', path, pathSpec, false)
-      return (await this.firePostOps('stat', path, pathSpec, false, fallback)) as FileStat
+      await this.firePreOps('stat', path, pathSpec, false, '')
+      return (await this.firePostOps('stat', path, pathSpec, false, fallback, '')) as FileStat
     }
     const [resource, pathSpec] = resolved
     const kwargs = resource.index !== undefined ? { index: resource.index } : {}

--- a/typescript/packages/core/src/workspace/fs.ts
+++ b/typescript/packages/core/src/workspace/fs.ts
@@ -18,7 +18,7 @@ import { getExtension } from '../commands/resolve.ts'
 import { MountNotAllowedError } from '../context/session_context.ts'
 import { OpRecord } from '../observe/record.ts'
 import { NO_FOLLOW_OPS, type NamespaceLinks } from '../ops/config.ts'
-import { mergeReaddir, structureListing, structureStat } from '../ops/structure.ts'
+import { mergeReaddir, namespaceListing, namespaceStat } from '../ops/namespace_view.ts'
 import type { StatOverlay } from '../ops/types.ts'
 import type { OpKwargs, OpsRegistry } from '../ops/registry.ts'
 import { type Policies, postOpsGate, preOpsGate } from '../policy/policies.ts'
@@ -83,10 +83,10 @@ export class WorkspaceFS {
    * link sits below it still lists and stats. Null for any other op,
    * or when the namespace knows nothing at `path`.
    */
-  private structureResult(op: string, path: string): string[] | FileStat | null {
+  private namespaceResult(op: string, path: string): string[] | FileStat | null {
     if (this.prefixes === null) return null
-    if (op === 'readdir') return structureListing(this.prefixes(), this.links, path)
-    if (op === 'stat') return structureStat(this.prefixes(), this.links, path)
+    if (op === 'readdir') return namespaceListing(this.prefixes(), this.links, path)
+    if (op === 'stat') return namespaceStat(this.prefixes(), this.links, path)
     return null
   }
 
@@ -208,7 +208,7 @@ export class WorkspaceFS {
       // too. The merged names are session-filtered, so an ungranted
       // mount's own content never leaks.
       const eligible = isMissingPath(err) || err instanceof MountNotAllowedError
-      const fallback = eligible ? this.structureResult('readdir', path) : null
+      const fallback = eligible ? this.namespaceResult('readdir', path) : null
       if (fallback === null) throw err
       const pathSpec = PathSpec.fromStrPath(path)
       await this.firePreOps('readdir', path, pathSpec, false, '')
@@ -232,7 +232,7 @@ export class WorkspaceFS {
         kwargs,
       )) as string[] | null
     } catch (err) {
-      const fallback = isMissingPath(err) ? this.structureResult('readdir', path) : null
+      const fallback = isMissingPath(err) ? this.namespaceResult('readdir', path) : null
       if (fallback === null) throw err
       result = fallback as string[]
     }
@@ -254,7 +254,7 @@ export class WorkspaceFS {
     } catch (err) {
       // Same gate routing as the readdir resolver miss above.
       const eligible = isMissingPath(err) || err instanceof MountNotAllowedError
-      const fallback = eligible ? this.structureResult('stat', path) : null
+      const fallback = eligible ? this.namespaceResult('stat', path) : null
       if (fallback === null) throw err
       const pathSpec = PathSpec.fromStrPath(path)
       await this.firePreOps('stat', path, pathSpec, false, '')
@@ -274,7 +274,7 @@ export class WorkspaceFS {
         kwargs,
       )) as FileStat
     } catch (err) {
-      const fallback = isMissingPath(err) ? this.structureResult('stat', path) : null
+      const fallback = isMissingPath(err) ? this.namespaceResult('stat', path) : null
       if (fallback === null) throw err
       result = fallback as FileStat
     }

--- a/typescript/packages/core/src/workspace/fs.ts
+++ b/typescript/packages/core/src/workspace/fs.ts
@@ -22,8 +22,8 @@ import type { StatOverlay } from '../ops/types.ts'
 import type { OpKwargs, OpsRegistry } from '../ops/registry.ts'
 import { type Policies, postOpsGate, preOpsGate } from '../policy/policies.ts'
 import type { Resource } from '../resource/base.ts'
-import type { FileStat, MountMode, PathSpec } from '../types.ts'
-import { FileType } from '../types.ts'
+import type { FileStat, MountMode } from '../types.ts'
+import { FileType, PathSpec } from '../types.ts'
 import { isMissingPath } from '../utils/errors.ts'
 
 const NOOP_ACCESSOR_INSTANCE = new NOOPAccessor()
@@ -194,9 +194,17 @@ export class WorkspaceFS {
     try {
       resolved = await this.resolver(path)
     } catch (err) {
+      // No mount serves the path; mirror the dispatcher and fire the
+      // gates anyway (prefixOf answers '' here) so a policy that bounds
+      // readdir by path covers the synthetic answer too.
       const fallback = isMissingPath(err) ? this.structureResult('readdir', path) : null
       if (fallback === null) throw err
-      return fallback as string[]
+      const pathSpec = PathSpec.fromStrPath(path)
+      await this.firePreOps('readdir', path, pathSpec, false)
+      return (
+        ((await this.firePostOps('readdir', path, pathSpec, false, fallback)) as string[] | null) ??
+        []
+      )
     }
     const [resource, pathSpec] = resolved
     const kwargs = resource.index !== undefined ? { index: resource.index } : {}
@@ -232,9 +240,12 @@ export class WorkspaceFS {
     try {
       resolved = await this.resolver(path)
     } catch (err) {
+      // Same gate routing as the readdir resolver miss above.
       const fallback = isMissingPath(err) ? this.structureResult('stat', path) : null
       if (fallback === null) throw err
-      return fallback as FileStat
+      const pathSpec = PathSpec.fromStrPath(path)
+      await this.firePreOps('stat', path, pathSpec, false)
+      return (await this.firePostOps('stat', path, pathSpec, false, fallback)) as FileStat
     }
     const [resource, pathSpec] = resolved
     const kwargs = resource.index !== undefined ? { index: resource.index } : {}

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -22,7 +22,7 @@ import type {
   RegisteredCommand,
 } from '../../commands/config.ts'
 import type { OpKwargs } from '../../ops/registry.ts'
-import type { LinkView, StatOverlay, StatPath } from '../../ops/types.ts'
+import type { ChildMounts, LinkView, StatOverlay, StatPath } from '../../ops/types.ts'
 
 const NOOP_ACCESSOR = new NOOPAccessor()
 import { getExtension } from '../../commands/resolve.ts'
@@ -392,6 +392,7 @@ export class MountEntry {
       statOverlay?: StatOverlay
       links?: LinkView
       statPath?: StatPath
+      childMounts?: ChildMounts
       signal?: AbortSignal
       limitOverride?: Limit | null
     } = {},
@@ -447,6 +448,7 @@ export class MountEntry {
       ...(opts.statOverlay !== undefined ? { statOverlay: opts.statOverlay } : {}),
       ...(opts.links !== undefined ? { links: opts.links } : {}),
       ...(opts.statPath !== undefined ? { statPath: opts.statPath } : {}),
+      ...(opts.childMounts !== undefined ? { childMounts: opts.childMounts } : {}),
     }
 
     return runWithMountPrefix(mountPrefix, () =>

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.test.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.test.ts
@@ -118,16 +118,6 @@ describe('Namespace symlink table', () => {
     await ws.close()
   })
 
-  it('linksUnder returns direct children only', async () => {
-    const ws = new Workspace({ '/data': new RAMResource() })
-    await ws.namespace.symlink('/data/a', '/t1', 1)
-    await ws.namespace.symlink('/data/sub/b', '/t2', 1)
-    await ws.namespace.symlink('/other/c', '/t3', 1)
-    expect(ws.namespace.linksUnder('/data')).toEqual(new Map([['a', '/t1']]))
-    expect(ws.namespace.linksUnder('/data/sub')).toEqual(new Map([['b', '/t2']]))
-    await ws.close()
-  })
-
   it('purgeUnder drops nested entries', async () => {
     const ws = new Workspace({ '/data': new RAMResource() })
     await ws.namespace.symlink('/data/sub/a', '/t1', 1)
@@ -179,7 +169,6 @@ describe('Namespace node metadata overlay', () => {
     await ws.namespace.setAttrs('/data/f.txt', { mode: 0o600 })
     expect(ws.namespace.symlinkTargets().size).toBe(0)
     expect(ws.namespace.hasLinks()).toBe(false)
-    expect(ws.namespace.linksUnder('/data').size).toBe(0)
     await ws.close()
   })
 

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
@@ -428,6 +428,10 @@ export class Namespace {
     return this.registry.mountFor(path)
   }
 
+  mountPrefixes(): string[] {
+    return this.registry.mountPrefixes()
+  }
+
   isMountRoot(path: string): boolean {
     return this.registry.isMountRoot(path)
   }

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
@@ -389,22 +389,6 @@ export class Namespace {
     return out
   }
 
-  // Links living directly under a directory: basename -> target.
-  linksUnder(directory: string): Map<string, string> {
-    const base = rstripSlash(directory) + '/'
-    const out = new Map<string, string>()
-    for (const [path, meta] of this.nodeTable) {
-      if (
-        meta.target !== undefined &&
-        path.startsWith(base) &&
-        !path.slice(base.length).includes('/')
-      ) {
-        out.set(path.slice(base.length), meta.target)
-      }
-    }
-    return out
-  }
-
   // Drop every node entry under a directory (`rm -r` semantics).
   async purgeUnder(directory: string): Promise<number> {
     const base = rstripSlash(directory) + '/'

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -257,23 +257,8 @@ export class MountRegistry {
     return out.sort((a, b) => (a.prefix < b.prefix ? -1 : a.prefix > b.prefix ? 1 : 0))
   }
 
-  childMountNames(parentPath: string, includeHidden = false): string[] {
-    const norm = normalizePrefix(parentPath)
-    const seen = new Set<string>()
-    const out: string[] = []
-    for (const m of this.mountList) {
-      if (m.prefix === norm) continue
-      if (!m.prefix.startsWith(norm)) continue
-      const rest = m.prefix.slice(norm.length)
-      const slash = rest.indexOf('/')
-      const name = slash === -1 ? rest : rest.slice(0, slash)
-      if (name === '') continue
-      if (!includeHidden && name.startsWith('.')) continue
-      if (seen.has(name)) continue
-      seen.add(name)
-      out.push(name)
-    }
-    return out.sort()
+  mountPrefixes(): string[] {
+    return this.mountList.map((m) => m.prefix)
   }
 
   opsMounts(): OpsMountInfo[] {

--- a/typescript/packages/core/src/workspace/session_modes.test.ts
+++ b/typescript/packages/core/src/workspace/session_modes.test.ts
@@ -13,10 +13,11 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { afterEach, describe, expect, it } from 'vitest'
+import { runWithSession } from '../context/session_context.ts'
 import { OpsRegistry } from '../ops/registry.ts'
 import { RAMSessionStore } from './session/ram.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
-import { MountMode } from '../types.ts'
+import { FileType, MountMode, type FileStat } from '../types.ts'
 import { getTestParser, stderrStr, stdoutStr } from './fixtures/workspace_fixture.ts'
 import { Workspace } from './workspace.ts'
 
@@ -187,6 +188,54 @@ describe('per-session mount grants', () => {
     const sess = ws.createSession('agent', { mounts: { '/a': 'rw' } })
     expect(sess.mountModes?.get('/a')).toBe(MountMode.WRITE)
     expect(() => ws.createSession('bits', { mounts: { '/a': 'w' } })).toThrow('invalid mount mode')
+  })
+})
+
+describe('structure below an ungranted mount', () => {
+  async function makeNestedWorkspace(): Promise<Workspace> {
+    const parser = await getTestParser()
+    const base = new RAMResource()
+    base.store.files.set('/top.txt', ENC.encode('TOP\n'))
+    const inner = new RAMResource()
+    inner.store.files.set('/deep.txt', ENC.encode('needle\n'))
+    const registry = new OpsRegistry()
+    registry.registerResource(base)
+    registry.registerResource(inner)
+    const ws = new Workspace(
+      { '/base': base, '/base/inner': inner },
+      { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+    )
+    open.push(ws)
+    return ws
+  }
+
+  it('a session granted only a nested mount can walk down to it', async () => {
+    // The root listing deliberately shows `base` as the traversal path
+    // to the grant, so readdir and stat on /base must answer with the
+    // granted structure; the ungranted backend's own content never
+    // appears, and a path the structure does not owe still denies.
+    const ws = await makeNestedWorkspace()
+    const sess = ws.createSession('agent', { mounts: ['/base/inner'] })
+    await runWithSession(sess, async () => {
+      expect(await ws.dispatch('readdir', '/base')).toEqual(['/base/inner'])
+      const st = (await ws.dispatch('stat', '/base')) as FileStat
+      expect(st.type).toBe(FileType.DIRECTORY)
+      expect(await ws.dispatch('readdir', '/base/inner')).toEqual(['/base/inner/deep.txt'])
+      await expect(ws.dispatch('readdir', '/base/other')).rejects.toThrow('not allowed')
+    })
+  })
+
+  it('a link below an ungranted mount stays out of a scoped listing', async () => {
+    const { ws } = await makeGrantsWorkspace()
+    const ln = await ws.execute('ln -s /b/secret.txt /b/leak')
+    expect(ln.exitCode).toBe(0)
+    const sess = ws.createSession('agent', { mounts: ['/a'] })
+    await runWithSession(sess, async () => {
+      const names = (await ws.dispatch('readdir', '/')) as string[]
+      expect(names).not.toContain('/b')
+      expect(names).toContain('/a')
+    })
+    expect((await ws.dispatch('readdir', '/')) as string[]).toContain('/b')
   })
 })
 

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -20,6 +20,7 @@ import { type EventDict, Observer } from '../observe/observer.ts'
 import type { OpRecord } from '../observe/record.ts'
 import { type OpKwargs, OpsRegistry } from '../ops/registry.ts'
 import { assertMountAllowed } from '../context/session_context.ts'
+import { isMissingPath } from '../utils/errors.ts'
 import type { Resource } from '../resource/base.ts'
 import { HISTORY_PREFIX, HistoryViewResource } from '../resource/history/history.ts'
 import { resourceStateRequiresOverride } from '../resource/secrets.ts'
@@ -387,10 +388,14 @@ export class Workspace {
               let stat: FileStat
               try {
                 stat = (await this.dispatch('stat', entry)) as FileStat
-              } catch {
+              } catch (err) {
                 // A dangling link, or an entry that vanished between
                 // list and stat, must not fail the whole listing; the
-                // guest's own open reports the miss.
+                // guest's own open reports the miss. Anything else
+                // (authorization, a timeout, a backend bug) propagates,
+                // or pyodide's syncMounts would replace a healthy
+                // snapshot with a silently degraded one.
+                if (!isMissingPath(err)) throw err
                 return { path: entry, size: 0, isDir: false, ...(isLink ? { isLink } : {}) }
               }
               const isDir = stat.type === FileType.DIRECTORY

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -261,6 +261,7 @@ export class Workspace {
       (path, stat) => mergeOverlayStat(this.namespace.metaFor(path), stat),
       this.registry.policies,
       (path) => this.registry.mountFor(path)?.prefix ?? '',
+      () => this.registry.mountPrefixes(),
     )
   }
 
@@ -382,9 +383,23 @@ export class Workspace {
               // skip the stat; unmarked entries (e.g. RAM) need one to
               // learn dir-ness.
               if (entry.endsWith('/')) return { path: entry, size: 0, isDir: true }
-              const stat = (await this.dispatch('stat', entry)) as FileStat
+              const isLink = this.namespace.isLink(entry)
+              let stat: FileStat
+              try {
+                stat = (await this.dispatch('stat', entry)) as FileStat
+              } catch {
+                // A dangling link, or an entry that vanished between
+                // list and stat, must not fail the whole listing; the
+                // guest's own open reports the miss.
+                return { path: entry, size: 0, isDir: false, ...(isLink ? { isLink } : {}) }
+              }
               const isDir = stat.type === FileType.DIRECTORY
-              return { path: entry, size: isDir ? 0 : (stat.size ?? 0), isDir }
+              return {
+                path: entry,
+                size: isDir ? 0 : (stat.size ?? 0),
+                isDir,
+                ...(isLink ? { isLink } : {}),
+              }
             }),
           )
         }

--- a/typescript/packages/node/src/fuse/core.ts
+++ b/typescript/packages/node/src/fuse/core.ts
@@ -78,7 +78,6 @@ export class MountCore {
   readonly session: Session | null
   private readonly now: Date
   private readonly root: string
-  private readonly prefixes: string[]
   readonly handles = new Map<number, Handle>()
   // In-memory extended attributes, keyed by path. Backends have no POSIX
   // xattrs, so these are advisory and never persisted; see setxattr.
@@ -93,9 +92,6 @@ export class MountCore {
     this.ws = ws
     this.now = new Date()
     this.root = options.rootPrefix !== undefined ? rstripSlash(options.rootPrefix) : ''
-    // When scoped to a single mount, the root maps onto that mount and
-    // there are no virtual intermediate directories to synthesize.
-    this.prefixes = this.root === '' ? ws.mounts().map((m) => m.prefix) : []
     this.uid = typeof process.getuid === 'function' ? process.getuid() : 0
     this.gid = typeof process.getgid === 'function' ? process.getgid() : 0
     this.session = options.session ?? null
@@ -193,29 +189,6 @@ export class MountCore {
     return entry
   }
 
-  isVirtualDir(path: string): boolean {
-    const bare = rstripSlash(path)
-    const normalized = bare + '/'
-    for (const p of this.prefixes) {
-      const pBare = rstripSlash(p)
-      if (p.startsWith(normalized) || pBare === bare) return true
-    }
-    return false
-  }
-
-  virtualChildren(path: string): string[] {
-    const normalized = path === '/' ? '/' : rstripSlash(path) + '/'
-    const children = new Set<string>()
-    for (const p of this.prefixes) {
-      if (p.startsWith(normalized) && p !== normalized) {
-        const rest = p.slice(normalized.length)
-        const child = rest.split('/')[0]
-        if (child !== undefined && child !== '') children.add(child)
-      }
-    }
-    return [...children].sort()
-  }
-
   cachedSize(path: string): number | null {
     for (const ctx of this.handles.values()) {
       if (ctx.path === path && ctx.data !== undefined) return ctx.data.byteLength
@@ -292,7 +265,6 @@ export class MountCore {
     // namespace links, so stat on a link path reports the target.
     const target = this.linkTarget(path)
     if (target !== null) return this.linkStat(target)
-    if (this.isVirtualDir(path)) return this.dirStat()
     const s = await this.ws.fs.stat(this.resolve(path))
     if (s.type === FileType.DIRECTORY) {
       return this.applyStatAttrs(this.dirStat(), s)
@@ -318,21 +290,15 @@ export class MountCore {
   }
 
   async readdir(path: string): Promise<string[]> {
-    const names = new Set(this.virtualChildren(path))
-    const links = this.ws.fs.links
-    if (links !== null) {
-      for (const linkName of links.linksUnder(this.resolve(path)).keys()) {
-        if (linkName !== '' && !isMacosMetadata(linkName)) names.add(linkName)
-      }
-    }
-    try {
-      const entries = await this.ws.fs.readdir(this.resolve(path))
-      for (const e of entries) {
-        const part = rstripSlash(e).split('/').pop() ?? ''
-        if (part !== '' && !isMacosMetadata(part)) names.add(part)
-      }
-    } catch (err) {
-      if (names.size === 0) throw err
+    // The workspace dispatcher merges namespace structure (child mounts
+    // and symlinks) into readdir and answers structure-only directories
+    // itself, so the core only normalizes entry shapes and drops macOS
+    // metadata names.
+    const names = new Set<string>()
+    const entries = await this.ws.fs.readdir(this.resolve(path))
+    for (const e of entries) {
+      const part = rstripSlash(e).split('/').pop() ?? ''
+      if (part !== '' && !isMacosMetadata(part)) names.add(part)
     }
     return ['.', '..', ...[...names].sort()]
   }


### PR DESCRIPTION
## Summary
- readdir and stat merge namespace structure (child mounts, symlinks) inside the dispatch door, session-filtered, in both languages; a structure-only directory now lists and stats
- delete the ls stdout patcher (inject_child_mounts / listed_names, both languages) and MountCore's private structure synthesis; ls receives a child_mounts fact merged as rows beside link rows
- session-filter fan-out and root listings: a scoped session no longer learns or reads ungranted mounts through grep -r /, ls -R /, find /, du -a / (the enumeration half of the confinement hole; the guest thread-hop half lands with R2)
- pyodide mounts only maximal prefixes; preload descends the merged readdir, skips symlink entries, and a dangling link no longer fails a guest listing
- recursive walkers now see link entries in readdir, so chmod -R skips them by name (GNU: a traversed link changes neither itself nor its referent)
- add the conformance worlds suite (python + typescript mirror); R1 xfails flipped green, the remaining python reds are pinned for R2 and cwd

Behavior change to note: walking commands descend into child mounts everywhere now, and injected ls rows sort into the listing instead of trailing it.

## Test plan
- cd python && uv run pytest
- pre-commit run --all-files
- cd typescript && pnpm build && pnpm typecheck && pnpm lint && pnpm test