### PR TITLE
feat(python3): parse CPython's option table, and seed sys.path on pyodide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,14 +254,22 @@ Both dataclasses are shared by every command in the repo, so a field
 added for one command is a field every other command's author has to
 read past, and a fourth one turns the grammar into a pile of per-command
 dialects. **Do not add a field to `CommandSpec`, `Operand` or `Option`
-unless POSIX or argparse already has the concept, and then name it after
-theirs, not after the mechanism it trips inside the parser.**
+unless POSIX *and* argparse both already have the concept, and then name
+it after theirs, not after the mechanism it trips inside the parser.**
 
-The test is literal, not a judgement call: write the equivalent line in
-argparse and run it. If argparse parses it, the concept is borrowed and
-the field is allowed. If argparse cannot express it, the behavior belongs
-to the one command that needs it and must be handled in that command,
-not in the shared grammar.
+Both, not either. The test is literal, not a judgement call: write the
+equivalent line in argparse and run it. If argparse parses it, the
+concept is borrowed and the field is allowed. If argparse cannot express
+it, the behavior belongs to the one command that needs it and must be
+handled in that command, not in the shared grammar.
+
+POSIX alone is not enough, and python3 is exactly why: POSIX specifies
+an option whose argument is a program (`sh -c command_string [command_name [argument...]]`, and python3's own synopsis
+`python [option] ... [-c cmd | -m mod | file | -] [arg] ...`), so an
+either-or rule would license the `Option` field this section exists to
+refuse. argparse is the narrower gate because it is the parser this
+spec layer is modelled on, so a concept it cannot express is one the
+grammar has no shape for.
 
 Both halves of python3's command line are the worked example, and they
 come out on opposite sides:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,43 @@ never lists it. Two mechanisms follow from that, and they are separate.
   refusing one that happens to spell a mount root would deny an
   ordinary listing.
 
+## `CommandSpec` and `Operand` are not a scratchpad
+
+Both dataclasses are shared by every command in the repo, so a field
+added for one command is a field every other command's author has to
+read past, and a fourth one turns the grammar into a pile of per-command
+dialects. **Do not add a field to `CommandSpec`, `Operand` or `Option`
+unless POSIX or argparse already has the concept, and then name it after
+theirs, not after the mechanism it trips inside the parser.**
+
+The test is literal, not a judgement call: write the equivalent line in
+argparse and run it. If argparse parses it, the concept is borrowed and
+the field is allowed. If argparse cannot express it, the behavior belongs
+to the one command that needs it and must be handled in that command,
+not in the shared grammar.
+
+Both halves of python3's command line are the worked example, and they
+come out on opposite sides:
+
+- **Allowed: `Operand.remainder`.** It is `nargs=argparse.REMAINDER`,
+  which is POSIX's own option order (the first operand ends option
+  parsing; GNU's permuting default is the extension, and `POSIXLY_CORRECT=1 ls a -1` shows the difference). argparse spells
+  it on the positional slot, so mirage spells it on `Operand` too, and
+  `CommandSpec` does not change at all.
+- **Not allowed: an option whose argument is a program.** `python3 -c 'code' -u x` must hand `-u` to the code, but
+  `add_argument("-c"); add_argument("rest", nargs=REMAINDER)` answers
+  `unrecognized arguments: -u`. CPython's own command line is parsed in C
+  for exactly this reason. There is no concept to borrow, so this does
+  not become an `Option` field.
+
+A `CLISpec` **is** a `CommandSpec` (python: subclass; TypeScript:
+`extends`), and every level of a CLI tree parses with the ordinary spec
+machinery. Moving a command to the CLI tier therefore does not exempt it
+from this rule, because it still parses with the same `Option` and
+`Operand`. The CLI tier is for a program *tree* (a verb the line selects,
+like `git status` or `ntn api`), not for a program with an unusual
+option grammar.
+
 ## An option that chdirs: `operand_base`
 
 `tar -C` is not a flag the command reads once, it is a chdir for the path

--- a/integ/runtime/policy.json
+++ b/integ/runtime/policy.json
@@ -20,7 +20,7 @@
           "command": "python3 -c \"print(argv[0])\"",
           "expect": {
             "exit": 0,
-            "stdout": "main.py\n"
+            "stdout": "-c\n"
           }
         },
         {
@@ -35,7 +35,7 @@
           "command": "python3 -c \"print(argv[0])\"",
           "expect": {
             "exit": 0,
-            "stdout": "main.py\n"
+            "stdout": "-c\n"
           }
         }
       ]
@@ -62,7 +62,7 @@
           "command": "python3 -c \"print(argv[0])\"",
           "expect": {
             "exit": 0,
-            "stdout": "main.py\n"
+            "stdout": "-c\n"
           }
         },
         {
@@ -127,7 +127,7 @@
           "command": "python3 -c \"print(argv[0])\"",
           "expect": {
             "exit": 0,
-            "stdout": "main.py\n"
+            "stdout": "-c\n"
           }
         },
         {

--- a/python/mirage/commands/builtin/general/interpreter.py
+++ b/python/mirage/commands/builtin/general/interpreter.py
@@ -13,13 +13,14 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Callable, Literal, TypeAlias
 
 from mirage.commands.builtin.utils.paths import resolve_script
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.io.types import ByteSource, CommandOutput, IOResult
 from mirage.runtime.base import Runtime
 from mirage.runtime.language import LanguageRuntime
+from mirage.runtime.python.base import PythonRuntime
 from mirage.runtime.types import RunArgs, RunResult
 from mirage.types import PathSpec
 
@@ -41,6 +42,46 @@ def run_output(result: RunResult) -> CommandOutput:
     )
 
 
+# Which of an interpreter's four doors the source came through. The
+# mode is what decides argv[0], so the two travel together: CPython
+# spells it "-c" for a payload, the module's file for -m, the file as
+# typed for a script, "-" for the explicit stdin operand, and "" for
+# stdin with no operand at all. Pinned on CPython 3.12.13.
+SourceMode: TypeAlias = Literal["payload", "module", "file", "stdin"]
+
+# argv[0] for the two modes that do not read it off the command line.
+PAYLOAD_ARGV0 = "-c"
+STDIN_ARGV0 = "-"
+STDIN_OPERAND = "-"
+
+# `-m` is runpy's job on any real CPython: run_module finds the module,
+# runs it under __main__, and alter_sys rewrites sys.argv[0] to the
+# module's own file, which is what CPython puts there. Engines that are
+# not CPython declare runs_modules False and never see this.
+#
+# The existence probe is not redundant with run_module: CPython answers
+# a missing module with one line and exit 1, while bare run_module
+# raises, which would reach the user as a runpy traceback. Probing
+# first also keeps an ImportError raised INSIDE the module distinct
+# from the module itself being absent, which a try around run_module
+# could not tell apart.
+MODULE_SOURCE = (
+    "import importlib.util, runpy, sys\n"
+    "_name = {name!r}\n"
+    "_label = {label!r}\n"
+    "try:\n"
+    "    _found = importlib.util.find_spec(_name) is not None\n"
+    "except (ImportError, TypeError, ValueError):\n"
+    # find_spec raises rather than returning None when an ancestor of a
+    # dotted name is missing or is not a package; either way the module
+    # cannot be found, and the message below reports it.
+    "    _found = False\n"
+    "if not _found:\n"
+    "    sys.stderr.write(_label + ': No module named ' + _name + chr(10))\n"
+    "    raise SystemExit(1)\n"
+    "runpy.run_module(_name, run_name='__main__', alter_sys=True)\n")
+
+
 @dataclass(frozen=True, slots=True)
 class Source:
     """An interpreter command's inputs, resolved from the command line.
@@ -48,17 +89,23 @@ class Source:
     Args:
         code (str): the source to run (script content, payload flag,
             or piped stdin).
-        args (list[str]): argv exposed to the script.
+        args (list[str]): argv exposed to the script, argv[0] excluded.
         stdin (bytes | None): remaining stdin after any consumed as
             source.
         script_path (PathSpec | None): the resolved script operand,
             None for payload/stdin sources.
+        mode (SourceMode): which door the source came through.
+        argv0 (str): the program's own name for argv[0], derived from
+            the mode. Never None: "" is CPython's own answer for stdin
+            with no operand, so a runtime must not treat it as absent.
     """
 
     code: str
     args: list[str] = field(default_factory=list)
     stdin: bytes | None = None
     script_path: PathSpec | None = None
+    mode: SourceMode = "payload"
+    argv0: str = PAYLOAD_ARGV0
 
 
 async def resolve_source(
@@ -70,6 +117,7 @@ async def resolve_source(
     dispatch: Callable[..., Any] | None,
     cwd: PathSpec | None,
     exec_allowed: bool,
+    module: str | None = None,
 ) -> tuple[CommandOutput | None, Source | None]:
     """Resolve what an interpreter command should run, shared by all.
 
@@ -102,16 +150,41 @@ async def resolve_source(
     text_list = list(texts)
     code = payload
     script_path: PathSpec | None = None
-    if code is not None:
+    mode: SourceMode = "payload"
+    argv0 = PAYLOAD_ARGV0
+    if module is not None:
+        # runpy's alter_sys overwrites argv[0] with the module's own
+        # file, which no caller can know here; the module name stands
+        # in for the runtimes that never reach runpy.
+        code = MODULE_SOURCE.format(name=module, label=label)
+        arg_strs = [p.virtual for p in paths] + text_list
+        mode = "module"
+        argv0 = module
+    elif code is not None:
         arg_strs = [p.virtual for p in paths] + text_list
     elif paths:
         script_path = paths[0]
         arg_strs = [p.virtual for p in paths[1:]] + text_list
+        mode = "file"
+        argv0 = paths[0].raw_path
+    elif text_list and text_list[0] == STDIN_OPERAND:
+        # The explicit stdin spelling. It is an operand, not a flag, so
+        # it ends option parsing like any other, and the words after it
+        # are the program's argv exactly as a script's would be.
+        arg_strs = text_list[1:]
+        mode = "stdin"
+        argv0 = STDIN_ARGV0
     elif text_list:
         script_path = resolve_script(text_list[0], cwd)
         arg_strs = text_list[1:]
+        mode = "file"
+        # As typed, which is what CPython puts in argv[0]; the resolved
+        # spelling is script_path's job.
+        argv0 = text_list[0]
     else:
         arg_strs = []
+        mode = "stdin"
+        argv0 = ""
 
     if code is None and script_path is not None:
         if dispatch is None:
@@ -136,7 +209,9 @@ async def resolve_source(
     return None, Source(code=code,
                         args=arg_strs,
                         stdin=stdin_data,
-                        script_path=script_path)
+                        script_path=script_path,
+                        mode=mode,
+                        argv0=argv0)
 
 
 async def run_code(
@@ -178,9 +253,18 @@ async def run_code(
         hint = unavailable or "command not found"
         return None, IOResult(exit_code=127,
                               stderr=f"{label}: {hint}\n".encode())
+    if (prepared.mode == "module" and isinstance(runtime, PythonRuntime)
+            and not runtime.runs_modules):
+        # Exit 1, CPython's code for a `-m` that could not run, but not
+        # its "No module named" wording: nothing was searched for, so
+        # naming the runtime is the honest report.
+        err = (f"{label}: -m is not supported by the {runtime.name!r} "
+               f"runtime\n").encode()
+        return None, IOResult(exit_code=1, stderr=err)
     result = await runtime.run(
         RunArgs(code=prepared.code,
                 args=prepared.args,
+                prog=prepared.argv0,
                 env=env or {},
                 stdin=prepared.stdin,
                 flags=flags))

--- a/python/mirage/commands/builtin/general/interpreter.py
+++ b/python/mirage/commands/builtin/general/interpreter.py
@@ -49,10 +49,57 @@ def run_output(result: RunResult) -> CommandOutput:
 # stdin with no operand at all. Pinned on CPython 3.12.13.
 SourceMode: TypeAlias = Literal["payload", "module", "file", "stdin"]
 
-# argv[0] for the two modes that do not read it off the command line.
-PAYLOAD_ARGV0 = "-c"
-STDIN_ARGV0 = "-"
 STDIN_OPERAND = "-"
+
+
+def skip_first_line(code: str) -> str:
+    """Drop a script's first line the way CPython's ``-x`` does.
+
+    The first line is emptied rather than removed, because CPython
+    keeps the line numbering of the whole file: a raise on physical
+    line 2 still reports line 2 under ``-x`` (pinned on 3.12.11). A
+    file with no newline at all is one line, so ``-x`` leaves nothing.
+
+    Args:
+        code (str): the script's text as read.
+    """
+    _, sep, rest = code.partition("\n")
+    return sep + rest if sep else ""
+
+
+@dataclass(frozen=True, slots=True)
+class Argv0Rules:
+    """What an interpreter calls itself in the doors with no file name.
+
+    File mode is universal (the operand as typed), so only these three
+    differ, and they differ per interpreter rather than per language:
+    CPython puts "-c" in argv[0] for a payload, while qjs leaves
+    scriptArgs alone for `-e` and fills it only when it runs a file. An
+    interpreter that names none of them passes None, and its runtime
+    sees the unnamed program it saw before.
+
+    Args:
+        payload (str | None): argv[0] for a -c/-e payload.
+        stdin_operand (str | None): argv[0] for an explicit "-" operand.
+        bare_stdin (str | None): argv[0] for a program piped in with no
+            operand at all.
+        names_file (bool): file mode puts the operand in argv[0]. False
+            for qjs, whose scriptArgs start at the first argument even
+            when it runs a file, so prepending the path would shift
+            every index the program reads.
+    """
+
+    payload: str | None = None
+    stdin_operand: str | None = None
+    bare_stdin: str | None = None
+    names_file: bool = False
+
+
+# CPython's own four answers, pinned on 3.12.13/3.13.7.
+CPYTHON_ARGV0 = Argv0Rules(payload="-c",
+                           stdin_operand="-",
+                           bare_stdin="",
+                           names_file=True)
 
 # `-m` is runpy's job on any real CPython: run_module finds the module,
 # runs it under __main__, and alter_sys rewrites sys.argv[0] to the
@@ -95,9 +142,10 @@ class Source:
         script_path (PathSpec | None): the resolved script operand,
             None for payload/stdin sources.
         mode (SourceMode): which door the source came through.
-        argv0 (str): the program's own name for argv[0], derived from
-            the mode. Never None: "" is CPython's own answer for stdin
-            with no operand, so a runtime must not treat it as absent.
+        argv0 (str | None): the program's own name for argv[0],
+            derived from the mode and the interpreter's own rules. ""
+            is meaningful (CPython's answer for stdin with no operand);
+            None means this interpreter names no program here.
     """
 
     code: str
@@ -105,7 +153,7 @@ class Source:
     stdin: bytes | None = None
     script_path: PathSpec | None = None
     mode: SourceMode = "payload"
-    argv0: str = PAYLOAD_ARGV0
+    argv0: str | None = None
 
 
 async def resolve_source(
@@ -118,6 +166,8 @@ async def resolve_source(
     cwd: PathSpec | None,
     exec_allowed: bool,
     module: str | None = None,
+    argv0_rules: Argv0Rules = Argv0Rules(),
+    skip_line: bool = False,
 ) -> tuple[CommandOutput | None, Source | None]:
     """Resolve what an interpreter command should run, shared by all.
 
@@ -136,6 +186,12 @@ async def resolve_source(
             reading the script operand.
         cwd (PathSpec | None): the session cwd for script resolution.
         exec_allowed (bool): whether the root mount is in EXEC mode.
+        module (str | None): the -m module name, if given.
+        argv0_rules (Argv0Rules): what this interpreter calls itself in
+            the doors that carry no file name.
+        skip_line (bool): drop the script file's first line (CPython's
+            -x). File mode only, which is CPython's own scope: -c, -m
+            and stdin are unaffected.
 
     Returns:
         tuple[CommandOutput | None, Source | None]: an early
@@ -151,7 +207,7 @@ async def resolve_source(
     code = payload
     script_path: PathSpec | None = None
     mode: SourceMode = "payload"
-    argv0 = PAYLOAD_ARGV0
+    argv0: str | None = argv0_rules.payload
     if module is not None:
         # runpy's alter_sys overwrites argv[0] with the module's own
         # file, which no caller can know here; the module name stands
@@ -166,25 +222,25 @@ async def resolve_source(
         script_path = paths[0]
         arg_strs = [p.virtual for p in paths[1:]] + text_list
         mode = "file"
-        argv0 = paths[0].raw_path
+        argv0 = paths[0].raw_path if argv0_rules.names_file else None
     elif text_list and text_list[0] == STDIN_OPERAND:
         # The explicit stdin spelling. It is an operand, not a flag, so
         # it ends option parsing like any other, and the words after it
         # are the program's argv exactly as a script's would be.
         arg_strs = text_list[1:]
         mode = "stdin"
-        argv0 = STDIN_ARGV0
+        argv0 = argv0_rules.stdin_operand
     elif text_list:
         script_path = resolve_script(text_list[0], cwd)
         arg_strs = text_list[1:]
         mode = "file"
         # As typed, which is what CPython puts in argv[0]; the resolved
         # spelling is script_path's job.
-        argv0 = text_list[0]
+        argv0 = text_list[0] if argv0_rules.names_file else None
     else:
         arg_strs = []
         mode = "stdin"
-        argv0 = ""
+        argv0 = argv0_rules.bare_stdin
 
     if code is None and script_path is not None:
         if dispatch is None:
@@ -196,6 +252,8 @@ async def resolve_source(
             err = f"{label}: {script_path.virtual}: No such file\n".encode()
             return (None, IOResult(exit_code=1, stderr=err)), None
         code = data.decode(errors="replace") if isinstance(data, bytes) else ""
+        if skip_line:
+            code = skip_first_line(code)
 
     stdin_data = await _read_stdin_async(stdin)
     if code is None:

--- a/python/mirage/commands/builtin/general/python.py
+++ b/python/mirage/commands/builtin/general/python.py
@@ -30,6 +30,17 @@ async def _python3(
     paths: list[PathSpec] | None = None,
     *texts: str,
     c: str | None = None,
+    m: str | None = None,
+    u: bool = False,
+    q: bool = False,
+    B: bool = False,
+    E: bool = False,
+    s: bool = False,
+    S: bool = False,
+    args_I: bool = False,
+    args_O: int = 0,
+    W: list[str] | None = None,
+    X: list[str] | None = None,
     stdin: ByteSource | None = None,
     dispatch: Callable[..., Any] | None = None,
     cwd: PathSpec | None = None,
@@ -40,11 +51,25 @@ async def _python3(
     **_extra: FlagValue,
 ) -> CommandOutput:
     error, prepared = await resolve_source("python3", paths, texts, c, stdin,
-                                           dispatch, cwd, exec_allowed)
+                                           dispatch, cwd, exec_allowed, m)
     if error is not None or prepared is None:
         assert error is not None
         return error
-    return await run_code("python3", prepared, env, {}, runtime,
+    # Keyed by CPython's own letter, which is how mirage.runtime.python
+    # .flags reads them; -u and -q are absent because mirage buffers
+    # every stream and prints no banner, so no engine can differ on
+    # them.
+    init_flags: dict[str, Any] = {
+        "B": B,
+        "E": E,
+        "I": args_I,
+        "O": args_O,
+        "s": s,
+        "S": S,
+        "W": W or [],
+        "X": X or [],
+    }
+    return await run_code("python3", prepared, env, init_flags, runtime,
                           runtime_unavailable)
 
 

--- a/python/mirage/commands/builtin/general/python.py
+++ b/python/mirage/commands/builtin/general/python.py
@@ -15,7 +15,8 @@
 from typing import Any, Callable
 
 from mirage.accessor.base import Accessor, NOOPAccessor
-from mirage.commands.builtin.general.interpreter import (resolve_source,
+from mirage.commands.builtin.general.interpreter import (CPYTHON_ARGV0,
+                                                         resolve_source,
                                                          run_code)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -33,14 +34,18 @@ async def _python3(
     m: str | None = None,
     u: bool = False,
     q: bool = False,
+    b: int = 0,
     B: bool = False,
     E: bool = False,
+    P: bool = False,
     s: bool = False,
     S: bool = False,
+    x: bool = False,
     args_I: bool = False,
     args_O: int = 0,
     W: list[str] | None = None,
     X: list[str] | None = None,
+    check_hash_based_pycs: str | None = None,
     stdin: ByteSource | None = None,
     dispatch: Callable[..., Any] | None = None,
     cwd: PathSpec | None = None,
@@ -51,23 +56,30 @@ async def _python3(
     **_extra: FlagValue,
 ) -> CommandOutput:
     error, prepared = await resolve_source("python3", paths, texts, c, stdin,
-                                           dispatch, cwd, exec_allowed, m)
+                                           dispatch, cwd, exec_allowed, m,
+                                           CPYTHON_ARGV0, x)
     if error is not None or prepared is None:
         assert error is not None
         return error
     # Keyed by CPython's own letter, which is how mirage.runtime.python
-    # .flags reads them; -u and -q are absent because mirage buffers
-    # every stream and prints no banner, so no engine can differ on
-    # them.
+    # .flags reads them; the one long switch is keyed by its canonical
+    # spelling, having no letter. -u and -q are absent because mirage
+    # buffers every stream and prints no banner, so no engine can
+    # differ on them, and -x is absent because it selects source rather
+    # than configuring an interpreter, so resolve_source answered it
+    # above.
     init_flags: dict[str, Any] = {
+        "b": b,
         "B": B,
         "E": E,
         "I": args_I,
         "O": args_O,
+        "P": P,
         "s": s,
         "S": S,
         "W": W or [],
         "X": X or [],
+        "check_hash_based_pycs": check_hash_based_pycs,
     }
     return await run_code("python3", prepared, env, init_flags, runtime,
                           runtime_unavailable)

--- a/python/mirage/commands/spec/builtin_specs/runtime.py
+++ b/python/mirage/commands/spec/builtin_specs/runtime.py
@@ -24,11 +24,9 @@ from mirage.commands.spec.types import CommandSpec, Operand, Option
 _PYTHON_OPTIONS: tuple[Option, ...] = (
     Option(short="-c",
            type="str",
-           ends_options=True,
            description="Run the next argument as a program."),
     Option(short="-m",
            type="str",
-           ends_options=True,
            description="Run the named module as __main__."),
     Option(short="-u",
            description=("(Ignored) Unbuffered output. Mirage buffers "
@@ -74,15 +72,13 @@ SPECS: dict[str, CommandSpec] = {
     CommandSpec(
         description="Run Python on the workspace's bound runtime.",
         options=_PYTHON_OPTIONS,
-        rest=Operand(type="str"),
-        stop_at_operand=True,
+        rest=Operand(type="str", remainder=True),
     ),
     'python3':
     CommandSpec(
         description="Run Python on the workspace's bound runtime.",
         options=_PYTHON_OPTIONS,
-        rest=Operand(type="str"),
-        stop_at_operand=True,
+        rest=Operand(type="str", remainder=True),
     ),
     'js':
     CommandSpec(

--- a/python/mirage/commands/spec/builtin_specs/runtime.py
+++ b/python/mirage/commands/spec/builtin_specs/runtime.py
@@ -14,16 +14,75 @@
 
 from mirage.commands.spec.types import CommandSpec, Operand, Option
 
+# CPython's own option table, minus the interactive-only switches. The
+# three groups differ in who answers them: -c/-m select the source and
+# end option parsing (their argument is a program, so trailing words are
+# that program's argv); the init switches are handed to the runtime
+# through RunArgs.flags and honored by whichever engine can; -u is a
+# structural no-op, since mirage buffers every stream and returns it
+# whole. Pinned against CPython 3.12.13.
+_PYTHON_OPTIONS: tuple[Option, ...] = (
+    Option(short="-c",
+           type="str",
+           ends_options=True,
+           description="Run the next argument as a program."),
+    Option(short="-m",
+           type="str",
+           ends_options=True,
+           description="Run the named module as __main__."),
+    Option(short="-u",
+           description=("(Ignored) Unbuffered output. Mirage buffers "
+                        "every stream and returns it whole.")),
+    Option(short="-B", description="Do not write .pyc files on import."),
+    Option(short="-E", description="Ignore PYTHON* environment variables."),
+    Option(short="-I", description="Isolated mode: implies -E and -s."),
+    Option(short="-O",
+           count=True,
+           description=("Remove assert and __debug__ blocks; -OO also "
+                        "strips docstrings.")),
+    Option(short="-q",
+           description=("(Ignored) Suppress the version banner. Mirage "
+                        "prints none.")),
+    Option(short="-s",
+           description="Do not add the user site directory to sys.path."),
+    Option(short="-S",
+           description="Do not run 'import site' on initialization."),
+    Option(short="-W",
+           type="str",
+           multiple=True,
+           description="Set a warning control filter."),
+    Option(short="-X",
+           type="str",
+           multiple=True,
+           description="Set an implementation-specific option."),
+    # Aliases of the injected help/version options, not new behavior:
+    # sharing their long spelling means they share their dest, so
+    # _with_help_support short-circuits them on the one path every
+    # command uses. CPython's -VV adds build info; mirage has no
+    # CPython build to report, so -VV clusters into -V and prints the
+    # same line.
+    Option(short="-h",
+           long="--help",
+           description="Show this help message and exit."),
+    Option(short="-V",
+           long="--version",
+           description="Show version information and exit."),
+)
+
 SPECS: dict[str, CommandSpec] = {
     'python':
     CommandSpec(
-        options=(Option(short="-c", type="str"), ),
+        description="Run Python on the workspace's bound runtime.",
+        options=_PYTHON_OPTIONS,
         rest=Operand(type="str"),
+        stop_at_operand=True,
     ),
     'python3':
     CommandSpec(
-        options=(Option(short="-c", type="str"), ),
+        description="Run Python on the workspace's bound runtime.",
+        options=_PYTHON_OPTIONS,
         rest=Operand(type="str"),
+        stop_at_operand=True,
     ),
     'js':
     CommandSpec(

--- a/python/mirage/commands/spec/builtin_specs/runtime.py
+++ b/python/mirage/commands/spec/builtin_specs/runtime.py
@@ -14,13 +14,22 @@
 
 from mirage.commands.spec.types import CommandSpec, Operand, Option
 
-# CPython's own option table, minus the interactive-only switches. The
-# three groups differ in who answers them: -c/-m select the source and
-# end option parsing (their argument is a program, so trailing words are
-# that program's argv); the init switches are handed to the runtime
-# through RunArgs.flags and honored by whichever engine can; -u is a
-# structural no-op, since mirage buffers every stream and returns it
-# whole. Pinned against CPython 3.12.13.
+# CPython's own option table, minus four switches that describe a
+# process mirage does not have: -i (drop to an interactive prompt), -d
+# (parser debug, a debug-build-only switch), -v (trace every import to
+# stderr) and the --help-env/--help-xoptions/--help-all dumps, which
+# document a CPython build rather than this command. Everything else
+# CPython accepts, this accepts.
+#
+# The four groups differ in who answers them: -c/-m select the source
+# and end option parsing (their argument is a program, so trailing
+# words are that program's argv); -x also selects source, by dropping
+# the script file's first line, and is answered here rather than by a
+# runtime because every engine reads the same resolved text; the init
+# switches are handed to the runtime through RunArgs.flags and honored
+# by whichever engine can; -u is a structural no-op, since mirage
+# buffers every stream and returns it whole. Pinned against CPython
+# 3.12.11.
 _PYTHON_OPTIONS: tuple[Option, ...] = (
     Option(short="-c",
            type="str",
@@ -31,6 +40,10 @@ _PYTHON_OPTIONS: tuple[Option, ...] = (
     Option(short="-u",
            description=("(Ignored) Unbuffered output. Mirage buffers "
                         "every stream and returns it whole.")),
+    Option(short="-b",
+           count=True,
+           description=("Warn on str(bytes) and on comparing bytes with "
+                        "str; -bb raises instead.")),
     Option(short="-B", description="Do not write .pyc files on import."),
     Option(short="-E", description="Ignore PYTHON* environment variables."),
     Option(short="-I", description="Isolated mode: implies -E and -s."),
@@ -38,6 +51,9 @@ _PYTHON_OPTIONS: tuple[Option, ...] = (
            count=True,
            description=("Remove assert and __debug__ blocks; -OO also "
                         "strips docstrings.")),
+    Option(short="-P",
+           description=("Do not prepend the script's directory to "
+                        "sys.path.")),
     Option(short="-q",
            description=("(Ignored) Suppress the version banner. Mirage "
                         "prints none.")),
@@ -49,10 +65,20 @@ _PYTHON_OPTIONS: tuple[Option, ...] = (
            type="str",
            multiple=True,
            description="Set a warning control filter."),
+    Option(short="-x",
+           description=("Skip the script file's first line, for a "
+                        "non-Unix #! form.")),
     Option(short="-X",
            type="str",
            multiple=True,
            description="Set an implementation-specific option."),
+    # CPython parses this one by hand and so rejects the --opt=value
+    # spelling it accepts everywhere else; mirage's parser takes both,
+    # which is the harmless direction to diverge in.
+    Option(long="--check-hash-based-pycs",
+           type="str",
+           choices=("always", "default", "never"),
+           description="How to validate hash-based .pyc files."),
     # Aliases of the injected help/version options, not new behavior:
     # sharing their long spelling means they share their dest, so
     # _with_help_support short-circuits them on the one path every

--- a/python/mirage/commands/spec/compile.py
+++ b/python/mirage/commands/spec/compile.py
@@ -79,12 +79,9 @@ class CompiledSpec:
         numeric_dest (str | None): canonical spelling fed by the
             ``-<digits>`` shorthand, when one option declares it.
         rest_kind (ValueType | None): kind of the rest operand.
-        stop_at_operand (bool): parse options strictly until the first
-            operand, then take every remaining word verbatim
-            (``CommandSpec.stop_at_operand``, python3's rule).
-        ends_options_spellings (frozenset[str]): spellings whose value
-            ends option parsing (``Option.ends_options``, python3's
-            ``-c``/``-m``).
+        remainder (bool): the rest operand gathers every word from the
+            first operand on, options included (``Operand.remainder``,
+            argparse's ``nargs=REMAINDER``).
         base_dest (str | None): canonical spelling of the option that
             re-bases the path operands after it (``CommandSpec.
             operand_base``, tar's -C).
@@ -113,8 +110,7 @@ class CompiledSpec:
     numeric_dest: str | None = None
     rest_kind: ValueType | None = None
     base_dest: str | None = None
-    stop_at_operand: bool = False
-    ends_options_spellings: frozenset[str] = frozenset()
+    remainder: bool = False
 
     def dest_of(self, spelling: str) -> str:
         """Canonical spelling for a typed spelling.
@@ -167,7 +163,6 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
     bool_spellings: set[str] = set()
     value_spellings: list[str] = []
     attach_spellings: list[str] = []
-    ends_options_spellings: set[str] = set()
     long_bool_spellings: set[str] = set()
     long_value_spellings: set[str] = set()
     long_optional_spellings: set[str] = set()
@@ -244,15 +239,6 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
         if opt.env is not None:
             env_by_dest[canonical] = opt.env
 
-        if opt.ends_options:
-            if opt.type == "bool":
-                raise ValueError(f"option {canonical!r}: ends_options "
-                                 "requires a value flag (it ends parsing "
-                                 "after the value it carries)")
-            for spelling in (opt.short, opt.long):
-                if spelling is not None:
-                    ends_options_spellings.add(spelling)
-
         if opt.short:
             if opt.type == "bool":
                 bool_spellings.add(opt.short)
@@ -327,6 +313,5 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
         numeric_dest=numeric_dest,
         rest_kind=spec.rest.type if spec.rest is not None else None,
         base_dest=base_dest,
-        stop_at_operand=spec.stop_at_operand,
-        ends_options_spellings=frozenset(ends_options_spellings),
+        remainder=spec.rest is not None and spec.rest.remainder,
     )

--- a/python/mirage/commands/spec/compile.py
+++ b/python/mirage/commands/spec/compile.py
@@ -79,6 +79,12 @@ class CompiledSpec:
         numeric_dest (str | None): canonical spelling fed by the
             ``-<digits>`` shorthand, when one option declares it.
         rest_kind (ValueType | None): kind of the rest operand.
+        stop_at_operand (bool): parse options strictly until the first
+            operand, then take every remaining word verbatim
+            (``CommandSpec.stop_at_operand``, python3's rule).
+        ends_options_spellings (frozenset[str]): spellings whose value
+            ends option parsing (``Option.ends_options``, python3's
+            ``-c``/``-m``).
         base_dest (str | None): canonical spelling of the option that
             re-bases the path operands after it (``CommandSpec.
             operand_base``, tar's -C).
@@ -107,6 +113,8 @@ class CompiledSpec:
     numeric_dest: str | None = None
     rest_kind: ValueType | None = None
     base_dest: str | None = None
+    stop_at_operand: bool = False
+    ends_options_spellings: frozenset[str] = frozenset()
 
     def dest_of(self, spelling: str) -> str:
         """Canonical spelling for a typed spelling.
@@ -159,6 +167,7 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
     bool_spellings: set[str] = set()
     value_spellings: list[str] = []
     attach_spellings: list[str] = []
+    ends_options_spellings: set[str] = set()
     long_bool_spellings: set[str] = set()
     long_value_spellings: set[str] = set()
     long_optional_spellings: set[str] = set()
@@ -235,6 +244,15 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
         if opt.env is not None:
             env_by_dest[canonical] = opt.env
 
+        if opt.ends_options:
+            if opt.type == "bool":
+                raise ValueError(f"option {canonical!r}: ends_options "
+                                 "requires a value flag (it ends parsing "
+                                 "after the value it carries)")
+            for spelling in (opt.short, opt.long):
+                if spelling is not None:
+                    ends_options_spellings.add(spelling)
+
         if opt.short:
             if opt.type == "bool":
                 bool_spellings.add(opt.short)
@@ -309,4 +327,6 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
         numeric_dest=numeric_dest,
         rest_kind=spec.rest.type if spec.rest is not None else None,
         base_dest=base_dest,
+        stop_at_operand=spec.stop_at_operand,
+        ends_options_spellings=frozenset(ends_options_spellings),
     )

--- a/python/mirage/commands/spec/constants.py
+++ b/python/mirage/commands/spec/constants.py
@@ -53,7 +53,21 @@ USAGE_EXIT = {
     "awk": 2,
     "jq": 2,
     "tar": 64,
+    "python": 2,
+    "python3": 2,
 }
+
+# The interpreter commands answer option errors in CPython's words, not
+# GNU's: python3 is not a GNU tool, and its refusal names the
+# source-selecting options a reader needs. Plain strings for the same
+# no-cycle reason as USAGE_EXIT above.
+PYTHON_NAMES = frozenset({"python", "python3"})
+
+# Pinned on CPython 3.12.13, including two quirks worth keeping: the
+# hint always spells the program `python` (never `python3`, whichever
+# way it was invoked), and it quotes with a backquote/quote pair.
+PYTHON_USAGE = ("usage: {name} [option] ... [-c cmd | -m mod | file | -] "
+                "[arg] ...\nTry `python -h' for more information.\n")
 
 # An old-style cluster letter left without its argument exits 2, not
 # USAGE_EXIT's 64: tar reads the cluster itself and raises its own fatal

--- a/python/mirage/commands/spec/parser.py
+++ b/python/mirage/commands/spec/parser.py
@@ -148,16 +148,6 @@ def _match_mixed_cluster(
     return None
 
 
-def _ends_options(cs: CompiledSpec, spelling: str) -> bool:
-    """Whether this spelling's value is the last word parsed as ours.
-
-    Args:
-        cs (CompiledSpec): the compiled spec being parsed against.
-        spelling (str): the option spelling as matched on the line.
-    """
-    return cs.stop_at_operand and spelling in cs.ends_options_spellings
-
-
 def parse_command(
     spec: CommandSpec,
     argv: list[str],
@@ -226,8 +216,7 @@ def parse_command(
     # dash tokens verbatim; elsewhere they are dropped with a warning so a
     # stray flag never corrupts pattern/path classification.
     lenient_dash_operands = (cs.rest_kind is not None
-                             and cs.rest_kind != "path"
-                             and not cs.stop_at_operand)
+                             and cs.rest_kind != "path" and not cs.remainder)
     i = 0
     end_of_flags = False
 
@@ -330,7 +319,6 @@ def parse_command(
             if matched_optional:
                 continue
             matched_value = False
-            matched_spelling = ""
             for vf in cs.value_spellings:
                 if tok == vf and i + 1 < len(filtered_argv):
                     _set_value_flag(flags, cs, vf, filtered_argv[i + 1])
@@ -340,18 +328,14 @@ def parse_command(
                     base = _rebase(flags, cs, vf, filtered_argv[i + 1], base)
                     i += 2
                     matched_value = True
-                    matched_spelling = vf
                     break
                 if tok.startswith(vf) and len(tok) > len(vf):
                     _set_value_flag(flags, cs, vf, tok[len(vf):])
                     base = _rebase(flags, cs, vf, tok[len(vf):], base)
                     i += 1
                     matched_value = True
-                    matched_spelling = vf
                     break
             if matched_value:
-                if _ends_options(cs, matched_spelling):
-                    end_of_flags = True
                 continue
 
             if tok in cs.bool_spellings:
@@ -422,10 +406,10 @@ def parse_command(
         raw_args.append(tok)
         raw_indices.append(orig_indices[i])
         raw_bases.append(base)
-        # The first operand ends option parsing outright under
-        # stop_at_operand, so a script's own flags reach the script
-        # instead of being read as the interpreter's.
-        if cs.stop_at_operand:
+        # argparse's REMAINDER: the first operand ends option parsing,
+        # so a script's own flags reach the script instead of being read
+        # as the interpreter's.
+        if cs.remainder:
             end_of_flags = True
         i += 1
 

--- a/python/mirage/commands/spec/parser.py
+++ b/python/mirage/commands/spec/parser.py
@@ -148,6 +148,16 @@ def _match_mixed_cluster(
     return None
 
 
+def _ends_options(cs: CompiledSpec, spelling: str) -> bool:
+    """Whether this spelling's value is the last word parsed as ours.
+
+    Args:
+        cs (CompiledSpec): the compiled spec being parsed against.
+        spelling (str): the option spelling as matched on the line.
+    """
+    return cs.stop_at_operand and spelling in cs.ends_options_spellings
+
+
 def parse_command(
     spec: CommandSpec,
     argv: list[str],
@@ -216,7 +226,8 @@ def parse_command(
     # dash tokens verbatim; elsewhere they are dropped with a warning so a
     # stray flag never corrupts pattern/path classification.
     lenient_dash_operands = (cs.rest_kind is not None
-                             and cs.rest_kind != "path")
+                             and cs.rest_kind != "path"
+                             and not cs.stop_at_operand)
     i = 0
     end_of_flags = False
 
@@ -319,6 +330,7 @@ def parse_command(
             if matched_optional:
                 continue
             matched_value = False
+            matched_spelling = ""
             for vf in cs.value_spellings:
                 if tok == vf and i + 1 < len(filtered_argv):
                     _set_value_flag(flags, cs, vf, filtered_argv[i + 1])
@@ -328,14 +340,18 @@ def parse_command(
                     base = _rebase(flags, cs, vf, filtered_argv[i + 1], base)
                     i += 2
                     matched_value = True
+                    matched_spelling = vf
                     break
                 if tok.startswith(vf) and len(tok) > len(vf):
                     _set_value_flag(flags, cs, vf, tok[len(vf):])
                     base = _rebase(flags, cs, vf, tok[len(vf):], base)
                     i += 1
                     matched_value = True
+                    matched_spelling = vf
                     break
             if matched_value:
+                if _ends_options(cs, matched_spelling):
+                    end_of_flags = True
                 continue
 
             if tok in cs.bool_spellings:
@@ -406,6 +422,11 @@ def parse_command(
         raw_args.append(tok)
         raw_indices.append(orig_indices[i])
         raw_bases.append(base)
+        # The first operand ends option parsing outright under
+        # stop_at_operand, so a script's own flags reach the script
+        # instead of being read as the interpreter's.
+        if cs.stop_at_operand:
+            end_of_flags = True
         i += 1
 
     # Snapshot before defaults land, because "typed" and "present" stop

--- a/python/mirage/commands/spec/types.py
+++ b/python/mirage/commands/spec/types.py
@@ -179,11 +179,21 @@ class Option:
             frozen into the spec. Declaring it here is what keeps one
             fact in one place, since both the leaf that sends the value
             and the renderer that reports the line need it.
+        ends_options (bool): the option's value is the last thing parsed
+            as the command's own; every later word is an operand. This is
+            python3's ``-c``/``-m``, whose argument is a program and
+            whose trailing words are that program's argv, so
+            ``python3 -c 'code' -u`` passes ``-u`` to the code rather
+            than honoring it. Only meaningful under
+            ``CommandSpec.stop_at_operand``, and only on the options that
+            carry a program: ``-X dev -c 'code'`` still parses ``-c``,
+            because ``-X`` takes a value without carrying one.
         description (str | None): help text.
     """
     short: str | None = None
     long: str | None = None
     type: ValueType = "bool"
+    ends_options: bool = False
     numeric_shorthand: bool = False
     count: bool = False
     multiple: bool = False
@@ -255,6 +265,13 @@ class CommandSpec:
     # every other path-valued flag keeps resolving against the session
     # cwd, which is what GNU does with -f.
     operand_base: str | None = None
+    # python3's rule: parse options strictly until the first operand,
+    # then take every remaining word verbatim. An interpreter needs both
+    # halves at once -- an unknown flag before the script is a usage
+    # error, while `python3 s.py --foo` must hand `--foo` to the script
+    # -- and the free-text leniency that serves echo/bash can only
+    # express the second.
+    stop_at_operand: bool = False
 
 
 class FlagView:

--- a/python/mirage/commands/spec/types.py
+++ b/python/mirage/commands/spec/types.py
@@ -179,21 +179,11 @@ class Option:
             frozen into the spec. Declaring it here is what keeps one
             fact in one place, since both the leaf that sends the value
             and the renderer that reports the line need it.
-        ends_options (bool): the option's value is the last thing parsed
-            as the command's own; every later word is an operand. This is
-            python3's ``-c``/``-m``, whose argument is a program and
-            whose trailing words are that program's argv, so
-            ``python3 -c 'code' -u`` passes ``-u`` to the code rather
-            than honoring it. Only meaningful under
-            ``CommandSpec.stop_at_operand``, and only on the options that
-            carry a program: ``-X dev -c 'code'`` still parses ``-c``,
-            because ``-X`` takes a value without carrying one.
         description (str | None): help text.
     """
     short: str | None = None
     long: str | None = None
     type: ValueType = "bool"
-    ends_options: bool = False
     numeric_shorthand: bool = False
     count: bool = False
     multiple: bool = False
@@ -237,12 +227,26 @@ class Operand:
         required (bool): the line must supply this slot; one that does
             not is a usage error the parser reports, rather than
             something each leaf re-discovers and words its own way.
+        remainder (bool): every word from this slot on is gathered
+            verbatim, options included. This is argparse's
+            ``nargs=argparse.REMAINDER`` and POSIX's own option order:
+            the first operand ends option parsing, where GNU's default
+            permutes instead (``ls a -1`` reads ``-1`` as a flag,
+            ``POSIXLY_CORRECT=1 ls a -1`` reads it as a filename). Set
+            it for a command that dispatches to another program, which
+            is the case argparse documents it for: python3's script and
+            the words after it are the script's argv, so
+            ``python3 s.py --foo`` must hand ``--foo`` over untouched
+            while ``python3 -zz s.py`` must still refuse ``-zz`` as
+            python3's own. One switch cannot do both, which is why the
+            boundary has to be declared.
     """
     type: ValueType = "path"
     provided_by: tuple[str, ...] = ()
     text_when: tuple[str, ...] = ()
     name: str = ""
     required: bool = False
+    remainder: bool = False
 
 
 @dataclass(frozen=True)
@@ -265,13 +269,6 @@ class CommandSpec:
     # every other path-valued flag keeps resolving against the session
     # cwd, which is what GNU does with -f.
     operand_base: str | None = None
-    # python3's rule: parse options strictly until the first operand,
-    # then take every remaining word verbatim. An interpreter needs both
-    # halves at once -- an unknown flag before the script is a usage
-    # error, while `python3 s.py --foo` must hand `--foo` to the script
-    # -- and the free-text leniency that serves echo/bash can only
-    # express the second.
-    stop_at_operand: bool = False
 
 
 class FlagView:

--- a/python/mirage/commands/spec/usage.py
+++ b/python/mirage/commands/spec/usage.py
@@ -13,7 +13,8 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.commands.errors import UsageError
-from mirage.commands.spec.constants import (OLD_OPTION_EXIT, USAGE_EXIT,
+from mirage.commands.spec.constants import (OLD_OPTION_EXIT, PYTHON_NAMES,
+                                            PYTHON_USAGE, USAGE_EXIT,
                                             USAGE_HINT_PREFIX)
 from mirage.commands.spec.types import CommandName
 
@@ -25,6 +26,18 @@ def usage_exit_code(cmd_name: str) -> int:
         cmd_name (str): command name.
     """
     return USAGE_EXIT.get(cmd_name, 1)
+
+
+def python_option_error(cmd_name: str, line: str) -> tuple[bytes, int]:
+    """CPython's option refusal: one message line, then its usage block.
+
+    Args:
+        cmd_name (str): the interpreter as invoked, which names the
+            usage line ('python' or 'python3').
+        line (str): the message line, newline included.
+    """
+    return (line + PYTHON_USAGE.format(name=cmd_name)).encode(), \
+        usage_exit_code(cmd_name)
 
 
 def unknown_option_error(cmd_name: str, token: str) -> tuple[bytes, int]:
@@ -45,6 +58,14 @@ def unknown_option_error(cmd_name: str, token: str) -> tuple[bytes, int]:
         dashed = token if token.startswith("-") else f"-{token}"
         line = f"find: unknown predicate `{dashed}'\n"
         return line.encode(), usage_exit_code(cmd_name)
+    if cmd_name in PYTHON_NAMES:
+        # CPython's own two shapes, which do not match each other: the
+        # short form capitalizes and takes a colon, the long form does
+        # neither. Both pinned on 3.12.13.
+        if token.startswith("--"):
+            return python_option_error(cmd_name, f"unknown option {token}\n")
+        dashed = token if token.startswith("-") else f"-{token}"
+        return python_option_error(cmd_name, f"Unknown option: {dashed}\n")
     if token.startswith("--"):
         line = f"{cmd_name}: unrecognized option '{token}'\n"
     else:
@@ -118,6 +139,10 @@ def missing_value_error(cmd_name: str, token: str) -> tuple[bytes, int]:
         cmd_name (str): command name for the message and exit code.
         token (str): long token ('--max-depth') or short char ('m').
     """
+    if cmd_name in PYTHON_NAMES:
+        dashed = token if token.startswith("-") else f"-{token}"
+        return python_option_error(
+            cmd_name, f"Argument expected for the {dashed} option\n")
     if token.startswith("--"):
         line = f"{cmd_name}: option '{token}' requires an argument\n"
     else:

--- a/python/mirage/runtime/python/base.py
+++ b/python/mirage/runtime/python/base.py
@@ -30,3 +30,9 @@ class PythonRuntime(LanguageRuntime):
 
     language: ClassVar[Language] = "python"
     captures = ("python3", "python")
+    # Whether `python3 -m mod` can run at all. True for every engine
+    # that is real CPython, since runpy does the work; False for an
+    # engine implementing a subset of the language with no import
+    # system to find a module with. A capability of the tier, declared
+    # here rather than probed, so a refusal can name the runtime.
+    runs_modules: ClassVar[bool] = True

--- a/python/mirage/runtime/python/bootstrap.py
+++ b/python/mirage/runtime/python/bootstrap.py
@@ -1,0 +1,56 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+PAYLOAD_ARGV0 = "-c"
+STDIN_ARGV0 = "-"
+STDIN_FILENAME = "<stdin>"
+
+
+def bootstrap(code: str, prog: str | None) -> str:
+    """Wrap a program so a `-c` subprocess reports the right argv[0].
+
+    The subprocess tiers hand CPython the program through `-c`, because
+    the source comes off a mount and may not exist on the host at all.
+    CPython then hardcodes argv[0] to "-c" and names every frame
+    "<string>", which is right for a payload and wrong for the other
+    three doors: a script must see its own path in argv[0] and its own
+    name in a traceback.
+
+    Re-compiling under the real name fixes both at once, and the two
+    preamble lines bind no names (`__import__` is called, not imported)
+    and exec into `globals()`, which is `__main__`'s own dict, so the
+    program runs in the module identity CPython would have given it.
+
+    Deliberate divergence: the preamble is itself a frame, so a
+    traceback carries one extra `File "<string>", line 2` line above
+    the program's own. The frame that names the error is correct, which
+    is the one that matters; removing the outer frame would mean
+    catching and re-raising every exception, which would bind names in
+    the program's namespace and rewrite `__context__`.
+
+    Args:
+        code (str): the program's source.
+        prog (str | None): argv[0] for this run, as the source mode
+            resolved it. None or "-c" means a payload, which CPython
+            already reports correctly and which passes through
+            untouched.
+    """
+    if prog is None or prog == PAYLOAD_ARGV0:
+        return code
+    # "" (piped in with no operand) and "-" (the explicit operand) are
+    # both <stdin> to CPython, which reports the door rather than a
+    # path because there is no file to name.
+    filename = (STDIN_FILENAME if prog in ("", STDIN_ARGV0) else prog)
+    return (f"__import__('sys').argv[0] = {prog!r}\n"
+            f"exec(compile({code!r}, {filename!r}, 'exec'), globals())\n")

--- a/python/mirage/runtime/python/flags.py
+++ b/python/mirage/runtime/python/flags.py
@@ -20,18 +20,23 @@ from typing import Any
 # and `-q` are deliberately absent: mirage buffers every stream and
 # prints no banner, so they are structural no-ops in every runtime
 # rather than something one engine honors and another does not.
-BOOL_FLAGS: tuple[str, ...] = ("B", "E", "I", "s", "S")
+BOOL_FLAGS: tuple[str, ...] = ("B", "E", "I", "P", "s", "S")
+COUNT_FLAGS: tuple[str, ...] = ("O", "b")
 LIST_FLAGS: tuple[str, ...] = ("W", "X")
-OPTIMIZE_FLAG = "O"
+# The one init switch CPython spells long. Its key is the parser's
+# canonical spelling rather than a letter, since it has none.
+VALUE_FLAGS: dict[str, str] = {
+    "check_hash_based_pycs": "--check-hash-based-pycs",
+}
 
 
 def init_argv(flags: dict[str, Any]) -> list[str]:
     """CPython command-line switches for one run's interpreter flags.
 
     For the engines that spawn a real interpreter, honoring these is
-    just handing them back to CPython in its own spelling. ``-O``
-    repeats rather than taking a number, so level 2 is ``-O -O``, which
-    CPython reads exactly as ``-OO``.
+    just handing them back to CPython in its own spelling. ``-O`` and
+    ``-b`` repeat rather than taking a number, so level 2 is ``-O -O``,
+    which CPython reads exactly as ``-OO``.
 
     Args:
         flags (dict[str, Any]): the run's RunArgs.flags bag.
@@ -40,32 +45,54 @@ def init_argv(flags: dict[str, Any]) -> list[str]:
     for key in BOOL_FLAGS:
         if flags.get(key):
             argv.append(f"-{key}")
-    level = flags.get(OPTIMIZE_FLAG) or 0
-    argv.extend([f"-{OPTIMIZE_FLAG}"] * int(level))
+    for key in COUNT_FLAGS:
+        argv.extend([f"-{key}"] * int(flags.get(key) or 0))
     for key in LIST_FLAGS:
         for value in flags.get(key) or []:
             argv.extend([f"-{key}", value])
+    for key, spelling in VALUE_FLAGS.items():
+        value = flags.get(key)
+        if value:
+            # CPython parses this one by hand and rejects --opt=value,
+            # so it goes back as two words whatever the user typed.
+            argv.extend([spelling, str(value)])
     return argv
 
 
-def unhonored(flags: dict[str, Any]) -> list[str]:
-    """The init switches present on a line, in CPython's spelling.
+def unhonored(
+        flags: dict[str, Any],
+        honored: tuple[str, ...] = (),
+) -> list[str]:
+    """The init switches on a line that this engine did not act on.
 
     A runtime that cannot act on these reports them rather than
     dropping them silently, so a line behaving differently across
-    runtimes says so instead of being discovered later.
+    runtimes says so instead of being discovered later. ``honored`` is
+    the engine's own subset, by CPython letter; the default is none,
+    which is the honest answer for an engine that is not CPython at
+    all.
 
     Args:
         flags (dict[str, Any]): the run's RunArgs.flags bag.
+        honored (tuple[str, ...]): the letters this engine does act on.
     """
     present: list[str] = []
-    for key in (*BOOL_FLAGS, OPTIMIZE_FLAG, *LIST_FLAGS):
+    for key in (*BOOL_FLAGS, *COUNT_FLAGS, *LIST_FLAGS):
+        if key in honored:
+            continue
         if flags.get(key):
             present.append(f"-{key}")
+    for key, spelling in VALUE_FLAGS.items():
+        if key not in honored and flags.get(key):
+            present.append(spelling)
     return present
 
 
-def unhonored_notice(flags: dict[str, Any], runtime_name: str) -> bytes:
+def unhonored_notice(
+        flags: dict[str, Any],
+        runtime_name: str,
+        honored: tuple[str, ...] = (),
+) -> bytes:
     """One stderr line per init switch this runtime cannot act on.
 
     A warning rather than a refusal: the line still runs and still
@@ -76,9 +103,11 @@ def unhonored_notice(flags: dict[str, Any], runtime_name: str) -> bytes:
     Args:
         flags (dict[str, Any]): the run's RunArgs.flags bag.
         runtime_name (str): the engine's registry name, for the message.
+        honored (tuple[str, ...]): the letters this engine does act on.
     """
     lines = [
         f"python3: warning: {spelling} is ignored by the "
-        f"{runtime_name!r} runtime\n" for spelling in unhonored(flags)
+        f"{runtime_name!r} runtime\n"
+        for spelling in unhonored(flags, honored)
     ]
     return "".join(lines).encode()

--- a/python/mirage/runtime/python/flags.py
+++ b/python/mirage/runtime/python/flags.py
@@ -1,0 +1,84 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Any
+
+# The interpreter-init switches, keyed by CPython's own letter. These
+# configure the interpreter rather than selecting what it runs, so they
+# ride in RunArgs.flags and each engine answers the ones it can. `-u`
+# and `-q` are deliberately absent: mirage buffers every stream and
+# prints no banner, so they are structural no-ops in every runtime
+# rather than something one engine honors and another does not.
+BOOL_FLAGS: tuple[str, ...] = ("B", "E", "I", "s", "S")
+LIST_FLAGS: tuple[str, ...] = ("W", "X")
+OPTIMIZE_FLAG = "O"
+
+
+def init_argv(flags: dict[str, Any]) -> list[str]:
+    """CPython command-line switches for one run's interpreter flags.
+
+    For the engines that spawn a real interpreter, honoring these is
+    just handing them back to CPython in its own spelling. ``-O``
+    repeats rather than taking a number, so level 2 is ``-O -O``, which
+    CPython reads exactly as ``-OO``.
+
+    Args:
+        flags (dict[str, Any]): the run's RunArgs.flags bag.
+    """
+    argv: list[str] = []
+    for key in BOOL_FLAGS:
+        if flags.get(key):
+            argv.append(f"-{key}")
+    level = flags.get(OPTIMIZE_FLAG) or 0
+    argv.extend([f"-{OPTIMIZE_FLAG}"] * int(level))
+    for key in LIST_FLAGS:
+        for value in flags.get(key) or []:
+            argv.extend([f"-{key}", value])
+    return argv
+
+
+def unhonored(flags: dict[str, Any]) -> list[str]:
+    """The init switches present on a line, in CPython's spelling.
+
+    A runtime that cannot act on these reports them rather than
+    dropping them silently, so a line behaving differently across
+    runtimes says so instead of being discovered later.
+
+    Args:
+        flags (dict[str, Any]): the run's RunArgs.flags bag.
+    """
+    present: list[str] = []
+    for key in (*BOOL_FLAGS, OPTIMIZE_FLAG, *LIST_FLAGS):
+        if flags.get(key):
+            present.append(f"-{key}")
+    return present
+
+
+def unhonored_notice(flags: dict[str, Any], runtime_name: str) -> bytes:
+    """One stderr line per init switch this runtime cannot act on.
+
+    A warning rather than a refusal: the line still runs and still
+    reports the program's own exit code, so a script that works on
+    every other runtime keeps working here, while the difference stays
+    visible instead of being found later.
+
+    Args:
+        flags (dict[str, Any]): the run's RunArgs.flags bag.
+        runtime_name (str): the engine's registry name, for the message.
+    """
+    lines = [
+        f"python3: warning: {spelling} is ignored by the "
+        f"{runtime_name!r} runtime\n" for spelling in unhonored(flags)
+    ]
+    return "".join(lines).encode()

--- a/python/mirage/runtime/python/flags.py
+++ b/python/mirage/runtime/python/flags.py
@@ -29,6 +29,32 @@ VALUE_FLAGS: dict[str, str] = {
     "check_hash_based_pycs": "--check-hash-based-pycs",
 }
 
+# The -X names CPython gives an effect beyond landing in sys._xoptions,
+# so a warm interpreter that only populates that dict has not honored
+# them. Every one is read out of the read-only sys.flags or installed at
+# interpreter start (dev, utf8, warn_default_encoding, importtime,
+# frozen_modules, cpu_count, no_debug_ranges, perf*, showrefcount) or
+# needs a library call the engine does not make (faulthandler,
+# int_max_str_digits, pycache_prefix, tracemalloc). An arbitrary name is
+# deliberately absent: on CPython it does nothing but land in the dict
+# either. Pinned against `python3 --help-xoptions` on 3.13.7.
+X_EFFECTS: frozenset[str] = frozenset({
+    "cpu_count",
+    "dev",
+    "faulthandler",
+    "frozen_modules",
+    "importtime",
+    "int_max_str_digits",
+    "no_debug_ranges",
+    "perf",
+    "perf_jit",
+    "pycache_prefix",
+    "showrefcount",
+    "tracemalloc",
+    "utf8",
+    "warn_default_encoding",
+})
+
 
 def init_argv(flags: dict[str, Any]) -> list[str]:
     """CPython command-line switches for one run's interpreter flags.
@@ -85,6 +111,13 @@ def unhonored(
     for key, spelling in VALUE_FLAGS.items():
         if key not in honored and flags.get(key):
             present.append(spelling)
+    # Reported per name rather than per letter: an engine can honor what
+    # -X means for sys._xoptions and still not act on the handful of
+    # names CPython gives a real effect.
+    for value in flags.get("X") or []:
+        opt_name = str(value).split("=")[0]
+        if opt_name in X_EFFECTS and f"X:{opt_name}" not in honored:
+            present.append(f"-X {opt_name}")
     return present
 
 

--- a/python/mirage/runtime/python/local.py
+++ b/python/mirage/runtime/python/local.py
@@ -21,6 +21,8 @@ from typing import Any, Callable, ClassVar
 
 from mirage.runtime.config import HomeConfig, RuntimeConfig
 from mirage.runtime.python.base import PythonRuntime
+from mirage.runtime.python.bootstrap import bootstrap
+from mirage.runtime.python.flags import init_argv
 from mirage.runtime.types import RunArgs, RunResult, ScriptSource
 
 LOCAL_HOME_ENV = "MIRAGE_LOCAL_HOME"
@@ -63,10 +65,14 @@ class LocalRuntime(PythonRuntime):
             self._python = sys.executable
 
     async def run(self, args: RunArgs) -> RunResult:
+        # Honoring the init switches is just handing them back to the
+        # real interpreter, which is why this tier gets them exactly
+        # right (sys.flags included) where an in-process engine cannot.
         proc = await asyncio.create_subprocess_exec(
             self._python,
+            *init_argv(args.flags),
             "-c",
-            args.code,
+            bootstrap(args.code, args.prog),
             *args.args,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,

--- a/python/mirage/runtime/python/monty/runtime.py
+++ b/python/mirage/runtime/python/monty/runtime.py
@@ -18,12 +18,14 @@ import logging
 import os
 import signal
 from collections.abc import Sequence
-from typing import Any, Callable
+from dataclasses import replace
+from typing import Any, Callable, ClassVar
 
 from mirage.runtime.config import RuntimeConfig
 from mirage.runtime.errors import EvalError
 from mirage.runtime.mixin import EvaluatorMixin
 from mirage.runtime.python.base import PythonRuntime
+from mirage.runtime.python.flags import unhonored_notice
 from mirage.runtime.python.monty.binding import pydantic_monty
 from mirage.runtime.python.monty.constants import (DEFAULT_PROG,
                                                    INCOMPLETE_MARKERS,
@@ -53,6 +55,10 @@ class MontyRuntime(PythonRuntime, EvaluatorMixin):
     """
 
     name = "monty"
+    # No import system to resolve a module with, so `-m` has nothing to
+    # run; the refusal names this runtime rather than inventing a
+    # "No module named" that would imply a search happened.
+    runs_modules: ClassVar[bool] = False
 
     def __init__(
             self,
@@ -103,6 +109,24 @@ class MontyRuntime(PythonRuntime, EvaluatorMixin):
         return pool
 
     async def run(self, args: RunArgs) -> RunResult:
+        """Run one program, reporting any switch this engine cannot honor.
+
+        Monty implements a Python subset with no ``compile``, no
+        ``warnings`` and no ``sys.path``, so the interpreter-init
+        switches have nothing to act on here even though every
+        real-CPython engine honors them. The notice rides on stderr and
+        the program's own exit code stands.
+
+        Args:
+            args (RunArgs): the execution request.
+        """
+        notice = unhonored_notice(args.flags, self.name)
+        result = await self._run(args)
+        if not notice:
+            return result
+        return replace(result, stderr=notice + (result.stderr or b""))
+
+    async def _run(self, args: RunArgs) -> RunResult:
         # Execution lives in a monty worker subprocess (0.0.19 moved it
         # out of process so an interpreter crash cannot take the host
         # with it). feed_run awaits off the event loop, so the loop
@@ -115,7 +139,11 @@ class MontyRuntime(PythonRuntime, EvaluatorMixin):
         pool = await self._ensure_pool()
         # argv[0] is the program's own name when the caller has one (a
         # CLI install's head word), else the interpreter's placeholder.
-        argv = [args.prog or DEFAULT_PROG, *args.args]
+        # `is None`, not falsy: "" is CPython's own argv[0] for a
+        # program piped in with no operand, so an empty prog is an
+        # answer rather than an absent one.
+        prog = args.prog if args.prog is not None else DEFAULT_PROG
+        argv = [prog, *args.args]
         # Monty has no `sys.stdin`, so piped bytes ride in as a global
         # the same way argv does: raw bytes, None when nothing was piped.
         inputs = {"argv": argv, "stdin": args.stdin}

--- a/python/mirage/runtime/python/wasi.py
+++ b/python/mirage/runtime/python/wasi.py
@@ -20,6 +20,8 @@ from typing import Any, Callable, ClassVar
 
 from mirage.runtime.config import HomeConfig, RuntimeConfig
 from mirage.runtime.python.base import PythonRuntime
+from mirage.runtime.python.bootstrap import bootstrap
+from mirage.runtime.python.flags import init_argv
 from mirage.runtime.types import (DispatchFn, PrefixSource, RunArgs, RunResult,
                                   ScriptSource)
 from mirage.runtime.vfs import RuntimeVFS
@@ -113,9 +115,12 @@ class WasiRuntime(PythonRuntime):
                            self._mount_prefixes)
                 if self._dispatch is not None else None)
         fs = WasmVFS(WasmFsConfig(host_root=str(self._root)), core)
-        # sys.argv becomes ['-c', *args.args], matching the local runtime.
+        # sys.argv becomes [prog, *args.args], matching the local runtime.
         stdout, stderr, exit_code = await self._runtime.run(
-            argv=["python", "-c", args.code, *args.args],
+            argv=[
+                "python", *init_argv(args.flags), "-c",
+                bootstrap(args.code, args.prog), *args.args
+            ],
             stdin=args.stdin,
             env=[
                 *args.env.items(),

--- a/python/mirage/utils/ids.py
+++ b/python/mirage/utils/ids.py
@@ -11,7 +11,69 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
-import uuid6
+import secrets
+import threading
+import time
+import uuid
+
+TIMESTAMP_BITS = 48
+TIMESTAMP_MASK = (1 << TIMESTAMP_BITS) - 1
+# rand_a carries the intra-millisecond counter (RFC 9562 section 6.2,
+# "fixed-length dedicated counter"). Seeded well below its maximum so a
+# burst has room to climb without rolling over, which is what the RFC
+# asks for, while still starting unpredictably.
+COUNTER_MAX = (1 << 12) - 1
+COUNTER_SEED_BITS = 8
+RANDOM_BITS = 62
+# Written into the layout by hand: uuid.UUID's own `version` argument
+# refuses anything above 5 until Python 3.14.
+VERSION = 7
+VARIANT = 0b10
+
+_lock = threading.Lock()
+_last_ms = -1
+_counter = 0
+
+
+def _stamp() -> tuple[int, int]:
+    """Reserve one id's millisecond and counter value, atomically.
+
+    Two ids minted in the same millisecond are ordered by the counter,
+    which is the whole reason the counter exists: the obvious
+    alternative, bumping the timestamp instead, buys the same ordering
+    by stamping a millisecond that has not happened yet. That error is
+    unbounded and permanent, since the borrowed value becomes the next
+    call's floor: 5000 ids in a burst put every later id five seconds in
+    the future, and it stays there until the clock catches up. These ids
+    are database keys, so a timestamp ahead of the clock is wrong data,
+    not a rounding artifact.
+
+    A millisecond whose counter is exhausted waits for the next one
+    rather than borrowing. That needs more than ~3800 ids inside one
+    millisecond, roughly seven times the observed burst rate.
+
+    The clock moving backwards (NTP) is the one case where the stamp
+    stays ahead of the wall clock: ordering wins there, and the drift is
+    bounded by the size of the jump rather than growing per call.
+
+    Returns:
+        tuple[int, int]: the unix-millisecond timestamp and the counter.
+    """
+    global _last_ms, _counter
+    with _lock:
+        now_ms = time.time_ns() // 1_000_000
+        if now_ms > _last_ms:
+            _last_ms = now_ms
+            _counter = secrets.randbits(COUNTER_SEED_BITS)
+            return _last_ms, _counter
+        if _counter < COUNTER_MAX:
+            _counter += 1
+            return _last_ms, _counter
+        while now_ms <= _last_ms:
+            now_ms = time.time_ns() // 1_000_000
+        _last_ms = now_ms
+        _counter = secrets.randbits(COUNTER_SEED_BITS)
+        return _last_ms, _counter
 
 
 def uuid7() -> str:
@@ -19,14 +81,20 @@ def uuid7() -> str:
 
     The first 48 bits are a unix-millisecond timestamp, so ids sort by
     creation time and stay index-friendly as database primary keys; the
-    remaining 74 bits are random. Delegates to the ``uuid6`` package
-    until ``uuid.uuid7`` lands in the stdlib (Python 3.14).
+    next 12 bits order ids minted inside one millisecond, and the last
+    62 bits are random.
 
     Returns:
         str: canonical UUID string, e.g.
             ``0198c0de-6f3a-7d21-9c4e-8b1f2a3c4d5e``.
     """
-    return str(uuid6.uuid7())
+    timestamp_ms, counter = _stamp()
+    value = (timestamp_ms & TIMESTAMP_MASK) << 80
+    value |= VERSION << 76
+    value |= (counter & COUNTER_MAX) << 64
+    value |= VARIANT << 62
+    value |= secrets.randbits(RANDOM_BITS)
+    return str(uuid.UUID(int=value))
 
 
 def new_workspace_id() -> str:

--- a/python/mirage/workspace/expand/argv.py
+++ b/python/mirage/workspace/expand/argv.py
@@ -107,9 +107,16 @@ async def expand_argv(
 
     # Before anything reads the line: an option carrying a program hands
     # the words after it to that program, and POSIX's own `--` is how
-    # that handoff is spelled.
-    expanded = expanded[:consumed] + end_options_after_program(
-        name, expanded[consumed:])
+    # that handoff is spelled. Only when the interpreter is what runs,
+    # though: a shell function of the same name takes the line instead
+    # (bash's own rule), and it must receive the words as typed rather
+    # than a marker meant for a parser it does not have. `command
+    # python3` masks the function for its inner run, which is exactly
+    # when the rewrite applies again. A CLI cannot reach here at all,
+    # since register_cli refuses a shell builtin's name.
+    if name not in session.functions:
+        expanded = expanded[:consumed] + end_options_after_program(
+            name, expanded[consumed:])
 
     policy = word_policy(route(name, session, registry))
     word_kinds: list[ValueType | None] | None = None

--- a/python/mirage/workspace/expand/argv.py
+++ b/python/mirage/workspace/expand/argv.py
@@ -29,7 +29,8 @@ from mirage.workspace.expand.spec_hints import (spec_for_command,
                                                 spec_word_bases,
                                                 spec_word_kinds)
 from mirage.workspace.mount import MountRegistry
-from mirage.workspace.route import WordPolicy, route, word_policy
+from mirage.workspace.route import (WordPolicy, end_options_after_program,
+                                    route, word_policy)
 from mirage.workspace.session import Session
 
 
@@ -104,12 +105,21 @@ async def expand_argv(
     consumed = registry.match_command_prefix(expanded)
     name = " ".join(expanded[:consumed])
 
+    # Before anything reads the line: an option carrying a program hands
+    # the words after it to that program, and POSIX's own `--` is how
+    # that handoff is spelled.
+    expanded = expanded[:consumed] + end_options_after_program(
+        name, expanded[consumed:])
+
     policy = word_policy(route(name, session, registry))
     word_kinds: list[ValueType | None] | None = None
     word_bases: list[str | None] | None = None
     if policy is WordPolicy.MOUNT:
         spec = spec_for_command(name, registry, session.cwd)
         if spec:
+            # Before anything reads the line: an option carrying a
+            # program hands the words after it to that program, and
+            # POSIX's own `--` is how that is said.
             extra: list[ValueType | None] = ["str"] * (consumed - 1)
             word_kinds = extra + spec_word_kinds(spec, expanded[consumed:])
             bases = spec_word_bases(spec, expanded[consumed:], session.cwd)

--- a/python/mirage/workspace/route/__init__.py
+++ b/python/mirage/workspace/route/__init__.py
@@ -12,15 +12,15 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.workspace.route.constants import (JOB_BUILTINS, NAMESPACE_COMMANDS,
-                                              NO_FOLLOW_COMMANDS,
-                                              UNSUPPORTED_BUILTINS,
-                                              dereferences, reports_link)
+from mirage.workspace.route.constants import (  # isort: skip
+    JOB_BUILTINS, NAMESPACE_COMMANDS, NO_FOLLOW_COMMANDS, UNSUPPORTED_BUILTINS,
+    dereferences, end_options_after_program, reports_link)
 from mirage.workspace.route.route import route, route_all
 from mirage.workspace.route.types import (SHELL_CONSUMERS, Consumer,
                                           WordPolicy, word_policy)
 
 __all__ = [
+    "end_options_after_program",
     "Consumer",
     "JOB_BUILTINS",
     "NAMESPACE_COMMANDS",

--- a/python/mirage/workspace/route/constants.py
+++ b/python/mirage/workspace/route/constants.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.commands.spec import SPECS
+from mirage.commands.spec.compile import compile_spec
 from mirage.types import PathSpec
 from mirage.workspace.names import (JOB_BUILTINS, NAMESPACE_COMMANDS,
                                     NO_FOLLOW_COMMANDS, SHELL_NAMES,
@@ -43,6 +45,72 @@ DEREFERENCE_FLAGS = {
 # options before the first operand counts, which is where GNU accepts
 # them.
 LAST_WINS_LINK_OPTIONS = {"find": {"-P": False, "-H": True, "-L": True}}
+
+# Options whose argument is a program, so the words after it are that
+# program's argv rather than the command's own: python3's -c and -m
+# (`python3 -c 'code' -u x` hands -u to the code). This is a table
+# rather than a spec field on purpose. argparse cannot express it at
+# all (`add_argument("-c")` beside `nargs=REMAINDER` answers
+# `unrecognized arguments: -u`), and CPython parses its own command
+# line in C for the same reason, so it is one command's rule and not
+# part of the shared grammar.
+PROGRAM_OPTIONS: dict[str, tuple[str, ...]] = {
+    "python": ("-c", "-m"),
+    "python3": ("-c", "-m"),
+}
+
+
+def end_options_after_program(name: str, words: list[str]) -> list[str]:
+    """Insert POSIX's ``--`` after a program-carrying option's value.
+
+    The handoff already has a spelling every parser honors, so the rule
+    is applied by writing one down rather than by teaching the parser a
+    new kind of option. The marker is inserted unconditionally, never
+    skipped because the line already carries one: CPython stops parsing
+    at ``-c`` and passes a later ``--`` through as data
+    (``python3 -c p -- -u`` gives the program ``['-c', '--', '-u']``),
+    so the parser must consume exactly the one added here and leave any
+    typed one alone.
+
+    Only the option run before the first operand is scanned. A ``-c``
+    after an operand belongs to the program (``python3 s.py -c x``), and
+    the operand already ended option parsing by itself.
+
+    Args:
+        name (str): the command name as routed.
+        words (list[str]): the command's words, argv[0] excluded.
+    """
+    carriers = PROGRAM_OPTIONS.get(name)
+    if carriers is None:
+        return words
+    # Value spellings say which words carry a value, so `-W ignore -c p`
+    # steps over `ignore` instead of reading it as the first operand.
+    value_spellings = compile_spec(SPECS[name]).value_spellings
+    i = 0
+    while i < len(words):
+        word = words[i]
+        if word == "--":
+            return words
+        carrier = next((c for c in carriers if word.startswith(c)), None)
+        if carrier is not None:
+            # Attached (`-cCODE`) carries its value in this word; the
+            # detached form takes the next one.
+            after = i + 1 if word != carrier else i + 2
+            if after >= len(words):
+                # Nothing to hand over, and a detached form with no value
+                # at all is the parser's refusal to report, not ours to
+                # turn into a program named `--`.
+                return words
+            return words[:after] + ["--"] + words[after:]
+        if word in value_spellings:
+            i += 2
+            continue
+        if word.startswith("-") and word != "-":
+            i += 1
+            continue
+        return words
+    return words
+
 
 # The mirror: flags that make a following command report the link
 # itself. GNU ls dereferences a command-line symlink to a directory, but

--- a/python/mirage/workspace/route/constants.py
+++ b/python/mirage/workspace/route/constants.py
@@ -60,6 +60,44 @@ PROGRAM_OPTIONS: dict[str, tuple[str, ...]] = {
 }
 
 
+def _cluster_handoff(word: str, index: int, carriers: tuple[str, ...],
+                     value_spellings: tuple[str, ...]) -> int | None:
+    """Where a short cluster's program value ends, or None if it has one.
+
+    Args:
+        word (str): the option word, dash included.
+        index (int): the word's position in the command's words.
+        carriers (tuple[str, ...]): the spellings whose value is a
+            program.
+        value_spellings (tuple[str, ...]): every short spelling that
+            takes a value.
+    """
+    for j in range(1, len(word)):
+        letter = f"-{word[j]}"
+        rest = word[j + 1:]
+        if letter in carriers:
+            # Attached (`-cCODE`) carries its value in this word; the
+            # detached form takes the next one.
+            return index + 1 if rest else index + 2
+        if letter in value_spellings:
+            return None
+    return None
+
+
+def _cluster_words(word: str, value_spellings: tuple[str, ...]) -> int:
+    """How many words a short cluster with no program value consumes.
+
+    Args:
+        word (str): the option word, dash included.
+        value_spellings (tuple[str, ...]): every short spelling that
+            takes a value.
+    """
+    for j in range(1, len(word)):
+        if f"-{word[j]}" in value_spellings:
+            return 1 if word[j + 1:] else 2
+    return 1
+
+
 def end_options_after_program(name: str, words: list[str]) -> list[str]:
     """Insert POSIX's ``--`` after a program-carrying option's value.
 
@@ -76,6 +114,11 @@ def end_options_after_program(name: str, words: list[str]) -> list[str]:
     after an operand belongs to the program (``python3 s.py -c x``), and
     the operand already ended option parsing by itself.
 
+    The scan walks a short cluster letter by letter rather than matching
+    the word's prefix, because the carrier need not be first: CPython
+    reads ``python3 -uc 'p' -v`` and ``python3 -uc'p' -v`` the same way
+    it reads the unclustered forms, handing ``-v`` to the program.
+
     Args:
         name (str): the command name as routed.
         words (list[str]): the command's words, argv[0] excluded.
@@ -85,30 +128,31 @@ def end_options_after_program(name: str, words: list[str]) -> list[str]:
         return words
     # Value spellings say which words carry a value, so `-W ignore -c p`
     # steps over `ignore` instead of reading it as the first operand.
-    value_spellings = compile_spec(SPECS[name]).value_spellings
+    cs = compile_spec(SPECS[name])
     i = 0
     while i < len(words):
         word = words[i]
         if word == "--":
             return words
-        carrier = next((c for c in carriers if word.startswith(c)), None)
-        if carrier is not None:
-            # Attached (`-cCODE`) carries its value in this word; the
-            # detached form takes the next one.
-            after = i + 1 if word != carrier else i + 2
-            if after >= len(words):
-                # Nothing to hand over, and a detached form with no value
-                # at all is the parser's refusal to report, not ours to
-                # turn into a program named `--`.
-                return words
-            return words[:after] + ["--"] + words[after:]
-        if word in value_spellings:
-            i += 2
+        if not word.startswith("-") or word == "-":
+            # The first operand, which ended option parsing by itself.
+            return words
+        if word.startswith("--"):
+            long_name = word.split("=", 1)[0]
+            detached = ("=" not in word
+                        and long_name in cs.long_value_spellings)
+            i += 2 if detached else 1
             continue
-        if word.startswith("-") and word != "-":
-            i += 1
+        after = _cluster_handoff(word, i, carriers, cs.value_spellings)
+        if after is None:
+            i += _cluster_words(word, cs.value_spellings)
             continue
-        return words
+        if after >= len(words):
+            # Nothing to hand over, and a detached form with no value at
+            # all is the parser's refusal to report, not ours to turn
+            # into a program named `--`.
+            return words
+        return words[:after] + ["--"] + words[after:]
     return words
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     "jq>=1.11.0",
     "pyjwt[crypto]>=2.13.0",
     "dulwich>=1.2.5",
-    "uuid6>=2025.0.1",
     "tenacity>=9.1.4",
 ]
 

--- a/python/tests/commands/builtin/general/test_interpreter.py
+++ b/python/tests/commands/builtin/general/test_interpreter.py
@@ -14,9 +14,10 @@
 
 import pytest
 
-from mirage.commands.builtin.general.interpreter import (Source,
+from mirage.commands.builtin.general.interpreter import (Argv0Rules, Source,
                                                          resolve_source,
-                                                         run_code, run_output)
+                                                         run_code, run_output,
+                                                         skip_first_line)
 from mirage.runtime.language import LanguageRuntime
 from mirage.runtime.types import RunArgs, RunResult
 from mirage.types import PathSpec
@@ -145,3 +146,34 @@ def test_run_output_empty_stdout_becomes_no_stream():
     assert stdout is None
     assert io.exit_code == 0
     assert io.stderr is None
+
+
+def test_skip_first_line_empties_the_line_rather_than_dropping_it():
+    # CPython keeps the file's numbering under -x, so a raise on
+    # physical line 2 still reports line 2.
+    assert skip_first_line("junk\nprint(1)\n") == "\nprint(1)\n"
+
+
+def test_skip_first_line_on_a_one_line_file_leaves_nothing():
+    assert skip_first_line("junk") == ""
+
+
+@pytest.mark.asyncio
+async def test_skip_line_applies_to_a_script_operand():
+    _, prepared = await resolve_source("python3", [spec("/script.py")], (),
+                                       None, None, fake_dispatch, None, True,
+                                       None, Argv0Rules(), True)
+    assert prepared is not None
+    # The fixture script is a single line, so -x leaves nothing of it.
+    assert prepared.code == ""
+
+
+@pytest.mark.asyncio
+async def test_skip_line_leaves_a_payload_alone():
+    # CPython's -x reads the script file; -c, -m and stdin are
+    # untouched by it.
+    _, prepared = await resolve_source("python3", [], (), "print(1)",
+                                       None, None, None, True, None,
+                                       Argv0Rules(), True)
+    assert prepared is not None
+    assert prepared.code == "print(1)"

--- a/python/tests/commands/builtin/general/test_python.py
+++ b/python/tests/commands/builtin/general/test_python.py
@@ -1,0 +1,185 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+import pytest_asyncio
+
+from mirage import MountMode, RAMResource, Workspace
+from mirage.io.types import materialize
+from mirage.runtime.python import LocalRuntime
+
+
+@pytest_asyncio.fixture
+async def ws():
+    workspace = Workspace({"/": RAMResource()}, mode=MountMode.EXEC)
+    yield workspace
+    await workspace.close()
+
+
+@pytest_asyncio.fixture
+async def ws_cpython():
+    workspace = Workspace({"/": RAMResource()},
+                          mode=MountMode.EXEC,
+                          runtimes=[LocalRuntime()])
+    yield workspace
+    await workspace.close()
+
+
+@pytest.mark.asyncio
+async def test_dash_u_before_a_script_is_a_flag_not_the_script(ws):
+    await ws.execute("printf 'print(42)\\n' > /s.py")
+    io = await ws.execute("python3 -u /s.py")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"42\n"
+
+
+@pytest.mark.asyncio
+async def test_unknown_short_option_exits_2_naming_the_letter(ws):
+    io = await ws.execute("python3 -zz -c 'print(1)'")
+    assert io.exit_code == 2
+    assert b"Unknown option: -z" in (await materialize(io.stderr))
+
+
+@pytest.mark.asyncio
+async def test_unknown_long_option_uses_cpythons_lowercase_shape(ws):
+    io = await ws.execute("python3 --nope")
+    assert io.exit_code == 2
+    assert b"unknown option --nope" in (await materialize(io.stderr))
+
+
+@pytest.mark.asyncio
+async def test_payload_option_without_its_argument_exits_2(ws):
+    io = await ws.execute("python3 -c")
+    assert io.exit_code == 2
+    err = await materialize(io.stderr)
+    assert b"Argument expected for the -c option" in err
+    assert b"usage: python3 [option] ..." in err
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line", ["python3 -V", "python3 -VV"])
+async def test_dash_v_aliases_the_version_tier(ws, line):
+    io = await ws.execute(line)
+    assert io.exit_code == 0
+    assert b"(Mirage)" in (await materialize(io.stdout))
+
+
+@pytest.mark.asyncio
+async def test_dash_h_aliases_the_help_tier(ws):
+    io = await ws.execute("python3 -h")
+    assert io.exit_code == 0
+    assert b"Usage: python3" in (await materialize(io.stdout))
+
+
+@pytest.mark.asyncio
+async def test_words_after_the_script_reach_the_script_verbatim(ws):
+    await ws.execute("printf 'print(argv[1])\\n' > /s.py")
+    io = await ws.execute("python3 /s.py --not-my-flag")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"--not-my-flag\n"
+
+
+@pytest.mark.asyncio
+async def test_argv0_is_the_script_path_as_typed(ws):
+    await ws.execute("printf 'print(argv[0])\\n' > /s.py")
+    io = await ws.execute("python3 /s.py")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"/s.py\n"
+
+
+@pytest.mark.asyncio
+async def test_dash_operand_reads_the_program_from_stdin(ws):
+    io = await ws.execute("echo 'print(7)' | python3 -")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"7\n"
+
+
+@pytest.mark.asyncio
+async def test_argv0_under_dash_c_is_dash_c(ws):
+    io = await ws.execute("python3 -c 'print(argv[0])'")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"-c\n"
+
+
+@pytest.mark.asyncio
+async def test_dash_m_on_a_runtime_without_modules_refuses(ws):
+    io = await ws.execute("python3 -m json.tool")
+    assert io.exit_code == 1
+    err = await materialize(io.stderr)
+    assert b"-m" in err
+    assert b"monty" in err
+
+
+@pytest.mark.asyncio
+async def test_dash_m_runs_a_module_on_a_cpython_runtime(ws_cpython):
+    io = await ws_cpython.execute("python3 -m json.tool --help")
+    assert io.exit_code == 0
+    assert b"json.tool" in (await materialize(io.stdout))
+
+
+@pytest.mark.asyncio
+async def test_dash_m_missing_module_is_one_line_not_a_traceback(ws_cpython):
+    io = await ws_cpython.execute("python3 -m nosuchmod")
+    assert io.exit_code == 1
+    err = await materialize(io.stderr)
+    assert err == b"python3: No module named nosuchmod\n"
+
+
+@pytest.mark.asyncio
+async def test_dash_o_strips_asserts_on_a_cpython_runtime(ws_cpython):
+    io = await ws_cpython.execute(
+        "python3 -O -c 'assert False, \"boom\"; print(\"ok\")'")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"ok\n"
+
+
+@pytest.mark.asyncio
+async def test_init_flag_warns_on_a_runtime_that_cannot_honor_it(ws):
+    io = await ws.execute("python3 -O -c 'print(1)'")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"1\n"
+    err = await materialize(io.stderr)
+    assert b"-O is ignored by the 'monty' runtime" in err
+
+
+@pytest.mark.asyncio
+async def test_ignored_by_design_flags_do_not_warn(ws):
+    io = await ws.execute("python3 -u -q -c 'print(1)'")
+    assert io.exit_code == 0
+    assert not (await materialize(io.stderr))
+
+
+@pytest.mark.asyncio
+async def test_argv0_on_a_cpython_runtime_is_the_script_not_dash_c(ws_cpython):
+    await ws_cpython.execute(
+        "printf 'import sys\\nprint(sys.argv[0])\\n' > /s.py")
+    io = await ws_cpython.execute("python3 /s.py")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"/s.py\n"
+
+
+@pytest.mark.asyncio
+async def test_argv0_on_a_cpython_runtime_under_dash_operand(ws_cpython):
+    io = await ws_cpython.execute(
+        "echo 'import sys; print(sys.argv[0])' | python3 - a")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"-\n"
+
+
+@pytest.mark.asyncio
+async def test_traceback_names_the_script_on_a_cpython_runtime(ws_cpython):
+    await ws_cpython.execute("printf 'raise ValueError(1)\\n' > /boom.py")
+    io = await ws_cpython.execute("python3 /boom.py")
+    assert io.exit_code == 1
+    assert b'File "/boom.py"' in (await materialize(io.stderr))

--- a/python/tests/commands/builtin/general/test_python.py
+++ b/python/tests/commands/builtin/general/test_python.py
@@ -183,3 +183,36 @@ async def test_traceback_names_the_script_on_a_cpython_runtime(ws_cpython):
     io = await ws_cpython.execute("python3 /boom.py")
     assert io.exit_code == 1
     assert b'File "/boom.py"' in (await materialize(io.stderr))
+
+
+@pytest.mark.asyncio
+async def test_a_shadowing_function_receives_the_words_as_typed(ws):
+    # bash's own rule: a function of the same name takes the line. It
+    # has no CPython option table, so the `--` the interpreter's handoff
+    # would need must not be inserted into its arguments.
+    await ws.execute('python3() { echo "$@"; }')
+    io = await ws.execute('python3 -c payload -u x')
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"-c payload -u x\n"
+
+
+@pytest.mark.asyncio
+async def test_command_bypasses_the_function_and_restores_the_handoff(
+        ws_cpython):
+    # `command` masks the function for its inner run, so the interpreter
+    # is what runs and -u belongs to the program again.
+    await ws_cpython.execute('python3() { echo "$@"; }')
+    io = await ws_cpython.execute(
+        'command python3 -c "import sys; print(sys.argv)" -u x')
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"['-c', '-u', 'x']\n"
+
+
+@pytest.mark.asyncio
+async def test_unsetting_the_function_restores_the_handoff(ws_cpython):
+    await ws_cpython.execute('python3() { echo "$@"; }')
+    await ws_cpython.execute('unset -f python3')
+    io = await ws_cpython.execute(
+        'python3 -c "import sys; print(sys.argv)" -u x')
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"['-c', '-u', 'x']\n"

--- a/python/tests/commands/spec/test_parser.py
+++ b/python/tests/commands/spec/test_parser.py
@@ -193,7 +193,7 @@ def test_missing_value_reported_short_and_long():
 
 
 def test_text_rest_keeps_unknown_dash_tokens():
-    parsed = parse_command(SPECS["python"], ["-x", "hello"], "/")
+    parsed = parse_command(SPECS["expr"], ["-x", "hello"], "/")
     assert parsed.texts() == ["-x", "hello"]
     assert parsed.warnings == []
 
@@ -758,3 +758,29 @@ def test_operand_base_survives_the_old_style_cluster():
 def test_word_bases_are_empty_without_an_operand_base():
     parsed = parse_command(SPECS["cat"], ["a.txt"], cwd="/work")
     assert parsed.word_bases == [None]
+
+
+PYTHON_LIKE = CommandSpec(
+    options=(Option(short="-c", type="str",
+                    ends_options=True), Option(short="-u")),
+    rest=Operand(type="str"),
+    stop_at_operand=True,
+)
+
+
+def test_stop_at_operand_rejects_an_unknown_flag_before_the_operand():
+    parsed = parse_command(PYTHON_LIKE, ["-z", "-c", "print(1)"], "/")
+    assert parsed.invalid_options == ["z"]
+
+
+def test_stop_at_operand_keeps_dash_words_after_the_operand_verbatim():
+    parsed = parse_command(PYTHON_LIKE, ["s.py", "--foo", "-z"], "/")
+    assert parsed.texts() == ["s.py", "--foo", "-z"]
+    assert parsed.invalid_options == []
+
+
+def test_stop_at_operand_ends_option_parsing_after_a_payload_value():
+    parsed = parse_command(PYTHON_LIKE, ["-c", "print(1)", "-u", "x"], "/")
+    assert parsed.flags["-c"] == "print(1)"
+    assert parsed.flags.get("-u") is not True
+    assert parsed.texts() == ["-u", "x"]

--- a/python/tests/commands/spec/test_parser.py
+++ b/python/tests/commands/spec/test_parser.py
@@ -761,26 +761,27 @@ def test_word_bases_are_empty_without_an_operand_base():
 
 
 PYTHON_LIKE = CommandSpec(
-    options=(Option(short="-c", type="str",
-                    ends_options=True), Option(short="-u")),
-    rest=Operand(type="str"),
-    stop_at_operand=True,
+    options=(Option(short="-c", type="str"), Option(short="-u")),
+    rest=Operand(type="str", remainder=True),
 )
 
 
-def test_stop_at_operand_rejects_an_unknown_flag_before_the_operand():
+def test_remainder_rejects_an_unknown_flag_before_the_operand():
     parsed = parse_command(PYTHON_LIKE, ["-z", "-c", "print(1)"], "/")
     assert parsed.invalid_options == ["z"]
 
 
-def test_stop_at_operand_keeps_dash_words_after_the_operand_verbatim():
+def test_remainder_keeps_dash_words_after_the_operand_verbatim():
     parsed = parse_command(PYTHON_LIKE, ["s.py", "--foo", "-z"], "/")
     assert parsed.texts() == ["s.py", "--foo", "-z"]
     assert parsed.invalid_options == []
 
 
-def test_stop_at_operand_ends_option_parsing_after_a_payload_value():
-    parsed = parse_command(PYTHON_LIKE, ["-c", "print(1)", "-u", "x"], "/")
+def test_remainder_consumes_the_marker_that_hands_off_the_line():
+    # The router writes the `--`; the parser eats exactly that one, so
+    # the words after it are the program's argv.
+    parsed = parse_command(PYTHON_LIKE, ["-c", "print(1)", "--", "-u", "x"],
+                           "/")
     assert parsed.flags["-c"] == "print(1)"
     assert parsed.flags.get("-u") is not True
     assert parsed.texts() == ["-u", "x"]

--- a/python/tests/runtime/python/test_bootstrap.py
+++ b/python/tests/runtime/python/test_bootstrap.py
@@ -1,0 +1,51 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Any
+
+import pytest
+
+from mirage.runtime.python.bootstrap import bootstrap
+
+
+@pytest.mark.parametrize("prog", [None, "-c"])
+def test_a_payload_passes_through_untouched(prog):
+    assert bootstrap("print(1)", prog) == "print(1)"
+
+
+def test_a_script_sets_argv0_and_compiles_under_its_own_name():
+    out = bootstrap("print(1)", "/s.py")
+    assert "argv[0] = '/s.py'" in out
+    assert "'/s.py', 'exec'" in out
+
+
+@pytest.mark.parametrize("prog", ["", "-"])
+def test_both_stdin_doors_compile_as_stdin(prog):
+    out = bootstrap("print(1)", prog)
+    assert "'<stdin>', 'exec'" in out
+    assert f"argv[0] = {prog!r}" in out
+
+
+def test_the_preamble_binds_no_name_in_the_programs_namespace():
+    ns: dict[str, Any] = {}
+    exec(bootstrap("names = sorted(globals())", "/s.py"), ns)
+    # Read at the program's first statement, so it is what the program
+    # starts with: the preamble imported sys without binding it.
+    assert ns["names"] == ["__builtins__"]
+
+
+def test_a_quote_in_the_program_survives_the_round_trip():
+    ns: dict[str, Any] = {}
+    exec(bootstrap("v = 'it\\'s \"quoted\"'", "/s.py"), ns)
+    assert ns["v"] == "it's \"quoted\""

--- a/python/tests/runtime/python/test_flags.py
+++ b/python/tests/runtime/python/test_flags.py
@@ -69,3 +69,22 @@ def test_the_notice_names_the_runtime_once_per_switch():
 
 def test_the_notice_is_empty_when_the_line_carried_no_switch():
     assert unhonored_notice({}, "pyodide") == b""
+
+
+def test_a_known_x_name_is_reported_by_name():
+    # Populating sys._xoptions is all a warm interpreter can do for
+    # -X dev, whose real effect is read out of the read-only sys.flags.
+    assert unhonored({"X": ["dev"]}, ("X", )) == ["-X dev"]
+
+
+def test_a_known_x_name_with_a_value_is_reported_without_it():
+    assert unhonored({"X": ["tracemalloc=5"]}, ("X", )) == ["-X tracemalloc"]
+
+
+def test_an_arbitrary_x_name_stays_silent():
+    # On CPython it does nothing but land in sys._xoptions either.
+    assert unhonored({"X": ["nosuchopt"]}, ("X", )) == []
+
+
+def test_an_engine_that_acts_on_a_known_x_name_says_nothing():
+    assert unhonored({"X": ["dev"]}, ("X", "X:dev")) == []

--- a/python/tests/runtime/python/test_flags.py
+++ b/python/tests/runtime/python/test_flags.py
@@ -1,0 +1,69 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.runtime.python.flags import (init_argv, unhonored,
+                                         unhonored_notice)
+
+
+def test_an_empty_bag_asks_for_nothing():
+    assert init_argv({}) == []
+
+
+def test_a_bool_switch_goes_back_in_cpythons_own_spelling():
+    assert init_argv({"B": True, "E": False, "P": True}) == ["-B", "-P"]
+
+
+def test_a_count_switch_repeats_because_cpython_counts_occurrences():
+    # CPython reads `-O -O` exactly as `-OO`; the same is true of -b.
+    assert init_argv({"O": 2, "b": 1}) == ["-O", "-O", "-b"]
+
+
+def test_a_list_switch_repeats_the_spelling_per_value():
+    assert init_argv({"W": ["ignore", "error::UserWarning"]}) == [
+        "-W", "ignore", "-W", "error::UserWarning"
+    ]
+
+
+def test_the_long_switch_goes_back_as_two_words():
+    # CPython parses --check-hash-based-pycs by hand and rejects the
+    # --opt=value spelling, so it can only be handed back detached.
+    assert init_argv({"check_hash_based_pycs": "never"}) == [
+        "--check-hash-based-pycs", "never"
+    ]
+
+
+def test_an_engine_that_honors_nothing_reports_every_switch_present():
+    flags = {"B": True, "O": 2, "W": ["ignore"], "check_hash_based_pycs": "never"}
+    assert unhonored(flags) == ["-B", "-O", "-W", "--check-hash-based-pycs"]
+
+
+def test_a_switch_the_engine_honors_is_not_reported():
+    flags = {"B": True, "O": 2, "E": True}
+    assert unhonored(flags, ("B", "O")) == ["-E"]
+
+
+def test_an_absent_switch_is_not_reported():
+    assert unhonored({"B": False, "O": 0, "W": []}) == []
+
+
+def test_the_notice_names_the_runtime_once_per_switch():
+    notice = unhonored_notice({"E": True, "s": True}, "pyodide")
+    assert notice == (b"python3: warning: -E is ignored by the 'pyodide' "
+                      b"runtime\n"
+                      b"python3: warning: -s is ignored by the 'pyodide' "
+                      b"runtime\n")
+
+
+def test_the_notice_is_empty_when_the_line_carried_no_switch():
+    assert unhonored_notice({}, "pyodide") == b""

--- a/python/tests/runtime/python/test_flags.py
+++ b/python/tests/runtime/python/test_flags.py
@@ -12,8 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.runtime.python.flags import (init_argv, unhonored,
-                                         unhonored_notice)
+from mirage.runtime.python.flags import init_argv, unhonored, unhonored_notice
 
 
 def test_an_empty_bag_asks_for_nothing():
@@ -30,21 +29,24 @@ def test_a_count_switch_repeats_because_cpython_counts_occurrences():
 
 
 def test_a_list_switch_repeats_the_spelling_per_value():
-    assert init_argv({"W": ["ignore", "error::UserWarning"]}) == [
-        "-W", "ignore", "-W", "error::UserWarning"
-    ]
+    assert init_argv({"W": ["ignore", "error::UserWarning"]
+                      }) == ["-W", "ignore", "-W", "error::UserWarning"]
 
 
 def test_the_long_switch_goes_back_as_two_words():
     # CPython parses --check-hash-based-pycs by hand and rejects the
     # --opt=value spelling, so it can only be handed back detached.
-    assert init_argv({"check_hash_based_pycs": "never"}) == [
-        "--check-hash-based-pycs", "never"
-    ]
+    assert init_argv({"check_hash_based_pycs":
+                      "never"}) == ["--check-hash-based-pycs", "never"]
 
 
 def test_an_engine_that_honors_nothing_reports_every_switch_present():
-    flags = {"B": True, "O": 2, "W": ["ignore"], "check_hash_based_pycs": "never"}
+    flags = {
+        "B": True,
+        "O": 2,
+        "W": ["ignore"],
+        "check_hash_based_pycs": "never"
+    }
     assert unhonored(flags) == ["-B", "-O", "-W", "--check-hash-based-pycs"]
 
 

--- a/python/tests/utils/test_ids.py
+++ b/python/tests/utils/test_ids.py
@@ -28,12 +28,29 @@ def test_uuid7_is_canonical_and_version_7():
 
 
 def test_uuid7_embeds_current_timestamp():
-    # uuid6 smooths its clock for monotonicity, so allow a little skew.
+    # No skew allowance: the stamp is a clock reading taken between
+    # these two, never a value derived from the previous id.
     before_ms = time.time_ns() // 1_000_000
     parsed = uuid.UUID(uuid7())
     after_ms = time.time_ns() // 1_000_000
     embedded_ms = parsed.int >> 80
-    assert before_ms - 10 <= embedded_ms <= after_ms + 10
+    assert before_ms <= embedded_ms <= after_ms
+
+
+def test_uuid7_timestamp_never_runs_ahead_of_the_clock():
+    # Minting faster than one id per millisecond must not borrow from
+    # the future: these ids are database keys, and a timestamp ahead of
+    # the clock is wrong data that never corrects itself.
+    for _ in range(5000):
+        uuid7()
+    after_ms = time.time_ns() // 1_000_000
+    embedded_ms = uuid.UUID(uuid7()).int >> 80
+    assert embedded_ms <= after_ms
+
+
+def test_uuid7_orders_within_one_millisecond():
+    values = [uuid7() for _ in range(200)]
+    assert values == sorted(values)
 
 
 def test_uuid7_orders_across_milliseconds():

--- a/python/tests/workspace/route/test_program_options.py
+++ b/python/tests/workspace/route/test_program_options.py
@@ -68,3 +68,35 @@ def test_a_payload_with_no_value_is_left_for_the_parser_to_refuse():
 
 def test_nothing_is_added_when_no_words_follow_the_value():
     assert rewrite(["-c", "print(1)"]) == ["-c", "print(1)"]
+
+
+def test_a_clustered_payload_hands_off_from_inside_the_cluster():
+    # `python3 -uc 'p' -v` gives the program ['-c', '-v'] on CPython,
+    # so the carrier is found by walking letters, not by prefix.
+    assert rewrite(["-uc", "p", "-v",
+                    "foo"]) == ["-uc", "p", "--", "-v", "foo"]
+
+
+def test_a_clustered_attached_payload_hands_off_after_its_own_word():
+    assert rewrite(["-ucp", "-v", "foo"]) == ["-ucp", "--", "-v", "foo"]
+
+
+def test_a_clustered_payload_with_no_value_is_left_alone():
+    assert rewrite(["-uc"]) == ["-uc"]
+
+
+def test_a_long_value_option_before_the_payload_is_stepped_over():
+    assert rewrite([
+        "--check-hash-based-pycs", "never", "-c", "p", "-u", "z"
+    ]) == ["--check-hash-based-pycs", "never", "-c", "p", "--", "-u", "z"]
+
+
+def test_an_attached_long_value_option_consumes_only_its_own_word():
+    assert rewrite([
+        "--check-hash-based-pycs=never", "-c", "p", "-u", "z"
+    ]) == ["--check-hash-based-pycs=never", "-c", "p", "--", "-u", "z"]
+
+
+def test_an_attached_short_value_option_consumes_only_its_own_word():
+    assert rewrite(["-Wignore", "-c", "p", "-u",
+                    "z"]) == ["-Wignore", "-c", "p", "--", "-u", "z"]

--- a/python/tests/workspace/route/test_program_options.py
+++ b/python/tests/workspace/route/test_program_options.py
@@ -1,0 +1,70 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.workspace.route import end_options_after_program
+
+
+def rewrite(words: list[str]) -> list[str]:
+    return end_options_after_program("python3", words)
+
+
+def test_a_command_with_no_program_option_is_untouched():
+    words = ["-c", "print(1)", "-u"]
+    assert end_options_after_program("cat", words) == words
+
+
+def test_the_marker_lands_after_the_payload_value():
+    assert rewrite(["-c", "print(1)", "-u",
+                    "x"]) == ["-c", "print(1)", "--", "-u", "x"]
+
+
+def test_the_marker_lands_after_an_attached_payload_value():
+    assert rewrite(["-cprint(1)", "-u"]) == ["-cprint(1)", "--", "-u"]
+
+
+def test_a_value_option_before_the_payload_is_stepped_over():
+    # -W takes a value, so `ignore` is not the first operand.
+    assert rewrite(["-W", "ignore", "-c", "p",
+                    "x"]) == ["-W", "ignore", "-c", "p", "--", "x"]
+
+
+def test_a_typed_marker_survives_because_ours_is_added_anyway():
+    # CPython stops parsing at -c and passes a later `--` through as
+    # data, so the parser must eat ours and leave theirs.
+    assert rewrite(["-c", "p", "--", "-u"]) == ["-c", "p", "--", "--", "-u"]
+
+
+def test_a_payload_option_after_an_operand_belongs_to_the_program():
+    # `python3 s.py -c x` runs s.py; the -c is the script's own.
+    assert rewrite(["s.py", "-c", "x"]) == ["s.py", "-c", "x"]
+
+
+def test_a_marker_before_the_payload_ends_the_scan():
+    assert rewrite(["--", "-c", "x"]) == ["--", "-c", "x"]
+
+
+def test_a_module_option_hands_off_the_same_way():
+    assert rewrite(["-m", "json.tool",
+                    "-h"]) == ["-m", "json.tool", "--", "-h"]
+
+
+def test_a_payload_with_no_value_is_left_for_the_parser_to_refuse():
+    # `python3 -c` must report the missing argument, not run a program
+    # named `--`.
+    assert rewrite(["-c"]) == ["-c"]
+    assert rewrite(["-cprint(1)"]) == ["-cprint(1)"]
+
+
+def test_nothing_is_added_when_no_words_follow_the_value():
+    assert rewrite(["-c", "print(1)"]) == ["-c", "print(1)"]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -4087,7 +4087,6 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-bash" },
     { name = "typer" },
-    { name = "uuid6" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -4348,7 +4347,6 @@ requires-dist = [
     { name = "tree-sitter", specifier = ">=0.25.2" },
     { name = "tree-sitter-bash", specifier = ">=0.25.1" },
     { name = "typer", specifier = ">=0.12.0" },
-    { name = "uuid6", specifier = ">=2025.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
     { name = "wasmtime", marker = "extra == 'quickjs'", specifier = ">=46" },
     { name = "wasmtime", marker = "extra == 'wasi'", specifier = ">=46" },
@@ -10747,15 +10745,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/20/049418d094d396dfa6606b30af925cc68a6670c3b9103b23e6990f84b589/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50fffc2827348c1e48972eed3d1c698959e63f9d030aa5dd82ba451113158a62", size = 476731, upload-time = "2026-02-20T22:50:30.589Z" },
     { url = "https://files.pythonhosted.org/packages/77/a1/0857f64d53a90321e6a46a3d4cc394f50e1366132dcd2ae147f9326ca98b/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dbe718765f70f5b7f9b7f66b6a937802941b1cc56bcf642ce0274169741e01", size = 338902, upload-time = "2026-02-20T22:50:33.927Z" },
     { url = "https://files.pythonhosted.org/packages/ed/d0/5bf7cbf1ac138c92b9ac21066d18faf4d7e7f651047b700eb192ca4b9fdb/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:258186964039a8e36db10810c1ece879d229b01331e09e9030bc5dcabe231bd2", size = 364700, upload-time = "2026-02-20T22:50:21.732Z" },
-]
-
-[[package]]
-name = "uuid6"
-version = "2025.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
 ]
 
 [[package]]

--- a/spec/python/general/python.json
+++ b/spec/python/general/python.json
@@ -14,13 +14,86 @@
     "has_write": false,
     "resources": []
   },
+  "description": "Run Python on the workspace's bound runtime.",
   "options": [
     {
+      "description": "Run the next argument as a program.",
       "short": "-c",
       "type": "str"
+    },
+    {
+      "description": "Run the named module as __main__.",
+      "short": "-m",
+      "type": "str"
+    },
+    {
+      "description": "(Ignored) Unbuffered output. Mirage buffers every stream and returns it whole.",
+      "short": "-u",
+      "type": "bool"
+    },
+    {
+      "description": "Do not write .pyc files on import.",
+      "short": "-B",
+      "type": "bool"
+    },
+    {
+      "description": "Ignore PYTHON* environment variables.",
+      "short": "-E",
+      "type": "bool"
+    },
+    {
+      "description": "Isolated mode: implies -E and -s.",
+      "short": "-I",
+      "type": "bool"
+    },
+    {
+      "count": true,
+      "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
+      "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "(Ignored) Suppress the version banner. Mirage prints none.",
+      "short": "-q",
+      "type": "bool"
+    },
+    {
+      "description": "Do not add the user site directory to sys.path.",
+      "short": "-s",
+      "type": "bool"
+    },
+    {
+      "description": "Do not run 'import site' on initialization.",
+      "short": "-S",
+      "type": "bool"
+    },
+    {
+      "description": "Set a warning control filter.",
+      "multiple": true,
+      "short": "-W",
+      "type": "str"
+    },
+    {
+      "description": "Set an implementation-specific option.",
+      "multiple": true,
+      "short": "-X",
+      "type": "str"
+    },
+    {
+      "description": "Show this help message and exit.",
+      "long": "--help",
+      "short": "-h",
+      "type": "bool"
+    },
+    {
+      "description": "Show version information and exit.",
+      "long": "--version",
+      "short": "-V",
+      "type": "bool"
     }
   ],
   "rest": {
+    "remainder": true,
     "type": "str"
   }
 }

--- a/spec/python/general/python.json
+++ b/spec/python/general/python.json
@@ -32,6 +32,12 @@
       "type": "bool"
     },
     {
+      "count": true,
+      "description": "Warn on str(bytes) and on comparing bytes with str; -bb raises instead.",
+      "short": "-b",
+      "type": "bool"
+    },
+    {
       "description": "Do not write .pyc files on import.",
       "short": "-B",
       "type": "bool"
@@ -50,6 +56,11 @@
       "count": true,
       "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
       "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "Do not prepend the script's directory to sys.path.",
+      "short": "-P",
       "type": "bool"
     },
     {
@@ -74,9 +85,24 @@
       "type": "str"
     },
     {
+      "description": "Skip the script file's first line, for a non-Unix #! form.",
+      "short": "-x",
+      "type": "bool"
+    },
+    {
       "description": "Set an implementation-specific option.",
       "multiple": true,
       "short": "-X",
+      "type": "str"
+    },
+    {
+      "choices": [
+        "always",
+        "default",
+        "never"
+      ],
+      "description": "How to validate hash-based .pyc files.",
+      "long": "--check-hash-based-pycs",
       "type": "str"
     },
     {

--- a/spec/python/general/python3.json
+++ b/spec/python/general/python3.json
@@ -14,13 +14,86 @@
     "has_write": false,
     "resources": []
   },
+  "description": "Run Python on the workspace's bound runtime.",
   "options": [
     {
+      "description": "Run the next argument as a program.",
       "short": "-c",
       "type": "str"
+    },
+    {
+      "description": "Run the named module as __main__.",
+      "short": "-m",
+      "type": "str"
+    },
+    {
+      "description": "(Ignored) Unbuffered output. Mirage buffers every stream and returns it whole.",
+      "short": "-u",
+      "type": "bool"
+    },
+    {
+      "description": "Do not write .pyc files on import.",
+      "short": "-B",
+      "type": "bool"
+    },
+    {
+      "description": "Ignore PYTHON* environment variables.",
+      "short": "-E",
+      "type": "bool"
+    },
+    {
+      "description": "Isolated mode: implies -E and -s.",
+      "short": "-I",
+      "type": "bool"
+    },
+    {
+      "count": true,
+      "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
+      "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "(Ignored) Suppress the version banner. Mirage prints none.",
+      "short": "-q",
+      "type": "bool"
+    },
+    {
+      "description": "Do not add the user site directory to sys.path.",
+      "short": "-s",
+      "type": "bool"
+    },
+    {
+      "description": "Do not run 'import site' on initialization.",
+      "short": "-S",
+      "type": "bool"
+    },
+    {
+      "description": "Set a warning control filter.",
+      "multiple": true,
+      "short": "-W",
+      "type": "str"
+    },
+    {
+      "description": "Set an implementation-specific option.",
+      "multiple": true,
+      "short": "-X",
+      "type": "str"
+    },
+    {
+      "description": "Show this help message and exit.",
+      "long": "--help",
+      "short": "-h",
+      "type": "bool"
+    },
+    {
+      "description": "Show version information and exit.",
+      "long": "--version",
+      "short": "-V",
+      "type": "bool"
     }
   ],
   "rest": {
+    "remainder": true,
     "type": "str"
   }
 }

--- a/spec/python/general/python3.json
+++ b/spec/python/general/python3.json
@@ -32,6 +32,12 @@
       "type": "bool"
     },
     {
+      "count": true,
+      "description": "Warn on str(bytes) and on comparing bytes with str; -bb raises instead.",
+      "short": "-b",
+      "type": "bool"
+    },
+    {
       "description": "Do not write .pyc files on import.",
       "short": "-B",
       "type": "bool"
@@ -50,6 +56,11 @@
       "count": true,
       "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
       "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "Do not prepend the script's directory to sys.path.",
+      "short": "-P",
       "type": "bool"
     },
     {
@@ -74,9 +85,24 @@
       "type": "str"
     },
     {
+      "description": "Skip the script file's first line, for a non-Unix #! form.",
+      "short": "-x",
+      "type": "bool"
+    },
+    {
       "description": "Set an implementation-specific option.",
       "multiple": true,
       "short": "-X",
+      "type": "str"
+    },
+    {
+      "choices": [
+        "always",
+        "default",
+        "never"
+      ],
+      "description": "How to validate hash-based .pyc files.",
+      "long": "--check-hash-based-pycs",
       "type": "str"
     },
     {

--- a/spec/typescript/browser/general/python.json
+++ b/spec/typescript/browser/general/python.json
@@ -14,13 +14,86 @@
     "has_write": false,
     "resources": []
   },
+  "description": "Run Python on the workspace's bound runtime.",
   "options": [
     {
+      "description": "Run the next argument as a program.",
       "short": "-c",
       "type": "str"
+    },
+    {
+      "description": "Run the named module as __main__.",
+      "short": "-m",
+      "type": "str"
+    },
+    {
+      "description": "(Ignored) Unbuffered output. Mirage buffers every stream and returns it whole.",
+      "short": "-u",
+      "type": "bool"
+    },
+    {
+      "description": "Do not write .pyc files on import.",
+      "short": "-B",
+      "type": "bool"
+    },
+    {
+      "description": "Ignore PYTHON* environment variables.",
+      "short": "-E",
+      "type": "bool"
+    },
+    {
+      "description": "Isolated mode: implies -E and -s.",
+      "short": "-I",
+      "type": "bool"
+    },
+    {
+      "count": true,
+      "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
+      "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "(Ignored) Suppress the version banner. Mirage prints none.",
+      "short": "-q",
+      "type": "bool"
+    },
+    {
+      "description": "Do not add the user site directory to sys.path.",
+      "short": "-s",
+      "type": "bool"
+    },
+    {
+      "description": "Do not run 'import site' on initialization.",
+      "short": "-S",
+      "type": "bool"
+    },
+    {
+      "description": "Set a warning control filter.",
+      "multiple": true,
+      "short": "-W",
+      "type": "str"
+    },
+    {
+      "description": "Set an implementation-specific option.",
+      "multiple": true,
+      "short": "-X",
+      "type": "str"
+    },
+    {
+      "description": "Show this help message and exit.",
+      "long": "--help",
+      "short": "-h",
+      "type": "bool"
+    },
+    {
+      "description": "Show version information and exit.",
+      "long": "--version",
+      "short": "-V",
+      "type": "bool"
     }
   ],
   "rest": {
+    "remainder": true,
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/python.json
+++ b/spec/typescript/browser/general/python.json
@@ -32,6 +32,12 @@
       "type": "bool"
     },
     {
+      "count": true,
+      "description": "Warn on str(bytes) and on comparing bytes with str; -bb raises instead.",
+      "short": "-b",
+      "type": "bool"
+    },
+    {
       "description": "Do not write .pyc files on import.",
       "short": "-B",
       "type": "bool"
@@ -50,6 +56,11 @@
       "count": true,
       "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
       "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "Do not prepend the script's directory to sys.path.",
+      "short": "-P",
       "type": "bool"
     },
     {
@@ -74,9 +85,24 @@
       "type": "str"
     },
     {
+      "description": "Skip the script file's first line, for a non-Unix #! form.",
+      "short": "-x",
+      "type": "bool"
+    },
+    {
       "description": "Set an implementation-specific option.",
       "multiple": true,
       "short": "-X",
+      "type": "str"
+    },
+    {
+      "choices": [
+        "always",
+        "default",
+        "never"
+      ],
+      "description": "How to validate hash-based .pyc files.",
+      "long": "--check-hash-based-pycs",
       "type": "str"
     },
     {

--- a/spec/typescript/browser/general/python3.json
+++ b/spec/typescript/browser/general/python3.json
@@ -14,13 +14,86 @@
     "has_write": false,
     "resources": []
   },
+  "description": "Run Python on the workspace's bound runtime.",
   "options": [
     {
+      "description": "Run the next argument as a program.",
       "short": "-c",
       "type": "str"
+    },
+    {
+      "description": "Run the named module as __main__.",
+      "short": "-m",
+      "type": "str"
+    },
+    {
+      "description": "(Ignored) Unbuffered output. Mirage buffers every stream and returns it whole.",
+      "short": "-u",
+      "type": "bool"
+    },
+    {
+      "description": "Do not write .pyc files on import.",
+      "short": "-B",
+      "type": "bool"
+    },
+    {
+      "description": "Ignore PYTHON* environment variables.",
+      "short": "-E",
+      "type": "bool"
+    },
+    {
+      "description": "Isolated mode: implies -E and -s.",
+      "short": "-I",
+      "type": "bool"
+    },
+    {
+      "count": true,
+      "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
+      "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "(Ignored) Suppress the version banner. Mirage prints none.",
+      "short": "-q",
+      "type": "bool"
+    },
+    {
+      "description": "Do not add the user site directory to sys.path.",
+      "short": "-s",
+      "type": "bool"
+    },
+    {
+      "description": "Do not run 'import site' on initialization.",
+      "short": "-S",
+      "type": "bool"
+    },
+    {
+      "description": "Set a warning control filter.",
+      "multiple": true,
+      "short": "-W",
+      "type": "str"
+    },
+    {
+      "description": "Set an implementation-specific option.",
+      "multiple": true,
+      "short": "-X",
+      "type": "str"
+    },
+    {
+      "description": "Show this help message and exit.",
+      "long": "--help",
+      "short": "-h",
+      "type": "bool"
+    },
+    {
+      "description": "Show version information and exit.",
+      "long": "--version",
+      "short": "-V",
+      "type": "bool"
     }
   ],
   "rest": {
+    "remainder": true,
     "type": "str"
   }
 }

--- a/spec/typescript/browser/general/python3.json
+++ b/spec/typescript/browser/general/python3.json
@@ -32,6 +32,12 @@
       "type": "bool"
     },
     {
+      "count": true,
+      "description": "Warn on str(bytes) and on comparing bytes with str; -bb raises instead.",
+      "short": "-b",
+      "type": "bool"
+    },
+    {
       "description": "Do not write .pyc files on import.",
       "short": "-B",
       "type": "bool"
@@ -50,6 +56,11 @@
       "count": true,
       "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
       "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "Do not prepend the script's directory to sys.path.",
+      "short": "-P",
       "type": "bool"
     },
     {
@@ -74,9 +85,24 @@
       "type": "str"
     },
     {
+      "description": "Skip the script file's first line, for a non-Unix #! form.",
+      "short": "-x",
+      "type": "bool"
+    },
+    {
       "description": "Set an implementation-specific option.",
       "multiple": true,
       "short": "-X",
+      "type": "str"
+    },
+    {
+      "choices": [
+        "always",
+        "default",
+        "never"
+      ],
+      "description": "How to validate hash-based .pyc files.",
+      "long": "--check-hash-based-pycs",
       "type": "str"
     },
     {

--- a/spec/typescript/node/general/python.json
+++ b/spec/typescript/node/general/python.json
@@ -14,13 +14,86 @@
     "has_write": false,
     "resources": []
   },
+  "description": "Run Python on the workspace's bound runtime.",
   "options": [
     {
+      "description": "Run the next argument as a program.",
       "short": "-c",
       "type": "str"
+    },
+    {
+      "description": "Run the named module as __main__.",
+      "short": "-m",
+      "type": "str"
+    },
+    {
+      "description": "(Ignored) Unbuffered output. Mirage buffers every stream and returns it whole.",
+      "short": "-u",
+      "type": "bool"
+    },
+    {
+      "description": "Do not write .pyc files on import.",
+      "short": "-B",
+      "type": "bool"
+    },
+    {
+      "description": "Ignore PYTHON* environment variables.",
+      "short": "-E",
+      "type": "bool"
+    },
+    {
+      "description": "Isolated mode: implies -E and -s.",
+      "short": "-I",
+      "type": "bool"
+    },
+    {
+      "count": true,
+      "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
+      "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "(Ignored) Suppress the version banner. Mirage prints none.",
+      "short": "-q",
+      "type": "bool"
+    },
+    {
+      "description": "Do not add the user site directory to sys.path.",
+      "short": "-s",
+      "type": "bool"
+    },
+    {
+      "description": "Do not run 'import site' on initialization.",
+      "short": "-S",
+      "type": "bool"
+    },
+    {
+      "description": "Set a warning control filter.",
+      "multiple": true,
+      "short": "-W",
+      "type": "str"
+    },
+    {
+      "description": "Set an implementation-specific option.",
+      "multiple": true,
+      "short": "-X",
+      "type": "str"
+    },
+    {
+      "description": "Show this help message and exit.",
+      "long": "--help",
+      "short": "-h",
+      "type": "bool"
+    },
+    {
+      "description": "Show version information and exit.",
+      "long": "--version",
+      "short": "-V",
+      "type": "bool"
     }
   ],
   "rest": {
+    "remainder": true,
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/python.json
+++ b/spec/typescript/node/general/python.json
@@ -32,6 +32,12 @@
       "type": "bool"
     },
     {
+      "count": true,
+      "description": "Warn on str(bytes) and on comparing bytes with str; -bb raises instead.",
+      "short": "-b",
+      "type": "bool"
+    },
+    {
       "description": "Do not write .pyc files on import.",
       "short": "-B",
       "type": "bool"
@@ -50,6 +56,11 @@
       "count": true,
       "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
       "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "Do not prepend the script's directory to sys.path.",
+      "short": "-P",
       "type": "bool"
     },
     {
@@ -74,9 +85,24 @@
       "type": "str"
     },
     {
+      "description": "Skip the script file's first line, for a non-Unix #! form.",
+      "short": "-x",
+      "type": "bool"
+    },
+    {
       "description": "Set an implementation-specific option.",
       "multiple": true,
       "short": "-X",
+      "type": "str"
+    },
+    {
+      "choices": [
+        "always",
+        "default",
+        "never"
+      ],
+      "description": "How to validate hash-based .pyc files.",
+      "long": "--check-hash-based-pycs",
       "type": "str"
     },
     {

--- a/spec/typescript/node/general/python3.json
+++ b/spec/typescript/node/general/python3.json
@@ -14,13 +14,86 @@
     "has_write": false,
     "resources": []
   },
+  "description": "Run Python on the workspace's bound runtime.",
   "options": [
     {
+      "description": "Run the next argument as a program.",
       "short": "-c",
       "type": "str"
+    },
+    {
+      "description": "Run the named module as __main__.",
+      "short": "-m",
+      "type": "str"
+    },
+    {
+      "description": "(Ignored) Unbuffered output. Mirage buffers every stream and returns it whole.",
+      "short": "-u",
+      "type": "bool"
+    },
+    {
+      "description": "Do not write .pyc files on import.",
+      "short": "-B",
+      "type": "bool"
+    },
+    {
+      "description": "Ignore PYTHON* environment variables.",
+      "short": "-E",
+      "type": "bool"
+    },
+    {
+      "description": "Isolated mode: implies -E and -s.",
+      "short": "-I",
+      "type": "bool"
+    },
+    {
+      "count": true,
+      "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
+      "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "(Ignored) Suppress the version banner. Mirage prints none.",
+      "short": "-q",
+      "type": "bool"
+    },
+    {
+      "description": "Do not add the user site directory to sys.path.",
+      "short": "-s",
+      "type": "bool"
+    },
+    {
+      "description": "Do not run 'import site' on initialization.",
+      "short": "-S",
+      "type": "bool"
+    },
+    {
+      "description": "Set a warning control filter.",
+      "multiple": true,
+      "short": "-W",
+      "type": "str"
+    },
+    {
+      "description": "Set an implementation-specific option.",
+      "multiple": true,
+      "short": "-X",
+      "type": "str"
+    },
+    {
+      "description": "Show this help message and exit.",
+      "long": "--help",
+      "short": "-h",
+      "type": "bool"
+    },
+    {
+      "description": "Show version information and exit.",
+      "long": "--version",
+      "short": "-V",
+      "type": "bool"
     }
   ],
   "rest": {
+    "remainder": true,
     "type": "str"
   }
 }

--- a/spec/typescript/node/general/python3.json
+++ b/spec/typescript/node/general/python3.json
@@ -32,6 +32,12 @@
       "type": "bool"
     },
     {
+      "count": true,
+      "description": "Warn on str(bytes) and on comparing bytes with str; -bb raises instead.",
+      "short": "-b",
+      "type": "bool"
+    },
+    {
       "description": "Do not write .pyc files on import.",
       "short": "-B",
       "type": "bool"
@@ -50,6 +56,11 @@
       "count": true,
       "description": "Remove assert and __debug__ blocks; -OO also strips docstrings.",
       "short": "-O",
+      "type": "bool"
+    },
+    {
+      "description": "Do not prepend the script's directory to sys.path.",
+      "short": "-P",
       "type": "bool"
     },
     {
@@ -74,9 +85,24 @@
       "type": "str"
     },
     {
+      "description": "Skip the script file's first line, for a non-Unix #! form.",
+      "short": "-x",
+      "type": "bool"
+    },
+    {
       "description": "Set an implementation-specific option.",
       "multiple": true,
       "short": "-X",
+      "type": "str"
+    },
+    {
+      "choices": [
+        "always",
+        "default",
+        "never"
+      ],
+      "description": "How to validate hash-based .pyc files.",
+      "long": "--check-hash-based-pycs",
       "type": "str"
     },
     {

--- a/typescript/packages/core/src/commands/builtin/general/interpreter.ts
+++ b/typescript/packages/core/src/commands/builtin/general/interpreter.ts
@@ -44,6 +44,22 @@ export const STDIN_ARGV0 = '-'
 export const STDIN_OPERAND = '-'
 
 /**
+ * Drop a script's first line the way CPython's `-x` does.
+ *
+ * The first line is emptied rather than removed, because CPython keeps
+ * the line numbering of the whole file: a raise on physical line 2
+ * still reports line 2 under `-x` (pinned on 3.12.11). A file with no
+ * newline at all is one line, so `-x` leaves nothing.
+ *
+ * Args:
+ *   code: the script's text as read.
+ */
+export function skipFirstLine(code: string): string {
+  const at = code.indexOf('\n')
+  return at === -1 ? '' : code.slice(at)
+}
+
+/**
  * The program that `-m mod` runs, on any engine that is real CPython.
  *
  * runpy does the work: run_module finds the module, runs it under

--- a/typescript/packages/core/src/commands/builtin/general/interpreter.ts
+++ b/typescript/packages/core/src/commands/builtin/general/interpreter.ts
@@ -30,3 +30,56 @@ export function runOutput(result: RunResult): [Uint8Array | null, IOResult] {
     new IOResult({ exitCode: result.exitCode, stderr: result.stderr }),
   ]
 }
+
+// Which of an interpreter's four doors the source came through. The
+// mode is what decides argv[0], so the two travel together: CPython
+// spells it '-c' for a payload, the module's file for -m, the file as
+// typed for a script, '-' for the explicit stdin operand, and '' for
+// stdin with no operand at all. Pinned on CPython 3.12.13.
+export type SourceMode = 'payload' | 'module' | 'file' | 'stdin'
+
+// argv[0] for the two modes that do not read it off the command line.
+export const PAYLOAD_ARGV0 = '-c'
+export const STDIN_ARGV0 = '-'
+export const STDIN_OPERAND = '-'
+
+/**
+ * The program that `-m mod` runs, on any engine that is real CPython.
+ *
+ * runpy does the work: run_module finds the module, runs it under
+ * __main__, and alter_sys rewrites sys.argv[0] to the module's own
+ * file, which is what CPython puts there. Engines that are not CPython
+ * declare runsModules false and never see this.
+ *
+ * The existence probe is not redundant with run_module: CPython answers
+ * a missing module with one line and exit 1, while bare run_module
+ * raises, which would reach the user as a runpy traceback. Probing
+ * first also keeps an ImportError raised INSIDE the module distinct
+ * from the module itself being absent, which a try around run_module
+ * could not tell apart.
+ *
+ * Args:
+ *   name: the module to run.
+ *   label: the command name used in the not-found message.
+ */
+export function moduleSource(name: string, label: string): string {
+  const mod = JSON.stringify(name)
+  const lbl = JSON.stringify(label)
+  return [
+    'import importlib.util, runpy, sys',
+    `_name = ${mod}`,
+    `_label = ${lbl}`,
+    'try:',
+    '    _found = importlib.util.find_spec(_name) is not None',
+    // find_spec raises rather than returning None when an ancestor of a
+    // dotted name is missing or is not a package; either way the module
+    // cannot be found, and the message below reports it.
+    'except (ImportError, TypeError, ValueError):',
+    '    _found = False',
+    'if not _found:',
+    "    sys.stderr.write(_label + ': No module named ' + _name + chr(10))",
+    '    raise SystemExit(1)',
+    "runpy.run_module(_name, run_name='__main__', alter_sys=True)",
+    '',
+  ].join('\n')
+}

--- a/typescript/packages/core/src/commands/builtin/general/python.ts
+++ b/typescript/packages/core/src/commands/builtin/general/python.ts
@@ -34,20 +34,26 @@ const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
 
 // Keyed by CPython's own letter, which is how runtime/python/flags reads
-// them; -u and -q are absent because mirage buffers every stream and
-// prints no banner, so no engine can differ on them.
+// them; the one long switch is keyed by its canonical spelling, having
+// no letter. -u and -q are absent because mirage buffers every stream
+// and prints no banner, so no engine can differ on them, and -x is
+// absent because it selects source rather than configuring an
+// interpreter, so handlePython answers it.
 function initFlags(fl: FlagView): InitFlags {
   return {
+    b: fl.asInt('b') ?? 0,
     B: fl.asBool('B'),
     E: fl.asBool('E'),
     // -I and -O canonicalize to args_I/args_O (AMBIGUOUS_NAMES), so the
     // spec-checked FlagView refuses the bare letters.
     I: fl.asBool('args_I'),
+    P: fl.asBool('P'),
     s: fl.asBool('s'),
     S: fl.asBool('S'),
     O: fl.asInt('args_O') ?? 0,
     W: fl.asList('W'),
     X: fl.asList('X'),
+    check_hash_based_pycs: fl.asStr('check_hash_based_pycs') ?? null,
   }
 }
 
@@ -151,6 +157,7 @@ async function pythonCommand(
       code: resolvedCode,
       prog: argv0,
       mode,
+      skipFirstLine: fl.asBool('x'),
       initFlags: initFlags(fl),
       ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
       ...(opts.timeoutSeconds !== undefined ? { timeoutSeconds: opts.timeoutSeconds } : {}),

--- a/typescript/packages/core/src/commands/builtin/general/python.ts
+++ b/typescript/packages/core/src/commands/builtin/general/python.ts
@@ -21,9 +21,35 @@ import { LanguageRuntime } from '../../../runtime/language.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { resolveScript } from '../utils/operands.ts'
 import { FlagView } from '../../spec/types.ts'
+import {
+  moduleSource,
+  PAYLOAD_ARGV0,
+  STDIN_ARGV0,
+  STDIN_OPERAND,
+  type SourceMode,
+} from './interpreter.ts'
+import type { InitFlags } from '../../../runtime/python/flags.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
+
+// Keyed by CPython's own letter, which is how runtime/python/flags reads
+// them; -u and -q are absent because mirage buffers every stream and
+// prints no banner, so no engine can differ on them.
+function initFlags(fl: FlagView): InitFlags {
+  return {
+    B: fl.asBool('B'),
+    E: fl.asBool('E'),
+    // -I and -O canonicalize to args_I/args_O (AMBIGUOUS_NAMES), so the
+    // spec-checked FlagView refuses the bare letters.
+    I: fl.asBool('args_I'),
+    s: fl.asBool('s'),
+    S: fl.asBool('S'),
+    O: fl.asInt('args_O') ?? 0,
+    W: fl.asList('W'),
+    X: fl.asList('X'),
+  }
+}
 
 async function pythonCommand(
   _accessor: Accessor,
@@ -63,22 +89,49 @@ async function pythonCommand(
 
   const fl = new FlagView(opts.flags, specOf('python3'))
   const code = fl.asStr('c') ?? null
+  const moduleName = fl.asStr('m') ?? null
   const hasCode = code !== null
   let scriptPath: PathSpec | null = null
   let argStrs: string[]
-  if (hasCode) {
+  // Which door the source came through decides argv[0], so the two are
+  // computed together. CPython spells it '-c' for a payload, the file as
+  // typed for a script, '-' for the explicit stdin operand, and '' for
+  // stdin with no operand at all; under -m runpy's alter_sys overwrites
+  // it with the module's own file.
+  let mode: SourceMode = 'payload'
+  let argv0 = PAYLOAD_ARGV0
+  if (moduleName !== null) {
+    argStrs = [...paths.map((p) => p.virtual), ...texts]
+    mode = 'module'
+    argv0 = moduleName
+  } else if (hasCode) {
     argStrs = [...paths.map((p) => p.virtual), ...texts]
   } else if (paths.length > 0) {
     scriptPath = paths[0] ?? null
     argStrs = [...paths.slice(1).map((p) => p.virtual), ...texts]
+    mode = 'file'
+    argv0 = paths[0]?.rawPath ?? ''
+  } else if (texts[0] === STDIN_OPERAND) {
+    // The explicit stdin spelling. It is an operand, not a flag, so the
+    // words after it are the program's argv exactly as a script's would
+    // be.
+    argStrs = texts.slice(1)
+    mode = 'stdin'
+    argv0 = STDIN_ARGV0
   } else if (texts.length > 0) {
     scriptPath = resolveScript(texts[0] ?? '', opts.cwd)
     argStrs = texts.slice(1)
+    mode = 'file'
+    // As typed, which is what CPython puts in argv[0]; the resolved
+    // spelling is scriptPath's job.
+    argv0 = texts[0] ?? ''
   } else {
     argStrs = []
+    mode = 'stdin'
+    argv0 = ''
   }
 
-  let resolvedCode: string | null = code
+  let resolvedCode: string | null = moduleName !== null ? moduleSource(moduleName, 'python3') : code
   let stdinForRuntime = opts.stdin
   if (resolvedCode === null && scriptPath === null && opts.stdin !== null) {
     const bytes = await materialize(opts.stdin)
@@ -96,6 +149,9 @@ async function pythonCommand(
       stdin: stdinForRuntime,
       env: opts.env ?? {},
       code: resolvedCode,
+      prog: argv0,
+      mode,
+      initFlags: initFlags(fl),
       ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
       ...(opts.timeoutSeconds !== undefined ? { timeoutSeconds: opts.timeoutSeconds } : {}),
     },

--- a/typescript/packages/core/src/commands/spec/builtin_specs/runtime.ts
+++ b/typescript/packages/core/src/commands/spec/builtin_specs/runtime.ts
@@ -25,13 +25,13 @@ const PYTHON_OPTIONS: readonly Option[] = [
   new Option({
     short: '-c',
     type: 'str',
-    endsOptions: true,
+
     description: 'Run the next argument as a program.',
   }),
   new Option({
     short: '-m',
     type: 'str',
-    endsOptions: true,
+
     description: 'Run the named module as __main__.',
   }),
   new Option({
@@ -205,14 +205,12 @@ export const SPECS: Record<string, CommandSpec> = {
   python: new CommandSpec({
     description: "Run Python on the workspace's bound runtime.",
     options: PYTHON_OPTIONS,
-    rest: new Operand({ type: 'str' }),
-    stopAtOperand: true,
+    rest: new Operand({ type: 'str', remainder: true }),
   }),
   python3: new CommandSpec({
     description: "Run Python on the workspace's bound runtime.",
     options: PYTHON_OPTIONS,
-    rest: new Operand({ type: 'str' }),
-    stopAtOperand: true,
+    rest: new Operand({ type: 'str', remainder: true }),
   }),
   sleep: new CommandSpec({
     description: 'Delay for a specified amount of time.',

--- a/typescript/packages/core/src/commands/spec/builtin_specs/runtime.ts
+++ b/typescript/packages/core/src/commands/spec/builtin_specs/runtime.ts
@@ -14,6 +14,69 @@
 
 import { CommandSpec, Operand, Option } from '../types.ts'
 
+// CPython's own option table, minus the interactive-only switches. The
+// three groups differ in who answers them: -c/-m select the source and
+// end option parsing (their argument is a program, so trailing words are
+// that program's argv); the init switches are handed to the runtime
+// through RunArgs.flags and honored by whichever engine can; -u is a
+// structural no-op, since mirage buffers every stream and returns it
+// whole. Pinned against CPython 3.12.13.
+const PYTHON_OPTIONS: readonly Option[] = [
+  new Option({
+    short: '-c',
+    type: 'str',
+    endsOptions: true,
+    description: 'Run the next argument as a program.',
+  }),
+  new Option({
+    short: '-m',
+    type: 'str',
+    endsOptions: true,
+    description: 'Run the named module as __main__.',
+  }),
+  new Option({
+    short: '-u',
+    description: '(Ignored) Unbuffered output. Mirage buffers every stream and returns it whole.',
+  }),
+  new Option({ short: '-B', description: 'Do not write .pyc files on import.' }),
+  new Option({ short: '-E', description: 'Ignore PYTHON* environment variables.' }),
+  new Option({ short: '-I', description: 'Isolated mode: implies -E and -s.' }),
+  new Option({
+    short: '-O',
+    count: true,
+    description: 'Remove assert and __debug__ blocks; -OO also strips docstrings.',
+  }),
+  new Option({
+    short: '-q',
+    description: '(Ignored) Suppress the version banner. Mirage prints none.',
+  }),
+  new Option({ short: '-s', description: 'Do not add the user site directory to sys.path.' }),
+  new Option({ short: '-S', description: "Do not run 'import site' on initialization." }),
+  new Option({
+    short: '-W',
+    type: 'str',
+    multiple: true,
+    description: 'Set a warning control filter.',
+  }),
+  new Option({
+    short: '-X',
+    type: 'str',
+    multiple: true,
+    description: 'Set an implementation-specific option.',
+  }),
+  // Aliases of the injected help/version options, not new behavior:
+  // sharing their long spelling means they share their dest, so the
+  // help/version tier short-circuits them on the one path every command
+  // uses. CPython's -VV adds build info; mirage has no CPython build to
+  // report, so -VV clusters into -V and prints the same line.
+  new Option({ short: '-h', long: '--help', description: 'Show this help message and exit.' }),
+  new Option({
+    short: '-V',
+    long: '--version',
+    description: 'Show version information and exit.',
+  }),
+]
+
 export const SPECS: Record<string, CommandSpec> = {
   bash: new CommandSpec({
     description:
@@ -140,12 +203,16 @@ export const SPECS: Record<string, CommandSpec> = {
     rest: new Operand({ type: 'str' }),
   }),
   python: new CommandSpec({
-    options: [new Option({ short: '-c', type: 'str' })],
+    description: "Run Python on the workspace's bound runtime.",
+    options: PYTHON_OPTIONS,
     rest: new Operand({ type: 'str' }),
+    stopAtOperand: true,
   }),
   python3: new CommandSpec({
-    options: [new Option({ short: '-c', type: 'str' })],
+    description: "Run Python on the workspace's bound runtime.",
+    options: PYTHON_OPTIONS,
     rest: new Operand({ type: 'str' }),
+    stopAtOperand: true,
   }),
   sleep: new CommandSpec({
     description: 'Delay for a specified amount of time.',

--- a/typescript/packages/core/src/commands/spec/builtin_specs/runtime.ts
+++ b/typescript/packages/core/src/commands/spec/builtin_specs/runtime.ts
@@ -14,13 +14,22 @@
 
 import { CommandSpec, Operand, Option } from '../types.ts'
 
-// CPython's own option table, minus the interactive-only switches. The
-// three groups differ in who answers them: -c/-m select the source and
-// end option parsing (their argument is a program, so trailing words are
-// that program's argv); the init switches are handed to the runtime
-// through RunArgs.flags and honored by whichever engine can; -u is a
-// structural no-op, since mirage buffers every stream and returns it
-// whole. Pinned against CPython 3.12.13.
+// CPython's own option table, minus four switches that describe a
+// process mirage does not have: -i (drop to an interactive prompt), -d
+// (parser debug, a debug-build-only switch), -v (trace every import to
+// stderr) and the --help-env/--help-xoptions/--help-all dumps, which
+// document a CPython build rather than this command. Everything else
+// CPython accepts, this accepts.
+//
+// The four groups differ in who answers them: -c/-m select the source
+// and end option parsing (their argument is a program, so trailing
+// words are that program's argv); -x also selects source, by dropping
+// the script file's first line, and is answered here rather than by a
+// runtime because every engine reads the same resolved text; the init
+// switches are handed to the runtime through RunArgs.flags and honored
+// by whichever engine can; -u is a structural no-op, since mirage
+// buffers every stream and returns it whole. Pinned against CPython
+// 3.12.11.
 const PYTHON_OPTIONS: readonly Option[] = [
   new Option({
     short: '-c',
@@ -38,6 +47,11 @@ const PYTHON_OPTIONS: readonly Option[] = [
     short: '-u',
     description: '(Ignored) Unbuffered output. Mirage buffers every stream and returns it whole.',
   }),
+  new Option({
+    short: '-b',
+    count: true,
+    description: 'Warn on str(bytes) and on comparing bytes with str; -bb raises instead.',
+  }),
   new Option({ short: '-B', description: 'Do not write .pyc files on import.' }),
   new Option({ short: '-E', description: 'Ignore PYTHON* environment variables.' }),
   new Option({ short: '-I', description: 'Isolated mode: implies -E and -s.' }),
@@ -45,6 +59,10 @@ const PYTHON_OPTIONS: readonly Option[] = [
     short: '-O',
     count: true,
     description: 'Remove assert and __debug__ blocks; -OO also strips docstrings.',
+  }),
+  new Option({
+    short: '-P',
+    description: "Do not prepend the script's directory to sys.path.",
   }),
   new Option({
     short: '-q',
@@ -59,10 +77,23 @@ const PYTHON_OPTIONS: readonly Option[] = [
     description: 'Set a warning control filter.',
   }),
   new Option({
+    short: '-x',
+    description: "Skip the script file's first line, for a non-Unix #! form.",
+  }),
+  new Option({
     short: '-X',
     type: 'str',
     multiple: true,
     description: 'Set an implementation-specific option.',
+  }),
+  // CPython parses this one by hand and so rejects the --opt=value
+  // spelling it accepts everywhere else; mirage's parser takes both,
+  // which is the harmless direction to diverge in.
+  new Option({
+    long: '--check-hash-based-pycs',
+    type: 'str',
+    choices: ['always', 'default', 'never'],
+    description: 'How to validate hash-based .pyc files.',
   }),
   // Aliases of the injected help/version options, not new behavior:
   // sharing their long spelling means they share their dest, so the

--- a/typescript/packages/core/src/commands/spec/compile.ts
+++ b/typescript/packages/core/src/commands/spec/compile.ts
@@ -86,10 +86,9 @@ export class CompiledSpec {
   readonly numericDest: string | null
   /** Kind of the rest operand. */
   readonly restKind: ValueType | null
-  // python3's rule, carried through from CommandSpec.stopAtOperand.
-  readonly stopAtOperand: boolean
-  // Spellings whose value ends option parsing (Option.endsOptions).
-  readonly endsOptionsSpellings: ReadonlySet<string>
+  // The rest operand gathers every word from the first operand on,
+  // options included (Operand.remainder, argparse nargs=REMAINDER).
+  readonly remainder: boolean
   // Canonical spelling of the option that re-bases the path operands
   // after it (CommandSpec.operandBase, tar's -C).
   readonly baseDest: string | null
@@ -118,8 +117,7 @@ export class CompiledSpec {
     numericDest: string | null
     restKind: ValueType | null
     baseDest: string | null
-    stopAtOperand: boolean
-    endsOptionsSpellings: ReadonlySet<string>
+    remainder: boolean
   }) {
     this.boolSpellings = fields.boolSpellings
     this.valueSpellings = fields.valueSpellings
@@ -144,8 +142,7 @@ export class CompiledSpec {
     this.numericDest = fields.numericDest
     this.restKind = fields.restKind
     this.baseDest = fields.baseDest
-    this.stopAtOperand = fields.stopAtOperand
-    this.endsOptionsSpellings = fields.endsOptionsSpellings
+    this.remainder = fields.remainder
   }
 
   /** Canonical spelling for a typed spelling. */
@@ -163,7 +160,6 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
 
   const boolSpellings = new Set<string>()
   const valueSpellings: string[] = []
-  const endsOptionsSpellings = new Set<string>()
   const attachSpellings: string[] = []
   const longBoolSpellings = new Set<string>()
   const longValueSpellings = new Set<string>()
@@ -197,17 +193,6 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     }
     if (opt.pair && opt.valueOptional) {
       throw new Error(`option '${canonical}': pair and valueOptional are mutually exclusive`)
-    }
-    if (opt.endsOptions) {
-      if (opt.type === 'bool') {
-        throw new Error(
-          `option '${canonical}': endsOptions requires a value flag ` +
-            `(it ends parsing after the value it carries)`,
-        )
-      }
-      for (const spelling of [opt.short, opt.long]) {
-        if (spelling !== null) endsOptionsSpellings.add(spelling)
-      }
     }
     if (opt.pair && opt.short !== null) {
       // A short spelling clusters and takes an attached value, both of
@@ -331,8 +316,7 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     numericDest,
     restKind: spec.rest !== null ? spec.rest.type : null,
     baseDest,
-    stopAtOperand: spec.stopAtOperand,
-    endsOptionsSpellings,
+    remainder: spec.rest?.remainder ?? false,
   })
   CACHE.set(spec, compiled)
   return compiled

--- a/typescript/packages/core/src/commands/spec/compile.ts
+++ b/typescript/packages/core/src/commands/spec/compile.ts
@@ -86,6 +86,10 @@ export class CompiledSpec {
   readonly numericDest: string | null
   /** Kind of the rest operand. */
   readonly restKind: ValueType | null
+  // python3's rule, carried through from CommandSpec.stopAtOperand.
+  readonly stopAtOperand: boolean
+  // Spellings whose value ends option parsing (Option.endsOptions).
+  readonly endsOptionsSpellings: ReadonlySet<string>
   // Canonical spelling of the option that re-bases the path operands
   // after it (CommandSpec.operandBase, tar's -C).
   readonly baseDest: string | null
@@ -114,6 +118,8 @@ export class CompiledSpec {
     numericDest: string | null
     restKind: ValueType | null
     baseDest: string | null
+    stopAtOperand: boolean
+    endsOptionsSpellings: ReadonlySet<string>
   }) {
     this.boolSpellings = fields.boolSpellings
     this.valueSpellings = fields.valueSpellings
@@ -138,6 +144,8 @@ export class CompiledSpec {
     this.numericDest = fields.numericDest
     this.restKind = fields.restKind
     this.baseDest = fields.baseDest
+    this.stopAtOperand = fields.stopAtOperand
+    this.endsOptionsSpellings = fields.endsOptionsSpellings
   }
 
   /** Canonical spelling for a typed spelling. */
@@ -155,6 +163,7 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
 
   const boolSpellings = new Set<string>()
   const valueSpellings: string[] = []
+  const endsOptionsSpellings = new Set<string>()
   const attachSpellings: string[] = []
   const longBoolSpellings = new Set<string>()
   const longValueSpellings = new Set<string>()
@@ -188,6 +197,17 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     }
     if (opt.pair && opt.valueOptional) {
       throw new Error(`option '${canonical}': pair and valueOptional are mutually exclusive`)
+    }
+    if (opt.endsOptions) {
+      if (opt.type === 'bool') {
+        throw new Error(
+          `option '${canonical}': endsOptions requires a value flag ` +
+            `(it ends parsing after the value it carries)`,
+        )
+      }
+      for (const spelling of [opt.short, opt.long]) {
+        if (spelling !== null) endsOptionsSpellings.add(spelling)
+      }
     }
     if (opt.pair && opt.short !== null) {
       // A short spelling clusters and takes an attached value, both of
@@ -311,6 +331,8 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     numericDest,
     restKind: spec.rest !== null ? spec.rest.type : null,
     baseDest,
+    stopAtOperand: spec.stopAtOperand,
+    endsOptionsSpellings,
   })
   CACHE.set(spec, compiled)
   return compiled

--- a/typescript/packages/core/src/commands/spec/constants.ts
+++ b/typescript/packages/core/src/commands/spec/constants.ts
@@ -71,4 +71,21 @@ export const USAGE_EXIT: Readonly<Record<string, number>> = Object.freeze({
   awk: 2,
   jq: 2,
   tar: 64,
+  python: 2,
+  python3: 2,
 })
+
+// The interpreter commands answer option errors in CPython's words, not
+// GNU's: python3 is not a GNU tool, and its refusal names the
+// source-selecting options a reader needs.
+export const PYTHON_NAMES: ReadonlySet<string> = new Set(['python', 'python3'])
+
+// Pinned on CPython 3.12.13, including two quirks worth keeping: the
+// hint always spells the program `python` (never `python3`, whichever
+// way it was invoked), and it quotes with a backquote/quote pair.
+export function pythonUsage(name: string): string {
+  return (
+    `usage: ${name} [option] ... [-c cmd | -m mod | file | -] [arg] ...\n` +
+    "Try `python -h' for more information.\n"
+  )
+}

--- a/typescript/packages/core/src/commands/spec/parser.test.ts
+++ b/typescript/packages/core/src/commands/spec/parser.test.ts
@@ -1112,14 +1112,10 @@ describe('options an environment variable supplies', () => {
   })
 })
 
-describe('parseCommand — stopAtOperand (python3 rule)', () => {
+describe('parseCommand — remainder (argparse nargs=REMAINDER)', () => {
   const PYTHON_LIKE = new CommandSpec({
-    options: [
-      new Option({ short: '-c', type: 'str', endsOptions: true }),
-      new Option({ short: '-u' }),
-    ],
-    rest: new Operand({ type: 'str' }),
-    stopAtOperand: true,
+    options: [new Option({ short: '-c', type: 'str' }), new Option({ short: '-u' })],
+    rest: new Operand({ type: 'str', remainder: true }),
   })
 
   it('rejects an unknown flag before the operand', () => {
@@ -1133,24 +1129,12 @@ describe('parseCommand — stopAtOperand (python3 rule)', () => {
     expect(p.invalidOptions).toEqual([])
   })
 
-  it('ends option parsing after a payload value', () => {
-    const p = parseCommand(PYTHON_LIKE, ['-c', 'print(1)', '-u', 'x'], '/')
+  it('consumes the marker that hands off the line', () => {
+    // The router writes the `--`; the parser eats exactly that one, so
+    // the words after it are the program's argv.
+    const p = parseCommand(PYTHON_LIKE, ['-c', 'print(1)', '--', '-u', 'x'], '/')
     expect(p.flags['-c']).toBe('print(1)')
     expect(p.flags['-u']).not.toBe(true)
     expect(p.texts()).toEqual(['-u', 'x'])
-  })
-
-  it('refuses endsOptions on a boolean option', () => {
-    expect(() =>
-      parseCommand(
-        new CommandSpec({
-          options: [new Option({ short: '-b', endsOptions: true })],
-          rest: new Operand({ type: 'str' }),
-          stopAtOperand: true,
-        }),
-        [],
-        '/',
-      ),
-    ).toThrow(/endsOptions requires a value flag/)
   })
 })

--- a/typescript/packages/core/src/commands/spec/parser.test.ts
+++ b/typescript/packages/core/src/commands/spec/parser.test.ts
@@ -391,7 +391,7 @@ describe('parseCommand — unknown dash tokens warn and drop', () => {
   })
 
   it('keeps dash tokens for TEXT-rest commands', () => {
-    const p = parseCommand(specOf('python'), ['-x', 'hello'], '/')
+    const p = parseCommand(specOf('expr'), ['-x', 'hello'], '/')
     expect(p.texts()).toEqual(['-x', 'hello'])
     expect(p.warnings).toEqual([])
   })
@@ -1109,5 +1109,48 @@ describe('options an environment variable supplies', () => {
     const parsed = parseCommand(versioned, [], '/', { X_VERSION: '9' })
     expect(parsed.flags['--version']).toBe('9')
     expect(parsed.typedDests).toEqual([])
+  })
+})
+
+describe('parseCommand — stopAtOperand (python3 rule)', () => {
+  const PYTHON_LIKE = new CommandSpec({
+    options: [
+      new Option({ short: '-c', type: 'str', endsOptions: true }),
+      new Option({ short: '-u' }),
+    ],
+    rest: new Operand({ type: 'str' }),
+    stopAtOperand: true,
+  })
+
+  it('rejects an unknown flag before the operand', () => {
+    const p = parseCommand(PYTHON_LIKE, ['-z', '-c', 'print(1)'], '/')
+    expect(p.invalidOptions).toEqual(['z'])
+  })
+
+  it('keeps dash words after the operand verbatim', () => {
+    const p = parseCommand(PYTHON_LIKE, ['s.py', '--foo', '-z'], '/')
+    expect(p.texts()).toEqual(['s.py', '--foo', '-z'])
+    expect(p.invalidOptions).toEqual([])
+  })
+
+  it('ends option parsing after a payload value', () => {
+    const p = parseCommand(PYTHON_LIKE, ['-c', 'print(1)', '-u', 'x'], '/')
+    expect(p.flags['-c']).toBe('print(1)')
+    expect(p.flags['-u']).not.toBe(true)
+    expect(p.texts()).toEqual(['-u', 'x'])
+  })
+
+  it('refuses endsOptions on a boolean option', () => {
+    expect(() =>
+      parseCommand(
+        new CommandSpec({
+          options: [new Option({ short: '-b', endsOptions: true })],
+          rest: new Operand({ type: 'str' }),
+          stopAtOperand: true,
+        }),
+        [],
+        '/',
+      ),
+    ).toThrow(/endsOptions requires a value flag/)
   })
 })

--- a/typescript/packages/core/src/commands/spec/parser.ts
+++ b/typescript/packages/core/src/commands/spec/parser.ts
@@ -191,7 +191,7 @@ export function parseCommand(
   // Free-text commands (echo/python/bash-style TEXT rest) keep unknown dash
   // tokens verbatim; elsewhere they are dropped with a warning so a stray
   // flag never corrupts pattern/path classification.
-  const lenientDashOperands = cs.restKind !== null && cs.restKind !== 'path' && !cs.stopAtOperand
+  const lenientDashOperands = cs.restKind !== null && cs.restKind !== 'path' && !cs.remainder
   i = 0
   let endOfFlags = false
 
@@ -310,7 +310,6 @@ export function parseCommand(
       }
       if (matchedOptional) continue
       let matchedValue = false
-      let matchedSpelling = ''
       for (const vf of cs.valueSpellings) {
         if (tok === vf && i + 1 < filteredArgv.length) {
           setValueFlag(flags, cs, vf, filteredArgv[i + 1] ?? '')
@@ -319,7 +318,6 @@ export function parseCommand(
           base = rebase(flags, cs, vf, filteredArgv[i + 1] ?? '', base)
           i += 2
           matchedValue = true
-          matchedSpelling = vf
           break
         }
         if (tok.startsWith(vf) && tok.length > vf.length) {
@@ -327,14 +325,10 @@ export function parseCommand(
           base = rebase(flags, cs, vf, tok.slice(vf.length), base)
           i += 1
           matchedValue = true
-          matchedSpelling = vf
           break
         }
       }
       if (matchedValue) {
-        if (cs.stopAtOperand && cs.endsOptionsSpellings.has(matchedSpelling)) {
-          endOfFlags = true
-        }
         continue
       }
 
@@ -409,9 +403,9 @@ export function parseCommand(
     rawIndices.push(origIndices[i] ?? -1)
     rawBases.push(base)
     // The first operand ends option parsing outright under
-    // stopAtOperand, so a script's own flags reach the script instead
+    // argparse's REMAINDER, so a script's own flags reach the script
     // of being read as the interpreter's.
-    if (cs.stopAtOperand) endOfFlags = true
+    if (cs.remainder) endOfFlags = true
     i += 1
   }
 

--- a/typescript/packages/core/src/commands/spec/parser.ts
+++ b/typescript/packages/core/src/commands/spec/parser.ts
@@ -191,7 +191,7 @@ export function parseCommand(
   // Free-text commands (echo/python/bash-style TEXT rest) keep unknown dash
   // tokens verbatim; elsewhere they are dropped with a warning so a stray
   // flag never corrupts pattern/path classification.
-  const lenientDashOperands = cs.restKind !== null && cs.restKind !== 'path'
+  const lenientDashOperands = cs.restKind !== null && cs.restKind !== 'path' && !cs.stopAtOperand
   i = 0
   let endOfFlags = false
 
@@ -310,6 +310,7 @@ export function parseCommand(
       }
       if (matchedOptional) continue
       let matchedValue = false
+      let matchedSpelling = ''
       for (const vf of cs.valueSpellings) {
         if (tok === vf && i + 1 < filteredArgv.length) {
           setValueFlag(flags, cs, vf, filteredArgv[i + 1] ?? '')
@@ -318,6 +319,7 @@ export function parseCommand(
           base = rebase(flags, cs, vf, filteredArgv[i + 1] ?? '', base)
           i += 2
           matchedValue = true
+          matchedSpelling = vf
           break
         }
         if (tok.startsWith(vf) && tok.length > vf.length) {
@@ -325,10 +327,16 @@ export function parseCommand(
           base = rebase(flags, cs, vf, tok.slice(vf.length), base)
           i += 1
           matchedValue = true
+          matchedSpelling = vf
           break
         }
       }
-      if (matchedValue) continue
+      if (matchedValue) {
+        if (cs.stopAtOperand && cs.endsOptionsSpellings.has(matchedSpelling)) {
+          endOfFlags = true
+        }
+        continue
+      }
 
       if (cs.boolSpellings.has(tok)) {
         setBoolFlag(flags, cs, tok)
@@ -400,6 +408,10 @@ export function parseCommand(
     rawArgs.push(tok)
     rawIndices.push(origIndices[i] ?? -1)
     rawBases.push(base)
+    // The first operand ends option parsing outright under
+    // stopAtOperand, so a script's own flags reach the script instead
+    // of being read as the interpreter's.
+    if (cs.stopAtOperand) endOfFlags = true
     i += 1
   }
 

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -168,16 +168,6 @@ export interface OptionInit {
    * leaf that sends the value and the renderer that reports the line need it.
    */
   env?: string
-  /**
-   * The option's value is the last thing parsed as the command's own;
-   * every later word is an operand. This is python3's `-c`/`-m`, whose
-   * argument is a program and whose trailing words are that program's
-   * argv, so `python3 -c 'code' -u` passes `-u` to the code rather than
-   * honoring it. Only meaningful under CommandSpec.stopAtOperand, and
-   * only on the options that carry a program: `-X dev -c 'code'` still
-   * parses `-c`, because `-X` takes a value without carrying one.
-   */
-  endsOptions?: boolean
   description?: string
 }
 
@@ -196,7 +186,6 @@ export class Option {
   readonly default: string | null
   readonly metavar: string | null
   readonly env: string | null
-  readonly endsOptions: boolean
   readonly description: string | null
 
   constructor(init: OptionInit = {}) {
@@ -214,7 +203,6 @@ export class Option {
     this.default = init.default ?? null
     this.metavar = init.metavar ?? null
     this.env = init.env ?? null
-    this.endsOptions = init.endsOptions ?? false
     this.description = init.description ?? null
     Object.freeze(this)
   }
@@ -231,6 +219,18 @@ export interface OperandInit {
    * line, not of the slot, so it cannot be spelled in the type alone.
    */
   textWhen?: readonly string[]
+  /**
+   * Every word from this slot on is gathered verbatim, options included.
+   * This is argparse's `nargs=argparse.REMAINDER` and POSIX's own option
+   * order: the first operand ends option parsing, where GNU's default
+   * permutes instead (`ls a -1` reads -1 as a flag, `POSIXLY_CORRECT=1
+   * ls a -1` reads it as a filename). Set it for a command that
+   * dispatches to another program, which is the case argparse documents
+   * it for: python3's script and the words after it are the script's
+   * argv, so `python3 s.py --foo` must hand --foo over untouched while
+   * `python3 -zz s.py` must still refuse -zz as python3's own.
+   */
+  remainder?: boolean
   /**
    * Flags that supply this operand's value. When any is present the slot is
    * skipped and remaining args classify as rest (e.g. grep's pattern with
@@ -262,6 +262,7 @@ export class Operand {
   readonly textWhen: readonly string[]
   readonly name: string
   readonly required: boolean
+  readonly remainder: boolean
 
   constructor(init: OperandInit = {}) {
     this.type = init.type ?? 'path'
@@ -269,6 +270,7 @@ export class Operand {
     this.textWhen = init.textWhen ?? []
     this.name = init.name ?? ''
     this.required = init.required ?? false
+    this.remainder = init.remainder ?? false
     Object.freeze(this)
   }
 }
@@ -289,7 +291,6 @@ export interface CommandSpecInit {
   epilog?: string | null
   oldOptionStyle?: boolean
   operandBase?: string | null
-  stopAtOperand?: boolean
 }
 
 export class CommandSpec {
@@ -317,7 +318,6 @@ export class CommandSpec {
   // error, while `python3 s.py --foo` must hand `--foo` to the script
   // -- and the free-text leniency that serves echo/bash can only
   // express the second.
-  readonly stopAtOperand: boolean
 
   constructor(init: CommandSpecInit = {}) {
     this.options = init.options ?? []
@@ -328,7 +328,6 @@ export class CommandSpec {
     this.epilog = init.epilog ?? null
     this.oldOptionStyle = init.oldOptionStyle ?? false
     this.operandBase = init.operandBase ?? null
-    this.stopAtOperand = init.stopAtOperand ?? false
     // A subclass (CLISpec) still has its own fields to assign, so only
     // freeze here when constructed directly; subclasses freeze themselves.
     if (new.target === CommandSpec) Object.freeze(this)

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -168,6 +168,16 @@ export interface OptionInit {
    * leaf that sends the value and the renderer that reports the line need it.
    */
   env?: string
+  /**
+   * The option's value is the last thing parsed as the command's own;
+   * every later word is an operand. This is python3's `-c`/`-m`, whose
+   * argument is a program and whose trailing words are that program's
+   * argv, so `python3 -c 'code' -u` passes `-u` to the code rather than
+   * honoring it. Only meaningful under CommandSpec.stopAtOperand, and
+   * only on the options that carry a program: `-X dev -c 'code'` still
+   * parses `-c`, because `-X` takes a value without carrying one.
+   */
+  endsOptions?: boolean
   description?: string
 }
 
@@ -186,6 +196,7 @@ export class Option {
   readonly default: string | null
   readonly metavar: string | null
   readonly env: string | null
+  readonly endsOptions: boolean
   readonly description: string | null
 
   constructor(init: OptionInit = {}) {
@@ -203,6 +214,7 @@ export class Option {
     this.default = init.default ?? null
     this.metavar = init.metavar ?? null
     this.env = init.env ?? null
+    this.endsOptions = init.endsOptions ?? false
     this.description = init.description ?? null
     Object.freeze(this)
   }
@@ -277,6 +289,7 @@ export interface CommandSpecInit {
   epilog?: string | null
   oldOptionStyle?: boolean
   operandBase?: string | null
+  stopAtOperand?: boolean
 }
 
 export class CommandSpec {
@@ -298,6 +311,13 @@ export class CommandSpec {
   // every other path-valued flag keeps resolving against the session
   // cwd, which is what GNU does with -f.
   readonly operandBase: string | null
+  // python3's rule: parse options strictly until the first operand,
+  // then take every remaining word verbatim. An interpreter needs both
+  // halves at once -- an unknown flag before the script is a usage
+  // error, while `python3 s.py --foo` must hand `--foo` to the script
+  // -- and the free-text leniency that serves echo/bash can only
+  // express the second.
+  readonly stopAtOperand: boolean
 
   constructor(init: CommandSpecInit = {}) {
     this.options = init.options ?? []
@@ -308,6 +328,7 @@ export class CommandSpec {
     this.epilog = init.epilog ?? null
     this.oldOptionStyle = init.oldOptionStyle ?? false
     this.operandBase = init.operandBase ?? null
+    this.stopAtOperand = init.stopAtOperand ?? false
     // A subclass (CLISpec) still has its own fields to assign, so only
     // freeze here when constructed directly; subclasses freeze themselves.
     if (new.target === CommandSpec) Object.freeze(this)

--- a/typescript/packages/core/src/commands/spec/usage.ts
+++ b/typescript/packages/core/src/commands/spec/usage.ts
@@ -13,7 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { UsageError } from '../errors.ts'
-import { OLD_OPTION_EXIT, USAGE_EXIT, USAGE_HINT_PREFIX } from './constants'
+import {
+  OLD_OPTION_EXIT,
+  PYTHON_NAMES,
+  pythonUsage,
+  USAGE_EXIT,
+  USAGE_HINT_PREFIX,
+} from './constants'
 import { CommandName } from './types.ts'
 
 /** GNU usage-error exit code for a command. */
@@ -31,6 +37,10 @@ export function usageExitCode(cmdName: string): number {
  * are deliberately omitted; the `--help` hint line is kept because every
  * registered command serves `--help`.
  */
+function pythonOptionError(cmdName: string, line: string): [Uint8Array, number] {
+  return [new TextEncoder().encode(line + pythonUsage(cmdName)), usageExitCode(cmdName)]
+}
+
 export function unknownOptionError(cmdName: string, token: string): [Uint8Array, number] {
   if (cmdName === (CommandName.FIND as string)) {
     const dashed = token.startsWith('-') ? token : `-${token}`
@@ -38,6 +48,16 @@ export function unknownOptionError(cmdName: string, token: string): [Uint8Array,
       new TextEncoder().encode(`find: unknown predicate \`${dashed}'\n`),
       usageExitCode(cmdName),
     ]
+  }
+  if (PYTHON_NAMES.has(cmdName)) {
+    // CPython's own two shapes, which do not match each other: the short
+    // form capitalizes and takes a colon, the long form does neither.
+    // Both pinned on 3.12.13.
+    if (token.startsWith('--')) {
+      return pythonOptionError(cmdName, `unknown option ${token}\n`)
+    }
+    const dashed = token.startsWith('-') ? token : `-${token}`
+    return pythonOptionError(cmdName, `Unknown option: ${dashed}\n`)
   }
   const line = token.startsWith('--')
     ? `${cmdName}: unrecognized option '${token}'\n`
@@ -100,6 +120,10 @@ export function invalidFloatError(
 
 /** GNU-shaped error for a declared value flag with no argument left. */
 export function missingValueError(cmdName: string, token: string): [Uint8Array, number] {
+  if (PYTHON_NAMES.has(cmdName)) {
+    const dashed = token.startsWith('-') ? token : `-${token}`
+    return pythonOptionError(cmdName, `Argument expected for the ${dashed} option\n`)
+  }
   const line = token.startsWith('--')
     ? `${cmdName}: option '${token}' requires an argument\n`
     : `${cmdName}: option requires an argument -- '${token}'\n`

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -581,6 +581,12 @@ export {
   type Policy,
 } from './policy/index.ts'
 export { buildRuntime, candidates, registerRuntime, RUNTIMES } from './runtime/table.ts'
+// The concrete runtime classes stay unexported on purpose: buildRuntime
+// is the one construction door, and a config block reaches it as a plain
+// object. Exporting the config TYPE is what makes that object checkable,
+// so `buildRuntime('pyodide', { config: cfg })` refuses a misspelled key
+// at compile time instead of at first run.
+export type { PyodideConfig } from './runtime/python/pyodide.ts'
 export { RemoteSandbox } from './runtime/sandbox/base.ts'
 export { type NormalizedSandboxConfig, type SandboxConfig } from './runtime/sandbox/config.ts'
 export { stdinPath, stdinRedirect } from './runtime/sandbox/constants.ts'

--- a/typescript/packages/core/src/runtime/python/base.ts
+++ b/typescript/packages/core/src/runtime/python/base.ts
@@ -32,6 +32,14 @@ export abstract class PythonRuntime extends LanguageRuntime {
   readonly language: RuntimeLanguage = 'python'
   /** The tier's head words: the class-default captures of every python engine. */
   static readonly commands: readonly string[] = ['python3', 'python'] as const
+  /**
+   * Whether `python3 -m mod` can run at all. True for every engine that
+   * is real CPython, since runpy does the work; false for an engine
+   * implementing a subset of the language with no import system to find
+   * a module with. A capability of the tier, declared here rather than
+   * probed, so a refusal can name the runtime.
+   */
+  readonly runsModules: boolean = true
 
   constructor(options: RuntimeOptions<object> = {}, configKeys: readonly string[] = []) {
     super(options, PythonRuntime.commands, configKeys)

--- a/typescript/packages/core/src/runtime/python/flags.test.ts
+++ b/typescript/packages/core/src/runtime/python/flags.test.ts
@@ -1,0 +1,53 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { unhonoredNotice } from './flags.ts'
+
+const text = (bytes: Uint8Array): string => new TextDecoder().decode(bytes)
+
+describe('unhonoredNotice', () => {
+  it('names the runtime once per switch present', () => {
+    expect(text(unhonoredNotice({ E: true, s: true }, 'pyodide'))).toBe(
+      "python3: warning: -E is ignored by the 'pyodide' runtime\n" +
+        "python3: warning: -s is ignored by the 'pyodide' runtime\n",
+    )
+  })
+
+  it('says nothing when the line carried no switch', () => {
+    expect(unhonoredNotice({}, 'pyodide').length).toBe(0)
+  })
+
+  it('says nothing about a switch the engine honors', () => {
+    expect(unhonoredNotice({ B: true, O: 2, E: true }, 'pyodide', ['B', 'O'])).toEqual(
+      unhonoredNotice({ E: true }, 'pyodide'),
+    )
+  })
+
+  it('reports an optimize level above one', () => {
+    // -OO is level 2; reporting only level 1 would have made the
+    // stricter spelling the quiet one.
+    expect(text(unhonoredNotice({ O: 2 }, 'monty'))).toContain('-O is ignored')
+  })
+
+  it('reports the long switch by its own spelling', () => {
+    expect(text(unhonoredNotice({ check_hash_based_pycs: 'never' }, 'monty'))).toContain(
+      '--check-hash-based-pycs is ignored',
+    )
+  })
+
+  it('says nothing about an absent switch', () => {
+    expect(unhonoredNotice({ B: false, O: 0, W: [] }, 'monty').length).toBe(0)
+  })
+})

--- a/typescript/packages/core/src/runtime/python/flags.test.ts
+++ b/typescript/packages/core/src/runtime/python/flags.test.ts
@@ -50,4 +50,26 @@ describe('unhonoredNotice', () => {
   it('says nothing about an absent switch', () => {
     expect(unhonoredNotice({ B: false, O: 0, W: [] }, 'monty').length).toBe(0)
   })
+
+  it('reports a known -X name even when -X itself is honored', () => {
+    // Populating sys._xoptions is all a warm interpreter can do for
+    // -X dev, whose real effect is read out of the read-only sys.flags.
+    expect(text(unhonoredNotice({ X: ['dev'] }, 'pyodide', ['X']))).toBe(
+      "python3: warning: -X dev is ignored by the 'pyodide' runtime\n",
+    )
+  })
+
+  it('reports a known -X name without its value', () => {
+    expect(text(unhonoredNotice({ X: ['tracemalloc=5'] }, 'pyodide', ['X']))).toContain(
+      '-X tracemalloc is ignored',
+    )
+  })
+
+  it('stays silent about an arbitrary -X name', () => {
+    expect(unhonoredNotice({ X: ['nosuchopt'] }, 'pyodide', ['X']).length).toBe(0)
+  })
+
+  it('stays silent about a known -X name the engine acts on', () => {
+    expect(unhonoredNotice({ X: ['dev'] }, 'pyodide', ['X', 'X:dev']).length).toBe(0)
+  })
 })

--- a/typescript/packages/core/src/runtime/python/flags.ts
+++ b/typescript/packages/core/src/runtime/python/flags.ts
@@ -27,6 +27,33 @@ const VALUE_FLAGS: Readonly<Record<string, string>> = {
   check_hash_based_pycs: '--check-hash-based-pycs',
 }
 
+// The -X names CPython gives an effect beyond landing in
+// sys._xoptions, so a warm interpreter that only populates that dict
+// has not honored them. Every one is read out of the read-only
+// sys.flags or installed at interpreter start (dev, utf8,
+// warn_default_encoding, importtime, frozen_modules, cpu_count,
+// no_debug_ranges, perf*, showrefcount) or needs a library call this
+// wrapper does not make (faulthandler, int_max_str_digits,
+// pycache_prefix, tracemalloc). An arbitrary name is deliberately
+// absent: on CPython it does nothing but land in the dict either.
+// Pinned against `python3 --help-xoptions` on 3.13.7.
+const X_EFFECTS: ReadonlySet<string> = new Set([
+  'cpu_count',
+  'dev',
+  'faulthandler',
+  'frozen_modules',
+  'importtime',
+  'int_max_str_digits',
+  'no_debug_ranges',
+  'perf',
+  'perf_jit',
+  'pycache_prefix',
+  'showrefcount',
+  'tracemalloc',
+  'utf8',
+  'warn_default_encoding',
+])
+
 /** One run's interpreter-init switches, as the command parsed them. */
 export interface InitFlags {
   b?: number
@@ -66,6 +93,15 @@ function unhonored(flags: InitFlags, honored: readonly string[]): string[] {
   for (const [key, spelling] of Object.entries(VALUE_FLAGS)) {
     if (honored.includes(key)) continue
     if (flags[key as keyof InitFlags]) present.push(spelling)
+  }
+  // Reported per name rather than per letter: an engine can honor what
+  // -X means for sys._xoptions and still not act on the handful of
+  // names CPython gives a real effect.
+  for (const value of flags.X ?? []) {
+    const optName = value.split('=')[0] ?? ''
+    if (X_EFFECTS.has(optName) && !honored.includes(`X:${optName}`)) {
+      present.push(`-X ${optName}`)
+    }
   }
   return present
 }

--- a/typescript/packages/core/src/runtime/python/flags.ts
+++ b/typescript/packages/core/src/runtime/python/flags.ts
@@ -1,0 +1,74 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+// The interpreter-init switches, keyed by CPython's own letter. These
+// configure the interpreter rather than selecting what it runs, so they
+// ride in RunArgs.flags and each engine answers the ones it can. `-u`
+// and `-q` are deliberately absent: mirage buffers every stream and
+// prints no banner, so they are structural no-ops in every runtime
+// rather than something one engine honors and another does not.
+const BOOL_FLAGS: readonly string[] = ['B', 'E', 'I', 's', 'S']
+const LIST_FLAGS: readonly string[] = ['W', 'X']
+const OPTIMIZE_FLAG = 'O'
+
+/** One run's interpreter-init switches, as the command parsed them. */
+export interface InitFlags {
+  B?: boolean
+  E?: boolean
+  I?: boolean
+  s?: boolean
+  S?: boolean
+  O?: number
+  W?: readonly string[]
+  X?: readonly string[]
+}
+
+/**
+ * The init switches present on a line, in CPython's spelling.
+ *
+ * A runtime that cannot act on these reports them rather than dropping
+ * them silently, so a line behaving differently across runtimes says so
+ * instead of being discovered later.
+ *
+ * Args:
+ *   flags: the run's RunArgs.flags bag.
+ */
+function unhonored(flags: InitFlags): string[] {
+  const present: string[] = []
+  for (const key of [...BOOL_FLAGS, OPTIMIZE_FLAG, ...LIST_FLAGS]) {
+    const value = flags[key as keyof InitFlags]
+    const set = Array.isArray(value) ? value.length > 0 : value === true || value === 1
+    if (set) present.push(`-${key}`)
+  }
+  return present
+}
+
+/**
+ * One stderr line per init switch this runtime cannot act on.
+ *
+ * A warning rather than a refusal: the line still runs and still
+ * reports the program's own exit code, so a script that works on every
+ * other runtime keeps working here, while the difference stays visible
+ * instead of being found later.
+ *
+ * Args:
+ *   flags: the run's RunArgs.flags bag.
+ *   runtimeName: the engine's registry name, for the message.
+ */
+export function unhonoredNotice(flags: InitFlags, runtimeName: string): Uint8Array {
+  const lines = unhonored(flags).map(
+    (spelling) => `python3: warning: ${spelling} is ignored by the '${runtimeName}' runtime\n`,
+  )
+  return new TextEncoder().encode(lines.join(''))
+}

--- a/typescript/packages/core/src/runtime/python/flags.ts
+++ b/typescript/packages/core/src/runtime/python/flags.ts
@@ -18,38 +18,54 @@
 // and `-q` are deliberately absent: mirage buffers every stream and
 // prints no banner, so they are structural no-ops in every runtime
 // rather than something one engine honors and another does not.
-const BOOL_FLAGS: readonly string[] = ['B', 'E', 'I', 's', 'S']
+const BOOL_FLAGS: readonly string[] = ['B', 'E', 'I', 'P', 's', 'S']
+const COUNT_FLAGS: readonly string[] = ['O', 'b']
 const LIST_FLAGS: readonly string[] = ['W', 'X']
-const OPTIMIZE_FLAG = 'O'
+// The one init switch CPython spells long. Its key is the parser's
+// canonical spelling rather than a letter, since it has none.
+const VALUE_FLAGS: Readonly<Record<string, string>> = {
+  check_hash_based_pycs: '--check-hash-based-pycs',
+}
 
 /** One run's interpreter-init switches, as the command parsed them. */
 export interface InitFlags {
+  b?: number
   B?: boolean
   E?: boolean
   I?: boolean
+  P?: boolean
   s?: boolean
   S?: boolean
   O?: number
   W?: readonly string[]
   X?: readonly string[]
+  check_hash_based_pycs?: string | null
 }
 
 /**
- * The init switches present on a line, in CPython's spelling.
+ * The init switches present on a line that this engine did not act on.
  *
  * A runtime that cannot act on these reports them rather than dropping
  * them silently, so a line behaving differently across runtimes says so
- * instead of being discovered later.
+ * instead of being discovered later. `honored` is the engine's own
+ * subset, by CPython letter; the default is none, which is the honest
+ * answer for an engine that is not CPython at all.
  *
  * Args:
  *   flags: the run's RunArgs.flags bag.
+ *   honored: the letters this engine does act on.
  */
-function unhonored(flags: InitFlags): string[] {
+function unhonored(flags: InitFlags, honored: readonly string[]): string[] {
   const present: string[] = []
-  for (const key of [...BOOL_FLAGS, OPTIMIZE_FLAG, ...LIST_FLAGS]) {
+  for (const key of [...BOOL_FLAGS, ...COUNT_FLAGS, ...LIST_FLAGS]) {
+    if (honored.includes(key)) continue
     const value = flags[key as keyof InitFlags]
-    const set = Array.isArray(value) ? value.length > 0 : value === true || value === 1
+    const set = Array.isArray(value) ? value.length > 0 : value === true || Number(value) > 0
     if (set) present.push(`-${key}`)
+  }
+  for (const [key, spelling] of Object.entries(VALUE_FLAGS)) {
+    if (honored.includes(key)) continue
+    if (flags[key as keyof InitFlags]) present.push(spelling)
   }
   return present
 }
@@ -65,9 +81,14 @@ function unhonored(flags: InitFlags): string[] {
  * Args:
  *   flags: the run's RunArgs.flags bag.
  *   runtimeName: the engine's registry name, for the message.
+ *   honored: the letters this engine does act on.
  */
-export function unhonoredNotice(flags: InitFlags, runtimeName: string): Uint8Array {
-  const lines = unhonored(flags).map(
+export function unhonoredNotice(
+  flags: InitFlags,
+  runtimeName: string,
+  honored: readonly string[] = [],
+): Uint8Array {
+  const lines = unhonored(flags, honored).map(
     (spelling) => `python3: warning: ${spelling} is ignored by the '${runtimeName}' runtime\n`,
   )
   return new TextEncoder().encode(lines.join(''))

--- a/typescript/packages/core/src/runtime/python/loader.ts
+++ b/typescript/packages/core/src/runtime/python/loader.ts
@@ -73,7 +73,20 @@ async function resolveNodeIndexURL(): Promise<string | null> {
   }
 }
 
-export async function loadPyodideRuntime(home?: string): Promise<PyodideInterface> {
+/** Distribution knobs a deployment can point at its own prebuilt assets. */
+export interface PyodideLoadOptions {
+  home?: string
+  // Where wheels are fetched from, which is NOT indexURL: the npm
+  // pyodide package ships pyodide-lock.json and no wheels at all, so a
+  // deployment wanting packages offline points this at its own build.
+  packageBaseUrl?: string
+  lockFileURL?: string
+  packages?: readonly string[]
+}
+
+export async function loadPyodideRuntime(
+  options: PyodideLoadOptions = {},
+): Promise<PyodideInterface> {
   let mod: { loadPyodide: (opts?: Record<string, unknown>) => Promise<unknown> }
   try {
     mod = (await import('pyodide')) as unknown as {
@@ -86,8 +99,16 @@ export async function loadPyodideRuntime(home?: string): Promise<PyodideInterfac
     )
   }
   const indexURL =
-    home ?? envHome() ?? (await resolveNodeIndexURL()) ?? (isNode() ? null : PYODIDE_CDN_URL)
+    options.home ??
+    envHome() ??
+    (await resolveNodeIndexURL()) ??
+    (isNode() ? null : PYODIDE_CDN_URL)
   const opts: Record<string, unknown> = { stdout: noopIo, stderr: noopIo }
+  if (options.packageBaseUrl !== undefined) opts.packageBaseUrl = options.packageBaseUrl
+  if (options.lockFileURL !== undefined) opts.lockFileURL = options.lockFileURL
+  if (options.packages !== undefined && options.packages.length > 0) {
+    opts.packages = [...options.packages]
+  }
   if (indexURL !== null) opts.indexURL = indexURL
   try {
     const runtime = await mod.loadPyodide(opts)

--- a/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
@@ -536,3 +536,88 @@ describe('buildRuntime', () => {
     expect(() => buildRuntime('local')).toThrow(/mirage-node/)
   })
 })
+
+describe('python3 option table (CPython-pinned)', () => {
+  async function run(line: string) {
+    const parser = await getTestParser()
+    const ws = new Workspace(
+      { '/': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser, runtimes: ['monty', 'vfs'] },
+    )
+    try {
+      return await ws.execute(line)
+    } finally {
+      await ws.close()
+    }
+  }
+
+  it('takes -u before a script as a flag, not as the script', async () => {
+    const parser = await getTestParser()
+    const ws = new Workspace(
+      { '/': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser, runtimes: ['monty', 'vfs'] },
+    )
+    try {
+      await ws.execute("printf 'print(42)\\n' > /s.py")
+      const io = await ws.execute('python3 -u /s.py')
+      expect(io.exitCode).toBe(0)
+      expect(new TextDecoder().decode(io.stdout)).toBe('42\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('exits 2 naming the letter for an unknown short option', async () => {
+    const io = await run("python3 -zz -c 'print(1)'")
+    expect(io.exitCode).toBe(2)
+    expect(new TextDecoder().decode(io.stderr)).toContain('Unknown option: -z')
+  })
+
+  it("exits 2 with CPython's wording when a payload has no argument", async () => {
+    const io = await run('python3 -c')
+    expect(io.exitCode).toBe(2)
+    const err = new TextDecoder().decode(io.stderr)
+    expect(err).toContain('Argument expected for the -c option')
+    expect(err).toContain('usage: python3 [option] ...')
+  })
+
+  it('sets argv[0] to the script as typed', async () => {
+    const parser = await getTestParser()
+    const ws = new Workspace(
+      { '/': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser, runtimes: ['monty', 'vfs'] },
+    )
+    try {
+      await ws.execute("printf 'print(argv[0])\\n' > /s.py")
+      const io = await ws.execute('python3 /s.py')
+      expect(new TextDecoder().decode(io.stdout)).toBe('/s.py\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('sets argv[0] to -c under a payload', async () => {
+    const io = await run("python3 -c 'print(argv[0])'")
+    expect(new TextDecoder().decode(io.stdout)).toBe('-c\n')
+  })
+
+  it('refuses -m on a runtime with no import system', async () => {
+    const io = await run('python3 -m json.tool')
+    expect(io.exitCode).toBe(1)
+    const err = new TextDecoder().decode(io.stderr)
+    expect(err).toContain('-m')
+    expect(err).toContain('monty')
+  })
+
+  it('warns on an init switch monty cannot honor', async () => {
+    const io = await run("python3 -O -c 'print(1)'")
+    expect(io.exitCode).toBe(0)
+    expect(new TextDecoder().decode(io.stderr)).toContain("-O is ignored by the 'monty' runtime")
+  })
+
+  it('does not warn for the by-design no-ops', async () => {
+    const io = await run("python3 -u -q -c 'print(1)'")
+    expect(io.exitCode).toBe(0)
+    expect(new TextDecoder().decode(io.stderr)).toBe('')
+  })
+})

--- a/typescript/packages/core/src/runtime/python/monty/runtime.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.ts
@@ -26,6 +26,7 @@ import {
   type MontySessionLike,
 } from './binding.ts'
 import { DEFAULT_PROG, EVAL_INTERRUPT_SECONDS, INCOMPLETE_MARKERS } from './constants.ts'
+import { unhonoredNotice, type InitFlags } from '../flags.ts'
 import { displayError } from './errors.ts'
 import { MirageOSAccess } from './osaccess.ts'
 import { MontyVFS } from './vfs.ts'
@@ -93,6 +94,10 @@ function toEvalValue(value: unknown): EvalValue {
  */
 export class MontyRuntime extends PythonRuntime implements Evaluator {
   readonly name = 'monty'
+  // No import system to resolve a module with, so `-m` has nothing to
+  // run; the refusal names this runtime rather than inventing a
+  // "No module named" that would imply a search happened.
+  override readonly runsModules = false
   readonly [EVALUATOR] = true as const
   private workspaceBridge: BridgeDispatchFn | null = null
   private listMounts: PrefixSource = () => []
@@ -114,7 +119,29 @@ export class MontyRuntime extends PythonRuntime implements Evaluator {
     }
   }
 
+  /**
+   * Run one program, reporting any switch this engine cannot honor.
+   *
+   * Monty implements a Python subset with no `compile`, no `warnings`
+   * and no `sys.path`, so the interpreter-init switches have nothing to
+   * act on here even though every real-CPython engine honors them. The
+   * notice rides on stderr and the program's own exit code stands.
+   *
+   * Args:
+   *   args: the execution request.
+   */
   async run(args: RunArgs): Promise<RunResult> {
+    const notice = unhonoredNotice((args.flags ?? {}) as InitFlags, this.name)
+    const result = await this.runOne(args)
+    if (notice.length === 0) return result
+    const stderr = result.stderr ?? new Uint8Array()
+    const merged = new Uint8Array(notice.length + stderr.length)
+    merged.set(notice, 0)
+    merged.set(stderr, notice.length)
+    return { ...result, stderr: merged }
+  }
+
+  private async runOne(args: RunArgs): Promise<RunResult> {
     const pool = await this.ensurePool()
     const session = await pool.checkout()
     // Monty executes on its own worker process, so the event loop stays

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -33,6 +33,7 @@ import { preloadInto } from './vfs/preload.ts'
 import { MirageFs } from './vfs/vfs.ts'
 import { MirageFsSeed } from './vfs/seed.ts'
 import { PYTHON_EVAL_WRAPPER, PYTHON_REPL_WRAPPER, PYTHON_WRAPPER } from './wrapper.ts'
+import { unhonoredNotice, type InitFlags } from './flags.ts'
 
 function bridgeBytes(value: Uint8Array | ArrayLike<number>): Uint8Array {
   return value instanceof Uint8Array ? value : new Uint8Array(value)
@@ -41,6 +42,21 @@ function bridgeBytes(value: Uint8Array | ArrayLike<number>): Uint8Array {
 function bridgeStderr(value: Uint8Array | ArrayLike<number>): Uint8Array | null {
   const bytes = bridgeBytes(value)
   return bytes.length > 0 ? bytes : null
+}
+
+// The init switches this engine acts on, by CPython letter. The rest
+// (-E, -I, -s, -S) only change how an interpreter *starts*, and this
+// one is already running by the time a line is typed, so it reports
+// them instead of pretending. See PYTHON_WRAPPER for what honoring the
+// four below amounts to.
+const HONORED_FLAGS: readonly string[] = ['B', 'O', 'W', 'X']
+
+function decodeNoticeLines(notice: Uint8Array): string[] {
+  if (notice.length === 0) return []
+  return new TextDecoder()
+    .decode(notice)
+    .split('\n')
+    .filter((line) => line.length > 0)
 }
 
 function appendStderrLines(stderr: Uint8Array | null, lines: string[]): Uint8Array | null {
@@ -622,8 +638,14 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
   private async runOne(args: RunArgs): Promise<RunResult> {
     const pyodide = await this.ensureLoaded()
     // Seeding happened inside ensureLoaded; its notices ride out on
-    // this run's stderr, beside any flush failure.
-    const seedNotices = this.takeSeedNotices()
+    // this run's stderr, beside any flush failure and any init switch
+    // this engine could not act on.
+    const seedNotices = [
+      ...this.takeSeedNotices(),
+      ...decodeNoticeLines(
+        unhonoredNotice((args.flags ?? {}) as InitFlags, this.name, HONORED_FLAGS),
+      ),
+    ]
     await this.loadImports(pyodide, args.code)
     const mergedEnv = { ...runtimeEnv(), ...args.env }
     // sys.argv[0] is the program's own name when the caller has one (a

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -135,6 +135,36 @@ export interface PyodideConfig {
   autoLoadFromImports?: boolean
   bootstrapCode?: string
   denyPackages?: readonly string[]
+  /**
+   * Virtual paths prepended to sys.path once the mounts are in place, so
+   * an agent can `import openpyxl` without writing sys.path.append
+   * itself. Entries are MOUNT paths, not host paths: the glob runs
+   * inside the interpreter against the mounted tree. A `.whl` may be
+   * named directly (zipimport reads a pure-python wheel in place), and a
+   * pattern may contain `*`, `?` or `[`.
+   *
+   * Prepended, not appended: a vendored package of the same name must
+   * win over a bundled one, which is also CPython's own PYTHONPATH
+   * precedence.
+   */
+  sysPath?: readonly string[]
+  /**
+   * Packages loaded once at init from the pyodide distribution, before
+   * the first run. Composes with autoLoadFromImports rather than
+   * replacing it: the per-run import scan is a no-op for anything
+   * already resident.
+   */
+  packages?: readonly string[]
+  /**
+   * Where package wheels are fetched from. Distinct from `home`, which
+   * only sets indexURL: the npm pyodide package ships the lock file and
+   * NO wheels, so a deployment that wants `packages` working offline
+   * points this at its own prebuilt distribution. A `://` value makes
+   * package loading a network fetch; a local path keeps it on disk.
+   */
+  packageBaseUrl?: string
+  /** A custom pyodide-lock.json, for a prebuilt distribution. */
+  lockFileURL?: string
   // Where the pyodide distribution loads from; falls back to
   // MIRAGE_PYODIDE_HOME, then the installed package in Node or the
   // pinned CDN in the browser. Override for self-hosted assets.
@@ -146,7 +176,44 @@ const PYODIDE_CONFIG_KEYS: readonly string[] = [
   'bootstrapCode',
   'denyPackages',
   'home',
+  'sysPath',
+  'packages',
+  'packageBaseUrl',
+  'lockFileURL',
 ]
+
+// Prepend, glob-expand, and invalidate. Three things are load-bearing.
+// Prepending (not appending) lets a vendored package beat a bundled one
+// of the same name, which is CPython's own PYTHONPATH precedence. A
+// pattern that expands to nothing is collected into `_seed_misses` for
+// the host to report, because a silent [] shows up much later as a bare
+// ModuleNotFoundError with nothing pointing at the config; the seed
+// cannot report it itself, since this runs inside syncMounts, where
+// nothing is capturing sys.stderr yet. And invalidate_caches() runs
+// UNCONDITIONALLY, because
+// syncMounts remounts every prefix on every run: zipimport's archive
+// table of contents is keyed by path rather than mtime, so a remounted
+// wheel would otherwise keep serving the previous run's contents.
+const SYS_PATH_SEED_PY = `
+import sys, glob, importlib
+
+_seed_misses = []
+_expanded = []
+for _p in _seed_paths:
+    if any(c in _p for c in '*?['):
+        _hits = sorted(glob.glob(_p))
+        if not _hits:
+            _seed_misses.append(_p)
+        _expanded.extend(_hits)
+    else:
+        _expanded.append(_p)
+
+_new = [p for p in _expanded if p not in sys.path]
+if _new:
+    sys.path[:0] = _new
+
+importlib.invalidate_caches()
+`
 
 // One-shot eval is bounded like quickjs's: nothing above the runtime
 // can stop a hung guest on this thread, so the runtime owns its own
@@ -166,12 +233,23 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
   private readonly denyPackages: ReadonlySet<string>
   private listMounts: () => string[] = () => []
   private readonly home: string | null
+  private readonly sysPath: readonly string[]
+  private readonly packages: readonly string[]
+  private readonly packageBaseUrl: string | null
+  private readonly lockFileURL: string | null
   private vfs: RuntimeVFS | null = null
   private readonly journal: MutationJournal = createJournal()
   private readonly mounted = new Set<string>()
   // Prefixes this runtime cannot mount, remembered so the refusal is
   // reported once rather than on every run.
   private readonly refused = new Set<string>()
+  // Same rule for a sysPath glob that expanded to nothing. Seeding runs
+  // on every syncMounts pass, so without this a misconfigured pattern
+  // would warn on every line the agent types; and a pattern can start
+  // matching later (the wheels are written to the mount after boot),
+  // which is why the miss is reported rather than refused.
+  private readonly seedMissesReported = new Set<string>()
+  private seedNotices: string[] = []
   // The guest executes on this event loop, so only the watchdog-backed
   // interrupt buffer can stop a busy loop (see interrupt.ts); null
   // where SharedArrayBuffer/workers are unavailable (runs unbounded).
@@ -185,6 +263,18 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
     this.bootstrapCode = config.bootstrapCode ?? null
     this.denyPackages = new Set(config.denyPackages ?? [])
     this.home = config.home ?? null
+    this.sysPath = config.sysPath ?? []
+    this.packages = config.packages ?? []
+    this.packageBaseUrl = config.packageBaseUrl ?? null
+    this.lockFileURL = config.lockFileURL ?? null
+    const denied = new Set(this.denyPackages)
+    const contradictory = this.packages.filter((name) => denied.has(name))
+    if (contradictory.length > 0) {
+      throw new Error(
+        `pyodide config: ${contradictory.map((n) => `'${n}'`).join(', ')} ` +
+          `appears in both packages and denyPackages`,
+      )
+    }
   }
 
   override attach(dispatch: BridgeDispatchFn, listMounts: () => string[]): void {
@@ -320,7 +410,12 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       await this.wireInterruptIfNeeded(this.pyodide)
       return this.pyodide
     }
-    this.initPromise ??= loadPyodideRuntime(this.home ?? undefined)
+    this.initPromise ??= loadPyodideRuntime({
+      ...(this.home !== null ? { home: this.home } : {}),
+      ...(this.packageBaseUrl !== null ? { packageBaseUrl: this.packageBaseUrl } : {}),
+      ...(this.lockFileURL !== null ? { lockFileURL: this.lockFileURL } : {}),
+      ...(this.packages.length > 0 ? { packages: this.packages } : {}),
+    })
     this.pyodide = await this.initPromise
     if (this.bootstrapCode !== null) {
       const code = this.bootstrapCode
@@ -408,6 +503,73 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       fs.seed(seed)
       this.mounted.add(prefix)
     }
+    await this.seedSysPath(pyodide)
+  }
+
+  /**
+   * Put the configured paths on sys.path, after every mount is in place.
+   *
+   * Runs on EVERY syncMounts pass rather than once at load: each pass
+   * unmounts and remounts the prefixes, and zipimport caches an
+   * archive's table of contents by path, so a `.whl` served from a
+   * remounted tree would keep answering from the previous run. Both
+   * guards inside are idempotent, so repeating is cheap.
+   *
+   * Args:
+   *   pyodide: the loaded interpreter.
+   */
+  private async seedSysPath(pyodide: PyodideInterface): Promise<void> {
+    if (this.sysPath.length === 0) return
+    const seedPy = pyodide.toPy([...this.sysPath])
+    pyodide.globals.set('_seed_paths', seedPy)
+    try {
+      await pyodide.runPythonAsync(SYS_PATH_SEED_PY)
+      this.recordSeedMisses(pyodide)
+    } finally {
+      pyodide.globals.delete?.('_seed_paths')
+      if (seedPy !== null && typeof seedPy === 'object' && 'destroy' in seedPy) {
+        try {
+          ;(seedPy as { destroy: () => void }).destroy()
+        } catch {
+          // destroy is best-effort; ignore double-destroy errors
+        }
+      }
+    }
+  }
+
+  /**
+   * Queue a notice for each glob that expanded to nothing this pass.
+   *
+   * The seed cannot report these itself: it runs inside syncMounts,
+   * before the run's stdout/stderr are captured, so anything it wrote
+   * to sys.stderr reached nobody. Queuing here and draining onto the
+   * run's stderr puts the warning in front of the same agent whose
+   * import is about to fail.
+   *
+   * Args:
+   *   pyodide: the loaded interpreter, holding the seed's `_seed_misses`.
+   */
+  private recordSeedMisses(pyodide: PyodideInterface): void {
+    const proxy = pyodide.globals.get('_seed_misses') as
+      | { toJs?: () => unknown; destroy?: () => void }
+      | null
+      | undefined
+    const misses = proxy?.toJs?.()
+    proxy?.destroy?.()
+    pyodide.globals.delete?.('_seed_misses')
+    if (!Array.isArray(misses)) return
+    for (const miss of misses as unknown[]) {
+      const pattern = String(miss)
+      if (this.seedMissesReported.has(pattern)) continue
+      this.seedMissesReported.add(pattern)
+      this.seedNotices.push(`python3: sysPath: '${pattern}' matched nothing`)
+    }
+  }
+
+  private takeSeedNotices(): string[] {
+    const notices = this.seedNotices
+    this.seedNotices = []
+    return notices
   }
 
   /**
@@ -459,6 +621,9 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
 
   private async runOne(args: RunArgs): Promise<RunResult> {
     const pyodide = await this.ensureLoaded()
+    // Seeding happened inside ensureLoaded; its notices ride out on
+    // this run's stderr, beside any flush failure.
+    const seedNotices = this.takeSeedNotices()
     await this.loadImports(pyodide, args.code)
     const mergedEnv = { ...runtimeEnv(), ...args.env }
     // sys.argv[0] is the program's own name when the caller has one (a
@@ -470,7 +635,9 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
     const argvPy = pyodide.toPy(argv)
     const userGlobalsPy = pyodide.toPy({})
 
+    const initFlagsPy = pyodide.toPy(args.flags ?? {})
     pyodide.globals.set('_user_code', args.code)
+    pyodide.globals.set('_init_flags', initFlagsPy)
     pyodide.globals.set('_argv', argvPy)
     pyodide.globals.set('_merged_env', mergedEnvPy)
     pyodide.globals.set('_stdin_bytes', stdinBytes)
@@ -505,14 +672,17 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
           stdout: new Uint8Array(),
           stderr: appendStderrLines(
             new TextEncoder().encode('python3: runtime returned no result\n'),
-            flushFailures,
+            [...seedNotices, ...flushFailures],
           ),
           exitCode: 1,
         }
       }
       return {
         stdout: bridgeBytes(arr[0]),
-        stderr: appendStderrLines(bridgeStderr(arr[1]), flushFailures),
+        // A seed notice rides on stderr but never on the exit code: an
+        // unmatched glob is a warning about the environment, not a
+        // failure of the program that just ran.
+        stderr: appendStderrLines(bridgeStderr(arr[1]), [...seedNotices, ...flushFailures]),
         exitCode: flushFailures.length > 0 && arr[2] === 0 ? 1 : arr[2],
       }
     } catch (err) {
@@ -521,7 +691,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       // Files closed before the failure are complete in MEMFS, so their
       // marks still flush; failures can only be warned here.
       const deadline = armed?.disarm() === 'deadline'
-      for (const failure of await this.drainMutations()) console.warn(failure)
+      for (const notice of [...seedNotices, ...(await this.drainMutations())]) console.warn(notice)
       if (deadline && args.timeoutSeconds !== undefined) {
         throw new CommandTimeoutError(this.name, args.timeoutSeconds)
       }
@@ -529,6 +699,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
     } finally {
       armed?.disarm()
       pyodide.globals.delete?.('_user_code')
+      pyodide.globals.delete?.('_init_flags')
       pyodide.globals.delete?.('_argv')
       pyodide.globals.delete?.('_merged_env')
       pyodide.globals.delete?.('_stdin_bytes')
@@ -544,6 +715,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
         }
       }
       maybeDestroy(mergedEnvPy)
+      maybeDestroy(initFlagsPy)
       maybeDestroy(argvPy)
       maybeDestroy(userGlobalsPy)
     }

--- a/typescript/packages/core/src/runtime/python/syspath.test.ts
+++ b/typescript/packages/core/src/runtime/python/syspath.test.ts
@@ -1,0 +1,63 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { PyodideRuntime } from './pyodide.ts'
+import type { BridgeDispatchFn } from '../types.ts'
+
+const EMPTY_MOUNT: BridgeDispatchFn = (op) => Promise.resolve(op === 'LIST' ? [] : new Uint8Array())
+
+function decode(bytes: Uint8Array | null | undefined): string {
+  return bytes ? new TextDecoder().decode(bytes) : ''
+}
+
+describe('PyodideRuntime sysPath', () => {
+  it('reports a glob that matched nothing on the run stderr', async () => {
+    const rt = new PyodideRuntime({ config: { sysPath: ['/ram/*.whl'] } })
+    rt.attach(EMPTY_MOUNT, () => ['/ram/'])
+    const result = await rt.run({ code: 'print(1)', args: [], env: {}, stdin: new Uint8Array() })
+    expect(decode(result.stderr)).toContain('/ram/*.whl')
+    expect(decode(result.stderr)).toContain('matched nothing')
+    // A misconfigured path is a warning, not a failure: the program ran.
+    expect(decode(result.stdout)).toContain('1')
+    expect(result.exitCode).toBe(0)
+    await rt.close()
+  }, 60_000)
+
+  it('reports each missing glob once, not on every run', async () => {
+    const rt = new PyodideRuntime({ config: { sysPath: ['/ram/*.whl'] } })
+    rt.attach(EMPTY_MOUNT, () => ['/ram/'])
+    const args = { code: 'print(1)', args: [], env: {}, stdin: new Uint8Array() }
+    await rt.run(args)
+    const second = await rt.run(args)
+    expect(decode(second.stderr)).not.toContain('matched nothing')
+    await rt.close()
+  }, 60_000)
+
+  it('says nothing about a literal path that does not exist', async () => {
+    // Only a glob can silently expand to nothing; a literal entry is on
+    // sys.path exactly as configured, which is what CPython does too.
+    const rt = new PyodideRuntime({ config: { sysPath: ['/ram/vendor'] } })
+    rt.attach(EMPTY_MOUNT, () => ['/ram/'])
+    const result = await rt.run({
+      code: `import sys; print('/ram/vendor' in sys.path)`,
+      args: [],
+      env: {},
+      stdin: new Uint8Array(),
+    })
+    expect(decode(result.stderr)).not.toContain('matched nothing')
+    expect(decode(result.stdout)).toContain('True')
+    await rt.close()
+  }, 60_000)
+})

--- a/typescript/packages/core/src/runtime/python/wrapper.ts
+++ b/typescript/packages/core/src/runtime/python/wrapper.ts
@@ -178,9 +178,20 @@ _stdin_text = io.TextIOWrapper(_stdin_buf, encoding='utf-8', errors='replace')
 # Deleting PYTHON* from os.environ was that fake, and it was wrong in
 # the other direction too: CPython's -E stops those variables
 # configuring startup, it does not hide them from the program, which
-# can still read PYTHONPATH out of os.environ. One divergence stands:
-# sys.flags is read-only, so introspecting code sees optimize == 0 even
-# when -O was honored.
+# can still read PYTHONPATH out of os.environ.
+#
+# Two bounded divergences follow from the same fact, that the resident
+# interpreter's own level is 0 and cannot be changed: introspecting
+# code sees sys.flags.optimize == 0 even when -O was honored, and -O
+# reaches only the code compiled here, so a module imported from
+# sys.path still compiles unoptimized (its asserts run, and -OO leaves
+# its docstrings). Reporting -O as ignored would be the larger lie,
+# since the payload really is compiled at the requested level.
+# A known -X name is a third case and is reported, because populating
+# sys._xoptions is all this can do for one: -X dev and
+# -X warn_default_encoding are read out of sys.flags, which is
+# read-only. An arbitrary -X name is silent, since landing in
+# sys._xoptions is all it does on CPython either.
 _flags     = dict(_init_flags) if _init_flags is not None else {}
 # CPython counts -OOO as optimize 3 in sys.flags but compile() accepts
 # only -1..2 and raises ValueError above that, so the extra Os saturate
@@ -206,7 +217,14 @@ try:
         # that asked for nothing.
         _saved_filters = _warnings.filters[:]
         for _spec in _flags.get('W') or []:
-            _warnings._setoption(str(_spec))
+            try:
+                _warnings._setoption(str(_spec))
+            except _warnings._OptionError as _werr:
+                # CPython names a bad filter at startup and runs the
+                # program anyway; raising here would kill a line every
+                # other runtime completes. The message is _OptionError's
+                # own, which is what CPython prints after the colon.
+                _err_text.write('Invalid -W option ignored: %s\\n' % (_werr,))
     sys.stdin  = _stdin_text
     sys.stdout = _out_text
     sys.stderr = _err_text

--- a/typescript/packages/core/src/runtime/python/wrapper.ts
+++ b/typescript/packages/core/src/runtime/python/wrapper.ts
@@ -169,16 +169,44 @@ _err_text  = io.TextIOWrapper(_err_bytes, encoding='utf-8', errors='replace',
 _stdin_buf  = io.BytesIO(bytes(_stdin_bytes) if _stdin_bytes is not None else b'')
 _stdin_text = io.TextIOWrapper(_stdin_buf, encoding='utf-8', errors='replace')
 
+# The interpreter-init switches, honored here because this engine is
+# real CPython even though it is already running: -O is a compile()
+# argument, -B and -X are writable attributes, and -W is what the
+# warnings module does anyway. -E/-I/-s/-S reduce to dropping entries
+# from the env and sys.path, both of which this wrapper already
+# saves and restores. One divergence stands: sys.flags is read-only, so
+# introspecting code sees optimize == 0 even when -O was honored.
+_flags     = dict(_init_flags) if _init_flags is not None else {}
+_optimize  = int(_flags.get('O') or 0)
+_isolated  = bool(_flags.get('I'))
+_no_env    = bool(_flags.get('E')) or _isolated
+_saved_dwb = sys.dont_write_bytecode
+_saved_xop = dict(sys._xoptions)
+
 _exit_code = 0
 try:
     os.environ.clear()
-    os.environ.update(dict(_merged_env))
+    _env = dict(_merged_env)
+    if _no_env:
+        for _key in [k for k in _env if k.startswith('PYTHON')]:
+            del _env[_key]
+    os.environ.update(_env)
+    if _flags.get('B'):
+        sys.dont_write_bytecode = True
+    for _xopt in _flags.get('X') or []:
+        _name, _, _value = str(_xopt).partition('=')
+        sys._xoptions[_name] = _value if _value else True
+    if _flags.get('W'):
+        import warnings as _warnings
+        for _spec in _flags.get('W') or []:
+            _warnings._setoption(str(_spec))
     sys.stdin  = _stdin_text
     sys.stdout = _out_text
     sys.stderr = _err_text
     sys.argv   = list(_argv)
     try:
-        exec(compile(_user_code, '<string>', 'exec'), dict(_user_globals))
+        exec(compile(_user_code, '<string>', 'exec', optimize=_optimize),
+             dict(_user_globals))
     except SystemExit as _e:
         _code = _e.code
         if _code is None:
@@ -199,6 +227,9 @@ finally:
     os.environ.clear()
     os.environ.update(_saved_env)
     sys.path[:]  = _saved_path
+    sys.dont_write_bytecode = _saved_dwb
+    sys._xoptions.clear()
+    sys._xoptions.update(_saved_xop)
     sys.stdin    = _saved_stdin
     sys.stdout   = _saved_stdout
     sys.stderr   = _saved_stderr

--- a/typescript/packages/core/src/runtime/python/wrapper.ts
+++ b/typescript/packages/core/src/runtime/python/wrapper.ts
@@ -169,28 +169,31 @@ _err_text  = io.TextIOWrapper(_err_bytes, encoding='utf-8', errors='replace',
 _stdin_buf  = io.BytesIO(bytes(_stdin_bytes) if _stdin_bytes is not None else b'')
 _stdin_text = io.TextIOWrapper(_stdin_buf, encoding='utf-8', errors='replace')
 
-# The interpreter-init switches, honored here because this engine is
-# real CPython even though it is already running: -O is a compile()
-# argument, -B and -X are writable attributes, and -W is what the
-# warnings module does anyway. -E/-I/-s/-S reduce to dropping entries
-# from the env and sys.path, both of which this wrapper already
-# saves and restores. One divergence stands: sys.flags is read-only, so
-# introspecting code sees optimize == 0 even when -O was honored.
+# The interpreter-init switches this engine can act on, which is the
+# set that is still settable after startup: -O is a compile() argument,
+# -B and -X are writable attributes, and -W is what the warnings module
+# does anyway. -E, -I, -s and -S are NOT among them: they only change
+# how an interpreter starts up, and this one started long before the
+# line was typed, so the runtime reports them rather than faking them.
+# Deleting PYTHON* from os.environ was that fake, and it was wrong in
+# the other direction too: CPython's -E stops those variables
+# configuring startup, it does not hide them from the program, which
+# can still read PYTHONPATH out of os.environ. One divergence stands:
+# sys.flags is read-only, so introspecting code sees optimize == 0 even
+# when -O was honored.
 _flags     = dict(_init_flags) if _init_flags is not None else {}
-_optimize  = int(_flags.get('O') or 0)
-_isolated  = bool(_flags.get('I'))
-_no_env    = bool(_flags.get('E')) or _isolated
+# CPython counts -OOO as optimize 3 in sys.flags but compile() accepts
+# only -1..2 and raises ValueError above that, so the extra Os saturate
+# here rather than failing the run.
+_optimize  = min(int(_flags.get('O') or 0), 2)
 _saved_dwb = sys.dont_write_bytecode
 _saved_xop = dict(sys._xoptions)
+_saved_filters = None
 
 _exit_code = 0
 try:
     os.environ.clear()
-    _env = dict(_merged_env)
-    if _no_env:
-        for _key in [k for k in _env if k.startswith('PYTHON')]:
-            del _env[_key]
-    os.environ.update(_env)
+    os.environ.update(_merged_env)
     if _flags.get('B'):
         sys.dont_write_bytecode = True
     for _xopt in _flags.get('X') or []:
@@ -198,6 +201,10 @@ try:
         sys._xoptions[_name] = _value if _value else True
     if _flags.get('W'):
         import warnings as _warnings
+        # _setoption mutates a process-global list, and this interpreter
+        # outlives the run, so -W error would follow every later command
+        # that asked for nothing.
+        _saved_filters = _warnings.filters[:]
         for _spec in _flags.get('W') or []:
             _warnings._setoption(str(_spec))
     sys.stdin  = _stdin_text
@@ -230,6 +237,10 @@ finally:
     sys.dont_write_bytecode = _saved_dwb
     sys._xoptions.clear()
     sys._xoptions.update(_saved_xop)
+    if _saved_filters is not None:
+        import warnings as _warnings
+        _warnings.filters[:] = _saved_filters
+        _warnings._filters_mutated()
     sys.stdin    = _saved_stdin
     sys.stdout   = _saved_stdout
     sys.stderr   = _saved_stderr

--- a/typescript/packages/core/src/workspace/executor/python/handle.ts
+++ b/typescript/packages/core/src/workspace/executor/python/handle.ts
@@ -13,6 +13,9 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { runOutput } from '../../../commands/builtin/general/interpreter.ts'
+import type { SourceMode } from '../../../commands/builtin/general/interpreter.ts'
+import { PythonRuntime } from '../../../runtime/python/base.ts'
+import type { InitFlags } from '../../../runtime/python/flags.ts'
 import type { LanguageRuntime } from '../../../runtime/language.ts'
 import { CommandTimeoutError } from '../../../commands/builtin/utils/limit.ts'
 import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
@@ -54,6 +57,12 @@ export async function handlePython(
     stdin: ByteSource | null
     env: Record<string, string>
     code: string | null
+    // argv[0], derived from which door the source came through; '' is
+    // CPython's own answer for a program piped in with no operand, so a
+    // runtime must not treat it as absent.
+    prog?: string
+    mode?: SourceMode
+    initFlags?: InitFlags
     signal?: AbortSignal
     timeoutSeconds?: number
   },
@@ -91,11 +100,30 @@ export async function handlePython(
   }
 
   try {
+    if (
+      opts.mode === 'module' &&
+      deps.runtime instanceof PythonRuntime &&
+      !deps.runtime.runsModules
+    ) {
+      // Exit 1, CPython's code for a `-m` that could not run, but not
+      // its "No module named" wording: nothing was searched for, so
+      // naming the runtime is the honest report.
+      const err = new TextEncoder().encode(
+        `python3: -m is not supported by the '${deps.runtime.name}' runtime\n`,
+      )
+      return [
+        null,
+        new IOResult({ exitCode: 1, stderr: err }),
+        new ExecutionNode({ command: cmdStr, exitCode: 1 }),
+      ]
+    }
     const result = await deps.runtime.run({
       code,
       args,
       env: opts.env,
       stdin: stdinBytes,
+      ...(opts.prog !== undefined ? { prog: opts.prog } : {}),
+      ...(opts.initFlags !== undefined ? { flags: opts.initFlags as Record<string, unknown> } : {}),
       ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
       ...(opts.timeoutSeconds !== undefined ? { timeoutSeconds: opts.timeoutSeconds } : {}),
     })

--- a/typescript/packages/core/src/workspace/executor/python/handle.ts
+++ b/typescript/packages/core/src/workspace/executor/python/handle.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { runOutput } from '../../../commands/builtin/general/interpreter.ts'
+import { runOutput, skipFirstLine } from '../../../commands/builtin/general/interpreter.ts'
 import type { SourceMode } from '../../../commands/builtin/general/interpreter.ts'
 import { PythonRuntime } from '../../../runtime/python/base.ts'
 import type { InitFlags } from '../../../runtime/python/flags.ts'
@@ -62,6 +62,9 @@ export async function handlePython(
     // runtime must not treat it as absent.
     prog?: string
     mode?: SourceMode
+    // CPython's -x. File mode only, which is CPython's own scope: -c,
+    // -m and stdin are unaffected.
+    skipFirstLine?: boolean
     initFlags?: InitFlags
     signal?: AbortSignal
     timeoutSeconds?: number
@@ -84,6 +87,7 @@ export async function handlePython(
       const [data] = await dispatch('read', toPathSpec(pathScope))
       const bytes = await readAllBytes(data)
       code = new TextDecoder('utf-8', { fatal: false }).decode(bytes)
+      if (opts.skipFirstLine === true) code = skipFirstLine(code)
     } catch {
       const err = new TextEncoder().encode(`python3: ${pathScope.virtual}: No such file\n`)
       return [

--- a/typescript/packages/core/src/workspace/executor/python/python.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/python.test.ts
@@ -319,4 +319,69 @@ describe('python3: TS-specific (Pyodide isolation + mechanics)', { timeout: 3000
     expect(stdoutStr(check).trim()).toBe('False')
     await ws.close()
   }, 60_000)
+
+  it('a shadowing function receives the words as typed', async () => {
+    // bash's own rule: a function of the same name takes the line. It has
+    // no CPython option table, so the `--` the interpreter's handoff would
+    // need must not be inserted into its arguments.
+    const { ws } = await makeWorkspace()
+    await ws.execute('python3() { echo "$@"; }')
+    const io = await ws.execute('python3 -c payload -u x')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('-c payload -u x\n')
+    await ws.close()
+  })
+
+  it('command bypasses the function and restores the handoff', async () => {
+    // `command` masks the function for its inner run, so the interpreter
+    // is what runs and -u belongs to the program again.
+    const { ws } = await makeWorkspace()
+    await ws.execute('python3() { echo "$@"; }')
+    const io = await ws.execute('command python3 -c "import sys; print(sys.argv)" -u x')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe("['-c', '-u', 'x']\n")
+    await ws.close()
+  }, 60_000)
+
+  it('an invalid -W filter is reported and the program still runs', async () => {
+    // CPython names a bad filter at startup and runs the program anyway;
+    // aborting would kill a line every other runtime completes.
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute('python3 -W nonsense -c "print(42)"')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('42\n')
+    expect(stderrStr(io)).toBe("Invalid -W option ignored: invalid action: 'nonsense'\n")
+    await ws.close()
+  }, 60_000)
+
+  it('a known -X name is reported as unhonored', async () => {
+    // -X dev's real effect is read out of sys.flags, which is read-only,
+    // so populating sys._xoptions is all this engine can do for it.
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute('python3 -X dev -c "print(7)"')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('7\n')
+    expect(stderrStr(io)).toContain("-X dev is ignored by the 'pyodide' runtime")
+    await ws.close()
+  }, 60_000)
+
+  it('an arbitrary -X name lands in sys._xoptions in silence', async () => {
+    // On CPython it does nothing but land in the dict either.
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute('python3 -X nosuchopt -c "import sys; print(sys._xoptions)"')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe("{'nosuchopt': True}\n")
+    expect(stderrStr(io)).toBe('')
+    await ws.close()
+  }, 60_000)
+
+  it('unsetting the function restores the handoff', async () => {
+    const { ws } = await makeWorkspace()
+    await ws.execute('python3() { echo "$@"; }')
+    await ws.execute('unset -f python3')
+    const io = await ws.execute('python3 -c "import sys; print(sys.argv)" -u x')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe("['-c', '-u', 'x']\n")
+    await ws.close()
+  }, 60_000)
 })

--- a/typescript/packages/core/src/workspace/expand/argv.ts
+++ b/typescript/packages/core/src/workspace/expand/argv.ts
@@ -15,7 +15,7 @@
 import type { CallStack } from '../../shell/call_stack.ts'
 import { PathSpec, wordText } from '../../types.ts'
 import type { MountRegistry } from '../mount/registry.ts'
-import { WordPolicy, route, wordPolicy } from '../route/index.ts'
+import { WordPolicy, endOptionsAfterProgram, route, wordPolicy } from '../route/index.ts'
 import type { Session } from '../session/session.ts'
 import { classifyParts } from './classify/index.ts'
 import { resolveGlobs } from './globs.ts'
@@ -85,6 +85,13 @@ export async function expandArgv(
   // `gws docs documents get`); the registry says how many.
   const consumed = registry.matchCommandPrefix(expanded)
   const name = expanded.slice(0, consumed).join(' ')
+  // Before anything reads the line: an option carrying a program hands
+  // the words after it to that program, and POSIX's own `--` is how that
+  // handoff is spelled.
+  const lineWords = [
+    ...expanded.slice(0, consumed),
+    ...endOptionsAfterProgram(name, expanded.slice(consumed)),
+  ]
 
   const policy = wordPolicy(route(name, session, registry))
   let wordKinds: (ValueType | null)[] | null = null
@@ -93,15 +100,15 @@ export async function expandArgv(
     const spec = specForCommand(name, registry, session.cwd)
     if (spec !== null) {
       const extra: (ValueType | null)[] = new Array<ValueType | null>(consumed - 1).fill('str')
-      wordKinds = [...extra, ...specWordKinds(spec, expanded.slice(consumed))]
-      const bases = specWordBases(spec, expanded.slice(consumed), session.cwd)
+      wordKinds = [...extra, ...specWordKinds(spec, lineWords.slice(consumed))]
+      const bases = specWordBases(spec, lineWords.slice(consumed), session.cwd)
       if (bases !== null) {
         wordBases = [...new Array<string | null>(consumed - 1).fill(null), ...bases]
       }
     }
   }
 
-  let classified = classifyParts(expanded, registry, session.cwd, wordKinds, wordBases)
+  let classified = classifyParts(lineWords, registry, session.cwd, wordKinds, wordBases)
   // set -f: glob words become literal paths for every consumer,
   // including backend pushdown, so `cat *.txt` looks up a file
   // literally named `*.txt` like bash with noglob.

--- a/typescript/packages/core/src/workspace/expand/argv.ts
+++ b/typescript/packages/core/src/workspace/expand/argv.ts
@@ -87,11 +87,17 @@ export async function expandArgv(
   const name = expanded.slice(0, consumed).join(' ')
   // Before anything reads the line: an option carrying a program hands
   // the words after it to that program, and POSIX's own `--` is how that
-  // handoff is spelled.
-  const lineWords = [
-    ...expanded.slice(0, consumed),
-    ...endOptionsAfterProgram(name, expanded.slice(consumed)),
-  ]
+  // handoff is spelled. Only when the interpreter is what runs, though:
+  // a shell function of the same name takes the line instead (bash's own
+  // rule), and it must receive the words as typed rather than a marker
+  // meant for a parser it does not have. `command python3` masks the
+  // function for its inner run, which is exactly when the rewrite
+  // applies again. A CLI cannot reach here at all, since registerCli
+  // refuses a shell builtin's name.
+  const shadowed = Object.hasOwn(session.functions, name)
+  const lineWords = shadowed
+    ? [...expanded]
+    : [...expanded.slice(0, consumed), ...endOptionsAfterProgram(name, expanded.slice(consumed))]
 
   const policy = wordPolicy(route(name, session, registry))
   let wordKinds: (ValueType | null)[] | null = null

--- a/typescript/packages/core/src/workspace/route/constants.ts
+++ b/typescript/packages/core/src/workspace/route/constants.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { SPECS } from '../../commands/spec/index.ts'
+import { compileSpec } from '../../commands/spec/compile.ts'
 import { ShellBuiltin } from '../../shell/types.ts'
 import type { PathSpec } from '../../types.ts'
 
@@ -173,6 +175,70 @@ export function reportsLink(name: string, words: readonly (string | PathSpec)[])
   if (dereferences(name, words)) return false
   const spec = NO_FOLLOW_FLAGS[name]
   return spec !== undefined && hasOption(words, spec[0], spec[1])
+}
+
+// Options whose argument is a program, so the words after it are that
+// program's argv rather than the command's own: python3's -c and -m
+// (`python3 -c 'code' -u x` hands -u to the code). This is a table
+// rather than a spec field on purpose. argparse cannot express it at
+// all (`add_argument("-c")` beside `nargs=REMAINDER` answers
+// `unrecognized arguments: -u`), and CPython parses its own command
+// line in C for the same reason, so it is one command's rule and not
+// part of the shared grammar.
+const PROGRAM_OPTIONS: Record<string, readonly string[]> = {
+  python: ['-c', '-m'],
+  python3: ['-c', '-m'],
+}
+
+/**
+ * Insert POSIX's `--` after a program-carrying option's value.
+ *
+ * The handoff already has a spelling every parser honors, so the rule is
+ * applied by writing one down rather than by teaching the parser a new
+ * kind of option. The marker is inserted unconditionally, never skipped
+ * because the line already carries one: CPython stops parsing at -c and
+ * passes a later `--` through as data (`python3 -c p -- -u` gives the
+ * program `['-c', '--', '-u']`), so the parser must consume exactly the
+ * one added here and leave any typed one alone.
+ *
+ * Only the option run before the first operand is scanned. A -c after an
+ * operand belongs to the program (`python3 s.py -c x`), and the operand
+ * already ended option parsing by itself.
+ */
+export function endOptionsAfterProgram(name: string, words: string[]): string[] {
+  const carriers = PROGRAM_OPTIONS[name]
+  if (carriers === undefined) return words
+  // Value spellings say which words carry a value, so `-W ignore -c p`
+  // steps over `ignore` instead of reading it as the first operand.
+  const spec = SPECS[name]
+  if (spec === undefined) return words
+  const valueSpellings = compileSpec(spec).valueSpellings
+  let i = 0
+  while (i < words.length) {
+    const word = words[i] ?? ''
+    if (word === '--') return words
+    const carrier = carriers.find((c) => word.startsWith(c))
+    if (carrier !== undefined) {
+      // Attached (`-cCODE`) carries its value in this word; the detached
+      // form takes the next one.
+      const after = word !== carrier ? i + 1 : i + 2
+      // Nothing to hand over, and a detached form with no value at all is
+      // the parser's refusal to report, not ours to turn into a program
+      // named `--`.
+      if (after >= words.length) return words
+      return [...words.slice(0, after), '--', ...words.slice(after)]
+    }
+    if (valueSpellings.includes(word)) {
+      i += 2
+      continue
+    }
+    if (word.startsWith('-') && word !== '-') {
+      i += 1
+      continue
+    }
+    return words
+  }
+  return words
 }
 
 export const SHELL_NAMES: ReadonlySet<string> = new Set([

--- a/typescript/packages/core/src/workspace/route/constants.ts
+++ b/typescript/packages/core/src/workspace/route/constants.ts
@@ -191,6 +191,45 @@ const PROGRAM_OPTIONS: Record<string, readonly string[]> = {
 }
 
 /**
+ * Where a short cluster's program value ends, or null if it has none.
+ *
+ * Args:
+ *   word: the option word, dash included.
+ *   index: the word's position in the command's words.
+ *   carriers: the spellings whose value is a program.
+ *   valueSpellings: every short spelling that takes a value.
+ */
+function clusterHandoff(
+  word: string,
+  index: number,
+  carriers: readonly string[],
+  valueSpellings: readonly string[],
+): number | null {
+  for (let j = 1; j < word.length; j++) {
+    const letter = `-${word[j] ?? ''}`
+    // Attached (`-cCODE`) carries its value in this word; the detached
+    // form takes the next one.
+    if (carriers.includes(letter)) return word.slice(j + 1) !== '' ? index + 1 : index + 2
+    if (valueSpellings.includes(letter)) return null
+  }
+  return null
+}
+
+/**
+ * How many words a short cluster with no program value consumes.
+ *
+ * Args:
+ *   word: the option word, dash included.
+ *   valueSpellings: every short spelling that takes a value.
+ */
+function clusterWords(word: string, valueSpellings: readonly string[]): number {
+  for (let j = 1; j < word.length; j++) {
+    if (valueSpellings.includes(`-${word[j] ?? ''}`)) return word.slice(j + 1) !== '' ? 1 : 2
+  }
+  return 1
+}
+
+/**
  * Insert POSIX's `--` after a program-carrying option's value.
  *
  * The handoff already has a spelling every parser honors, so the rule is
@@ -204,6 +243,11 @@ const PROGRAM_OPTIONS: Record<string, readonly string[]> = {
  * Only the option run before the first operand is scanned. A -c after an
  * operand belongs to the program (`python3 s.py -c x`), and the operand
  * already ended option parsing by itself.
+ *
+ * The scan walks a short cluster letter by letter rather than matching
+ * the word's prefix, because the carrier need not be first: CPython
+ * reads `python3 -uc 'p' -v` and `python3 -uc'p' -v` the same way it
+ * reads the unclustered forms, handing `-v` to the program.
  */
 export function endOptionsAfterProgram(name: string, words: string[]): string[] {
   const carriers = PROGRAM_OPTIONS[name]
@@ -212,31 +256,29 @@ export function endOptionsAfterProgram(name: string, words: string[]): string[] 
   // steps over `ignore` instead of reading it as the first operand.
   const spec = SPECS[name]
   if (spec === undefined) return words
-  const valueSpellings = compileSpec(spec).valueSpellings
+  const compiled = compileSpec(spec)
   let i = 0
   while (i < words.length) {
     const word = words[i] ?? ''
     if (word === '--') return words
-    const carrier = carriers.find((c) => word.startsWith(c))
-    if (carrier !== undefined) {
-      // Attached (`-cCODE`) carries its value in this word; the detached
-      // form takes the next one.
-      const after = word !== carrier ? i + 1 : i + 2
-      // Nothing to hand over, and a detached form with no value at all is
-      // the parser's refusal to report, not ours to turn into a program
-      // named `--`.
-      if (after >= words.length) return words
-      return [...words.slice(0, after), '--', ...words.slice(after)]
-    }
-    if (valueSpellings.includes(word)) {
-      i += 2
+    // The first operand, which ended option parsing by itself.
+    if (!word.startsWith('-') || word === '-') return words
+    if (word.startsWith('--')) {
+      const attached = word.includes('=')
+      const longName = word.split('=', 1)[0] ?? word
+      i += attached || !compiled.longValueSpellings.has(longName) ? 1 : 2
       continue
     }
-    if (word.startsWith('-') && word !== '-') {
-      i += 1
+    const after = clusterHandoff(word, i, carriers, compiled.valueSpellings)
+    if (after === null) {
+      i += clusterWords(word, compiled.valueSpellings)
       continue
     }
-    return words
+    // Nothing to hand over, and a detached form with no value at all is
+    // the parser's refusal to report, not ours to turn into a program
+    // named `--`.
+    if (after >= words.length) return words
+    return [...words.slice(0, after), '--', ...words.slice(after)]
   }
   return words
 }

--- a/typescript/packages/core/src/workspace/route/index.ts
+++ b/typescript/packages/core/src/workspace/route/index.ts
@@ -18,6 +18,7 @@ export {
   NO_FOLLOW_COMMANDS,
   UNSUPPORTED_BUILTINS,
   dereferences,
+  endOptionsAfterProgram,
   reportsLink,
 } from './constants.ts'
 export { route, routeAll } from './route.ts'

--- a/typescript/packages/core/src/workspace/route/program_options.test.ts
+++ b/typescript/packages/core/src/workspace/route/program_options.test.ts
@@ -1,0 +1,75 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { endOptionsAfterProgram } from './constants.ts'
+
+const rewrite = (words: string[]): string[] => endOptionsAfterProgram('python3', words)
+
+describe('endOptionsAfterProgram', () => {
+  it('leaves a command with no program option untouched', () => {
+    const words = ['-c', 'print(1)', '-u']
+    expect(endOptionsAfterProgram('cat', words)).toEqual(words)
+  })
+
+  it('puts the marker after the payload value', () => {
+    expect(rewrite(['-c', 'print(1)', '-u', 'x'])).toEqual(['-c', 'print(1)', '--', '-u', 'x'])
+  })
+
+  it('puts the marker after an attached payload value', () => {
+    expect(rewrite(['-cprint(1)', '-u'])).toEqual(['-cprint(1)', '--', '-u'])
+  })
+
+  it('steps over a value option before the payload', () => {
+    // -W takes a value, so `ignore` is not the first operand.
+    expect(rewrite(['-W', 'ignore', '-c', 'p', 'x'])).toEqual([
+      '-W',
+      'ignore',
+      '-c',
+      'p',
+      '--',
+      'x',
+    ])
+  })
+
+  it('adds its own marker even when the line already carries one', () => {
+    // CPython stops parsing at -c and passes a later `--` through as
+    // data, so the parser must eat ours and leave theirs.
+    expect(rewrite(['-c', 'p', '--', '-u'])).toEqual(['-c', 'p', '--', '--', '-u'])
+  })
+
+  it('leaves a payload option after an operand to the program', () => {
+    // `python3 s.py -c x` runs s.py; the -c is the script's own.
+    expect(rewrite(['s.py', '-c', 'x'])).toEqual(['s.py', '-c', 'x'])
+  })
+
+  it('stops at a marker that precedes the payload', () => {
+    expect(rewrite(['--', '-c', 'x'])).toEqual(['--', '-c', 'x'])
+  })
+
+  it('hands off a module the same way', () => {
+    expect(rewrite(['-m', 'json.tool', '-h'])).toEqual(['-m', 'json.tool', '--', '-h'])
+  })
+
+  it('leaves a payload with no value for the parser to refuse', () => {
+    // `python3 -c` must report the missing argument, not run a program
+    // named `--`.
+    expect(rewrite(['-c'])).toEqual(['-c'])
+    expect(rewrite(['-cprint(1)'])).toEqual(['-cprint(1)'])
+  })
+
+  it('adds nothing when no words follow the value', () => {
+    expect(rewrite(['-c', 'print(1)'])).toEqual(['-c', 'print(1)'])
+  })
+})

--- a/typescript/packages/core/src/workspace/route/program_options.test.ts
+++ b/typescript/packages/core/src/workspace/route/program_options.test.ts
@@ -72,4 +72,52 @@ describe('endOptionsAfterProgram', () => {
   it('adds nothing when no words follow the value', () => {
     expect(rewrite(['-c', 'print(1)'])).toEqual(['-c', 'print(1)'])
   })
+
+  it('hands off from inside a cluster', () => {
+    // `python3 -uc 'p' -v` gives the program ['-c', '-v'] on CPython,
+    // so the carrier is found by walking letters, not by prefix.
+    expect(rewrite(['-uc', 'p', '-v', 'foo'])).toEqual(['-uc', 'p', '--', '-v', 'foo'])
+  })
+
+  it('hands off after a cluster carrying an attached value', () => {
+    expect(rewrite(['-ucp', '-v', 'foo'])).toEqual(['-ucp', '--', '-v', 'foo'])
+  })
+
+  it('leaves a clustered payload with no value alone', () => {
+    expect(rewrite(['-uc'])).toEqual(['-uc'])
+  })
+
+  it('steps over a long value option before the payload', () => {
+    expect(rewrite(['--check-hash-based-pycs', 'never', '-c', 'p', '-u', 'z'])).toEqual([
+      '--check-hash-based-pycs',
+      'never',
+      '-c',
+      'p',
+      '--',
+      '-u',
+      'z',
+    ])
+  })
+
+  it('consumes only its own word for an attached long value option', () => {
+    expect(rewrite(['--check-hash-based-pycs=never', '-c', 'p', '-u', 'z'])).toEqual([
+      '--check-hash-based-pycs=never',
+      '-c',
+      'p',
+      '--',
+      '-u',
+      'z',
+    ])
+  })
+
+  it('consumes only its own word for an attached short value option', () => {
+    expect(rewrite(['-Wignore', '-c', 'p', '-u', 'z'])).toEqual([
+      '-Wignore',
+      '-c',
+      'p',
+      '--',
+      '-u',
+      'z',
+    ])
+  })
 })

--- a/typescript/scripts/gen-specs.ts
+++ b/typescript/scripts/gen-specs.ts
@@ -170,6 +170,7 @@ function operandFields(op: Operand): Record<string, unknown> {
   return {
     name: op.name,
     provided_by: [...op.providedBy],
+    remainder: op.remainder,
     required: op.required,
     text_when: [...op.textWhen],
     type: op.type,


### PR DESCRIPTION
## Summary

- **`python3` had no option table.** Its spec carried one option (`-c`) plus a free-text rest, so every other switch fell through to the operand slot: `python3 -u s.py` ran a file called `/-u`, `python3 -zz -c 'x'` exited 0 with the flag swallowed, and `-V`/`-h` were read as paths.
- **The boundary is argparse's `nargs=REMAINDER`**, declared as `Operand.remainder`. An unknown dash word before the script is python3's usage error; after it, it is data the script must receive. One leniency switch cannot do both, and this is POSIX's own option order (GNU's permuting default is the extension, as `POSIXLY_CORRECT=1 ls a -1` shows). `CommandSpec` and `Option` are unchanged.
- **An option whose argument is a program is not in the grammar.** argparse cannot express it (`add_argument('-c')` beside `nargs=REMAINDER` answers `unrecognized arguments: -u`), and CPython parses its own command line in C for that reason. POSIX already spells the handoff `--`, so a command-name table in `workspace/route` inserts one after `-c`/`-m`'s value, beside the existing line rules. It is added unconditionally, because CPython passes a typed `--` through as data.
- **`-m`** runs through runpy, with a `find_spec` probe so a missing module is CPython's one line rather than a traceback.
- **argv[0]** now matches CPython for all four source doors. The local and wasi tiers hand CPython the program via `-c`, which hardcodes argv[0] to `-c` and names every frame `<string>`; `bootstrap()` re-compiles under the real name, fixing argv[0] and the traceback filename together.
- **Init switches** (`-O -B -W -X -E -I`) ride in `RunArgs.flags`, honored where the engine can and reported on stderr where it cannot.
- **Pyodide `sysPath`** glob-expands and prepends mount paths once the mounts are in place, so a vendored wheel imports without the `sys.path.append` incantation. A glob matching nothing is reported on the run's stderr (the seed runs inside `syncMounts`, before stderr is captured, so it cannot report it itself). Plus `packages` / `packageBaseUrl` / `lockFileURL` for a prebuilt distribution.
- **Separate commit — `fix(ids)`:** `uuid6.uuid7` ordered ids inside a millisecond by bumping the timestamp past the previous one, and the borrowed value became the next call's floor, so a burst of 5000 ids stamped 4991 ms into the future and stayed there. Replaced with RFC 9562's counter in `rand_a`; `uuid6` dropped. TypeScript was already correct.

## Test plan

- Differential harness against vanilla CPython 3.13.7: **14/14** lines match on stdout, stderr and exit code, plus the three `--`-handoff lines checked separately.
- Pyodide exercised live with a real wheel on a RAM mount: import through the glob, prepend order, argv[0], `-O`/`-B`/`-X`, re-seed on later runs, and the zero-expansion warning.
- Python suite exit 0; TS core 591 files / 7171 tests; spec parity 93/93; `git diff --exit-code spec/` clean.

## Notes for review

- `CLISpec` **is** a `CommandSpec` in both languages, so the CLI tier is not a way to escape the shared grammar. CLAUDE.md now states the field rule as a literal test (write the line in argparse and run it), with both python3 halves as the worked example.
