### PR TITLE
fix(lifecycle,config): close the index, evict synchronously, forbid unknown config keys (#609 T1-M + T1-L)

### DIFF
--- a/docs/home/cache.mdx
+++ b/docs/home/cache.mdx
@@ -34,12 +34,12 @@ ws = Workspace(
 ```
 
 ```typescript TypeScript
-import { RedisFileCacheStore, S3Resource, Workspace } from '@struktoai/mirage-node'
+import { S3Resource, Workspace } from '@struktoai/mirage-node'
 
 const ws = new Workspace(
   { '/s3': new S3Resource({ bucket: 'my-bucket' }) },
   {
-    cache: new RedisFileCacheStore({ url: 'redis://localhost:6379/0', cacheLimit: '8GB' }),
+    cache: { type: 'redis', url: 'redis://localhost:6379/0', limit: '8GB' },
     index: { type: 'redis', url: 'redis://localhost:6379/0', ttl: 600 },
   },
 )

--- a/integ/fixtures/config/accepted.json
+++ b/integ/fixtures/config/accepted.json
@@ -1,0 +1,95 @@
+{
+  "note": "Workspace configs both loaders must accept. The counterpart to rejected.json, and the reason it exists: TypeScript checks keys against hand-written tables that mirror Python's pydantic models, so a field added on the Python side would be silently refused by TypeScript until a config using it turned up. Every key of every block appears here at least once, which turns that drift into a failing test. Values are only as real as validation demands — no resource is built and no script is read, both loaders stop at the shape.",
+  "cases": [
+    {
+      "name": "top level: every key",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "clis": { "sl": { "cli": "slack" } },
+        "runtimes": ["node"],
+        "policy": "policy.py",
+        "guards": [{ "reason": "no rm here", "commands": ["rm"], "paths": ["/d/*"] }],
+        "mode": "write",
+        "consistency": "lazy",
+        "default_session_id": "s1",
+        "default_agent_id": "a1",
+        "workspace_id": "w1",
+        "cache": { "type": "ram" },
+        "index": { "type": "ram" },
+        "store": { "type": "ram" }
+      }
+    },
+    {
+      "name": "mount block: every key",
+      "config": {
+        "mounts": {
+          "/d": {
+            "resource": "ram",
+            "mode": "read",
+            "config": { "root": "/tmp/x" },
+            "command_limits": { "cat": { "max_bytes": 1024, "on_exceed": "error" } },
+            "backend": "vfs",
+            "mountpoint": "/mnt/d"
+          }
+        }
+      }
+    },
+    {
+      "name": "cache and index: every ram key",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "cache": { "type": "ram", "limit": "1MB", "max_drain_bytes": 8 },
+        "index": { "type": "ram", "ttl": 5 }
+      }
+    },
+    {
+      "name": "cache and index: every redis key",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "cache": {
+          "type": "redis",
+          "limit": "1MB",
+          "max_drain_bytes": 8,
+          "url": "redis://localhost:6379/0",
+          "key_prefix": "mirage:cache:"
+        },
+        "index": {
+          "type": "redis",
+          "ttl": 5,
+          "url": "redis://localhost:6379/0",
+          "key_prefix": "mirage:index:"
+        }
+      }
+    },
+    {
+      "name": "store: every key, one backend per plane",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "store": {
+          "type": "redis",
+          "url": "redis://localhost:6379/0",
+          "key_prefix": "mirage:",
+          "root": "/tmp/state",
+          "namespace": { "type": "ram" },
+          "observer": { "type": "disk", "root": "/tmp/observer" },
+          "workspace": {
+            "type": "s3",
+            "bucket": "b",
+            "region": "us-east-1",
+            "endpoint_url": "http://localhost:9000",
+            "path_style": true,
+            "timeout": 5,
+            "key_prefix": "mirage/"
+          }
+        }
+      }
+    },
+    {
+      "name": "clis entry: the script form takes a runtime and a config",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "clis": { "tool": { "script": "tool.py", "runtime": "py", "config": { "token": "t" } } }
+      }
+    }
+  ]
+}

--- a/integ/fixtures/config/rejected.json
+++ b/integ/fixtures/config/rejected.json
@@ -1,0 +1,82 @@
+{
+  "note": "Workspace configs both loaders must refuse. Python forbids extra keys on every config block (config.py's ConfigDict(extra='forbid')); the TypeScript loader mirrors those tables in server/src/config.ts. A config that loads in one language and not the other is the bug this fixture exists to catch, so the spellings here are Python's canonical snake_case ones — a camelCase alias TypeScript would otherwise accept for free is just as unportable as a typo.",
+  "cases": [
+    {
+      "name": "mount block: mount_point for mountpoint",
+      "config": { "mounts": { "/d": { "resource": "ram", "mount_point": "/mnt/x" } } }
+    },
+    {
+      "name": "mount block: resourse for resource",
+      "config": { "mounts": { "/d": { "resourse": "ram" } } }
+    },
+    {
+      "name": "top level: consistancy for consistency",
+      "config": { "mounts": { "/d": { "resource": "ram" } }, "consistancy": "lazy" }
+    },
+    {
+      "name": "cache block: limitt for limit",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "cache": { "type": "ram", "limitt": "1MB" }
+      }
+    },
+    {
+      "name": "index block: camelCase keyPrefix",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "index": { "type": "redis", "keyPrefix": "x:" }
+      }
+    },
+    {
+      "name": "cache block: camelCase maxDrainBytes",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "cache": { "type": "ram", "maxDrainBytes": 8 }
+      }
+    },
+    {
+      "name": "clis entry: a cli takes no mode",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "clis": { "sl": { "cli": "slack", "mode": "write" } }
+      }
+    },
+    {
+      "name": "store block: key_prefixx for key_prefix",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "store": { "type": "ram", "key_prefixx": "m:" }
+      }
+    },
+    {
+      "name": "store group: urlz for url",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "store": { "type": "ram", "observer": { "type": "redis", "urlz": "redis://x" } }
+      }
+    },
+    {
+      "name": "cache block: type is the union discriminator, not optional",
+      "config": { "mounts": { "/d": { "resource": "ram" } }, "cache": { "limit": "1MB" } }
+    },
+    {
+      "name": "index block: type is the union discriminator, not optional",
+      "config": { "mounts": { "/d": { "resource": "ram" } }, "index": { "ttl": 5 } }
+    },
+    {
+      "name": "cache block: no such backend",
+      "config": { "mounts": { "/d": { "resource": "ram" } }, "cache": { "type": "memcached" } }
+    },
+    {
+      "name": "store block: s3 hosts only the workspace group, never the default",
+      "config": { "mounts": { "/d": { "resource": "ram" } }, "store": { "type": "s3" } }
+    },
+    {
+      "name": "guard entry: path for paths",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "guards": [{ "reason": "no", "path": ["/x"] }]
+      }
+    }
+  ]
+}

--- a/integ/fixtures/config/rejected.json
+++ b/integ/fixtures/config/rejected.json
@@ -77,6 +77,30 @@
         "mounts": { "/d": { "resource": "ram" } },
         "guards": [{ "reason": "no", "path": ["/x"] }]
       }
+    },
+    {
+      "name": "store s3 group: a typo in a backend key is still a load error",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "store": {
+          "type": "ram",
+          "workspace": { "type": "s3", "bucket": "b", "endpoint_urll": "http://x" }
+        }
+      }
+    },
+    {
+      "name": "store s3 group: hosts only sessions+meta, not the namespace plane",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "store": { "type": "ram", "namespace": { "type": "s3", "bucket": "b" } }
+      }
+    },
+    {
+      "name": "store s3 group: hosts only sessions+meta, not the observer plane",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "store": { "type": "ram", "observer": { "type": "s3", "bucket": "b" } }
+      }
     }
   ]
 }

--- a/python/mirage/config.py
+++ b/python/mirage/config.py
@@ -492,7 +492,7 @@ class WorkspaceConfig(BaseModel):
         """Produce kwargs ready to splat into ``Workspace(**kwargs)``.
 
         Async because building a mount's resource can be: a backend
-        whose setup needs I/O does it in ``BaseResource.create``. Only
+        whose setup needs I/O does it in ``BaseResource.build``. Only
         the resources are awaited — ``Workspace(**kwargs)`` itself stays
         synchronous. Mirrors the TypeScript ``configToWorkspaceArgs``.
 

--- a/python/mirage/config.py
+++ b/python/mirage/config.py
@@ -224,6 +224,28 @@ class StoreBlock(BaseModel):
     observer: StoreGroupBlock | None = None
     workspace: StoreGroupBlock | None = None
 
+    @model_validator(mode="after")
+    def _s3_hosts_only_the_workspace_group(self) -> "StoreBlock":
+        """Refuse an s3 override on a plane the s3 store cannot host.
+
+        The type alone permits it on any group, but ``S3WorkspaceStateStore``
+        raises when asked to build a namespace or observer plane, so
+        without this the config loads and the workspace fails to
+        construct.
+
+        Raises:
+            ValueError: an s3 group was given for namespace or observer.
+        """
+        for group in ("namespace", "observer"):
+            block = getattr(self, group)
+            if block is not None and block.type == "s3":
+                raise ValueError(
+                    f"config `store.{group}` cannot be s3: the s3 store hosts "
+                    f"only the sessions+meta group; keep the {group} plane on "
+                    "ram or redis and pass the s3 store as the 'workspace' "
+                    "group override")
+        return self
+
 
 class GuardBlock(BaseModel):
     """One declarative command guard (the yaml ``guards:`` entries).

--- a/python/mirage/observe/disk_store.py
+++ b/python/mirage/observe/disk_store.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import os
+import stat
 
 import aiofiles
 import aiofiles.os
@@ -85,6 +86,22 @@ class DiskObserverStore(ObserverStoreBase):
         for d in reversed(dirs):
             await aiofiles.os.rmdir(d)
 
+    async def _root_is_dir(self) -> bool:
+        """Whether the recorder's directory exists.
+
+        ``os.path.isdir`` would answer False for an unreadable root as
+        well as a missing one, and an unreadable root must not read as
+        an empty recording; only "nothing written yet" does.
+
+        Returns:
+            bool: True when root exists and is a directory.
+        """
+        try:
+            st = await aiofiles.os.stat(self._root)
+        except FileNotFoundError:
+            return False
+        return stat.S_ISDIR(st.st_mode)
+
     async def _walk(self) -> tuple[list[str], list[str]]:
         """List all file paths and directories under root.
 
@@ -94,7 +111,7 @@ class DiskObserverStore(ObserverStoreBase):
         """
         files: list[str] = []
         dirs: list[str] = []
-        if not await aiofiles.os.path.isdir(self._root):
+        if not await self._root_is_dir():
             return files, dirs
         stack = [self._root]
         while stack:

--- a/python/tests/config/test_loader.py
+++ b/python/tests/config/test_loader.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import json
 from pathlib import Path
 
 import pytest
@@ -629,3 +630,17 @@ def test_clis_block_refuses_unknown_keys():
                 }
             },
         })
+
+
+def test_shared_rejection_fixture_is_refused():
+    # integ/fixtures/config/rejected.json is the contract: the TypeScript
+    # suite (packages/server/src/config.test.ts) refuses the same configs,
+    # so a config that loads in one language and not the other fails a
+    # test until both loaders agree.
+    fixture = (Path(__file__).parents[3] / "integ" / "fixtures" / "config" /
+               "rejected.json")
+    cases = json.loads(fixture.read_text())["cases"]
+    assert cases, "the rejection fixture must not be empty"
+    for case in cases:
+        with pytest.raises(ValueError):
+            load_config(case["config"])

--- a/python/tests/config/test_loader.py
+++ b/python/tests/config/test_loader.py
@@ -632,15 +632,26 @@ def test_clis_block_refuses_unknown_keys():
         })
 
 
-def test_shared_rejection_fixture_is_refused():
-    # integ/fixtures/config/rejected.json is the contract: the TypeScript
-    # suite (packages/server/src/config.test.ts) refuses the same configs,
-    # so a config that loads in one language and not the other fails a
-    # test until both loaders agree.
+def _shared_fixture_cases(name: str) -> list[dict]:
+    # integ/fixtures/config/{rejected,accepted}.json are the contract: the
+    # TypeScript suite (packages/server/src/config.test.ts) reads the same
+    # two files, so a config that loads in one language and not the other
+    # fails a test until both loaders agree.
     fixture = (Path(__file__).parents[3] / "integ" / "fixtures" / "config" /
-               "rejected.json")
+               f"{name}.json")
     cases = json.loads(fixture.read_text())["cases"]
-    assert cases, "the rejection fixture must not be empty"
-    for case in cases:
+    assert cases, f"the {name} fixture must not be empty"
+    return cases
+
+
+def test_shared_rejection_fixture_is_refused():
+    for case in _shared_fixture_cases("rejected"):
         with pytest.raises(ValueError):
             load_config(case["config"])
+
+
+def test_shared_acceptance_fixture_is_accepted():
+    # Every key of every block, so a field added to a model here and
+    # never mirrored into the TypeScript key tables fails there.
+    for case in _shared_fixture_cases("accepted"):
+        load_config(case["config"])

--- a/python/tests/observe/test_disk_store.py
+++ b/python/tests/observe/test_disk_store.py
@@ -13,6 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import os
+
+import pytest
 
 from mirage.observe.disk_store import DiskObserverStore
 from mirage.observe.observer import Observer
@@ -66,3 +69,24 @@ def test_clear_empties_store(tmp_path):
     asyncio.run(store.append("/d/s.jsonl", b"a\n"))
     asyncio.run(store.clear())
     assert asyncio.run(store.read_all()) == {}
+
+
+def test_missing_root_reads_as_no_history(tmp_path):
+    store = DiskObserverStore(str(tmp_path / "never-written"))
+    assert asyncio.run(store.read_all()) == {}
+
+
+@pytest.mark.skipif(os.geteuid() == 0,
+                    reason="root ignores the permission bits under test")
+def test_an_unreadable_root_raises_instead_of_reading_empty(tmp_path):
+    # A partial recording that reports success is worse than a failure:
+    # /.bash_history and the history builtin would show a truncated
+    # history with nothing to say it was truncated.
+    root = tmp_path / "obs"
+    asyncio.run(DiskObserverStore(str(root)).append("/d/s.jsonl", b"a\n"))
+    root.chmod(0o000)
+    try:
+        with pytest.raises(PermissionError):
+            asyncio.run(DiskObserverStore(str(root)).read_all())
+    finally:
+        root.chmod(0o755)

--- a/typescript/packages/cli/src/workspace.ts
+++ b/typescript/packages/cli/src/workspace.ts
@@ -15,7 +15,7 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import type { Command } from 'commander'
-import { interpolateEnv, loadWorkspaceConfigFile } from '@struktoai/mirage-server'
+import { checkWorkspaceConfigFile, interpolateEnv } from '@struktoai/mirage-server'
 import { parse as yamlParse } from 'yaml'
 import { makeClient } from './client.ts'
 import { emit, fail, formatAge, formatTable, handleResponse } from './output.ts'
@@ -155,7 +155,11 @@ export function registerWorkspaceCommands(program: Command): void {
     .argument('<config>', 'YAML/JSON workspace config')
     .option('--id <id>', 'Explicit workspace id')
     .action(async (configPath: string, opts: { id?: string }) => {
-      const cfg = loadWorkspaceConfigFile(configPath)
+      // Checked and env-interpolated here (the user's shell env is the
+      // source of truth, and a missing var must fail before the round
+      // trip), but sent in the file's own spelling: the daemon runs the
+      // same check, and it speaks snake_case like the Python one.
+      const cfg = checkWorkspaceConfigFile(configPath)
       const body: { config: unknown; id?: string } = { config: cfg }
       if (opts.id !== undefined) body.id = opts.id
       const c = buildClient()

--- a/typescript/packages/core/src/cache/file/config.ts
+++ b/typescript/packages/core/src/cache/file/config.ts
@@ -1,0 +1,35 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export const CacheType = Object.freeze({
+  RAM: 'ram',
+  REDIS: 'redis',
+} as const)
+
+export type CacheType = (typeof CacheType)[keyof typeof CacheType]
+
+/**
+ * Declarative description of the workspace's file cache, the twin of
+ * {@link IndexConfig} for the byte cache. Mirrors Python `CacheConfig`.
+ */
+export interface CacheConfig {
+  type?: CacheType
+  limit?: string | number
+  maxDrainBytes?: number | null
+}
+
+export interface RedisCacheConfig extends CacheConfig {
+  url?: string
+  keyPrefix?: string
+}

--- a/typescript/packages/core/src/cache/file/mixin.ts
+++ b/typescript/packages/core/src/cache/file/mixin.ts
@@ -32,6 +32,18 @@ export interface FileCache {
   // entries went stale, only which mount's keyspace did. Stores that own
   // their keyspace remotely push the filter down rather than enumerating.
   evictPrefix(prefix: string): Promise<void>
+  /**
+   * Drop the given keys, synchronously.
+   *
+   * The load-time counterpart to {@link FileCache.remove}: `fromState`
+   * is sync, so it cannot await a per-path removal — and a fire-and-
+   * forget `void remove(...)` would let a read issued right after load
+   * be served the very snapshot bytes the caller asked to bypass (and
+   * would surface a rejection as an unhandled one). Stores whose state
+   * cannot be mutated synchronously (redis) implement this as a
+   * documented no-op. Mirrors Python `FileCacheMixin.evict_paths`.
+   */
+  evictPaths(paths: Iterable<string>): void
   exists(key: string | PathSpec): Promise<boolean>
   isFresh(key: string, remoteFingerprint: string): Promise<boolean>
   clear(): Promise<void>

--- a/typescript/packages/core/src/cache/file/ram.test.ts
+++ b/typescript/packages/core/src/cache/file/ram.test.ts
@@ -129,4 +129,16 @@ describe('RAMFileCacheStore', () => {
     expect(c.cacheSize).toBe(2)
     expect(c.cacheEntries).toBe(1)
   })
+
+  it('evictPaths drops the named keys synchronously', async () => {
+    const c = new RAMFileCacheStore({ limit: 1024 })
+    await c.set('/d/a.txt', encode('12345'))
+    await c.set('/d/b.txt', encode('xy'))
+    // No await on the eviction itself: the snapshot load path is sync,
+    // which is the whole reason this seam exists beside remove().
+    c.evictPaths(['/d/a.txt', '/d/missing.txt'])
+    expect(c.cacheSize).toBe(2)
+    expect(c.cacheEntries).toBe(1)
+    expect(await c.get('/d/a.txt')).toBeNull()
+  })
 })

--- a/typescript/packages/core/src/cache/file/ram.ts
+++ b/typescript/packages/core/src/cache/file/ram.ts
@@ -142,6 +142,17 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
     for (const key of keys) await this.remove(key)
   }
 
+  evictPaths(paths: Iterable<string>): void {
+    for (const key of paths) {
+      const entry = this.entries.get(key)
+      if (entry !== undefined) {
+        this.size -= entry.size
+        this.entries.delete(key)
+      }
+      this.store.files.delete(key)
+    }
+  }
+
   remove(key: string): Promise<void> {
     this.drainTasks.delete(key)
     return this.lock.withLock(key, () => {

--- a/typescript/packages/core/src/cache/index/redis.ts
+++ b/typescript/packages/core/src/cache/index/redis.ts
@@ -182,7 +182,7 @@ export class RedisIndexCacheStore extends IndexCacheStore {
     }
   }
 
-  async close(): Promise<void> {
+  override async close(): Promise<void> {
     if (this.providedClient !== null) return
     if (this.clientPromise === null) return
     const c = await this.clientPromise

--- a/typescript/packages/core/src/cache/index/store.ts
+++ b/typescript/packages/core/src/cache/index/store.ts
@@ -25,4 +25,17 @@ export abstract class IndexCacheStore {
   ): Promise<void>
   abstract invalidateDir(resourcePath: string): Promise<void>
   abstract clear(): Promise<void>
+
+  /**
+   * Release whatever the store holds open. The default is a no-op:
+   * an in-memory index owns nothing. A store backed by a connection
+   * (redis) overrides this and must be idempotent — `close()` is
+   * called once per owning resource, and a resource shared between
+   * workspaces is closed by whichever one owns it.
+   *
+   * Mirrors Python `IndexCacheStore.close` (`cache/index/store.py`).
+   */
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
 }

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -456,7 +456,6 @@ export { CacheType, type CacheConfig, type RedisCacheConfig } from './cache/file
 export {
   buildFileCache,
   registerFileCacheStore,
-  resolveFileCache,
   type FileCacheFactory,
   type FileCacheStore,
 } from './workspace/workspace/cache.ts'

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -193,7 +193,7 @@ export {
 export { OpRecord, type OpRecordInit } from './observe/record.ts'
 export { LogEntry, type LogEntryInit } from './observe/log_entry.ts'
 export { type EventDict, Observer } from './observe/observer.ts'
-export { type ObserverStore, RAMObserverStore } from './observe/store.ts'
+export { type ObserverStore, ObserverStoreBase, RAMObserverStore } from './observe/store.ts'
 export { NamespaceStore, type NodeFields } from './workspace/mount/namespace/store.ts'
 export { RAMNamespaceStore } from './workspace/mount/namespace/ram.ts'
 export { HISTORY_PREFIX, HistoryViewResource } from './resource/history/history.ts'
@@ -452,6 +452,14 @@ export { Precision, ProvisionResult, type ProvisionResultInit } from './provisio
 export { IndexEntry, type IndexEntryInit, ResourceType } from './cache/index/config.ts'
 export { drainBudget, type FileCache, validateMaxDrainBytes } from './cache/file/mixin.ts'
 export { CacheEntry, type CacheEntryInit } from './cache/file/entry.ts'
+export { CacheType, type CacheConfig, type RedisCacheConfig } from './cache/file/config.ts'
+export {
+  buildFileCache,
+  registerFileCacheStore,
+  resolveFileCache,
+  type FileCacheFactory,
+  type FileCacheStore,
+} from './workspace/workspace/cache.ts'
 export { defaultFingerprint, globEscape, parseLimit } from './cache/file/utils.ts'
 export { RAMFileCacheStore } from './cache/file/ram.ts'
 export { applyIo, readFingerprint } from './cache/file/io.ts'

--- a/typescript/packages/core/src/observe/store.ts
+++ b/typescript/packages/core/src/observe/store.ts
@@ -35,6 +35,29 @@ export interface ObserverStore {
   close(): Promise<void>
 }
 
+/**
+ * Shared ObserverStore behavior.
+ *
+ * Implementations only provide `append`/`write`/`readMatching`/`clear`;
+ * `readAll` is reading with the empty suffix (every key matches), and
+ * `close` defaults to a no-op for stores that hold no connections.
+ * Mirrors Python `ObserverStoreBase`.
+ */
+export abstract class ObserverStoreBase implements ObserverStore {
+  abstract append(path: string, data: Uint8Array): Promise<void>
+  abstract write(path: string, data: Uint8Array): Promise<void>
+  abstract readMatching(suffix: string): Promise<Map<string, Uint8Array>>
+  abstract clear(): Promise<void>
+
+  readAll(): Promise<Map<string, Uint8Array>> {
+    return this.readMatching('')
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
 function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
   const merged = new Uint8Array(a.length + b.length)
   merged.set(a, 0)
@@ -43,7 +66,7 @@ function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
 }
 
 /** In-memory ObserverStore backed by a Map (the default). */
-export class RAMObserverStore implements ObserverStore {
+export class RAMObserverStore extends ObserverStoreBase {
   readonly files = new Map<string, Uint8Array>()
 
   append(path: string, data: Uint8Array): Promise<void> {
@@ -57,10 +80,6 @@ export class RAMObserverStore implements ObserverStore {
     return Promise.resolve()
   }
 
-  readAll(): Promise<Map<string, Uint8Array>> {
-    return this.readMatching('')
-  }
-
   readMatching(suffix: string): Promise<Map<string, Uint8Array>> {
     const out = new Map<string, Uint8Array>()
     for (const [k, v] of this.files) {
@@ -71,10 +90,6 @@ export class RAMObserverStore implements ObserverStore {
 
   clear(): Promise<void> {
     this.files.clear()
-    return Promise.resolve()
-  }
-
-  close(): Promise<void> {
     return Promise.resolve()
   }
 }

--- a/typescript/packages/core/src/resource/base.test.ts
+++ b/typescript/packages/core/src/resource/base.test.ts
@@ -47,3 +47,26 @@ describe('BaseResource index', () => {
     expect(r.index).toBeInstanceOf(RedisIndexCacheStore)
   })
 })
+
+describe('BaseResource close', () => {
+  it('closes the index, once', async () => {
+    const r = new Probe()
+    let closes = 0
+    const index = r.index as RAMIndexCacheStore & { close: () => Promise<void> }
+    index.close = () => {
+      closes++
+      return Promise.resolve()
+    }
+    await r.close()
+    await r.close()
+    // Without this the redis client behind `index: {type: redis}` stays
+    // connected past closeWorkspace and the Node process never exits.
+    expect(closes).toBe(1)
+  })
+
+  it('does not build an index for a resource that never used one', async () => {
+    const r = new Probe()
+    await r.close()
+    expect((r as unknown as { _index?: unknown })._index).toBeUndefined()
+  })
+})

--- a/typescript/packages/core/src/resource/base.ts
+++ b/typescript/packages/core/src/resource/base.ts
@@ -137,6 +137,7 @@ export abstract class BaseResource {
   // each instance a serial number the first time it is asked.
   static #storageCounter = 0
   #storageSeq?: number
+  #closed = false
 
   get index(): IndexCacheStore {
     let store = this._index
@@ -184,5 +185,26 @@ export abstract class BaseResource {
   // truthfully — a real filesystem, or a provider quota — override this.
   statfs(): Promise<CapacityResult> {
     return Promise.resolve({ state: CapacityState.UNKNOWN })
+  }
+
+  /**
+   * Release what this resource owns, exactly once. The base teardown is
+   * the index store: a mount configured `index: {type: redis}` holds a
+   * client that nothing else closes, so without this a Node process
+   * stays alive after `closeWorkspace`.
+   *
+   * A backend with its own handles (a db pool, an ssh channel) overrides
+   * this and calls `super.close()` — its accessor is its own to close,
+   * since the Accessor seam carries no lifecycle of its own.
+   *
+   * Mirrors Python `BaseResource.close` (`resource/base.py`).
+   */
+  async close(): Promise<void> {
+    if (this.#closed) return
+    this.#closed = true
+    // Deliberately `_index`, not the `index` getter: reading the getter
+    // would build a store for a resource that never used one, only to
+    // close it.
+    await this._index?.close()
   }
 }

--- a/typescript/packages/core/src/resource/chroma/chroma.ts
+++ b/typescript/packages/core/src/resource/chroma/chroma.ts
@@ -55,10 +55,6 @@ export class ChromaResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   ops(): readonly RegisteredOp[] {
     return CHROMA_OPS
   }

--- a/typescript/packages/core/src/resource/dify/dify.ts
+++ b/typescript/packages/core/src/resource/dify/dify.ts
@@ -51,10 +51,6 @@ export class DifyResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   ops(): readonly RegisteredOp[] {
     return DIFY_OPS
   }

--- a/typescript/packages/core/src/resource/history/history.ts
+++ b/typescript/packages/core/src/resource/history/history.ts
@@ -52,10 +52,6 @@ export class HistoryViewResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   ops(): readonly RegisteredOp[] {
     return HISTORY_OPS
   }

--- a/typescript/packages/core/src/resource/mem0/mem0.ts
+++ b/typescript/packages/core/src/resource/mem0/mem0.ts
@@ -34,10 +34,6 @@ export class Mem0Resource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return MEM0_COMMANDS
   }

--- a/typescript/packages/core/src/resource/onedrive/onedrive.ts
+++ b/typescript/packages/core/src/resource/onedrive/onedrive.ts
@@ -39,10 +39,6 @@ export class OneDriveResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return ONEDRIVE_COMMANDS
   }

--- a/typescript/packages/core/src/resource/qdrant/qdrant.ts
+++ b/typescript/packages/core/src/resource/qdrant/qdrant.ts
@@ -54,10 +54,6 @@ export class QdrantResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   ops(): readonly RegisteredOp[] {
     return QDRANT_OPS
   }

--- a/typescript/packages/core/src/resource/ram/ram.ts
+++ b/typescript/packages/core/src/resource/ram/ram.ts
@@ -86,10 +86,6 @@ export class RAMResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   ops(): readonly RegisteredOp[] {
     return RAM_OPS
   }

--- a/typescript/packages/core/src/resource/sharepoint/sharepoint.ts
+++ b/typescript/packages/core/src/resource/sharepoint/sharepoint.ts
@@ -39,10 +39,6 @@ export class SharePointResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return SHAREPOINT_COMMANDS
   }

--- a/typescript/packages/core/src/workspace/mount/storage.test.ts
+++ b/typescript/packages/core/src/workspace/mount/storage.test.ts
@@ -23,9 +23,6 @@ class StoreResource extends BaseResource implements Resource {
   open(): Promise<void> {
     return Promise.resolve()
   }
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
 }
 
 // A resource pinned by config, the way disk/s3/redis are: two instances
@@ -39,9 +36,6 @@ class RootedResource extends BaseResource implements Resource {
     return `${this.kind}:${this.root}`
   }
   open(): Promise<void> {
-    return Promise.resolve()
-  }
-  close(): Promise<void> {
     return Promise.resolve()
   }
 }

--- a/typescript/packages/core/src/workspace/snapshot/drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot/drift.test.ts
@@ -17,10 +17,13 @@ import { OpRecord } from '../../observe/record.ts'
 import type { Resource } from '../../resource/base.ts'
 import { FileStat } from '../../types.ts'
 import type { MountEntry } from '../mount/mount.ts'
+import { DriftPolicy } from '../../types.ts'
 import {
   captureFingerprints,
   checkDrift,
   ContentDriftError,
+  DriftQueue,
+  installDriftState,
   liveOnlyMountPrefixes,
 } from './drift.ts'
 
@@ -199,5 +202,33 @@ describe('checkDrift', () => {
     await expect(
       checkDrift(makeRegistry([mount]), makeStatFn(stats), '/gmail/a', 'fp-snap'),
     ).resolves.toBeUndefined()
+  })
+})
+
+describe('installDriftState under DriftPolicy.OFF', () => {
+  it('evicts the snapshot bytes before it returns', () => {
+    // fromState is sync, so a fire-and-forget remove() would let the
+    // very next read be served the bytes OFF exists to bypass.
+    const evicted: string[] = []
+    const cache = {
+      evictPaths: (paths: Iterable<string>): void => {
+        evicted.push(...paths)
+      },
+    }
+    const drift = new DriftQueue()
+    installDriftState(
+      { mountFor: () => null, allMounts: () => [] },
+      cache,
+      drift,
+      {
+        fingerprints: [
+          { path: '/d/a.txt', mount_prefix: '/d', fingerprint: 'f1' },
+          { path: '/d/b.txt', mount_prefix: '/d', fingerprint: 'f2' },
+        ],
+      },
+      DriftPolicy.OFF,
+    )
+    expect(evicted).toEqual(['/d/a.txt', '/d/b.txt'])
+    expect(drift.pending).toBe(false)
   })
 })

--- a/typescript/packages/core/src/workspace/snapshot/drift.ts
+++ b/typescript/packages/core/src/workspace/snapshot/drift.ts
@@ -119,7 +119,7 @@ export class DriftQueue {
  */
 export function installDriftState(
   registry: RegistryLike,
-  cache: { remove(key: string): Promise<void> },
+  cache: { evictPaths(paths: Iterable<string>): void },
   drift: DriftQueue,
   state: { fingerprints?: FingerprintEntry[]; live_only_mounts?: string[] },
   policy: DriftPolicy,
@@ -128,9 +128,10 @@ export function installDriftState(
   const entries = state.fingerprints ?? []
   if (entries.length === 0) return
   if (policy === DriftPolicy.OFF) {
-    for (const e of entries) {
-      void cache.remove(e.path)
-    }
+    // Synchronously: this function returns into a sync `fromState`, so
+    // a fire-and-forget `remove()` would let the very next read be
+    // served the snapshot bytes OFF exists to bypass.
+    cache.evictPaths(entries.map((e) => e.path))
     return
   }
   for (const e of entries) {

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -136,6 +136,9 @@ describe('Workspace custom cache option', () => {
       }
       return Promise.resolve()
     }
+    evictPaths(paths: Iterable<string>): void {
+      for (const key of paths) this.store.delete(key)
+    }
     exists(key: string | PathSpec): Promise<boolean> {
       const k = typeof key === 'string' ? key : key.mountPath
       return Promise.resolve(this.store.has(k))

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import type { CacheConfig } from '../cache/file/config.ts'
 import type { FileCache } from '../cache/file/mixin.ts'
 import { OpsRegistry } from '../ops/registry.ts'
 import { MountMode, ResourceName, type PathSpec } from '../types.ts'
@@ -158,10 +159,14 @@ describe('Workspace custom cache option', () => {
     }
   }
 
-  it('accepts a user-supplied FileCache', () => {
+  it('refuses a built store where the cache config goes', () => {
+    // Every CacheConfig field is optional, so this typechecks; before
+    // the guard it built a RAM cache instead and the supplied store
+    // never saw a read, a write, or a close.
     const cache = new StubCache()
-    const ws = new Workspace({}, { cache })
-    expect(ws).toBeDefined()
+    expect(() => new Workspace({}, { cache: cache as unknown as CacheConfig })).toThrow(
+      /not a built store/,
+    )
   })
 })
 

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { RAMFileCacheStore } from '../cache/file/ram.ts'
 import type { FileCache } from '../cache/file/mixin.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { IOResult } from '../io/types.ts'
@@ -32,6 +31,7 @@ import type { CLIInstall } from './cli/types.ts'
 import { resolveLimit } from '../policy/index.ts'
 import { JobTable } from '../shell/job_table.ts'
 import type { ShellParser } from '../shell/parse.ts'
+import { resolveFileCache } from './workspace/cache.ts'
 import { DriftQueue, installDriftState } from './snapshot/drift.ts'
 import { snapshot as writeSnapshot } from './snapshot/api.ts'
 import { readFileBytes } from './snapshot/fs.ts'
@@ -192,7 +192,7 @@ export class Workspace {
     )
     this.observer = new Observer(stores.observe)
     this.registry.mount(HISTORY_PREFIX, new HistoryViewResource(this.observer), MountMode.READ)
-    this.cache = options.cache ?? new RAMFileCacheStore({ limit: options.cacheLimit ?? '512MB' })
+    this.cache = resolveFileCache(options.cache, options.cacheLimit)
     this.registry.attachFileCache(this.cache)
     // Only an explicit agentId claims the workspace user; a bare launch
     // adopts whatever identity the namespace store holds.

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -31,7 +31,7 @@ import type { CLIInstall } from './cli/types.ts'
 import { resolveLimit } from '../policy/index.ts'
 import { JobTable } from '../shell/job_table.ts'
 import type { ShellParser } from '../shell/parse.ts'
-import { resolveFileCache } from './workspace/cache.ts'
+import { buildFileCache } from './workspace/cache.ts'
 import { DriftQueue, installDriftState } from './snapshot/drift.ts'
 import { snapshot as writeSnapshot } from './snapshot/api.ts'
 import { readFileBytes } from './snapshot/fs.ts'
@@ -105,7 +105,6 @@ export class Workspace {
   readonly jobTable = new JobTable()
   readonly agentId: string | null
   readonly cache: FileCache & Resource
-  private readonly ownsCache: boolean
   readonly namespace: Namespace
   private readonly dispatcher: Dispatcher
   readonly observer: Observer
@@ -193,9 +192,7 @@ export class Workspace {
     )
     this.observer = new Observer(stores.observe)
     this.registry.mount(HISTORY_PREFIX, new HistoryViewResource(this.observer), MountMode.READ)
-    const resolvedCache = resolveFileCache(options.cache, options.cacheLimit)
-    this.cache = resolvedCache.cache
-    this.ownsCache = resolvedCache.owned
+    this.cache = buildFileCache(options.cache, options.cacheLimit)
     this.registry.attachFileCache(this.cache)
     // Only an explicit agentId claims the workspace user; a bare launch
     // adopts whatever identity the namespace store holds.
@@ -947,7 +944,6 @@ export class Workspace {
     await closeWorkspace({
       watch: this.watchManager,
       cache: this.cache,
-      ownsCache: this.ownsCache,
       ownsStateStore: this.ownsStateStore,
       stateStore: this.stateStoreInternal,
       closers: this.closers,

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -105,6 +105,7 @@ export class Workspace {
   readonly jobTable = new JobTable()
   readonly agentId: string | null
   readonly cache: FileCache & Resource
+  private readonly ownsCache: boolean
   readonly namespace: Namespace
   private readonly dispatcher: Dispatcher
   readonly observer: Observer
@@ -192,7 +193,9 @@ export class Workspace {
     )
     this.observer = new Observer(stores.observe)
     this.registry.mount(HISTORY_PREFIX, new HistoryViewResource(this.observer), MountMode.READ)
-    this.cache = resolveFileCache(options.cache, options.cacheLimit)
+    const resolvedCache = resolveFileCache(options.cache, options.cacheLimit)
+    this.cache = resolvedCache.cache
+    this.ownsCache = resolvedCache.owned
     this.registry.attachFileCache(this.cache)
     // Only an explicit agentId claims the workspace user; a bare launch
     // adopts whatever identity the namespace store holds.
@@ -944,6 +947,7 @@ export class Workspace {
     await closeWorkspace({
       watch: this.watchManager,
       cache: this.cache,
+      ownsCache: this.ownsCache,
       ownsStateStore: this.ownsStateStore,
       stateStore: this.stateStoreInternal,
       closers: this.closers,

--- a/typescript/packages/core/src/workspace/workspace/build.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/build.test.ts
@@ -34,6 +34,14 @@ describe('resolveControlStores', () => {
     expect(stores.owned).toBe(false)
   })
 
+  it('claims a passed provider when told it owns it', () => {
+    // What the config loader and the daemon pass: a store built for
+    // this workspace alone, whose client nothing else would release.
+    const provider = new RAMWorkspaceStateStore()
+    const stores = resolveControlStores('ws1', { store: provider, ownsStore: true })
+    expect(stores.owned).toBe(true)
+  })
+
   it('lets plane overrides win over the provider', () => {
     const provider = new RAMWorkspaceStateStore()
     const observe = provider.observer('other')

--- a/typescript/packages/core/src/workspace/workspace/build.ts
+++ b/typescript/packages/core/src/workspace/workspace/build.ts
@@ -38,10 +38,10 @@ export interface ControlStores {
  * per-plane options (observe / namespaceStore / sessionStore) remain as
  * direct overrides that win over the provider. A caller-passed provider
  * may be shared with sibling workspaces, so only a workspace that built
- * its own provider closes it.
+ * its own provider — or was told it owns the passed one — closes it.
  */
 export function resolveControlStores(wsId: string, options: WorkspaceOptions): ControlStores {
-  const owned = options.store === undefined
+  const owned = options.store === undefined || options.ownsStore === true
   const stateStore = options.store ?? new RAMWorkspaceStateStore()
   return {
     stateStore,

--- a/typescript/packages/core/src/workspace/workspace/cache.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/cache.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest'
 import { CacheType } from '../../cache/file/config.ts'
 import { RAMFileCacheStore } from '../../cache/file/ram.ts'
 import { Workspace } from '../workspace.ts'
-import { buildFileCache, registerFileCacheStore, resolveFileCache } from './cache.ts'
+import { buildFileCache, registerFileCacheStore } from './cache.ts'
 
 describe('buildFileCache', () => {
   it('defaults to RAM sized by cacheLimit', () => {
@@ -45,26 +45,18 @@ describe('buildFileCache', () => {
   })
 })
 
-describe('resolveFileCache', () => {
-  it('passes a built store through untouched, and disclaims it', () => {
-    const store = new RAMFileCacheStore({ limit: 8 })
-    expect(resolveFileCache(store)).toEqual({ cache: store, owned: false })
-  })
-
-  it('owns what it builds', () => {
-    expect(resolveFileCache(undefined).owned).toBe(true)
-    expect(resolveFileCache({ type: CacheType.RAM }).owned).toBe(true)
-  })
-
-  it('lets a workspace take the cache as config, the way index already does', () => {
+describe('the workspace cache', () => {
+  it('takes the cache as config, the way index already does', () => {
     const ws = new Workspace({}, { cache: { type: CacheType.RAM, limit: 4096 } })
     expect(ws.cache).toBeInstanceOf(RAMFileCacheStore)
     expect(ws.cache.cacheLimit).toBe(4096)
   })
 
-  it('closes the store it built, and not one it was handed', async () => {
+  it('closes the store it built', async () => {
     // A `cache: {type: redis}` config leaves the workspace holding a
-    // client that nothing else would close.
+    // client that nothing else would close. Config is the only form the
+    // option takes — as in Python — so every cache is workspace-built
+    // and every cache is workspace-closed.
     const built = new RAMFileCacheStore({ limit: 4096 })
     let builtClosed = 0
     built.close = () => {
@@ -72,18 +64,8 @@ describe('resolveFileCache', () => {
       return Promise.resolve()
     }
     registerFileCacheStore('probe-close' as CacheType, () => built)
-    const owning = new Workspace({}, { cache: { type: 'probe-close' as CacheType } })
-    await owning.close()
+    const ws = new Workspace({}, { cache: { type: 'probe-close' as CacheType } })
+    await ws.close()
     expect(builtClosed).toBe(1)
-
-    const supplied = new RAMFileCacheStore({ limit: 4096 })
-    let suppliedClosed = 0
-    supplied.close = () => {
-      suppliedClosed++
-      return Promise.resolve()
-    }
-    const borrowing = new Workspace({}, { cache: supplied })
-    await borrowing.close()
-    expect(suppliedClosed).toBe(0)
   })
 })

--- a/typescript/packages/core/src/workspace/workspace/cache.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/cache.test.ts
@@ -1,0 +1,59 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { CacheType } from '../../cache/file/config.ts'
+import { RAMFileCacheStore } from '../../cache/file/ram.ts'
+import { Workspace } from '../workspace.ts'
+import { buildFileCache, registerFileCacheStore, resolveFileCache } from './cache.ts'
+
+describe('buildFileCache', () => {
+  it('defaults to RAM sized by cacheLimit', () => {
+    const cache = buildFileCache(undefined, 1024)
+    expect(cache).toBeInstanceOf(RAMFileCacheStore)
+    expect(cache.cacheLimit).toBe(1024)
+  })
+
+  it('a config limit wins over the legacy cacheLimit knob', () => {
+    const cache = buildFileCache({ type: CacheType.RAM, limit: 2048 }, 1024)
+    expect(cache.cacheLimit).toBe(2048)
+  })
+
+  it('names the package to import rather than degrading to RAM', () => {
+    // Silently handing back a RAM cache would look like it worked while
+    // nothing was shared between processes.
+    expect(() => buildFileCache({ type: 'memcached' as CacheType })).toThrow(
+      /no 'memcached' file cache is registered/,
+    )
+  })
+
+  it('builds a registered type through its factory', () => {
+    const store = new RAMFileCacheStore({ limit: 7 })
+    registerFileCacheStore('probe' as CacheType, () => store)
+    expect(buildFileCache({ type: 'probe' as CacheType })).toBe(store)
+  })
+})
+
+describe('resolveFileCache', () => {
+  it('passes a built store through untouched', () => {
+    const store = new RAMFileCacheStore({ limit: 8 })
+    expect(resolveFileCache(store)).toBe(store)
+  })
+
+  it('lets a workspace take the cache as config, the way index already does', () => {
+    const ws = new Workspace({}, { cache: { type: CacheType.RAM, limit: 4096 } })
+    expect(ws.cache).toBeInstanceOf(RAMFileCacheStore)
+    expect(ws.cache.cacheLimit).toBe(4096)
+  })
+})

--- a/typescript/packages/core/src/workspace/workspace/cache.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/cache.test.ts
@@ -46,14 +46,44 @@ describe('buildFileCache', () => {
 })
 
 describe('resolveFileCache', () => {
-  it('passes a built store through untouched', () => {
+  it('passes a built store through untouched, and disclaims it', () => {
     const store = new RAMFileCacheStore({ limit: 8 })
-    expect(resolveFileCache(store)).toBe(store)
+    expect(resolveFileCache(store)).toEqual({ cache: store, owned: false })
+  })
+
+  it('owns what it builds', () => {
+    expect(resolveFileCache(undefined).owned).toBe(true)
+    expect(resolveFileCache({ type: CacheType.RAM }).owned).toBe(true)
   })
 
   it('lets a workspace take the cache as config, the way index already does', () => {
     const ws = new Workspace({}, { cache: { type: CacheType.RAM, limit: 4096 } })
     expect(ws.cache).toBeInstanceOf(RAMFileCacheStore)
     expect(ws.cache.cacheLimit).toBe(4096)
+  })
+
+  it('closes the store it built, and not one it was handed', async () => {
+    // A `cache: {type: redis}` config leaves the workspace holding a
+    // client that nothing else would close.
+    const built = new RAMFileCacheStore({ limit: 4096 })
+    let builtClosed = 0
+    built.close = () => {
+      builtClosed++
+      return Promise.resolve()
+    }
+    registerFileCacheStore('probe-close' as CacheType, () => built)
+    const owning = new Workspace({}, { cache: { type: 'probe-close' as CacheType } })
+    await owning.close()
+    expect(builtClosed).toBe(1)
+
+    const supplied = new RAMFileCacheStore({ limit: 4096 })
+    let suppliedClosed = 0
+    supplied.close = () => {
+      suppliedClosed++
+      return Promise.resolve()
+    }
+    const borrowing = new Workspace({}, { cache: supplied })
+    await borrowing.close()
+    expect(suppliedClosed).toBe(0)
   })
 })

--- a/typescript/packages/core/src/workspace/workspace/cache.ts
+++ b/typescript/packages/core/src/workspace/workspace/cache.ts
@@ -50,6 +50,17 @@ export function buildFileCache(
   cache: CacheConfig | undefined,
   cacheLimit: string | number = '512MB',
 ): FileCacheStore {
+  // Every CacheConfig field is optional, so a built store is
+  // structurally assignable to it and would slip through to the RAM
+  // branch below — silently replaced by a cache that never sees a read.
+  // Structural typing cannot refuse this; say so instead.
+  if (cache !== undefined && typeof (cache as Partial<FileCache>).get === 'function') {
+    throw new Error(
+      'options.cache takes the config to build a cache from, not a built store; ' +
+        'register a factory for its type with registerFileCacheStore(type, ...) ' +
+        'and name that type here',
+    )
+  }
   const type = cache?.type ?? CacheType.RAM
   if (type !== CacheType.RAM) {
     const factory = FACTORIES[type]

--- a/typescript/packages/core/src/workspace/workspace/cache.ts
+++ b/typescript/packages/core/src/workspace/workspace/cache.ts
@@ -67,6 +67,16 @@ export function buildFileCache(
   })
 }
 
+export interface ResolvedFileCache {
+  cache: FileCacheStore
+  /**
+   * Whether the workspace built this store, and so must close it. False
+   * for a store the caller built and still owns — the same split
+   * `ownsStateStore` draws.
+   */
+  owned: boolean
+}
+
 /**
  * Resolve `WorkspaceOptions.cache`, which is either a store already
  * built by the caller or the config to build one from. A built store
@@ -75,9 +85,9 @@ export function buildFileCache(
 export function resolveFileCache(
   option: FileCacheStore | CacheConfig | undefined,
   cacheLimit: string | number = '512MB',
-): FileCacheStore {
+): ResolvedFileCache {
   if (option !== undefined && typeof (option as FileCache).get === 'function') {
-    return option as FileCacheStore
+    return { cache: option as FileCacheStore, owned: false }
   }
-  return buildFileCache(option as CacheConfig | undefined, cacheLimit)
+  return { cache: buildFileCache(option as CacheConfig | undefined, cacheLimit), owned: true }
 }

--- a/typescript/packages/core/src/workspace/workspace/cache.ts
+++ b/typescript/packages/core/src/workspace/workspace/cache.ts
@@ -1,0 +1,83 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { CacheType, type CacheConfig, type RedisCacheConfig } from '../../cache/file/config.ts'
+import type { FileCache } from '../../cache/file/mixin.ts'
+import { RAMFileCacheStore } from '../../cache/file/ram.ts'
+import type { Resource } from '../../resource/base.ts'
+
+export type FileCacheStore = FileCache & Resource
+export type FileCacheFactory = (config: RedisCacheConfig) => FileCacheStore
+
+const FACTORIES: Record<string, FileCacheFactory> = {}
+
+/**
+ * Register the store that backs a `type:` in {@link buildFileCache}.
+ *
+ * The redis store extends a node-only resource, and core cannot import
+ * node, so `@struktoai/mirage-node` registers it on import — the same
+ * seam `registerRuntime` uses for the runtimes it owns. Python needs no
+ * equivalent: there, redis is an optional extra of one package, so
+ * `build_file_cache` imports it directly behind a try/except.
+ */
+export function registerFileCacheStore(type: CacheType, factory: FileCacheFactory): void {
+  FACTORIES[type] = factory
+}
+
+/**
+ * Build the workspace's file cache from its config.
+ *
+ * Mirrors Python `build_file_cache` (`workspace/workspace/cache.py`),
+ * including its failure mode: asking for a store whose package has not
+ * been loaded names the package rather than silently degrading to RAM.
+ *
+ * @param cache the cache config; undefined keeps the RAM store sized by
+ *   `cacheLimit`.
+ * @param cacheLimit the size knob used only when no config is given.
+ */
+export function buildFileCache(
+  cache: CacheConfig | undefined,
+  cacheLimit: string | number = '512MB',
+): FileCacheStore {
+  const type = cache?.type ?? CacheType.RAM
+  if (type !== CacheType.RAM) {
+    const factory = FACTORIES[type]
+    if (factory === undefined) {
+      throw new Error(
+        `no '${type}' file cache is registered; import '@struktoai/mirage-node' ` +
+          `(which registers it) or pass a built FileCache as options.cache`,
+      )
+    }
+    return factory(cache as RedisCacheConfig)
+  }
+  return new RAMFileCacheStore({
+    limit: cache?.limit ?? cacheLimit,
+    maxDrainBytes: cache?.maxDrainBytes ?? null,
+  })
+}
+
+/**
+ * Resolve `WorkspaceOptions.cache`, which is either a store already
+ * built by the caller or the config to build one from. A built store
+ * carries the FileCache methods; a config is a plain data object.
+ */
+export function resolveFileCache(
+  option: FileCacheStore | CacheConfig | undefined,
+  cacheLimit: string | number = '512MB',
+): FileCacheStore {
+  if (option !== undefined && typeof (option as FileCache).get === 'function') {
+    return option as FileCacheStore
+  }
+  return buildFileCache(option as CacheConfig | undefined, cacheLimit)
+}

--- a/typescript/packages/core/src/workspace/workspace/cache.ts
+++ b/typescript/packages/core/src/workspace/workspace/cache.ts
@@ -56,7 +56,7 @@ export function buildFileCache(
     if (factory === undefined) {
       throw new Error(
         `no '${type}' file cache is registered; import '@struktoai/mirage-node' ` +
-          `(which registers it) or pass a built FileCache as options.cache`,
+          `(which registers it) or call registerFileCacheStore('${type}', ...)`,
       )
     }
     return factory(cache as RedisCacheConfig)
@@ -65,29 +65,4 @@ export function buildFileCache(
     limit: cache?.limit ?? cacheLimit,
     maxDrainBytes: cache?.maxDrainBytes ?? null,
   })
-}
-
-export interface ResolvedFileCache {
-  cache: FileCacheStore
-  /**
-   * Whether the workspace built this store, and so must close it. False
-   * for a store the caller built and still owns — the same split
-   * `ownsStateStore` draws.
-   */
-  owned: boolean
-}
-
-/**
- * Resolve `WorkspaceOptions.cache`, which is either a store already
- * built by the caller or the config to build one from. A built store
- * carries the FileCache methods; a config is a plain data object.
- */
-export function resolveFileCache(
-  option: FileCacheStore | CacheConfig | undefined,
-  cacheLimit: string | number = '512MB',
-): ResolvedFileCache {
-  if (option !== undefined && typeof (option as FileCache).get === 'function') {
-    return { cache: option as FileCacheStore, owned: false }
-  }
-  return { cache: buildFileCache(option as CacheConfig | undefined, cacheLimit), owned: true }
 }

--- a/typescript/packages/core/src/workspace/workspace/lifecycle.ts
+++ b/typescript/packages/core/src/workspace/workspace/lifecycle.ts
@@ -22,6 +22,7 @@ import type { WatchManager } from './watch.ts'
 export interface CloseDeps {
   watch: WatchManager
   cache: FileCache & Resource
+  ownsCache: boolean
   ownsStateStore: boolean
   stateStore: WorkspaceStateStore
   closers: (() => Promise<void>)[]
@@ -54,7 +55,16 @@ export async function closeWorkspace(deps: CloseDeps): Promise<void> {
   if (deps.ownsStateStore) {
     await deps.stateStore.close()
   }
-  await deps.cache.clear()
+  try {
+    await deps.cache.clear()
+  } finally {
+    // A `cache: {type: redis}` config leaves the workspace holding a
+    // client — and clear() connects to it — so the store the workspace
+    // built is the workspace's to release. One the caller built stays
+    // open here; its owner closes it. Mirrors the try/finally pairing
+    // in Python's `close_async`.
+    if (deps.ownsCache) await deps.cache.close()
+  }
   for (const fn of deps.closers.splice(0)) {
     try {
       await fn()

--- a/typescript/packages/core/src/workspace/workspace/lifecycle.ts
+++ b/typescript/packages/core/src/workspace/workspace/lifecycle.ts
@@ -22,7 +22,6 @@ import type { WatchManager } from './watch.ts'
 export interface CloseDeps {
   watch: WatchManager
   cache: FileCache & Resource
-  ownsCache: boolean
   ownsStateStore: boolean
   stateStore: WorkspaceStateStore
   closers: (() => Promise<void>)[]
@@ -58,12 +57,11 @@ export async function closeWorkspace(deps: CloseDeps): Promise<void> {
   try {
     await deps.cache.clear()
   } finally {
-    // A `cache: {type: redis}` config leaves the workspace holding a
-    // client — and clear() connects to it — so the store the workspace
-    // built is the workspace's to release. One the caller built stays
-    // open here; its owner closes it. Mirrors the try/finally pairing
-    // in Python's `close_async`.
-    if (deps.ownsCache) await deps.cache.close()
+    // The workspace builds its own cache, so it always closes it: a
+    // `cache: {type: redis}` config leaves it holding a client that
+    // nothing else would release, and clear() above connects to it.
+    // Mirrors the try/finally pairing in Python's `close_async`.
+    await deps.cache.close()
   }
   for (const fn of deps.closers.splice(0)) {
     try {

--- a/typescript/packages/core/src/workspace/workspace/types.ts
+++ b/typescript/packages/core/src/workspace/workspace/types.ts
@@ -13,7 +13,6 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { CacheConfig } from '../../cache/file/config.ts'
-import type { FileCache } from '../../cache/file/mixin.ts'
 import type { IndexConfig } from '../../cache/index/config.ts'
 import type { CLISpec } from '../../commands/cli/types.ts'
 import type { ByteSource } from '../../io/types.ts'
@@ -62,19 +61,28 @@ export interface WorkspaceOptions {
   sessionId?: string
   cacheLimit?: string | number
   /**
-   * The workspace's byte cache: the config describing one, coerced
-   * through `buildFileCache` exactly as `index` is — and the only form
-   * Python takes — or a store the caller built. A caller-built store
-   * stays the caller's to close; one built from config is closed with
-   * the workspace.
+   * The workspace's byte cache, described the way `index` is: the
+   * config to build one from. A store core cannot build reaches
+   * `buildFileCache` by registering a factory for its `type`
+   * (`registerFileCacheStore`), the seam node's redis store already
+   * uses — so the workspace always builds this cache, and always
+   * closes it.
    */
-  cache?: (FileCache & Resource) | CacheConfig
+  cache?: CacheConfig
   index?: IndexConfig
   observe?: ObserverStore
   namespaceStore?: NamespaceStore
   sessionStore?: SessionStore
   workspaceId?: string
   store?: WorkspaceStateStore
+  /**
+   * Whether a passed `store` is this workspace's to close. A provider
+   * may be shared with sibling workspaces, so a passed one is borrowed
+   * by default; a caller that built the store for this workspace alone
+   * (the config loader, the daemon's disk default) sets this so its
+   * client is released on close. Mirrors Python's `owns_store`.
+   */
+  ownsStore?: boolean
   python?: {
     autoLoadFromImports?: boolean
     bootstrapCode?: string

--- a/typescript/packages/core/src/workspace/workspace/types.ts
+++ b/typescript/packages/core/src/workspace/workspace/types.ts
@@ -62,9 +62,11 @@ export interface WorkspaceOptions {
   sessionId?: string
   cacheLimit?: string | number
   /**
-   * The workspace's byte cache: a built store, or — like `index` — the
-   * config describing one, coerced through `buildFileCache`. Mirrors
-   * Python's `cache: CacheConfig | None`.
+   * The workspace's byte cache: the config describing one, coerced
+   * through `buildFileCache` exactly as `index` is — and the only form
+   * Python takes — or a store the caller built. A caller-built store
+   * stays the caller's to close; one built from config is closed with
+   * the workspace.
    */
   cache?: (FileCache & Resource) | CacheConfig
   index?: IndexConfig

--- a/typescript/packages/core/src/workspace/workspace/types.ts
+++ b/typescript/packages/core/src/workspace/workspace/types.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { CacheConfig } from '../../cache/file/config.ts'
 import type { FileCache } from '../../cache/file/mixin.ts'
 import type { IndexConfig } from '../../cache/index/config.ts'
 import type { CLISpec } from '../../commands/cli/types.ts'
@@ -60,7 +61,12 @@ export interface WorkspaceOptions {
   agentId?: string
   sessionId?: string
   cacheLimit?: string | number
-  cache?: FileCache & Resource
+  /**
+   * The workspace's byte cache: a built store, or — like `index` — the
+   * config describing one, coerced through `buildFileCache`. Mirrors
+   * Python's `cache: CacheConfig | None`.
+   */
+  cache?: (FileCache & Resource) | CacheConfig
   index?: IndexConfig
   observe?: ObserverStore
   namespaceStore?: NamespaceStore

--- a/typescript/packages/node/src/cache/redis/file.ts
+++ b/typescript/packages/node/src/cache/redis/file.ts
@@ -13,11 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
+  CacheType,
   type FileCache,
   defaultFingerprint,
   globEscape,
   parseLimit,
   type PathSpec,
+  registerFileCacheStore,
   validateMaxDrainBytes,
 } from '@struktoai/mirage-core'
 import type { RedisClientType } from 'redis'
@@ -158,6 +160,14 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
     }
   }
 
+  evictPaths(_paths: Iterable<string>): void {
+    // No-op: the redis cache holds nothing restored from a snapshot
+    // (only RAM caches are repopulated at load), and the load path is
+    // sync so a redis delete cannot be awaited here. To drop live
+    // redis-cached entries, call `remove(key)` per path from an async
+    // context. Mirrors Python `RedisFileCacheStore.evict_paths`.
+  }
+
   async clear(): Promise<void> {
     this.drainTasks.clear()
     const c = await this.cacheClient()
@@ -184,3 +194,15 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
     return out
   }
 }
+
+// Registered on import so a declarative `cache: {type: redis}` resolves
+// here: core owns buildFileCache but cannot import this package. Same
+// seam the runtimes use (`registerRuntime`).
+registerFileCacheStore(CacheType.REDIS, (config) => {
+  return new RedisFileCacheStore({
+    ...(config.limit !== undefined ? { cacheLimit: config.limit } : {}),
+    ...(config.maxDrainBytes !== undefined ? { maxDrainBytes: config.maxDrainBytes } : {}),
+    ...(config.url !== undefined ? { url: config.url } : {}),
+    ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
+  })
+})

--- a/typescript/packages/node/src/index.ts
+++ b/typescript/packages/node/src/index.ts
@@ -96,6 +96,7 @@ export {
   type DatabricksProfile,
 } from './resource/databricks_volume/profile.ts'
 export {
+  normalizeS3Config,
   redactConfig as redactS3Config,
   type S3Config,
   type S3ConfigRedacted,

--- a/typescript/packages/node/src/observe/disk_store.test.ts
+++ b/typescript/packages/node/src/observe/disk_store.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mkdtempSync, rmSync } from 'node:fs'
+import { chmodSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Observer } from '@struktoai/mirage-core'
@@ -83,5 +83,23 @@ describe('DiskObserverStore', () => {
     const last = events[events.length - 1]
     expect(last?.type).toBe('clear')
     expect(last?.session).toBe('s1')
+  })
+  it('an unwritten root reads as no history', async () => {
+    const store = new DiskObserverStore(join(root, 'never-written'))
+    expect((await store.readAll()).size).toBe(0)
+  })
+
+  it('an unreadable directory raises instead of reading empty', async () => {
+    // A partial recording that reports success is worse than a failure:
+    // /.bash_history and the history builtin would show a truncated
+    // recording with nothing to say it was truncated.
+    const dir = join(root, 'obs')
+    await new DiskObserverStore(dir).append('/d/s.jsonl', ENC.encode('a\n'))
+    chmodSync(dir, 0o000)
+    try {
+      await expect(new DiskObserverStore(dir).readAll()).rejects.toThrow(/EACCES|EPERM/)
+    } finally {
+      chmodSync(dir, 0o755)
+    }
   })
 })

--- a/typescript/packages/node/src/observe/disk_store.ts
+++ b/typescript/packages/node/src/observe/disk_store.ts
@@ -12,18 +12,28 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { appendFile, mkdir, readdir, readFile, rmdir, unlink, writeFile } from 'node:fs/promises'
+import {
+  appendFile,
+  mkdir,
+  readdir,
+  readFile,
+  rmdir,
+  stat,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
 import path from 'node:path'
-import type { ObserverStore } from '@struktoai/mirage-core'
+import { ObserverStoreBase } from '@struktoai/mirage-core'
 
 /**
  * ObserverStore backed by a directory of JSONL files. Created lazily on
  * first append. Mirrors the Python DiskObserverStore.
  */
-export class DiskObserverStore implements ObserverStore {
+export class DiskObserverStore extends ObserverStoreBase {
   private readonly root: string
 
   constructor(root: string) {
+    super()
     this.root = root
   }
 
@@ -43,10 +53,6 @@ export class DiskObserverStore implements ObserverStore {
     await writeFile(absPath, data)
   }
 
-  readAll(): Promise<Map<string, Uint8Array>> {
-    return this.readMatching('')
-  }
-
   async readMatching(suffix: string): Promise<Map<string, Uint8Array>> {
     const out = new Map<string, Uint8Array>()
     const { files } = await this.walk()
@@ -64,23 +70,31 @@ export class DiskObserverStore implements ObserverStore {
     for (const d of [...dirs].reverse()) await rmdir(d)
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
+  private async rootIsDir(): Promise<boolean> {
+    try {
+      return (await stat(this.root)).isDirectory()
+    } catch (err) {
+      // Nothing recorded yet is the normal state before the first
+      // append; anything else (EACCES, EIO) is a real fault and must
+      // not read as an empty history.
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false
+      throw err
+    }
   }
 
   private async walk(): Promise<{ files: string[]; dirs: string[] }> {
     const files: string[] = []
     const dirs: string[] = []
+    if (!(await this.rootIsDir())) return { files, dirs }
     const stack: string[] = [this.root]
     while (stack.length > 0) {
       const d = stack.pop()
       if (d === undefined) break
-      let entries
-      try {
-        entries = await readdir(d, { withFileTypes: true })
-      } catch {
-        continue
-      }
+      // Deliberately unguarded: a readdir that fails mid-tree used to
+      // be swallowed, so readAll/readMatching returned a silently
+      // partial recording and clear() reported success while leaving
+      // files behind.
+      const entries = await readdir(d, { withFileTypes: true })
       dirs.push(d)
       for (const entry of entries) {
         const full = path.join(d, entry.name)

--- a/typescript/packages/node/src/observe/redis_store.ts
+++ b/typescript/packages/node/src/observe/redis_store.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { RedisClientType } from 'redis'
-import type { ObserverStore } from '@struktoai/mirage-core'
+import { ObserverStoreBase } from '@struktoai/mirage-core'
 import { loadOptionalPeer } from '../optional_peer.ts'
 
 export interface RedisObserverStoreOptions {
@@ -28,13 +28,14 @@ export interface RedisObserverStoreOptions {
  * file keys exist so readAll needs no SCAN. Mirrors the Python
  * RedisObserverStore.
  */
-export class RedisObserverStore implements ObserverStore {
+export class RedisObserverStore extends ObserverStoreBase {
   readonly url: string
   private readonly prefix: string
   private readonly indexKey: string
   private clientPromise: Promise<RedisClientType> | null = null
 
   constructor(options: RedisObserverStoreOptions = {}) {
+    super()
     this.url = options.url ?? 'redis://localhost:6379/0'
     this.prefix = options.keyPrefix ?? 'mirage:observer:'
     this.indexKey = `${this.prefix}keys`
@@ -69,10 +70,6 @@ export class RedisObserverStore implements ObserverStore {
     const c = await this.client()
     const buf = Buffer.from(data.buffer, data.byteOffset, data.byteLength)
     await c.multi().set(`${this.prefix}${key}`, buf).sAdd(this.indexKey, key).exec()
-  }
-
-  readAll(): Promise<Map<string, Uint8Array>> {
-    return this.readMatching('')
   }
 
   async readMatching(suffix: string): Promise<Map<string, Uint8Array>> {
@@ -114,7 +111,7 @@ export class RedisObserverStore implements ObserverStore {
     if (keys.length > 0) await c.del(keys)
   }
 
-  async close(): Promise<void> {
+  override async close(): Promise<void> {
     // Idempotent: the workspace closes the plane store it consumed and the
     // owning WorkspaceStateStore closes every plane it built; the second
     // close must be a no-op, not a crash on an already-quit client.

--- a/typescript/packages/node/src/resource/box/box.ts
+++ b/typescript/packages/node/src/resource/box/box.ts
@@ -71,10 +71,6 @@ export class BoxResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return BOX_COMMANDS
   }

--- a/typescript/packages/node/src/resource/databricks_volume/databricks_volume.ts
+++ b/typescript/packages/node/src/resource/databricks_volume/databricks_volume.ts
@@ -120,10 +120,6 @@ export class DatabricksVolumeResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return DATABRICKS_VOLUME_COMMANDS
   }

--- a/typescript/packages/node/src/resource/discord/discord.ts
+++ b/typescript/packages/node/src/resource/discord/discord.ts
@@ -69,10 +69,6 @@ export class DiscordResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return DISCORD_COMMANDS
   }

--- a/typescript/packages/node/src/resource/disk/disk.ts
+++ b/typescript/packages/node/src/resource/disk/disk.ts
@@ -130,10 +130,6 @@ export class DiskResource extends BaseResource implements Resource {
     await mkdir(this.root, { recursive: true })
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   // A real filesystem reports real numbers (QUOTA). GNU df: used counts
   // reserved blocks (blocks - bfree), available excludes them (bavail).
   override async statfs(): Promise<CapacityResult> {

--- a/typescript/packages/node/src/resource/dropbox/dropbox.ts
+++ b/typescript/packages/node/src/resource/dropbox/dropbox.ts
@@ -67,10 +67,6 @@ export class DropboxResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return DROPBOX_COMMANDS
   }

--- a/typescript/packages/node/src/resource/email/email.ts
+++ b/typescript/packages/node/src/resource/email/email.ts
@@ -66,8 +66,9 @@ export class EmailResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  async close(): Promise<void> {
+  override async close(): Promise<void> {
     await this.accessor.close()
+    await super.close()
   }
 
   commands(): readonly RegisteredCommand[] {

--- a/typescript/packages/node/src/resource/gdocs/gdocs.ts
+++ b/typescript/packages/node/src/resource/gdocs/gdocs.ts
@@ -62,10 +62,6 @@ export class GDocsResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return GDOCS_COMMANDS
   }

--- a/typescript/packages/node/src/resource/gdrive/gdrive.ts
+++ b/typescript/packages/node/src/resource/gdrive/gdrive.ts
@@ -61,10 +61,6 @@ export class GDriveResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return GDRIVE_COMMANDS
   }

--- a/typescript/packages/node/src/resource/github/github.ts
+++ b/typescript/packages/node/src/resource/github/github.ts
@@ -95,10 +95,6 @@ export class GitHubResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return GITHUB_COMMANDS
   }

--- a/typescript/packages/node/src/resource/github_ci/github_ci.ts
+++ b/typescript/packages/node/src/resource/github_ci/github_ci.ts
@@ -67,10 +67,6 @@ export class GitHubCIResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return GITHUB_CI_COMMANDS
   }

--- a/typescript/packages/node/src/resource/gmail/gmail.ts
+++ b/typescript/packages/node/src/resource/gmail/gmail.ts
@@ -66,10 +66,6 @@ export class GmailResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return GMAIL_COMMANDS
   }

--- a/typescript/packages/node/src/resource/gridfs/gridfs.ts
+++ b/typescript/packages/node/src/resource/gridfs/gridfs.ts
@@ -104,8 +104,9 @@ export class GridFSResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  async close(): Promise<void> {
+  override async close(): Promise<void> {
     await this.accessor.close()
+    await super.close()
   }
 
   commands(): readonly RegisteredCommand[] {

--- a/typescript/packages/node/src/resource/gsheets/gsheets.ts
+++ b/typescript/packages/node/src/resource/gsheets/gsheets.ts
@@ -62,10 +62,6 @@ export class GSheetsResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return GSHEETS_COMMANDS
   }

--- a/typescript/packages/node/src/resource/gslides/gslides.ts
+++ b/typescript/packages/node/src/resource/gslides/gslides.ts
@@ -62,10 +62,6 @@ export class GSlidesResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return GSLIDES_COMMANDS
   }

--- a/typescript/packages/node/src/resource/hf_buckets/base.ts
+++ b/typescript/packages/node/src/resource/hf_buckets/base.ts
@@ -72,10 +72,6 @@ export abstract class HfResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return HF_COMMANDS
   }

--- a/typescript/packages/node/src/resource/jaeger/jaeger.ts
+++ b/typescript/packages/node/src/resource/jaeger/jaeger.ts
@@ -80,10 +80,6 @@ export class JaegerResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return JAEGER_COMMANDS
   }

--- a/typescript/packages/node/src/resource/lancedb/lancedb.ts
+++ b/typescript/packages/node/src/resource/lancedb/lancedb.ts
@@ -64,8 +64,9 @@ export class LanceDBResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  async close(): Promise<void> {
+  override async close(): Promise<void> {
     await this.store.close()
+    await super.close()
   }
 
   ops(): readonly RegisteredOp[] {

--- a/typescript/packages/node/src/resource/langfuse/langfuse.ts
+++ b/typescript/packages/node/src/resource/langfuse/langfuse.ts
@@ -78,10 +78,6 @@ export class LangfuseResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return LANGFUSE_COMMANDS
   }

--- a/typescript/packages/node/src/resource/linear/linear.ts
+++ b/typescript/packages/node/src/resource/linear/linear.ts
@@ -81,10 +81,6 @@ export class LinearResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return LINEAR_COMMANDS
   }

--- a/typescript/packages/node/src/resource/mongodb/mongodb.ts
+++ b/typescript/packages/node/src/resource/mongodb/mongodb.ts
@@ -69,8 +69,9 @@ export class MongoDBResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  async close(): Promise<void> {
+  override async close(): Promise<void> {
     await this.store.close()
+    await super.close()
   }
 
   ops(): readonly RegisteredOp[] {

--- a/typescript/packages/node/src/resource/nextcloud/nextcloud.ts
+++ b/typescript/packages/node/src/resource/nextcloud/nextcloud.ts
@@ -86,10 +86,6 @@ export class NextcloudResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return NEXTCLOUD_COMMANDS
   }

--- a/typescript/packages/node/src/resource/notion/notion.ts
+++ b/typescript/packages/node/src/resource/notion/notion.ts
@@ -67,10 +67,6 @@ export class NotionResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return NOTION_COMMANDS
   }

--- a/typescript/packages/node/src/resource/postgres/postgres.ts
+++ b/typescript/packages/node/src/resource/postgres/postgres.ts
@@ -66,8 +66,9 @@ export class PostgresResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  async close(): Promise<void> {
+  override async close(): Promise<void> {
     await this.store.close()
+    await super.close()
   }
 
   ops(): readonly RegisteredOp[] {

--- a/typescript/packages/node/src/resource/redis/redis.ts
+++ b/typescript/packages/node/src/resource/redis/redis.ts
@@ -131,8 +131,9 @@ export class RedisResource extends BaseResource implements Resource {
     await this.store.client()
   }
 
-  close(): Promise<void> {
-    return this.store.close()
+  override async close(): Promise<void> {
+    await this.store.close()
+    await super.close()
   }
 
   client(): Promise<RedisClientType> {

--- a/typescript/packages/node/src/resource/s3/s3.ts
+++ b/typescript/packages/node/src/resource/s3/s3.ts
@@ -124,10 +124,6 @@ export class S3Resource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return S3_COMMANDS
   }

--- a/typescript/packages/node/src/resource/slack/slack.ts
+++ b/typescript/packages/node/src/resource/slack/slack.ts
@@ -72,10 +72,6 @@ export class SlackResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return SLACK_COMMANDS
   }

--- a/typescript/packages/node/src/resource/ssh/ssh.ts
+++ b/typescript/packages/node/src/resource/ssh/ssh.ts
@@ -98,8 +98,9 @@ export class SSHResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return this.accessor.close()
+  override async close(): Promise<void> {
+    await this.accessor.close()
+    await super.close()
   }
 
   ops(): readonly RegisteredOp[] {

--- a/typescript/packages/node/src/resource/trello/trello.ts
+++ b/typescript/packages/node/src/resource/trello/trello.ts
@@ -76,10 +76,6 @@ export class TrelloResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return TRELLO_COMMANDS
   }

--- a/typescript/packages/server/src/config.test.ts
+++ b/typescript/packages/server/src/config.test.ts
@@ -23,6 +23,7 @@ import {
   RedisNamespaceStore,
   RedisWorkspaceStateStore,
   ScriptSource,
+  Workspace,
 } from '@struktoai/mirage-node'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -244,6 +245,30 @@ describe('configToWorkspaceArgs', () => {
     const args = await configToWorkspaceArgs(cfg)
     expect(args.options.store).toBeInstanceOf(RedisWorkspaceStateStore)
     expect(args.options.store?.namespace('ws1')).toBeInstanceOf(RedisNamespaceStore)
+    // A store built here has no other owner, so the workspace must be
+    // told to close it — without this the redis client is never quit.
+    expect(args.options.ownsStore).toBe(true)
+  })
+
+  it('hands the workspace a store it will actually close', async () => {
+    // The store built here has no other owner, so a workspace that
+    // treats it as borrowed leaks it — for redis or s3 that is a client
+    // that is never quit, once per workspace the daemon creates.
+    const cfg = loadWorkspaceConfig({
+      mounts: { '/': { resource: 'ram' } },
+      store: { type: 'ram' },
+    })
+    const args = await configToWorkspaceArgs(cfg)
+    const store = args.options.store
+    if (store === undefined) throw new Error('the store block built no store')
+    let closed = 0
+    store.close = () => {
+      closed++
+      return Promise.resolve()
+    }
+    const ws = new Workspace({}, args.options)
+    await ws.close()
+    expect(closed).toBe(1)
   })
 
   it('builds a ram state store from a store block', async () => {

--- a/typescript/packages/server/src/config.test.ts
+++ b/typescript/packages/server/src/config.test.ts
@@ -23,7 +23,6 @@ import {
   RedisNamespaceStore,
   RedisWorkspaceStateStore,
   ScriptSource,
-  type CacheConfig,
 } from '@struktoai/mirage-node'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -405,7 +404,7 @@ describe('configToWorkspaceArgs', () => {
       keyPrefix: 'c:',
       maxDrainBytes: 1024,
     })
-    expect(buildFileCache(args.options.cache as CacheConfig)).toBeInstanceOf(RedisFileCacheStore)
+    expect(buildFileCache(args.options.cache)).toBeInstanceOf(RedisFileCacheStore)
   })
 
   it('coerces consistency (default lazy, accepts always, rejects junk)', async () => {
@@ -636,19 +635,23 @@ describe('CLI to daemon round trip', () => {
   })
 })
 
-describe('shared rejection fixture', () => {
-  // integ/fixtures/config/rejected.json is the contract: the python suite
-  // (tests/config/test_loader.py) refuses the same configs, so a config
-  // that loads in one language and not the other fails a test until both
-  // loaders agree.
-  const FIXTURE = fileURLToPath(
-    new URL('../../../../integ/fixtures/config/rejected.json', import.meta.url),
+// integ/fixtures/config/{rejected,accepted}.json are the contract: the
+// python suite (tests/config/test_loader.py) reads the same two files, so
+// a config that loads in one language and not the other fails a test
+// until both loaders agree.
+function fixtureCases(name: string): { name: string; config: Record<string, unknown> }[] {
+  const path = fileURLToPath(
+    new URL(`../../../../integ/fixtures/config/${name}.json`, import.meta.url),
   )
-  const cases = (
-    JSON.parse(readFileSync(FIXTURE, 'utf8')) as {
+  return (
+    JSON.parse(readFileSync(path, 'utf8')) as {
       cases: { name: string; config: Record<string, unknown> }[]
     }
   ).cases
+}
+
+describe('shared rejection fixture', () => {
+  const cases = fixtureCases('rejected')
 
   it('has cases', () => {
     expect(cases.length).toBeGreaterThan(0)
@@ -656,5 +659,21 @@ describe('shared rejection fixture', () => {
 
   it.each(cases)('refuses $name', ({ config }) => {
     expect(() => loadWorkspaceConfig(config)).toThrow()
+  })
+})
+
+describe('shared acceptance fixture', () => {
+  // The key tables are copied by hand from Python's models, so the drift
+  // this catches is a field added there and never mirrored here: every
+  // key of every block appears in the fixture, and an unmirrored one
+  // comes back as `unknown ... key`.
+  const cases = fixtureCases('accepted')
+
+  it('has cases', () => {
+    expect(cases.length).toBeGreaterThan(0)
+  })
+
+  it.each(cases)('accepts $name', ({ config }) => {
+    expect(() => loadWorkspaceConfig(config)).not.toThrow()
   })
 })

--- a/typescript/packages/server/src/config.test.ts
+++ b/typescript/packages/server/src/config.test.ts
@@ -29,6 +29,7 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
+  checkWorkspaceConfigFile,
   interpolateEnv,
   loadWorkspaceConfig,
   loadWorkspaceConfigFile,
@@ -561,6 +562,37 @@ describe('clis section', () => {
       clis: { sl: { cli: 'slack', runtime: 'monty' } },
     })
     await expect(configToWorkspaceArgs(cfg)).rejects.toThrow(/it takes script/)
+  })
+})
+
+describe('CLI to daemon round trip', () => {
+  it('the shape a CLI sends passes the daemon check unchanged', () => {
+    // `workspace create` checks the file client-side (env interpolation
+    // needs the user's shell) and POSTs the result; the daemon runs the
+    // same check on what arrives. Camelizing before sending would force
+    // the loader to accept its own output, and with it the camelCase
+    // spellings Python refuses.
+    const dir = mkdtempSync(join(tmpdir(), 'mirage-wire-'))
+    const file = join(dir, 'w.yaml')
+    writeFileSync(
+      file,
+      [
+        'mounts:',
+        '  /:',
+        '    resource: ram',
+        'default_session_id: mysess',
+        'cache:',
+        '  type: ram',
+        '  limit: 256MB',
+        '  max_drain_bytes: 1048576',
+        '',
+      ].join('\n'),
+    )
+    const wire = checkWorkspaceConfigFile(file)
+    expect(Object.keys(wire)).toContain('default_session_id')
+    const cfg = loadWorkspaceConfig(wire)
+    expect(cfg.defaultSessionId).toBe('mysess')
+    rmSync(dir, { recursive: true, force: true })
   })
 })
 

--- a/typescript/packages/server/src/config.test.ts
+++ b/typescript/packages/server/src/config.test.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
+  buildFileCache,
   CLISpec,
   DiskNamespaceStore,
   DiskWorkspaceStateStore,
@@ -22,6 +23,7 @@ import {
   RedisNamespaceStore,
   RedisWorkspaceStateStore,
   ScriptSource,
+  type CacheConfig,
 } from '@struktoai/mirage-node'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -269,16 +271,47 @@ describe('configToWorkspaceArgs', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('takes an s3 group as the workspace override', async () => {
-    const cfg = loadWorkspaceConfig({
+  it('takes an s3 group as the workspace override, credentials intact', async () => {
+    // An s3 group IS an S3Config, whose snake_case keys do not camelize
+    // into the TS field names (`aws_access_key_id` is `accessKeyId`, not
+    // `awsAccessKeyId`), so a plain camelize would silently drop the
+    // credentials and endpoint and authenticate against the wrong thing.
+    const raw = {
       mounts: { '/': { resource: 'ram' } },
       store: {
         type: 'ram',
-        workspace: { type: 's3', bucket: 'b', region: 'us-east-1' },
+        workspace: {
+          type: 's3',
+          bucket: 'b',
+          region: 'us-east-1',
+          aws_access_key_id: 'AKIA',
+          aws_secret_access_key: 'secret',
+          endpoint_url: 'http://localhost:9000',
+          path_style: true,
+          timeout: 5,
+        },
       },
-    })
+    }
+    const cfg = loadWorkspaceConfig(raw)
+    const group = (cfg.store as unknown as { workspace: Record<string, unknown> }).workspace
+    expect(group.aws_access_key_id).toBe('AKIA')
     const args = await configToWorkspaceArgs(cfg)
     expect(args.options.store?.namespace('ws1')).toBeInstanceOf(RAMNamespaceStore)
+    const s3 = (
+      args.options.store as unknown as {
+        workspaceOverride: { config: Record<string, unknown> }
+      }
+    ).workspaceOverride
+    expect(s3.config).toMatchObject({
+      bucket: 'b',
+      region: 'us-east-1',
+      accessKeyId: 'AKIA',
+      secretAccessKey: 'secret',
+      endpoint: 'http://localhost:9000',
+      forcePathStyle: true,
+      timeoutMs: 5000,
+      keyPrefix: 'mirage/',
+    })
   })
 
   it('routes a per-group override to its own backend', async () => {
@@ -359,13 +392,20 @@ describe('configToWorkspaceArgs', () => {
     })
   })
 
-  it('builds a redis cache from snake_case key_prefix / max_drain_bytes', async () => {
+  it('hands a redis cache to the workspace as config, not as a store', async () => {
+    // The workspace builds it, so the workspace closes it; building it
+    // here would leave the redis client with no owner at shutdown.
     const cfg = loadWorkspaceConfig({
       mounts: { '/': { resource: 'ram' } },
       cache: { type: 'redis', key_prefix: 'c:', max_drain_bytes: 1024 },
     })
     const args = await configToWorkspaceArgs(cfg)
-    expect(args.options.cache).toBeInstanceOf(RedisFileCacheStore)
+    expect(args.options.cache).toEqual({
+      type: 'redis',
+      keyPrefix: 'c:',
+      maxDrainBytes: 1024,
+    })
+    expect(buildFileCache(args.options.cache as CacheConfig)).toBeInstanceOf(RedisFileCacheStore)
   })
 
   it('coerces consistency (default lazy, accepts always, rejects junk)', async () => {

--- a/typescript/packages/server/src/config.test.ts
+++ b/typescript/packages/server/src/config.test.ts
@@ -14,6 +14,8 @@
 
 import {
   CLISpec,
+  DiskNamespaceStore,
+  DiskWorkspaceStateStore,
   RAMNamespaceStore,
   RAMWorkspaceStateStore,
   RedisFileCacheStore,
@@ -21,9 +23,10 @@ import {
   RedisWorkspaceStateStore,
   ScriptSource,
 } from '@struktoai/mirage-node'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
   interpolateEnv,
@@ -216,26 +219,19 @@ describe('configToWorkspaceArgs', () => {
     await expect(configToWorkspaceArgs(cfg)).rejects.toThrow(/reference a \.py\/\.js file/)
   })
 
-  it('builds a redis index config from an index block', async () => {
-    const cfg = loadWorkspaceConfig({
-      mounts: { '/': { resource: 'ram' } },
-      index: { type: 'redis', url: 'redis://localhost:6379/0', keyPrefix: 'x:' },
-    })
-    const args = await configToWorkspaceArgs(cfg)
-    expect(args.options.index).toEqual({
-      type: 'redis',
-      url: 'redis://localhost:6379/0',
-      keyPrefix: 'x:',
-    })
-  })
-
-  it('builds a redis file cache from a cache block', async () => {
-    const cfg = loadWorkspaceConfig({
-      mounts: { '/': { resource: 'ram' } },
-      cache: { type: 'redis', keyPrefix: 'c:' },
-    })
-    const args = await configToWorkspaceArgs(cfg)
-    expect(args.options.cache).toBeInstanceOf(RedisFileCacheStore)
+  // The camelCase spelling of a snake_case config key is a key Python
+  // rejects, so accepting it here would make the same YAML load in one
+  // language and fail in the other. See the snake_case twins below.
+  it('refuses the camelCase spelling of a config key', () => {
+    for (const block of [
+      { index: { type: 'redis', keyPrefix: 'x:' } },
+      { cache: { type: 'redis', keyPrefix: 'c:' } },
+      { cache: { type: 'ram', maxDrainBytes: 8 } },
+    ]) {
+      expect(() => loadWorkspaceConfig({ mounts: { '/': { resource: 'ram' } }, ...block })).toThrow(
+        /unknown (cache|index)/,
+      )
+    }
   })
 
   it('builds a redis state store from a store block (snake_case key_prefix)', async () => {
@@ -255,6 +251,32 @@ describe('configToWorkspaceArgs', () => {
     })
     const args = await configToWorkspaceArgs(cfg)
     expect(args.options.store).toBeInstanceOf(RAMWorkspaceStateStore)
+    expect(args.options.store?.namespace('ws1')).toBeInstanceOf(RAMNamespaceStore)
+  })
+
+  it('builds a disk state store from a store block', async () => {
+    // `store: {type: disk}` used to build a RAM store here while Python
+    // built a disk one, so state a user believed was persisted was not.
+    const dir = mkdtempSync(join(tmpdir(), 'mirage-store-'))
+    const cfg = loadWorkspaceConfig({
+      mounts: { '/': { resource: 'ram' } },
+      store: { type: 'disk', root: dir },
+    })
+    const args = await configToWorkspaceArgs(cfg)
+    expect(args.options.store).toBeInstanceOf(DiskWorkspaceStateStore)
+    expect(args.options.store?.namespace('ws1')).toBeInstanceOf(DiskNamespaceStore)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('takes an s3 group as the workspace override', async () => {
+    const cfg = loadWorkspaceConfig({
+      mounts: { '/': { resource: 'ram' } },
+      store: {
+        type: 'ram',
+        workspace: { type: 's3', bucket: 'b', region: 'us-east-1' },
+      },
+    })
+    const args = await configToWorkspaceArgs(cfg)
     expect(args.options.store?.namespace('ws1')).toBeInstanceOf(RAMNamespaceStore)
   })
 
@@ -429,14 +451,16 @@ describe('configToWorkspaceArgs', () => {
     await expect(configToWorkspaceArgs(cfg)).rejects.toThrow(/reason/)
   })
 
-  it('a guard with an unknown key fails loud', async () => {
+  it('a guard with an unknown key fails loud', () => {
     // A typo like `path:` would otherwise widen the guard into an
-    // unconditional denial (mirrors Python's extra="forbid").
-    const cfg = loadWorkspaceConfig({
-      mounts: { '/data': { resource: 'ram' } },
-      guards: [{ reason: 'x', path: ['/data/prod/*'] }],
-    })
-    await expect(configToWorkspaceArgs(cfg)).rejects.toThrow(/unknown guard key/)
+    // unconditional denial (mirrors Python's extra="forbid"), and like
+    // Python it must fail at load, not when the args are built.
+    expect(() =>
+      loadWorkspaceConfig({
+        mounts: { '/data': { resource: 'ram' } },
+        guards: [{ reason: 'x', path: ['/data/prod/*'] }],
+      }),
+    ).toThrow(/unknown guard key/)
   })
 })
 
@@ -457,12 +481,13 @@ describe('clis section', () => {
     })
   })
 
-  it('refuses unknown keys in a clis entry', async () => {
-    const cfg = loadWorkspaceConfig({
-      mounts: { '/data': { resource: 'ram' } },
-      clis: { sl: { cli: 'slack', mode: 'write' } },
-    })
-    await expect(configToWorkspaceArgs(cfg)).rejects.toThrow(/unknown keys: mode/)
+  it('refuses unknown keys in a clis entry', () => {
+    expect(() =>
+      loadWorkspaceConfig({
+        mounts: { '/data': { resource: 'ram' } },
+        clis: { sl: { cli: 'slack', mode: 'write' } },
+      }),
+    ).toThrow(/unknown cli `sl` key `mode`/)
   })
 
   it('a script entry synthesizes a spec', async () => {
@@ -536,5 +561,28 @@ describe('clis section', () => {
       clis: { sl: { cli: 'slack', runtime: 'monty' } },
     })
     await expect(configToWorkspaceArgs(cfg)).rejects.toThrow(/it takes script/)
+  })
+})
+
+describe('shared rejection fixture', () => {
+  // integ/fixtures/config/rejected.json is the contract: the python suite
+  // (tests/config/test_loader.py) refuses the same configs, so a config
+  // that loads in one language and not the other fails a test until both
+  // loaders agree.
+  const FIXTURE = fileURLToPath(
+    new URL('../../../../integ/fixtures/config/rejected.json', import.meta.url),
+  )
+  const cases = (
+    JSON.parse(readFileSync(FIXTURE, 'utf8')) as {
+      cases: { name: string; config: Record<string, unknown> }[]
+    }
+  ).cases
+
+  it('has cases', () => {
+    expect(cases.length).toBeGreaterThan(0)
+  })
+
+  it.each(cases)('refuses $name', ({ config }) => {
+    expect(() => loadWorkspaceConfig(config)).toThrow()
   })
 })

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -39,6 +39,7 @@ import {
   type RedisIndexConfig,
   type Resource,
   type S3Config,
+  type WorkspaceOptions,
   type WorkspaceStateStore,
 } from '@struktoai/mirage-node'
 
@@ -638,20 +639,14 @@ export function loadWorkspaceConfigFile(
 
 export interface WorkspaceArgs {
   resources: Record<string, [Resource, MountMode, Record<string, Limit>]>
-  options: {
-    mode: MountMode
-    consistency: ConsistencyPolicy
-    sessionId?: string
-    agentId?: string
-    cache?: CacheConfig
-    index?: IndexConfig
-    workspaceId?: string
-    store?: WorkspaceStateStore
-    runtimes?: RuntimeEntry[]
-    policy?: ScriptSource
-    guards?: GuardSpec[]
-    clis?: Record<string, [string | CLISpec, Record<string, unknown> | null]>
-  }
+  /**
+   * Exactly what `new Workspace` takes, minus the two the loader always
+   * resolves. Spelling the fields out here instead is what once dropped
+   * `clis` and `guards` on the way to the daemon: a config knob was
+   * parsed and validated, then discarded by a list nobody remembered to
+   * extend.
+   */
+  options: WorkspaceOptions & { mode: MountMode; consistency: ConsistencyPolicy }
   kernelMounts: Record<string, [MountBackend, string | undefined]>
 }
 
@@ -744,7 +739,11 @@ export async function configToWorkspaceArgs(cfg: WorkspaceConfigRaw): Promise<Wo
       ...(cfg.workspaceId !== undefined ? { workspaceId: cfg.workspaceId } : {}),
       ...(cfg.cache !== undefined && cfg.cache !== null ? { cache: cfg.cache } : {}),
       ...(index !== undefined ? { index } : {}),
-      ...(stateStore !== undefined ? { store: stateStore } : {}),
+      // Built here for this workspace alone, so it is the workspace's
+      // to close — a redis or s3 store has a client that nothing else
+      // would ever release. Mirrors the `owns_store` Python's loader
+      // sets beside the same store.
+      ...(stateStore !== undefined ? { store: stateStore, ownsStore: true } : {}),
       ...(cfg.runtimes !== undefined && cfg.runtimes !== null
         ? { runtimes: buildRuntimeEntries(cfg.runtimes) }
         : {}),

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -25,17 +25,21 @@ import {
   ScriptSource,
   MountMode,
   OnExceed,
-  RAMFileCacheStore,
   RAMWorkspaceStateStore,
-  RedisFileCacheStore,
   RedisWorkspaceStateStore,
+  DiskWorkspaceStateStore,
+  S3WorkspaceStateStore,
+  snakeToCamel,
+  buildFileCache,
   buildRuntime,
   type RuntimeEntry,
-  type FileCache,
+  type CacheConfig,
+  type FileCacheStore,
   type GuardSpec,
   type IndexConfig,
   type RedisIndexConfig,
   type Resource,
+  type S3Config,
   type WorkspaceStateStore,
 } from '@struktoai/mirage-node'
 
@@ -109,20 +113,6 @@ function coerceOnExceed(value: string): OnExceed {
   return value.toLowerCase() as OnExceed
 }
 
-function snakeToCamel(key: string): string {
-  let out = ''
-  let upper = false
-  for (const ch of key) {
-    if (ch === '_') {
-      upper = true
-      continue
-    }
-    out += upper ? ch.toUpperCase() : ch
-    upper = false
-  }
-  return out
-}
-
 function camelizeKeys(obj: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {}
   for (const [k, v] of Object.entries(obj)) out[snakeToCamel(k)] = v
@@ -131,6 +121,163 @@ function camelizeKeys(obj: Record<string, unknown>): Record<string, unknown> {
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v)
+}
+
+// Python sets extra="forbid" on every workspace-config block, so a typo
+// like `mount_point:` for `mountpoint:`, `consistancy:` or `limitt:` is
+// a hard ValueError there. These tables mirror those models field for
+// field so the same YAML is accepted (and rejected) by both languages.
+//
+// The spellings are Python's canonical snake_case ones on purpose: a
+// camelCase alias that TS would accept for free is a key Python rejects,
+// which is the same portability break pointing the other way. Blocks
+// that carry a backend's own credentials (`mounts.*.config`, an s3 store
+// group) are deliberately absent — those are validated by the backend's
+// config model, one layer down, exactly as in Python.
+const TOP_LEVEL_KEYS = [
+  'mounts',
+  'clis',
+  'runtimes',
+  'policy',
+  'guards',
+  'mode',
+  'consistency',
+  'default_session_id',
+  'default_agent_id',
+  'workspace_id',
+  'cache',
+  'index',
+  'store',
+] as const
+const MOUNT_KEYS = [
+  'resource',
+  'mode',
+  'config',
+  'command_limits',
+  'backend',
+  'mountpoint',
+] as const
+const CACHE_KEYS: Record<string, readonly string[]> = {
+  ram: ['type', 'limit', 'max_drain_bytes'],
+  redis: ['type', 'limit', 'max_drain_bytes', 'url', 'key_prefix'],
+}
+const INDEX_KEYS: Record<string, readonly string[]> = {
+  ram: ['type', 'ttl'],
+  redis: ['type', 'ttl', 'url', 'key_prefix'],
+}
+const STORE_KEYS = [
+  'type',
+  'url',
+  'key_prefix',
+  'root',
+  'namespace',
+  'observer',
+  'workspace',
+] as const
+const STORE_GROUP_KEYS: Record<string, readonly string[]> = {
+  ram: ['type'],
+  disk: ['type', 'root'],
+  redis: ['type', 'url', 'key_prefix'],
+}
+const CLI_KEYS = ['cli', 'script', 'runtime', 'config'] as const
+const GUARD_KEYS = ['reason', 'commands', 'paths'] as const
+
+function rejectUnknownKeys(
+  block: Record<string, unknown>,
+  allowed: readonly string[],
+  what: string,
+): void {
+  for (const key of Object.keys(block)) {
+    if (allowed.includes(key)) continue
+    throw new Error(`unknown ${what} key \`${key}\` (allowed: ${allowed.join(', ')})`)
+  }
+}
+
+/**
+ * The `type:` discriminator of a typed block. `fallback` is the type
+ * assumed when the key is absent; leave it out where Python models the
+ * block as a discriminated union, which makes `type` mandatory.
+ */
+function blockType(
+  block: Record<string, unknown>,
+  what: string,
+  known: readonly string[],
+  fallback?: string,
+): string {
+  const type = block.type ?? fallback
+  if (type === undefined) {
+    throw new Error(`config \`${what}\` needs a \`type\` (one of ${known.join(', ')})`)
+  }
+  if (typeof type !== 'string') {
+    throw new Error(`config \`${what}\` type must be a string (one of ${known.join(', ')})`)
+  }
+  if (!known.includes(type)) {
+    throw new Error(`unknown ${what} type \`${type}\` (expected one of ${known.join(', ')})`)
+  }
+  return type
+}
+
+function validateTypedBlock(
+  value: unknown,
+  table: Record<string, readonly string[]>,
+  what: string,
+  fallback?: string,
+): void {
+  if (value === undefined || value === null) return
+  if (!isPlainObject(value)) throw new Error(`config \`${what}\` must be a mapping`)
+  const type = blockType(value, what, Object.keys(table), fallback)
+  rejectUnknownKeys(value, table[type] ?? [], `${what} (${type})`)
+}
+
+function validateStoreBlock(value: unknown): void {
+  if (value === undefined || value === null) return
+  if (!isPlainObject(value)) throw new Error('config `store` must be a mapping')
+  // The top level picks the default backend for every plane; s3 hosts
+  // only the sessions+meta group, so it is a `workspace` override and
+  // never the default. Mirrors Python's StoreBlock.
+  blockType(value, 'store', ['ram', 'disk', 'redis'], 'ram')
+  rejectUnknownKeys(value, STORE_KEYS, 'store')
+  for (const group of ['namespace', 'observer', 'workspace'] as const) {
+    const block = value[group]
+    if (block === undefined || block === null) continue
+    if (!isPlainObject(block)) throw new Error(`config \`store.${group}\` must be a mapping`)
+    // An s3 group IS an S3Config plus the discriminator, so its keys
+    // belong to the s3 config model rather than to this table.
+    if (block.type === 's3') continue
+    validateTypedBlock(block, STORE_GROUP_KEYS, `store.${group}`, 'ram')
+  }
+}
+
+/**
+ * Reject any key no Python config model declares, before normalization
+ * folds snake_case into camelCase and the distinction is gone.
+ */
+function validateConfigKeys(raw: Record<string, unknown>): void {
+  rejectUnknownKeys(raw, TOP_LEVEL_KEYS, 'config')
+  if (isPlainObject(raw.mounts)) {
+    for (const [prefix, block] of Object.entries(raw.mounts)) {
+      if (!isPlainObject(block)) throw new Error(`mount \`${prefix}\` must be a mapping`)
+      rejectUnknownKeys(block, MOUNT_KEYS, `mount \`${prefix}\``)
+    }
+  }
+  if (isPlainObject(raw.clis)) {
+    for (const [name, block] of Object.entries(raw.clis)) {
+      if (!isPlainObject(block)) throw new Error(`cli \`${name}\` must be a mapping`)
+      rejectUnknownKeys(block, CLI_KEYS, `cli \`${name}\``)
+    }
+  }
+  if (raw.guards !== undefined && raw.guards !== null) {
+    if (!Array.isArray(raw.guards)) throw new Error('config `guards` must be a list')
+    for (const entry of raw.guards) {
+      if (!isPlainObject(entry)) throw new Error('each guard must be a mapping with a `reason`')
+      // A typo like `path:` would widen the guard into an
+      // unconditional denial rather than fail.
+      rejectUnknownKeys(entry, GUARD_KEYS, 'guard')
+    }
+  }
+  validateTypedBlock(raw.cache, CACHE_KEYS, 'cache')
+  validateTypedBlock(raw.index, INDEX_KEYS, 'index')
+  validateStoreBlock(raw.store)
 }
 
 // Workspace YAML uses Python's snake_case keys (default_session_id, the
@@ -307,13 +454,32 @@ interface RamStoreGroupBlock {
   type?: 'ram'
 }
 
+interface DiskStoreGroupBlock {
+  type: 'disk'
+  root?: string
+}
+
 interface RedisStoreGroupBlock {
   type: 'redis'
   url?: string
   keyPrefix?: string
 }
 
-type StoreGroupBlock = RamStoreGroupBlock | RedisStoreGroupBlock
+/**
+ * An S3 group IS an S3Config plus the discriminator, so its keys are
+ * the backend's, validated by the s3 config model rather than here.
+ * It hosts only the sessions+meta plane (conditional-PUT CAS), so it
+ * is valid as the `workspace` override and never as the default.
+ */
+interface S3StoreGroupBlock extends Partial<S3Config> {
+  type: 's3'
+}
+
+type StoreGroupBlock =
+  | RamStoreGroupBlock
+  | DiskStoreGroupBlock
+  | RedisStoreGroupBlock
+  | S3StoreGroupBlock
 
 /**
  * The workspace state store: one block, four planes. The top-level
@@ -324,9 +490,10 @@ type StoreGroupBlock = RamStoreGroupBlock | RedisStoreGroupBlock
  * design, so there is one `workspace` override, not two.
  */
 interface StoreBlock {
-  type?: 'ram' | 'redis'
+  type?: 'ram' | 'disk' | 'redis'
   url?: string
   keyPrefix?: string
+  root?: string
   namespace?: StoreGroupBlock | null
   observer?: StoreGroupBlock | null
   workspace?: StoreGroupBlock | null
@@ -381,8 +548,7 @@ export function loadWorkspaceConfig(
   const raw = { ...source }
   const useEnv = env ?? readProcessEnv()
   const interpolated = interpolateEnv(raw, useEnv)
-  const normalized = normalizeConfigKeys(interpolated)
-  const mounts = normalized.mounts
+  const mounts = interpolated.mounts
   if (
     mounts === undefined ||
     typeof mounts !== 'object' ||
@@ -391,7 +557,8 @@ export function loadWorkspaceConfig(
   ) {
     throw new Error('config requires a `mounts` mapping')
   }
-  return normalized as unknown as WorkspaceConfigRaw
+  validateConfigKeys(interpolated)
+  return normalizeConfigKeys(interpolated) as unknown as WorkspaceConfigRaw
 }
 
 /**
@@ -447,7 +614,7 @@ export interface WorkspaceArgs {
     consistency: ConsistencyPolicy
     sessionId?: string
     agentId?: string
-    cache?: FileCache & Resource
+    cache?: FileCacheStore
     index?: IndexConfig
     workspaceId?: string
     store?: WorkspaceStateStore
@@ -459,22 +626,14 @@ export interface WorkspaceArgs {
   kernelMounts: Record<string, [MountBackend, string | undefined]>
 }
 
+// The block IS the cache config once normalized, so the loader only
+// decides whether one was given; building it belongs to core, where
+// `WorkspaceOptions.cache` accepts the same shape.
 function buildCache(
   block: RamCacheBlock | RedisCacheBlock | null | undefined,
-): (FileCache & Resource) | undefined {
+): FileCacheStore | undefined {
   if (block === null || block === undefined) return undefined
-  if (block.type === 'redis') {
-    return new RedisFileCacheStore({
-      ...(block.limit !== undefined ? { cacheLimit: block.limit } : {}),
-      ...(block.maxDrainBytes !== undefined ? { maxDrainBytes: block.maxDrainBytes } : {}),
-      ...(block.url !== undefined ? { url: block.url } : {}),
-      ...(block.keyPrefix !== undefined ? { keyPrefix: block.keyPrefix } : {}),
-    })
-  }
-  return new RAMFileCacheStore({
-    ...(block.limit !== undefined ? { limit: block.limit } : {}),
-    ...(block.maxDrainBytes !== undefined ? { maxDrainBytes: block.maxDrainBytes } : {}),
-  })
+  return buildFileCache(block as CacheConfig)
 }
 
 function buildIndex(
@@ -500,6 +659,19 @@ function buildStoreGroup(block: StoreGroupBlock): WorkspaceStateStore {
       ...(block.keyPrefix !== undefined ? { keyPrefix: block.keyPrefix } : {}),
     })
   }
+  if (block.type === 'disk') {
+    return new DiskWorkspaceStateStore({
+      ...(block.root !== undefined ? { root: block.root } : {}),
+    })
+  }
+  if (block.type === 's3') {
+    // The block IS the S3Config once the discriminator is dropped, so
+    // new S3Config fields flow through without being re-declared here
+    // (the same reason Python's S3StoreBlock subclasses S3Config).
+    const s3: Record<string, unknown> = { keyPrefix: 'mirage/', ...block }
+    delete s3.type
+    return new S3WorkspaceStateStore(s3 as unknown as S3Config)
+  }
   return new RAMWorkspaceStateStore()
 }
 
@@ -514,6 +686,12 @@ function buildStateStore(block: StoreBlock | null | undefined): WorkspaceStateSt
     return new RedisWorkspaceStateStore({
       ...(block.url !== undefined ? { url: block.url } : {}),
       ...(block.keyPrefix !== undefined ? { keyPrefix: block.keyPrefix } : {}),
+      ...overrides,
+    })
+  }
+  if (block.type === 'disk') {
+    return new DiskWorkspaceStateStore({
+      ...(block.root !== undefined ? { root: block.root } : {}),
       ...overrides,
     })
   }

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -34,7 +34,6 @@ import {
   buildRuntime,
   type RuntimeEntry,
   type CacheConfig,
-  type FileCacheStore,
   type GuardSpec,
   type IndexConfig,
   type RedisIndexConfig,
@@ -165,22 +164,27 @@ const INDEX_KEYS: Record<string, readonly string[]> = {
   ram: ['type', 'ttl'],
   redis: ['type', 'ttl', 'url', 'key_prefix'],
 }
-const STORE_KEYS = [
-  'type',
-  'url',
-  'key_prefix',
-  'root',
-  'namespace',
-  'observer',
-  'workspace',
-] as const
+const STORE_GROUPS = ['namespace', 'observer', 'workspace'] as const
+const STORE_KEYS = ['type', 'url', 'key_prefix', 'root', ...STORE_GROUPS] as const
 const STORE_GROUP_KEYS: Record<string, readonly string[]> = {
   ram: ['type'],
   disk: ['type', 'root'],
   redis: ['type', 'url', 'key_prefix'],
 }
-const CLI_KEYS = ['cli', 'script', 'runtime', 'config'] as const
+const CLI_KEYS: readonly string[] = ['cli', 'script', 'runtime', 'config']
 const GUARD_KEYS = ['reason', 'commands', 'paths'] as const
+
+// A store group whose `type` names a backend IS that backend's config
+// plus the discriminator: its keys belong to the backend's model and its
+// spellings to the backend's own translation, exactly like a mount's
+// `config:` block. So such a group is neither key-checked nor camelized
+// here — a future backend-backed group joins this set, and both sites
+// follow without being found again.
+const BACKEND_CONFIG_TYPES: ReadonlySet<string> = new Set(['s3'])
+
+function isBackendConfigBlock(block: Record<string, unknown>): boolean {
+  return typeof block.type === 'string' && BACKEND_CONFIG_TYPES.has(block.type)
+}
 
 function rejectUnknownKeys(
   block: Record<string, unknown>,
@@ -237,13 +241,11 @@ function validateStoreBlock(value: unknown): void {
   // never the default. Mirrors Python's StoreBlock.
   blockType(value, 'store', ['ram', 'disk', 'redis'], 'ram')
   rejectUnknownKeys(value, STORE_KEYS, 'store')
-  for (const group of ['namespace', 'observer', 'workspace'] as const) {
+  for (const group of STORE_GROUPS) {
     const block = value[group]
     if (block === undefined || block === null) continue
     if (!isPlainObject(block)) throw new Error(`config \`store.${group}\` must be a mapping`)
-    // An s3 group IS an S3Config plus the discriminator, so its keys
-    // belong to the s3 config model rather than to this table.
-    if (block.type === 's3') continue
+    if (isBackendConfigBlock(block)) continue
     validateTypedBlock(block, STORE_GROUP_KEYS, `store.${group}`, 'ram')
   }
 }
@@ -292,15 +294,14 @@ function normalizeConfigKeys(raw: Record<string, unknown>): Record<string, unkno
   if (isPlainObject(out.index)) out.index = camelizeKeys(out.index)
   if (isPlainObject(out.store)) {
     const store = camelizeKeys(out.store)
-    for (const group of ['namespace', 'observer', 'workspace']) {
+    for (const group of STORE_GROUPS) {
       const block = store[group]
       if (!isPlainObject(block)) continue
-      // An s3 group IS an S3Config, whose snake_case spellings do not
-      // camelize into the TS field names (`aws_access_key_id` is
-      // `accessKeyId`, not `awsAccessKeyId`). Left alone here for the
-      // same reason `mounts.*.config` is: `normalizeS3Config` owns that
-      // translation, and camelizing first would hide the keys from it.
-      if (block.type === 's3') continue
+      // A backend's own spellings do not camelize into its TS field
+      // names (`aws_access_key_id` is `accessKeyId`, not
+      // `awsAccessKeyId`), and camelizing first would hide the keys from
+      // the translation that does know them.
+      if (isBackendConfigBlock(block)) continue
       store[group] = camelizeKeys(block)
     }
     out.store = store
@@ -430,20 +431,6 @@ export interface MountBlock {
   mountpoint?: string
 }
 
-interface RamCacheBlock {
-  type?: 'ram'
-  limit?: string | number
-  maxDrainBytes?: number | null
-}
-
-interface RedisCacheBlock {
-  type: 'redis'
-  limit?: string | number
-  maxDrainBytes?: number | null
-  url?: string
-  keyPrefix?: string
-}
-
 interface RamIndexBlock {
   type?: 'ram'
   ttl?: number
@@ -534,7 +521,13 @@ export interface WorkspaceConfigRaw {
   defaultSessionId?: string
   defaultAgentId?: string
   workspaceId?: string
-  cache?: RamCacheBlock | RedisCacheBlock | null
+  /**
+   * The normalized block IS a `CacheConfig` — so it is handed to the
+   * workspace as one rather than built here. A store the workspace
+   * builds is a store the workspace closes; building it here would
+   * leave a redis client with no owner once the workspace shut down.
+   */
+  cache?: CacheConfig | null
   index?: RamIndexBlock | RedisIndexBlock | null
   store?: StoreBlock | null
 }
@@ -592,20 +585,18 @@ export function loadWorkspaceConfig(
  * happens to run". In-memory object configs are untouched.
  */
 function absolutizeScripts(raw: Record<string, unknown>, base: string): void {
-  // `policy`, `runtimes`, `clis` and `script` are spelled the same in
-  // both cases, so this runs before or after normalization alike.
   const policy = raw.policy
   if (typeof policy === 'string' && isScriptPath(policy) && !isAbsolute(policy.trim())) {
     raw.policy = join(base, policy.trim())
   }
   if (Array.isArray(raw.runtimes)) {
     for (const entry of raw.runtimes) {
-      if (typeof entry !== 'string') absolutizeScriptKey(entry as Record<string, unknown>, base)
+      if (isPlainObject(entry)) absolutizeScriptKey(entry, base)
     }
   }
-  if (raw.clis !== undefined && raw.clis !== null) {
-    for (const block of Object.values(raw.clis as Record<string, unknown>)) {
-      absolutizeScriptKey(block as Record<string, unknown>, base)
+  if (isPlainObject(raw.clis)) {
+    for (const block of Object.values(raw.clis)) {
+      if (isPlainObject(block)) absolutizeScriptKey(block, base)
     }
   }
 }
@@ -652,7 +643,7 @@ export interface WorkspaceArgs {
     consistency: ConsistencyPolicy
     sessionId?: string
     agentId?: string
-    cache?: FileCacheStore | CacheConfig
+    cache?: CacheConfig
     index?: IndexConfig
     workspaceId?: string
     store?: WorkspaceStateStore
@@ -662,18 +653,6 @@ export interface WorkspaceArgs {
     clis?: Record<string, [string | CLISpec, Record<string, unknown> | null]>
   }
   kernelMounts: Record<string, [MountBackend, string | undefined]>
-}
-
-// The block IS the cache config once normalized, so it is handed to the
-// workspace as one rather than built here: `WorkspaceOptions.cache`
-// accepts the same shape, and a store the workspace builds is a store
-// the workspace closes. Building it here would leave a redis client with
-// no owner once the workspace shut down.
-function buildCache(
-  block: RamCacheBlock | RedisCacheBlock | null | undefined,
-): CacheConfig | undefined {
-  if (block === null || block === undefined) return undefined
-  return block as CacheConfig
 }
 
 function buildIndex(
@@ -753,7 +732,6 @@ export async function configToWorkspaceArgs(cfg: WorkspaceConfigRaw): Promise<Wo
     const backend = (block.backend ?? MountBackend.VFS) as MountBackend
     if (KERNEL_BACKENDS.includes(backend)) kernelMounts[prefix] = [backend, block.mountpoint]
   }
-  const cache = buildCache(cfg.cache)
   const index = buildIndex(cfg.index)
   const stateStore = buildStateStore(cfg.store)
   return {
@@ -764,7 +742,7 @@ export async function configToWorkspaceArgs(cfg: WorkspaceConfigRaw): Promise<Wo
       ...(cfg.defaultSessionId !== undefined ? { sessionId: cfg.defaultSessionId } : {}),
       ...(cfg.defaultAgentId !== undefined ? { agentId: cfg.defaultAgentId } : {}),
       ...(cfg.workspaceId !== undefined ? { workspaceId: cfg.workspaceId } : {}),
-      ...(cache !== undefined ? { cache } : {}),
+      ...(cfg.cache !== undefined && cfg.cache !== null ? { cache: cfg.cache } : {}),
       ...(index !== undefined ? { index } : {}),
       ...(stateStore !== undefined ? { store: stateStore } : {}),
       ...(cfg.runtimes !== undefined && cfg.runtimes !== null
@@ -786,14 +764,13 @@ function buildCliEntries(
   clis: Record<string, CLIBlock>,
 ): Record<string, [string | CLISpec, Record<string, unknown> | null]> {
   const out: Record<string, [string | CLISpec, Record<string, unknown> | null]> = {}
-  const known = new Set(['cli', 'script', 'runtime', 'config'])
   for (const [name, block] of Object.entries(clis as Record<string, unknown>)) {
     // The raw config arrives as unvalidated YAML: the CLIBlock type is
     // a claim, not a guarantee, so validate the shape here.
     if (!isPlainObject(block)) {
       throw new Error(`clis entry '${name}' must be a mapping`)
     }
-    const unknown = Object.keys(block).filter((k) => !known.has(k))
+    const unknown = Object.keys(block).filter((k) => !CLI_KEYS.includes(k))
     if (unknown.length > 0) {
       throw new Error(`clis entry '${name}': unknown keys: ${unknown.sort().join(', ')}`)
     }

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -29,8 +29,8 @@ import {
   RedisWorkspaceStateStore,
   DiskWorkspaceStateStore,
   S3WorkspaceStateStore,
+  normalizeS3Config,
   snakeToCamel,
-  buildFileCache,
   buildRuntime,
   type RuntimeEntry,
   type CacheConfig,
@@ -293,9 +293,15 @@ function normalizeConfigKeys(raw: Record<string, unknown>): Record<string, unkno
   if (isPlainObject(out.store)) {
     const store = camelizeKeys(out.store)
     for (const group of ['namespace', 'observer', 'workspace']) {
-      if (isPlainObject(store[group])) {
-        store[group] = camelizeKeys(store[group])
-      }
+      const block = store[group]
+      if (!isPlainObject(block)) continue
+      // An s3 group IS an S3Config, whose snake_case spellings do not
+      // camelize into the TS field names (`aws_access_key_id` is
+      // `accessKeyId`, not `awsAccessKeyId`). Left alone here for the
+      // same reason `mounts.*.config` is: `normalizeS3Config` owns that
+      // translation, and camelizing first would hide the keys from it.
+      if (block.type === 's3') continue
+      store[group] = camelizeKeys(block)
     }
     out.store = store
   }
@@ -646,7 +652,7 @@ export interface WorkspaceArgs {
     consistency: ConsistencyPolicy
     sessionId?: string
     agentId?: string
-    cache?: FileCacheStore
+    cache?: FileCacheStore | CacheConfig
     index?: IndexConfig
     workspaceId?: string
     store?: WorkspaceStateStore
@@ -658,14 +664,16 @@ export interface WorkspaceArgs {
   kernelMounts: Record<string, [MountBackend, string | undefined]>
 }
 
-// The block IS the cache config once normalized, so the loader only
-// decides whether one was given; building it belongs to core, where
-// `WorkspaceOptions.cache` accepts the same shape.
+// The block IS the cache config once normalized, so it is handed to the
+// workspace as one rather than built here: `WorkspaceOptions.cache`
+// accepts the same shape, and a store the workspace builds is a store
+// the workspace closes. Building it here would leave a redis client with
+// no owner once the workspace shut down.
 function buildCache(
   block: RamCacheBlock | RedisCacheBlock | null | undefined,
-): FileCacheStore | undefined {
+): CacheConfig | undefined {
   if (block === null || block === undefined) return undefined
-  return buildFileCache(block as CacheConfig)
+  return block as CacheConfig
 }
 
 function buildIndex(
@@ -699,10 +707,13 @@ function buildStoreGroup(block: StoreGroupBlock): WorkspaceStateStore {
   if (block.type === 's3') {
     // The block IS the S3Config once the discriminator is dropped, so
     // new S3Config fields flow through without being re-declared here
-    // (the same reason Python's S3StoreBlock subclasses S3Config).
-    const s3: Record<string, unknown> = { keyPrefix: 'mirage/', ...block }
+    // (the same reason Python's S3StoreBlock subclasses S3Config). The
+    // keys are still the file's snake_case ones, so they go through the
+    // same translation the s3 mount uses — `key_prefix` and friends do
+    // not survive a plain camelize.
+    const s3: Record<string, unknown> = { key_prefix: 'mirage/', ...block }
     delete s3.type
-    return new S3WorkspaceStateStore(s3 as unknown as S3Config)
+    return new S3WorkspaceStateStore(normalizeS3Config(s3))
   }
   return new RAMWorkspaceStateStore()
 }

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -541,10 +541,20 @@ function readProcessEnv(): Record<string, string> {
   return out
 }
 
-export function loadWorkspaceConfig(
+/**
+ * Interpolate `${VAR}` and check every key, leaving the spelling alone.
+ *
+ * This is the shape that travels: the CLI prepares a config here and
+ * POSTs it, and the daemon runs the same check on what arrives, so the
+ * wire carries Python's snake_case exactly as `model_dump()` does on
+ * that side. Camelizing before sending would make the loader have to
+ * accept its own output, which is how a camelCase spelling Python
+ * rejects would creep back in.
+ */
+export function checkWorkspaceConfig(
   source: Record<string, unknown>,
   env?: Record<string, string>,
-): WorkspaceConfigRaw {
+): Record<string, unknown> {
   const raw = { ...source }
   const useEnv = env ?? readProcessEnv()
   const interpolated = interpolateEnv(raw, useEnv)
@@ -558,7 +568,14 @@ export function loadWorkspaceConfig(
     throw new Error('config requires a `mounts` mapping')
   }
   validateConfigKeys(interpolated)
-  return normalizeConfigKeys(interpolated) as unknown as WorkspaceConfigRaw
+  return interpolated
+}
+
+export function loadWorkspaceConfig(
+  source: Record<string, unknown>,
+  env?: Record<string, string>,
+): WorkspaceConfigRaw {
+  return normalizeConfigKeys(checkWorkspaceConfig(source, env)) as unknown as WorkspaceConfigRaw
 }
 
 /**
@@ -568,18 +585,20 @@ export function loadWorkspaceConfig(
  * file" (the docker build-context model), never "wherever the server
  * happens to run". In-memory object configs are untouched.
  */
-function absolutizeScripts(raw: WorkspaceConfigRaw, base: string): void {
+function absolutizeScripts(raw: Record<string, unknown>, base: string): void {
+  // `policy`, `runtimes`, `clis` and `script` are spelled the same in
+  // both cases, so this runs before or after normalization alike.
   const policy = raw.policy
   if (typeof policy === 'string' && isScriptPath(policy) && !isAbsolute(policy.trim())) {
     raw.policy = join(base, policy.trim())
   }
   if (Array.isArray(raw.runtimes)) {
     for (const entry of raw.runtimes) {
-      if (typeof entry !== 'string') absolutizeScriptKey(entry, base)
+      if (typeof entry !== 'string') absolutizeScriptKey(entry as Record<string, unknown>, base)
     }
   }
   if (raw.clis !== undefined && raw.clis !== null) {
-    for (const block of Object.values(raw.clis)) {
+    for (const block of Object.values(raw.clis as Record<string, unknown>)) {
       absolutizeScriptKey(block as Record<string, unknown>, base)
     }
   }
@@ -593,18 +612,31 @@ function absolutizeScriptKey(entry: Record<string, unknown>, base: string): void
   }
 }
 
-export function loadWorkspaceConfigFile(
+/**
+ * Read a config file into the shape that travels: checked, env
+ * interpolated, script paths resolved against the file's directory —
+ * and still spelled the way the file spelled it. What a CLI sends to
+ * the daemon.
+ */
+export function checkWorkspaceConfigFile(
   path: string,
   env?: Record<string, string>,
-): WorkspaceConfigRaw {
+): Record<string, unknown> {
   const text = readFileSync(path, 'utf-8')
   const parsed: unknown = parseYaml(text)
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error(`config source must be a mapping`)
   }
-  const config = loadWorkspaceConfig(parsed as Record<string, unknown>, env)
+  const config = checkWorkspaceConfig(parsed as Record<string, unknown>, env)
   absolutizeScripts(config, dirname(resolve(path)))
   return config
+}
+
+export function loadWorkspaceConfigFile(
+  path: string,
+  env?: Record<string, string>,
+): WorkspaceConfigRaw {
+  return normalizeConfigKeys(checkWorkspaceConfigFile(path, env)) as unknown as WorkspaceConfigRaw
 }
 
 export interface WorkspaceArgs {

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -130,10 +130,13 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 //
 // The spellings are Python's canonical snake_case ones on purpose: a
 // camelCase alias that TS would accept for free is a key Python rejects,
-// which is the same portability break pointing the other way. Blocks
-// that carry a backend's own credentials (`mounts.*.config`, an s3 store
-// group) are deliberately absent — those are validated by the backend's
-// config model, one layer down, exactly as in Python.
+// which is the same portability break pointing the other way.
+//
+// `mounts.*.config` is the one block with no table, because Python types
+// it as a bare dict and validates it in the resource's own model. Do not
+// generalize that to every credential-carrying block: an s3 store group
+// has a strict Python model (`S3StoreBlock`, extra="forbid"), so it is
+// tabled here like the rest.
 const TOP_LEVEL_KEYS = [
   'mounts',
   'clis',
@@ -167,24 +170,50 @@ const INDEX_KEYS: Record<string, readonly string[]> = {
 }
 const STORE_GROUPS = ['namespace', 'observer', 'workspace'] as const
 const STORE_KEYS = ['type', 'url', 'key_prefix', 'root', ...STORE_GROUPS] as const
+// An s3 group IS `S3Config` plus the discriminator, so its keys are that
+// model's, spelled Python's way. Python declares it as
+// `S3StoreBlock(S3Config)` with extra="forbid" — a strict model, unlike
+// the untyped `mounts.*.config` — so a typo is a load error there and
+// must be one here.
 const STORE_GROUP_KEYS: Record<string, readonly string[]> = {
   ram: ['type'],
   disk: ['type', 'root'],
   redis: ['type', 'url', 'key_prefix'],
+  s3: [
+    'type',
+    'bucket',
+    'region',
+    'endpoint_url',
+    'aws_access_key_id',
+    'aws_secret_access_key',
+    'aws_session_token',
+    'aws_profile',
+    'path_style',
+    'timeout',
+    'proxy',
+    'key_prefix',
+  ],
 }
+// The s3 store hosts only the sessions+meta plane, so it is valid as the
+// `workspace` override and nowhere else — as the top-level default it is
+// already refused above. Its store raises when asked to build another
+// plane; both languages now refuse the config instead of the plane.
+const S3_HOSTED_GROUP = 'workspace'
+const PLAIN_STORE_GROUP_KEYS: Record<string, readonly string[]> = Object.fromEntries(
+  Object.entries(STORE_GROUP_KEYS).filter(([type]) => type !== 's3'),
+)
 const CLI_KEYS: readonly string[] = ['cli', 'script', 'runtime', 'config']
 const GUARD_KEYS = ['reason', 'commands', 'paths'] as const
 
-// A store group whose `type` names a backend IS that backend's config
-// plus the discriminator: its keys belong to the backend's model and its
-// spellings to the backend's own translation, exactly like a mount's
-// `config:` block. So such a group is neither key-checked nor camelized
-// here — a future backend-backed group joins this set, and both sites
-// follow without being found again.
-const BACKEND_CONFIG_TYPES: ReadonlySet<string> = new Set(['s3'])
+// A store group whose `type` names a backend carries that backend's own
+// spellings: `aws_access_key_id` is `accessKeyId`, not `awsAccessKeyId`,
+// so camelizing here would hide the key from the translation that does
+// know it. Its *keys* are still checked — the backend's model declares
+// them (see STORE_GROUP_KEYS above) — only the renaming is skipped.
+const BACKEND_SPELLED_TYPES: ReadonlySet<string> = new Set(['s3'])
 
-function isBackendConfigBlock(block: Record<string, unknown>): boolean {
-  return typeof block.type === 'string' && BACKEND_CONFIG_TYPES.has(block.type)
+function keepsBackendSpellings(block: Record<string, unknown>): boolean {
+  return typeof block.type === 'string' && BACKEND_SPELLED_TYPES.has(block.type)
 }
 
 function rejectUnknownKeys(
@@ -246,8 +275,15 @@ function validateStoreBlock(value: unknown): void {
     const block = value[group]
     if (block === undefined || block === null) continue
     if (!isPlainObject(block)) throw new Error(`config \`store.${group}\` must be a mapping`)
-    if (isBackendConfigBlock(block)) continue
-    validateTypedBlock(block, STORE_GROUP_KEYS, `store.${group}`, 'ram')
+    if (block.type === 's3' && group !== S3_HOSTED_GROUP) {
+      throw new Error(
+        `config \`store.${group}\` cannot be s3: the s3 store hosts only the ` +
+          `sessions+meta group; keep the ${group} plane on ram or redis and pass ` +
+          `the s3 store as the '${S3_HOSTED_GROUP}' group override`,
+      )
+    }
+    const table = group === S3_HOSTED_GROUP ? STORE_GROUP_KEYS : PLAIN_STORE_GROUP_KEYS
+    validateTypedBlock(block, table, `store.${group}`, 'ram')
   }
 }
 
@@ -298,11 +334,7 @@ function normalizeConfigKeys(raw: Record<string, unknown>): Record<string, unkno
     for (const group of STORE_GROUPS) {
       const block = store[group]
       if (!isPlainObject(block)) continue
-      // A backend's own spellings do not camelize into its TS field
-      // names (`aws_access_key_id` is `accessKeyId`, not
-      // `awsAccessKeyId`), and camelizing first would hide the keys from
-      // the translation that does know them.
-      if (isBackendConfigBlock(block)) continue
+      if (keepsBackendSpellings(block)) continue
       store[group] = camelizeKeys(block)
     }
     out.store = store

--- a/typescript/packages/server/src/index.ts
+++ b/typescript/packages/server/src/index.ts
@@ -14,6 +14,8 @@
 
 export { buildApp, type BuildAppOptions, type MirageApp } from './app.ts'
 export {
+  checkWorkspaceConfig,
+  checkWorkspaceConfigFile,
   configToWorkspaceArgs,
   interpolateEnv,
   loadWorkspaceConfig,

--- a/typescript/packages/server/src/routers/workspaces.ts
+++ b/typescript/packages/server/src/routers/workspaces.ts
@@ -114,6 +114,9 @@ export function registerWorkspacesRoutes(app: FastifyInstance, deps: WorkspaceRo
           // with zero infrastructure, like git init); the library default
           // stays ram. An explicit store always wins.
           store: args.options.store ?? new DiskWorkspaceStateStore({ root: deps.stateRoot }),
+          // Whichever of the two built it, no sibling workspace shares
+          // it, so this workspace is the one that closes it.
+          ownsStore: true,
           ...(Object.keys(commandLimits).length > 0 ? { commandLimits } : {}),
         })
       } catch (e) {


### PR DESCRIPTION
Two Tier 1 cleanup-plan items, both the same shape: a contract Python enforces and TypeScript doesn't.

## T1-M — core lifecycle

**Index leak.** `RedisIndexCacheStore.close()` had zero callers, so a mount configured `index: {type: redis}` kept its client open past `closeWorkspace` and the Node process never exited. `BaseResource` now owns a `close()` that releases the index behind a `#closed` guard, mirroring `resource/base.py:199`.

That meant confronting the 29 `close() { return Promise.resolve() }` overrides. They existed only to satisfy the `Resource` interface, and each one silently opted its backend out of any future base teardown — so they're deleted, and the seven with real work call `super.close()`. `noImplicitOverride` turns forgetting it into a compile error, which is the gate the plan asked for.

**Load ordering.** `installDriftState` fired `void cache.remove(path)` per entry from a function declared `: void`. Under `DriftPolicy.OFF`, `fromState` returned before the snapshot bytes were dropped, so a read issued right after load could be served the very content OFF exists to bypass — and a rejected `remove()` was an unhandled rejection. Adds the sync `FileCache.evictPaths` seam Python has had since `cache/file/mixin.py:88`: real in the RAM store, a documented no-op in redis (its state can't be mutated synchronously).

**Silent partial history.** `DiskObserverStore.walk` wrapped `readdir` in `try { … } catch { continue }`, so an EACCES or EIO mid-tree produced a silently partial `readAll`/`readMatching` and a `clear()` that reported success while leaving files — a truncated `/.bash_history` with nothing to say it was truncated. Errors now propagate; only a missing root reads as "nothing recorded yet". Python's root probe used `os.path.isdir`, which has the same blind spot for an unreadable root, so it moves to the same explicit check — the two walks stay behavior-identical. Also adds `ObserverStoreBase` (twin of Python's) so `readAll`/`close` stop being copy-pasted into three stores.

## T1-L — TS workspace-config validation and cache-as-config

**Forbid-extras.** Python sets `extra="forbid"` on 13 config blocks; the TS loader validated unknown keys in exactly two places and copied everything else through, so `mount_point:` for `mountpoint:`, `consistancy:` and `limitt:` were hard `ValueError`s in one language and silently ignored in the other. Adds per-block allowed-key tables (top level, mounts, cache, index, store + groups, clis, guards), checked before normalization so the snake_case/camelCase distinction still exists.

The tables use Python's canonical snake_case spellings deliberately: a camelCase alias TS would accept for free is a key Python rejects, which is the same portability break pointing the other way. Guards now fail at load rather than at `configToWorkspaceArgs`, matching Python. The module-local `snakeToCamel` — which diverged from core's exported one on uppercase-after-underscore and trailing underscore — is gone.

> **This rejects configs that currently "work"**, which is the intent. Every workspace-config YAML in the repo (integ, examples, fixtures) was loaded through the new loader and still passes; nothing in `docs/` uses a camelCase spelling in workspace YAML.

**Store backends.** Found while writing the tables: `store: {type: disk}` silently built a RAM state store, so state a user believed was persisted was not. Disk and s3 groups are now wired, matching `_build_state_store`.

**Cache as config.** `WorkspaceOptions.cache` took a *built* store where `index` takes a *config*, so a programmatic TS consumer could not request a redis file cache declaratively. Adds `core/workspace/workspace/cache.ts` (`buildFileCache`, twin of `workspace/workspace/cache.py:31`) and widens the option to `FileCache | CacheConfig`. Core can't import node, so the redis store registers itself through a `registerFileCacheStore` seam — the same pattern the runtimes already use. Asking for an unregistered type names the package to import rather than degrading to RAM.

## Verification

- New shared fixture `integ/fixtures/config/rejected.json` — 14 configs both loaders must refuse, asserted from `python/tests/config/test_loader.py` and `packages/server/src/config.test.ts`. A config accepted by one and refused by the other fails a test until they agree. Same pattern as `integ/fixtures/filetype/tables.json`.
- Unit tests: index closed once and never built just to close it; `evictPaths` drops keys with no await; `installDriftState` OFF evicts before returning; disk observer store raises on an unreadable tree and reads empty for an unwritten root (both languages); `buildFileCache` defaults, factory dispatch, and error; `Workspace` accepting a cache config.
- `pnpm -r typecheck` clean, all TS suites pass (core 7224, node 2120, browser 182, server 237); `pytest` full suite passes; `pre-commit run --all-files` clean; spec drift + parity gates clean; integ `ram` 2332/2332 and `disk` 2297/2297 on the Python runner, `ram` 2332/2332 on the TS runner, `integ/root.py` all checks OK.
- `packages/agents/src/pi/extension.test.ts` fails locally on `undici`/Node (`webidl.util.markAsUncloneable`); confirmed identical on a clean tree, unrelated to this change.

Refs #609. Related: #24, #16, #411, #518 (T1-M is the seam those sit on, and the plan sequences it before the `fork()` tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)