### PR TITLE
fix(shell): run `sh FILE` / `bash FILE` as a script

### DIFF
--- a/integ/bash/control/bash.json
+++ b/integ/bash/control/bash.json
@@ -200,6 +200,142 @@
         "stdout": "traced\n",
         "stderr": "+ echo traced\n"
       }
+    },
+    {
+      "id": "ctl_bash_script_file_set_o",
+      "seq": 502158,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'false | true\\necho pipefail=$?\\n' > /data/bo.sh && bash -o pipefail /data/bo.sh && rm /data/bo.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "pipefail=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ctl_bash_script_file_plus_flag",
+      "seq": 502159,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'echo hi\\n' > /data/bp.sh && bash +x /data/bp.sh && rm /data/bp.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "hi\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ctl_bash_script_file_export_isolated",
+      "seq": 502160,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'export LEAK=1\\n' > /data/be.sh && bash /data/be.sh && echo [$LEAK] && rm /data/be.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "[]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ctl_bash_unknown_long_option",
+      "seq": 502161,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "bash --nosuch",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "bash: --nosuch: unsupported option\n"
+      }
     }
   ]
 }

--- a/integ/bash/control/bash.json
+++ b/integ/bash/control/bash.json
@@ -132,6 +132,74 @@
         "stdout": "hi\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "ctl_bash_script_file_args",
+      "seq": 502154,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'echo zero=$0 argc=$# args=$@\\n' > /data/bf.sh && bash /data/bf.sh AA BB && rm /data/bf.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "zero=/data/bf.sh argc=2 args=AA BB\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ctl_bash_script_file_xtrace",
+      "seq": 502155,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'echo traced\\n' > /data/bx.sh && bash -x /data/bx.sh && rm /data/bx.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "traced\n",
+        "stderr": "+ echo traced\n"
+      }
     }
   ]
 }

--- a/integ/bash/control/sh.json
+++ b/integ/bash/control/sh.json
@@ -33,6 +33,74 @@
         "stdout": "hi\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "ctl_sh_script_file",
+      "seq": 502152,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'for f in a b\\ndo\\n  echo item=$f arg=$1\\ndone\\n' > /data/sf.sh && sh /data/sf.sh ARG && rm /data/sf.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "item=a arg=ARG\nitem=b arg=ARG\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ctl_sh_script_file_missing",
+      "seq": 502153,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "sh /data/nosuch.sh",
+      "expect": {
+        "exit": 127,
+        "stdout": "",
+        "stderr": "sh: /data/nosuch.sh: No such file or directory\n"
+      }
     }
   ]
 }

--- a/integ/bash/control/sh.json
+++ b/integ/bash/control/sh.json
@@ -101,6 +101,74 @@
         "stdout": "",
         "stderr": "sh: /data/nosuch.sh: No such file or directory\n"
       }
+    },
+    {
+      "id": "ctl_sh_script_file_stdin",
+      "seq": 502156,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "echo 'echo zero=$0 one=$1' | sh -s AA BB",
+      "expect": {
+        "exit": 0,
+        "stdout": "zero=sh one=AA\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ctl_sh_script_file_cwd_isolated",
+      "seq": 502157,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'cd /\\n' > /data/cd.sh && cd /data && sh /data/cd.sh && pwd && rm /data/cd.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/bash/control/sh.json
+++ b/integ/bash/control/sh.json
@@ -163,10 +163,44 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "printf 'cd /\\n' > /data/cd.sh && cd /data && sh /data/cd.sh && pwd && rm /data/cd.sh",
+      "command": "printf 'cd /\\n' > /data/cd.sh && ( cd /data && sh /data/cd.sh && pwd ) && rm /data/cd.sh",
       "expect": {
         "exit": 0,
         "stdout": "/data\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ctl_sh_script_file_symlink",
+      "seq": 502162,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/shl && printf 'echo linked\\n' > /data/shl/run.sh && ln -s /data/shl/run.sh /data/shl/link.sh && sh /data/shl/link.sh && rm -r /data/shl",
+      "expect": {
+        "exit": 0,
+        "stdout": "linked\n",
         "stderr": ""
       }
     }

--- a/python/mirage/shell/constants.py
+++ b/python/mirage/shell/constants.py
@@ -40,3 +40,8 @@ ARITH_SIGN = 1 << 63
 # Recursion budget for variables holding expressions (`x="1+2"; $((x))`),
 # mirroring bash's expression recursion limit.
 ARITH_MAX_DEPTH = 16
+
+# What the shell calls itself when no script is running, bash's "bash".
+# A nested `bash`/`sh` overrides it through Session.script_name, and
+# `Session.argv0` is the one place the two are folded together.
+SHELL_ARGV0 = "mirage"

--- a/python/mirage/shell/options.py
+++ b/python/mirage/shell/options.py
@@ -12,26 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from dataclasses import dataclass
-
-from mirage.shell.types import SET_FLAG_TO_OPTION
-
-
-@dataclass(frozen=True, slots=True)
-class OptionWord:
-    """One word of the shell's option grammar.
-
-    Args:
-        settings (tuple[tuple[str, bool], ...]): shell options the word
-            turns on or off, in the order they were written.
-        other (str): cluster letters that name no shell option. `set`
-            ignores them; shell startup reads its own startup letters
-            out of them and refuses the rest.
-        consumed (int): words the option took, 2 for the `-o NAME` form.
-    """
-    settings: tuple[tuple[str, bool], ...] = ()
-    other: str = ""
-    consumed: int = 1
+from mirage.shell.types import SET_FLAG_TO_OPTION, OptionWord
 
 
 def parse_option_word(word: str, nxt: str | None) -> OptionWord | None:

--- a/python/mirage/shell/options.py
+++ b/python/mirage/shell/options.py
@@ -1,0 +1,71 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+
+from mirage.shell.types import SET_FLAG_TO_OPTION
+
+
+@dataclass(frozen=True, slots=True)
+class OptionWord:
+    """One word of the shell's option grammar.
+
+    Args:
+        settings (tuple[tuple[str, bool], ...]): shell options the word
+            turns on or off, in the order they were written.
+        other (str): cluster letters that name no shell option. `set`
+            ignores them; shell startup reads its own startup letters
+            out of them and refuses the rest.
+        consumed (int): words the option took, 2 for the `-o NAME` form.
+    """
+    settings: tuple[tuple[str, bool], ...] = ()
+    other: str = ""
+    consumed: int = 1
+
+
+def parse_option_word(word: str, nxt: str | None) -> OptionWord | None:
+    """Read one option word, or None when the word is an operand.
+
+    This is bash's `set` grammar, which shell startup speaks too: a
+    sign, then either `o` naming an option in the next word or a cluster
+    of single-letter options, where `-` turns them on and `+` turns them
+    off. `bash -x file` and `set -x` therefore cannot disagree about
+    what `-x` means, and an option one of them learns the other gets.
+
+    `-`, `--` and a `--long` word are not option words. The first two
+    end option parsing and the third belongs to whoever declares long
+    options, so both are the caller's to answer.
+
+    Args:
+        word (str): the word to read.
+        nxt (str | None): the word after it, for the `-o NAME` form.
+    """
+    if len(word) < 2 or word[0] not in "-+" or word.startswith("--"):
+        return None
+    enable = word[0] == "-"
+    settings: list[tuple[str, bool]] = []
+    other = ""
+    consumed = 1
+    for char in word[1:]:
+        if char == "o":
+            if nxt is not None:
+                settings.append((nxt, enable))
+                consumed = 2
+            continue
+        option = SET_FLAG_TO_OPTION.get(char)
+        if option is None:
+            other += char
+            continue
+        settings.append((option, enable))
+    return OptionWord(settings=tuple(settings), other=other, consumed=consumed)

--- a/python/mirage/shell/types.py
+++ b/python/mirage/shell/types.py
@@ -144,6 +144,23 @@ SET_FLAG_TO_OPTION = {
 }
 
 
+@dataclass(frozen=True, slots=True)
+class OptionWord:
+    """One word of the shell's option grammar.
+
+    Args:
+        settings (tuple[tuple[str, bool], ...]): shell options the word
+            turns on or off, in the order they were written.
+        other (str): cluster letters that name no shell option. `set`
+            ignores them; shell startup reads its own startup letters
+            out of them and refuses the rest.
+        consumed (int): words the option took, 2 for the `-o NAME` form.
+    """
+    settings: tuple[tuple[str, bool], ...] = ()
+    other: str = ""
+    consumed: int = 1
+
+
 class RedirectKind(StrEnum):
     STDOUT = "stdout"
     STDERR = "stderr"

--- a/python/mirage/workspace/executor/builtins/script.py
+++ b/python/mirage/workspace/executor/builtins/script.py
@@ -16,14 +16,18 @@ import asyncio
 import math
 import re
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 from mirage.io import IOResult
 from mirage.io.stream import materialize
 from mirage.io.types import ByteSource
-from mirage.types import PathSpec
+from mirage.shell.types import SET_FLAG_TO_OPTION
+from mirage.types import FileType, PathSpec
+from mirage.utils.errors import FS_ERRORS, fs_strerror
 from mirage.utils.path import resolve_path
 from mirage.workspace.abort import cancellable_sleep
+from mirage.workspace.executor.builtins.links import resolve_path_stat
 from mirage.workspace.executor.builtins.scope import _scope_path, _to_scope
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
@@ -81,32 +85,64 @@ async def handle_eval(
     return io.stdout, io, ExecutionNode(command="eval", exit_code=io.exit_code)
 
 
-_BASH_NOOP_SHORT_FLAGS = frozenset({"l", "i", "e", "u", "x"})
+# Startup flags with nothing to configure in an embedded shell: there is
+# no login profile, no rc file and no tty. Flags that name a `set` option
+# (-e -u -x -f) are not here; they are applied through SET_FLAG_TO_OPTION.
+_BASH_NOOP_SHORT_FLAGS = frozenset({"l", "i"})
 
 _BASH_NOOP_LONG_FLAGS = frozenset(
     {"--login", "--norc", "--noprofile", "--posix", "--rcfile"})
 
 
-async def handle_bash(
-    execute_fn: Callable[..., Any],
-    args: list[str],
-    session: Session,
-    stdin: ByteSource | None = None,
-) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
+def _bash_error(name: str, message: str,
+                code: int) -> tuple[None, IOResult, ExecutionNode]:
+    err = f"{name}: {message}\n".encode()
+    return None, IOResult(exit_code=code,
+                          stderr=err), ExecutionNode(command=name,
+                                                     exit_code=code,
+                                                     stderr=err)
+
+
+@dataclass(frozen=True, slots=True)
+class BashArgs:
+    """One parsed ``bash``/``sh`` invocation.
+
+    Args:
+        script (str | None): inline program text from ``-c``.
+        path (str | None): script file operand, as typed.
+        argv (list[str]): words after the program, ``$0`` first for the
+            ``-c`` form and all positional for the file form.
+        options (list[str]): shell options the startup flags turn on.
+        read_stdin (bool): ``-s`` was given.
+        error (tuple | None): a ready usage failure, when parsing failed.
+    """
     script: str | None = None
+    path: str | None = None
+    argv: list[str] = field(default_factory=list)
+    options: list[str] = field(default_factory=list)
+    read_stdin: bool = False
+    error: tuple[None, IOResult, ExecutionNode] | None = None
+
+
+def parse_bash_args(name: str, args: list[str]) -> BashArgs:
+    """Split a ``bash``/``sh`` argument list into flags, program and argv.
+
+    Option parsing stops at the first operand, so everything after a
+    script file (or after ``-c``'s program text) is positional, even when
+    it looks like a flag: ``bash run.sh -c foo`` passes ``-c foo`` to the
+    script.
+
+    Args:
+        name (str): the head word, used as the diagnostic prefix.
+        args (list[str]): words after the head word.
+    """
+    options: list[str] = []
     read_stdin = False
     i = 0
     while i < len(args):
         tok = args[i]
         if tok == "--":
             i += 1
-            break
-        if tok == "-c":
-            if i + 1 >= len(args):
-                err = b"bash: -c: option requires an argument\n"
-                return None, IOResult(exit_code=2, stderr=err), ExecutionNode(
-                    command="bash", exit_code=2, stderr=err)
-            script = args[i + 1]
             break
         if tok == "-s":
             read_stdin = True
@@ -118,41 +154,134 @@ async def handle_bash(
         if tok in _BASH_NOOP_LONG_FLAGS:
             i += 1
             continue
-        if (tok.startswith("-") and len(tok) > 1 and not tok.startswith("--")):
-            chars = tok[1:]
-            if "c" in chars:
-                if i + 1 >= len(args):
-                    err = b"bash: -c: option requires an argument\n"
-                    return None, IOResult(
-                        exit_code=2, stderr=err), ExecutionNode(command="bash",
-                                                                exit_code=2,
-                                                                stderr=err)
-                script = args[i + 1]
-                break
-            if all(ch in _BASH_NOOP_SHORT_FLAGS or ch == "s" for ch in chars):
-                if "s" in chars:
-                    read_stdin = True
-                i += 1
-                continue
-            err = (f"bash: {tok}: unsupported option\n").encode()
-            return None, IOResult(exit_code=2,
-                                  stderr=err), ExecutionNode(command="bash",
-                                                             exit_code=2,
-                                                             stderr=err)
-        if script is None:
-            script = tok
+        if not (tok.startswith("-") and len(tok) > 1
+                and not tok.startswith("--")):
             break
+        chars = tok[1:]
+        if "c" in chars:
+            if i + 1 >= len(args):
+                return BashArgs(error=_bash_error(
+                    name, "-c: option requires an argument", 2))
+            options.extend(SET_FLAG_TO_OPTION[c] for c in chars
+                           if c in SET_FLAG_TO_OPTION)
+            return BashArgs(script=args[i + 1],
+                            argv=args[i + 2:],
+                            options=options,
+                            read_stdin=read_stdin)
+        if not all(ch in _BASH_NOOP_SHORT_FLAGS or ch == "s"
+                   or ch in SET_FLAG_TO_OPTION for ch in chars):
+            return BashArgs(
+                error=_bash_error(name, f"{tok}: unsupported option", 2))
+        options.extend(SET_FLAG_TO_OPTION[c] for c in chars
+                       if c in SET_FLAG_TO_OPTION)
+        read_stdin = read_stdin or "s" in chars
         i += 1
-    if script is None and read_stdin and stdin is not None:
+    if i < len(args):
+        return BashArgs(path=args[i],
+                        argv=args[i + 1:],
+                        options=options,
+                        read_stdin=read_stdin)
+    return BashArgs(options=options, read_stdin=read_stdin)
+
+
+async def read_script_file(
+    dispatch: Callable[..., Any],
+    name: str,
+    path: str,
+    session: Session,
+) -> tuple[str, None] | tuple[None, tuple[None, IOResult, ExecutionNode]]:
+    """Read a script file operand, or the failure bash reports for it.
+
+    GNU splits the diagnostics by how far startup got. A file it cannot
+    open is blamed on the shell (``bash: run.sh: No such file or
+    directory``, exit 127; ``Permission denied``, exit 126), while a
+    directory opens fine and only fails on the first read, by which point
+    ``$0`` is already the operand, so bash prints it twice (``/tmp: /tmp:
+    Is a directory``, exit 126). Reproduced rather than tidied up: it is
+    what an agent copying a message into a search box will find.
+
+    A backend that cannot tell a missing path from an unreadable one
+    raises ENOENT for a directory too, so the stat probe runs on the
+    failure path to recover the distinction.
+
+    Args:
+        dispatch (Callable): op dispatcher, used to read the file.
+        name (str): the head word, used as the diagnostic prefix.
+        path (str): the script operand, as typed.
+        session (Session): shell session state, for the working directory.
+    """
+    scope = _to_scope(resolve_path(path, session.cwd))
+    try:
+        data, _ = await dispatch("read", scope)
+    except FS_ERRORS as exc:
+        stat = await resolve_path_stat(dispatch, scope)
+        if stat is not None and stat.type == FileType.DIRECTORY:
+            return None, _bash_error(path, f"{path}: Is a directory", 126)
+        strerror = fs_strerror(exc) or "No such file or directory"
+        code = 126 if isinstance(exc, PermissionError) else 127
+        return None, _bash_error(name, f"{path}: {strerror}", code)
+    return (data.decode(
+        errors="replace") if isinstance(data, bytes) else ""), None
+
+
+async def handle_bash(
+    dispatch: Callable[..., Any],
+    execute_fn: Callable[..., Any],
+    args: list[str],
+    session: Session,
+    stdin: ByteSource | None = None,
+    name: str = "bash",
+) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
+    """Run a nested shell: inline text from ``-c``, or a script file.
+
+    Args:
+        dispatch (Callable): op dispatcher, used to read a script file.
+        execute_fn (Callable): runs the program text in this session.
+        args (list[str]): words after the head word.
+        session (Session): shell session state.
+        stdin (ByteSource | None): input stream, also the program source
+            under ``-s``.
+        name (str): the head word (``bash`` or ``sh``). bash reports
+            itself by ``argv[0]``, so the diagnostics follow the spelling
+            the caller used.
+    """
+    parsed = parse_bash_args(name, args)
+    if parsed.error is not None:
+        return parsed.error
+    script = parsed.script
+    named = script is not None and bool(parsed.argv)
+    script_name = parsed.argv[0] if named else name
+    positional = parsed.argv[1:] if script is not None else parsed.argv
+    if script is None and parsed.path is not None:
+        script_name = parsed.path
+        script, failure = await read_script_file(dispatch, name, parsed.path,
+                                                 session)
+        if failure is not None:
+            return failure
+    if script is None and parsed.read_stdin and stdin is not None:
         stdin_data = await materialize(stdin)
         if stdin_data:
             script = stdin_data.decode(errors="replace")
             stdin = None
     if script is None:
-        return None, IOResult(), ExecutionNode(command="bash", exit_code=0)
-    io = await execute_fn(script, session_id=session.session_id, stdin=stdin)
-    return io.stdout, io, ExecutionNode(command=f"bash -c {script}",
-                                        exit_code=io.exit_code)
+        return None, IOResult(), ExecutionNode(command=name, exit_code=0)
+    saved_positional = session.positional_args
+    saved_script_name = session.script_name
+    saved_options = dict(session.shell_options)
+    session.positional_args = positional
+    session.script_name = script_name
+    for option in parsed.options:
+        session.shell_options[option] = True
+    try:
+        io = await execute_fn(script,
+                              session_id=session.session_id,
+                              stdin=stdin)
+    finally:
+        session.positional_args = saved_positional
+        session.script_name = saved_script_name
+        session.shell_options = saved_options
+    label = f"{name} {parsed.path}" if parsed.path else f"{name} -c {script}"
+    return io.stdout, io, ExecutionNode(command=label, exit_code=io.exit_code)
 
 
 # Finite non-negative decimals only ("0", "0.2", ".5", "1.", "+1", "1e-3").

--- a/python/mirage/workspace/executor/builtins/script.py
+++ b/python/mirage/workspace/executor/builtins/script.py
@@ -22,15 +22,81 @@ from typing import Any
 from mirage.io import IOResult
 from mirage.io.stream import materialize
 from mirage.io.types import ByteSource
-from mirage.shell.types import SET_FLAG_TO_OPTION
+from mirage.shell.options import parse_option_word
 from mirage.types import FileType, PathSpec
-from mirage.utils.errors import FS_ERRORS, fs_strerror
+from mirage.utils.errors import FS_ERRORS, eisdir, fs_strerror
 from mirage.utils.path import resolve_path
 from mirage.workspace.abort import cancellable_sleep
 from mirage.workspace.executor.builtins.links import resolve_path_stat
 from mirage.workspace.executor.builtins.scope import _scope_path, _to_scope
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
+
+# GNU prints the refusal and the usage line together, both under the
+# builtin's own name, and exits 2 without ending the script.
+SOURCE_USAGE = ("filename argument required\n"
+                "source: usage: source filename [arguments]")
+
+
+def script_error(
+        prefix: str,
+        message: str,
+        code: int,
+        command: str | None = None) -> tuple[None, IOResult, ExecutionNode]:
+    """A diagnostic from a shell that never got as far as running.
+
+    ``prefix`` and ``command`` come apart because bash reports itself by
+    ``argv[0]``, which for a script operand is the operand: the recorded
+    command still has to be the builtin that ran, not a file path.
+
+    Args:
+        prefix (str): what the line reports itself as, before the colon.
+        message (str): the rest of the line, without the newline.
+        code (int): the exit status.
+        command (str | None): what to record the failure under, when
+            that is not the prefix.
+    """
+    err = f"{prefix}: {message}\n".encode()
+    return None, IOResult(exit_code=code,
+                          stderr=err), ExecutionNode(command=command or prefix,
+                                                     exit_code=code,
+                                                     stderr=err)
+
+
+async def read_script_text(dispatch: Callable[..., Any], path: str,
+                           cwd: str) -> str:
+    """Read a script file through the op dispatcher.
+
+    Every way of running a script off a mount comes through here, so a
+    backend quirk is answered once rather than per caller. The one
+    answered today is a directory: a keyed backend has no directory
+    object to open, so it reports a read of one as ENOENT where a real
+    filesystem reports EISDIR. The stat probe that tells the two apart
+    runs only on the failure path, and asks both channels a backend can
+    answer on, since on a prefix store a directory is the set of keys
+    under it rather than an object.
+
+    The caller owns the diagnostic: `source` and a nested shell word
+    the same failure differently and exit differently on it.
+
+    Args:
+        dispatch (Callable): op dispatcher, used to read the file.
+        path (str): the script operand, as typed.
+        cwd (str): working directory a relative operand resolves against.
+    """
+    scope = _to_scope(resolve_path(path, cwd))
+    try:
+        data, _ = await dispatch("read", scope)
+    except FileNotFoundError:
+        stat = await resolve_path_stat(dispatch, scope)
+        if stat is not None and stat.type == FileType.DIRECTORY:
+            raise eisdir(path) from None
+        raise
+    if isinstance(data, bytes):
+        return data.decode(errors="replace")
+    if data is None:
+        return ""
+    return (await materialize(data)).decode(errors="replace")
 
 
 async def handle_source(
@@ -40,7 +106,12 @@ async def handle_source(
     session: Session,
     args: list[str] | None = None,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
-    """Read a script file and execute it.
+    """Read a script file and execute it in the calling shell.
+
+    Unlike a nested shell, a sourced file *is* the caller, so whatever
+    it sets stays set: `source f` where f runs `set -x` leaves the
+    caller tracing. Only the positional parameters come back, because
+    bash restores those and nothing else.
 
     Args:
         dispatch (Callable): op dispatcher, used to read the file.
@@ -53,13 +124,15 @@ async def handle_source(
             when omitted the parent's positional parameters are kept.
     """
     raw = _scope_path(path)
-    resolved = resolve_path(raw, session.cwd)
-    scope = _to_scope(resolved)
-    data, _ = await dispatch("read", scope)
-    if isinstance(data, bytes):
-        script = data.decode(errors="replace")
-    else:
-        script = ""
+    if not raw:
+        return script_error("source", SOURCE_USAGE, 2)
+    try:
+        script = await read_script_text(dispatch, raw, session.cwd)
+    except FS_ERRORS as exc:
+        return script_error("source",
+                            f"{raw}: {fs_strerror(exc)}",
+                            1,
+                            command=f"source {raw}")
     saved_positional: list[str] | None = None
     if args:
         saved_positional = session.positional_args
@@ -85,103 +158,109 @@ async def handle_eval(
     return io.stdout, io, ExecutionNode(command="eval", exit_code=io.exit_code)
 
 
-# Startup flags with nothing to configure in an embedded shell: there is
-# no login profile, no rc file and no tty. Flags that name a `set` option
-# (-e -u -x -f) are not here; they are applied through SET_FLAG_TO_OPTION.
-_BASH_NOOP_SHORT_FLAGS = frozenset({"l", "i"})
+# Startup letters bash has that `set` does not. `c` takes the program
+# text from the next word and `s` reads it from stdin; the rest have
+# nothing to configure in an embedded shell, which has no login profile,
+# no rc file and no tty. Letters that name a `set` option (-e -u -x -f)
+# are not here: parse_option_word already knows them, so the two
+# spellings cannot drift.
+_BASH_START_FLAGS = frozenset({"c", "s", "l", "i"})
 
-_BASH_NOOP_LONG_FLAGS = frozenset(
-    {"--login", "--norc", "--noprofile", "--posix", "--rcfile"})
-
-
-def _bash_error(name: str, message: str,
-                code: int) -> tuple[None, IOResult, ExecutionNode]:
-    err = f"{name}: {message}\n".encode()
-    return None, IOResult(exit_code=code,
-                          stderr=err), ExecutionNode(command=name,
-                                                     exit_code=code,
-                                                     stderr=err)
+# bash's long options, mapped to whether the option takes the next word.
+# A flat set of names to ignore cannot say that `--rcfile FILE` swallows
+# FILE, and read `bash --rcfile run.sh` as "run run.sh". Anything absent
+# is refused rather than mistaken for a script operand, which is what
+# made `bash --version` report a missing file.
+_BASH_LONG_OPTIONS: dict[str, bool] = {
+    "--login": False,
+    "--noediting": False,
+    "--noprofile": False,
+    "--norc": False,
+    "--posix": False,
+    "--init-file": True,
+    "--rcfile": True,
+}
 
 
 @dataclass(frozen=True, slots=True)
 class BashArgs:
     """One parsed ``bash``/``sh`` invocation.
 
+    The two failure fields report what went wrong rather than a rendered
+    message, the way ``ShellParse`` does: the wording and the exit code
+    belong to the caller, which is the only thing that knows the head
+    word the shell was spelled as.
+
     Args:
         script (str | None): inline program text from ``-c``.
         path (str | None): script file operand, as typed.
         argv (list[str]): words after the program, ``$0`` first for the
-            ``-c`` form and all positional for the file form.
-        options (list[str]): shell options the startup flags turn on.
-        read_stdin (bool): ``-s`` was given.
-        error (tuple | None): a ready usage failure, when parsing failed.
+            ``-c`` form and all positional for the other two.
+        settings (tuple[tuple[str, bool], ...]): shell options the
+            startup flags turn on or off, in the order written.
+        invalid (str | None): the option word the shell does not have.
+        needs_value (str | None): the option given no argument.
     """
     script: str | None = None
     path: str | None = None
     argv: list[str] = field(default_factory=list)
-    options: list[str] = field(default_factory=list)
-    read_stdin: bool = False
-    error: tuple[None, IOResult, ExecutionNode] | None = None
+    settings: tuple[tuple[str, bool], ...] = ()
+    invalid: str | None = None
+    needs_value: str | None = None
 
 
-def parse_bash_args(name: str, args: list[str]) -> BashArgs:
+def parse_bash_args(args: list[str]) -> BashArgs:
     """Split a ``bash``/``sh`` argument list into flags, program and argv.
 
     Option parsing stops at the first operand, so everything after a
     script file (or after ``-c``'s program text) is positional, even when
     it looks like a flag: ``bash run.sh -c foo`` passes ``-c foo`` to the
-    script.
+    script. ``-`` and ``--`` both end it without being operands.
+
+    ``-c`` takes the next *word*, never the rest of its cluster, which is
+    where bash's own parser departs from getopt: ``bash -cx 'echo hi'``
+    traces and runs ``echo hi`` rather than running ``x``.
 
     Args:
-        name (str): the head word, used as the diagnostic prefix.
         args (list[str]): words after the head word.
     """
-    options: list[str] = []
+    settings: list[tuple[str, bool]] = []
     read_stdin = False
     i = 0
     while i < len(args):
         tok = args[i]
-        if tok == "--":
+        if tok in ("--", "-"):
             i += 1
             break
-        if tok == "-s":
-            read_stdin = True
-            i += 1
+        if tok.startswith("--"):
+            takes_value = _BASH_LONG_OPTIONS.get(tok)
+            if takes_value is None:
+                return BashArgs(invalid=tok)
+            i += 2 if takes_value else 1
             continue
-        if tok in ("-o", "+o"):
-            i += 2
-            continue
-        if tok in _BASH_NOOP_LONG_FLAGS:
-            i += 1
-            continue
-        if not (tok.startswith("-") and len(tok) > 1
-                and not tok.startswith("--")):
+        nxt = args[i + 1] if i + 1 < len(args) else None
+        word = parse_option_word(tok, nxt)
+        if word is None:
             break
-        chars = tok[1:]
-        if "c" in chars:
-            if i + 1 >= len(args):
-                return BashArgs(error=_bash_error(
-                    name, "-c: option requires an argument", 2))
-            options.extend(SET_FLAG_TO_OPTION[c] for c in chars
-                           if c in SET_FLAG_TO_OPTION)
-            return BashArgs(script=args[i + 1],
-                            argv=args[i + 2:],
-                            options=options,
-                            read_stdin=read_stdin)
-        if not all(ch in _BASH_NOOP_SHORT_FLAGS or ch == "s"
-                   or ch in SET_FLAG_TO_OPTION for ch in chars):
-            return BashArgs(
-                error=_bash_error(name, f"{tok}: unsupported option", 2))
-        options.extend(SET_FLAG_TO_OPTION[c] for c in chars
-                       if c in SET_FLAG_TO_OPTION)
-        read_stdin = read_stdin or "s" in chars
-        i += 1
-    if i < len(args):
+        if any(ch not in _BASH_START_FLAGS for ch in word.other):
+            return BashArgs(invalid=tok)
+        settings.extend(word.settings)
+        read_stdin = read_stdin or "s" in word.other
+        if "c" in word.other:
+            if i + word.consumed >= len(args):
+                return BashArgs(needs_value="-c")
+            return BashArgs(script=args[i + word.consumed],
+                            argv=args[i + word.consumed + 1:],
+                            settings=tuple(settings))
+        i += word.consumed
+    # The program comes from stdin whenever no operand names one, which
+    # is the rule `-s` states explicitly for the case where operands do
+    # follow: `bash -s A B` reads stdin and makes A and B positional.
+    if i < len(args) and not read_stdin:
         return BashArgs(path=args[i],
                         argv=args[i + 1:],
-                        options=options,
-                        read_stdin=read_stdin)
-    return BashArgs(options=options, read_stdin=read_stdin)
+                        settings=tuple(settings))
+    return BashArgs(argv=args[i:], settings=tuple(settings))
 
 
 async def read_script_file(
@@ -192,17 +271,16 @@ async def read_script_file(
 ) -> tuple[str, None] | tuple[None, tuple[None, IOResult, ExecutionNode]]:
     """Read a script file operand, or the failure bash reports for it.
 
-    GNU splits the diagnostics by how far startup got. A file it cannot
-    open is blamed on the shell (``bash: run.sh: No such file or
-    directory``, exit 127; ``Permission denied``, exit 126), while a
-    directory opens fine and only fails on the first read, by which point
-    ``$0`` is already the operand, so bash prints it twice (``/tmp: /tmp:
-    Is a directory``, exit 126). Reproduced rather than tidied up: it is
-    what an agent copying a message into a search box will find.
-
-    A backend that cannot tell a missing path from an unreadable one
-    raises ENOENT for a directory too, so the stat probe runs on the
-    failure path to recover the distinction.
+    GNU splits the diagnostics by how far startup got, and both halves
+    fall out of the errno rather than being listed case by case. A file
+    the shell cannot open at all is blamed on the shell, and only a
+    missing one is exit 127 (``bash: run.sh: No such file or directory``);
+    anything it found but could not run is 126 (``Permission denied``,
+    ``Not a directory``). A directory is the exception, because it opens
+    fine and fails on the first read, by which point ``$0`` is already the
+    operand, so bash prints it twice (``/tmp: /tmp: Is a directory``, exit
+    126). Reproduced rather than tidied up: it is what an agent copying a
+    message into a search box will find.
 
     Args:
         dispatch (Callable): op dispatcher, used to read the file.
@@ -210,18 +288,17 @@ async def read_script_file(
         path (str): the script operand, as typed.
         session (Session): shell session state, for the working directory.
     """
-    scope = _to_scope(resolve_path(path, session.cwd))
     try:
-        data, _ = await dispatch("read", scope)
+        return await read_script_text(dispatch, path, session.cwd), None
     except FS_ERRORS as exc:
-        stat = await resolve_path_stat(dispatch, scope)
-        if stat is not None and stat.type == FileType.DIRECTORY:
-            return None, _bash_error(path, f"{path}: Is a directory", 126)
-        strerror = fs_strerror(exc) or "No such file or directory"
-        code = 126 if isinstance(exc, PermissionError) else 127
-        return None, _bash_error(name, f"{path}: {strerror}", code)
-    return (data.decode(
-        errors="replace") if isinstance(data, bytes) else ""), None
+        strerror = fs_strerror(exc)
+        if isinstance(exc, IsADirectoryError):
+            return None, script_error(path,
+                                      f"{path}: {strerror}",
+                                      126,
+                                      command=name)
+        code = 127 if isinstance(exc, FileNotFoundError) else 126
+        return None, script_error(name, f"{path}: {strerror}", code)
 
 
 async def handle_bash(
@@ -234,20 +311,35 @@ async def handle_bash(
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     """Run a nested shell: inline text from ``-c``, or a script file.
 
+    A nested shell is a child shell, so it runs on a snapshot of the
+    session and the caller gets its state back afterwards:
+    ``bash -c 'cd /x'`` leaves the caller where it was, as it does in
+    bash, where the nested shell is a separate process. `source` is the
+    opposite case and deliberately does not snapshot, because a sourced
+    file is the caller.
+
     Args:
         dispatch (Callable): op dispatcher, used to read a script file.
         execute_fn (Callable): runs the program text in this session.
         args (list[str]): words after the head word.
         session (Session): shell session state.
         stdin (ByteSource | None): input stream, also the program source
-            under ``-s``.
+            when no operand names one.
         name (str): the head word (``bash`` or ``sh``). bash reports
             itself by ``argv[0]``, so the diagnostics follow the spelling
             the caller used.
     """
-    parsed = parse_bash_args(name, args)
-    if parsed.error is not None:
-        return parsed.error
+    parsed = parse_bash_args(args)
+    if parsed.invalid is not None:
+        # GNU words this "invalid option" and follows it with a usage
+        # block. One word covers both cases here on purpose: some of what
+        # lands here is an option bash has and mirage does not implement
+        # (`-r`, `-a`, `--version`), and calling those invalid would be a
+        # lie. The exit status is GNU's 2 either way.
+        return script_error(name, f"{parsed.invalid}: unsupported option", 2)
+    if parsed.needs_value is not None:
+        return script_error(
+            name, f"{parsed.needs_value}: option requires an argument", 2)
     script = parsed.script
     named = script is not None and bool(parsed.argv)
     script_name = parsed.argv[0] if named else name
@@ -258,28 +350,24 @@ async def handle_bash(
                                                  session)
         if failure is not None:
             return failure
-    if script is None and parsed.read_stdin and stdin is not None:
+    if script is None and stdin is not None:
         stdin_data = await materialize(stdin)
         if stdin_data:
             script = stdin_data.decode(errors="replace")
             stdin = None
     if script is None:
         return None, IOResult(), ExecutionNode(command=name, exit_code=0)
-    saved_positional = session.positional_args
-    saved_script_name = session.script_name
-    saved_options = dict(session.shell_options)
+    saved = session.snapshot()
     session.positional_args = positional
     session.script_name = script_name
-    for option in parsed.options:
-        session.shell_options[option] = True
+    for option, enable in parsed.settings:
+        session.shell_options[option] = enable
     try:
         io = await execute_fn(script,
                               session_id=session.session_id,
                               stdin=stdin)
     finally:
-        session.positional_args = saved_positional
-        session.script_name = saved_script_name
-        session.shell_options = saved_options
+        session.restore(saved)
     label = f"{name} {parsed.path}" if parsed.path else f"{name} -c {script}"
     return io.stdout, io, ExecutionNode(command=label, exit_code=io.exit_code)
 

--- a/python/mirage/workspace/executor/builtins/script.py
+++ b/python/mirage/workspace/executor/builtins/script.py
@@ -360,6 +360,10 @@ async def handle_bash(
     saved = session.snapshot()
     session.positional_args = positional
     session.script_name = script_name
+    # A child shell is outside every `source` its caller is inside, so a
+    # top-level `return` in the script it runs is the error bash reports
+    # rather than an early exit the program loop absorbs.
+    session.source_depth = 0
     for option, enable in parsed.settings:
         session.shell_options[option] = enable
     try:

--- a/python/mirage/workspace/executor/builtins/vars.py
+++ b/python/mirage/workspace/executor/builtins/vars.py
@@ -25,7 +25,7 @@ from mirage.io.types import ByteSource
 from mirage.shell.array import array_extent, array_unset
 from mirage.shell.call_stack import CallStack
 from mirage.shell.errors import ExitSignal
-from mirage.shell.types import SET_FLAG_TO_OPTION
+from mirage.shell.options import parse_option_word
 from mirage.workspace.executor.builtins.text import _PRINTF_TARGET_RE
 from mirage.workspace.executor.control import ReturnSignal
 from mirage.workspace.expand.variable import _array_index
@@ -713,23 +713,19 @@ async def handle_set(
         if tok == "--":
             session.positional_args = args[i + 1:]
             return None, IOResult(), ExecutionNode(command="set", exit_code=0)
-        if tok in ("-o", "+o"):
-            if i + 1 < len(args):
-                session.shell_options[args[i + 1]] = (tok == "-o")
-                i += 2
-                continue
-            i += 1
-            continue
-        if (tok.startswith("-") or tok.startswith("+")) and len(tok) > 1:
-            enable = tok[0] == "-"
-            for ch in tok[1:]:
-                opt = SET_FLAG_TO_OPTION.get(ch)
-                if opt:
-                    session.shell_options[opt] = enable
-            i += 1
-            continue
-        session.positional_args = args[i:]
-        break
+        word = parse_option_word(tok,
+                                 args[i + 1] if i + 1 < len(args) else None)
+        if word is None:
+            session.positional_args = args[i:]
+            break
+        for option, enable in word.settings:
+            session.shell_options[option] = enable
+        # A letter naming no option is ignored rather than refused: bash
+        # has options mirage does not implement (`-a`, `-B`, `-H`), and
+        # `set` is where a script turns those on without wanting to fail.
+        # A nested shell answers the same leftovers differently, which is
+        # why the grammar hands them back instead of deciding here.
+        i += word.consumed
     return None, IOResult(), ExecutionNode(command="set", exit_code=0)
 
 

--- a/python/mirage/workspace/executor/pipes.py
+++ b/python/mirage/workspace/executor/pipes.py
@@ -232,16 +232,7 @@ async def handle_subshell(
             (bash forks: the parent's table never sees these jobs).
         agent_id (str | None): agent identity for job bookkeeping.
     """
-    saved_cwd = session.cwd
-    saved_env = dict(session.env)
-    saved_options = dict(session.shell_options)
-    saved_readonly = set(session.readonly_vars)
-    saved_arrays = {k: list(v) for k, v in session.arrays.items()}
-    saved_functions = dict(session.functions)
-    saved_positional = list(getattr(session, "positional_args", None) or [])
-    saved_last_bg_job = session.last_bg_job_id
-    saved_getopts_pos = session._getopts_pos
-    saved_getopts_optind = session._getopts_optind
+    saved = session.snapshot()
     try:
         all_stdout: list[Any] = []
         merged_io = IOResult()
@@ -296,13 +287,4 @@ async def handle_subshell(
         combined = async_chain(*all_stdout) if all_stdout else None
         return combined, merged_io, last_exec
     finally:
-        session.cwd = saved_cwd
-        session.env = saved_env
-        session.shell_options = saved_options
-        session.readonly_vars = saved_readonly
-        session.arrays = saved_arrays
-        session.functions = saved_functions
-        session.positional_args = saved_positional
-        session.last_bg_job_id = saved_last_bg_job
-        session._getopts_pos = saved_getopts_pos
-        session._getopts_optind = saved_getopts_optind
+        session.restore(saved)

--- a/python/mirage/workspace/expand/variable.py
+++ b/python/mirage/workspace/expand/variable.py
@@ -116,7 +116,7 @@ def _lookup_var(var: str,
     if var.isdigit():
         idx = int(var)
         if idx == 0:
-            return session.script_name or SHELL_ARGV0
+            return session.argv0
         if call_stack and call_stack.get_positional(idx):
             return call_stack.get_positional(idx)
         if positional and 0 < idx <= len(positional):
@@ -692,13 +692,6 @@ def _slice_array(arr: ShellArray, groups: list[str],
     return array_slice(arr, offset, length)
 
 
-# What the shell calls itself, bash's "bash", when no script is running:
-# a nested `bash`/`sh` overrides it through Session.script_name. It is a
-# value of "$@" only through a slice, where bash numbers the positional
-# parameters from 1 and index 0 is this.
-SHELL_ARGV0 = "mirage"
-
-
 def _is_at_splat(p: _BraceParse) -> bool:
     """Whether a parsed "${...}" splats one word per element.
 
@@ -782,8 +775,7 @@ async def expand_array_at(node: tree_sitter.Node, session: Session,
         # it ahead of $1. Pinned on bash 5.2.37; macOS bash 3.2 drops
         # it, so probe this one in docker, not locally.
         params: list[str | None] = [*_positional_args(session, call_stack)]
-        argv0 = session.script_name or SHELL_ARGV0
-        arr = [argv0, *params] if p.op == ":" else params
+        arr = [session.argv0, *params] if p.op == ":" else params
     else:
         arrays = getattr(session, "arrays", {})
         arr = arrays.get(p.var_name)

--- a/python/mirage/workspace/expand/variable.py
+++ b/python/mirage/workspace/expand/variable.py
@@ -116,7 +116,7 @@ def _lookup_var(var: str,
     if var.isdigit():
         idx = int(var)
         if idx == 0:
-            return SHELL_ARGV0
+            return session.script_name or SHELL_ARGV0
         if call_stack and call_stack.get_positional(idx):
             return call_stack.get_positional(idx)
         if positional and 0 < idx <= len(positional):
@@ -692,9 +692,10 @@ def _slice_array(arr: ShellArray, groups: list[str],
     return array_slice(arr, offset, length)
 
 
-# What the shell calls itself, bash's "bash". It is a value of "$@"
-# only through a slice, where bash numbers the positional parameters
-# from 1 and index 0 is this.
+# What the shell calls itself, bash's "bash", when no script is running:
+# a nested `bash`/`sh` overrides it through Session.script_name. It is a
+# value of "$@" only through a slice, where bash numbers the positional
+# parameters from 1 and index 0 is this.
 SHELL_ARGV0 = "mirage"
 
 
@@ -781,7 +782,8 @@ async def expand_array_at(node: tree_sitter.Node, session: Session,
         # it ahead of $1. Pinned on bash 5.2.37; macOS bash 3.2 drops
         # it, so probe this one in docker, not locally.
         params: list[str | None] = [*_positional_args(session, call_stack)]
-        arr = [SHELL_ARGV0, *params] if p.op == ":" else params
+        argv0 = session.script_name or SHELL_ARGV0
+        arr = [argv0, *params] if p.op == ":" else params
     else:
         arrays = getattr(session, "arrays", {})
         arr = arrays.get(p.var_name)

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -399,7 +399,8 @@ async def _run_argv(
         return await handle_eval(execute_fn, args, session)
 
     if name in (SB.BASH, SB.SH):
-        return await handle_bash(execute_fn, args, session, stdin)
+        return await handle_bash(dispatch, execute_fn, args, session, stdin,
+                                 str(name))
 
     if name == SB.EXPORT:
         return await handle_export(args, session)

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -19,8 +19,83 @@ from typing import Any
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource
 from mirage.shell.array import ShellArray
+from mirage.shell.constants import SHELL_ARGV0
 from mirage.shell.types import FunctionBody
 from mirage.types import MountMode
+
+# What a fork of this session carries over. Written down once because
+# `fork` builds a copy from it and `tests/workspace/session/test_session.py`
+# asserts that every dataclass field is either here or in
+# TRANSIENT_FIELDS, so a field added later cannot be silently dropped by
+# a hand-written literal the way `script_name` was.
+INHERITED_FIELDS: tuple[str, ...] = (
+    "session_id",
+    "cwd",
+    "env",
+    "created_at",
+    "functions",
+    "last_exit_code",
+    "shell_options",
+    "readonly_vars",
+    "arrays",
+    "mount_modes",
+    "generation",
+    "pipeline_timeout_seconds",
+    "last_bg_job_id",
+    "positional_args",
+    "script_name",
+    "_getopts_pos",
+    "_getopts_optind",
+)
+
+# State that belongs to the line being executed, not to the shell, so a
+# fork starts it fresh: the errexit marker, the source nesting depth, the
+# stdin the caller happened to pass and the running function's locals.
+TRANSIENT_FIELDS: tuple[str, ...] = (
+    "errexit_immune",
+    "source_depth",
+    "_stdin_buffer",
+    "_stdin_source",
+    "_local_vars",
+    "_local_arrays",
+    "_cmdsub_seq",
+    "_cmdsub_status",
+)
+
+# What a child shell gets its own copy of, and the parent gets back
+# afterwards. A `( … )` subshell and a nested `bash`/`sh` are both child
+# shells and both read this list, so neither can drift into isolating a
+# field the other leaks. `last_exit_code` is deliberately absent: `$?`
+# after a child shell is the child's status, which is the one thing it
+# reports back.
+CHILD_SHELL_FIELDS: tuple[str, ...] = (
+    "cwd",
+    "env",
+    "functions",
+    "shell_options",
+    "readonly_vars",
+    "arrays",
+    "positional_args",
+    "script_name",
+    "last_bg_job_id",
+    "_getopts_pos",
+    "_getopts_optind",
+)
+
+
+def copy_state(value: Any) -> Any:
+    """Copy one session field deeply enough that a child cannot write back.
+
+    Args:
+        value (Any): the field value.
+    """
+    if isinstance(value, dict):
+        return {k: copy_state(v) for k, v in value.items()}
+    if isinstance(value, set):
+        return set(value)
+    if isinstance(value, list):
+        return list(value)
+    return value
 
 
 @dataclass
@@ -98,52 +173,51 @@ class Session:
             }
         return cls(**data)
 
+    @property
+    def argv0(self) -> str:
+        """What ``$0`` expands to.
+
+        None is the shell itself; a nested `bash`/`sh` sets it to the
+        script it is running, or to the name given after `-c`. An empty
+        name is a name, so it is not folded into the default: GNU
+        ``bash -c 'echo "[$0]"' ""`` prints ``[]``.
+        """
+        return SHELL_ARGV0 if self.script_name is None else self.script_name
+
     def fork(self, **overrides: Any) -> "Session":
         """Return a copy of this session with overrides applied.
 
-        Mutable containers (env, functions, readonly_vars, arrays,
-        shell_options) are shallow-copied so mutations on the fork do
-        not leak back into the source. Every field, including
-        capability fields like ``mount_modes``, is propagated, so
-        callers cannot accidentally forget one when adding new fields.
+        Every inherited field is copied deeply enough that mutations on
+        the fork do not leak back into the source. The field list is
+        INHERITED_FIELDS rather than a literal written out here, so a
+        field added to the dataclass is propagated by construction.
 
         Args:
             **overrides: Field-name kwargs to override on the copy.
         """
         defaults: dict[str, Any] = {
-            "session_id":
-            self.session_id,
-            "cwd":
-            self.cwd,
-            "env":
-            dict(self.env),
-            "created_at":
-            self.created_at,
-            "functions":
-            dict(self.functions),
-            "last_exit_code":
-            self.last_exit_code,
-            "shell_options":
-            dict(self.shell_options),
-            "readonly_vars":
-            set(self.readonly_vars),
-            "arrays": {
-                k: list(v)
-                for k, v in self.arrays.items()
-            },
-            "mount_modes":
-            (dict(self.mount_modes) if self.mount_modes is not None else None),
-            "generation":
-            self.generation,
-            "pipeline_timeout_seconds":
-            self.pipeline_timeout_seconds,
-            "last_bg_job_id":
-            self.last_bg_job_id,
-            "positional_args":
-            list(self.positional_args),
+            name: copy_state(getattr(self, name))
+            for name in INHERITED_FIELDS
         }
         defaults.update(overrides)
-        forked = Session(**defaults)
-        forked._getopts_pos = self._getopts_pos
-        forked._getopts_optind = self._getopts_optind
-        return forked
+        return Session(**defaults)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Copy the state a child shell runs on top of.
+
+        Args:
+            None
+        """
+        return {
+            name: copy_state(getattr(self, name))
+            for name in CHILD_SHELL_FIELDS
+        }
+
+    def restore(self, state: dict[str, Any]) -> None:
+        """Put back a snapshot, ending a child shell.
+
+        Args:
+            state (dict[str, Any]): what ``snapshot`` returned.
+        """
+        for name, value in state.items():
+            setattr(self, name, value)

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -39,6 +39,10 @@ class Session:
     pipeline_timeout_seconds: float | None = None
     last_bg_job_id: int | None = None
     positional_args: list[str] = field(default_factory=list)
+    # What `$0` expands to. None is the shell itself; a nested `bash`/`sh`
+    # sets it to the script file it is running, or to the name given after
+    # `-c`, and restores it afterwards.
+    script_name: str | None = None
     # Transient `set -e` marker: True when the failure just returned
     # came from a short-circuited &&/|| branch or a `!`-negated command,
     # which bash exempts from errexit. Reset on every node execution.

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -70,6 +70,7 @@ TRANSIENT_FIELDS: tuple[str, ...] = (
 # reports back.
 CHILD_SHELL_FIELDS: tuple[str, ...] = (
     "cwd",
+    "source_depth",
     "env",
     "functions",
     "shell_options",

--- a/python/tests/shell/test_options.py
+++ b/python/tests/shell/test_options.py
@@ -1,0 +1,71 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.shell.options import parse_option_word
+
+
+def test_operand_is_not_an_option_word():
+    assert parse_option_word("run.sh", None) is None
+
+
+def test_end_of_options_markers_are_not_option_words():
+    assert parse_option_word("--", None) is None
+    assert parse_option_word("-", None) is None
+
+
+def test_long_word_is_not_an_option_word():
+    assert parse_option_word("--norc", None) is None
+
+
+def test_minus_enables_and_plus_disables():
+    assert parse_option_word("-x", None).settings == (("xtrace", True), )
+    assert parse_option_word("+x", None).settings == (("xtrace", False), )
+
+
+def test_cluster_keeps_written_order():
+    word = parse_option_word("-eux", None)
+    assert word.settings == (("errexit", True), ("nounset", True), ("xtrace",
+                                                                    True))
+    assert word.other == ""
+
+
+def test_letters_naming_no_option_come_back_as_other():
+    word = parse_option_word("-xc", None)
+    assert word.settings == (("xtrace", True), )
+    assert word.other == "c"
+    assert word.consumed == 1
+
+
+def test_o_names_the_option_in_the_next_word():
+    word = parse_option_word("-o", "pipefail")
+    assert word.settings == (("pipefail", True), )
+    assert word.consumed == 2
+
+
+def test_plus_o_disables_the_named_option():
+    word = parse_option_word("+o", "xtrace")
+    assert word.settings == (("xtrace", False), )
+    assert word.consumed == 2
+
+
+def test_o_is_read_from_anywhere_in_a_cluster():
+    word = parse_option_word("-xo", "pipefail")
+    assert word.settings == (("xtrace", True), ("pipefail", True))
+    assert word.consumed == 2
+
+
+def test_o_with_no_following_word_sets_nothing():
+    word = parse_option_word("-o", None)
+    assert word.settings == ()
+    assert word.consumed == 1

--- a/python/tests/shell/test_script_file.py
+++ b/python/tests/shell/test_script_file.py
@@ -1,0 +1,101 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+
+@pytest.mark.parametrize("head", ["sh", "bash"])
+def test_script_file_runs_its_lines(shell, head):
+    shell.create_file("run.sh", b"echo one\necho two\n")
+    assert shell.mirage(f"{head} /data/run.sh") == "one\ntwo\n"
+
+
+def test_script_file_relative_to_cwd(shell):
+    shell.create_file("run.sh", b"echo hi\n")
+    assert shell.mirage("sh run.sh") == "hi\n"
+
+
+def test_script_file_after_double_dash(shell):
+    shell.create_file("run.sh", b"echo hi\n")
+    assert shell.mirage("bash -- /data/run.sh") == "hi\n"
+
+
+def test_script_file_takes_positional_args(shell):
+    shell.create_file("run.sh", b"echo $# $1 $2\n")
+    assert shell.mirage("sh /data/run.sh a b") == "2 a b\n"
+
+
+def test_script_file_operands_are_not_flags(shell):
+    shell.create_file("run.sh", b'echo "$@"\n')
+    assert shell.mirage("sh /data/run.sh -c foo") == "-c foo\n"
+
+
+def test_script_file_sets_dollar_zero(shell):
+    shell.create_file("run.sh", b"echo $0\n")
+    assert shell.mirage("sh /data/run.sh") == "/data/run.sh\n"
+
+
+def test_script_file_restores_positional_args(shell):
+    shell.create_file("run.sh", b"echo inner $1\n")
+    out = shell.mirage("set -- outer; sh /data/run.sh inner-arg; echo $0 $1")
+    assert out == "inner inner-arg\nmirage outer\n"
+
+
+def test_script_file_exit_status_propagates(shell):
+    shell.create_file("run.sh", b"exit 7\n")
+    assert shell.mirage_exit("sh /data/run.sh") == 7
+
+
+@pytest.mark.parametrize("head", ["sh", "bash"])
+def test_missing_script_reports_the_file_and_exits_127(shell, head):
+    code, _, err = shell.mirage_result(f"{head} /data/nope.sh")
+    assert err == f"{head}: /data/nope.sh: No such file or directory\n"
+    assert code == 127
+
+
+def test_directory_script_exits_126(shell):
+    shell.create_file("sub/keep.txt", b"x\n")
+    code, _, err = shell.mirage_result("sh /data/sub")
+    assert err == "/data/sub: /data/sub: Is a directory\n"
+    assert code == 126
+
+
+def test_dash_x_traces_the_script(shell):
+    shell.create_file("run.sh", b"echo hi\n")
+    code, out, err = shell.mirage_result("bash -x /data/run.sh")
+    assert out == "hi\n"
+    assert err == "+ echo hi\n"
+    assert code == 0
+
+
+def test_dash_x_does_not_leak_into_the_caller(shell):
+    shell.create_file("run.sh", b"echo hi\n")
+    code, _, err = shell.mirage_result("bash -x /data/run.sh; echo after")
+    assert err == "+ echo hi\n"
+    assert code == 0
+
+
+def test_dash_c_still_runs_inline_text(shell):
+    assert shell.mirage("sh -c 'echo hello'") == "hello\n"
+
+
+def test_dash_c_takes_name_and_positional_args(shell):
+    out = shell.mirage("sh -c 'echo $0 $# $1 $2' myname a b")
+    assert out == "myname 2 a b\n"
+
+
+def test_dash_c_missing_argument_names_the_head_word(shell):
+    code, _, err = shell.mirage_result("sh -c")
+    assert err == "sh: -c: option requires an argument\n"
+    assert code == 2

--- a/python/tests/shell/test_script_file.py
+++ b/python/tests/shell/test_script_file.py
@@ -194,3 +194,23 @@ def test_source_with_no_operand_is_a_usage_error(shell):
                    "source: usage: source filename [arguments]\n")
     assert out == "after=2\n"
     assert code == 0
+
+
+@pytest.mark.parametrize("head", ["sh", "bash", "source"])
+def test_script_operand_follows_a_symlink(shell, head):
+    shell.create_file("run.sh", b"echo hi\n")
+    out = shell.mirage(
+        f"ln -s /data/run.sh /data/link.sh; {head} /data/link.sh")
+    assert out == "hi\n"
+
+
+def test_script_operand_follows_a_relative_symlink(shell):
+    shell.create_file("run.sh", b"echo hi\n")
+    assert shell.mirage("ln -s run.sh /data/rel.sh; sh /data/rel.sh") == "hi\n"
+
+
+def test_broken_symlink_operand_reports_the_link(shell):
+    code, _, err = shell.mirage_result(
+        "ln -s /data/gone.sh /data/dead.sh; sh /data/dead.sh")
+    assert err == "sh: /data/dead.sh: No such file or directory\n"
+    assert code == 127

--- a/python/tests/shell/test_script_file.py
+++ b/python/tests/shell/test_script_file.py
@@ -99,3 +99,98 @@ def test_dash_c_missing_argument_names_the_head_word(shell):
     code, _, err = shell.mirage_result("sh -c")
     assert err == "sh: -c: option requires an argument\n"
     assert code == 2
+
+
+def test_dash_o_applies_the_named_option(shell):
+    shell.create_file("pf.sh", b"false | true\necho pipefail=$?\n")
+    assert shell.mirage("bash -o pipefail /data/pf.sh") == "pipefail=1\n"
+
+
+def test_dash_o_applies_from_inside_a_cluster(shell):
+    shell.create_file("pf.sh", b"false | true\necho pipefail=$?\n")
+    code, out, err = shell.mirage_result("bash -xo pipefail /data/pf.sh")
+    assert out == "pipefail=1\n"
+    assert err == "+ false\n+ true\n+ echo pipefail=1\n"
+    assert code == 0
+
+
+def test_plus_flag_is_an_option_word_not_an_operand(shell):
+    shell.create_file("run.sh", b"echo hi\n")
+    assert shell.mirage_result("bash +x /data/run.sh") == (0, "hi\n", "")
+
+
+def test_plus_o_is_an_option_word_not_an_operand(shell):
+    shell.create_file("run.sh", b"echo hi\n")
+    assert shell.mirage_result("bash +o xtrace /data/run.sh") == (0, "hi\n",
+                                                                  "")
+
+
+def test_single_dash_ends_option_parsing(shell):
+    shell.create_file("run.sh", b"echo hi\n")
+    assert shell.mirage("bash - /data/run.sh") == "hi\n"
+
+
+def test_long_option_with_a_value_consumes_it(shell):
+    shell.create_file("run.sh", b"echo hi\n")
+    assert shell.mirage_result("bash --rcfile /data/run.sh") == (0, "", "")
+
+
+def test_unknown_long_option_is_a_usage_error(shell):
+    code, _, err = shell.mirage_result("bash --nosuch /data/run.sh")
+    assert err == "bash: --nosuch: unsupported option\n"
+    assert code == 2
+
+
+def test_program_comes_from_stdin_when_no_operand_names_one(shell):
+    assert shell.mirage("echo 'echo hi' | bash") == "hi\n"
+
+
+def test_dash_s_makes_every_operand_positional(shell):
+    out = shell.mirage("echo 'echo zero=$0 one=$1' | bash -s A B")
+    assert out == "zero=bash one=A\n"
+
+
+def test_nested_shell_does_not_leak_the_working_directory(shell):
+    shell.create_file("sub/keep.txt", b"x\n")
+    shell.create_file("cd.sh", b"cd /data/sub\n")
+    assert shell.mirage("bash /data/cd.sh; pwd") == "/data\n"
+
+
+def test_nested_shell_does_not_leak_an_export(shell):
+    shell.create_file("exp.sh", b"export LEAK=1\n")
+    assert shell.mirage("bash /data/exp.sh; echo [$LEAK]") == "[]\n"
+
+
+def test_nested_shell_options_do_not_leak_into_the_caller(shell):
+    shell.create_file("opt.sh", b"set -f\n")
+    shell.create_file("a.txt", b"x\n")
+    assert shell.mirage(
+        "bash /data/opt.sh; echo /data/*.txt") == "/data/a.txt\n"
+
+
+def test_sourced_shell_options_stay_set_in_the_caller(shell):
+    shell.create_file("opt.sh", b"set -f\n")
+    shell.create_file("a.txt", b"x\n")
+    assert shell.mirage(
+        "source /data/opt.sh; echo /data/*.txt") == "/data/*.txt\n"
+
+
+def test_source_reports_a_missing_file_as_typed(shell):
+    code, _, err = shell.mirage_result("source nope.sh")
+    assert err == "source: nope.sh: No such file or directory\n"
+    assert code == 1
+
+
+def test_source_reports_a_directory_operand(shell):
+    shell.create_file("sub/keep.txt", b"x\n")
+    code, _, err = shell.mirage_result("source /data/sub")
+    assert err == "source: /data/sub: Is a directory\n"
+    assert code == 1
+
+
+def test_source_with_no_operand_is_a_usage_error(shell):
+    code, out, err = shell.mirage_result("source; echo after=$?")
+    assert err == ("source: filename argument required\n"
+                   "source: usage: source filename [arguments]\n")
+    assert out == "after=2\n"
+    assert code == 0

--- a/python/tests/shell/test_script_file.py
+++ b/python/tests/shell/test_script_file.py
@@ -214,3 +214,18 @@ def test_broken_symlink_operand_reports_the_link(shell):
         "ln -s /data/gone.sh /data/dead.sh; sh /data/dead.sh")
     assert err == "sh: /data/dead.sh: No such file or directory\n"
     assert code == 127
+
+
+def test_return_in_a_child_shell_is_invalid_even_when_sourced(shell):
+    shell.create_file("child.sh", b"return 5\necho child-after\n")
+    shell.create_file("lib.sh", b"bash /data/child.sh\necho after=$?\n")
+    code, out, err = shell.mirage_result("source /data/lib.sh; echo done")
+    assert out == "child-after\nafter=0\ndone\n"
+    assert err == ("return: can only `return' from a function or "
+                   "sourced script\n")
+    assert code == 0
+
+
+def test_return_stays_valid_in_the_sourced_file_itself(shell):
+    shell.create_file("child.sh", b"return 5\necho child-after\n")
+    assert shell.mirage("source /data/child.sh; echo after=$?") == "after=5\n"

--- a/python/tests/workspace/executor/builtins/test_script.py
+++ b/python/tests/workspace/executor/builtins/test_script.py
@@ -16,7 +16,53 @@ import time
 
 import pytest
 
-from mirage.workspace.executor.builtins.script import handle_sleep
+from mirage.workspace.executor.builtins.script import (handle_sleep,
+                                                       parse_bash_args)
+
+
+def test_parse_bash_args_file_operand_ends_option_parsing():
+    parsed = parse_bash_args("sh", ["run.sh", "-x", "a"])
+    assert parsed.path == "run.sh"
+    assert parsed.argv == ["-x", "a"]
+    assert parsed.options == []
+
+
+def test_parse_bash_args_double_dash_protects_a_flag_shaped_file():
+    parsed = parse_bash_args("sh", ["--", "-weird.sh", "a"])
+    assert parsed.path == "-weird.sh"
+    assert parsed.argv == ["a"]
+
+
+def test_parse_bash_args_clustered_c_keeps_set_options():
+    parsed = parse_bash_args("bash", ["-xc", "echo hi", "name", "a"])
+    assert parsed.script == "echo hi"
+    assert parsed.argv == ["name", "a"]
+    assert parsed.options == ["xtrace"]
+
+
+def test_parse_bash_args_maps_set_flags_to_options():
+    parsed = parse_bash_args("bash", ["-eux", "run.sh"])
+    assert parsed.path == "run.sh"
+    assert parsed.options == ["errexit", "nounset", "xtrace"]
+
+
+def test_parse_bash_args_dash_s_reads_stdin():
+    parsed = parse_bash_args("bash", ["-s"])
+    assert parsed.read_stdin is True
+    assert parsed.path is None and parsed.script is None
+
+
+def test_parse_bash_args_skips_o_and_its_value():
+    parsed = parse_bash_args("bash", ["-o", "pipefail", "run.sh"])
+    assert parsed.path == "run.sh"
+
+
+def test_parse_bash_args_unsupported_option_is_a_usage_error():
+    parsed = parse_bash_args("sh", ["-Z"])
+    assert parsed.error is not None
+    _, io, _ = parsed.error
+    assert io.exit_code == 2
+    assert io.stderr == b"sh: -Z: unsupported option\n"
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/executor/builtins/test_script.py
+++ b/python/tests/workspace/executor/builtins/test_script.py
@@ -16,53 +16,79 @@ import time
 
 import pytest
 
+from mirage.types import FileStat, FileType
+from mirage.utils.errors import enoent
 from mirage.workspace.executor.builtins.script import (handle_sleep,
-                                                       parse_bash_args)
+                                                       parse_bash_args,
+                                                       read_script_text)
+from mirage.workspace.session import Session
 
 
 def test_parse_bash_args_file_operand_ends_option_parsing():
-    parsed = parse_bash_args("sh", ["run.sh", "-x", "a"])
+    parsed = parse_bash_args(["run.sh", "-x", "a"])
     assert parsed.path == "run.sh"
     assert parsed.argv == ["-x", "a"]
-    assert parsed.options == []
+    assert parsed.settings == ()
 
 
 def test_parse_bash_args_double_dash_protects_a_flag_shaped_file():
-    parsed = parse_bash_args("sh", ["--", "-weird.sh", "a"])
+    parsed = parse_bash_args(["--", "-weird.sh", "a"])
     assert parsed.path == "-weird.sh"
     assert parsed.argv == ["a"]
 
 
+def test_parse_bash_args_single_dash_ends_option_parsing():
+    parsed = parse_bash_args(["-", "run.sh"])
+    assert parsed.path == "run.sh"
+
+
 def test_parse_bash_args_clustered_c_keeps_set_options():
-    parsed = parse_bash_args("bash", ["-xc", "echo hi", "name", "a"])
+    parsed = parse_bash_args(["-xc", "echo hi", "name", "a"])
     assert parsed.script == "echo hi"
     assert parsed.argv == ["name", "a"]
-    assert parsed.options == ["xtrace"]
+    assert parsed.settings == (("xtrace", True), )
 
 
 def test_parse_bash_args_maps_set_flags_to_options():
-    parsed = parse_bash_args("bash", ["-eux", "run.sh"])
+    parsed = parse_bash_args(["-eux", "run.sh"])
     assert parsed.path == "run.sh"
-    assert parsed.options == ["errexit", "nounset", "xtrace"]
+    assert parsed.settings == (("errexit", True), ("nounset", True), ("xtrace",
+                                                                      True))
 
 
-def test_parse_bash_args_dash_s_reads_stdin():
-    parsed = parse_bash_args("bash", ["-s"])
-    assert parsed.read_stdin is True
+def test_parse_bash_args_last_sign_wins_within_one_invocation():
+    parsed = parse_bash_args(["-e", "+e", "run.sh"])
+    assert parsed.path == "run.sh"
+    assert parsed.settings == (("errexit", True), ("errexit", False))
+
+
+def test_parse_bash_args_dash_s_keeps_operands_positional():
+    parsed = parse_bash_args(["-s", "A", "B"])
     assert parsed.path is None and parsed.script is None
+    assert parsed.argv == ["A", "B"]
 
 
-def test_parse_bash_args_skips_o_and_its_value():
-    parsed = parse_bash_args("bash", ["-o", "pipefail", "run.sh"])
+def test_parse_bash_args_applies_o_and_its_value():
+    parsed = parse_bash_args(["-o", "pipefail", "run.sh"])
+    assert parsed.path == "run.sh"
+    assert parsed.settings == (("pipefail", True), )
+
+
+def test_parse_bash_args_long_option_consumes_its_value():
+    parsed = parse_bash_args(["--rcfile", "rc", "run.sh"])
     assert parsed.path == "run.sh"
 
 
-def test_parse_bash_args_unsupported_option_is_a_usage_error():
-    parsed = parse_bash_args("sh", ["-Z"])
-    assert parsed.error is not None
-    _, io, _ = parsed.error
-    assert io.exit_code == 2
-    assert io.stderr == b"sh: -Z: unsupported option\n"
+def test_parse_bash_args_unsupported_short_option():
+    assert parse_bash_args(["-Z"]).invalid == "-Z"
+
+
+def test_parse_bash_args_unsupported_long_option():
+    assert parse_bash_args(["--nosuch", "run.sh"]).invalid == "--nosuch"
+
+
+def test_parse_bash_args_dash_c_needs_a_value():
+    assert parse_bash_args(["-c"]).needs_value == "-c"
 
 
 @pytest.mark.asyncio
@@ -99,3 +125,39 @@ async def test_sleep_zero_returns_promptly():
     _, io, _ = await handle_sleep(["0"])
     assert io.exit_code == 0
     assert time.monotonic() - start < 0.05
+
+
+@pytest.mark.asyncio
+async def test_read_script_text_reports_a_missing_file():
+    session = Session(session_id="s", cwd="/")
+
+    async def dispatch(op, path, **kwargs):
+        raise enoent(path)
+
+    with pytest.raises(FileNotFoundError):
+        await read_script_text(dispatch, "/missing.sh", session.cwd)
+
+
+@pytest.mark.asyncio
+async def test_read_script_text_calls_a_directory_a_directory():
+    session = Session(session_id="s", cwd="/")
+    stat = FileStat(name="sub", path="/sub", type=FileType.DIRECTORY, size=0)
+
+    async def dispatch(op, path, **kwargs):
+        if op == "stat":
+            return stat, None
+        raise enoent(path)
+
+    with pytest.raises(IsADirectoryError):
+        await read_script_text(dispatch, "/sub", session.cwd)
+
+
+@pytest.mark.asyncio
+async def test_read_script_text_propagates_a_non_filesystem_failure():
+    session = Session(session_id="s", cwd="/")
+
+    async def dispatch(op, path, **kwargs):
+        raise RuntimeError("token expired")
+
+    with pytest.raises(RuntimeError, match="token expired"):
+        await read_script_text(dispatch, "/script.sh", session.cwd)

--- a/python/tests/workspace/session/test_session.py
+++ b/python/tests/workspace/session/test_session.py
@@ -12,8 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import dataclasses
+
 from mirage.types import MountMode
 from mirage.workspace.session import Session
+from mirage.workspace.session.session import (CHILD_SHELL_FIELDS,
+                                              INHERITED_FIELDS,
+                                              TRANSIENT_FIELDS)
 
 
 def test_session_defaults():
@@ -189,3 +194,38 @@ def test_fork_deep_copies_mutable_containers():
     forked.arrays["A"].append("2")
     assert "NEW" not in original.env
     assert original.arrays["A"] == ["1"]
+
+
+def test_every_field_is_classified_as_inherited_or_transient():
+    declared = {f.name for f in dataclasses.fields(Session)}
+    classified = set(INHERITED_FIELDS) | set(TRANSIENT_FIELDS)
+    assert declared == classified
+
+
+def test_child_shell_fields_are_a_subset_of_the_declared_fields():
+    declared = {f.name for f in dataclasses.fields(Session)}
+    assert set(CHILD_SHELL_FIELDS) <= declared
+
+
+def test_fork_carries_every_inherited_field():
+    original = Session(session_id="orig", script_name="/data/run.sh")
+    assert original.fork().script_name == "/data/run.sh"
+
+
+def test_snapshot_and_restore_undo_a_child_shell():
+    session = Session(session_id="s", cwd="/data", env={"A": "1"})
+    saved = session.snapshot()
+    session.cwd = "/other"
+    session.env["A"] = "2"
+    session.functions["f"] = []
+    session.script_name = "run.sh"
+    session.restore(saved)
+    assert session.cwd == "/data"
+    assert session.env == {"A": "1"}
+    assert session.functions == {}
+    assert session.script_name is None
+
+
+def test_argv0_keeps_an_empty_script_name():
+    assert Session(session_id="s").argv0 == "mirage"
+    assert Session(session_id="s", script_name="").argv0 == ""

--- a/typescript/packages/core/src/shell/constants.ts
+++ b/typescript/packages/core/src/shell/constants.ts
@@ -45,3 +45,8 @@ export const ARITH_ASSIGN_OPS = new Set([
 // Recursion budget for variables holding expressions (`x="1+2"; $((x))`),
 // mirroring bash's expression recursion limit.
 export const ARITH_MAX_DEPTH = 16
+
+// What the shell calls itself when no script is running, bash's "bash".
+// A nested `bash`/`sh` overrides it through Session.scriptName, and
+// `Session.argv0` is the one place the two are folded together.
+export const SHELL_ARGV0 = 'mirage'

--- a/typescript/packages/core/src/shell/options.test.ts
+++ b/typescript/packages/core/src/shell/options.test.ts
@@ -1,0 +1,78 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { parseOptionWord } from './options.ts'
+
+describe('parseOptionWord', () => {
+  it('reads an operand as no option word', () => {
+    expect(parseOptionWord('run.sh', null)).toBeNull()
+  })
+
+  it('reads the end-of-options markers as no option word', () => {
+    expect(parseOptionWord('--', null)).toBeNull()
+    expect(parseOptionWord('-', null)).toBeNull()
+  })
+
+  it('leaves a long word to the caller', () => {
+    expect(parseOptionWord('--norc', null)).toBeNull()
+  })
+
+  it('enables on minus and disables on plus', () => {
+    expect(parseOptionWord('-x', null)?.settings).toEqual([['xtrace', true]])
+    expect(parseOptionWord('+x', null)?.settings).toEqual([['xtrace', false]])
+  })
+
+  it('keeps a cluster in written order', () => {
+    const word = parseOptionWord('-eux', null)
+    expect(word?.settings).toEqual([
+      ['errexit', true],
+      ['nounset', true],
+      ['xtrace', true],
+    ])
+    expect(word?.other).toBe('')
+  })
+
+  it('hands back letters naming no option', () => {
+    const word = parseOptionWord('-xc', null)
+    expect(word?.settings).toEqual([['xtrace', true]])
+    expect(word?.other).toBe('c')
+    expect(word?.consumed).toBe(1)
+  })
+
+  it('reads the option named by o out of the next word', () => {
+    const word = parseOptionWord('-o', 'pipefail')
+    expect(word?.settings).toEqual([['pipefail', true]])
+    expect(word?.consumed).toBe(2)
+  })
+
+  it('disables the option named after plus o', () => {
+    expect(parseOptionWord('+o', 'xtrace')?.settings).toEqual([['xtrace', false]])
+  })
+
+  it('reads o from anywhere in a cluster', () => {
+    const word = parseOptionWord('-xo', 'pipefail')
+    expect(word?.settings).toEqual([
+      ['xtrace', true],
+      ['pipefail', true],
+    ])
+    expect(word?.consumed).toBe(2)
+  })
+
+  it('sets nothing for a trailing o with no following word', () => {
+    const word = parseOptionWord('-o', null)
+    expect(word?.settings).toEqual([])
+    expect(word?.consumed).toBe(1)
+  })
+})

--- a/typescript/packages/core/src/shell/options.ts
+++ b/typescript/packages/core/src/shell/options.ts
@@ -1,0 +1,66 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { SET_FLAG_TO_OPTION } from './types.ts'
+
+export interface OptionWord {
+  // Shell options the word turns on or off, in the order written.
+  settings: [string, boolean][]
+  // Cluster letters that name no shell option. `set` ignores them;
+  // shell startup reads its own startup letters out of them and refuses
+  // the rest.
+  other: string
+  // Words the option took, 2 for the `-o NAME` form.
+  consumed: number
+}
+
+/**
+ * Read one option word, or null when the word is an operand.
+ *
+ * This is bash's `set` grammar, which shell startup speaks too: a sign,
+ * then either `o` naming an option in the next word or a cluster of
+ * single-letter options, where `-` turns them on and `+` turns them off.
+ * `bash -x file` and `set -x` therefore cannot disagree about what `-x`
+ * means, and an option one of them learns the other gets.
+ *
+ * `-`, `--` and a `--long` word are not option words. The first two end
+ * option parsing and the third belongs to whoever declares long options,
+ * so both are the caller's to answer.
+ */
+export function parseOptionWord(word: string, next: string | null): OptionWord | null {
+  const sign = word.charAt(0)
+  if (word.length < 2 || (sign !== '-' && sign !== '+') || word.startsWith('--')) return null
+  const enable = sign === '-'
+  const settings: [string, boolean][] = []
+  let other = ''
+  let consumed = 1
+  const chars = word.slice(1)
+  for (let i = 0; i < chars.length; i++) {
+    const char = chars.charAt(i)
+    if (char === 'o') {
+      if (next !== null) {
+        settings.push([next, enable])
+        consumed = 2
+      }
+      continue
+    }
+    const option = SET_FLAG_TO_OPTION[char]
+    if (option === undefined) {
+      other += char
+      continue
+    }
+    settings.push([option, enable])
+  }
+  return { settings, other, consumed }
+}

--- a/typescript/packages/core/src/shell/options.ts
+++ b/typescript/packages/core/src/shell/options.ts
@@ -13,17 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { SET_FLAG_TO_OPTION } from './types.ts'
-
-export interface OptionWord {
-  // Shell options the word turns on or off, in the order written.
-  settings: [string, boolean][]
-  // Cluster letters that name no shell option. `set` ignores them;
-  // shell startup reads its own startup letters out of them and refuses
-  // the rest.
-  other: string
-  // Words the option took, 2 for the `-o NAME` form.
-  consumed: number
-}
+import type { OptionWord } from './types.ts'
 
 /**
  * Read one option word, or null when the word is an operand.

--- a/typescript/packages/core/src/shell/types.ts
+++ b/typescript/packages/core/src/shell/types.ts
@@ -133,6 +133,17 @@ export const SET_FLAG_TO_OPTION: Readonly<Record<string, string>> = Object.freez
   f: 'noglob',
 })
 
+export interface OptionWord {
+  // Shell options the word turns on or off, in the order written.
+  settings: [string, boolean][]
+  // Cluster letters that name no shell option. `set` ignores them;
+  // shell startup reads its own startup letters out of them and refuses
+  // the rest.
+  other: string
+  // Words the option took, 2 for the `-o NAME` form.
+  consumed: number
+}
+
 export const RedirectKind = Object.freeze({
   STDOUT: 'stdout',
   STDERR: 'stderr',

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -18,6 +18,7 @@ import { GENERAL_COMMANDS } from '../../commands/builtin/general/index.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
+import { enoent } from '../../utils/errors.ts'
 import { byteChar } from '../../shell/bytes.ts'
 import { CallStack } from '../../shell/call_stack.ts'
 import { FileStat, FileType, MountMode } from '../../types.ts'
@@ -1186,11 +1187,25 @@ describe('handleSource', () => {
 
   it('returns exit 1 with stderr on read failure', async () => {
     const s = new Session({ sessionId: 'test', cwd: '/' })
-    const dispatch = vi.fn(() => Promise.reject(new Error('not found'))) as unknown as DispatchFn
+    const dispatch = vi.fn(() => Promise.reject(enoent('/missing.sh'))) as unknown as DispatchFn
     const executeFn = vi.fn(() => Promise.resolve(new IOResult()))
     const [, io] = await handleSource(dispatch, executeFn, '/missing.sh', s)
     expect(io.exitCode).toBe(1)
-    expect(decode(io.stderr instanceof Uint8Array ? io.stderr : null)).toMatch(/missing.sh/)
+    expect(decode(io.stderr instanceof Uint8Array ? io.stderr : null)).toBe(
+      'source: /missing.sh: No such file or directory\n',
+    )
+    expect(executeFn).not.toHaveBeenCalled()
+  })
+
+  it('propagates a failure that is not a filesystem error', async () => {
+    const s = new Session({ sessionId: 'test', cwd: '/' })
+    const dispatch = vi.fn(() =>
+      Promise.reject(new Error('token expired')),
+    ) as unknown as DispatchFn
+    const executeFn = vi.fn(() => Promise.resolve(new IOResult()))
+    await expect(handleSource(dispatch, executeFn, '/script.sh', s)).rejects.toThrow(
+      'token expired',
+    )
     expect(executeFn).not.toHaveBeenCalled()
   })
 

--- a/typescript/packages/core/src/workspace/executor/builtins/script.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/script.test.ts
@@ -1,0 +1,67 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { materialize } from '../../../io/types.ts'
+import { parseBashArgs } from './script.ts'
+
+const DEC = new TextDecoder()
+
+describe('parseBashArgs', () => {
+  it('ends option parsing at a script file operand', () => {
+    const parsed = parseBashArgs('sh', ['run.sh', '-x', 'a'])
+    expect(parsed.path).toBe('run.sh')
+    expect(parsed.argv).toEqual(['-x', 'a'])
+    expect(parsed.options).toEqual([])
+  })
+
+  it('takes a flag-shaped file after --', () => {
+    const parsed = parseBashArgs('sh', ['--', '-weird.sh', 'a'])
+    expect(parsed.path).toBe('-weird.sh')
+    expect(parsed.argv).toEqual(['a'])
+  })
+
+  it('keeps set options from a cluster ending in c', () => {
+    const parsed = parseBashArgs('bash', ['-xc', 'echo hi', 'name', 'a'])
+    expect(parsed.script).toBe('echo hi')
+    expect(parsed.argv).toEqual(['name', 'a'])
+    expect(parsed.options).toEqual(['xtrace'])
+  })
+
+  it('maps set flags to shell options', () => {
+    const parsed = parseBashArgs('bash', ['-eux', 'run.sh'])
+    expect(parsed.path).toBe('run.sh')
+    expect(parsed.options).toEqual(['errexit', 'nounset', 'xtrace'])
+  })
+
+  it('reads the program from stdin under -s', () => {
+    const parsed = parseBashArgs('bash', ['-s'])
+    expect(parsed.readStdin).toBe(true)
+    expect(parsed.path).toBeNull()
+    expect(parsed.script).toBeNull()
+  })
+
+  it('skips -o and its value', () => {
+    const parsed = parseBashArgs('bash', ['-o', 'pipefail', 'run.sh'])
+    expect(parsed.path).toBe('run.sh')
+  })
+
+  it('reports an unsupported option as a usage error', async () => {
+    const parsed = parseBashArgs('sh', ['-Z'])
+    if (parsed.error === null) throw new Error('expected a usage error')
+    const [, io] = parsed.error
+    expect(io.exitCode).toBe(2)
+    expect(DEC.decode(await materialize(io.stderr))).toBe('sh: -Z: unsupported option\n')
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/builtins/script.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/script.test.ts
@@ -13,55 +13,77 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { materialize } from '../../../io/types.ts'
 import { parseBashArgs } from './script.ts'
-
-const DEC = new TextDecoder()
 
 describe('parseBashArgs', () => {
   it('ends option parsing at a script file operand', () => {
-    const parsed = parseBashArgs('sh', ['run.sh', '-x', 'a'])
+    const parsed = parseBashArgs(['run.sh', '-x', 'a'])
     expect(parsed.path).toBe('run.sh')
     expect(parsed.argv).toEqual(['-x', 'a'])
-    expect(parsed.options).toEqual([])
+    expect(parsed.settings).toEqual([])
   })
 
   it('takes a flag-shaped file after --', () => {
-    const parsed = parseBashArgs('sh', ['--', '-weird.sh', 'a'])
+    const parsed = parseBashArgs(['--', '-weird.sh', 'a'])
     expect(parsed.path).toBe('-weird.sh')
     expect(parsed.argv).toEqual(['a'])
   })
 
+  it('ends option parsing at a single dash', () => {
+    expect(parseBashArgs(['-', 'run.sh']).path).toBe('run.sh')
+  })
+
   it('keeps set options from a cluster ending in c', () => {
-    const parsed = parseBashArgs('bash', ['-xc', 'echo hi', 'name', 'a'])
+    const parsed = parseBashArgs(['-xc', 'echo hi', 'name', 'a'])
     expect(parsed.script).toBe('echo hi')
     expect(parsed.argv).toEqual(['name', 'a'])
-    expect(parsed.options).toEqual(['xtrace'])
+    expect(parsed.settings).toEqual([['xtrace', true]])
   })
 
   it('maps set flags to shell options', () => {
-    const parsed = parseBashArgs('bash', ['-eux', 'run.sh'])
+    const parsed = parseBashArgs(['-eux', 'run.sh'])
     expect(parsed.path).toBe('run.sh')
-    expect(parsed.options).toEqual(['errexit', 'nounset', 'xtrace'])
+    expect(parsed.settings).toEqual([
+      ['errexit', true],
+      ['nounset', true],
+      ['xtrace', true],
+    ])
   })
 
-  it('reads the program from stdin under -s', () => {
-    const parsed = parseBashArgs('bash', ['-s'])
-    expect(parsed.readStdin).toBe(true)
+  it('lets the last sign win within one invocation', () => {
+    const parsed = parseBashArgs(['-e', '+e', 'run.sh'])
+    expect(parsed.settings).toEqual([
+      ['errexit', true],
+      ['errexit', false],
+    ])
+  })
+
+  it('keeps every operand positional under -s', () => {
+    const parsed = parseBashArgs(['-s', 'A', 'B'])
     expect(parsed.path).toBeNull()
     expect(parsed.script).toBeNull()
+    expect(parsed.argv).toEqual(['A', 'B'])
   })
 
-  it('skips -o and its value', () => {
-    const parsed = parseBashArgs('bash', ['-o', 'pipefail', 'run.sh'])
+  it('applies -o and its value', () => {
+    const parsed = parseBashArgs(['-o', 'pipefail', 'run.sh'])
     expect(parsed.path).toBe('run.sh')
+    expect(parsed.settings).toEqual([['pipefail', true]])
   })
 
-  it('reports an unsupported option as a usage error', async () => {
-    const parsed = parseBashArgs('sh', ['-Z'])
-    if (parsed.error === null) throw new Error('expected a usage error')
-    const [, io] = parsed.error
-    expect(io.exitCode).toBe(2)
-    expect(DEC.decode(await materialize(io.stderr))).toBe('sh: -Z: unsupported option\n')
+  it('consumes a long option value', () => {
+    expect(parseBashArgs(['--rcfile', 'rc', 'run.sh']).path).toBe('run.sh')
+  })
+
+  it('reports an unsupported short option', () => {
+    expect(parseBashArgs(['-Z']).invalid).toBe('-Z')
+  })
+
+  it('reports an unsupported long option', () => {
+    expect(parseBashArgs(['--nosuch', 'run.sh']).invalid).toBe('--nosuch')
+  })
+
+  it('reports -c with no value', () => {
+    expect(parseBashArgs(['-c']).needsValue).toBe('-c')
   })
 })

--- a/typescript/packages/core/src/workspace/executor/builtins/script.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/script.ts
@@ -15,11 +15,15 @@
 import { resolvePath } from '../../../utils/path.ts'
 import { materialize, IOResult } from '../../../io/types.ts'
 import type { ByteSource } from '../../../io/types.ts'
+import { SET_FLAG_TO_OPTION } from '../../../shell/types.ts'
+import { FileType } from '../../../types.ts'
 import type { PathSpec } from '../../../types.ts'
+import { fsStrerror, isFsError } from '../../../utils/errors.ts'
 import type { Session } from '../../session/session.ts'
 import { sleep } from '../../abort.ts'
 import { ExecutionNode } from '../../types.ts'
 import type { DispatchFn } from '../cross_mount.ts'
+import { resolvePathStat } from './links.ts'
 import { toScope, scopePath } from './scope.ts'
 import type { Result, ExecuteStringFn } from './scope.ts'
 
@@ -33,37 +37,73 @@ export async function handleEval(
   return [io.stdout, io, new ExecutionNode({ command: 'eval', exitCode: io.exitCode })]
 }
 
-const BASH_NOOP_SHORT_FLAGS = new Set(['l', 'i', 'e', 'u', 'x'])
+// Startup flags with nothing to configure in an embedded shell: there is no
+// login profile, no rc file and no tty. Flags that name a `set` option
+// (-e -u -x -f) are not here; they are applied through SET_FLAG_TO_OPTION.
+const BASH_NOOP_SHORT_FLAGS = new Set(['l', 'i'])
 const BASH_NOOP_LONG_FLAGS = new Set(['--login', '--norc', '--noprofile', '--posix', '--rcfile'])
 
-function bashCError(): Result {
-  const err = new TextEncoder().encode('bash: -c: option requires an argument\n')
+function bashError(name: string, message: string, code: number): Result {
+  const err = new TextEncoder().encode(`${name}: ${message}\n`)
   return [
     null,
-    new IOResult({ exitCode: 2, stderr: err }),
-    new ExecutionNode({ command: 'bash', exitCode: 2, stderr: err }),
+    new IOResult({ exitCode: code, stderr: err }),
+    new ExecutionNode({ command: name, exitCode: code, stderr: err }),
   ]
 }
 
-export async function handleBash(
-  executeFn: ExecuteStringFn,
-  args: string[],
-  session: Session,
-  stdin: ByteSource | null = null,
-): Promise<Result> {
-  let script: string | null = null
+export interface BashArgs {
+  // Inline program text from `-c`.
+  script: string | null
+  // Script file operand, as typed.
+  path: string | null
+  // Words after the program: `$0` first for the `-c` form, all
+  // positional for the file form.
+  argv: string[]
+  // Shell options the startup flags turn on.
+  options: string[]
+  // Whether `-s` was given.
+  readStdin: boolean
+  // A ready usage failure, when parsing failed.
+  error: Result | null
+}
+
+function bashArgs(partial: Partial<BashArgs>): BashArgs {
+  return {
+    script: null,
+    path: null,
+    argv: [],
+    options: [],
+    readStdin: false,
+    error: null,
+    ...partial,
+  }
+}
+
+function setOptions(chars: string): string[] {
+  const options: string[] = []
+  for (let j = 0; j < chars.length; j++) {
+    const option = SET_FLAG_TO_OPTION[chars.charAt(j)]
+    if (option !== undefined) options.push(option)
+  }
+  return options
+}
+
+/**
+ * Split a `bash`/`sh` argument list into flags, program and argv.
+ *
+ * Option parsing stops at the first operand, so everything after a script
+ * file (or after `-c`'s program text) is positional, even when it looks
+ * like a flag: `bash run.sh -c foo` passes `-c foo` to the script.
+ */
+export function parseBashArgs(name: string, args: string[]): BashArgs {
+  const options: string[] = []
   let readStdin = false
   let i = 0
   while (i < args.length) {
     const tok = args[i] ?? ''
     if (tok === '--') {
       i += 1
-      break
-    }
-    if (tok === '-c') {
-      const next = args[i + 1]
-      if (next === undefined) return bashCError()
-      script = next
       break
     }
     if (tok === '-s') {
@@ -79,38 +119,103 @@ export async function handleBash(
       i += 1
       continue
     }
-    if (tok.startsWith('-') && tok.length > 1 && !tok.startsWith('--')) {
-      const chars = tok.slice(1)
-      if (chars.includes('c')) {
-        const next = args[i + 1]
-        if (next === undefined) return bashCError()
-        script = next
-        break
+    if (!(tok.startsWith('-') && tok.length > 1 && !tok.startsWith('--'))) break
+    const chars = tok.slice(1)
+    if (chars.includes('c')) {
+      const next = args[i + 1]
+      if (next === undefined) {
+        return bashArgs({ error: bashError(name, '-c: option requires an argument', 2) })
       }
-      let allNoop = true
-      for (let j = 0; j < chars.length; j++) {
-        const ch = chars.charAt(j)
-        if (!BASH_NOOP_SHORT_FLAGS.has(ch) && ch !== 's') {
-          allNoop = false
-          break
-        }
-      }
-      if (allNoop) {
-        if (chars.includes('s')) readStdin = true
-        i += 1
+      options.push(...setOptions(chars))
+      return bashArgs({ script: next, argv: args.slice(i + 2), options, readStdin })
+    }
+    let known = true
+    for (let j = 0; j < chars.length; j++) {
+      const ch = chars.charAt(j)
+      if (BASH_NOOP_SHORT_FLAGS.has(ch) || ch === 's' || SET_FLAG_TO_OPTION[ch] !== undefined) {
         continue
       }
-      const err = new TextEncoder().encode(`bash: ${tok}: unsupported option\n`)
-      return [
-        null,
-        new IOResult({ exitCode: 2, stderr: err }),
-        new ExecutionNode({ command: 'bash', exitCode: 2, stderr: err }),
-      ]
+      known = false
+      break
     }
-    script = tok
-    break
+    if (!known) return bashArgs({ error: bashError(name, `${tok}: unsupported option`, 2) })
+    options.push(...setOptions(chars))
+    readStdin = readStdin || chars.includes('s')
+    i += 1
   }
-  if (script === null && readStdin && stdin !== null) {
+  if (i < args.length) {
+    return bashArgs({ path: args[i] ?? '', argv: args.slice(i + 1), options, readStdin })
+  }
+  return bashArgs({ options, readStdin })
+}
+
+/**
+ * Read a script file operand, or the failure bash reports for it.
+ *
+ * GNU splits the diagnostics by how far startup got. A file it cannot open
+ * is blamed on the shell (`bash: run.sh: No such file or directory`, exit
+ * 127; `Permission denied`, exit 126), while a directory opens fine and
+ * only fails on the first read, by which point `$0` is already the operand,
+ * so bash prints it twice (`/tmp: /tmp: Is a directory`, exit 126).
+ * Reproduced rather than tidied up: it is what an agent copying a message
+ * into a search box will find.
+ *
+ * A backend that cannot tell a missing path from an unreadable one raises
+ * ENOENT for a directory too, so the stat probe runs on the failure path to
+ * recover the distinction.
+ */
+async function readScriptFile(
+  dispatch: DispatchFn,
+  name: string,
+  path: string,
+  session: Session,
+): Promise<[string, null] | [null, Result]> {
+  const scope = toScope(resolvePath(path, session.cwd))
+  let data: unknown
+  try {
+    ;[data] = await dispatch('read', scope)
+  } catch (exc) {
+    if (!isFsError(exc)) throw exc
+    const stat = await resolvePathStat(dispatch, scope)
+    if (stat !== null && stat.type === FileType.DIRECTORY) {
+      return [null, bashError(path, `${path}: Is a directory`, 126)]
+    }
+    const strerror = fsStrerror(exc) ?? 'No such file or directory'
+    const code = (exc as { code?: string }).code === 'EACCES' ? 126 : 127
+    return [null, bashError(name, `${path}: ${strerror}`, code)]
+  }
+  if (data instanceof Uint8Array) return [new TextDecoder().decode(data), null]
+  if (data === null || data === undefined) return ['', null]
+  const collected = await materialize(data as ByteSource)
+  return [new TextDecoder().decode(collected), null]
+}
+
+/**
+ * Run a nested shell: inline text from `-c`, or a script file.
+ *
+ * `name` is the head word (`bash` or `sh`). bash reports itself by
+ * `argv[0]`, so the diagnostics follow the spelling the caller used.
+ */
+export async function handleBash(
+  dispatch: DispatchFn,
+  executeFn: ExecuteStringFn,
+  args: string[],
+  session: Session,
+  stdin: ByteSource | null = null,
+  name = 'bash',
+): Promise<Result> {
+  const parsed = parseBashArgs(name, args)
+  if (parsed.error !== null) return parsed.error
+  let script = parsed.script
+  let scriptName = script !== null && parsed.argv.length > 0 ? (parsed.argv[0] ?? name) : name
+  const positional = script !== null ? parsed.argv.slice(1) : parsed.argv
+  if (script === null && parsed.path !== null) {
+    scriptName = parsed.path
+    const [text, failure] = await readScriptFile(dispatch, name, parsed.path, session)
+    if (failure !== null) return failure
+    script = text
+  }
+  if (script === null && parsed.readStdin && stdin !== null) {
     const data = await materialize(stdin)
     if (data.length > 0) {
       script = new TextDecoder().decode(data)
@@ -118,10 +223,24 @@ export async function handleBash(
     }
   }
   if (script === null) {
-    return [null, new IOResult(), new ExecutionNode({ command: 'bash', exitCode: 0 })]
+    return [null, new IOResult(), new ExecutionNode({ command: name, exitCode: 0 })]
   }
-  const io = await executeFn(script, { sessionId: session.sessionId, stdin })
-  return [io.stdout, io, new ExecutionNode({ command: `bash -c ${script}`, exitCode: io.exitCode })]
+  const savedPositional = session.positionalArgs
+  const savedScriptName = session.scriptName
+  const savedOptions = { ...session.shellOptions }
+  session.positionalArgs = positional
+  session.scriptName = scriptName
+  for (const option of parsed.options) session.shellOptions[option] = true
+  let io
+  try {
+    io = await executeFn(script, { sessionId: session.sessionId, stdin })
+  } finally {
+    session.positionalArgs = savedPositional
+    session.scriptName = savedScriptName
+    session.shellOptions = savedOptions
+  }
+  const label = parsed.path !== null ? `${name} ${parsed.path}` : `${name} -c ${script}`
+  return [io.stdout, io, new ExecutionNode({ command: label, exitCode: io.exitCode })]
 }
 
 export async function handleSource(

--- a/typescript/packages/core/src/workspace/executor/builtins/script.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/script.ts
@@ -286,6 +286,10 @@ export async function handleBash(
   const saved = session.snapshot()
   session.positionalArgs = positional
   session.scriptName = scriptName
+  // A child shell is outside every `source` its caller is inside, so a
+  // top-level `return` in the script it runs is the error bash reports
+  // rather than an early exit the program loop absorbs.
+  session.sourceDepth = 0
   for (const [option, enable] of parsed.settings) session.shellOptions[option] = enable
   let io
   try {

--- a/typescript/packages/core/src/workspace/executor/builtins/script.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/script.ts
@@ -15,10 +15,10 @@
 import { resolvePath } from '../../../utils/path.ts'
 import { materialize, IOResult } from '../../../io/types.ts'
 import type { ByteSource } from '../../../io/types.ts'
-import { SET_FLAG_TO_OPTION } from '../../../shell/types.ts'
+import { parseOptionWord } from '../../../shell/options.ts'
 import { FileType } from '../../../types.ts'
 import type { PathSpec } from '../../../types.ts'
-import { fsStrerror, isFsError } from '../../../utils/errors.ts'
+import { eisdir, fsStrerror } from '../../../utils/errors.ts'
 import type { Session } from '../../session/session.ts'
 import { sleep } from '../../abort.ts'
 import { ExecutionNode } from '../../types.ts'
@@ -37,18 +37,45 @@ export async function handleEval(
   return [io.stdout, io, new ExecutionNode({ command: 'eval', exitCode: io.exitCode })]
 }
 
-// Startup flags with nothing to configure in an embedded shell: there is no
-// login profile, no rc file and no tty. Flags that name a `set` option
-// (-e -u -x -f) are not here; they are applied through SET_FLAG_TO_OPTION.
-const BASH_NOOP_SHORT_FLAGS = new Set(['l', 'i'])
-const BASH_NOOP_LONG_FLAGS = new Set(['--login', '--norc', '--noprofile', '--posix', '--rcfile'])
+// Startup letters bash has that `set` does not. `c` takes the program text
+// from the next word and `s` reads it from stdin; the rest have nothing to
+// configure in an embedded shell, which has no login profile, no rc file and
+// no tty. Letters that name a `set` option (-e -u -x -f) are not here:
+// parseOptionWord already knows them, so the two spellings cannot drift.
+const BASH_START_FLAGS = new Set(['c', 's', 'l', 'i'])
 
-function bashError(name: string, message: string, code: number): Result {
-  const err = new TextEncoder().encode(`${name}: ${message}\n`)
+// bash's long options, mapped to whether the option takes the next word. A
+// flat set of names to ignore cannot say that `--rcfile FILE` swallows FILE,
+// and read `bash --rcfile run.sh` as "run run.sh". Anything absent is refused
+// rather than mistaken for a script operand, which is what made
+// `bash --version` report a missing file.
+const BASH_LONG_OPTIONS: Readonly<Record<string, boolean>> = Object.freeze({
+  '--login': false,
+  '--noediting': false,
+  '--noprofile': false,
+  '--norc': false,
+  '--posix': false,
+  '--init-file': true,
+  '--rcfile': true,
+})
+
+// GNU prints the refusal and the usage line together, both under the
+// builtin's own name, and exits 2 without ending the script.
+const SOURCE_USAGE = 'filename argument required\nsource: usage: source filename [arguments]'
+
+/**
+ * A diagnostic from a shell that never got as far as running.
+ *
+ * `prefix` and `command` come apart because bash reports itself by
+ * `argv[0]`, which for a script operand is the operand: the recorded
+ * command still has to be the builtin that ran, not a file path.
+ */
+function scriptError(prefix: string, message: string, code: number, command?: string): Result {
+  const err = new TextEncoder().encode(`${prefix}: ${message}\n`)
   return [
     null,
     new IOResult({ exitCode: code, stderr: err }),
-    new ExecutionNode({ command: name, exitCode: code, stderr: err }),
+    new ExecutionNode({ command: command ?? prefix, exitCode: code, stderr: err }),
   ]
 }
 
@@ -58,14 +85,14 @@ export interface BashArgs {
   // Script file operand, as typed.
   path: string | null
   // Words after the program: `$0` first for the `-c` form, all
-  // positional for the file form.
+  // positional for the other two.
   argv: string[]
-  // Shell options the startup flags turn on.
-  options: string[]
-  // Whether `-s` was given.
-  readStdin: boolean
-  // A ready usage failure, when parsing failed.
-  error: Result | null
+  // Shell options the startup flags turn on or off, in the order written.
+  settings: [string, boolean][]
+  // The option word the shell does not have.
+  invalid: string | null
+  // The option given no argument.
+  needsValue: string | null
 }
 
 function bashArgs(partial: Partial<BashArgs>): BashArgs {
@@ -73,20 +100,11 @@ function bashArgs(partial: Partial<BashArgs>): BashArgs {
     script: null,
     path: null,
     argv: [],
-    options: [],
-    readStdin: false,
-    error: null,
+    settings: [],
+    invalid: null,
+    needsValue: null,
     ...partial,
   }
-}
-
-function setOptions(chars: string): string[] {
-  const options: string[] = []
-  for (let j = 0; j < chars.length; j++) {
-    const option = SET_FLAG_TO_OPTION[chars.charAt(j)]
-    if (option !== undefined) options.push(option)
-  }
-  return options
 }
 
 /**
@@ -94,75 +112,104 @@ function setOptions(chars: string): string[] {
  *
  * Option parsing stops at the first operand, so everything after a script
  * file (or after `-c`'s program text) is positional, even when it looks
- * like a flag: `bash run.sh -c foo` passes `-c foo` to the script.
+ * like a flag: `bash run.sh -c foo` passes `-c foo` to the script. `-` and
+ * `--` both end it without being operands.
+ *
+ * `-c` takes the next *word*, never the rest of its cluster, which is where
+ * bash's own parser departs from getopt: `bash -cx 'echo hi'` traces and
+ * runs `echo hi` rather than running `x`.
+ *
+ * The two failure fields report what went wrong rather than a rendered
+ * message, the way `ShellParse` does: the wording and the exit code belong
+ * to the caller, which is the only thing that knows the head word the shell
+ * was spelled as.
  */
-export function parseBashArgs(name: string, args: string[]): BashArgs {
-  const options: string[] = []
+export function parseBashArgs(args: string[]): BashArgs {
+  const settings: [string, boolean][] = []
   let readStdin = false
   let i = 0
   while (i < args.length) {
     const tok = args[i] ?? ''
-    if (tok === '--') {
+    if (tok === '--' || tok === '-') {
       i += 1
       break
     }
-    if (tok === '-s') {
-      readStdin = true
-      i += 1
+    if (tok.startsWith('--')) {
+      const takesValue = BASH_LONG_OPTIONS[tok]
+      if (takesValue === undefined) return bashArgs({ invalid: tok })
+      i += takesValue ? 2 : 1
       continue
     }
-    if (tok === '-o' || tok === '+o') {
-      i += 2
-      continue
-    }
-    if (BASH_NOOP_LONG_FLAGS.has(tok)) {
-      i += 1
-      continue
-    }
-    if (!(tok.startsWith('-') && tok.length > 1 && !tok.startsWith('--'))) break
-    const chars = tok.slice(1)
-    if (chars.includes('c')) {
-      const next = args[i + 1]
-      if (next === undefined) {
-        return bashArgs({ error: bashError(name, '-c: option requires an argument', 2) })
-      }
-      options.push(...setOptions(chars))
-      return bashArgs({ script: next, argv: args.slice(i + 2), options, readStdin })
-    }
+    const word = parseOptionWord(tok, args[i + 1] ?? null)
+    if (word === null) break
     let known = true
-    for (let j = 0; j < chars.length; j++) {
-      const ch = chars.charAt(j)
-      if (BASH_NOOP_SHORT_FLAGS.has(ch) || ch === 's' || SET_FLAG_TO_OPTION[ch] !== undefined) {
-        continue
+    for (let j = 0; j < word.other.length; j++) {
+      if (!BASH_START_FLAGS.has(word.other.charAt(j))) {
+        known = false
+        break
       }
-      known = false
-      break
     }
-    if (!known) return bashArgs({ error: bashError(name, `${tok}: unsupported option`, 2) })
-    options.push(...setOptions(chars))
-    readStdin = readStdin || chars.includes('s')
-    i += 1
+    if (!known) return bashArgs({ invalid: tok })
+    settings.push(...word.settings)
+    readStdin = readStdin || word.other.includes('s')
+    if (word.other.includes('c')) {
+      const next = args[i + word.consumed]
+      if (next === undefined) return bashArgs({ needsValue: '-c' })
+      return bashArgs({ script: next, argv: args.slice(i + word.consumed + 1), settings })
+    }
+    i += word.consumed
   }
-  if (i < args.length) {
-    return bashArgs({ path: args[i] ?? '', argv: args.slice(i + 1), options, readStdin })
+  // The program comes from stdin whenever no operand names one, which is
+  // the rule `-s` states explicitly for the case where operands do follow:
+  // `bash -s A B` reads stdin and makes A and B positional.
+  if (i < args.length && !readStdin) {
+    return bashArgs({ path: args[i] ?? '', argv: args.slice(i + 1), settings })
   }
-  return bashArgs({ options, readStdin })
+  return bashArgs({ argv: args.slice(i), settings })
+}
+
+/**
+ * Read a script file through the op dispatcher.
+ *
+ * Every way of running a script off a mount comes through here, so a backend
+ * quirk is answered once rather than per caller. The one answered today is a
+ * directory: a keyed backend has no directory object to open, so it reports a
+ * read of one as ENOENT where a real filesystem reports EISDIR. The stat
+ * probe that tells the two apart runs only on the failure path, and asks both
+ * channels a backend can answer on, since on a prefix store a directory is
+ * the set of keys under it rather than an object.
+ *
+ * The caller owns the diagnostic: `source` and a nested shell word the same
+ * failure differently and exit differently on it.
+ */
+async function readScriptText(dispatch: DispatchFn, path: string, cwd: string): Promise<string> {
+  const scope = toScope(resolvePath(path, cwd))
+  let data: unknown
+  try {
+    ;[data] = await dispatch('read', scope)
+  } catch (exc) {
+    if ((exc as { code?: string }).code !== 'ENOENT') throw exc
+    const stat = await resolvePathStat(dispatch, scope)
+    if (stat !== null && stat.type === FileType.DIRECTORY) throw eisdir(path)
+    throw exc
+  }
+  if (data instanceof Uint8Array) return new TextDecoder().decode(data)
+  if (data === null || data === undefined) return ''
+  return new TextDecoder().decode(await materialize(data as ByteSource))
 }
 
 /**
  * Read a script file operand, or the failure bash reports for it.
  *
- * GNU splits the diagnostics by how far startup got. A file it cannot open
- * is blamed on the shell (`bash: run.sh: No such file or directory`, exit
- * 127; `Permission denied`, exit 126), while a directory opens fine and
- * only fails on the first read, by which point `$0` is already the operand,
- * so bash prints it twice (`/tmp: /tmp: Is a directory`, exit 126).
- * Reproduced rather than tidied up: it is what an agent copying a message
- * into a search box will find.
- *
- * A backend that cannot tell a missing path from an unreadable one raises
- * ENOENT for a directory too, so the stat probe runs on the failure path to
- * recover the distinction.
+ * GNU splits the diagnostics by how far startup got, and both halves fall out
+ * of the errno rather than being listed case by case. A file the shell cannot
+ * open at all is blamed on the shell, and only a missing one is exit 127
+ * (`bash: run.sh: No such file or directory`); anything it found but could not
+ * run is 126 (`Permission denied`, `Not a directory`). A directory is the
+ * exception, because it opens fine and fails on the first read, by which point
+ * `$0` is already the operand, so bash prints it twice (`/tmp: /tmp: Is a
+ * directory`, exit 126). Reproduced rather than tidied up: it is what an agent
+ * copying a message into a search box will find.
  */
 async function readScriptFile(
   dispatch: DispatchFn,
@@ -170,24 +217,19 @@ async function readScriptFile(
   path: string,
   session: Session,
 ): Promise<[string, null] | [null, Result]> {
-  const scope = toScope(resolvePath(path, session.cwd))
-  let data: unknown
   try {
-    ;[data] = await dispatch('read', scope)
+    return [await readScriptText(dispatch, path, session.cwd), null]
   } catch (exc) {
-    if (!isFsError(exc)) throw exc
-    const stat = await resolvePathStat(dispatch, scope)
-    if (stat !== null && stat.type === FileType.DIRECTORY) {
-      return [null, bashError(path, `${path}: Is a directory`, 126)]
+    // A strerror is exactly what makes this a filesystem error, so the
+    // lookup is both the test and the message.
+    const strerror = fsStrerror(exc)
+    if (strerror === null) throw exc
+    const code = (exc as { code?: string }).code
+    if (code === 'EISDIR') {
+      return [null, scriptError(path, `${path}: ${strerror}`, 126, name)]
     }
-    const strerror = fsStrerror(exc) ?? 'No such file or directory'
-    const code = (exc as { code?: string }).code === 'EACCES' ? 126 : 127
-    return [null, bashError(name, `${path}: ${strerror}`, code)]
+    return [null, scriptError(name, `${path}: ${strerror}`, code === 'ENOENT' ? 127 : 126)]
   }
-  if (data instanceof Uint8Array) return [new TextDecoder().decode(data), null]
-  if (data === null || data === undefined) return ['', null]
-  const collected = await materialize(data as ByteSource)
-  return [new TextDecoder().decode(collected), null]
 }
 
 /**
@@ -195,6 +237,12 @@ async function readScriptFile(
  *
  * `name` is the head word (`bash` or `sh`). bash reports itself by
  * `argv[0]`, so the diagnostics follow the spelling the caller used.
+ *
+ * A nested shell is a child shell, so it runs on a snapshot of the session
+ * and the caller gets its state back afterwards: `bash -c 'cd /x'` leaves the
+ * caller where it was, as it does in bash, where the nested shell is a
+ * separate process. `handleSource` is the opposite case and deliberately does
+ * not snapshot, because a sourced file is the caller.
  */
 export async function handleBash(
   dispatch: DispatchFn,
@@ -204,8 +252,18 @@ export async function handleBash(
   stdin: ByteSource | null = null,
   name = 'bash',
 ): Promise<Result> {
-  const parsed = parseBashArgs(name, args)
-  if (parsed.error !== null) return parsed.error
+  const parsed = parseBashArgs(args)
+  if (parsed.invalid !== null) {
+    // GNU words this "invalid option" and follows it with a usage block.
+    // One word covers both cases here on purpose: some of what lands here
+    // is an option bash has and mirage does not implement (`-r`, `-a`,
+    // `--version`), and calling those invalid would be a lie. The exit
+    // status is GNU's 2 either way.
+    return scriptError(name, `${parsed.invalid}: unsupported option`, 2)
+  }
+  if (parsed.needsValue !== null) {
+    return scriptError(name, `${parsed.needsValue}: option requires an argument`, 2)
+  }
   let script = parsed.script
   let scriptName = script !== null && parsed.argv.length > 0 ? (parsed.argv[0] ?? name) : name
   const positional = script !== null ? parsed.argv.slice(1) : parsed.argv
@@ -215,7 +273,7 @@ export async function handleBash(
     if (failure !== null) return failure
     script = text
   }
-  if (script === null && parsed.readStdin && stdin !== null) {
+  if (script === null && stdin !== null) {
     const data = await materialize(stdin)
     if (data.length > 0) {
       script = new TextDecoder().decode(data)
@@ -225,19 +283,15 @@ export async function handleBash(
   if (script === null) {
     return [null, new IOResult(), new ExecutionNode({ command: name, exitCode: 0 })]
   }
-  const savedPositional = session.positionalArgs
-  const savedScriptName = session.scriptName
-  const savedOptions = { ...session.shellOptions }
+  const saved = session.snapshot()
   session.positionalArgs = positional
   session.scriptName = scriptName
-  for (const option of parsed.options) session.shellOptions[option] = true
+  for (const [option, enable] of parsed.settings) session.shellOptions[option] = enable
   let io
   try {
     io = await executeFn(script, { sessionId: session.sessionId, stdin })
   } finally {
-    session.positionalArgs = savedPositional
-    session.scriptName = savedScriptName
-    session.shellOptions = savedOptions
+    session.restore(saved)
   }
   const label = parsed.path !== null ? `${name} ${parsed.path}` : `${name} -c ${script}`
   return [io.stdout, io, new ExecutionNode({ command: label, exitCode: io.exitCode })]
@@ -251,31 +305,14 @@ export async function handleSource(
   args: string[] = [],
 ): Promise<Result> {
   const raw = scopePath(path)
-  const resolved = resolvePath(raw, session.cwd)
-  const scope = toScope(resolved)
-  let script = ''
+  if (raw === '') return scriptError('source', SOURCE_USAGE, 2)
+  let script: string
   try {
-    const [data] = await dispatch('read', scope)
-    if (data instanceof Uint8Array) {
-      script = new TextDecoder().decode(data)
-    } else if (data !== null && data !== undefined) {
-      // ByteSource: collect into a string
-      const chunks: number[] = []
-      for await (const chunk of data as AsyncIterable<Uint8Array>) {
-        for (const b of chunk) chunks.push(b)
-      }
-      script = new TextDecoder().decode(new Uint8Array(chunks))
-    }
+    script = await readScriptText(dispatch, raw, session.cwd)
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [
-      null,
-      new IOResult({
-        exitCode: 1,
-        stderr: new TextEncoder().encode(`source: ${raw}: ${msg}\n`),
-      }),
-      new ExecutionNode({ command: `source ${raw}`, exitCode: 1 }),
-    ]
+    const strerror = fsStrerror(err)
+    if (strerror === null) throw err
+    return scriptError('source', `${raw}: ${strerror}`, 1, `source ${raw}`)
   }
   let savedPositional: string[] | null = null
   if (args.length > 0) {

--- a/typescript/packages/core/src/workspace/executor/builtins/vars.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/vars.ts
@@ -20,7 +20,7 @@ import type { ByteSource } from '../../../io/types.ts'
 import type { CallStack } from '../../../shell/call_stack.ts'
 import { ExitSignal } from '../../../shell/errors.ts'
 import { shellJoin } from '../../../shell/join.ts'
-import { SET_FLAG_TO_OPTION } from '../../../shell/types.ts'
+import { parseOptionWord } from '../../../shell/options.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
 import { arrayExtent, arrayUnset } from '../../../shell/array.ts'
 import { arrayIndex } from '../../expand/variable.ts'
@@ -626,27 +626,18 @@ export function handleSet(
       session.positionalArgs = args.slice(i + 1)
       return [null, new IOResult(), new ExecutionNode({ command: 'set', exitCode: 0 })]
     }
-    if (tok === '-o' || tok === '+o') {
-      if (i + 1 < args.length) {
-        const optName = args[i + 1] ?? ''
-        session.shellOptions[optName] = tok === '-o'
-        i += 2
-        continue
-      }
-      i += 1
-      continue
+    const word = parseOptionWord(tok, args[i + 1] ?? null)
+    if (word === null) {
+      session.positionalArgs = args.slice(i)
+      break
     }
-    if ((tok.startsWith('-') || tok.startsWith('+')) && tok.length > 1) {
-      const enable = tok.startsWith('-')
-      for (const ch of tok.slice(1)) {
-        const opt = SET_FLAG_TO_OPTION[ch]
-        if (opt !== undefined) session.shellOptions[opt] = enable
-      }
-      i += 1
-      continue
-    }
-    session.positionalArgs = args.slice(i)
-    break
+    for (const [option, enable] of word.settings) session.shellOptions[option] = enable
+    // A letter naming no option is ignored rather than refused: bash has
+    // options mirage does not implement (`-a`, `-B`, `-H`), and `set` is
+    // where a script turns those on without wanting to fail. A nested shell
+    // answers the same leftovers differently, which is why the grammar hands
+    // them back instead of deciding here.
+    i += word.consumed
   }
   return [null, new IOResult(), new ExecutionNode({ command: 'set', exitCode: 0 })]
 }

--- a/typescript/packages/core/src/workspace/executor/pipes.ts
+++ b/typescript/packages/core/src/workspace/executor/pipes.ts
@@ -17,12 +17,11 @@ import { asyncChain, closeQuietly, mergeStdoutStderr } from '../../io/stream.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import { finishStatement } from './statement.ts'
-import type { ShellArray } from '../../shell/array.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
 import { ExitSignal } from '../../shell/errors.ts'
 import { ERREXIT_EXEMPT_TYPES, NodeType as NT } from '../../shell/types.ts'
 import type { JobTable } from '../../shell/job_table.ts'
-import { ownRecord, type Session } from '../session/session.ts'
+import type { Session } from '../session/session.ts'
 import type { TSNodeLike } from '../../shell/types.ts'
 import { ExecutionNode } from '../types.ts'
 import { type ExecuteNodeFn, handleBackground } from './jobs.ts'
@@ -255,17 +254,7 @@ export async function handleSubshell(
   jobTable: JobTable | null = null,
   agentId: string | null = null,
 ): Promise<Result> {
-  const savedCwd = session.cwd
-  const savedEnv = ownRecord(session.env)
-  const savedOptions = { ...session.shellOptions }
-  const savedReadonly = new Set(session.readonlyVars)
-  const savedArrays: Record<string, ShellArray> = ownRecord()
-  for (const [k, v] of Object.entries(session.arrays)) savedArrays[k] = [...v]
-  const savedFunctions = ownRecord(session.functions)
-  const savedPositional = [...session.positionalArgs]
-  const savedLastBgJob = session.lastBgJobId
-  const savedGetoptsPos = session.getoptsPos
-  const savedGetoptsOptind = session.getoptsOptind
+  const saved = session.snapshot()
   try {
     const allStdout: ByteSource[] = []
     let mergedIo = new IOResult()
@@ -339,16 +328,7 @@ export async function handleSubshell(
     const combined = allStdout.length > 0 ? asyncChain(...allStdout) : null
     return [combined, mergedIo, lastExec]
   } finally {
-    session.cwd = savedCwd
-    session.env = savedEnv
-    session.shellOptions = savedOptions
-    session.readonlyVars = savedReadonly
-    session.arrays = savedArrays
-    session.functions = savedFunctions
-    session.positionalArgs = savedPositional
-    session.lastBgJobId = savedLastBgJob
-    session.getoptsPos = savedGetoptsPos
-    session.getoptsOptind = savedGetoptsOptind
+    session.restore(saved)
   }
 }
 

--- a/typescript/packages/core/src/workspace/expand/variable.ts
+++ b/typescript/packages/core/src/workspace/expand/variable.ts
@@ -148,7 +148,7 @@ export function lookupVar(
   }
   if (/^\d+$/.test(name)) {
     const idx = parseInt(name, 10)
-    if (idx === 0) return session.scriptName ?? SHELL_ARGV0
+    if (idx === 0) return session.argv0
     if (callStack) {
       const fromCall = callStack.getPositional(idx)
       if (fromCall !== '') return fromCall
@@ -538,12 +538,6 @@ function sliceArray(arr: ShellArray, groups: string[], env: Record<string, strin
 // plain, slice, per-element strip/replace/case ops, and ${!a[@]}
 // indices. False for single-word forms (${a[*]}, ${#a[@]}, non-@
 // subscript, or a default/alternate op acting on the joined value).
-// What the shell calls itself, bash's "bash", when no script is running:
-// a nested `bash`/`sh` overrides it through Session.scriptName. It is a
-// value of "$@" only through a slice, where bash numbers the positional
-// parameters from 1 and index 0 is this.
-const SHELL_ARGV0 = 'mirage'
-
 // The positional parameters in scope, function args winning.
 function positionalArgs(session: Session, callStack: CallStack | null): string[] {
   if (callStack !== null && callStack.getAllPositional().length > 0) {
@@ -597,8 +591,7 @@ export async function expandArrayAt(
     // of $1. Pinned on bash 5.2.37; macOS bash 3.2 drops it, so probe
     // this one in docker, not locally.
     const params = positionalArgs(session, callStack)
-    const argv0 = session.scriptName ?? SHELL_ARGV0
-    arr = p.op === ':' ? [argv0, ...params] : params
+    arr = p.op === ':' ? [session.argv0, ...params] : params
   } else {
     arr = session.arrays[p.varName ?? '']
   }

--- a/typescript/packages/core/src/workspace/expand/variable.ts
+++ b/typescript/packages/core/src/workspace/expand/variable.ts
@@ -148,7 +148,7 @@ export function lookupVar(
   }
   if (/^\d+$/.test(name)) {
     const idx = parseInt(name, 10)
-    if (idx === 0) return 'mirage'
+    if (idx === 0) return session.scriptName ?? SHELL_ARGV0
     if (callStack) {
       const fromCall = callStack.getPositional(idx)
       if (fromCall !== '') return fromCall
@@ -538,9 +538,10 @@ function sliceArray(arr: ShellArray, groups: string[], env: Record<string, strin
 // plain, slice, per-element strip/replace/case ops, and ${!a[@]}
 // indices. False for single-word forms (${a[*]}, ${#a[@]}, non-@
 // subscript, or a default/alternate op acting on the joined value).
-// What the shell calls itself, bash's "bash". It is a value of "$@"
-// only through a slice, where bash numbers the positional parameters
-// from 1 and index 0 is this.
+// What the shell calls itself, bash's "bash", when no script is running:
+// a nested `bash`/`sh` overrides it through Session.scriptName. It is a
+// value of "$@" only through a slice, where bash numbers the positional
+// parameters from 1 and index 0 is this.
 const SHELL_ARGV0 = 'mirage'
 
 // The positional parameters in scope, function args winning.
@@ -596,7 +597,8 @@ export async function expandArrayAt(
     // of $1. Pinned on bash 5.2.37; macOS bash 3.2 drops it, so probe
     // this one in docker, not locally.
     const params = positionalArgs(session, callStack)
-    arr = p.op === ':' ? [SHELL_ARGV0, ...params] : params
+    const argv0 = session.scriptName ?? SHELL_ARGV0
+    arr = p.op === ':' ? [argv0, ...params] : params
   } else {
     arr = session.arrays[p.varName ?? '']
   }

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -566,7 +566,7 @@ async function runArgv(
 
   if (name === SB.EVAL) return handleEval(executeFn, args, session)
   if (name === SB.BASH || name === SB.SH) {
-    return handleBash(executeFn, args, session, stdin)
+    return handleBash(dispatch, executeFn, args, session, stdin, name)
   }
   if (name === SB.EXPORT) return handleExport(args, session)
   if (name === SB.UNSET) return handleUnset(args, session)

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -63,6 +63,7 @@ export interface SessionInit {
   functions?: Record<string, unknown>
   lastExitCode?: number
   positionalArgs?: string[]
+  scriptName?: string | null
   shellOptions?: Record<string, boolean>
   readonlyVars?: Set<string>
   arrays?: Record<string, ShellArray>
@@ -89,6 +90,10 @@ export class Session {
   functions: Record<string, unknown>
   lastExitCode: number
   positionalArgs: string[]
+  // What `$0` expands to. Null is the shell itself; a nested `bash`/`sh`
+  // sets it to the script file it is running, or to the name given after
+  // `-c`, and restores it afterwards.
+  scriptName: string | null
   shellOptions: Record<string, boolean>
   readonlyVars: Set<string>
   arrays: Record<string, ShellArray>
@@ -140,6 +145,7 @@ export class Session {
     this.functions = ownRecord(init.functions)
     this.lastExitCode = init.lastExitCode ?? 0
     this.positionalArgs = init.positionalArgs ?? []
+    this.scriptName = init.scriptName ?? null
     this.shellOptions = init.shellOptions ?? {}
     this.readonlyVars = init.readonlyVars ?? new Set()
     this.arrays = ownRecord(init.arrays)
@@ -166,6 +172,7 @@ export class Session {
       functions: overrides.functions ?? { ...this.functions },
       lastExitCode: overrides.lastExitCode ?? this.lastExitCode,
       positionalArgs: overrides.positionalArgs ?? [...this.positionalArgs],
+      scriptName: overrides.scriptName ?? this.scriptName,
       shellOptions: overrides.shellOptions ?? { ...this.shellOptions },
       readonlyVars: overrides.readonlyVars ?? new Set(this.readonlyVars),
       arrays:

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -24,10 +24,12 @@ import type { MountMode } from '../../types.ts'
  * field the other leaks, and adding a field here is a compile error
  * until `snapshot` and `restore` both carry it. `lastExitCode` is
  * deliberately absent: `$?` after a child shell is the child's status,
- * which is the one thing it reports back.
+ * which is the one thing it reports back. `sourceDepth` is here because a
+ * child shell starts outside any `source` its caller is inside.
  */
 export interface ChildShellState {
   cwd: string
+  sourceDepth: number
   env: Record<string, string>
   functions: Record<string, unknown>
   shellOptions: Record<string, boolean>
@@ -235,6 +237,7 @@ export class Session {
     for (const [name, value] of Object.entries(this.arrays)) arrays[name] = [...value]
     return {
       cwd: this.cwd,
+      sourceDepth: this.sourceDepth,
       env: ownRecord(this.env),
       functions: ownRecord(this.functions),
       shellOptions: { ...this.shellOptions },
@@ -251,6 +254,7 @@ export class Session {
   /** Put back a snapshot, ending a child shell. */
   restore(state: ChildShellState): void {
     this.cwd = state.cwd
+    this.sourceDepth = state.sourceDepth
     this.env = state.env
     this.functions = state.functions
     this.shellOptions = state.shellOptions

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -12,9 +12,33 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { SHELL_ARGV0 } from '../../shell/constants.ts'
 import type { AsyncLineIterator } from '../../io/async_line_iterator.ts'
 import type { ShellArray } from '../../shell/array.ts'
 import type { MountMode } from '../../types.ts'
+
+/**
+ * What a child shell gets its own copy of, and the parent gets back
+ * afterwards. A `( … )` subshell and a nested `bash`/`sh` are both child
+ * shells and both read this shape, so neither can drift into isolating a
+ * field the other leaks, and adding a field here is a compile error
+ * until `snapshot` and `restore` both carry it. `lastExitCode` is
+ * deliberately absent: `$?` after a child shell is the child's status,
+ * which is the one thing it reports back.
+ */
+export interface ChildShellState {
+  cwd: string
+  env: Record<string, string>
+  functions: Record<string, unknown>
+  shellOptions: Record<string, boolean>
+  readonlyVars: Set<string>
+  arrays: Record<string, ShellArray>
+  positionalArgs: string[]
+  scriptName: string | null
+  lastBgJobId: number | null
+  getoptsPos: number
+  getoptsOptind: number | null
+}
 
 /**
  * Read one entry of a session record, ignoring anything inherited from
@@ -189,6 +213,54 @@ export class Session {
     forked.cmdsubSeq = this.cmdsubSeq
     forked.cmdsubStatus = this.cmdsubStatus
     return forked
+  }
+
+  /**
+   * What `$0` expands to. Null is the shell itself; a nested `bash`/`sh`
+   * sets it to the script it is running, or to the name given after
+   * `-c`. An empty name is a name, so it is not folded into the default:
+   * GNU `bash -c 'echo "[$0]"' ""` prints `[]`.
+   */
+  get argv0(): string {
+    return this.scriptName ?? SHELL_ARGV0
+  }
+
+  /**
+   * Copy the state a child shell runs on top of. The records go through
+   * `ownRecord` because they hold script-controlled names and must keep
+   * their null prototype across the round trip.
+   */
+  snapshot(): ChildShellState {
+    const arrays: Record<string, ShellArray> = ownRecord()
+    for (const [name, value] of Object.entries(this.arrays)) arrays[name] = [...value]
+    return {
+      cwd: this.cwd,
+      env: ownRecord(this.env),
+      functions: ownRecord(this.functions),
+      shellOptions: { ...this.shellOptions },
+      readonlyVars: new Set(this.readonlyVars),
+      arrays,
+      positionalArgs: [...this.positionalArgs],
+      scriptName: this.scriptName,
+      lastBgJobId: this.lastBgJobId,
+      getoptsPos: this.getoptsPos,
+      getoptsOptind: this.getoptsOptind,
+    }
+  }
+
+  /** Put back a snapshot, ending a child shell. */
+  restore(state: ChildShellState): void {
+    this.cwd = state.cwd
+    this.env = state.env
+    this.functions = state.functions
+    this.shellOptions = state.shellOptions
+    this.readonlyVars = state.readonlyVars
+    this.arrays = state.arrays
+    this.positionalArgs = state.positionalArgs
+    this.scriptName = state.scriptName
+    this.lastBgJobId = state.lastBgJobId
+    this.getoptsPos = state.getoptsPos
+    this.getoptsOptind = state.getoptsOptind
   }
 
   /**

--- a/typescript/packages/core/src/workspace/shell_script_file.test.ts
+++ b/typescript/packages/core/src/workspace/shell_script_file.test.ts
@@ -346,4 +346,28 @@ describe('sh/bash script file', () => {
       await ws.close()
     }
   })
+
+  it('keeps return invalid in a child shell run from a sourced file', async () => {
+    const { ws } = await makeIntegrationWS({
+      'child.sh': 'return 5\necho child-after\n',
+      'lib.sh': 'bash /data/child.sh\necho after=$?\n',
+    })
+    try {
+      const [code, out, err] = await runResult(ws, 'source /data/lib.sh; echo done')
+      expect(out).toBe('child-after\nafter=0\ndone\n')
+      expect(err).toBe("return: can only `return' from a function or sourced script\n")
+      expect(code).toBe(0)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('keeps return valid in the sourced file itself', async () => {
+    const { ws } = await makeIntegrationWS({ 'child.sh': 'return 5\necho child-after\n' })
+    try {
+      expect(await run(ws, 'source /data/child.sh; echo after=$?')).toBe('after=5\n')
+    } finally {
+      await ws.close()
+    }
+  })
 })

--- a/typescript/packages/core/src/workspace/shell_script_file.test.ts
+++ b/typescript/packages/core/src/workspace/shell_script_file.test.ts
@@ -161,4 +161,157 @@ describe('sh/bash script file', () => {
       await ws.close()
     }
   })
+
+  it('applies the option named by -o', async () => {
+    const { ws } = await makeIntegrationWS({ 'pf.sh': 'false | true\necho pipefail=$?\n' })
+    try {
+      expect(await run(ws, 'bash -o pipefail /data/pf.sh')).toBe('pipefail=1\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('applies -o from inside a cluster', async () => {
+    const { ws } = await makeIntegrationWS({ 'pf.sh': 'false | true\necho pipefail=$?\n' })
+    try {
+      const [code, out, err] = await runResult(ws, 'bash -xo pipefail /data/pf.sh')
+      expect(out).toBe('pipefail=1\n')
+      expect(err).toBe('+ false\n+ true\n+ echo pipefail=1\n')
+      expect(code).toBe(0)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('reads a + word as an option, not as the script', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      expect(await runResult(ws, 'bash +x /data/run.sh')).toEqual([0, 'hi\n', ''])
+      expect(await runResult(ws, 'bash +o xtrace /data/run.sh')).toEqual([0, 'hi\n', ''])
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('ends option parsing at a single dash', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      expect(await run(ws, 'bash - /data/run.sh')).toBe('hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('lets a long option consume its value', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      expect(await runResult(ws, 'bash --rcfile /data/run.sh')).toEqual([0, '', ''])
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('refuses an unknown long option', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      const [code, , err] = await runResult(ws, 'bash --nosuch /data/run.sh')
+      expect(err).toBe('bash: --nosuch: unsupported option\n')
+      expect(code).toBe(2)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('reads the program from stdin when no operand names one', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, "echo 'echo hi' | bash")).toBe('hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('keeps every operand positional under -s', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, "echo 'echo zero=$0 one=$1' | bash -s A B")).toBe('zero=bash one=A\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('does not leak the working directory out of a nested shell', async () => {
+    const { ws } = await makeIntegrationWS({
+      'cd.sh': 'cd /data/sub\n',
+      'sub/keep.txt': 'x\n',
+    })
+    try {
+      expect(await run(ws, 'cd /data; bash /data/cd.sh; pwd')).toBe('/data\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('does not leak an export out of a nested shell', async () => {
+    const { ws } = await makeIntegrationWS({ 'exp.sh': 'export LEAK=1\n' })
+    try {
+      expect(await run(ws, 'bash /data/exp.sh; echo [$LEAK]')).toBe('[]\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('does not leak a shell option out of a nested shell', async () => {
+    const { ws } = await makeIntegrationWS({ 'opt.sh': 'set -f\n', 'a.txt': 'x\n' })
+    try {
+      expect(await run(ws, 'bash /data/opt.sh; echo /data/*.txt')).toBe('/data/a.txt\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('keeps a sourced shell option set in the caller', async () => {
+    const { ws } = await makeIntegrationWS({ 'opt.sh': 'set -f\n', 'a.txt': 'x\n' })
+    try {
+      expect(await run(ws, 'source /data/opt.sh; echo /data/*.txt')).toBe('/data/*.txt\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('reports a file source cannot read, as typed', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [code, , err] = await runResult(ws, 'cd /data; source nope.sh')
+      expect(err).toBe('source: nope.sh: No such file or directory\n')
+      expect(code).toBe(1)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('reports a directory operand to source', async () => {
+    const { ws } = await makeIntegrationWS({ 'sub/keep.txt': 'x\n' })
+    try {
+      const [code, , err] = await runResult(ws, 'source /data/sub')
+      expect(err).toBe('source: /data/sub: Is a directory\n')
+      expect(code).toBe(1)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('refuses source with no operand', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [code, out, err] = await runResult(ws, 'source; echo after=$?')
+      expect(err).toBe(
+        'source: filename argument required\nsource: usage: source filename [arguments]\n',
+      )
+      expect(out).toBe('after=2\n')
+      expect(code).toBe(0)
+    } finally {
+      await ws.close()
+    }
+  })
 })

--- a/typescript/packages/core/src/workspace/shell_script_file.test.ts
+++ b/typescript/packages/core/src/workspace/shell_script_file.test.ts
@@ -1,0 +1,164 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeIntegrationWS, run, runExit, runResult } from './fixtures/integration_fixture.ts'
+
+describe('sh/bash script file', () => {
+  it.each(['sh', 'bash'])('%s runs the lines of a script file', async (head) => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo one\necho two\n' })
+    try {
+      expect(await run(ws, `${head} /data/run.sh`)).toBe('one\ntwo\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('resolves the script file against the working directory', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      expect(await run(ws, 'cd /data; sh run.sh')).toBe('hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('takes a script file after --', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      expect(await run(ws, 'bash -- /data/run.sh')).toBe('hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('passes operands to the script as positional parameters', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo $# $1 $2\n' })
+    try {
+      expect(await run(ws, 'sh /data/run.sh a b')).toBe('2 a b\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('stops parsing options at the script file', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo "$@"\n' })
+    try {
+      expect(await run(ws, 'sh /data/run.sh -c foo')).toBe('-c foo\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('sets $0 to the script file', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo $0\n' })
+    try {
+      expect(await run(ws, 'sh /data/run.sh')).toBe('/data/run.sh\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('restores $0 and the positional parameters afterwards', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo inner $1\n' })
+    try {
+      const out = await run(ws, 'set -- outer; sh /data/run.sh inner-arg; echo $0 $1')
+      expect(out).toBe('inner inner-arg\nmirage outer\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('propagates the script exit status', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'exit 7\n' })
+    try {
+      expect(await runExit(ws, 'sh /data/run.sh')).toBe(7)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it.each(['sh', 'bash'])('%s reports a missing script and exits 127', async (head) => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [code, , err] = await runResult(ws, `${head} /data/nope.sh`)
+      expect(err).toBe(`${head}: /data/nope.sh: No such file or directory\n`)
+      expect(code).toBe(127)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('reports a directory operand and exits 126', async () => {
+    const { ws } = await makeIntegrationWS({ 'sub/keep.txt': 'x\n' })
+    try {
+      const [code, , err] = await runResult(ws, 'sh /data/sub')
+      expect(err).toBe('/data/sub: /data/sub: Is a directory\n')
+      expect(code).toBe(126)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('traces the script under -x', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      const [code, out, err] = await runResult(ws, 'bash -x /data/run.sh')
+      expect(out).toBe('hi\n')
+      expect(err).toBe('+ echo hi\n')
+      expect(code).toBe(0)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('does not leak -x into the caller', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      const [, , err] = await runResult(ws, 'bash -x /data/run.sh; echo after')
+      expect(err).toBe('+ echo hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('still runs inline text under -c', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, "sh -c 'echo hello'")).toBe('hello\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('takes a name and positional parameters after -c', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, "sh -c 'echo $0 $# $1 $2' myname a b")).toBe('myname 2 a b\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('names the head word when -c has no argument', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [code, , err] = await runResult(ws, 'sh -c')
+      expect(err).toBe('sh: -c: option requires an argument\n')
+      expect(code).toBe(2)
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/shell_script_file.test.ts
+++ b/typescript/packages/core/src/workspace/shell_script_file.test.ts
@@ -314,4 +314,36 @@ describe('sh/bash script file', () => {
       await ws.close()
     }
   })
+
+  it.each(['sh', 'bash', 'source'])('%s follows a symlinked script operand', async (head) => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      expect(await run(ws, `ln -s /data/run.sh /data/link.sh; ${head} /data/link.sh`)).toBe('hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('follows a relative symlinked script operand', async () => {
+    const { ws } = await makeIntegrationWS({ 'run.sh': 'echo hi\n' })
+    try {
+      expect(await run(ws, 'ln -s run.sh /data/rel.sh; sh /data/rel.sh')).toBe('hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('reports the link for a broken symlinked script operand', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [code, , err] = await runResult(
+        ws,
+        'ln -s /data/gone.sh /data/dead.sh; sh /data/dead.sh',
+      )
+      expect(err).toBe('sh: /data/dead.sh: No such file or directory\n')
+      expect(code).toBe(127)
+    } finally {
+      await ws.close()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

`sh /work/run.sh` printed `/work/run.sh: command not found`. `sh`/`bash` are shell builtins and were dispatched fine; `handle_bash` treated the first non-flag operand as the program *text*, so it ran the literal string `/work/run.sh` as a one-line script. That string is not a command, hence the misleading error naming the file.

- read the operand through the op dispatcher and run its contents
- positional parameters from the operands, and from `-c 'prog' name a b` (previously dropped)
- `$0` is the script path, or the name after `-c` (new `Session.script_name`, read by `$0` and `${@:0}`)
- `-e -u -x -f` were silently ignored, so `bash -x script` traced nothing; they now map through the existing `SET_FLAG_TO_OPTION` table and are restored afterwards
- diagnostics pinned against GNU bash 5.2 in `debian:stable-slim`: missing file 127, unreadable 126, directory 126 (GNU prints the path twice there, because `$0` is already set), prefixed with the head word so `sh` no longer says `bash:`

Not in scope: `bash FILE` still shares the caller's session, so a `cd` inside the script leaks out. Already true of `bash -c`; isolating it needs a string-level subshell.

## Test plan

- new `tests/shell/test_script_file.py` and `shell_script_file.test.ts` (behavior), plus parser unit tests in both languages
- four integ cases added to `integ/bash/control/{sh,bash}.json`, which had `-c` coverage only
- full python suite, TS core (597 files / 7275 tests), integ on ram/disk/redis in both languages, `pre-commit run --all-files`