### PR TITLE
fix(tar): drop the GPL bzip2 dependency, and parse tar with modern-tar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,28 @@ Invoke the venv's `pre-commit` binary directly (not via `uv --directory python r
   `-x a -x b` says the same thing), and the `adding:` line carries no
   `(deflated N%)` suffix, since the ratio depends on the compressor and
   would differ between the two languages.
+- **Tar formats come from a library, not from hand-rolled block code, and
+  bzip2 is read-only in TypeScript.** Python builds archives with stdlib
+  `tarfile`; TypeScript uses `modern-tar` behind `tar_helper.ts`, which
+  keeps the `TarEntry` shape (`name`/`data`/`isFile`/`isDir`/`linkname`)
+  the two call sites already speak and is the only place the dependency
+  is named. Do not go back to writing ustar blocks by hand: the version
+  that did truncated any name past 100 bytes instead of using the ustar
+  `prefix` field or a PAX header (so a deep member extracted to the wrong
+  path), and read a PAX/GNU extension block as if it were a member (so
+  `tar -t` on any archive GNU or Python wrote listed a phantom
+  `././@PaxHeader` row). `writeTar`/`readTar` are async for this reason.
+  Compression is a registry (`registerCompressionCodec`): gzip is built
+  in via `CompressionStream`, and a codec may be **decompress-only**,
+  which is the one deliberate py/ts divergence here. Python reads and
+  writes `.tar.bz2` because `bz2` is stdlib; TypeScript only reads one,
+  because every JavaScript bzip2 *compressor* is GPL (`compressjs`,
+  `archive-wasm`) and an Apache-2.0 package cannot ship that, while
+  `seek-bzip` (MIT) decodes. `tar -cj` therefore exits 1 with
+  `tar: bzip2 not supported`, the same answer browser core already gives
+  for an unregistered codec. If a permissively licensed bzip2 compressor
+  appears, adding `compress` to that one codec closes the gap with no
+  other change.
 - **The TypeScript `walkFind` answers in mount-relative keys; the Python
   `walk_find` answers in virtual paths.** TS's stands in for a backend's
   native find op, so a caller that needs virtual paths (tar does, to

--- a/typescript/knip.json
+++ b/typescript/knip.json
@@ -8,8 +8,8 @@
     "packages/node": {
       "ignoreDependencies": [
         "@napi-rs/lzma",
-        "compressjs",
         "fs-monkey",
+        "seek-bzip",
         "tree-sitter-bash",
         "web-tree-sitter"
       ]

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -64,6 +64,7 @@
     "bson": "^6.10.4",
     "isomorphic-git": "^1.38.1",
     "jq-wasm": "1.1.0-jq-1.8.1",
+    "modern-tar": "^0.8.4",
     "uuid": "^14.0.1",
     "web-tree-sitter": "^0.26.8",
     "zod": "^4.3.6"

--- a/typescript/packages/core/src/commands/builtin/generic/tar.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar.ts
@@ -74,8 +74,19 @@ async function compress(raw: Uint8Array, kind: Compression): Promise<Uint8Array>
   if (kind === null) return raw
   if (kind === 'gzip') return gzip(raw)
   const codec = getCompressionCodec(kind)
-  if (codec === undefined) throw new Error(`tar: ${kind} not supported`)
+  if (codec?.compress === undefined) throw new Error(`tar: ${kind} not supported`)
   return codec.compress(raw)
+}
+
+// gzip is built in; bzip2 (-j) / xz (-J) need a codec registered by the
+// runtime package, and a codec may be decompress-only (bzip2 is), which only
+// rules out creating an archive. Answers the kind that cannot be served, so
+// the caller names it.
+function unsupportedKind(compression: Compression, create: boolean): CompressionKind | null {
+  if (compression !== 'bzip2' && compression !== 'xz') return null
+  const codec = getCompressionCodec(compression)
+  if (codec === undefined) return compression
+  return create && codec.compress === undefined ? compression : null
 }
 
 async function decompress(data: Uint8Array, kind: Compression): Promise<Uint8Array> {
@@ -113,7 +124,7 @@ async function writeArchive(
     })
     names.push(member.name)
   }
-  const raw = writeTar(entries)
+  const raw = await writeTar(entries)
   const archive = await compress(raw, compression)
   await deps.write(makePathSpec(archivePath, mountPrefix), archive)
   const stderr = stderrOf(plan.notices)
@@ -139,15 +150,11 @@ export async function tarGeneric(
   const list = fl.asBool('t')
   const compression = compressionOf(opts)
   const verbose = fl.asBool('v')
-  // gzip is built in; bzip2 (-j) / xz (-J) need a codec registered by the
-  // runtime package. Unregistered (e.g. browser core) -> not supported.
-  if (
-    (compression === 'bzip2' || compression === 'xz') &&
-    getCompressionCodec(compression) === undefined
-  ) {
+  const missing = unsupportedKind(compression, create)
+  if (missing !== null) {
     return [
       null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('tar: bzip2/xz not supported\n') }),
+      new IOResult({ exitCode: 1, stderr: ENC.encode(`tar: ${missing} not supported\n`) }),
     ]
   }
   const fFlag = fl.asStr('f') ?? null
@@ -195,7 +202,7 @@ export async function tarGeneric(
     }
     const raw = await materialize(deps.stream(makePathSpec(archivePath, mountPrefix)))
     const data = await decompress(raw, compression)
-    const entries = readTar(data)
+    const entries = await readTar(data)
     const out: ByteSource = ENC.encode(
       entries.map((e) => (e.isDir === true ? `${rstripSlash(e.name)}/` : e.name)).join('\n') + '\n',
     )
@@ -209,7 +216,7 @@ export async function tarGeneric(
     const raw = await materialize(deps.stream(makePathSpec(archivePath, mountPrefix)))
     const data = await decompress(raw, compression)
     const writes: Record<string, Uint8Array> = {}
-    for (const entry of readTar(data)) {
+    for (const entry of await readTar(data)) {
       // A symlink member has no bytes to write and no namespace to write
       // into from here (links are workspace state, not the backend's),
       // so extraction skips it rather than dropping an empty file where

--- a/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
@@ -20,6 +20,7 @@ import { RAMResource } from '../../../resource/ram/ram.ts'
 import type { LinkView } from '../../../ops/types.ts'
 import { FileStat, FileType, LINK_TARGET_KEY, PathSpec } from '../../../types.ts'
 import { CycleError } from '../../../utils/path.ts'
+import { readTar } from '../tar_helper.ts'
 const RAM_TAR = RAM_COMMANDS.filter((c) => c.name === 'tar' && c.filetype == null)
 const RAM_ZIP = RAM_COMMANDS.filter((c) => c.name === 'zip' && c.filetype == null)
 const RAM_UNZIP = RAM_COMMANDS.filter((c) => c.name === 'unzip' && c.filetype == null)
@@ -730,6 +731,70 @@ describe('archive planner regressions', () => {
     expect(DEC.decode(out).trim()).toBe('link')
     const { out: listed } = await runCmd(RAM_TAR, resource, [], { t: true, f: '/out.tar' })
     expect(DEC.decode(listed).trim()).toBe('link')
+  })
+
+  it('stores a symlink operand with its target and no bytes', async () => {
+    // The name alone cannot tell the two apart, so read the archive back:
+    // a link member carries linkname and no content.
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const links = linkView({ '/link': '/d/a.txt' })
+    const { writes } = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/link', 'link')],
+      { c: true, f: '/out.tar' },
+      [],
+      '',
+      links,
+    )
+    const entries = await readTar(writes['/out.tar'] ?? new Uint8Array(0))
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.name).toBe('link')
+    expect(entries[0]?.linkname).toBe('/d/a.txt')
+    expect(entries[0]?.isFile).toBe(false)
+    expect(entries[0]?.data.byteLength).toBe(0)
+  })
+
+  it('-h stores the target bytes under the link name', async () => {
+    // GNU tar -h follows the link, so the member keeps the link's name but
+    // becomes a regular file holding what the target holds.
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const links = linkView({ '/link': '/d/a.txt' })
+    const { writes } = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/link', 'link')],
+      { c: true, h: true, f: '/out.tar' },
+      [],
+      '',
+      links,
+    )
+    const entries = await readTar(writes['/out.tar'] ?? new Uint8Array(0))
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.name).toBe('link')
+    expect(entries[0]?.isFile).toBe(true)
+    expect(entries[0]?.linkname).toBe('')
+    expect(DEC.decode(entries[0]?.data)).toBe('alpha')
+  })
+
+  it('-h on a link whose target is gone reports it and writes no member', async () => {
+    const resource = new RAMResource()
+    const links = linkView({ '/link': '/d/missing.txt' })
+    const { exitCode, stderr } = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/link', 'link')],
+      { c: true, h: true, f: '/out.tar' },
+      [],
+      '',
+      links,
+    )
+    expect(exitCode).toBe(2)
+    expect(DEC.decode(stderr)).toContain('No such file or directory')
   })
 
   it('fails at the first unenterable -C, not the last', async () => {

--- a/typescript/packages/core/src/commands/builtin/tar_helper.test.ts
+++ b/typescript/packages/core/src/commands/builtin/tar_helper.test.ts
@@ -1,0 +1,68 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { readTar, writeTar, type TarEntry } from './tar_helper.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+describe('tar_helper', () => {
+  it('round-trips a name past the 100 byte ustar limit', async () => {
+    // ustar stores a name in 100 bytes; anything longer needs the prefix
+    // field or a PAX header. Truncating it silently used to write the
+    // member under a shortened path, so extraction landed on the wrong one.
+    const name = `deep/${'x'.repeat(120)}/b.txt`
+    const entries = await readTar(
+      await writeTar([{ name, data: ENC.encode('bbb\n'), isFile: true }]),
+    )
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.name).toBe(name)
+    expect(DEC.decode(entries[0]?.data)).toBe('bbb\n')
+  })
+
+  it('reports no member for the extended header a long name needs', async () => {
+    // A PAX header is a block with its own typeflag, not a member. Reading
+    // it as one used to add a phantom `././@PaxHeader` row to `tar -t`.
+    const entries = await readTar(
+      await writeTar([
+        { name: 'a.txt', data: ENC.encode('aaa\n'), isFile: true },
+        { name: `${'y'.repeat(150)}.txt`, data: ENC.encode('yyy\n'), isFile: true },
+      ]),
+    )
+    expect(entries.map((e) => e.name)).toEqual(['a.txt', `${'y'.repeat(150)}.txt`])
+  })
+
+  it('round-trips a directory member as content-free with a trailing slash', async () => {
+    const entries = await readTar(
+      await writeTar([{ name: 'folder', data: new Uint8Array(0), isFile: false, isDir: true }]),
+    )
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.name).toBe('folder/')
+    expect(entries[0]?.isDir).toBe(true)
+    expect(entries[0]?.isFile).toBe(false)
+    expect(entries[0]?.data.byteLength).toBe(0)
+  })
+
+  it('round-trips a symlink member as its target, not its target bytes', async () => {
+    const entries: TarEntry[] = [
+      { name: 'link', data: ENC.encode('ignored'), isFile: false, linkname: '../target' },
+    ]
+    const back = await readTar(await writeTar(entries))
+    expect(back).toHaveLength(1)
+    expect(back[0]?.linkname).toBe('../target')
+    expect(back[0]?.isFile).toBe(false)
+    expect(back[0]?.data.byteLength).toBe(0)
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/tar_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/tar_helper.ts
@@ -12,14 +12,11 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-const BLOCK_SIZE = 512
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
+import { packTar, unpackTar, type TarHeader } from 'modern-tar'
 
-// A ustar typeflag byte, restricted to the three kinds mirage records.
-const REGTYPE = 0x30
-const SYMTYPE = 0x32
-const DIRTYPE = 0x35
+const DIR_MODE = 0o755
+const LINK_MODE = 0o777
+const FILE_MODE = 0o644
 
 export interface TarEntry {
   name: string
@@ -31,129 +28,43 @@ export interface TarEntry {
   linkname?: string
 }
 
-function writeOctalField(buf: Uint8Array, offset: number, length: number, value: number): void {
-  const str = value.toString(8).padStart(length - 1, '0')
-  const bytes = ENC.encode(str)
-  buf.set(bytes, offset)
-  buf[offset + length - 1] = 0
-}
-
-function writeStringField(buf: Uint8Array, offset: number, length: number, value: string): void {
-  const bytes = ENC.encode(value)
-  const len = Math.min(bytes.byteLength, length)
-  buf.set(bytes.subarray(0, len), offset)
-}
-
-function computeChecksum(header: Uint8Array): number {
-  let sum = 0
-  for (let i = 0; i < BLOCK_SIZE; i++) sum += header[i] ?? 0
-  return sum
-}
-
-function buildHeader(entry: TarEntry, size: number): Uint8Array {
-  const header = new Uint8Array(BLOCK_SIZE)
-  header.fill(0)
-  const isDir = entry.isDir === true
-  const isLink = entry.linkname !== undefined && entry.linkname !== ''
-  // A directory member is spelled with a trailing slash; that slash is
-  // what tells every extractor it holds no content.
-  const name = isDir && !entry.name.endsWith('/') ? `${entry.name}/` : entry.name
-  writeStringField(header, 0, 100, name)
-  writeOctalField(header, 100, 8, isDir ? 0o755 : isLink ? 0o777 : 0o644)
-  writeOctalField(header, 108, 8, 0) // uid
-  writeOctalField(header, 116, 8, 0) // gid
-  writeOctalField(header, 124, 12, size)
-  writeOctalField(header, 136, 12, Math.floor(Date.now() / 1000))
-  // checksum placeholder: spaces
-  for (let i = 148; i < 156; i++) header[i] = 0x20
-  header[156] = isDir ? DIRTYPE : isLink ? SYMTYPE : REGTYPE
-  if (isLink) writeStringField(header, 157, 100, entry.linkname ?? '')
-  writeStringField(header, 257, 6, 'ustar\0')
-  writeStringField(header, 263, 2, '00')
-  const checksum = computeChecksum(header)
-  writeOctalField(header, 148, 7, checksum)
-  header[155] = 0x20
-  return header
-}
-
-function readOctalField(buf: Uint8Array, offset: number, length: number): number {
-  const bytes = buf.subarray(offset, offset + length)
-  let str = ''
-  for (const b of bytes) {
-    if (b === 0 || b === 0x20) break
-    str += String.fromCharCode(b)
+function headerOf(entry: TarEntry): TarHeader {
+  if (entry.isDir === true) {
+    // A directory member is spelled with a trailing slash; that slash is
+    // what tells every extractor it holds no content.
+    const name = entry.name.endsWith('/') ? entry.name : `${entry.name}/`
+    return { name, size: 0, type: 'directory', mode: DIR_MODE }
   }
-  if (str === '') return 0
-  return Number.parseInt(str, 8)
-}
-
-function readStringField(buf: Uint8Array, offset: number, length: number): string {
-  const bytes = buf.subarray(offset, offset + length)
-  let end = 0
-  while (end < bytes.byteLength && bytes[end] !== 0) end += 1
-  return DEC.decode(bytes.subarray(0, end))
-}
-
-export function writeTar(entries: readonly TarEntry[]): Uint8Array {
-  const blocks: Uint8Array[] = []
-  for (const entry of entries) {
-    // A directory and a symlink record their identity in the header and
-    // occupy no data blocks, whatever the caller put in `data`.
-    const carries = entry.isDir !== true && (entry.linkname ?? '') === ''
-    const data = carries ? entry.data : new Uint8Array(0)
-    blocks.push(buildHeader(entry, data.byteLength))
-    if (data.byteLength > 0) blocks.push(data)
-    const padding = (BLOCK_SIZE - (data.byteLength % BLOCK_SIZE)) % BLOCK_SIZE
-    if (padding > 0) blocks.push(new Uint8Array(padding))
+  const linkname = entry.linkname ?? ''
+  if (linkname !== '') {
+    return { name: entry.name, size: 0, type: 'symlink', mode: LINK_MODE, linkname }
   }
-  blocks.push(new Uint8Array(BLOCK_SIZE * 2))
-  return concat(blocks)
+  return { name: entry.name, size: entry.data.byteLength, type: 'file', mode: FILE_MODE }
 }
 
-export function readTar(data: Uint8Array): TarEntry[] {
-  const entries: TarEntry[] = []
-  let offset = 0
-  while (offset + BLOCK_SIZE <= data.byteLength) {
-    const header = data.subarray(offset, offset + BLOCK_SIZE)
-    let allZero = true
-    for (let i = 0; i < BLOCK_SIZE; i++) {
-      if (header[i] !== 0) {
-        allZero = false
-        break
-      }
-    }
-    if (allZero) break
-    const name = readStringField(header, 0, 100)
-    const size = readOctalField(header, 124, 12)
-    const typeflag = header[156]
-    const isFile = typeflag === 0 || typeflag === REGTYPE
+export async function writeTar(entries: readonly TarEntry[]): Promise<Uint8Array> {
+  // A directory and a symlink record their identity in the header and
+  // occupy no data blocks, whatever the caller put in `data`.
+  return packTar(
+    entries.map((entry) => {
+      const header = headerOf(entry)
+      return header.type === 'file' ? { header, body: entry.data } : { header }
+    }),
+  )
+}
+
+export async function readTar(data: Uint8Array): Promise<TarEntry[]> {
+  const parsed = await unpackTar(data)
+  return parsed.map((entry) => {
     // A trailing slash marks a directory even on an archive written
     // before ustar typeflags (GNU tar has always spelled it that way).
-    const isDir = typeflag === DIRTYPE || name.endsWith('/')
-    const linkname = typeflag === SYMTYPE ? readStringField(header, 157, 100) : ''
-    offset += BLOCK_SIZE
-    const fileData = data.subarray(offset, offset + size)
-    entries.push({
-      name,
-      data: new Uint8Array(fileData),
-      isFile: isFile && !isDir,
+    const isDir = entry.header.type === 'directory' || entry.header.name.endsWith('/')
+    return {
+      name: entry.header.name,
+      data: entry.data ?? new Uint8Array(0),
+      isFile: entry.header.type === 'file' && !isDir,
       isDir,
-      linkname,
-    })
-    const padded = Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE
-    offset += padded
-  }
-  return entries
-}
-
-function concat(chunks: readonly Uint8Array[]): Uint8Array {
-  let total = 0
-  for (const c of chunks) total += c.byteLength
-  const out = new Uint8Array(total)
-  let offset = 0
-  for (const c of chunks) {
-    out.set(c, offset)
-    offset += c.byteLength
-  }
-  return out
+      linkname: entry.header.linkname ?? '',
+    }
+  })
 }

--- a/typescript/packages/core/src/utils/compress.ts
+++ b/typescript/packages/core/src/utils/compress.ts
@@ -38,8 +38,11 @@ export async function inflateRaw(bytes: Uint8Array): Promise<Uint8Array> {
   return runThrough(bytes, new DecompressionStream('deflate-raw'))
 }
 
+// `compress` is optional because a codec may be decompress-only: every
+// permissively licensed bzip2 implementation decompresses only, so mirage
+// reads a .tar.bz2 and refuses to create one.
 export interface CompressionCodec {
-  compress(bytes: Uint8Array): Promise<Uint8Array>
+  compress?(bytes: Uint8Array): Promise<Uint8Array>
   decompress(bytes: Uint8Array): Promise<Uint8Array>
 }
 

--- a/typescript/packages/core/src/workspace/snapshot/tar_io.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot/tar_io.test.ts
@@ -38,7 +38,7 @@ describe('writeSnapshotTar / readSnapshotTar', () => {
   it('writes valid JSON as manifest.json inside the tar', async () => {
     const manifest = { version: 2, mounts: [], cache: { limit: 0, entries: [] } }
     const tarBytes = await writeSnapshotTar(manifest as Record<string, unknown>, {})
-    const entries = readTar(tarBytes)
+    const entries = await readTar(tarBytes)
     const mf = entries.find((e) => e.name === 'manifest.json')
     if (mf === undefined) throw new Error('manifest.json not found in tar')
     const parsed = JSON.parse(DEC.decode(mf.data)) as Record<string, unknown>
@@ -74,7 +74,7 @@ describe('readSnapshotTar path-traversal defense', () => {
     const entries: TarEntry[] = [
       { name: 'manifest.json', data: ENC.encode(JSON.stringify(manifest)), isFile: true },
     ]
-    const tarBytes = writeTar(entries)
+    const tarBytes = await writeTar(entries)
     await expect(readSnapshotTar(tarBytes)).rejects.toThrow(/Unsafe blob path/)
   })
 
@@ -96,13 +96,13 @@ describe('readSnapshotTar path-traversal defense', () => {
     const entries: TarEntry[] = [
       { name: 'manifest.json', data: ENC.encode(JSON.stringify(manifest)), isFile: true },
     ]
-    const tarBytes = writeTar(entries)
+    const tarBytes = await writeTar(entries)
     await expect(readSnapshotTar(tarBytes)).rejects.toThrow(/Unsafe blob path/)
   })
 
   it('throws when manifest.json is missing from the tar', async () => {
     const entries: TarEntry[] = [{ name: 'other.txt', data: ENC.encode('x'), isFile: true }]
-    const tarBytes = writeTar(entries)
+    const tarBytes = await writeTar(entries)
     await expect(readSnapshotTar(tarBytes)).rejects.toThrow(/manifest\.json/)
   })
 })

--- a/typescript/packages/core/src/workspace/snapshot/tar_io.ts
+++ b/typescript/packages/core/src/workspace/snapshot/tar_io.ts
@@ -34,7 +34,7 @@ export async function writeSnapshotTar(
   for (const [path, data] of Object.entries(blobs)) {
     entries.push({ name: path, data, isFile: true })
   }
-  const tarBytes = writeTar(entries)
+  const tarBytes = await writeTar(entries)
   if (compress === 'gz') return gzip(tarBytes)
   return tarBytes
 }
@@ -44,7 +44,7 @@ export async function readSnapshotTar(
   compress: CompressMode = null,
 ): Promise<unknown> {
   const tarBytes = compress === 'gz' ? await gunzip(data) : data
-  const entries = readTar(tarBytes)
+  const entries = await readTar(tarBytes)
   const byName = new Map<string, Uint8Array>()
   for (const e of entries) byName.set(e.name, e.data)
   const manifestRaw = byName.get(MANIFEST_NAME)

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -50,12 +50,12 @@
   "dependencies": {
     "@napi-rs/lzma": "^1.4.5",
     "@struktoai/mirage-core": "workspace:*",
-    "compressjs": "^1.0.3",
     "fast-xml-parser": "^5.9.0",
     "fast-xml-validator": "^1.4.0",
     "fs-monkey": "^1.1.0",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
+    "seek-bzip": "^2.0.0",
     "tree-sitter-bash": "^0.25.1",
     "web-tree-sitter": "^0.26.8"
   },

--- a/typescript/packages/node/src/commands/native_tar.test.ts
+++ b/typescript/packages/node/src/commands/native_tar.test.ts
@@ -16,6 +16,18 @@ import { describe, expect, it } from 'vitest'
 import { makeEnv, NATIVE_BACKENDS } from './native_fixture.ts'
 
 const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+// A .tar.bz2 holding a.txt and b.txt, written by GNU-compatible tar rather
+// than by mirage: bzip2 is decompress-only here, so the read path has no
+// writer of its own to round-trip against.
+const BZIP2_FIXTURE = Uint8Array.from(
+  atob(
+    'QlpoOTFBWSZTWb5cDKYAAIl7gMmQABBAAXWAAAhwAB5ACCggAHQShE0aA0eoNqBVJAAAaA+6YFC2QJVR' +
+      'EIU4zaLiTBWsQhIczkjNuTLKIYCgg4wgxJypYcoUGGDPpbubQsplyCC5BU0EQPxdyRThQkL5cDKY',
+  ),
+  (c) => c.charCodeAt(0),
+)
 
 describe.each(NATIVE_BACKENDS)('native tar (%s backend)', (kind) => {
   it('tar cz tf', async () => {
@@ -33,16 +45,39 @@ describe.each(NATIVE_BACKENDS)('native tar (%s backend)', (kind) => {
     }
   })
 
-  it('tar j create list (bzip2)', async () => {
+  it('tar j lists an archive another tar wrote (bzip2)', async () => {
     const env = makeEnv(kind)
     try {
-      env.createFile('a.txt', ENC.encode('aaa\n'))
-      env.createFile('b.txt', ENC.encode('bbb\n'))
-      await env.mirage('tar -c -j -f /data/out.tar.bz2 /data/a.txt /data/b.txt')
+      env.createFile('out.tar.bz2', BZIP2_FIXTURE)
       const listing = await env.mirage('tar -t -f /data/out.tar.bz2')
       const names = listing.trim().split('\n')
       expect(names.join(' ')).toContain('a.txt')
       expect(names.join(' ')).toContain('b.txt')
+    } finally {
+      await env.cleanup()
+    }
+  })
+
+  it('tar xj extracts an archive another tar wrote (bzip2)', async () => {
+    const env = makeEnv(kind)
+    try {
+      env.createFile('out.tar.bz2', BZIP2_FIXTURE)
+      await env.mirage('tar -x -j -f /data/out.tar.bz2 -C /data/ex')
+      expect(await env.mirage('cat /data/ex/a.txt')).toBe('aaa\n')
+      expect(await env.mirage('cat /data/ex/b.txt')).toBe('bbb\n')
+    } finally {
+      await env.cleanup()
+    }
+  })
+
+  it('tar cj refuses to create, since bzip2 is decompress-only', async () => {
+    const env = makeEnv(kind)
+    try {
+      env.createFile('a.txt', ENC.encode('aaa\n'))
+      env.ws.cwd = '/data'
+      const io = await env.ws.execute('tar -c -j -f /data/out.tar.bz2 /data/a.txt')
+      expect(io.exitCode).toBe(1)
+      expect(DEC.decode(io.stderr)).toBe('tar: bzip2 not supported\n')
     } finally {
       await env.cleanup()
     }

--- a/typescript/packages/node/src/commands/native_tar.test.ts
+++ b/typescript/packages/node/src/commands/native_tar.test.ts
@@ -58,6 +58,22 @@ describe.each(NATIVE_BACKENDS)('native tar (%s backend)', (kind) => {
     }
   })
 
+  it('tar xJ round-trips file bodies through the xz codec', async () => {
+    // Listing only proves the headers survived; extracting proves the
+    // decompressed bodies are byte-exact.
+    const env = makeEnv(kind)
+    try {
+      env.createFile('a.txt', ENC.encode('aaa\n'))
+      env.createFile('b.txt', ENC.encode('bbb\n'))
+      await env.mirage('tar -c -J -f /data/out.tar.xz /data/a.txt /data/b.txt')
+      await env.mirage('tar -x -J -f /data/out.tar.xz -C /data/ex')
+      expect(await env.mirage('cat /data/ex/data/a.txt')).toBe('aaa\n')
+      expect(await env.mirage('cat /data/ex/data/b.txt')).toBe('bbb\n')
+    } finally {
+      await env.cleanup()
+    }
+  })
+
   it('tar xj extracts an archive another tar wrote (bzip2)', async () => {
     const env = makeEnv(kind)
     try {

--- a/typescript/packages/node/src/compression_codecs.ts
+++ b/typescript/packages/node/src/compression_codecs.ts
@@ -15,9 +15,8 @@
 import { createRequire } from 'node:module'
 import { registerCompressionCodec } from '@struktoai/mirage-core'
 
-interface Bzip2Module {
-  compressFile(input: Uint8Array): Uint8Array
-  decompressFile(input: Uint8Array): Uint8Array
+interface BunzipModule {
+  decode(input: Uint8Array): Uint8Array
 }
 
 interface XzModule {
@@ -25,16 +24,20 @@ interface XzModule {
   decompress(input: Uint8Array): Promise<Uint8Array>
 }
 
-// compressjs and @napi-rs/lzma are CommonJS; load them via createRequire so
+// seek-bzip and @napi-rs/lzma are CommonJS; load them via createRequire so
 // the built ESM output resolves their exports without named-import interop
 // pitfalls (mirrors the createRequire usage in workspace.ts).
 const requireCjs = createRequire(import.meta.url)
-const { Bzip2 } = requireCjs('compressjs') as { Bzip2: Bzip2Module }
+const bunzip = requireCjs('seek-bzip') as BunzipModule
 const { xz } = requireCjs('@napi-rs/lzma') as { xz: XzModule }
 
+// bzip2 is decompress-only on purpose: seek-bzip is the maintained
+// permissively licensed implementation and it only decodes, so `tar -cj`
+// reports unsupported while `-xj` / `-tj` work. The pure-JS compressor that
+// used to sit here (compressjs) is GPL, which an Apache-2.0 package cannot
+// ship.
 registerCompressionCodec('bzip2', {
-  compress: (bytes) => Promise.resolve(Uint8Array.from(Bzip2.compressFile(bytes))),
-  decompress: (bytes) => Promise.resolve(Uint8Array.from(Bzip2.decompressFile(bytes))),
+  decompress: (bytes) => Promise.resolve(Uint8Array.from(bunzip.decode(bytes))),
 })
 
 registerCompressionCodec('xz', {

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -438,6 +438,9 @@ importers:
       jq-wasm:
         specifier: 1.1.0-jq-1.8.1
         version: 1.1.0-jq-1.8.1
+      modern-tar:
+        specifier: ^0.8.4
+        version: 0.8.4
       redis:
         specifier: ^5.0.0
         version: 5.12.1(@opentelemetry/api@1.9.0)
@@ -487,9 +490,6 @@ importers:
       '@struktoai/mirage-core':
         specifier: workspace:*
         version: link:../core
-      compressjs:
-        specifier: ^1.0.3
-        version: 1.0.3
       fast-xml-parser:
         specifier: ^5.9.0
         version: 5.9.0
@@ -505,6 +505,9 @@ importers:
       https-proxy-agent:
         specifier: ^7.0.6
         version: 7.0.6
+      seek-bzip:
+        specifier: ^2.0.0
+        version: 2.0.0
       tree-sitter-bash:
         specifier: ^0.25.1
         version: 0.25.1
@@ -3414,10 +3417,6 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  amdefine@1.0.1:
-    resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
-    engines: {node: '>=0.4.2'}
-
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -3784,12 +3783,12 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
-  commander@2.8.1:
-    resolution: {integrity: sha512-+pJLBFVk+9ZZdlAOB5WuIElVPPth47hILFkmGym57aq8kwxsowvByvB0DHs1vQAhyMZzdcpTtF0VDKGkSDR4ZQ==}
-    engines: {node: '>= 0.6.x'}
-
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
 
   commondir@1.0.1:
@@ -3797,10 +3796,6 @@ packages:
 
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
-
-  compressjs@1.0.3:
-    resolution: {integrity: sha512-jpKJjBTretQACTGLNuvnozP1JdP2ZLrjdGdBgk/tz1VfXlUcBhhSZW6vEsuThmeot/yjvSrPQKEgfF3X2Lpi8Q==}
-    hasBin: true
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -4474,9 +4469,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graceful-readlink@1.0.1:
-    resolution: {integrity: sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==}
-
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -5145,6 +5137,10 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  modern-tar@0.8.4:
+    resolution: {integrity: sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==}
+    engines: {node: '>=18.0.0'}
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -5884,6 +5880,10 @@ packages:
 
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+
+  seek-bzip@2.0.0:
+    resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
+    hasBin: true
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -10133,8 +10133,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  amdefine@1.0.1: {}
-
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -10206,7 +10204,7 @@ snapshots:
 
   axios@1.18.1:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -10482,20 +10480,13 @@ snapshots:
 
   commander@14.0.3: {}
 
-  commander@2.8.1:
-    dependencies:
-      graceful-readlink: 1.0.1
-
   commander@4.1.1: {}
+
+  commander@6.2.1: {}
 
   commondir@1.0.1: {}
 
   compare-versions@6.1.1: {}
-
-  compressjs@1.0.3:
-    dependencies:
-      amdefine: 1.0.1
-      commander: 2.8.1
 
   concat-map@0.0.1: {}
 
@@ -11107,6 +11098,8 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  follow-redirects@1.16.0: {}
+
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
@@ -11273,8 +11266,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  graceful-readlink@1.0.1: {}
 
   gray-matter@4.0.3:
     dependencies:
@@ -12085,6 +12076,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  modern-tar@0.8.4: {}
+
   module-details-from-path@1.0.4: {}
 
   mongodb-connection-string-url@3.0.2:
@@ -12850,6 +12843,10 @@ snapshots:
   secure-json-parse@2.7.0: {}
 
   secure-json-parse@4.1.0: {}
+
+  seek-bzip@2.0.0:
+    dependencies:
+      commander: 6.2.1
 
   selderee@0.11.0:
     dependencies:


### PR DESCRIPTION
Two changes to the TypeScript archive path. Python is untouched: its stdlib `tarfile` / `bz2` already do more than either package here.

## 1. The GPL dependency

`compressjs` is **GPLv2-or-later** and sat in `dependencies` of `@struktoai/mirage-node`, which ships Apache-2.0. Anyone installing that package pulled GPL code into their tree.

It is replaced by `seek-bzip` (MIT). seek-bzip only decodes, so `CompressionCodec.compress` is now optional and a codec may be decompress-only. `tar -cj` exits 1 with `tar: bzip2 not supported`, which is the answer browser core already gave for an unregistered codec. Reading `.tar.bz2` still works.

Every permissively licensed JS bzip2 *compressor* is either GPL (`compressjs`, `archive-wasm`) or unmaintained 2022 source that mutates `globalThis` (`bzip2-wasm`), so this is a deliberate py/ts divergence: Python reads and writes `.tar.bz2`, TypeScript only reads one. It is written down in CLAUDE.md along with the exit condition, since adding `compress` to that one codec closes the gap with no other change.

`pnpm licenses list --prod` now reports **no GPL/AGPL/CDDL/EPL/MPL anywhere in the production tree**.

## 2. The hand-rolled tar

`tar_helper.ts` wrote and parsed ustar blocks by hand. Two real bugs, both confirmed against an archive written by Python's `tarfile` before changing anything:

- **Names past 100 bytes were silently truncated.** `deep/<120 chars>/b.txt` lost `/b.txt` entirely, so the member extracted to the wrong path. ustar needs the `prefix` field or a PAX header for those.
- **A PAX extension block was read as a member.** `tar -t` on any archive GNU or Python wrote listed a phantom `././@PaxHeader` row.

It now delegates to `modern-tar` (MIT, zero dependency, web streams, USTAR + PAX), kept behind the same `TarEntry` shape the two call sites already speak, so the dependency is named in exactly one file. `writeTar` / `readTar` became async.

## Tests

New `tar_helper.test.ts` covers the long name, the absent phantom member, and directory / symlink members.

A flag-coverage audit turned up two gaps that are now closed:

- **`-h` (dereference) had no test at all.** A link member carries the same *name* whether tar stored the link or followed it, so the existing symlink test could not tell the two apart. The new tests read the archive back and assert the member kind in both directions, plus the unreachable-target case.
- **The xz test created and listed**, which only proves headers survived. It now extracts too, checking decompressed bodies byte for byte.

`native_tar.test.ts` also swaps the bzip2 create+list test for list and extract against a fixture another tar wrote, plus the create refusal.

The other half of `tar_helper.ts` is `workspace/snapshot/tar_io.ts`, a cross-language format. `integ/cross.sh` (the "Cross-language snapshot interop" job) covers that directly: it snapshots a 4-mount workspace with one language's CLI, loads the tar with the other's, and requires the re-run command output to match byte for byte, in both directions. It passes on this branch.

- core 7012 pass, node 2282 pass, browser 182 pass, 0 fail
- `tsc --noEmit` clean on all five packages
- eslint, prettier, knip, and `pre-commit run --all-files` clean

## Known gap, deliberately not closed here

**Compression x `--strip-components` / `--exclude` combinations** are only covered for `-z`. These are orthogonal by construction: compression wraps the finished tar blob, while strip and exclude act on the plan before any bytes are written.