### PR TITLE
fix(tee): write every operand, and use the append slot (#609 T1-I)

### DIFF
--- a/integ/unix/tee/operands.json
+++ b/integ/unix/tee/operands.json
@@ -1,0 +1,97 @@
+{
+  "cases": [
+    {
+      "id": "tee_multi_operand",
+      "seq": 601052,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/ptee3 && printf 'DUP' | tee /data/ptee3/a.txt /data/ptee3/b.txt > /dev/null && cat /data/ptee3/a.txt && printf '|' && cat /data/ptee3/b.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "DUP|DUP",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "tee_a_multi_operand",
+      "seq": 601053,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/ptee4 && printf 'x' > /data/ptee4/a.txt && printf 'y' > /data/ptee4/b.txt && printf 'Z' | tee -a /data/ptee4/a.txt /data/ptee4/b.txt > /dev/null && cat /data/ptee4/a.txt && printf '|' && cat /data/ptee4/b.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "xZ|yZ",
+        "stderr": ""
+      },
+      "flags": [
+        "a"
+      ]
+    },
+    {
+      "id": "tee_a_creates_missing",
+      "seq": 601054,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/ptee5 && printf 'NEW' | tee -a /data/ptee5/fresh.txt > /dev/null && cat /data/ptee5/fresh.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "NEW",
+        "stderr": ""
+      },
+      "flags": [
+        "a"
+      ]
+    }
+  ]
+}

--- a/python/mirage/commands/builtin/generic/tee.py
+++ b/python/mirage/commands/builtin/generic/tee.py
@@ -12,38 +12,133 @@ from mirage.utils.errors import fs_error_line, fs_strerror
 @dataclass(frozen=True, slots=True)
 class TeeFlags:
     append: bool = False
+    stop_on_error: bool = False
 
 
 def parse_flags(flags: Mapping[str, FlagValue]) -> TeeFlags:
     # --output-error values are validated declaratively: the spec's
     # choices= makes the parser report any other value and the executor
-    # refuse with GNU's ARGMATCH shape before tee runs.
+    # refuse with GNU's ARGMATCH shape before tee runs. Only the exit/
+    # warn axis is observable here: the -nopipe half distinguishes a pipe
+    # sink from a file sink, and every operand tee writes is a file.
+    # A bare --output-error means warn (GNU 9.7).
     fl = FlagView(flags, spec=SPECS["tee"])
-    return TeeFlags(append=fl.as_bool("append"))
+    mode = fl.as_str("output_error")
+    return TeeFlags(append=fl.as_bool("append"),
+                    stop_on_error=mode in ("exit", "exit-nopipe"))
+
+
+def error_line(path: PathSpec, exc: OSError) -> bytes:
+    """GNU's diagnostic for one unwritable operand.
+
+    A recognized filesystem refusal reads like GNU (operand as typed,
+    shared strerror); anything else keeps its own message, which is the
+    only description of the cause a transport error has.
+
+    Args:
+        path (PathSpec): the operand that could not be written.
+        exc (OSError): the refusal.
+    """
+    if fs_strerror(exc) is not None:
+        return fs_error_line("tee", path, exc).encode()
+    return f"tee: {path.mount_path}: {exc}\n".encode()
+
+
+async def write_one(
+    path: PathSpec,
+    raw: bytes,
+    parsed: TeeFlags,
+    read_stream: Callable[..., AsyncIterator[bytes]],
+    write_bytes: Callable[..., Awaitable[None]],
+    append_bytes: Callable[..., Awaitable[None]] | None,
+) -> bytes | None:
+    """Write one operand, returning its new content when that is known.
+
+    ``None`` means "written, but the resulting bytes are not in hand" —
+    the native append case. The caller then lists the path in ``writes``
+    without listing it in ``cache``, which is how ``apply_io`` is told to
+    drop the stale entry instead of caching a wrong one. That costs one
+    read on the next access and saves reading and re-uploading the whole
+    object on this one.
+
+    Args:
+        path (PathSpec): the operand to write.
+        raw (bytes): what tee was handed.
+        parsed (TeeFlags): the parsed flags.
+        read_stream (Callable): backend read, for the emulated append.
+        write_bytes (Callable): backend whole-file write.
+        append_bytes (Callable | None): backend native append, when the
+            backend wired the slot.
+    """
+    if not parsed.append:
+        await write_bytes(path, raw)
+        return raw
+    if append_bytes is not None:
+        await append_bytes(path, raw)
+        return None
+    existing = b""
+    try:
+        async for chunk in read_stream(path):
+            existing += chunk
+    except FileNotFoundError:
+        # GNU tee -a creates a missing file: append to empty.
+        pass
+    data = existing + raw
+    await write_bytes(path, data)
+    return data
 
 
 async def write_output(
+    paths: list[PathSpec],
+    raw: bytes,
+    parsed: TeeFlags,
+    read_stream: Callable[..., AsyncIterator[bytes]],
     write_bytes: Callable[..., Awaitable[None]],
-    path: PathSpec,
-    data: bytes,
-    passthrough: ByteSource,
+    append_bytes: Callable[..., Awaitable[None]] | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
-    try:
-        await write_bytes(path, data)
-    except OSError as exc:
-        # GNU tee still copies stdin to stdout on a write error, prints a
-        # diagnostic, and exits non-zero. With a single output sink the
-        # --output-error modes (warn/exit/*-nopipe) collapse to this. A
-        # recognized filesystem refusal reads like GNU (operand as typed,
-        # shared strerror); anything else keeps its own message, which is
-        # the only description of the cause a transport error has.
-        if fs_strerror(exc) is not None:
-            err = fs_error_line("tee", path, exc).encode()
-        else:
-            err = f"tee: {path.mount_path}: {exc}\n".encode()
-        return passthrough, IOResult(exit_code=1, stderr=err)
-    return passthrough, IOResult(writes={path.mount_path: data},
-                                 cache=[path.mount_path])
+    """Copy ``raw`` to every operand, GNU-style.
+
+    An operand that cannot be written is diagnosed and skipped rather
+    than ending the run: GNU keeps going and still writes the rest, and
+    only ``--output-error=exit`` stops at the first failure. stdin always
+    reaches stdout either way.
+
+    Deliberate divergence: GNU opens every operand up front, so under
+    ``exit`` an *open* failure aborts before any data is written. A mount
+    has no open/write split — ``write_bytes`` is one call — so the
+    operands before the failure are already written. The two agree
+    whenever the failure is at write time, which is what a remote backend
+    reports.
+
+    Args:
+        paths (list[PathSpec]): every output operand, in order.
+        raw (bytes): what tee was handed, and what reaches stdout.
+        parsed (TeeFlags): the parsed flags.
+        read_stream (Callable): backend read, for the emulated append.
+        write_bytes (Callable): backend whole-file write.
+        append_bytes (Callable | None): backend native append, if wired.
+    """
+    writes: dict[str, ByteSource] = {}
+    cache: list[str] = []
+    errors: list[bytes] = []
+    for path in paths:
+        try:
+            data = await write_one(path, raw, parsed, read_stream, write_bytes,
+                                   append_bytes)
+        except OSError as exc:
+            errors.append(error_line(path, exc))
+            if parsed.stop_on_error:
+                break
+            continue
+        writes[path.mount_path] = raw if data is None else data
+        if data is not None:
+            cache.append(path.mount_path)
+    if errors:
+        return raw, IOResult(exit_code=1,
+                             stderr=b"".join(errors),
+                             writes=writes,
+                             cache=cache)
+    return raw, IOResult(writes=writes, cache=cache)
 
 
 async def tee(
@@ -52,6 +147,7 @@ async def tee(
     *,
     read_stream: Callable[..., AsyncIterator[bytes]],
     write_bytes: Callable[..., Awaitable[None]],
+    append_bytes: Callable[..., Awaitable[None]] | None = None,
     stdin: ByteSource | None = None,
     flags: Mapping[str, FlagValue] | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
@@ -61,17 +157,10 @@ async def tee(
     raw = await _read_stdin_async(stdin)
     if raw is None:
         raw = (" ".join(texts)).encode() if texts else b""
-    write_data = raw
-    if parsed.append:
-        try:
-            existing = b""
-            async for chunk in read_stream(paths[0]):
-                existing += chunk
-            write_data = existing + raw
-        except FileNotFoundError:
-            # GNU tee -a creates a missing file: append to empty.
-            pass
-    return await write_output(write_bytes, paths[0], write_data, raw)
+    return await write_output(paths, raw, parsed, read_stream, write_bytes,
+                              append_bytes)
 
 
-__all__ = ["tee", "parse_flags", "TeeFlags", "write_output"]
+__all__ = [
+    "tee", "parse_flags", "TeeFlags", "write_output", "write_one", "error_line"
+]

--- a/python/mirage/commands/builtin/generic/tee.py
+++ b/python/mirage/commands/builtin/generic/tee.py
@@ -28,7 +28,7 @@ def parse_flags(flags: Mapping[str, FlagValue]) -> TeeFlags:
                     stop_on_error=mode in ("exit", "exit-nopipe"))
 
 
-def error_line(path: PathSpec, exc: OSError) -> bytes:
+def error_line(path: PathSpec, exc: Exception) -> bytes:
     """GNU's diagnostic for one unwritable operand.
 
     A recognized filesystem refusal reads like GNU (operand as typed,
@@ -37,7 +37,7 @@ def error_line(path: PathSpec, exc: OSError) -> bytes:
 
     Args:
         path (PathSpec): the operand that could not be written.
-        exc (OSError): the refusal.
+        exc (Exception): the refusal.
     """
     if fs_strerror(exc) is not None:
         return fs_error_line("tee", path, exc).encode()
@@ -103,6 +103,16 @@ async def write_output(
     only ``--output-error=exit`` stops at the first failure. stdin always
     reaches stdout either way.
 
+    "Cannot be written" is any exception the backend raises, not just
+    ``OSError``. Most remote writes forward their SDK's own error class —
+    ``core/s3/write.py`` hands back botocore's ``ClientError``,
+    ``core/gridfs/write.py`` pymongo's ``PyMongoError`` — and none of
+    those is an ``OSError``, so narrowing the catch would let one
+    unreachable operand abort the whole command. ``error_line`` already
+    tells the two apart, and this is not swallowing: every caught error is
+    named on stderr and the command exits 1. ``Exception`` rather than
+    ``BaseException`` keeps cancellation propagating.
+
     Deliberate divergence: GNU opens every operand up front, so under
     ``exit`` an *open* failure aborts before any data is written. A mount
     has no open/write split — ``write_bytes`` is one call — so the
@@ -125,7 +135,7 @@ async def write_output(
         try:
             data = await write_one(path, raw, parsed, read_stream, write_bytes,
                                    append_bytes)
-        except OSError as exc:
+        except Exception as exc:
             errors.append(error_line(path, exc))
             if parsed.stop_on_error:
                 break

--- a/python/mirage/commands/builtin/generic_bind/builders/tee.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/tee.py
@@ -36,14 +36,17 @@ async def tee(
     if not paths:
         raise ValueError("tee: missing operand")
     paths = await ops.resolve_glob(accessor, paths, index)
-    return await generic_tee(paths,
-                             texts,
-                             read_stream=bound_op(ops.read_stream, accessor,
-                                                  index),
-                             write_bytes=partial(ops.require(Operation.WRITE),
-                                                 accessor),
-                             stdin=stdin,
-                             flags=flags)
+    # A backend that can append natively does; the rest fall back to the
+    # read-modify-write inside the generic.
+    append = ops.append
+    return await generic_tee(
+        paths,
+        texts,
+        read_stream=bound_op(ops.read_stream, accessor, index),
+        write_bytes=partial(ops.require(Operation.WRITE), accessor),
+        append_bytes=(None if append is None else partial(append, accessor)),
+        stdin=stdin,
+        flags=flags)
 
 
 BUILDER = Builder('tee',

--- a/python/mirage/commands/builtin/gridfs/tee.py
+++ b/python/mirage/commands/builtin/gridfs/tee.py
@@ -16,9 +16,8 @@ from functools import partial
 
 from mirage.accessor.gridfs import GridFSAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.generic.tee import parse_flags, write_output
+from mirage.commands.builtin.generic.tee import tee as generic_tee
 from mirage.commands.builtin.gridfs.io import resolve_glob
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagValue
@@ -39,23 +38,15 @@ async def tee(
 ) -> tuple[ByteSource | None, IOResult]:
     if not paths:
         raise ValueError("tee: missing operand")
-    try:
-        parsed = parse_flags(flags)
-    except ValueError as exc:
-        return None, IOResult(exit_code=1, stderr=(str(exc) + "\n").encode())
     paths = await resolve_glob(accessor, paths, index)
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raw = (" ".join(texts)).encode() if texts else b""
-    write_data = raw
-    if parsed.append:
-        try:
-            existing = b""
-            async for chunk in read_stream(accessor, paths[0], index=index):
-                existing += chunk
-            write_data = existing + raw
-        except FileNotFoundError:
-            # appending to a missing object starts from empty
-            pass
-    return await write_output(partial(write_bytes, accessor), paths[0],
-                              write_data, raw)
+    # The wrapper is wiring only: every flag semantic, the write to each
+    # operand and the append fallback live in the generic. This file used
+    # to restate them and wrote only paths[0].
+    return await generic_tee(paths,
+                             texts,
+                             read_stream=partial(read_stream,
+                                                 accessor,
+                                                 index=index),
+                             write_bytes=partial(write_bytes, accessor),
+                             stdin=stdin,
+                             flags=flags)

--- a/python/mirage/commands/builtin/s3/tee.py
+++ b/python/mirage/commands/builtin/s3/tee.py
@@ -16,9 +16,8 @@ from functools import partial
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.generic.tee import parse_flags, write_output
+from mirage.commands.builtin.generic.tee import tee as generic_tee
 from mirage.commands.builtin.s3.io import resolve_glob
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagValue
@@ -39,23 +38,15 @@ async def tee(
 ) -> tuple[ByteSource | None, IOResult]:
     if not paths:
         raise ValueError("tee: missing operand")
-    try:
-        parsed = parse_flags(flags)
-    except ValueError as exc:
-        return None, IOResult(exit_code=1, stderr=(str(exc) + "\n").encode())
     paths = await resolve_glob(accessor, paths, index)
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raw = (" ".join(texts)).encode() if texts else b""
-    write_data = raw
-    if parsed.append:
-        try:
-            existing = b""
-            async for chunk in read_stream(accessor, paths[0], index=index):
-                existing += chunk
-            write_data = existing + raw
-        except FileNotFoundError:
-            # appending to a missing object starts from empty
-            pass
-    return await write_output(partial(write_bytes, accessor), paths[0],
-                              write_data, raw)
+    # The wrapper is wiring only: every flag semantic, the write to each
+    # operand and the append fallback live in the generic. This file used
+    # to restate them and wrote only paths[0].
+    return await generic_tee(paths,
+                             texts,
+                             read_stream=partial(read_stream,
+                                                 accessor,
+                                                 index=index),
+                             write_bytes=partial(write_bytes, accessor),
+                             stdin=stdin,
+                             flags=flags)

--- a/python/mirage/commands/builtin/ssh/io.py
+++ b/python/mirage/commands/builtin/ssh/io.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.commands.builtin.generic_bind import CommandIO, DuOps
+from mirage.core.ssh.append import append_bytes as _append
 from mirage.core.ssh.constants import SCOPE_ERROR
 from mirage.core.ssh.copy import copy as _copy
 from mirage.core.ssh.create import create as _create
@@ -43,6 +44,7 @@ IO = CommandIO(
     local=False,
     max_glob_matches=SCOPE_ERROR,
     write=_write,
+    append=_append,
     exists=_exists,
     mkdir=_mkdir,
     unlink=_unlink,

--- a/python/tests/commands/builtin/generic/test_tee.py
+++ b/python/tests/commands/builtin/generic/test_tee.py
@@ -10,6 +10,17 @@ def _spec(path: str) -> PathSpec:
     return PathSpec.from_str_path(path)
 
 
+class _SdkError(Exception):
+    """What a remote backend actually raises on a failed write.
+
+    ``core/s3/write.py`` forwards botocore's ``ClientError`` and
+    ``core/gridfs/write.py`` pymongo's ``PyMongoError`` straight out of
+    ``put_object`` / ``upload_from_stream``; neither is an ``OSError``.
+    The TypeScript sink rejects with a plain ``Error`` for the same
+    reason, so both suites drive the loop with a non-filesystem failure.
+    """
+
+
 def test_parse_flags_append_short_and_long():
     assert parse_flags({"append": True}) == TeeFlags(append=True)
 
@@ -70,6 +81,31 @@ async def test_write_error_passes_stdout_and_exits_one():
 
 
 @pytest.mark.asyncio
+async def test_an_sdk_write_failure_is_diagnosed_not_raised():
+    # Narrowing the catch to OSError let one unreachable operand abort the
+    # whole command on every remote backend, because none of their SDK
+    # error classes is an OSError.
+
+    async def _write(_p, _d):
+        raise _SdkError("An error occurred (AccessDenied)")
+
+    async def _read(_p):
+        if False:
+            yield b""
+
+    source, io = await tee([_spec("/a.txt"), _spec("/b.txt")], (),
+                           read_stream=_read,
+                           write_bytes=_write,
+                           stdin=b"hello",
+                           flags={})
+    assert await materialize(source) == b"hello"
+    assert io.exit_code == 1
+    assert await materialize(
+        io.stderr) == (b"tee: /a.txt: An error occurred (AccessDenied)\n"
+                       b"tee: /b.txt: An error occurred (AccessDenied)\n")
+
+
+@pytest.mark.asyncio
 async def test_unusable_destination_reports_the_gnu_strerror():
     # A recognized filesystem refusal carries only the path as its message,
     # so the strerror has to come from the shared table (GNU:
@@ -122,7 +158,7 @@ def _sink(fail: frozenset[str] = frozenset()):
 
     async def _write(p, d):
         if p.mount_path in fail:
-            raise OSError("disk full")
+            raise _SdkError("disk full")
         written[p.mount_path] = d
 
     return written, _write

--- a/python/tests/commands/builtin/generic/test_tee.py
+++ b/python/tests/commands/builtin/generic/test_tee.py
@@ -12,7 +12,6 @@ def _spec(path: str) -> PathSpec:
 
 def test_parse_flags_append_short_and_long():
     assert parse_flags({"append": True}) == TeeFlags(append=True)
-    assert parse_flags({"append": True}) == TeeFlags(append=True)
 
 
 def test_parse_flags_i_and_p_are_noops():
@@ -22,13 +21,21 @@ def test_parse_flags_i_and_p_are_noops():
     }) == TeeFlags(append=False)
 
 
-def test_parse_flags_valid_output_error_modes():
-    # Value validation moved to the spec's choices=: the parser reports a
-    # bad mode and the executor refuses before tee runs, so parse_flags
-    # only reads append.
-    for mode in ("warn", "warn-nopipe", "exit", "exit-nopipe"):
-        assert parse_flags({"output_error": mode}) == TeeFlags(append=False)
-    assert parse_flags({"output_error": True}) == TeeFlags(append=False)
+def test_parse_flags_reads_the_exit_warn_axis():
+    # Value validation lives in the spec's choices=. Only the exit/warn
+    # axis is observable here: the -nopipe half distinguishes a pipe sink
+    # from a file sink, and every operand tee writes is a file.
+    for mode in ("warn", "warn-nopipe"):
+        assert parse_flags({"output_error":
+                            mode}) == TeeFlags(stop_on_error=False)
+    for mode in ("exit", "exit-nopipe"):
+        assert parse_flags({"output_error":
+                            mode}) == TeeFlags(stop_on_error=True)
+
+
+def test_a_bare_output_error_means_warn():
+    # GNU 9.7.
+    assert parse_flags({"output_error": True}) == TeeFlags(stop_on_error=False)
 
 
 def test_bad_output_error_mode_is_reported_by_the_parser():
@@ -108,3 +115,134 @@ async def test_writes_stdin_and_reports_cache():
     assert written["/out.txt"] == b"hello"
     assert io.writes == {"/out.txt": b"hello"}
     assert io.cache == ["/out.txt"]
+
+
+def _sink(fail: frozenset[str] = frozenset()):
+    written: dict[str, bytes] = {}
+
+    async def _write(p, d):
+        if p.mount_path in fail:
+            raise OSError("disk full")
+        written[p.mount_path] = d
+
+    return written, _write
+
+
+async def _empty(_p):
+    if False:
+        yield b""
+
+
+@pytest.mark.asyncio
+async def test_every_operand_is_written():
+    # GNU 9.7: `printf x | tee a b c` puts x in all three. Both generics
+    # used to write paths[0] and silently drop the rest, while the spec
+    # declared a variadic rest operand.
+    written, write = _sink()
+    source, io = await tee(
+        [_spec("/a"), _spec("/b"), _spec("/c")], (),
+        read_stream=_empty,
+        write_bytes=write,
+        stdin=b"hi",
+        flags={})
+    assert written == {"/a": b"hi", "/b": b"hi", "/c": b"hi"}
+    assert await materialize(source) == b"hi"
+    assert io.exit_code == 0
+    assert io.cache == ["/a", "/b", "/c"]
+
+
+@pytest.mark.asyncio
+async def test_one_bad_operand_does_not_stop_the_others():
+    # GNU pins: `tee p bad q` writes p and q, diagnoses bad, exits 1.
+    written, write = _sink(frozenset({"/bad"}))
+    source, io = await tee(
+        [_spec("/p"), _spec("/bad"), _spec("/q")], (),
+        read_stream=_empty,
+        write_bytes=write,
+        stdin=b"x",
+        flags={})
+    assert written == {"/p": b"x", "/q": b"x"}
+    assert io.exit_code == 1
+    assert await materialize(io.stderr) == b"tee: /bad: disk full\n"
+    assert await materialize(source) == b"x"
+
+
+@pytest.mark.asyncio
+async def test_output_error_exit_stops_at_the_first_failure():
+    written, write = _sink(frozenset({"/bad"}))
+    _source, io = await tee(
+        [_spec("/p"), _spec("/bad"), _spec("/q")], (),
+        read_stream=_empty,
+        write_bytes=write,
+        stdin=b"x",
+        flags={"output_error": "exit"})
+    assert written == {"/p": b"x"}
+    assert io.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_each_failing_operand_is_diagnosed():
+    _written, write = _sink(frozenset({"/b1", "/b2"}))
+    _source, io = await tee([_spec("/b1"), _spec("/b2")], (),
+                            read_stream=_empty,
+                            write_bytes=write,
+                            stdin=b"x",
+                            flags={})
+    assert await materialize(io.stderr
+                             ) == b"tee: /b1: disk full\ntee: /b2: disk full\n"
+    assert io.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_append_to_a_missing_file_creates_it():
+    written, write = _sink()
+
+    async def _missing(p):
+        raise FileNotFoundError(p.virtual)
+        yield b""
+
+    _source, io = await tee([_spec("/new")], (),
+                            read_stream=_missing,
+                            write_bytes=write,
+                            stdin=b"hi",
+                            flags={"append": True})
+    assert written == {"/new": b"hi"}
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_a_native_append_skips_the_read_modify_write():
+    appended: dict[str, bytes] = {}
+    written, write = _sink()
+
+    async def _append(p, d):
+        appended[p.mount_path] = d
+
+    _source, io = await tee([_spec("/n")], (),
+                            read_stream=_empty,
+                            write_bytes=write,
+                            append_bytes=_append,
+                            stdin=b"add",
+                            flags={"append": True})
+    assert appended == {"/n": b"add"}
+    assert written == {}
+    # Listed as written but not as cacheable: the resulting content is not
+    # in hand, so the stale cache entry must be dropped, not replaced.
+    assert list(io.writes) == ["/n"]
+    assert io.cache == []
+
+
+@pytest.mark.asyncio
+async def test_without_a_native_append_it_reads_and_rewrites():
+    written, write = _sink()
+
+    async def _old(_p):
+        yield b"old"
+
+    _source, io = await tee([_spec("/n")], (),
+                            read_stream=_old,
+                            write_bytes=write,
+                            stdin=b"add",
+                            flags={"append": True})
+    assert written == {"/n": b"oldadd"}
+    assert io.cache == ["/n"]

--- a/python/tests/ops/test_inventory.py
+++ b/python/tests/ops/test_inventory.py
@@ -285,6 +285,7 @@ OPS_INVENTORY = {
         ("stat", "slack", "", False),
     ],
     "ssh": [
+        ("append", "ssh", "", True),
         ("create", "ssh", "", True),
         ("mkdir", "ssh", "", True),
         ("read", "ssh", "", False),

--- a/spec/parity_exceptions.json
+++ b/spec/parity_exceptions.json
@@ -22,7 +22,7 @@
       "slots": "python range-reads; typescript has no core/sharepoint/read.ts to add a window to."
     },
     "ssh": {
-      "slots": "python range-reads over SFTP; typescript's read is whole-file because of the ssh2 256 KiB packet cap. append is wired in typescript and read by no builder on either side \u2014 tee is read-modify-write everywhere \u2014 so the slot is pending a decision to wire it or drop it."
+      "slots": "python range-reads over SFTP; typescript's read is whole-file because of the ssh2 256 KiB packet cap."
     }
   },
   "command_io_aliases": {

--- a/spec/python/resources.json
+++ b/spec/python/resources.json
@@ -997,6 +997,7 @@
       "max_du_entries": 10000,
       "max_glob_matches": 5000,
       "slots": [
+        "append",
         "copy",
         "create",
         "du",

--- a/typescript/packages/core/src/commands/builtin/generic/find.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.ts
@@ -14,7 +14,8 @@
 
 import { specOf } from '../../spec/builtins.ts'
 import { FlagView } from '../../spec/types.ts'
-import { isEnoent, modifiedTs } from '../../../core/generic/find.ts'
+import { modifiedTs } from '../../../core/generic/find.ts'
+import { isEnoent } from '../../../utils/errors.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { FindOptions } from '../../../resource/base.ts'
 import { parseFindExpression, parseSize } from '../findParse.ts'

--- a/typescript/packages/core/src/commands/builtin/generic/tee.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tee.test.ts
@@ -16,28 +16,36 @@ import { describe, expect, it } from 'vitest'
 import { PathSpec } from '../../../types.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { parseCommand } from '../../spec/parser.ts'
+import { enoent } from '../../../utils/errors.ts'
 import { parseTeeFlags, writeOutput } from './tee.ts'
 
 const DEC = new TextDecoder()
 
 describe('parseTeeFlags', () => {
   it('accepts -a / --append', () => {
-    expect(parseTeeFlags({ append: true })).toEqual({ append: true })
-    expect(parseTeeFlags({ append: true })).toEqual({ append: true })
+    expect(parseTeeFlags({ append: true })).toEqual({ append: true, stopOnError: false })
   })
 
   it('treats -i / -p as accepted no-ops', () => {
-    expect(parseTeeFlags({ ignore_interrupts: true, p: true })).toEqual({ append: false })
+    expect(parseTeeFlags({ ignore_interrupts: true, p: true })).toEqual({
+      append: false,
+      stopOnError: false,
+    })
   })
 
-  it('accepts valid --output-error modes', () => {
-    for (const mode of ['warn', 'warn-nopipe', 'exit', 'exit-nopipe']) {
-      expect(parseTeeFlags({ output_error: mode })).toEqual({ append: false })
+  it('reads the exit/warn axis of --output-error', () => {
+    // Only this axis is observable: the -nopipe half distinguishes a pipe
+    // sink from a file sink, and every operand tee writes is a file.
+    for (const mode of ['warn', 'warn-nopipe']) {
+      expect(parseTeeFlags({ output_error: mode })).toEqual({ append: false, stopOnError: false })
+    }
+    for (const mode of ['exit', 'exit-nopipe']) {
+      expect(parseTeeFlags({ output_error: mode })).toEqual({ append: false, stopOnError: true })
     }
   })
 
-  it('accepts bare --output-error', () => {
-    expect(parseTeeFlags({ output_error: true })).toEqual({ append: false })
+  it('treats a bare --output-error as warn, like GNU 9.7', () => {
+    expect(parseTeeFlags({ output_error: true })).toEqual({ append: false, stopOnError: false })
   })
 
   it('reports an invalid --output-error mode through the parser channel', () => {
@@ -53,33 +61,128 @@ describe('parseTeeFlags', () => {
 
 describe('writeOutput', () => {
   const ENC = new TextEncoder()
-  const path = PathSpec.fromStrPath('/out.txt')
+  const paths = (...names: string[]): PathSpec[] => names.map((n) => PathSpec.fromStrPath(n))
+  const PLAIN = { append: false, stopOnError: false }
+  const APPEND = { append: true, stopOnError: false }
+  const noStream = (): AsyncIterable<Uint8Array> => {
+    throw enoent('/unused')
+  }
 
-  it('reports writes and cache on success', async () => {
-    const written: Record<string, Uint8Array> = {}
-    const [out, io] = await writeOutput(
-      (p, d) => {
-        written[p.mountPath] = d
+  function sink(fail = new Set<string>()): {
+    written: Record<string, string>
+    write: (p: PathSpec, d: Uint8Array) => Promise<void>
+  } {
+    const written: Record<string, string> = {}
+    return {
+      written,
+      write: (p, d) => {
+        if (fail.has(p.mountPath)) return Promise.reject(new Error('disk full'))
+        written[p.mountPath] = DEC.decode(d)
         return Promise.resolve()
       },
-      path,
+    }
+  }
+
+  it('writes every operand, not just the first', async () => {
+    // GNU 9.7: `printf x | tee a b c` puts x in all three. Both generics
+    // used to write paths[0] and silently drop the rest, while the spec
+    // declared a variadic rest operand.
+    const s = sink()
+    const [out, io] = await writeOutput(
+      paths('/a', '/b', '/c'),
       ENC.encode('hi'),
-      ENC.encode('hi'),
+      PLAIN,
+      noStream,
+      s.write,
     )
+    expect(s.written).toEqual({ '/a': 'hi', '/b': 'hi', '/c': 'hi' })
     expect(DEC.decode(out as Uint8Array)).toBe('hi')
     expect(io.exitCode).toBe(0)
-    expect(io.cache).toEqual(['/out.txt'])
+    expect(io.cache).toEqual(['/a', '/b', '/c'])
   })
 
-  it('passes stdout through and exits 1 on a write error', async () => {
+  it('keeps writing the others when one operand fails', async () => {
+    // GNU pins: `tee p bad q` writes p and q, diagnoses bad, exits 1.
+    const s = sink(new Set(['/bad']))
     const [out, io] = await writeOutput(
-      () => Promise.reject(new Error('disk full')),
-      path,
-      ENC.encode('hi'),
-      ENC.encode('hi'),
+      paths('/p', '/bad', '/q'),
+      ENC.encode('x'),
+      PLAIN,
+      noStream,
+      s.write,
     )
-    expect(DEC.decode(out as Uint8Array)).toBe('hi')
+    expect(s.written).toEqual({ '/p': 'x', '/q': 'x' })
     expect(io.exitCode).toBe(1)
-    expect(DEC.decode(io.stderr as Uint8Array)).toBe('tee: /out.txt: disk full\n')
+    expect(DEC.decode(io.stderr as Uint8Array)).toBe('tee: /bad: disk full\n')
+    expect(DEC.decode(out as Uint8Array)).toBe('x')
+  })
+
+  it('stops at the first failure under --output-error=exit', async () => {
+    const s = sink(new Set(['/bad']))
+    const [, io] = await writeOutput(
+      paths('/p', '/bad', '/q'),
+      ENC.encode('x'),
+      { append: false, stopOnError: true },
+      noStream,
+      s.write,
+    )
+    expect(s.written).toEqual({ '/p': 'x' })
+    expect(io.exitCode).toBe(1)
+  })
+
+  it('diagnoses every failing operand', async () => {
+    const s = sink(new Set(['/b1', '/b2']))
+    const [, io] = await writeOutput(paths('/b1', '/b2'), ENC.encode('x'), PLAIN, noStream, s.write)
+    expect(DEC.decode(io.stderr as Uint8Array)).toBe('tee: /b1: disk full\ntee: /b2: disk full\n')
+    expect(io.exitCode).toBe(1)
+  })
+
+  it('appends to a missing file by creating it', async () => {
+    // The regression this pins: the not-found test matched the message for
+    // /not found/i, but enoent() puts the *path* in the message, so this
+    // threw on every backend instead of creating the file.
+    const s = sink()
+    const [, io] = await writeOutput(paths('/new'), ENC.encode('hi'), APPEND, noStream, s.write)
+    expect(s.written).toEqual({ '/new': 'hi' })
+    expect(io.exitCode).toBe(0)
+  })
+
+  it('appends through the native slot without re-uploading', async () => {
+    const appended: Record<string, string> = {}
+    const s = sink()
+    const [, io] = await writeOutput(
+      paths('/n'),
+      ENC.encode('add'),
+      APPEND,
+      noStream,
+      s.write,
+      (p, d) => {
+        appended[p.mountPath] = DEC.decode(d)
+        return Promise.resolve()
+      },
+    )
+    expect(appended).toEqual({ '/n': 'add' })
+    expect(s.written).toEqual({})
+    // Listed as written but not as cacheable: the resulting content is not
+    // in hand, so the stale cache entry must be dropped, not replaced.
+    expect(Object.keys(io.writes)).toEqual(['/n'])
+    expect(io.cache).toEqual([])
+  })
+
+  it('falls back to read-modify-write when the backend has no append', async () => {
+    const s = sink()
+    const [, io] = await writeOutput(
+      paths('/n'),
+      ENC.encode('add'),
+      APPEND,
+      () =>
+        (async function* () {
+          await Promise.resolve()
+          yield ENC.encode('old')
+        })(),
+      s.write,
+    )
+    expect(s.written).toEqual({ '/n': 'oldadd' })
+    expect(io.cache).toEqual(['/n'])
   })
 })

--- a/typescript/packages/core/src/commands/builtin/generic/tee.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tee.ts
@@ -15,7 +15,7 @@
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
-import { fsErrorLine, isFsError } from '../../../utils/errors.ts'
+import { fsErrorLine, isEnoent, isFsError } from '../../../utils/errors.ts'
 import { readStdinAsync } from '../utils/stream.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { FlagView, type FlagValue } from '../../spec/types.ts'
@@ -24,14 +24,22 @@ const ENC = new TextEncoder()
 
 export interface TeeOptions {
   append: boolean
+  stopOnError: boolean
 }
 
 export function parseTeeFlags(flags: Record<string, FlagValue>): TeeOptions {
   // --output-error values are validated declaratively: the spec's
   // choices= makes the parser report any other value and the executor
-  // refuse with GNU's ARGMATCH shape before tee runs.
+  // refuse with GNU's ARGMATCH shape before tee runs. Only the exit/warn
+  // axis is observable here: the -nopipe half distinguishes a pipe sink
+  // from a file sink, and every operand tee writes is a file. A bare
+  // --output-error means warn (GNU 9.7).
   const fl = new FlagView(flags, specOf('tee'))
-  return { append: fl.asBool('append') }
+  const mode = fl.asStr('output_error')
+  return {
+    append: fl.asBool('append'),
+    stopOnError: mode === 'exit' || mode === 'exit-nopipe',
+  }
 }
 
 export async function teeGeneric(
@@ -40,51 +48,104 @@ export async function teeGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
+  append?: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
   if (paths.length === 0) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('tee: missing operand\n') })]
   }
   const parsed = parseTeeFlags(opts.flags)
-  const first = paths[0]
-  if (first === undefined) return [null, new IOResult()]
   const stdinData = await readStdinAsync(opts.stdin)
   const raw: Uint8Array = stdinData ?? ENC.encode(texts.join(' '))
-  let writeData = raw
-  if (parsed.append) {
-    try {
-      const existing = await materialize(stream(first))
-      writeData = new Uint8Array(existing.byteLength + raw.byteLength)
-      writeData.set(existing, 0)
-      writeData.set(raw, existing.byteLength)
-    } catch (err) {
-      if (!(err instanceof Error) || !/not found/i.test(err.message)) throw err
-    }
-  }
-  return writeOutput(write, first, writeData, raw)
+  return writeOutput(paths, raw, parsed, stream, write, append)
 }
 
-export async function writeOutput(
-  write: (p: PathSpec, data: Uint8Array) => Promise<void>,
+/**
+ * Write one operand, returning its new content when that is known.
+ *
+ * `null` means "written, but the resulting bytes are not in hand" — the native
+ * append case. The caller then lists the path in `writes` without listing it in
+ * `cache`, which is how the cache layer is told to drop the stale entry instead
+ * of caching a wrong one. That costs one read on the next access and saves
+ * reading and re-uploading the whole object on this one.
+ */
+async function writeOne(
   path: PathSpec,
-  data: Uint8Array,
-  passthrough: ByteSource,
-): Promise<[ByteSource | null, IOResult]> {
-  try {
-    await write(path, data)
-  } catch (err) {
-    // GNU tee still copies stdin to stdout on a write error, prints a
-    // diagnostic, and exits non-zero. With a single output sink the
-    // --output-error modes (warn/exit/*-nopipe) collapse to this. The
-    // operand is named as typed and the strerror comes from the shared
-    // table, so an unwritable destination reads like GNU rather than
-    // exposing the backend's own exception text.
-    const line = isFsError(err)
-      ? fsErrorLine('tee', path, err)
-      : `tee: ${path.mountPath}: ${err instanceof Error ? err.message : String(err)}\n`
-    return [passthrough, new IOResult({ exitCode: 1, stderr: ENC.encode(line) })]
+  raw: Uint8Array,
+  parsed: TeeOptions,
+  stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
+  write: (p: PathSpec, data: Uint8Array) => Promise<void>,
+  append: ((p: PathSpec, data: Uint8Array) => Promise<void>) | undefined,
+): Promise<Uint8Array | null> {
+  if (!parsed.append) {
+    await write(path, raw)
+    return raw
   }
-  return [
-    passthrough,
-    new IOResult({ writes: { [path.mountPath]: data }, cache: [path.mountPath] }),
-  ]
+  if (append !== undefined) {
+    await append(path, raw)
+    return null
+  }
+  let existing: Uint8Array = new Uint8Array(0)
+  try {
+    existing = await materialize(stream(path))
+  } catch (err) {
+    // GNU tee -a creates a missing file: append to empty. This used to test
+    // the message for /not found/i, which never matched — `enoent()` puts the
+    // *path* in the message — so `tee -a missing` threw on every backend, and
+    // s3/gridfs grew bespoke wrappers with an exists() pre-check to dodge it.
+    if (!isEnoent(err)) throw err
+  }
+  const data = new Uint8Array(existing.byteLength + raw.byteLength)
+  data.set(existing, 0)
+  data.set(raw, existing.byteLength)
+  await write(path, data)
+  return data
+}
+
+/**
+ * Copy `raw` to every operand, GNU-style.
+ *
+ * An operand that cannot be written is diagnosed and skipped rather than ending
+ * the run: GNU keeps going and still writes the rest, and only
+ * `--output-error=exit` stops at the first failure. stdin always reaches stdout
+ * either way. The operand is named as typed and the strerror comes from the
+ * shared table, so an unwritable destination reads like GNU rather than
+ * exposing the backend's own exception text.
+ *
+ * Deliberate divergence: GNU opens every operand up front, so under `exit` an
+ * *open* failure aborts before any data is written. A mount has no open/write
+ * split — `write` is one call — so the operands before the failure are already
+ * written. The two agree whenever the failure is at write time, which is what a
+ * remote backend reports.
+ */
+export async function writeOutput(
+  paths: PathSpec[],
+  raw: Uint8Array,
+  parsed: TeeOptions,
+  stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
+  write: (p: PathSpec, data: Uint8Array) => Promise<void>,
+  append?: (p: PathSpec, data: Uint8Array) => Promise<void>,
+): Promise<[ByteSource | null, IOResult]> {
+  const writes: Record<string, ByteSource> = {}
+  const cache: string[] = []
+  const errors: string[] = []
+  for (const path of paths) {
+    let data: Uint8Array | null
+    try {
+      data = await writeOne(path, raw, parsed, stream, write, append)
+    } catch (err) {
+      errors.push(
+        isFsError(err)
+          ? fsErrorLine('tee', path, err)
+          : `tee: ${path.mountPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+      )
+      if (parsed.stopOnError) break
+      continue
+    }
+    writes[path.mountPath] = data ?? raw
+    if (data !== null) cache.push(path.mountPath)
+  }
+  if (errors.length > 0) {
+    return [raw, new IOResult({ exitCode: 1, stderr: ENC.encode(errors.join('')), writes, cache })]
+  }
+  return [raw, new IOResult({ writes, cache })]
 }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -143,8 +143,10 @@ export interface CommandIO<A extends Accessor = Accessor> {
   find?: FindOp<A>
   du?: DuOps<A>
   maxDuEntries?: number
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  append?: (...args: any[]) => unknown
+  // Typed like `write`, now that the tee generic actually calls it. It stayed
+  // an `any` bag for as long as nothing read it, which is what let five
+  // backends wire a slot no builder could consume.
+  append?: (accessor: A, path: PathSpec, data: Uint8Array) => Promise<void>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setAttrs?: (...args: any[]) => unknown
 }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/tee.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/tee.ts
@@ -21,17 +21,20 @@ export const TEE_BUILDER: Builder = {
   requirements: ['write'],
   fn: async (ops, accessor, paths, texts, opts) => {
     const idx = opts.index ?? undefined
-    const { write } = ops
+    const { write, append } = ops
     if (write === undefined) {
       throw new Error('tee: backend provides no write op')
     }
     const resolved = paths.length > 0 ? await resolveGlobOf(ops)(accessor, paths, idx) : []
+    // A backend that can append natively does; the rest fall back to the
+    // read-modify-write inside the generic.
     return teeGeneric(
       resolved,
       texts,
       opts,
       (p) => ops.readStream(accessor, p, idx),
       (p, d) => write(accessor, p, d),
+      append === undefined ? undefined : (p, d) => append(accessor, p, d),
     )
   },
 }

--- a/typescript/packages/core/src/commands/builtin/s3/tee.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/tee.ts
@@ -13,17 +13,15 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { exists as s3Exists } from '../../../core/s3/exists.ts'
 import { resolveGlobOf } from '../generic_bind/index.ts'
-import { parseTeeFlags, writeOutput } from '../generic/tee.ts'
+import { teeGeneric } from '../generic/tee.ts'
 import { S3_IO } from './io.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { write as s3Write } from '../../../core/s3/write.ts'
-import { IOResult, materialize } from '../../../io/types.ts'
+import { IOResult } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
 
 const resolveGlob = resolveGlobOf(S3_IO)
 
@@ -38,31 +36,18 @@ async function teeCommand(
   if (paths.length === 0) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('tee: missing operand\n') })]
   }
-  const parsed = parseTeeFlags(opts.flags)
-  if (typeof parsed === 'string') {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(parsed) })]
-  }
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const first = resolved[0]
-  if (first === undefined) return [null, new IOResult()]
-  const stdinData = await readStdinAsync(opts.stdin)
-  const raw: Uint8Array = stdinData ?? ENC.encode(texts.join(' '))
-  let writeData = raw
-  if (parsed.append) {
-    let existingFound = false
-    try {
-      existingFound = await s3Exists(accessor, first)
-    } catch {
-      existingFound = false
-    }
-    if (existingFound) {
-      const existing = await materialize(s3Stream(accessor, first))
-      writeData = new Uint8Array(existing.byteLength + raw.byteLength)
-      writeData.set(existing, 0)
-      writeData.set(raw, existing.byteLength)
-    }
-  }
-  return writeOutput((p, d) => s3Write(accessor, p, d), first, writeData, raw)
+  // Wiring only: every flag semantic, the write to each operand and the append
+  // fallback live in the generic. This file used to restate them, wrote only
+  // resolved[0], and carried an exists() pre-check to work around the
+  // generic's broken not-found test.
+  return teeGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => s3Stream(accessor, p),
+    (p, d) => s3Write(accessor, p, d),
+  )
 }
 
 export const S3_TEE = command({

--- a/typescript/packages/core/src/core/generic/find.test.ts
+++ b/typescript/packages/core/src/core/generic/find.test.ts
@@ -15,7 +15,8 @@
 import { mountKey } from '../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
-import { isEnoent, modifiedTs, walkFind, type WalkFindDeps } from './find.ts'
+import { modifiedTs, walkFind, type WalkFindDeps } from './find.ts'
+import { isEnoent } from '../../utils/errors.ts'
 
 function enoent(p: string): Error {
   const e = new Error(`ENOENT: ${p}`) as Error & { code: string }

--- a/typescript/packages/core/src/core/generic/find.ts
+++ b/typescript/packages/core/src/core/generic/find.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { isEnoent } from '../../utils/errors.ts'
 import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import type { FindOptions } from '../../resource/base.ts'
@@ -40,10 +41,6 @@ interface WalkEntry {
   path: string
   depth: number
   file: boolean
-}
-
-export function isEnoent(err: unknown): boolean {
-  return err instanceof Error && (err as Error & { code?: string }).code === 'ENOENT'
 }
 
 export function modifiedTs(modified: string | null): number | null {

--- a/typescript/packages/core/src/utils/errors.ts
+++ b/typescript/packages/core/src/utils/errors.ts
@@ -223,6 +223,13 @@ export function isFsError(err: unknown): boolean {
   return typeof code === 'string' && gnuStrerror(code) !== null
 }
 
+// `enoent()` puts the *path* in the message, so matching on message text never
+// fires; the stamped code is the only reliable signal. Python's twin is
+// `except FileNotFoundError`. Three modules had grown their own copy of this.
+export function isEnoent(err: unknown): boolean {
+  return err instanceof Error && (err as Error & { code?: string }).code === 'ENOENT'
+}
+
 // The per-entry swallow set for walk-and-warn commands (ls, tree, rg):
 // every stamped filesystem code plus the unstamped no-mount refusal.
 // Mirrors Python's `except (OSError, ValueError)`, where ValueError is

--- a/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
@@ -16,7 +16,7 @@ import { IOResult } from '../../../io/types.ts'
 import { PolicyDenied } from '../../../policy/index.ts'
 import type { FileStat } from '../../../types.ts'
 import { FileType, PathSpec } from '../../../types.ts'
-import { fsStrerror, isFsError, isMissingOp } from '../../../utils/errors.ts'
+import { fsStrerror, isEnoent, isFsError, isMissingOp } from '../../../utils/errors.ts'
 import { DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, parseMode } from '../../../utils/mode.ts'
 import { CycleError, resolvePath } from '../../../utils/path.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
@@ -236,10 +236,6 @@ function isReadOnlyError(err: unknown): boolean {
   // text happens to contain "read-only".
   if (err instanceof PolicyDenied) return false
   return err instanceof Error && err.message.includes('read-only')
-}
-
-function isEnoent(err: unknown): boolean {
-  return err instanceof Error && (err as { code?: string }).code === 'ENOENT'
 }
 
 interface SetAttrFields {

--- a/typescript/packages/core/src/workspace/reconcile.ts
+++ b/typescript/packages/core/src/workspace/reconcile.ts
@@ -17,7 +17,7 @@ import type { FileCache } from '../cache/file/mixin.ts'
 import type { OpsRegistry } from '../ops/registry.ts'
 import type { Resource } from '../resource/base.ts'
 import { ConsistencyPolicy, FileStat, PathSpec } from '../types.ts'
-import { enoent } from '../utils/errors.ts'
+import { enoent, isEnoent } from '../utils/errors.ts'
 import { mountKey } from '../utils/key_prefix.ts'
 import { rstripSlash } from '../utils/slash.ts'
 import type { MountEntry } from './mount/mount.ts'
@@ -31,10 +31,6 @@ enum Verdict {
   STALE = 'stale',
   GONE = 'gone',
   UNKNOWN = 'unknown',
-}
-
-function isEnoent(err: unknown): boolean {
-  return (err as { code?: unknown }).code === 'ENOENT'
 }
 
 /**

--- a/typescript/packages/node/src/commands/builtin/gridfs/tee.ts
+++ b/typescript/packages/node/src/commands/builtin/gridfs/tee.ts
@@ -16,18 +16,14 @@ import {
   IOResult,
   ResourceName,
   command,
-  materialize,
-  parseTeeFlags,
-  readStdinAsync,
   resolveGlobOf,
   specOf,
-  writeOutput,
+  teeGeneric,
   type CommandFnResult,
   type CommandOpts,
   type PathSpec,
 } from '@struktoai/mirage-core'
 import type { GridFSAccessor } from '../../../accessor/gridfs.ts'
-import { exists as gridfsExists } from '../../../core/gridfs/exists.ts'
 import { stream as gridfsStream } from '../../../core/gridfs/stream.ts'
 import { write as gridfsWrite } from '../../../core/gridfs/write.ts'
 import { GRIDFS_IO } from './io.ts'
@@ -45,31 +41,18 @@ async function teeCommand(
   if (paths.length === 0) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('tee: missing operand\n') })]
   }
-  const parsed = parseTeeFlags(opts.flags)
-  if (typeof parsed === 'string') {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(parsed) })]
-  }
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const first = resolved[0]
-  if (first === undefined) return [null, new IOResult()]
-  const stdinData = await readStdinAsync(opts.stdin)
-  const raw: Uint8Array = stdinData ?? ENC.encode(texts.join(' '))
-  let writeData = raw
-  if (parsed.append) {
-    let existingFound = false
-    try {
-      existingFound = await gridfsExists(accessor, first)
-    } catch {
-      existingFound = false
-    }
-    if (existingFound) {
-      const existing = await materialize(gridfsStream(accessor, first))
-      writeData = new Uint8Array(existing.byteLength + raw.byteLength)
-      writeData.set(existing, 0)
-      writeData.set(raw, existing.byteLength)
-    }
-  }
-  return writeOutput((p, d) => gridfsWrite(accessor, p, d), first, writeData, raw)
+  // Wiring only: every flag semantic, the write to each operand and the append
+  // fallback live in the generic. This file used to restate them, wrote only
+  // resolved[0], and carried an exists() pre-check to work around the
+  // generic's broken not-found test.
+  return teeGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => gridfsStream(accessor, p),
+    (p, d) => gridfsWrite(accessor, p, d),
+  )
 }
 
 export const GRIDFS_TEE = command({


### PR DESCRIPTION
## `tee a b` silently dropped `b`

`tee`'s spec declares `rest: {type: "path"}`, so the parser accepts N file operands — and both generics wrote only `paths[0]`. Identical in both languages, which is why no parity gate saw it: a shared bug is not a divergence.

GNU 9.7, pinned in docker:

| case | GNU |
|---|---|
| `printf x \| tee a b c` | all three written |
| `tee p bad q` | p and q written, `bad` diagnosed, exit 1 |
| `--output-error=exit` | stops at the first failure |
| bare `--output-error` | means `warn` |

`--output-error` had never been implemented because with a single sink it was unobservable — the old comment said exactly that — so it was parsed and ignored. It is real now.

**Deliberate divergence**, documented at the call site: GNU opens every operand up front, so under `exit` an *open* failure aborts before anything is written. A mount has no open/write split, so operands before the failure are already written. The two agree whenever the failure is at write time, which is what a remote backend reports.

## The `append` slot is wired

Per the decision to wire rather than delete. It was declared on both adapters, wired by five backends, and read by no builder — so `tee -a` was read-modify-write everywhere, which on ssh means downloading and re-uploading the whole file plus a lost-update window.

Where the native path runs the resulting content is not in hand, so the path is reported in `writes` but **not** in `cache` — that is how `apply_io` is told to drop the stale entry rather than cache a wrong one. Costs one read on the next access, saves a full round-trip on this one.

The slot was typed `(...args: any[]) => unknown`, which is what let five backends wire something no builder could consume. Typed like `write` now.

Found while wiring it: python's `core/ssh/append.py` existed with no importer outside the resource, so python ssh took the read-modify-write path its TS twin did not. Wired.

## Two more real bugs on the way through

- **TS `tee -a missing-file` threw instead of creating the file.** The not-found test was `/not found/i.test(err.message)`, but `enoent()` puts the *path* in the message, so it never matched — verified by running it. Python's `except FileNotFoundError` was always correct. That broken test is why s3 and gridfs grew bespoke tee wrappers with an `exists()` pre-check (and a `catch {}` that swallowed everything) to route around the generic. All four wrappers — s3 and gridfs in both languages — are wiring only now, which fixes their multi-operand bug in the same edit.
- **`isEnoent` existed in three copies** (`core/generic/find.ts`, `workspace/reconcile.ts`, `executor/builtins/metadata.ts`), none of them next to `isFsError`. One copy now, in `utils/errors.ts`.

## Verification

Three integ cases across 17 targets, each proven **red on pre-fix code and green after, on both hosts**:

```
FAIL [ram] tee_multi_operand: stdout: expected "DUP|DUP", got "DUP|"
FAIL [ram] tee_a_multi_operand: stdout: expected "xZ|yZ", got "xZ|y"
FAIL [ram] tee_a_creates_missing: expected "NEW", got "" (typescript only)
```

`xm_tee_multi` passed all along because it is cross-mount: one operand per mount, so each backend tee wrote its single `paths[0]`. The bug needed two operands on one mount.

Full core/node/browser vitest and the python suite green; both spec trees regenerate with no drift and the parity gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)