### PR TITLE
fix(github): build resources asynchronously, delete the sync HTTP path (#609 T1-J)

### DIFF
--- a/docs/home/introduction.mdx
+++ b/docs/home/introduction.mdx
@@ -175,7 +175,7 @@ grep -r "mirage" /slack /gmail /github
     from mirage.resource.slack import SlackConfig, SlackResource
 
     slack = SlackResource(SlackConfig(token="xoxb-..."))
-    github = GitHubResource(
+    github = await GitHubResource.build(
         GitHubConfig(token="github_pat_..."),
         owner="strukto-ai",
         repo="mirage",
@@ -226,7 +226,7 @@ grep -r "mirage" /slack /gmail /github
     import { MirageShell, buildSystemPrompt } from '@struktoai/mirage-agents/openai'
 
     const slack = new SlackResource({ token: process.env.SLACK_BOT_TOKEN! })
-    const github = new GitHubResource({
+    const github = await GitHubResource.create({
       token: process.env.GITHUB_TOKEN!,
       owner: 'strukto-ai',
       repo: 'mirage',

--- a/docs/python/resource/github.mdx
+++ b/docs/python/resource/github.mdx
@@ -17,7 +17,7 @@ from mirage import MountMode, Workspace
 from mirage.resource.github import GitHubConfig, GitHubResource
 
 config = GitHubConfig(token=os.environ["GITHUB_TOKEN"])
-resource = GitHubResource(
+resource = await GitHubResource.build(
     config=config, owner="my-org", repo="my-repo", ref="main")
 ws = Workspace({"/github": resource}, mode=MountMode.READ)
 ```
@@ -44,7 +44,9 @@ the path - those are specified at mount time.
 
 ## Tree Fetching
 
-The resource fetches the full recursive tree at init. For repos with
+`GitHubResource.build` fetches the full recursive tree, which is why it is
+a coroutine — the constructor itself takes that tree and touches no
+network. For repos with
 
 > 100K entries, it falls back to per-directory fetching.
 
@@ -68,7 +70,7 @@ load_dotenv(".env.development")
 
 async def main():
     config = GitHubConfig(token=os.environ["GITHUB_TOKEN"])
-    resource = GitHubResource(
+    resource = await GitHubResource.build(
         config=config, owner="my-org", repo="my-repo", ref="main")
     ws = Workspace({"/github": resource}, mode=MountMode.READ)
 

--- a/docs/python/setup/github.mdx
+++ b/docs/python/setup/github.mdx
@@ -18,10 +18,15 @@ from mirage import Workspace, MountMode
 from mirage.resource.github import GitHubConfig, GitHubResource
 
 config = GitHubConfig(token=os.environ["GITHUB_TOKEN"])
-resource = GitHubResource(
+resource = await GitHubResource.build(
     config=config, owner="my-org", repo="my-repo", ref="main")
 ws = Workspace({"/github": resource}, mode=MountMode.READ)
 ```
+
+`build` is a coroutine because it fetches the repo's git tree up front, so
+call it from async code. Every resource inherits a `build`; only the ones
+that need I/O to start override it, so `await Resource.build(...)` is
+uniform.
 
 ## Config Reference
 

--- a/docs/typescript/setup/github.mdx
+++ b/docs/typescript/setup/github.mdx
@@ -17,7 +17,7 @@ pnpm add @struktoai/mirage-node
 ```ts
 import { GitHubResource, MountMode, Workspace } from '@struktoai/mirage-node'
 
-const gh = new GitHubResource({
+const gh = await GitHubResource.create({
   token: process.env.GITHUB_TOKEN!,
   owner: 'strukto-ai',
   repo: 'mirage',
@@ -28,6 +28,10 @@ const ws = new Workspace({ '/repo': gh }, { mode: MountMode.READ })
 await ws.execute('cat /repo/README.md')
 ```
 
+The constructor is private: `create` fetches the repo's git tree before it
+builds the resource, so it has to be awaited. Python's equivalent is
+`await GitHubResource.build(...)`.
+
 ## Browser
 
 ```bash
@@ -37,7 +41,7 @@ pnpm add @struktoai/mirage-browser
 ```ts
 import { GitHubResource, MountMode, Workspace } from '@struktoai/mirage-browser'
 
-const gh = new GitHubResource({
+const gh = await GitHubResource.create({
   token: GITHUB_TOKEN,
   owner: 'strukto-ai',
   repo: 'mirage',

--- a/examples/python/demo/design_feedback.py
+++ b/examples/python/demo/design_feedback.py
@@ -47,7 +47,7 @@ async def main() -> None:
         token=os.environ["SLACK_BOT_TOKEN"],
         search_token=os.environ.get("SLACK_USER_TOKEN"),
     ))
-    github = GitHubResource(
+    github = await GitHubResource.build(
         config=GitHubConfig(token=os.environ["GITHUB_TOKEN"]),
         owner=GITHUB_OWNER,
         repo=GITHUB_REPO,

--- a/examples/python/github/github.py
+++ b/examples/python/github/github.py
@@ -34,7 +34,7 @@ async def _timed(ws, cmd):
 
 
 async def main() -> None:
-    resource = GitHubResource(
+    resource = await GitHubResource.build(
         config=config,
         owner="strukto-ai",
         repo="mirage",

--- a/examples/python/github/github_fuse.py
+++ b/examples/python/github/github_fuse.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 import os
 
 from dotenv import load_dotenv
@@ -23,12 +24,16 @@ load_dotenv(".env.development")
 
 config = GitHubConfig(token=os.environ["GITHUB_TOKEN"])
 
-resource = GitHubResource(
-    config=config,
-    owner="strukto-ai",
-    repo="mirage",
-    ref="main",
-)
+# Only the repo fetch is async; the rest of this example is deliberately
+# synchronous, because that is the point of a FUSE mount. There is no
+# outer loop here to conflict with.
+resource = asyncio.run(
+    GitHubResource.build(
+        config=config,
+        owner="strukto-ai",
+        repo="mirage",
+        ref="main",
+    ))
 
 with Workspace({
         "/github/":

--- a/examples/python/github/github_vfs.py
+++ b/examples/python/github/github_vfs.py
@@ -27,7 +27,7 @@ config = GitHubConfig(token=os.environ["GITHUB_TOKEN"])
 
 
 async def main():
-    resource = GitHubResource(
+    resource = await GitHubResource.build(
         config=config,
         owner="strukto-ai",
         repo="mirage",

--- a/examples/python/glob/example.py
+++ b/examples/python/glob/example.py
@@ -37,12 +37,17 @@ gdrive_config = GoogleDriveConfig(
 )
 github_config = GitHubConfig(token=os.environ["GITHUB_TOKEN"])
 
+# GitHub fetches the repo tree while it builds, so its resource is the
+# one mount here that has to be awaited. Each aiohttp session opens and
+# closes inside that call, so bootstrapping on its own loop is safe.
+github_resource = asyncio.run(
+    GitHubResource.build(github_config, owner="strukto", repo="mirage"))
+
 ws = Workspace(
     {
         "/s3/": S3Resource(s3_config),
         "/gdrive/": GoogleDriveResource(gdrive_config),
-        "/github/": GitHubResource(
-            github_config, owner="strukto", repo="mirage"),
+        "/github/": github_resource,
     },
     mode=MountMode.READ,
 )

--- a/integ/root.py
+++ b/integ/root.py
@@ -112,7 +112,7 @@ async def yaml_controls_root() -> None:
                     }
                 }
             }})
-        kwargs = cfg.to_workspace_kwargs()
+        kwargs = await cfg.to_workspace_kwargs()
         check("yaml: '/' mount present in resources", "/"
               in kwargs["resources"])
         ws = Workspace(**kwargs)
@@ -124,7 +124,7 @@ async def yaml_controls_root() -> None:
               os.path.exists(os.path.join(tmp, "y.txt")))
         await ws.close()
 
-    ws = Workspace(**load_config({
+    ws = Workspace(**await load_config({
         "mounts": {
             "/data": {
                 "resource": "ram"

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -18,6 +18,7 @@ import functools
 import gzip
 import imaplib
 import importlib.util
+import inspect
 import json
 import logging
 import os
@@ -996,10 +997,13 @@ class GitHubService:
     """Points github mounts at the fake api.github.com server.
 
     The server (integ/server/github_server.py) runs out of process on
-    GITHUB_URL, mirroring the fake Slack and Google Workspace servers.
-    In-process is not an option here: GitHubResource fetches the repo tree
-    with a blocking urlopen from its constructor, which would starve an
-    aiohttp fake sharing the runner's event loop.
+    GITHUB_URL, mirroring the fake Slack and Google Workspace servers and
+    shared with the typescript host. It used to be out of process by
+    necessity — GitHubResource fetched the repo tree with a blocking
+    urlopen from its constructor, which would starve an aiohttp fake on
+    the runner's loop. That constraint is gone now that the fetch is
+    awaited in `GitHubResource.build`; sharing one fake across both hosts
+    is why it stays external.
 
     Args:
         url (str): GITHUB_URL origin the fake is listening on.
@@ -1012,9 +1016,9 @@ class GitHubService:
     async def create(cls) -> "GitHubService":
         return cls(os.environ["GITHUB_URL"].rstrip("/"))
 
-    def resource(self, mount: dict) -> GitHubResource:
+    async def resource(self, mount: dict) -> GitHubResource:
         owner, _, repo = mount["repo"].partition("/")
-        return GitHubResource(
+        return await GitHubResource.build(
             GitHubConfig(token="ghp-integ",
                          owner=owner,
                          repo=repo,
@@ -1886,11 +1890,11 @@ def build_nextcloud(
     return service.resource(mount), _noop
 
 
-def build_github(
+async def build_github(
         mount: dict, run_id: str, service: Service | None
 ) -> tuple[object, Callable[[], Awaitable[None]]]:
     assert isinstance(service, GitHubService)
-    return service.resource(mount), _noop
+    return await service.resource(mount), _noop
 
 
 def build_github_ci(
@@ -2107,7 +2111,7 @@ async def make_service(target: dict, run_id: str) -> "Service | None":
     return None
 
 
-def build_mounts(
+async def build_mounts(
     target: dict, run_id: str, service: "Service | None"
 ) -> tuple[dict[str, object], list[Callable[[], Awaitable[None]]]]:
     mounts: dict[str, object] = {}
@@ -2124,7 +2128,13 @@ def build_mounts(
             cleanup = _noop
         else:
             builder = BUILDERS[mount["resource"]]
-            resource, cleanup = builder(mount, run_id, service)
+            # A builder is async only when its resource needs I/O to come
+            # up — github fetches the repo tree. Awaiting whatever the
+            # table returns keeps the other forty builders plain.
+            pair = builder(mount, run_id, service)
+            if inspect.isawaitable(pair):
+                pair = await pair
+            resource, cleanup = pair
         built[mount["path"]] = resource
         if mount.get("mode") == "read":
             mounts[mount["path"]] = (resource, MountMode.READ)
@@ -2182,7 +2192,7 @@ async def open_target(
 ) -> tuple[Workspace, Callable[[], Awaitable[None]]]:
     run_id = uuid.uuid4().hex[:8]
     service = await make_service(target, run_id)
-    mounts, cleanups = build_mounts(target, run_id, service)
+    mounts, cleanups = await build_mounts(target, run_id, service)
     agent_id = target.get("agentId")
     if consistency is not None:
         ws = Workspace(mounts,
@@ -2211,8 +2221,9 @@ async def open_consistency(
 ]:
     run_id = uuid.uuid4().hex[:8]
     service = await make_service(target, run_id)
-    read_mounts, read_cleanups = build_mounts(target, run_id, service)
-    shadow_mounts, shadow_cleanups = build_mounts(target, run_id, service)
+    read_mounts, read_cleanups = await build_mounts(target, run_id, service)
+    shadow_mounts, shadow_cleanups = await build_mounts(
+        target, run_id, service)
     read_ws = Workspace(read_mounts,
                         mode=MountMode.WRITE,
                         consistency=consistency)

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -1304,9 +1304,10 @@ async function openSlack(target: Target): Promise<Open> {
 }
 
 // The fake api.github.com server (integ/server/github_server.py) is external
-// and shared across both hosts, mirroring the fake Slack server. Out of
-// process is required for the python host, whose GitHubResource fetches the
-// repo tree with a blocking urlopen from its constructor.
+// and shared across both hosts, mirroring the fake Slack server. It used to
+// have to be out of process for the python host, whose GitHubResource
+// fetched the repo tree with a blocking urlopen from its constructor; that
+// fetch is awaited now, so being shared is the only reason left.
 async function openGitHub(target: Target): Promise<Open> {
   let base = process.env.GITHUB_URL ?? ''
   while (base.endsWith('/')) base = base.slice(0, -1)

--- a/python/mirage/config.py
+++ b/python/mirage/config.py
@@ -488,8 +488,13 @@ class WorkspaceConfig(BaseModel):
     def _v_cons(cls, v):
         return _coerce_consistency(v)
 
-    def to_workspace_kwargs(self) -> dict[str, Any]:
+    async def to_workspace_kwargs(self) -> dict[str, Any]:
         """Produce kwargs ready to splat into ``Workspace(**kwargs)``.
+
+        Async because building a mount's resource can be: a backend
+        whose setup needs I/O does it in ``BaseResource.create``. Only
+        the resources are awaited — ``Workspace(**kwargs)`` itself stays
+        synchronous. Mirrors the TypeScript ``configToWorkspaceArgs``.
 
         Returns:
             dict[str, Any]: resource instances, cache config, and
@@ -498,7 +503,7 @@ class WorkspaceConfig(BaseModel):
         """
         resources: dict[str, Mount] = {}
         for prefix, block in self.mounts.items():
-            prov = build_resource(block.resource, block.config)
+            prov = await build_resource(block.resource, block.config)
             mode = block.mode if block.mode is not None else self.mode
             resources[prefix] = Mount(
                 resource=prov,

--- a/python/mirage/core/github/_client.py
+++ b/python/mirage/core/github/_client.py
@@ -12,10 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
 from typing import Any
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
 
 import aiohttp
 from pydantic import SecretStr
@@ -50,17 +47,3 @@ async def github_get(token: SecretStr,
         async with session.get(url, headers=headers, params=params) as resp:
             resp.raise_for_status()
             return await resp.json()
-
-
-def github_get_sync(token: SecretStr,
-                    path: str,
-                    params: dict[str, Any] | None = None,
-                    *,
-                    base_url: str | None = None,
-                    **kwargs: str) -> dict[str, Any]:
-    url = github_url(path, base_url, **kwargs)
-    if params:
-        url = f"{url}?{urlencode(params)}"
-    req = Request(url, headers=github_headers(token), method="GET")
-    with urlopen(req) as resp:
-        return json.loads(resp.read())

--- a/python/mirage/core/github/repo.py
+++ b/python/mirage/core/github/repo.py
@@ -12,15 +12,15 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.github._client import github_get_sync
+from mirage.core.github._client import github_get
 from mirage.core.github.config import GitHubConfig
 
 
-def fetch_default_branch_sync(config: GitHubConfig, owner: str,
-                              repo: str) -> str:
-    data = github_get_sync(config.token,
-                           "/repos/{owner}/{repo}",
-                           base_url=config.base_url,
-                           owner=owner,
-                           repo=repo)
+async def fetch_default_branch(config: GitHubConfig, owner: str,
+                               repo: str) -> str:
+    data = await github_get(config.token,
+                            "/repos/{owner}/{repo}",
+                            base_url=config.base_url,
+                            owner=owner,
+                            repo=repo)
     return data["default_branch"]

--- a/python/mirage/core/github/tree.py
+++ b/python/mirage/core/github/tree.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Any
 
-from mirage.core.github._client import github_get, github_get_sync
+from mirage.core.github._client import github_get
 from mirage.core.github.config import GitHubConfig
 from mirage.core.github.tree_entry import TreeEntry
 
@@ -47,13 +47,13 @@ def _parse_tree_response(
     return result, truncated
 
 
-def fetch_tree_sync(
+async def fetch_tree(
     config: GitHubConfig,
     owner: str,
     repo: str,
     ref: str,
 ) -> tuple[dict[str, TreeEntry], bool]:
-    data = github_get_sync(
+    data = await github_get(
         config.token,
         "/repos/{owner}/{repo}/git/trees/{ref}",
         params={"recursive": "1"},

--- a/python/mirage/resource/base.py
+++ b/python/mirage/resource/base.py
@@ -78,6 +78,35 @@ class BaseResource:
         self._index: IndexCacheStore
         self.set_index(index)
 
+    @classmethod
+    async def build(cls, *args: Any, **kwargs: Any) -> "BaseResource":
+        """Construct a resource, awaiting any setup it needs first.
+
+        The default just calls the constructor: most backends open
+        nothing at build time, so there is nothing to await. A backend
+        whose setup needs I/O overrides this and keeps ``__init__``
+        free of network calls — a constructor cannot await, so doing
+        the I/O there means doing it with a blocking client, which
+        stalls whatever event loop the caller runs on.
+
+        Mirrors the TypeScript ``ResourceFactory``
+        (``node/src/resource/registry.ts``), which is uniformly
+        ``(config) => Promise<Resource>`` for the same reason. Named
+        ``build`` rather than TypeScript's ``create`` because ``create``
+        is already an op name (make an empty file, what ``touch``
+        calls): ops are served by ``__getattr__``, which only runs when
+        normal lookup fails, so a real ``create`` on the class would
+        shadow every backend's create op.
+
+        Args:
+            *args (Any): forwarded to the constructor.
+            **kwargs (Any): forwarded to the constructor.
+
+        Returns:
+            BaseResource: a fresh instance, ready to mount.
+        """
+        return cls(*args, **kwargs)
+
     def set_index(self, config: IndexConfig | None = None) -> None:
         cfg = (config if config is not None else IndexConfig(
             ttl=self.index_ttl))

--- a/python/mirage/resource/github/github.py
+++ b/python/mirage/resource/github/github.py
@@ -20,8 +20,8 @@ from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexConfig, IndexEntry
 from mirage.core.github.config import GitHubConfig
 from mirage.core.github.readdir import readdir
-from mirage.core.github.repo import fetch_default_branch_sync
-from mirage.core.github.tree import fetch_tree_sync
+from mirage.core.github.repo import fetch_default_branch
+from mirage.core.github.tree import fetch_tree
 from mirage.core.github.tree_entry import TreeEntry
 from mirage.resource.base import BaseResource
 from mirage.resource.github.prompt import PROMPT
@@ -49,27 +49,39 @@ class GitHubResource(BaseResource):
     def __init__(
         self,
         config: GitHubConfig,
-        owner: str | None = None,
-        repo: str | None = None,
-        ref: str | None = None,
+        owner: str,
+        repo: str,
+        ref: str,
+        default_branch: str,
+        tree: dict[str, TreeEntry],
+        truncated: bool = False,
     ) -> None:
+        """Build the mount from a tree that has already been fetched.
+
+        Takes the repo metadata rather than fetching it, so that
+        nothing here touches the network. Use :meth:`create` unless the
+        tree is already in hand.
+
+        Args:
+            config (GitHubConfig): token, base URL and defaults.
+            owner (str): repository owner.
+            repo (str): repository name.
+            ref (str): branch, tag or commit the mount is pinned to.
+            default_branch (str): the repo's default branch, for
+                ``is_default_branch``.
+            tree (dict[str, TreeEntry]): the recursive git tree, keyed
+                by repo-relative path.
+            truncated (bool): whether GitHub truncated that tree, in
+                which case readdir falls back to per-directory fetches.
+        """
         super().__init__()
-        owner = owner or config.owner
-        repo = repo or config.repo
-        ref = ref or config.ref
-        if owner is None or repo is None:
-            raise ValueError(
-                "GitHubResource requires owner and repo, either as "
-                "constructor kwargs or in GitHubConfig")
-        default_branch = fetch_default_branch_sync(config, owner, repo)
-        tree, truncated = fetch_tree_sync(config, owner, repo, ref)
         self.accessor = GitHubAccessor(config,
                                        owner,
                                        repo,
                                        ref,
                                        default_branch,
                                        truncated=truncated)
-        self._populate_index_sync(tree)
+        self._populate_index(tree)
         from mirage.commands.builtin.github import COMMANDS as _github_cmds
         from mirage.ops.github import OPS as _github_vfs_ops
 
@@ -78,7 +90,56 @@ class GitHubResource(BaseResource):
         for fn in _github_vfs_ops:
             self.register_op(fn)
 
-    def _populate_index_sync(self, tree: dict[str, TreeEntry]) -> None:
+    @classmethod
+    async def build(
+        cls,
+        config: GitHubConfig,
+        owner: str | None = None,
+        repo: str | None = None,
+        ref: str | None = None,
+    ) -> "GitHubResource":
+        """Fetch the repo's tree, then build the mount around it.
+
+        The two GitHub round trips this needs are why construction is
+        async. They used to run in ``__init__`` over a blocking
+        ``urlopen``, which froze whatever event loop the caller was on —
+        for the daemon that meant every other mount's in-flight I/O and
+        the FUSE queue stalling for the length of a recursive-tree call.
+        Mirrors the TypeScript ``GitHubResource.create``.
+
+        Args:
+            config (GitHubConfig): token, base URL and defaults.
+            owner (str | None): repository owner; falls back to
+                ``config.owner``.
+            repo (str | None): repository name; falls back to
+                ``config.repo``.
+            ref (str | None): branch, tag or commit; falls back to
+                ``config.ref``.
+
+        Returns:
+            GitHubResource: a mount pinned to ``ref``.
+
+        Raises:
+            ValueError: neither the kwargs nor the config name a repo.
+        """
+        owner = owner or config.owner
+        repo = repo or config.repo
+        ref = ref or config.ref
+        if owner is None or repo is None:
+            raise ValueError(
+                "GitHubResource requires owner and repo, either as "
+                "build() kwargs or in GitHubConfig")
+        default_branch = await fetch_default_branch(config, owner, repo)
+        tree, truncated = await fetch_tree(config, owner, repo, ref)
+        return cls(config,
+                   owner,
+                   repo,
+                   ref,
+                   default_branch,
+                   tree,
+                   truncated=truncated)
+
+    def _populate_index(self, tree: dict[str, TreeEntry]) -> None:
         dirs: dict[str, list[tuple[str, IndexEntry]]] = defaultdict(list)
         for path, entry in tree.items():
             parts = path.rsplit("/", 1)

--- a/python/mirage/resource/registry.py
+++ b/python/mirage/resource/registry.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import importlib.metadata
+import inspect
 import logging
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -258,8 +259,35 @@ def resolve_class(ref: str | type) -> type:
     return ref if isinstance(ref, type) else load_backend_class(ref)
 
 
-def build_resource(name: str,
-                   config: dict[str, Any] | None = None) -> "BaseResource":
+async def _instantiate(resource_cls: type, *args: Any,
+                       **kwargs: Any) -> "BaseResource":
+    """Build one resource, awaiting its factory when it has one.
+
+    :func:`register_resource` and the ``mirage.resources`` entry point
+    both accept any class, not only :class:`BaseResource` subclasses, so
+    the async ``build`` factory is not guaranteed to exist. A class
+    without one is constructed directly — which is how it has always
+    been built, and a plain constructor has nothing to await anyway.
+    The coroutine check also keeps a third-party class that happens to
+    carry a synchronous ``build`` attribute out of the await path.
+
+    Args:
+        resource_cls (type): the class to instantiate.
+        *args (Any): forwarded to ``build`` or the constructor.
+        **kwargs (Any): forwarded to ``build`` or the constructor.
+
+    Returns:
+        BaseResource: the new instance.
+    """
+    factory = getattr(resource_cls, "build", None)
+    if not inspect.iscoroutinefunction(factory):
+        return resource_cls(*args, **kwargs)
+    return await factory(*args, **kwargs)
+
+
+async def build_resource(name: str,
+                         config: dict[str, Any] | None = None
+                         ) -> "BaseResource":
     """Construct a resource instance by its registry name.
 
     Resolves resource and config classes lazily via importlib, so
@@ -267,6 +295,11 @@ def build_resource(name: str,
     dependencies. Only the resources actually used get loaded. Lookup
     order: builtin ``REGISTRY``, then :func:`register_resource` names,
     then ``mirage.resources`` entry points from installed packages.
+
+    Async because construction is: backends whose setup needs I/O do it
+    in :meth:`BaseResource.create`, which this awaits. The alternative
+    is a blocking client inside ``__init__``, which stalls the caller's
+    event loop. Mirrors the TypeScript ``buildResource``.
 
     Args:
         name (str): registry key such as ``"s3"`` or ``"ram"``.
@@ -294,6 +327,6 @@ def build_resource(name: str,
     if config_ref is None:
         config_ref = getattr(resource_cls, "CONFIG_CLS", None)
     if config_ref is None:
-        return resource_cls(**cfg_dict)
+        return await _instantiate(resource_cls, **cfg_dict)
     config_cls = resolve_class(config_ref)
-    return resource_cls(config_cls(**cfg_dict))
+    return await _instantiate(resource_cls, config_cls(**cfg_dict))

--- a/python/mirage/server/clone.py
+++ b/python/mirage/server/clone.py
@@ -21,7 +21,7 @@ from mirage.workspace.snapshot import requires_resource_override, to_state_dict
 from mirage.workspace.snapshot.utils import norm_mount_prefix
 
 
-def _build_override_resources(
+async def _build_override_resources(
         override: dict[str, Any] | None) -> dict[str, Any]:
     if not override:
         return {}
@@ -35,7 +35,8 @@ def _build_override_resources(
         config = block.get("config") or {}
         if resource_name is None:
             continue
-        out[norm_mount_prefix(prefix)] = build_resource(resource_name, config)
+        out[norm_mount_prefix(prefix)] = await build_resource(
+            resource_name, config)
     return out
 
 
@@ -81,7 +82,7 @@ async def clone_workspace_with_override(src_ws: Workspace,
         Workspace: a new, independent workspace.
     """
     state = await to_state_dict(src_ws)
-    override_resources = _build_override_resources(override)
+    override_resources = await _build_override_resources(override)
     existing = _existing_redacted_resources(src_ws,
                                             state,
                                             skip=set(override_resources))

--- a/python/mirage/server/routers/workspaces.py
+++ b/python/mirage/server/routers/workspaces.py
@@ -44,7 +44,7 @@ async def create_workspace(req: CreateWorkspaceRequest,
         # Map runtime entries construct their instances here, so a bad
         # entry (a wasi build dir that does not exist, an unknown
         # option) fails the create like any other config mistake.
-        kwargs = req.config.to_workspace_kwargs()
+        kwargs = await req.config.to_workspace_kwargs()
     except (FileNotFoundError, ImportError, ValueError, TypeError) as e:
         raise HTTPException(status_code=400, detail=str(e))
     # The registry id and the state-store scope must be the same identity,
@@ -161,7 +161,7 @@ async def load_workspace(req: LoadWorkspaceRequest,
     if req.id is not None and req.id in registry:
         raise HTTPException(status_code=409,
                             detail=f"workspace id already exists: {req.id!r}")
-    resources = _build_load_resources(req.override)
+    resources = await _build_load_resources(req.override)
     try:
         ws = await Workspace.load(str(safe_path), resources=resources)
     except FileNotFoundError:
@@ -176,7 +176,7 @@ async def load_workspace(req: LoadWorkspaceRequest,
     return await make_detail(entry)
 
 
-def _build_load_resources(
+async def _build_load_resources(
         override: dict[str, Any] | None) -> dict[str, Any] | None:
     if not override or "mounts" not in override:
         return None
@@ -188,5 +188,6 @@ def _build_load_resources(
         config = block.get("config") or {}
         if resource_name is None:
             continue
-        out[norm_mount_prefix(prefix)] = build_resource(resource_name, config)
+        out[norm_mount_prefix(prefix)] = await build_resource(
+            resource_name, config)
     return out or None

--- a/python/tests/commands/builtin/github/conftest.py
+++ b/python/tests/commands/builtin/github/conftest.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import pytest
+import pytest_asyncio
 
 from mirage.resource.github.github import GitHubResource
 from tests.fixtures.github_mock import github_config, mock_github_api
@@ -24,9 +24,9 @@ REPO = "test-repo"
 REF = "main"
 
 
-@pytest.fixture
-def github_env(mock_github_api, github_config):
-    resource = GitHubResource(
+@pytest_asyncio.fixture()
+async def github_env(mock_github_api, github_config):
+    resource = await GitHubResource.build(
         config=github_config,
         owner=OWNER,
         repo=REPO,

--- a/python/tests/config/test_loader.py
+++ b/python/tests/config/test_loader.py
@@ -45,7 +45,8 @@ def test_load_minimal_yaml():
     assert cfg.cache is None
 
 
-def test_load_full_yaml_with_env_interpolation():
+@pytest.mark.asyncio
+async def test_load_full_yaml_with_env_interpolation():
     env = {
         "TEST_BUCKET": "my-test-bucket",
         "TEST_AWS_KEY": "AKIAEXAMPLE",
@@ -63,7 +64,7 @@ def test_load_full_yaml_with_env_interpolation():
     assert cfg.kernel_mounts() == {
         "/": (MountBackend.FUSE, "/tmp/mirage-fuse-full")
     }
-    assert "kernel_mounts" not in cfg.to_workspace_kwargs()
+    assert "kernel_mounts" not in await cfg.to_workspace_kwargs()
 
 
 def test_missing_env_var_raises_with_full_list():
@@ -78,9 +79,10 @@ def test_redis_cache_discriminated_union():
     assert cfg.cache.key_prefix == "test_cache:"
 
 
-def test_to_workspace_kwargs_yields_constructible_workspace():
+@pytest.mark.asyncio
+async def test_to_workspace_kwargs_yields_constructible_workspace():
     cfg = load_config(FIXTURES / "minimal.yaml")
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert "/" in kwargs["resources"]
     mount = kwargs["resources"]["/"]
     assert isinstance(mount.resource, RAMResource)
@@ -89,14 +91,16 @@ def test_to_workspace_kwargs_yields_constructible_workspace():
     assert ws is not None
 
 
-def test_to_workspace_kwargs_emits_redis_cache_config():
+@pytest.mark.asyncio
+async def test_to_workspace_kwargs_emits_redis_cache_config():
     cfg = load_config(FIXTURES / "redis_cache.yaml")
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert isinstance(kwargs["cache"], RedisCacheConfig)
     assert kwargs["cache"].url == "redis://localhost:6379/3"
 
 
-def test_to_workspace_kwargs_emits_ram_cache_config():
+@pytest.mark.asyncio
+async def test_to_workspace_kwargs_emits_ram_cache_config():
     cfg = load_config({
         "cache": {
             "type": "ram",
@@ -108,13 +112,14 @@ def test_to_workspace_kwargs_emits_ram_cache_config():
             }
         },
     })
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert isinstance(kwargs["cache"], CacheConfig)
     assert not isinstance(kwargs["cache"], RedisCacheConfig)
     assert kwargs["cache"].limit == "128MB"
 
 
-def test_store_redis_block_builds_redis_provider():
+@pytest.mark.asyncio
+async def test_store_redis_block_builds_redis_provider():
     cfg = load_config({
         "store": {
             "type": "redis",
@@ -129,12 +134,13 @@ def test_store_redis_block_builds_redis_provider():
     })
     assert cfg.store is not None
     assert cfg.store.key_prefix == "test_store:"
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert isinstance(kwargs["store"], RedisWorkspaceStateStore)
     assert isinstance(kwargs["store"].namespace("ws1"), RedisNamespaceStore)
 
 
-def test_store_ram_block_builds_ram_provider():
+@pytest.mark.asyncio
+async def test_store_ram_block_builds_ram_provider():
     cfg = load_config({
         "store": {
             "type": "ram"
@@ -145,13 +151,14 @@ def test_store_ram_block_builds_ram_provider():
             }
         },
     })
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert isinstance(kwargs["store"], RAMWorkspaceStateStore)
     assert kwargs["owns_store"] is True
     assert isinstance(kwargs["store"].namespace("ws1"), RAMNamespaceStore)
 
 
-def test_store_disk_block_builds_disk_provider(tmp_path):
+@pytest.mark.asyncio
+async def test_store_disk_block_builds_disk_provider(tmp_path):
     cfg = load_config({
         "store": {
             "type": "disk",
@@ -165,13 +172,14 @@ def test_store_disk_block_builds_disk_provider(tmp_path):
     })
     assert cfg.store is not None
     assert cfg.store.root == str(tmp_path)
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert isinstance(kwargs["store"], DiskWorkspaceStateStore)
     assert kwargs["owns_store"] is True
     assert isinstance(kwargs["store"].namespace("ws1"), DiskNamespaceStore)
 
 
-def test_store_disk_group_override(tmp_path):
+@pytest.mark.asyncio
+async def test_store_disk_group_override(tmp_path):
     cfg = load_config({
         "store": {
             "type": "ram",
@@ -187,12 +195,13 @@ def test_store_disk_group_override(tmp_path):
         },
     })
     assert isinstance(cfg.store.workspace, DiskStoreBlock)
-    store = cfg.to_workspace_kwargs()["store"]
+    store = (await cfg.to_workspace_kwargs())["store"]
     assert isinstance(store, RAMWorkspaceStateStore)
     assert isinstance(store.sessions("ws1"), DiskSessionStore)
 
 
-def test_store_group_override_redirects_one_plane():
+@pytest.mark.asyncio
+async def test_store_group_override_redirects_one_plane():
     cfg = load_config({
         "store": {
             "type": "ram",
@@ -209,13 +218,14 @@ def test_store_group_override_redirects_one_plane():
         },
     })
     assert isinstance(cfg.store.observer, RedisStoreBlock)
-    store = cfg.to_workspace_kwargs()["store"]
+    store = (await cfg.to_workspace_kwargs())["store"]
     assert isinstance(store, RAMWorkspaceStateStore)
     assert isinstance(store.namespace("ws1"), RAMNamespaceStore)
     assert type(store.observer("ws1")).__name__ == "RedisObserverStore"
 
 
-def test_store_s3_workspace_group_builds_s3_provider():
+@pytest.mark.asyncio
+async def test_store_s3_workspace_group_builds_s3_provider():
     cfg = load_config({
         "store": {
             "type": "ram",
@@ -233,13 +243,14 @@ def test_store_s3_workspace_group_builds_s3_provider():
         },
     })
     assert isinstance(cfg.store.workspace, S3StoreBlock)
-    store = cfg.to_workspace_kwargs()["store"]
+    store = (await cfg.to_workspace_kwargs())["store"]
     assert isinstance(store, RAMWorkspaceStateStore)
     assert isinstance(store.namespace("ws1"), RAMNamespaceStore)
     assert type(store.sessions("ws1")).__name__ == "S3SessionStore"
 
 
-def test_workspace_id_passes_through():
+@pytest.mark.asyncio
+async def test_workspace_id_passes_through():
     cfg = load_config({
         "workspace_id": "agent-ws-7",
         "mounts": {
@@ -248,7 +259,7 @@ def test_workspace_id_passes_through():
             }
         },
     })
-    assert cfg.to_workspace_kwargs()["workspace_id"] == "agent-ws-7"
+    assert (await cfg.to_workspace_kwargs())["workspace_id"] == "agent-ws-7"
 
 
 def test_store_block_rejects_unknown_field():
@@ -283,12 +294,12 @@ def test_unknown_mount_field_rejected():
         })
 
 
-def test_workspace_built_from_config_executes_command():
+@pytest.mark.asyncio
+async def test_workspace_built_from_config_executes_command():
     cfg = load_config(FIXTURES / "minimal.yaml")
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     ws = Workspace(**kwargs)
-    import asyncio
-    result = asyncio.run(ws.execute("echo hello"))
+    result = await ws.execute("echo hello")
     assert result.exit_code == 0
     assert (result.stdout or b"").startswith(b"hello")
 
@@ -308,7 +319,8 @@ def test_round_trip_dict_source_matches_yaml(tmp_path):
     assert from_yaml.model_dump() == from_dict.model_dump()
 
 
-def test_resource_built_via_registry_has_correct_type():
+@pytest.mark.asyncio
+async def test_resource_built_via_registry_has_correct_type():
     cfg = load_config({
         "mounts": {
             "/s3": {
@@ -323,13 +335,14 @@ def test_resource_built_via_registry_has_correct_type():
             },
         },
     })
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     mount = kwargs["resources"]["/s3"]
     assert isinstance(mount.resource, S3Resource)
     assert mount.mode == MountMode.READ
 
 
-def test_script_paths_resolve_against_config_dir(tmp_path):
+@pytest.mark.asyncio
+async def test_script_paths_resolve_against_config_dir(tmp_path):
     (tmp_path / "policy.py").write_text("'local'")
     (tmp_path / "entry.py").write_text("ctx['command'] == 'python3'")
     cfg_file = tmp_path / "ws.yaml"
@@ -344,13 +357,14 @@ runtimes:
   - vfs
 """)
     cfg = load_config(cfg_file)
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert kwargs["policy"] == ScriptSource("'local'")
     entry = kwargs["runtimes"][0]
     assert entry.script == ScriptSource("ctx['command'] == 'python3'")
 
 
-def test_js_script_path_stamps_the_language(tmp_path):
+@pytest.mark.asyncio
+async def test_js_script_path_stamps_the_language(tmp_path):
     (tmp_path / "policy.js").write_text("null")
     cfg_file = tmp_path / "ws.yaml"
     cfg_file.write_text("""\
@@ -360,12 +374,13 @@ mounts:
 policy: policy.js
 """)
     cfg = load_config(cfg_file)
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert kwargs["policy"] == ScriptSource("null", language="js")
     assert kwargs["policy"].language == "js"
 
 
-def test_guards_block_compiles_to_guard_specs(tmp_path):
+@pytest.mark.asyncio
+async def test_guards_block_compiles_to_guard_specs(tmp_path):
     cfg_file = tmp_path / "ws.yaml"
     cfg_file.write_text("""\
 mounts:
@@ -379,7 +394,7 @@ guards:
     commands: [python3]
 """)
     cfg = load_config(cfg_file)
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert kwargs["guards"] == [
         GuardSpec(reason="production data is protected",
                   commands=("rm", "mv"),
@@ -388,7 +403,8 @@ guards:
     ]
 
 
-def test_clis_section_parses_and_maps_to_kwargs():
+@pytest.mark.asyncio
+async def test_clis_section_parses_and_maps_to_kwargs():
     cfg = load_config({
         "mounts": {
             "/data": {
@@ -407,7 +423,7 @@ def test_clis_section_parses_and_maps_to_kwargs():
             },
         },
     })
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert kwargs["clis"] == {
         "sl": ("slack", {
             "token": "x"
@@ -416,7 +432,8 @@ def test_clis_section_parses_and_maps_to_kwargs():
     }
 
 
-def test_clis_script_entry_synthesizes_a_spec(tmp_path):
+@pytest.mark.asyncio
+async def test_clis_script_entry_synthesizes_a_spec(tmp_path):
     (tmp_path / "pager.py").write_text("print('page')")
     cfg_file = tmp_path / "ws.yaml"
     cfg_file.write_text("""\
@@ -431,7 +448,7 @@ clis:
       page_size: 20
 """)
     cfg = load_config(cfg_file)
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     spec, config = kwargs["clis"]["pager"]
     assert spec.name == "pager"
     assert spec.script == ScriptSource("print('page')")
@@ -439,7 +456,8 @@ clis:
     assert config == {"page_size": 20}
 
 
-def test_clis_js_script_stamps_the_language(tmp_path):
+@pytest.mark.asyncio
+async def test_clis_js_script_stamps_the_language(tmp_path):
     (tmp_path / "pager.mjs").write_text("console.log('page')")
     cfg_file = tmp_path / "ws.yaml"
     cfg_file.write_text("""\
@@ -451,7 +469,7 @@ clis:
     script: pager.mjs
 """)
     cfg = load_config(cfg_file)
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     spec, _ = kwargs["clis"]["pager"]
     # .mjs also stamps module: the path is gone once the source is
     # embedded, so the engine could not otherwise know to run it as an
@@ -461,7 +479,8 @@ clis:
                                        module=True)
 
 
-def test_clis_plain_js_script_is_not_a_module(tmp_path):
+@pytest.mark.asyncio
+async def test_clis_plain_js_script_is_not_a_module(tmp_path):
     (tmp_path / "pager.js").write_text("console.log('page')")
     cfg_file = tmp_path / "ws.yaml"
     cfg_file.write_text("""\
@@ -472,12 +491,14 @@ clis:
   pager:
     script: pager.js
 """)
-    spec, _ = load_config(cfg_file).to_workspace_kwargs()["clis"]["pager"]
+    spec, _ = (await
+               load_config(cfg_file).to_workspace_kwargs())["clis"]["pager"]
     assert spec.script.language == "js"
     assert spec.script.module is False
 
 
-def test_clis_path_form_reference_rebases_on_the_config_dir(
+@pytest.mark.asyncio
+async def test_clis_path_form_reference_rebases_on_the_config_dir(
         tmp_path, monkeypatch):
     # `cli: ./tool.py:TREE` means "next to the config file", the same
     # build-context rule script: follows; without rebasing it resolves
@@ -497,11 +518,12 @@ clis:
 """)
     monkeypatch.chdir(tmp_path.parent)
     cfg = load_config(cfg_file)
-    ref, _ = cfg.to_workspace_kwargs()["clis"]["tool"]
+    ref, _ = (await cfg.to_workspace_kwargs())["clis"]["tool"]
     assert ref == f"{tmp_path / 'tool.py'}:TREE"
 
 
-def test_clis_module_dotpath_reference_is_left_alone(tmp_path):
+@pytest.mark.asyncio
+async def test_clis_module_dotpath_reference_is_left_alone(tmp_path):
     # importlib resolves a dotpath, not the filesystem, so rebasing it
     # would break the import.
     cfg_file = tmp_path / "ws.yaml"
@@ -514,11 +536,12 @@ clis:
     cli: mypkg.clis:TREE
 """)
     cfg = load_config(cfg_file)
-    ref, _ = cfg.to_workspace_kwargs()["clis"]["tool"]
+    ref, _ = (await cfg.to_workspace_kwargs())["clis"]["tool"]
     assert ref == "mypkg.clis:TREE"
 
 
-def test_clis_registered_name_reference_is_left_alone(tmp_path):
+@pytest.mark.asyncio
+async def test_clis_registered_name_reference_is_left_alone(tmp_path):
     cfg_file = tmp_path / "ws.yaml"
     cfg_file.write_text("""\
 mounts:
@@ -529,11 +552,12 @@ clis:
     cli: slack
 """)
     cfg = load_config(cfg_file)
-    ref, _ = cfg.to_workspace_kwargs()["clis"]["sl"]
+    ref, _ = (await cfg.to_workspace_kwargs())["clis"]["sl"]
     assert ref == "slack"
 
 
-def test_clis_script_file_must_exist(tmp_path):
+@pytest.mark.asyncio
+async def test_clis_script_file_must_exist(tmp_path):
     cfg_file = tmp_path / "ws.yaml"
     cfg_file.write_text("""\
 mounts:
@@ -545,7 +569,7 @@ clis:
 """)
     cfg = load_config(cfg_file)
     with pytest.raises(FileNotFoundError):
-        cfg.to_workspace_kwargs()
+        await cfg.to_workspace_kwargs()
 
 
 def test_clis_entry_takes_exactly_one_of_cli_or_script():

--- a/python/tests/core/github/test_repo.py
+++ b/python/tests/core/github/test_repo.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 import pytest
 
 from mirage.core.github.config import GitHubConfig
-from mirage.core.github.repo import fetch_default_branch_sync
+from mirage.core.github.repo import fetch_default_branch
 
 
 @pytest.fixture
@@ -25,20 +25,22 @@ def config():
     return GitHubConfig(token="ghp_test")
 
 
-@patch("mirage.core.github.repo.github_get_sync")
-def test_fetch_default_branch_main(mock_get, config):
+@pytest.mark.asyncio
+@patch("mirage.core.github.repo.github_get")
+async def test_fetch_default_branch_main(mock_get, config):
     mock_get.return_value = {"default_branch": "main"}
-    result = fetch_default_branch_sync(config, "acme", "proj")
+    result = await fetch_default_branch(config, "acme", "proj")
     assert result == "main"
-    mock_get.assert_called_once_with(config.token,
-                                     "/repos/{owner}/{repo}",
-                                     base_url=None,
-                                     owner="acme",
-                                     repo="proj")
+    mock_get.assert_awaited_once_with(config.token,
+                                      "/repos/{owner}/{repo}",
+                                      base_url=None,
+                                      owner="acme",
+                                      repo="proj")
 
 
-@patch("mirage.core.github.repo.github_get_sync")
-def test_fetch_default_branch_master(mock_get, config):
+@pytest.mark.asyncio
+@patch("mirage.core.github.repo.github_get")
+async def test_fetch_default_branch_master(mock_get, config):
     mock_get.return_value = {"default_branch": "master"}
-    result = fetch_default_branch_sync(config, "acme", "proj")
+    result = await fetch_default_branch(config, "acme", "proj")
     assert result == "master"

--- a/python/tests/core/github/test_tree.py
+++ b/python/tests/core/github/test_tree.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 import pytest
 
 from mirage.core.github.config import GitHubConfig
-from mirage.core.github.tree import fetch_dir_tree, fetch_tree_sync
+from mirage.core.github.tree import fetch_dir_tree, fetch_tree
 from mirage.core.github.tree_entry import TreeEntry
 
 
@@ -27,8 +27,9 @@ def config():
     return GitHubConfig(token="ghp_test")
 
 
-@patch("mirage.core.github.tree.github_get_sync")
-def test_fetch_tree_parses_entries(mock_get, config):
+@pytest.mark.asyncio
+@patch("mirage.core.github.tree.github_get")
+async def test_fetch_tree_parses_entries(mock_get, config):
     mock_get.return_value = {
         "truncated":
         False,
@@ -47,7 +48,7 @@ def test_fetch_tree_parses_entries(mock_get, config):
             },
         ],
     }
-    tree, truncated = fetch_tree_sync(config, "acme", "proj", "main")
+    tree, truncated = await fetch_tree(config, "acme", "proj", "main")
     assert "src" in tree
     assert "src/main.py" in tree
     assert tree["src"] == TreeEntry(path="src",
@@ -60,8 +61,9 @@ def test_fetch_tree_parses_entries(mock_get, config):
                                             size=120)
 
 
-@patch("mirage.core.github.tree.github_get_sync")
-def test_fetch_tree_excludes_submodule_gitlinks(mock_get, config):
+@pytest.mark.asyncio
+@patch("mirage.core.github.tree.github_get")
+async def test_fetch_tree_excludes_submodule_gitlinks(mock_get, config):
     mock_get.return_value = {
         "truncated":
         False,
@@ -80,7 +82,7 @@ def test_fetch_tree_excludes_submodule_gitlinks(mock_get, config):
             },
         ],
     }
-    tree, _ = fetch_tree_sync(config, "acme", "proj", "main")
+    tree, _ = await fetch_tree(config, "acme", "proj", "main")
     assert "extern" not in tree
     assert list(tree) == ["main.py"]
 
@@ -108,19 +110,21 @@ async def test_fetch_dir_tree_excludes_submodule_gitlinks(mock_get, config):
     assert [e.path for e in entries] == ["main.py"]
 
 
-@patch("mirage.core.github.tree.github_get_sync")
-def test_fetch_tree_truncation_warning(mock_get, config, caplog):
+@pytest.mark.asyncio
+@patch("mirage.core.github.tree.github_get")
+async def test_fetch_tree_truncation_warning(mock_get, config, caplog):
     mock_get.return_value = {"truncated": True, "tree": []}
     with caplog.at_level(logging.WARNING):
-        fetch_tree_sync(config, "acme", "proj", "main")
+        await fetch_tree(config, "acme", "proj", "main")
     assert "truncated" in caplog.text
 
 
-@patch("mirage.core.github.tree.github_get_sync")
-def test_fetch_tree_passes_params(mock_get, config):
+@pytest.mark.asyncio
+@patch("mirage.core.github.tree.github_get")
+async def test_fetch_tree_passes_params(mock_get, config):
     mock_get.return_value = {"tree": []}
-    fetch_tree_sync(config, "acme", "proj", "v1")
-    mock_get.assert_called_once_with(
+    await fetch_tree(config, "acme", "proj", "v1")
+    mock_get.assert_awaited_once_with(
         config.token,
         "/repos/{owner}/{repo}/git/trees/{ref}",
         params={"recursive": "1"},

--- a/python/tests/e2e/test_cli_dispatch.py
+++ b/python/tests/e2e/test_cli_dispatch.py
@@ -139,7 +139,7 @@ async def test_yaml_clis_section_installs_through_load_config():
                 }
             },
         })
-        ws = Workspace(**cfg.to_workspace_kwargs())
+        ws = Workspace(**await cfg.to_workspace_kwargs())
         code, out, _ = await run(ws, "sl message send -t x hi")
         assert (code, out) == (0, b"sent[yaml] to=x: hi\n")
         await ws.close()
@@ -177,7 +177,7 @@ async def test_yaml_cli_reference_form_installs(tmp_path):
             }
         },
     })
-    ws = Workspace(**cfg.to_workspace_kwargs())
+    ws = Workspace(**await cfg.to_workspace_kwargs())
     code, out, _ = await run(ws, "sl send")
     assert (code, out) == (0, b"sent[ref]\n")
     await ws.close()
@@ -198,7 +198,7 @@ async def test_yaml_unknown_cli_key_fails_loud():
         },
     })
     with pytest.raises(ValueError, match="unknown cli 'nope'"):
-        Workspace(**cfg.to_workspace_kwargs())
+        Workspace(**await cfg.to_workspace_kwargs())
 
 
 @pytest.mark.asyncio
@@ -374,7 +374,7 @@ async def test_yaml_script_entry_executes_end_to_end(tmp_path):
             }
         },
     })
-    ws = Workspace(**cfg.to_workspace_kwargs())
+    ws = Workspace(**await cfg.to_workspace_kwargs())
     code, out, _ = await run(ws, "pager report.txt")
     assert (code, out) == (0, b'yaml report.txt {"width": 80}\n')
     await ws.close()

--- a/python/tests/fixtures/github_mock.py
+++ b/python/tests/fixtures/github_mock.py
@@ -112,10 +112,10 @@ def github_config():
 @pytest.fixture
 def mock_github_api(monkeypatch):
 
-    def _fetch_default_branch_sync(config, owner, repo):
+    async def _fetch_default_branch(config, owner, repo):
         return MOCK_DEFAULT_BRANCH
 
-    def _fetch_tree_sync(config, owner, repo, ref):
+    async def _fetch_tree(config, owner, repo, ref):
         return dict(MOCK_TREE), False
 
     async def _read_bytes(config, owner, repo, sha):
@@ -127,10 +127,9 @@ def mock_github_api(monkeypatch):
             results = [r for r in results if r.path.startswith(path_filter)]
         return results
 
-    monkeypatch.setattr(
-        "mirage.resource.github.github.fetch_default_branch_sync",
-        _fetch_default_branch_sync)
-    monkeypatch.setattr("mirage.resource.github.github.fetch_tree_sync",
-                        _fetch_tree_sync)
+    monkeypatch.setattr("mirage.resource.github.github.fetch_default_branch",
+                        _fetch_default_branch)
+    monkeypatch.setattr("mirage.resource.github.github.fetch_tree",
+                        _fetch_tree)
     monkeypatch.setattr("mirage.core.github.read.read_bytes", _read_bytes)
     monkeypatch.setattr("mirage.core.github.search.search_code", _search_code)

--- a/python/tests/resource/chroma/test_resource.py
+++ b/python/tests/resource/chroma/test_resource.py
@@ -1,15 +1,18 @@
+import pytest
+
 from mirage.resource.registry import REGISTRY, build_resource
 from mirage.types import ResourceName
 
 
-def test_chroma_resource_is_registered():
+@pytest.mark.asyncio
+async def test_chroma_resource_is_registered():
     assert ResourceName.CHROMA == "chroma"
     assert REGISTRY[
         "chroma"].resource_path == "mirage.resource.chroma:ChromaResource"
     assert REGISTRY[
         "chroma"].config_path == "mirage.resource.chroma:ChromaConfig"
 
-    resource = build_resource("chroma", {"collection_name": "docs"})
+    resource = await build_resource("chroma", {"collection_name": "docs"})
 
     assert resource.name == ResourceName.CHROMA
     assert resource.caches_reads is False
@@ -19,8 +22,9 @@ def test_chroma_resource_is_registered():
     assert resource.accessor.config is resource.config
 
 
-def test_chroma_resource_registers_expected_commands_and_ops():
-    resource = build_resource("chroma", {"collection_name": "docs"})
+@pytest.mark.asyncio
+async def test_chroma_resource_registers_expected_commands_and_ops():
+    resource = await build_resource("chroma", {"collection_name": "docs"})
 
     commands = {item.name for item in resource.commands()}
     ops = {item.name for item in resource.ops_list()}

--- a/python/tests/resource/dify/test_resource.py
+++ b/python/tests/resource/dify/test_resource.py
@@ -6,13 +6,14 @@ from mirage.resource.registry import REGISTRY, build_resource
 from mirage.types import ResourceName
 
 
-def test_dify_resource_is_registered_and_redacts_api_key():
+@pytest.mark.asyncio
+async def test_dify_resource_is_registered_and_redacts_api_key():
     assert ResourceName.DIFY == "dify"
     assert REGISTRY[
         "dify"].resource_path == "mirage.resource.dify:DifyResource"
     assert REGISTRY["dify"].config_path == "mirage.resource.dify:DifyConfig"
 
-    resource = build_resource(
+    resource = await build_resource(
         "dify",
         {
             "api_key": "dataset-secret",
@@ -45,8 +46,9 @@ def test_dify_resource_is_registered_and_redacts_api_key():
     assert state["config"]["retry_max_delay"] == 30.0
 
 
-def test_dify_resource_accepts_configured_slug_metadata_name():
-    resource = build_resource(
+@pytest.mark.asyncio
+async def test_dify_resource_accepts_configured_slug_metadata_name():
+    resource = await build_resource(
         "dify",
         {
             "api_key": "dataset-secret",
@@ -80,8 +82,9 @@ def test_dify_config_rejects_non_positive_request_limits(field):
         DifyConfig(**values)
 
 
-def test_dify_resource_registers_expected_commands_and_ops():
-    resource = build_resource(
+@pytest.mark.asyncio
+async def test_dify_resource_registers_expected_commands_and_ops():
+    resource = await build_resource(
         "dify",
         {
             "api_key": "dataset-secret",
@@ -100,7 +103,7 @@ def test_dify_resource_registers_expected_commands_and_ops():
 
 @pytest.mark.asyncio
 async def test_dify_resource_close_closes_shared_client():
-    resource = build_resource(
+    resource = await build_resource(
         "dify",
         {
             "api_key": "dataset-secret",

--- a/python/tests/resource/dropbox/test_dropbox.py
+++ b/python/tests/resource/dropbox/test_dropbox.py
@@ -56,8 +56,9 @@ def test_state_does_not_leak_secrets():
     assert "sekret" not in dumped
 
 
-def test_registry_builds_dropbox():
-    resource = build_resource(
+@pytest.mark.asyncio
+async def test_registry_builds_dropbox():
+    resource = await build_resource(
         "dropbox", {
             "client_id": "c",
             "client_secret": "s",

--- a/python/tests/resource/github/test_github.py
+++ b/python/tests/resource/github/test_github.py
@@ -28,17 +28,17 @@ OWNER = "test-owner"
 REPO = "test-repo"
 
 
-def _make_resource(ref: str = "main",
-                   default_branch: str = "main",
-                   tree: dict | None = None,
-                   truncated: bool = False) -> GitHubResource:
+async def _make_resource(ref: str = "main",
+                         default_branch: str = "main",
+                         tree: dict | None = None,
+                         truncated: bool = False) -> GitHubResource:
     if tree is None:
         tree = {}
-    with patch("mirage.resource.github.github.fetch_default_branch_sync",
+    with patch("mirage.resource.github.github.fetch_default_branch",
                return_value=default_branch), \
-         patch("mirage.resource.github.github.fetch_tree_sync",
+         patch("mirage.resource.github.github.fetch_tree",
                return_value=(tree, truncated)):
-        return GitHubResource(
+        return await GitHubResource.build(
             config=CONFIG,
             owner=OWNER,
             repo=REPO,
@@ -46,69 +46,87 @@ def _make_resource(ref: str = "main",
         )
 
 
-def test_name() -> None:
-    resource = _make_resource()
+@pytest.mark.asyncio
+async def test_name() -> None:
+    resource = await _make_resource()
     assert resource.name == ResourceName.GITHUB
 
 
-def test_caches_reads() -> None:
-    resource = _make_resource()
+@pytest.mark.asyncio
+async def test_caches_reads() -> None:
+    resource = await _make_resource()
     assert resource.caches_reads is True
 
 
-def test_bind_args() -> None:
-    resource = _make_resource()
+@pytest.mark.asyncio
+async def test_bind_args() -> None:
+    resource = await _make_resource()
     assert resource.accessor.config is CONFIG
     assert resource.accessor.owner == OWNER
     assert resource.accessor.repo == REPO
     assert resource.accessor.ref == "main"
 
 
-def test_owner_repo_ref_fall_back_to_config() -> None:
+@pytest.mark.asyncio
+async def test_owner_repo_ref_fall_back_to_config() -> None:
     config = GitHubConfig(token="test-token",
                           owner="cfg-owner",
                           repo="cfg-repo",
                           ref="cfg-ref")
-    with patch("mirage.resource.github.github.fetch_default_branch_sync",
+    with patch("mirage.resource.github.github.fetch_default_branch",
                return_value="main"), \
-         patch("mirage.resource.github.github.fetch_tree_sync",
+         patch("mirage.resource.github.github.fetch_tree",
                return_value=({}, False)):
-        resource = GitHubResource(config=config)
+        resource = await GitHubResource.build(config=config)
     assert resource.accessor.owner == "cfg-owner"
     assert resource.accessor.repo == "cfg-repo"
     assert resource.accessor.ref == "cfg-ref"
 
 
-def test_kwargs_take_precedence_over_config() -> None:
+@pytest.mark.asyncio
+async def test_kwargs_take_precedence_over_config() -> None:
     config = GitHubConfig(token="test-token",
                           owner="cfg-owner",
                           repo="cfg-repo",
                           ref="cfg-ref")
-    with patch("mirage.resource.github.github.fetch_default_branch_sync",
+    with patch("mirage.resource.github.github.fetch_default_branch",
                return_value="main"), \
-         patch("mirage.resource.github.github.fetch_tree_sync",
+         patch("mirage.resource.github.github.fetch_tree",
                return_value=({}, False)):
-        resource = GitHubResource(config=config,
-                                  owner="kw-owner",
-                                  repo="kw-repo",
-                                  ref="kw-ref")
+        resource = await GitHubResource.build(config=config,
+                                              owner="kw-owner",
+                                              repo="kw-repo",
+                                              ref="kw-ref")
     assert resource.accessor.owner == "kw-owner"
     assert resource.accessor.repo == "kw-repo"
     assert resource.accessor.ref == "kw-ref"
 
 
-def test_missing_owner_repo_raises() -> None:
+@pytest.mark.asyncio
+async def test_missing_owner_repo_raises() -> None:
     with pytest.raises(ValueError, match="requires owner and repo"):
-        GitHubResource(config=GitHubConfig(token="test-token"))
+        await GitHubResource.build(config=GitHubConfig(token="test-token"))
 
 
-def test_is_default_branch_true() -> None:
-    resource = _make_resource(ref="main", default_branch="main")
+@pytest.mark.asyncio
+async def test_missing_owner_repo_refuses_before_any_fetch() -> None:
+    # The guard runs first, so a misconfigured mount costs no API call.
+    with patch("mirage.resource.github.github.fetch_default_branch") as branch:
+        with pytest.raises(ValueError, match="requires owner and repo"):
+            await GitHubResource.build(config=GitHubConfig(token="test-token"))
+    branch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_is_default_branch_true() -> None:
+    resource = await _make_resource(ref="main", default_branch="main")
     assert resource.is_default_branch is True
 
 
-def test_is_default_branch_false() -> None:
-    resource = _make_resource(ref="feature-branch", default_branch="main")
+@pytest.mark.asyncio
+async def test_is_default_branch_false() -> None:
+    resource = await _make_resource(ref="feature-branch",
+                                    default_branch="main")
     assert resource.is_default_branch is False
 
 
@@ -118,7 +136,7 @@ async def test_stat_returns_sha_fingerprint() -> None:
         "src/main.py":
         TreeEntry(path="src/main.py", type="blob", sha="abc123", size=100),
     }
-    resource = _make_resource(tree=tree)
+    resource = await _make_resource(tree=tree)
     result = await stat(resource.accessor,
                         PathSpec.from_str_path("/src/main.py"), resource.index)
     assert result.fingerprint == "abc123"
@@ -130,7 +148,7 @@ async def test_replacing_index_preserves_preloaded_tree() -> None:
         "src/main.py":
         TreeEntry(path="src/main.py", type="blob", sha="abc123", size=100),
     }
-    resource = _make_resource(tree=tree)
+    resource = await _make_resource(tree=tree)
     resource.set_index(IndexConfig())
 
     result = await stat(resource.accessor,
@@ -140,21 +158,42 @@ async def test_replacing_index_preserves_preloaded_tree() -> None:
 
 @pytest.mark.asyncio
 async def test_stat_raises_when_path_not_in_tree() -> None:
-    resource = _make_resource()
+    resource = await _make_resource()
     with pytest.raises(FileNotFoundError):
         await stat(resource.accessor,
                    PathSpec.from_str_path("/nonexistent.py"), resource.index)
 
 
-@patch("mirage.resource.github.github.fetch_tree_sync")
-@patch("mirage.resource.github.github.fetch_default_branch_sync")
-def test_init_fetches_default_branch(mock_fetch_branch,
-                                     mock_fetch_tree) -> None:
+@pytest.mark.asyncio
+@patch("mirage.resource.github.github.fetch_tree")
+@patch("mirage.resource.github.github.fetch_default_branch")
+async def test_create_fetches_default_branch(mock_fetch_branch,
+                                             mock_fetch_tree) -> None:
     mock_fetch_branch.return_value = "develop"
     mock_fetch_tree.return_value = ({}, False)
-    resource = GitHubResource(config=CONFIG,
-                              owner=OWNER,
-                              repo=REPO,
-                              ref="main")
+    resource = await GitHubResource.build(config=CONFIG,
+                                          owner=OWNER,
+                                          repo=REPO,
+                                          ref="main")
     assert resource.accessor.default_branch == "develop"
-    mock_fetch_branch.assert_called_once_with(CONFIG, OWNER, REPO)
+    mock_fetch_branch.assert_awaited_once_with(CONFIG, OWNER, REPO)
+
+
+@pytest.mark.asyncio
+async def test_the_constructor_reaches_no_network() -> None:
+    # The whole point of the build() split: __init__ takes the fetched
+    # tree, so building one never blocks the caller's event loop.
+    tree = {
+        "src/main.py":
+        TreeEntry(path="src/main.py", type="blob", sha="abc123", size=100),
+    }
+    branch_target = "mirage.resource.github.github.fetch_default_branch"
+    with patch(branch_target) as branch, \
+         patch("mirage.resource.github.github.fetch_tree") as fetch:
+        resource = GitHubResource(CONFIG, OWNER, REPO, "main", "main", tree)
+    branch.assert_not_called()
+    fetch.assert_not_called()
+    assert resource.accessor.default_branch == "main"
+    result = await stat(resource.accessor,
+                        PathSpec.from_str_path("/src/main.py"), resource.index)
+    assert result.fingerprint == "abc123"

--- a/python/tests/resource/lancedb/test_resource.py
+++ b/python/tests/resource/lancedb/test_resource.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import pytest
+
 from mirage.resource.lancedb import LanceDBConfig, LanceDBResource
 from mirage.resource.registry import REGISTRY, build_resource
 
@@ -46,9 +48,10 @@ def test_resource_registers_commands():
     assert expected <= {c.name for c in res.commands()}
 
 
-def test_resource_in_registry():
+@pytest.mark.asyncio
+async def test_resource_in_registry():
     assert "lancedb" in REGISTRY
-    res = build_resource("lancedb", {"uri": "/tmp/db"})
+    res = await build_resource("lancedb", {"uri": "/tmp/db"})
     assert res.name == "lancedb"
 
 

--- a/python/tests/resource/postgres/test_resource.py
+++ b/python/tests/resource/postgres/test_resource.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import pytest
+
 from mirage.resource.postgres import PostgresConfig, PostgresResource
 
 
@@ -37,11 +39,13 @@ def test_resource_registers_commands():
     assert expected <= cmd_names
 
 
-def test_resource_in_registry():
+@pytest.mark.asyncio
+async def test_resource_in_registry():
     from mirage.resource.registry import REGISTRY, build_resource
 
     assert "postgres" in REGISTRY
-    res = build_resource("postgres", config={"dsn": "postgres://localhost/db"})
+    res = await build_resource("postgres",
+                               config={"dsn": "postgres://localhost/db"})
     assert res.name == "postgres"
 
 

--- a/python/tests/resource/qdrant/test_resource.py
+++ b/python/tests/resource/qdrant/test_resource.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mirage.resource.qdrant import QdrantConfig, QdrantResource
 from mirage.resource.registry import REGISTRY, build_resource
 
@@ -29,9 +31,10 @@ def test_resource_registers_commands():
     assert expected <= {c.name for c in res.commands()}
 
 
-def test_resource_in_registry():
+@pytest.mark.asyncio
+async def test_resource_in_registry():
     assert "qdrant" in REGISTRY
-    res = build_resource("qdrant", {"collection": "docs"})
+    res = await build_resource("qdrant", {"collection": "docs"})
     assert res.name == "qdrant"
 
 

--- a/python/tests/resource/test_no_blocking_http.py
+++ b/python/tests/resource/test_no_blocking_http.py
@@ -1,0 +1,63 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import ast
+from pathlib import Path
+
+SOURCE = Path(__file__).resolve().parents[2] / "mirage"
+
+# Blocking HTTP clients. `urlopen` was the last one in the package: it
+# lived in core/github/_client.py because GitHubResource.__init__ had to
+# fetch the repo tree and a constructor cannot await. The fetch moved to
+# the async `BaseResource.build` factory, so nothing needs it any more.
+# aiohttp / httpx.AsyncClient are the supported way to reach a network.
+BLOCKING = {
+    "urllib.request": {"urlopen", "urlretrieve"},
+    "requests": {"get", "post", "put", "delete", "patch", "head", "request"},
+}
+
+
+def _imported_blocking_names(tree: ast.Module) -> set[str]:
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            banned = BLOCKING.get(node.module or "", set())
+            found |= {
+                a.asname or a.name
+                for a in node.names if a.name in banned
+            }
+        elif isinstance(node, ast.Import):
+            found |= {
+                a.asname or a.name
+                for a in node.names if a.name in BLOCKING
+            }
+    return found
+
+
+def test_no_blocking_http_client_in_the_package() -> None:
+    # A blocking call inside a resource constructor freezes whatever event
+    # loop the caller is on — for the daemon, every other mount's in-flight
+    # I/O and the FUSE queue. Async-native by default is a CLAUDE.md rule;
+    # this is the gate for it.
+    offenders: list[str] = []
+    for path in sorted(SOURCE.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        names = _imported_blocking_names(tree)
+        if names:
+            rel = path.relative_to(SOURCE)
+            offenders.append(f"{rel}: {', '.join(sorted(names))}")
+    assert offenders == [], (
+        "blocking HTTP client imported under mirage/; use aiohttp and do "
+        "the call in an async factory (BaseResource.build) instead:\n  " +
+        "\n  ".join(offenders))

--- a/python/tests/resource/test_registry.py
+++ b/python/tests/resource/test_registry.py
@@ -75,21 +75,24 @@ def test_capabilities_match_the_committed_spec_manifest():
                             "scripts/gen_specs.py")
 
 
-def test_build_ram_returns_ram_resource():
+@pytest.mark.asyncio
+async def test_build_ram_returns_ram_resource():
     from mirage.resource.ram import RAMResource
-    p = build_resource("ram")
+    p = await build_resource("ram")
     assert isinstance(p, RAMResource)
 
 
-def test_build_disk_takes_raw_kwargs(tmp_path):
+@pytest.mark.asyncio
+async def test_build_disk_takes_raw_kwargs(tmp_path):
     from mirage.resource.disk import DiskResource
-    p = build_resource("disk", {"root": str(tmp_path)})
+    p = await build_resource("disk", {"root": str(tmp_path)})
     assert isinstance(p, DiskResource)
 
 
-def test_build_s3_uses_config_class():
+@pytest.mark.asyncio
+async def test_build_s3_uses_config_class():
     from mirage.resource.s3 import S3Resource
-    p = build_resource(
+    p = await build_resource(
         "s3", {
             "bucket": "b",
             "region": "us-east-1",
@@ -101,9 +104,10 @@ def test_build_s3_uses_config_class():
     assert p.config.region == "us-east-1"
 
 
-def test_build_r2_uses_r2_config():
+@pytest.mark.asyncio
+async def test_build_r2_uses_r2_config():
     from mirage.resource.r2 import R2Resource
-    p = build_resource(
+    p = await build_resource(
         "r2", {
             "bucket": "b",
             "account_id": "acct",
@@ -115,18 +119,20 @@ def test_build_r2_uses_r2_config():
 
 @pytest.mark.skipif(not os.environ.get("REDIS_URL"),
                     reason="REDIS_URL not set")
-def test_build_redis_takes_raw_kwargs():
+@pytest.mark.asyncio
+async def test_build_redis_takes_raw_kwargs():
     from mirage.resource.redis import RedisResource
-    p = build_resource("redis", {
+    p = await build_resource("redis", {
         "url": os.environ["REDIS_URL"],
         "key_prefix": "test:",
     })
     assert isinstance(p, RedisResource)
 
 
-def test_unknown_resource_raises_keyerror():
+@pytest.mark.asyncio
+async def test_unknown_resource_raises_keyerror():
     with pytest.raises(KeyError, match="unknown resource 'nonsense'"):
-        build_resource("nonsense")
+        await build_resource("nonsense")
 
 
 def test_registry_module_import_is_free_of_resource_deps():
@@ -137,8 +143,9 @@ def test_registry_module_import_is_free_of_resource_deps():
     importlib.import_module("mirage.resource.registry")
 
 
-def test_build_hf_buckets_resource():
-    r = build_resource("hf_buckets", {"bucket": "o/b"})
+@pytest.mark.asyncio
+async def test_build_hf_buckets_resource():
+    r = await build_resource("hf_buckets", {"bucket": "o/b"})
     assert isinstance(r, HfBucketsResource)
 
 
@@ -174,23 +181,26 @@ def clean_registry(monkeypatch):
     monkeypatch.setattr(registry, "_entry_points_loaded", False)
 
 
-def test_register_resource_class_and_config(clean_registry):
+@pytest.mark.asyncio
+async def test_register_resource_class_and_config(clean_registry):
     register_resource("fake_custom", FakeCustomResource, FakeCustomConfig)
-    built = build_resource("fake_custom", {"url": "http://x"})
+    built = await build_resource("fake_custom", {"url": "http://x"})
     assert isinstance(built, FakeCustomResource)
     assert built.config.url == "http://x"
 
 
-def test_register_resource_kwargs_config(clean_registry):
+@pytest.mark.asyncio
+async def test_register_resource_kwargs_config(clean_registry):
     register_resource("fake_kwargs", FakeKwargsResource)
-    built = build_resource("fake_kwargs", {"root": "/data"})
+    built = await build_resource("fake_kwargs", {"root": "/data"})
     assert isinstance(built, FakeKwargsResource)
     assert built.root == "/data"
 
 
-def test_register_resource_config_cls_attribute(clean_registry):
+@pytest.mark.asyncio
+async def test_register_resource_config_cls_attribute(clean_registry):
     register_resource("fake_attr", FakeConfigClsResource)
-    built = build_resource("fake_attr", {"url": "http://y"})
+    built = await build_resource("fake_attr", {"url": "http://y"})
     assert built.config.url == "http://y"
 
 
@@ -199,10 +209,11 @@ def test_register_resource_rejects_builtin_shadow(clean_registry):
         register_resource("s3", FakeCustomResource)
 
 
-def test_register_resource_spec_string(clean_registry):
+@pytest.mark.asyncio
+async def test_register_resource_spec_string(clean_registry):
     register_resource("fake_spec",
                       "tests.resource.test_registry:FakeKwargsResource")
-    built = build_resource("fake_spec", {"root": "/spec"})
+    built = await build_resource("fake_spec", {"root": "/spec"})
     assert built.root == "/spec"
 
 
@@ -213,7 +224,8 @@ def test_known_resources_includes_custom(clean_registry):
     assert "s3" in names
 
 
-def test_entry_point_discovery(clean_registry, monkeypatch):
+@pytest.mark.asyncio
+async def test_entry_point_discovery(clean_registry, monkeypatch):
     import importlib.metadata
 
     ep = importlib.metadata.EntryPoint(
@@ -227,12 +239,14 @@ def test_entry_point_discovery(clean_registry, monkeypatch):
         return [ep]
 
     monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
-    built = build_resource("fake_ep", {"root": "/ep"})
+    built = await build_resource("fake_ep", {"root": "/ep"})
     assert built.root == "/ep"
     assert "fake_ep" in known_resources()
 
 
-def test_entry_point_does_not_shadow_registered(clean_registry, monkeypatch):
+@pytest.mark.asyncio
+async def test_entry_point_does_not_shadow_registered(clean_registry,
+                                                      monkeypatch):
     import importlib.metadata
 
     ep = importlib.metadata.EntryPoint(
@@ -243,10 +257,11 @@ def test_entry_point_does_not_shadow_registered(clean_registry, monkeypatch):
     monkeypatch.setattr(importlib.metadata, "entry_points",
                         lambda *, group: [ep])
     register_resource("fake_custom", FakeCustomResource, FakeCustomConfig)
-    built = build_resource("fake_custom", {"url": "http://z"})
+    built = await build_resource("fake_custom", {"url": "http://z"})
     assert isinstance(built, FakeCustomResource)
 
 
-def test_unknown_resource_lists_known(clean_registry):
+@pytest.mark.asyncio
+async def test_unknown_resource_lists_known(clean_registry):
     with pytest.raises(KeyError, match="unknown resource"):
-        build_resource("nope_not_real")
+        await build_resource("nope_not_real")

--- a/python/tests/resource/test_state_round_trip.py
+++ b/python/tests/resource/test_state_round_trip.py
@@ -272,15 +272,13 @@ def test_resource_get_state_redacts(mod, cls, cfg_cls, kwargs, leaks):
     assert "<REDACTED>" in blob
 
 
-def test_github_resource_get_state_redacts(monkeypatch):
+def test_github_resource_get_state_redacts():
     from mirage.resource.github import GitHubConfig, GitHubResource
-    monkeypatch.setattr(
-        "mirage.resource.github.github.fetch_default_branch_sync",
-        lambda *a, **k: "main")
-    monkeypatch.setattr("mirage.resource.github.github.fetch_tree_sync",
-                        lambda *a, **k: ({}, False))
+
+    # No fetch to stub: the constructor takes the tree, so building one
+    # for a state check costs nothing.
     cfg = GitHubConfig(token="GH-TOKEN-LEAK")
-    p = GitHubResource(cfg, owner="o", repo="r", ref="main")
+    p = GitHubResource(cfg, "o", "r", "main", "main", {})
     state = p.get_state()
     assert state["config"]["token"] == "<REDACTED>"
     assert "redacted_fields" not in state

--- a/python/tests/workspace/test_index_config.py
+++ b/python/tests/workspace/test_index_config.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import pytest
+
 from mirage import Workspace
 from mirage.cache.index import (RAMIndexCacheStore, RedisIndexCacheStore,
                                 RedisIndexConfig)
@@ -36,11 +38,12 @@ def test_workspace_default_index_is_ram():
     assert isinstance(r.index, RAMIndexCacheStore)
 
 
-def test_config_index_redis_block_builds_redis_config():
+@pytest.mark.asyncio
+async def test_config_index_redis_block_builds_redis_config():
     cfg = WorkspaceConfig(
         mounts={"/m": MountBlock(resource="ram")},
         index=RedisIndexBlock(type="redis"),
     )
-    kwargs = cfg.to_workspace_kwargs()
+    kwargs = await cfg.to_workspace_kwargs()
     assert isinstance(kwargs["index"], RedisIndexConfig)
     assert kwargs["index"].key_prefix == "mirage:index:"


### PR DESCRIPTION
## The bug

`GitHubResource.__init__` fetched the repo's default branch and its recursive git tree before returning, over `urllib.request.urlopen` — the **only blocking HTTP call in the package**. A constructor cannot `await`, which is the entire reason that sync client existed alongside the async `github_get` sitting right above it.

It is reachable on a live event loop: `server/routers/workspaces.py`'s `async def load_workspace` calls `build_resource` synchronously, so mounting a github repo froze the daemon's loop for two GitHub round trips — every other mount's in-flight I/O and the FUSE queue stalled with it. `git/trees?recursive=1` on a large repo is seconds.

Measured against a deliberately slow local GitHub, same wall clock both sides:

| | build time | 50ms heartbeat ticks |
|---|---|---|
| before | 1.24s | **1** — loop frozen |
| after | 1.24s | **24** — loop responsive |

## Why not the `open()` hook

The cleanup plan recorded this as "add TypeScript's `open()` lifecycle hook". That is not what TypeScript actually does here — `GitHubResource.open()` is `return Promise.resolve()`. The work lives in `static async create` behind a `private constructor`, and the whole factory type is declared async:

```ts
export type ResourceFactory = (config: Record<string, unknown>) => Promise<Resource>
```

Of 57 TS `open()` implementations, three do anything (disk, redis, opfs). Copying the hook alone would move github's failure from build time to first path resolution — a new divergence, not a fix. So this mirrors the async factory instead.

## Changes

- **`BaseResource.build`** — async classmethod factory; the default just calls the constructor. Named `build` rather than TypeScript's `create` because `create` is already an op name (make an empty file, what `touch` calls). Ops are served by `__getattr__`, which only runs when normal lookup fails, so a real `create` on the class shadows every backend's create op — the databricks_volume suite caught exactly that.
- **`build_resource` is async**, awaiting the factory through `_instantiate`, which falls back to the plain constructor: `register_resource` and the `mirage.resources` entry point both accept classes that do not subclass `BaseResource`.
- **`WorkspaceConfig.to_workspace_kwargs` follows**, matching TypeScript's already-async `configToWorkspaceArgs`. `Workspace(**kwargs)` itself stays synchronous.
- **`GitHubResource.__init__` takes the fetched tree** and touches no network; `GitHubResource.build` does the two fetches over the existing async `github_get`. `github_get_sync`, `fetch_tree_sync` and `fetch_default_branch_sync` are deleted.

## Verification

- New `tests/resource/test_no_blocking_http.py` fails on any `urlopen` / `urlretrieve` / `requests` import under `mirage/`, including function-local ones. Proved red by reintroducing one, then green.
- New unit pins: the constructor reaches no network, and a misconfigured mount refuses before spending an API call.
- Full Python suite green (`tests/fuse` excluded — no macFUSE on the dev box). `pre-commit --all-files` clean. `check_spec_parity.py`: 93 commands match.

## Docs

Updated on both sides. The TypeScript github pages showed `new GitHubResource({...})`, which has never compiled against its private constructor — fixed while in the same subject.

## Not touched

Snapshot load. github's state redacts its token, so `requires_resource_override` always routes it to the live-override path and `_construct_resource` is never reached for it.

Part of #609 (T1-J).

🤖 Generated with [Claude Code](https://claude.com/claude-code)