### PR TITLE
feat(gws): calendar and forms API passthrough

### DIFF
--- a/integ/cli/gws.json
+++ b/integ/cli/gws.json
@@ -559,6 +559,292 @@
         "stdout": "Zoneless\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "gw_calendar_calendars_get",
+      "seq": 563046,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar calendars get --params '{\"calendarId\":\"primary\"}' | jq -r '.summary + \" \" + .timeZone' ",
+      "expect": {
+        "exit": 0,
+        "stdout": "Integ User Asia/Hong_Kong\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_get_by_id",
+      "seq": 563047,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "ID=$(gws calendar events insert --params '{\"calendarId\":\"primary\"}' --json '{\"summary\":\"Vendor Sync\",\"start\":{\"dateTime\":\"2026-03-02T14:00:00+08:00\"},\"end\":{\"dateTime\":\"2026-03-02T15:00:00+08:00\"}}' | jq -r .id); gws calendar events get --params \"{\\\"calendarId\\\":\\\"primary\\\",\\\"eventId\\\":\\\"$ID\\\"}\" | jq -r '.summary + \" \" + .start.dateTime' ",
+      "expect": {
+        "exit": 0,
+        "stdout": "Vendor Sync 2026-03-02T14:00:00+08:00\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_patch_is_partial",
+      "seq": 563048,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "ID=$(gws calendar events insert --params '{\"calendarId\":\"primary\"}' --json '{\"summary\":\"Draft Review\",\"start\":{\"dateTime\":\"2026-03-03T09:00:00+08:00\"},\"end\":{\"dateTime\":\"2026-03-03T10:00:00+08:00\"}}' | jq -r .id); gws calendar events patch --params \"{\\\"calendarId\\\":\\\"primary\\\",\\\"eventId\\\":\\\"$ID\\\"}\" --json '{\"summary\":\"Draft Review (final)\"}' | jq -r '.summary + \" \" + .start.dateTime + \" \" + .end.dateTime' ",
+      "expect": {
+        "exit": 0,
+        "stdout": "Draft Review (final) 2026-03-03T09:00:00+08:00 2026-03-03T10:00:00+08:00\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_patch_reschedules_the_day",
+      "seq": 563049,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "ID=$(gws calendar events insert --params '{\"calendarId\":\"primary\"}' --json '{\"summary\":\"Standup Moved\",\"start\":{\"dateTime\":\"2026-03-04T09:00:00+08:00\"},\"end\":{\"dateTime\":\"2026-03-04T09:30:00+08:00\"}}' | jq -r .id); gws calendar events patch --params \"{\\\"calendarId\\\":\\\"primary\\\",\\\"eventId\\\":\\\"$ID\\\"}\" --json '{\"start\":{\"dateTime\":\"2026-03-05T09:00:00+08:00\"},\"end\":{\"dateTime\":\"2026-03-05T09:30:00+08:00\"}}' > /dev/null; gws calendar events list --params '{\"calendarId\":\"primary\",\"timeMin\":\"2026-03-04T00:00:00+08:00\",\"timeMax\":\"2026-03-05T00:00:00+08:00\"}' | jq -r '.items | length'; gws calendar events list --params '{\"calendarId\":\"primary\",\"timeMin\":\"2026-03-05T00:00:00+08:00\",\"timeMax\":\"2026-03-06T00:00:00+08:00\"}' | jq -r '.items[].summary' ",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\nStandup Moved\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_patch_unknown_is_not_found",
+      "seq": 563050,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events patch --params '{\"calendarId\":\"primary\",\"eventId\":\"nosuchevent\"}' --json '{\"summary\":\"x\"}' 2>&1 | grep -c 'Not Found' ",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_unknown_event_exit_code",
+      "seq": 563051,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events get --params '{\"calendarId\":\"primary\",\"eventId\":\"nosuchevent\"}' > /dev/null 2>&1; echo $?",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_list_paginates",
+      "seq": 563052,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events list --params '{\"calendarId\":\"primary\",\"timeMin\":\"2026-02-11T00:00:00+08:00\",\"timeMax\":\"2026-02-12T00:00:00+08:00\",\"orderBy\":\"startTime\",\"maxResults\":2}' | jq -r '.items | length'",
+      "expect": {
+        "exit": 0,
+        "stdout": "2\n1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_update_info_changes_title",
+      "seq": 563053,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "FID=$(gws forms forms create --json '{\"info\":{\"title\":\"Draft Survey\"}}' | jq -r .formId); gws forms forms batchUpdate --params \"{\\\"formId\\\":\\\"$FID\\\"}\" --json '{\"requests\":[{\"updateFormInfo\":{\"info\":{\"title\":\"Customer Survey\",\"description\":\"Tell us about your order\"},\"updateMask\":\"title,description\"}}]}' > /dev/null; gws forms forms get --params \"{\\\"formId\\\":\\\"$FID\\\"}\" | jq -r '.info.title + \" | \" + .info.description' ",
+      "expect": {
+        "exit": 0,
+        "stdout": "Customer Survey | Tell us about your order\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_create_item_honors_the_index",
+      "seq": 563054,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "FID=$(gws forms forms create --json '{\"info\":{\"title\":\"Ordered\"}}' | jq -r .formId); gws forms forms batchUpdate --params \"{\\\"formId\\\":\\\"$FID\\\"}\" --json '{\"requests\":[{\"createItem\":{\"item\":{\"title\":\"First asked\"},\"location\":{\"index\":0}}},{\"createItem\":{\"item\":{\"title\":\"Asked second\"},\"location\":{\"index\":0}}}]}' > /dev/null; gws forms forms get --params \"{\\\"formId\\\":\\\"$FID\\\"}\" | jq -r '.items[].title' ",
+      "expect": {
+        "exit": 0,
+        "stdout": "Asked second\nFirst asked\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_batch_update_bumps_the_revision",
+      "seq": 563055,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "FID=$(gws forms forms create --json '{\"info\":{\"title\":\"Revised\"}}' | jq -r .formId); gws forms forms get --params \"{\\\"formId\\\":\\\"$FID\\\"}\" | jq -r .revisionId; gws forms forms batchUpdate --params \"{\\\"formId\\\":\\\"$FID\\\"}\" --json '{\"requests\":[{\"updateFormInfo\":{\"info\":{\"description\":\"v2\"},\"updateMask\":\"description\"}}]}' > /dev/null; gws forms forms get --params \"{\\\"formId\\\":\\\"$FID\\\"}\" | jq -r .revisionId",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n2\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_get_unknown_is_not_found",
+      "seq": 563056,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws forms forms get --params '{\"formId\":\"nope\"}' 2>&1 | grep -ci 'not found' ",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_list_pages_are_ordered",
+      "seq": 563057,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events list --params '{\"calendarId\":\"primary\",\"timeMin\":\"2026-02-11T00:00:00+08:00\",\"timeMax\":\"2026-02-12T00:00:00+08:00\",\"orderBy\":\"startTime\",\"maxResults\":2}' | jq -r '.items[].summary'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Conference Offsite\nPublic Holiday\nPhD Dissertation Defense\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_list_names_every_calendar",
+      "seq": 563058,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar calendarList list | jq -r '.items[].summary'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Integ User\nTeam Roadmap\nHolidays in United States\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_list_reports_access_roles",
+      "seq": 563059,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar calendarList list | jq -r '.items[] | .id + \" \" + .accessRole'",
+      "expect": {
+        "exit": 0,
+        "stdout": "integ@example.com owner\nteam@group.calendar.google.com writer\nen.usa#holiday@group.v.calendar.google.com reader\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_on_a_secondary_calendar",
+      "seq": 563060,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events list --params '{\"calendarId\":\"team@group.calendar.google.com\"}' | jq -r '.items[].summary'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Roadmap Review\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_id_with_a_fragment_reaches_the_api",
+      "seq": 563061,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events list --params '{\"calendarId\":\"en.usa#holiday@group.v.calendar.google.com\"}' | jq -r '.items[].summary'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Presidents' Day\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_insert_on_a_reader_calendar_is_denied",
+      "seq": 563062,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events insert --params '{\"calendarId\":\"en.usa#holiday@group.v.calendar.google.com\"}' --json '{\"summary\":\"Nope\",\"start\":{\"date\":\"2026-02-20\"},\"end\":{\"date\":\"2026-02-21\"}}' 2>&1 | grep -c 'writer access'",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_reader_calendar_insert_exit_code",
+      "seq": 563063,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events insert --params '{\"calendarId\":\"en.usa#holiday@group.v.calendar.google.com\"}' --json '{\"summary\":\"Nope\",\"start\":{\"date\":\"2026-02-20\"},\"end\":{\"date\":\"2026-02-21\"}}' > /dev/null 2>&1; echo $?",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_freebusy_spans_calendars",
+      "seq": 563064,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar freebusy query --json '{\"timeMin\":\"2026-02-11T00:00:00+08:00\",\"timeMax\":\"2026-02-12T00:00:00+08:00\",\"items\":[{\"id\":\"primary\"},{\"id\":\"team@group.calendar.google.com\"}]}' | jq -r '.calendars[\"team@group.calendar.google.com\"].busy | length'",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_seeded_responses_are_listed",
+      "seq": 563065,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "FID=$(gws drive files list --params \"{\\\"q\\\":\\\"mimeType='application/vnd.google-apps.form'\\\"}\" | jq -r '.files[] | select(.name==\"Recall Survey\") | .id'); gws forms forms responses list --params \"{\\\"formId\\\":\\\"$FID\\\"}\" | jq -r '.responses[].responseId'",
+      "expect": {
+        "exit": 0,
+        "stdout": "resp0001\nresp0002\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_responses_get_one",
+      "seq": 563066,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "FID=$(gws drive files list --params \"{\\\"q\\\":\\\"mimeType='application/vnd.google-apps.form'\\\"}\" | jq -r '.files[] | select(.name==\"Recall Survey\") | .id'); gws forms forms responses get --params \"{\\\"formId\\\":\\\"$FID\\\",\\\"responseId\\\":\\\"resp0002\\\"}\" | jq -r '.answers.q_serial.textAnswers.answers[0].value'",
+      "expect": {
+        "exit": 0,
+        "stdout": "SN-9902\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_seeded_items_are_readable",
+      "seq": 563067,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "FID=$(gws drive files list --params \"{\\\"q\\\":\\\"mimeType='application/vnd.google-apps.form'\\\"}\" | jq -r '.files[] | select(.name==\"Recall Survey\") | .id'); gws forms forms get --params \"{\\\"formId\\\":\\\"$FID\\\"}\" | jq -r '.items[].title'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Serial number\nContact email\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/gws.json
+++ b/integ/cli/gws.json
@@ -546,6 +546,19 @@
         "stdout": "0\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "gw_calendar_zoneless_datetime_uses_declared_zone",
+      "seq": 563045,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events insert --params '{\"calendarId\":\"primary\"}' --json '{\"summary\":\"Zoneless\",\"start\":{\"dateTime\":\"2026-02-19T09:00:00\",\"timeZone\":\"Asia/Hong_Kong\"},\"end\":{\"dateTime\":\"2026-02-19T10:30:00\",\"timeZone\":\"Asia/Hong_Kong\"}}' > /dev/null; gws calendar events list --params '{\"calendarId\":\"primary\",\"timeMin\":\"2026-02-19T00:30:00Z\",\"timeMax\":\"2026-02-19T01:30:00Z\"}' | jq -r '.items[].summary'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Zoneless\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/gws.json
+++ b/integ/cli/gws.json
@@ -9,7 +9,7 @@
       "command": "gws --help | grep -c 'API commands'",
       "expect": {
         "exit": 0,
-        "stdout": "6\n",
+        "stdout": "8\n",
         "stderr": ""
       }
     },
@@ -388,6 +388,162 @@
       "expect": {
         "exit": 0,
         "stdout": "marcus@example.com\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_list_primary",
+      "seq": 563033,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar calendarList list | jq -r '.items[] | select(.primary) | .id'",
+      "expect": {
+        "exit": 0,
+        "stdout": "integ@example.com\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_timezone_is_reported",
+      "seq": 563034,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar calendarList list | jq -r '.items[0].timeZone'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Asia/Hong_Kong\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_list_day",
+      "seq": 563035,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events list --params '{\"calendarId\":\"primary\",\"timeMin\":\"2026-02-11T00:00:00+08:00\",\"timeMax\":\"2026-02-12T00:00:00+08:00\",\"orderBy\":\"startTime\"}' | jq -r '.items[].summary'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Conference Offsite\nPublic Holiday\nPhD Dissertation Defense\nAcademic Committee Meeting\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_all_day_end_is_exclusive",
+      "seq": 563036,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events list --params '{\"calendarId\":\"primary\",\"timeMin\":\"2026-02-12T00:00:00+08:00\",\"timeMax\":\"2026-02-13T00:00:00+08:00\"}' | jq -r '[.items[].summary] | join(\",\")'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Conference Offsite\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_q_search",
+      "seq": 563037,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events list --params '{\"calendarId\":\"primary\",\"q\":\"committee\"}' | jq -r '.items[].summary'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Academic Committee Meeting\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_insert_and_get",
+      "seq": 563038,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events insert --params '{\"calendarId\":\"primary\"}' --json '{\"summary\":\"COML camera-ready\",\"start\":{\"dateTime\":\"2026-02-21T20:59:00-12:00\"},\"end\":{\"dateTime\":\"2026-02-21T21:59:00-12:00\"}}' | jq -r '.start.dateTime'",
+      "expect": {
+        "exit": 0,
+        "stdout": "2026-02-21T20:59:00-12:00\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_event_id_is_26_chars",
+      "seq": 563039,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar events list --params '{\"calendarId\":\"primary\",\"q\":\"committee\"}' | jq -r '.items[0].id | length'",
+      "expect": {
+        "exit": 0,
+        "stdout": "26\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_freebusy_query",
+      "seq": 563040,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws calendar freebusy query --json '{\"timeMin\":\"2026-02-11T00:00:00+08:00\",\"timeMax\":\"2026-02-12T00:00:00+08:00\",\"items\":[{\"id\":\"primary\"}]}' | jq -r '.calendars.primary.busy | length'",
+      "expect": {
+        "exit": 0,
+        "stdout": "4\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_calendar_events_delete",
+      "seq": 563041,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "ID=$(gws calendar events list --params '{\"calendarId\":\"primary\",\"q\":\"committee\"}' | jq -r '.items[0].id'); gws calendar events delete --params \"{\\\"calendarId\\\":\\\"primary\\\",\\\"eventId\\\":\\\"$ID\\\"}\"; gws calendar events list --params '{\"calendarId\":\"primary\",\"q\":\"committee\"}' | jq -r '.items | length'",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_create_and_add_question",
+      "seq": 563042,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "FID=$(gws forms forms create --json '{\"info\":{\"title\":\"Recall Form\",\"documentTitle\":\"Recall\"}}' | jq -r .formId); gws forms forms batchUpdate --params \"{\\\"formId\\\":\\\"$FID\\\"}\" --json '{\"requests\":[{\"createItem\":{\"item\":{\"title\":\"Serial number?\",\"questionItem\":{\"question\":{\"textQuestion\":{}}}},\"location\":{\"index\":0}}}]}' > /dev/null; gws forms forms get --params \"{\\\"formId\\\":\\\"$FID\\\"}\" | jq -r '.items[].title'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Serial number?\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_id_is_the_drive_file_id",
+      "seq": 563043,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "FID=$(gws forms forms create --json '{\"info\":{\"title\":\"Survey\",\"documentTitle\":\"Survey\"}}' | jq -r .formId); gws drive files list --params '{\"q\":\"mimeType=\\u0027application/vnd.google-apps.form\\u0027\"}' | jq -r --arg f \"$FID\" '[.files[].id] | index($f) != null'",
+      "expect": {
+        "exit": 0,
+        "stdout": "true\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_forms_responses_empty",
+      "seq": 563044,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "FID=$(gws forms forms create --json '{\"info\":{\"title\":\"Poll\"}}' | jq -r .formId); gws forms forms responses list --params \"{\\\"formId\\\":\\\"$FID\\\"}\" | jq -r '.responses | length'",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n",
         "stderr": ""
       }
     }

--- a/integ/fixtures/calendar/v1.json
+++ b/integ/fixtures/calendar/v1.json
@@ -1,0 +1,22 @@
+[
+  {
+    "summary": "PhD Dissertation Defense",
+    "start": { "dateTime": "2026-02-11T09:00:00+08:00" },
+    "end": { "dateTime": "2026-02-11T10:30:00+08:00" }
+  },
+  {
+    "summary": "Academic Committee Meeting",
+    "start": { "dateTime": "2026-02-11T15:00:00+08:00" },
+    "end": { "dateTime": "2026-02-11T16:00:00+08:00" }
+  },
+  {
+    "summary": "Conference Offsite",
+    "start": { "dateTime": "2026-02-10T09:00:00+08:00" },
+    "end": { "dateTime": "2026-02-13T17:00:00+08:00" }
+  },
+  {
+    "summary": "Public Holiday",
+    "start": { "date": "2026-02-11" },
+    "end": { "date": "2026-02-12" }
+  }
+]

--- a/integ/fixtures/calendar/v1.json
+++ b/integ/fixtures/calendar/v1.json
@@ -1,22 +1,52 @@
-[
-  {
-    "summary": "PhD Dissertation Defense",
-    "start": { "dateTime": "2026-02-11T09:00:00+08:00" },
-    "end": { "dateTime": "2026-02-11T10:30:00+08:00" }
-  },
-  {
-    "summary": "Academic Committee Meeting",
-    "start": { "dateTime": "2026-02-11T15:00:00+08:00" },
-    "end": { "dateTime": "2026-02-11T16:00:00+08:00" }
-  },
-  {
-    "summary": "Conference Offsite",
-    "start": { "dateTime": "2026-02-10T09:00:00+08:00" },
-    "end": { "dateTime": "2026-02-13T17:00:00+08:00" }
-  },
-  {
-    "summary": "Public Holiday",
-    "start": { "date": "2026-02-11" },
-    "end": { "date": "2026-02-12" }
-  }
-]
+{
+  "events": [
+    {
+      "summary": "PhD Dissertation Defense",
+      "start": { "dateTime": "2026-02-11T09:00:00+08:00" },
+      "end": { "dateTime": "2026-02-11T10:30:00+08:00" }
+    },
+    {
+      "summary": "Academic Committee Meeting",
+      "start": { "dateTime": "2026-02-11T15:00:00+08:00" },
+      "end": { "dateTime": "2026-02-11T16:00:00+08:00" }
+    },
+    {
+      "summary": "Conference Offsite",
+      "start": { "dateTime": "2026-02-10T09:00:00+08:00" },
+      "end": { "dateTime": "2026-02-13T17:00:00+08:00" }
+    },
+    {
+      "summary": "Public Holiday",
+      "start": { "date": "2026-02-11" },
+      "end": { "date": "2026-02-12" }
+    }
+  ],
+  "calendars": [
+    {
+      "id": "team@group.calendar.google.com",
+      "summary": "Team Roadmap",
+      "timeZone": "Asia/Hong_Kong",
+      "accessRole": "writer",
+      "events": [
+        {
+          "summary": "Roadmap Review",
+          "start": { "dateTime": "2026-02-11T11:00:00+08:00" },
+          "end": { "dateTime": "2026-02-11T12:00:00+08:00" }
+        }
+      ]
+    },
+    {
+      "id": "en.usa#holiday@group.v.calendar.google.com",
+      "summary": "Holidays in United States",
+      "timeZone": "Asia/Hong_Kong",
+      "accessRole": "reader",
+      "events": [
+        {
+          "summary": "Presidents' Day",
+          "start": { "date": "2026-02-16" },
+          "end": { "date": "2026-02-17" }
+        }
+      ]
+    }
+  ]
+}

--- a/integ/fixtures/forms/v1.json
+++ b/integ/fixtures/forms/v1.json
@@ -1,0 +1,55 @@
+[
+  {
+    "title": "Product Recall Survey",
+    "documentTitle": "Recall Survey",
+    "description": "Owners of the affected batch",
+    "items": [
+      {
+        "itemId": "serial",
+        "title": "Serial number",
+        "questionItem": {
+          "question": { "questionId": "q_serial", "textQuestion": {} }
+        }
+      },
+      {
+        "itemId": "email",
+        "title": "Contact email",
+        "questionItem": {
+          "question": { "questionId": "q_email", "textQuestion": {} }
+        }
+      }
+    ],
+    "responses": [
+      {
+        "responseId": "resp0001",
+        "createTime": "2026-02-09T03:00:00Z",
+        "lastSubmittedTime": "2026-02-09T03:00:00Z",
+        "answers": {
+          "q_serial": {
+            "questionId": "q_serial",
+            "textAnswers": { "answers": [{ "value": "SN-4417" }] }
+          },
+          "q_email": {
+            "questionId": "q_email",
+            "textAnswers": { "answers": [{ "value": "dana@example.com" }] }
+          }
+        }
+      },
+      {
+        "responseId": "resp0002",
+        "createTime": "2026-02-09T04:30:00Z",
+        "lastSubmittedTime": "2026-02-09T04:30:00Z",
+        "answers": {
+          "q_serial": {
+            "questionId": "q_serial",
+            "textAnswers": { "answers": [{ "value": "SN-9902" }] }
+          },
+          "q_email": {
+            "questionId": "q_email",
+            "textAnswers": { "answers": [{ "value": "lila@example.com" }] }
+          }
+        }
+      }
+    ]
+  }
+]

--- a/integ/resources/google/g.json
+++ b/integ/resources/google/g.json
@@ -402,7 +402,7 @@
       "command": "gws --help | grep -c 'API commands'",
       "expect": {
         "exit": 0,
-        "stdout": "6\n",
+        "stdout": "8\n",
         "stderr": ""
       }
     },

--- a/integ/resources/google/gcal.json
+++ b/integ/resources/google/gcal.json
@@ -1,0 +1,160 @@
+{
+  "cases": [
+    {
+      "id": "gc_root_lists_one_dir_per_calendar",
+      "seq": 570000,
+      "targets": [
+        "gcal"
+      ],
+      "command": "ls /cal",
+      "expect": {
+        "exit": 0,
+        "stdout": "Holidays_in_United_States__en.usa#holiday@group.v.calendar.google.com\nTeam_Roadmap__team@group.calendar.google.com\nprimary\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_calendar_lists_days_holding_events",
+      "seq": 570001,
+      "targets": [
+        "gcal"
+      ],
+      "command": "ls /cal/primary",
+      "expect": {
+        "exit": 0,
+        "stdout": "2026-02-10\n2026-02-11\n2026-02-12\n2026-02-13\ncalendar.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_day_lists_one_file_per_event",
+      "seq": 570002,
+      "targets": [
+        "gcal"
+      ],
+      "command": "ls /cal/primary/2026-02-11 | sed 's/^[a-z0-9]*__/ID__/'",
+      "expect": {
+        "exit": 0,
+        "stdout": "ID__0900-1030_PhD_Dissertation_Defense.gcal.json\nID__1500-1600_Academic_Committee_Meeting.gcal.json\nID__0000-2400_Conference_Offsite.gcal.json\nID__0000-2400_Public_Holiday.gcal.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_calendar_json_reports_the_bucket_zone",
+      "seq": 570003,
+      "targets": [
+        "gcal"
+      ],
+      "command": "cat /cal/primary/calendar.json | jq -r '.accessRole + \" \" + .bucketTimeZone'",
+      "expect": {
+        "exit": 0,
+        "stdout": "owner Asia/Hong_Kong\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_event_payload_is_the_api_item",
+      "seq": 570004,
+      "targets": [
+        "gcal"
+      ],
+      "command": "cat /cal/primary/2026-02-11/*PhD*.gcal.json | jq -r '.summary + \" \" + .start.dateTime'",
+      "expect": {
+        "exit": 0,
+        "stdout": "PhD Dissertation Defense 2026-02-11T09:00:00+08:00\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_multi_day_event_appears_under_every_day",
+      "seq": 570005,
+      "targets": [
+        "gcal"
+      ],
+      "command": "ls /cal/primary/2026-02-10 /cal/primary/2026-02-12 | grep -c Conference_Offsite",
+      "expect": {
+        "exit": 0,
+        "stdout": "2\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_an_event_free_day_is_an_empty_directory",
+      "seq": 570006,
+      "targets": [
+        "gcal"
+      ],
+      "command": "ls /cal/primary/2027-03-04; echo $?",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_a_calendar_id_with_a_fragment_is_browsable",
+      "seq": 570007,
+      "targets": [
+        "gcal"
+      ],
+      "command": "ls '/cal/Holidays_in_United_States__en.usa#holiday@group.v.calendar.google.com'",
+      "expect": {
+        "exit": 0,
+        "stdout": "2026-02-16\ncalendar.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_free_busy_is_not_claimed_for_a_reader_calendar",
+      "seq": 570008,
+      "targets": [
+        "gcal"
+      ],
+      "command": "cat '/cal/Team_Roadmap__team@group.calendar.google.com/calendar.json' | jq -r .accessRole",
+      "expect": {
+        "exit": 0,
+        "stdout": "writer\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_find_type_f_reports_events_not_directories",
+      "seq": 570009,
+      "targets": [
+        "gcal"
+      ],
+      "command": "find /cal/primary/2026-02-11 -type f | wc -l | tr -d ' '",
+      "expect": {
+        "exit": 0,
+        "stdout": "4\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_rm_deletes_the_event",
+      "seq": 570010,
+      "targets": [
+        "gcal"
+      ],
+      "command": "rm /cal/primary/2026-02-11/*Committee*.gcal.json && ls /cal/primary/2026-02-11 | grep -c Committee; echo $?",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gc_rm_refuses_a_calendar_the_account_cannot_write",
+      "seq": 570011,
+      "targets": [
+        "gcal"
+      ],
+      "command": "rm '/cal/Holidays_in_United_States__en.usa#holiday@group.v.calendar.google.com/2026-02-16/'*.gcal.json > /dev/null 2>&1; echo $?",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -65,6 +65,8 @@ from mirage.resource.discord.discord import DiscordResource
 from mirage.resource.disk import DiskResource
 from mirage.resource.dropbox import DropboxConfig, DropboxResource
 from mirage.resource.email.email import EmailResource
+from mirage.resource.gcal.config import GCalConfig
+from mirage.resource.gcal.gcal import GCalResource
 from mirage.resource.gcs import GCSConfig, GCSResource
 from mirage.resource.gdocs.config import GDocsConfig
 from mirage.resource.gdocs.gdocs import GDocsResource
@@ -674,6 +676,15 @@ class GwsService:
             GSlidesConfig(client_id="integ",
                           refresh_token="integ",
                           api_base=self.url))
+
+    def gcal_resource(self) -> GCalResource:
+        # today is pinned so the rolling window is the same on both hosts
+        # and lands on the seeded events.
+        return GCalResource(
+            GCalConfig(client_id="integ",
+                       refresh_token="integ",
+                       api_base=self.url,
+                       today="2026-02-11"))
 
     def gmail_resource(self) -> GmailResource:
         return GmailResource(
@@ -1909,6 +1920,13 @@ def build_email(
     return service.resource(mount), _noop
 
 
+def build_gcal(
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
+    assert isinstance(service, GwsService)
+    return service.gcal_resource(), _noop
+
+
 def build_gmail(
         mount: dict, run_id: str, service: Service | None
 ) -> tuple[object, Callable[[], Awaitable[None]]]:
@@ -2062,6 +2080,7 @@ BUILDERS = {
     "gdocs": build_gdocs,
     "gsheets": build_gsheets,
     "gslides": build_gslides,
+    "gcal": build_gcal,
     "gmail": build_gmail,
     "email": build_email,
     "hf": build_hf,

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -532,6 +532,12 @@ class GwsService:
                 ).parents[2] / "fixtures" / f"{mail}.json"
                 await cls._seed_mail(session, url,
                                      json.loads(manifest.read_text()))
+            calendar = target.get("calendar")
+            if calendar:
+                manifest = Path(__file__).resolve(
+                ).parents[2] / "fixtures" / f"{calendar}.json"
+                await cls._seed_calendar(session, url,
+                                         json.loads(manifest.read_text()))
         return cls(url, folder_ids, target.get("cli_scope"))
 
     @staticmethod
@@ -577,6 +583,18 @@ class GwsService:
                     resp.raise_for_status()
             else:
                 raise ValueError(f"unknown google-apps kind: {kind}")
+
+    @staticmethod
+    async def _seed_calendar(session: aiohttp.ClientSession, url: str,
+                             entries: list[dict]) -> None:
+        # Events are API objects, so they seed through events.insert and
+        # take the ids the server mints; the manifest pins the times, which
+        # is what the day directories are derived from.
+        for entry in entries:
+            async with session.post(
+                    f"{url}/calendar/v3/calendars/primary/events",
+                    json=entry) as resp:
+                resp.raise_for_status()
 
     @staticmethod
     async def _seed_mail(session: aiohttp.ClientSession, url: str,

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -501,7 +501,16 @@ class GwsService:
         # Native mounts (gdocs/gsheets/gslides) render the modified date
         # into filenames, so those targets pin the server clock.
         epoch = target.get("epoch")
-        reset_body = {"epoch": epoch} if epoch else {}
+        reset_body: dict = {"epoch": epoch} if epoch else {}
+        # Secondary calendars and seeded form responses are declared to
+        # /reset rather than inserted: a calendar's accessRole and a form
+        # response are both states no API call can produce.
+        calendar = cls._manifest(target.get("calendar"))
+        if calendar and calendar.get("calendars"):
+            reset_body["calendars"] = calendar["calendars"]
+        forms = cls._manifest(target.get("forms"))
+        if forms:
+            reset_body["forms"] = forms
         async with aiohttp.ClientSession() as session:
             async with session.post(f"{url}/reset", json=reset_body) as resp:
                 resp.raise_for_status()
@@ -520,25 +529,31 @@ class GwsService:
                 for segment in str(mount["root"]).split("/"):
                     parent = await cls._folder(session, url, segment, parent)
                 folder_ids[mount["path"]] = parent
-            apps = target.get("apps")
+            apps = cls._manifest(target.get("apps"))
             if apps:
-                manifest = Path(__file__).resolve(
-                ).parents[2] / "fixtures" / f"{apps}.json"
-                await cls._seed_apps(session, url,
-                                     json.loads(manifest.read_text()))
-            mail = target.get("mail")
+                await cls._seed_apps(session, url, apps)
+            mail = cls._manifest(target.get("mail"))
             if mail:
-                manifest = Path(__file__).resolve(
-                ).parents[2] / "fixtures" / f"{mail}.json"
-                await cls._seed_mail(session, url,
-                                     json.loads(manifest.read_text()))
-            calendar = target.get("calendar")
+                await cls._seed_mail(session, url, mail)
             if calendar:
-                manifest = Path(__file__).resolve(
-                ).parents[2] / "fixtures" / f"{calendar}.json"
-                await cls._seed_calendar(session, url,
-                                         json.loads(manifest.read_text()))
+                await cls._seed_calendar(session, url, calendar["events"])
         return cls(url, folder_ids, target.get("cli_scope"))
+
+    @staticmethod
+    def _manifest(name: str | None) -> list | dict | None:
+        """Read a fixture manifest by its targets.json name.
+
+        Args:
+            name (str | None): the fixture path, e.g. ``calendar/v1``.
+
+        Returns:
+            list | dict | None: the parsed manifest, or None when unnamed.
+        """
+        if not name:
+            return None
+        path = Path(
+            __file__).resolve().parents[2] / "fixtures" / f"{name}.json"
+        return json.loads(path.read_text())
 
     @staticmethod
     async def _seed_apps(session: aiohttp.ClientSession, url: str,

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -1119,6 +1119,33 @@ interface CalendarEntry {
   end: { date?: string; dateTime?: string }
 }
 
+interface SeedCalendar {
+  id: string
+  summary: string
+  timeZone?: string
+  accessRole?: string
+  hidden?: boolean
+  events?: CalendarEntry[]
+}
+
+interface SeedForm {
+  title: string
+  documentTitle?: string
+  description?: string
+  items?: Record<string, unknown>[]
+  responses?: Record<string, unknown>[]
+}
+
+interface CalendarFixture {
+  events: CalendarEntry[]
+  calendars?: SeedCalendar[]
+}
+
+function gwsManifest<T>(name: string | undefined): T | undefined {
+  if (name === undefined) return undefined
+  return JSON.parse(readFileSync(join(integRoot(), 'fixtures', `${name}.json`), 'utf8')) as T
+}
+
 interface MailEntry {
   from: string
   to: string
@@ -1217,11 +1244,20 @@ async function openGws(target: Target): Promise<Open> {
   while (base.endsWith('/')) base = base.slice(0, -1)
   if (base === '') throw new Error('gdrive target requires GWS_URL')
   // Native mounts (gdocs/gsheets/gslides) render the modified date into
-  // filenames, so those targets pin the server clock.
+  // filenames, so those targets pin the server clock. Secondary calendars
+  // and seeded form responses ride the same call rather than being
+  // inserted: a calendar's accessRole and a form response are both states
+  // no API call can produce.
+  const calendar = gwsManifest<CalendarFixture>(target.calendar)
+  const forms = gwsManifest<SeedForm[]>(target.forms)
+  const reset: Record<string, unknown> = {}
+  if (target.epoch !== undefined) reset.epoch = target.epoch
+  if (calendar?.calendars !== undefined) reset.calendars = calendar.calendars
+  if (forms !== undefined) reset.forms = forms
   await gwsJson(`${base}/reset`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(target.epoch !== undefined ? { epoch: target.epoch } : {}),
+    body: JSON.stringify(reset),
   })
   const mounts: Record<
     string,
@@ -1262,18 +1298,11 @@ async function openGws(target: Target): Promise<Open> {
     })
     folderIds[m.path] = parent
   }
-  if (target.apps !== undefined) {
-    const manifest = join(integRoot(), 'fixtures', `${target.apps}.json`)
-    await seedGwsApps(base, JSON.parse(readFileSync(manifest, 'utf8')) as GwsAppEntry[])
-  }
-  if (target.mail !== undefined) {
-    const manifest = join(integRoot(), 'fixtures', `${target.mail}.json`)
-    await seedGwsMail(base, JSON.parse(readFileSync(manifest, 'utf8')) as MailEntry[])
-  }
-  if (target.calendar !== undefined) {
-    const manifest = join(integRoot(), 'fixtures', `${target.calendar}.json`)
-    await seedGwsCalendar(base, JSON.parse(readFileSync(manifest, 'utf8')) as CalendarEntry[])
-  }
+  const apps = gwsManifest<GwsAppEntry[]>(target.apps)
+  if (apps !== undefined) await seedGwsApps(base, apps)
+  const mail = gwsManifest<MailEntry[]>(target.mail)
+  if (mail !== undefined) await seedGwsMail(base, mail)
+  if (calendar !== undefined) await seedGwsCalendar(base, calendar.events)
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   if (target.clis?.includes('gws') === true) {
     // A target may scope the gws install to one mount's folder, the

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -1111,6 +1111,14 @@ async function seedGwsApps(base: string, entries: GwsAppEntry[]): Promise<void> 
   }
 }
 
+interface CalendarEntry {
+  summary: string
+  // A timed event carries dateTime with a mandatory offset; an all-day one
+  // carries a floating date and no zone at all.
+  start: { date?: string; dateTime?: string }
+  end: { date?: string; dateTime?: string }
+}
+
 interface MailEntry {
   from: string
   to: string
@@ -1174,6 +1182,19 @@ async function seedGwsMail(base: string, entries: MailEntry[]): Promise<void> {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ raw, labelIds: entry.labels ?? [] }),
+    })
+  }
+}
+
+// Events are API objects, so they seed through events.insert and take the
+// ids the server mints; the manifest pins the times, which is what the day
+// directories are derived from.
+async function seedGwsCalendar(base: string, entries: CalendarEntry[]): Promise<void> {
+  for (const entry of entries) {
+    await gwsJson(`${base}/calendar/v3/calendars/primary/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(entry),
     })
   }
 }
@@ -1248,6 +1269,10 @@ async function openGws(target: Target): Promise<Open> {
   if (target.mail !== undefined) {
     const manifest = join(integRoot(), 'fixtures', `${target.mail}.json`)
     await seedGwsMail(base, JSON.parse(readFileSync(manifest, 'utf8')) as MailEntry[])
+  }
+  if (target.calendar !== undefined) {
+    const manifest = join(integRoot(), 'fixtures', `${target.calendar}.json`)
+    await seedGwsCalendar(base, JSON.parse(readFileSync(manifest, 'utf8')) as CalendarEntry[])
   }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   if (target.clis?.includes('gws') === true) {

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -40,6 +40,7 @@ import {
   GDocsResource,
   GDriveResource,
   GmailResource,
+  GCalResource,
   GCSResource,
   GitHubResource,
   GitHubCIResource,
@@ -1229,13 +1230,16 @@ async function seedGwsCalendar(base: string, entries: CalendarEntry[]): Promise<
 function gwsNativeResource(
   resource: string,
   base: string,
-): GDocsResource | GSheetsResource | GSlidesResource | GmailResource {
+): GDocsResource | GSheetsResource | GSlidesResource | GmailResource | GCalResource {
   // apiBase points the backend at the fake server through the same
   // config field a real embedder uses; nothing is monkey-patched.
   const config = { clientId: 'integ', clientSecret: 'integ', refreshToken: 'integ', apiBase: base }
   if (resource === 'gdocs') return new GDocsResource(config)
   if (resource === 'gsheets') return new GSheetsResource(config)
   if (resource === 'gmail') return new GmailResource(config)
+  // today is pinned so the rolling window is the same on both hosts and
+  // lands on the seeded events.
+  if (resource === 'gcal') return new GCalResource({ ...config, today: '2026-02-11' })
   return new GSlidesResource(config)
 }
 
@@ -1612,6 +1616,7 @@ export const ADAPTERS: Record<string, (target: Target) => Promise<Open>> = {
   nextcloud: openNextcloud,
   gridfs: openGridfs,
   ssh: openSsh,
+  gcal: openGws,
   gdrive: openGws,
   gdocs: openGws,
   gsheets: openGws,

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -60,6 +60,7 @@ export interface Target {
   epoch?: string
   apps?: string
   mail?: string
+  calendar?: string
   dataset?: string
   agentId?: string
   facet?: string

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -61,6 +61,7 @@ export interface Target {
   apps?: string
   mail?: string
   calendar?: string
+  forms?: string
   dataset?: string
   agentId?: string
   facet?: string

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -60,6 +60,7 @@ const FOLDER_MIME = 'application/vnd.google-apps.folder'
 const DOC_MIME = 'application/vnd.google-apps.document'
 const SHEET_MIME = 'application/vnd.google-apps.spreadsheet'
 const SLIDE_MIME = 'application/vnd.google-apps.presentation'
+const FORM_MIME = 'application/vnd.google-apps.form'
 const OWNER = { displayName: 'Integ User', emailAddress: 'integ@example.com', me: true }
 
 // The grid a new spreadsheet gets, and the pixel sizes the live API
@@ -150,6 +151,57 @@ interface GmailLabel {
 
 const SYSTEM_LABELS = ['INBOX', 'SENT', 'UNREAD', 'TRASH']
 
+// A timed event carries dateTime (RFC3339, offset mandatory) and may name its
+// own IANA zone; an all-day event carries a floating `date` and no zone at all.
+interface EventTime {
+  date?: string
+  dateTime?: string
+  timeZone?: string
+}
+
+interface CalendarEvent {
+  id: string
+  status: string
+  summary?: string
+  description?: string
+  location?: string
+  start: EventTime
+  end: EventTime
+  attendees?: Record<string, unknown>[]
+  created: string
+  updated: string
+}
+
+interface CalendarEntry {
+  id: string
+  summary: string
+  timeZone: string
+  accessRole: string
+  primary?: boolean
+  hidden?: boolean
+}
+
+interface FormItem {
+  itemId: string
+  title?: string
+  questionItem?: Record<string, unknown>
+}
+
+interface FormDoc {
+  formId: string
+  title: string
+  documentTitle: string
+  description?: string
+  items: FormItem[]
+  responses: Record<string, unknown>[]
+  revision: number
+}
+
+// Non-UTC on purpose: a UTC default would hide exactly the day-bucketing
+// bugs this mock exists to catch. /reset can pin a different one.
+const DEFAULT_CALENDAR_TZ = 'Asia/Hong_Kong'
+const PRIMARY_CALENDAR_ID = 'integ@example.com'
+
 class GwsState {
   files = new Map<string, DriveItem>()
   drives = new Map<string, { id: string; name: string }>()
@@ -158,6 +210,9 @@ class GwsState {
   presentations = new Map<string, Presentation>()
   messages = new Map<string, GmailMessage>()
   labels = new Map<string, GmailLabel>()
+  calendars = new Map<string, CalendarEntry>()
+  events = new Map<string, Map<string, CalendarEvent>>()
+  forms = new Map<string, FormDoc>()
   private counters = new Map<string, number>()
   private ticks = 0
   // Frozen at construction (i.e. per /reset) so find -mtime windows
@@ -167,15 +222,32 @@ class GwsState {
   // gslides date prefixes, gmail date dirs) need fully baked-in listings.
   private readonly baseMs: number
 
-  constructor(epoch?: string) {
+  constructor(epoch?: string, calendarTz?: string) {
     this.baseMs = epoch === undefined ? Date.now() : Date.parse(epoch)
     for (const id of SYSTEM_LABELS) this.labels.set(id, { id, name: id, type: 'system' })
+    this.calendars.set(PRIMARY_CALENDAR_ID, {
+      id: PRIMARY_CALENDAR_ID,
+      summary: 'Integ User',
+      timeZone: calendarTz ?? DEFAULT_CALENDAR_TZ,
+      accessRole: 'owner',
+      primary: true,
+    })
+    this.events.set(PRIMARY_CALENDAR_ID, new Map())
   }
 
   nextId(kind: string): string {
     const n = (this.counters.get(kind) ?? 0) + 1
     this.counters.set(kind, n)
     return `${kind}${String(n).padStart(4, '0')}`
+  }
+
+  // Real Google event ids are 26 chars of base32hex (0-9a-v); filenames on a
+  // gcal mount embed them, so the mock must produce the real shape, not a
+  // short counter. Deterministic so integ truth files stay stable.
+  nextEventId(): string {
+    const n = (this.counters.get('event') ?? 0) + 1
+    this.counters.set('event', n)
+    return `evt${String(n).padStart(23, '0')}`
   }
 
   nowMs(): number {
@@ -1709,13 +1781,24 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
     return [200, { access_token: 'gws-integ-token', expires_in: 3600, token_type: 'Bearer' }]
   }
   if (method === 'POST' && path === '/reset') {
-    const body = ctx.body.length > 0 ? (json(ctx) as { epoch?: string }) : {}
-    state = new GwsState(body.epoch)
+    const body =
+      ctx.body.length > 0 ? (json(ctx) as { epoch?: string; calendarTimeZone?: string }) : {}
+    state = new GwsState(body.epoch, body.calendarTimeZone)
     return [200, { ok: true }]
   }
 
   if (path.startsWith('/gmail/v1/')) {
     const handled = routeGmail(ctx)
+    if (handled !== null) return handled
+  }
+
+  if (path.startsWith('/calendar/v3/')) {
+    const handled = routeCalendar(ctx)
+    if (handled !== null) return handled
+  }
+
+  if (path.startsWith('/v1/forms')) {
+    const handled = routeForms(ctx)
     if (handled !== null) return handled
   }
 
@@ -2171,6 +2254,386 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
   }
 
   return googleError(404, `Unknown route: ${method} ${path}`, 'NOT_FOUND')
+}
+
+function zoneOffsetMs(instant: number, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(new Date(instant))
+  const get = (t: string): number => Number(parts.find((p) => p.type === t)?.value ?? '0')
+  const asUtc = Date.UTC(
+    get('year'),
+    get('month') - 1,
+    get('day'),
+    get('hour') % 24,
+    get('minute'),
+    get('second'),
+  )
+  return asUtc - instant
+}
+
+// Midnight local to `timeZone` on a floating date, as an absolute instant.
+// Two passes because the offset itself depends on the instant: on a DST
+// boundary the first guess lands in the wrong offset and corrects on retry.
+function zonedMidnight(date: string, timeZone: string): number {
+  const [y, mo, d] = date.split('-').map(Number)
+  const guess = Date.UTC(y as number, (mo as number) - 1, d as number)
+  const once = guess - zoneOffsetMs(guess, timeZone)
+  return guess - zoneOffsetMs(once, timeZone)
+}
+
+function eventStartMs(ev: CalendarEvent, tz: string): number {
+  if (ev.start.dateTime !== undefined) return Date.parse(ev.start.dateTime)
+  return zonedMidnight(ev.start.date as string, tz)
+}
+
+// An all-day event's end.date is EXCLUSIVE, so a single-day event spans
+// start=D, end=D+1 and its instant end is midnight opening the next day.
+function eventEndMs(ev: CalendarEvent, tz: string): number {
+  if (ev.end.dateTime !== undefined) return Date.parse(ev.end.dateTime)
+  if (ev.end.date !== undefined) return zonedMidnight(ev.end.date, tz)
+  return eventStartMs(ev, tz)
+}
+
+function calendarOr404(id: string): CalendarEntry | null {
+  const decoded = decodeURIComponent(id)
+  const key = decoded === 'primary' ? PRIMARY_CALENDAR_ID : decoded
+  return state.calendars.get(key) ?? null
+}
+
+function eventsOf(calendarId: string): Map<string, CalendarEvent> {
+  let bucket = state.events.get(calendarId)
+  if (bucket === undefined) {
+    bucket = new Map()
+    state.events.set(calendarId, bucket)
+  }
+  return bucket
+}
+
+function fmtEvent(cal: CalendarEntry, ev: CalendarEvent): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    kind: 'calendar#event',
+    id: ev.id,
+    status: ev.status,
+    start: ev.start,
+    end: ev.end,
+    created: ev.created,
+    updated: ev.updated,
+    iCalUID: `${ev.id}@google.com`,
+    htmlLink: `https://www.google.com/calendar/event?eid=${ev.id}`,
+  }
+  // freeBusyReader sees availability only: no summary, description or
+  // location ever reaches the caller, which is what makes a day directory
+  // on such a calendar render opaque busy blocks.
+  if (cal.accessRole !== 'freeBusyReader') {
+    if (ev.summary !== undefined) out.summary = ev.summary
+    if (ev.description !== undefined) out.description = ev.description
+    if (ev.location !== undefined) out.location = ev.location
+    if (ev.attendees !== undefined) out.attendees = ev.attendees
+  }
+  return out
+}
+
+function matchesQ(ev: CalendarEvent, q: string): boolean {
+  const needle = q.toLowerCase()
+  const hay = [ev.summary, ev.description, ev.location].filter((v) => v !== undefined)
+  return hay.some((v) => (v as string).toLowerCase().includes(needle))
+}
+
+function listCalendarEvents(cal: CalendarEntry, query: URLSearchParams): [number, object] {
+  const tz = query.get('timeZone') ?? cal.timeZone
+  const showDeleted = query.get('showDeleted') === 'true'
+  const q = query.get('q')
+  const timeMin = query.get('timeMin')
+  const timeMax = query.get('timeMax')
+  let rows = [...eventsOf(cal.id).values()]
+  if (!showDeleted) rows = rows.filter((ev) => ev.status !== 'cancelled')
+  // timeMin is a lower bound on the event's END and timeMax an upper bound on
+  // its START, both exclusive: the pair is an OVERLAP query, not containment,
+  // so a multi-day or midnight-crossing event is returned by every day window
+  // it touches.
+  if (timeMin !== null) {
+    const bound = Date.parse(timeMin)
+    rows = rows.filter((ev) => eventEndMs(ev, cal.timeZone) > bound)
+  }
+  if (timeMax !== null) {
+    const bound = Date.parse(timeMax)
+    rows = rows.filter((ev) => eventStartMs(ev, cal.timeZone) < bound)
+  }
+  if (q !== null) rows = rows.filter((ev) => matchesQ(ev, q))
+  if (query.get('orderBy') === 'startTime') {
+    rows.sort((a, b) => eventStartMs(a, cal.timeZone) - eventStartMs(b, cal.timeZone))
+  }
+  const max = Number(query.get('maxResults') ?? '250')
+  const start = Number(query.get('pageToken') ?? '0')
+  const page = rows.slice(start, start + max)
+  const out: Record<string, unknown> = {
+    kind: 'calendar#events',
+    summary: cal.summary,
+    timeZone: tz,
+    accessRole: cal.accessRole,
+    items: page.map((ev) => fmtEvent(cal, ev)),
+  }
+  if (start + max < rows.length) out.nextPageToken = String(start + max)
+  return [200, out]
+}
+
+function readEventTimes(
+  body: Record<string, unknown>,
+  fallback?: CalendarEvent,
+): { start: EventTime; end: EventTime } | null {
+  const start = (body.start as EventTime | undefined) ?? fallback?.start
+  const end = (body.end as EventTime | undefined) ?? fallback?.end
+  if (start === undefined || end === undefined) return null
+  for (const t of [start, end]) {
+    if (t.date === undefined && t.dateTime === undefined) return null
+  }
+  return { start, end }
+}
+
+function routeCalendar(ctx: Ctx): [number, object | Buffer | null, string?] | null {
+  const { method, path, query } = ctx
+  const base = '/calendar/v3'
+
+  if (path === `${base}/users/me/calendarList` && method === 'GET') {
+    const showHidden = query.get('showHidden') === 'true'
+    const items = [...state.calendars.values()].filter((c) => showHidden || c.hidden !== true)
+    return [
+      200,
+      {
+        kind: 'calendar#calendarList',
+        items: items.map((c) => ({
+          kind: 'calendar#calendarListEntry',
+          id: c.id,
+          summary: c.summary,
+          timeZone: c.timeZone,
+          accessRole: c.accessRole,
+          ...(c.primary === true ? { primary: true } : {}),
+        })),
+      },
+    ]
+  }
+
+  let m = new RegExp(`^${base}/calendars/([^/]+)$`).exec(path)
+  if (m !== null && method === 'GET') {
+    const cal = calendarOr404(m[1] as string)
+    if (cal === null) return NOT_FOUND
+    return [
+      200,
+      { kind: 'calendar#calendar', id: cal.id, summary: cal.summary, timeZone: cal.timeZone },
+    ]
+  }
+
+  m = new RegExp(`^${base}/calendars/([^/]+)/events$`).exec(path)
+  if (m !== null) {
+    const cal = calendarOr404(m[1] as string)
+    if (cal === null) return NOT_FOUND
+    if (method === 'GET') return listCalendarEvents(cal, query)
+    if (method === 'POST') {
+      if (cal.accessRole !== 'owner' && cal.accessRole !== 'writer') {
+        return googleError(403, 'You need to have writer access.', 'PERMISSION_DENIED')
+      }
+      const body = json(ctx)
+      const times = readEventTimes(body)
+      if (times === null) {
+        return googleError(400, 'Missing end time.', 'INVALID_ARGUMENT')
+      }
+      const now = state.now()
+      const ev: CalendarEvent = {
+        id: state.nextEventId(),
+        status: 'confirmed',
+        summary: body.summary as string | undefined,
+        description: body.description as string | undefined,
+        location: body.location as string | undefined,
+        attendees: body.attendees as Record<string, unknown>[] | undefined,
+        start: times.start,
+        end: times.end,
+        created: now,
+        updated: now,
+      }
+      eventsOf(cal.id).set(ev.id, ev)
+      return [200, fmtEvent(cal, ev)]
+    }
+  }
+
+  m = new RegExp(`^${base}/calendars/([^/]+)/events/([^/]+)$`).exec(path)
+  if (m !== null) {
+    const cal = calendarOr404(m[1] as string)
+    if (cal === null) return NOT_FOUND
+    const eventId = decodeURIComponent(m[2] as string)
+    const bucket = eventsOf(cal.id)
+    const ev = bucket.get(eventId)
+    if (ev === undefined) {
+      return googleError(404, 'Not Found', 'NOT_FOUND')
+    }
+    if (method === 'GET') return [200, fmtEvent(cal, ev)]
+    if (cal.accessRole !== 'owner' && cal.accessRole !== 'writer') {
+      return googleError(403, 'You need to have writer access.', 'PERMISSION_DENIED')
+    }
+    if (method === 'PATCH') {
+      const body = json(ctx)
+      const times = readEventTimes(body, ev)
+      if (times === null) return googleError(400, 'Missing end time.', 'INVALID_ARGUMENT')
+      const next: CalendarEvent = {
+        ...ev,
+        summary: (body.summary as string | undefined) ?? ev.summary,
+        description: (body.description as string | undefined) ?? ev.description,
+        location: (body.location as string | undefined) ?? ev.location,
+        start: times.start,
+        end: times.end,
+        updated: state.now(),
+      }
+      bucket.set(eventId, next)
+      return [200, fmtEvent(cal, next)]
+    }
+    if (method === 'DELETE') {
+      bucket.delete(eventId)
+      return [204, null]
+    }
+  }
+
+  if (path === `${base}/freeBusy` && method === 'POST') {
+    const body = json(ctx)
+    const timeMin = String(body.timeMin ?? '')
+    const timeMax = String(body.timeMax ?? '')
+    const lo = Date.parse(timeMin)
+    const hi = Date.parse(timeMax)
+    const items = (body.items as { id?: string }[] | undefined) ?? []
+    const calendars: Record<string, unknown> = {}
+    for (const item of items) {
+      const cal = calendarOr404(String(item.id ?? ''))
+      if (cal === null) {
+        calendars[String(item.id ?? '')] = {
+          errors: [{ domain: 'global', reason: 'notFound' }],
+        }
+        continue
+      }
+      const busy = [...eventsOf(cal.id).values()]
+        .filter((ev) => ev.status !== 'cancelled')
+        .filter(
+          (ev) =>
+            eventEndMs(ev, cal.timeZone) > lo && eventStartMs(ev, cal.timeZone) < hi,
+        )
+        .sort((a, b) => eventStartMs(a, cal.timeZone) - eventStartMs(b, cal.timeZone))
+        .map((ev) => ({
+          start: new Date(eventStartMs(ev, cal.timeZone)).toISOString(),
+          end: new Date(eventEndMs(ev, cal.timeZone)).toISOString(),
+        }))
+      calendars[String(item.id ?? '')] = { busy }
+    }
+    return [200, { kind: 'calendar#freeBusy', timeMin, timeMax, calendars }]
+  }
+
+  return null
+}
+
+function fmtForm(form: FormDoc): Record<string, unknown> {
+  return {
+    formId: form.formId,
+    info: {
+      title: form.title,
+      documentTitle: form.documentTitle,
+      ...(form.description === undefined ? {} : { description: form.description }),
+    },
+    items: form.items,
+    revisionId: String(form.revision),
+    responderUri: `https://docs.google.com/forms/d/e/${form.formId}/viewform`,
+  }
+}
+
+function applyFormRequest(form: FormDoc, req: Record<string, unknown>): void {
+  const createItem = req.createItem as
+    | { item?: Record<string, unknown>; location?: { index?: number } }
+    | undefined
+  if (createItem?.item !== undefined) {
+    const item: FormItem = {
+      itemId: state.nextId('item'),
+      ...(createItem.item as Omit<FormItem, 'itemId'>),
+    }
+    const at = createItem.location?.index ?? form.items.length
+    form.items.splice(at, 0, item)
+    return
+  }
+  const updateInfo = req.updateFormInfo as
+    | { info?: { title?: string; description?: string } }
+    | undefined
+  if (updateInfo?.info !== undefined) {
+    if (updateInfo.info.title !== undefined) form.title = updateInfo.info.title
+    if (updateInfo.info.description !== undefined) form.description = updateInfo.info.description
+  }
+}
+
+function routeForms(ctx: Ctx): [number, object | Buffer | null, string?] | null {
+  const { method, path } = ctx
+
+  if (path === '/v1/forms' && method === 'POST') {
+    const body = json(ctx)
+    const info = (body.info as { title?: string; documentTitle?: string } | undefined) ?? {}
+    const title = info.title ?? 'Untitled form'
+    // Created through the Drive table on purpose: a form's formId IS its
+    // Drive file id (verified against real Google), which is the only way an
+    // agent can find an existing form, since the Forms API has no list method.
+    const item = createDriveItem(
+      info.documentTitle ?? title,
+      FORM_MIME,
+      [],
+      Buffer.alloc(0),
+      state.nextId('form'),
+    )
+    const form: FormDoc = {
+      formId: item.id,
+      title,
+      documentTitle: info.documentTitle ?? title,
+      items: [],
+      responses: [],
+      revision: 1,
+    }
+    state.forms.set(form.formId, form)
+    return [200, fmtForm(form)]
+  }
+
+  let m = /^\/v1\/forms\/([^/:]+)$/.exec(path)
+  if (m !== null && method === 'GET') {
+    const form = state.forms.get(m[1] as string)
+    if (form === undefined) return NOT_FOUND
+    return [200, fmtForm(form)]
+  }
+
+  m = /^\/v1\/forms\/([^/:]+):batchUpdate$/.exec(path)
+  if (m !== null && method === 'POST') {
+    const form = state.forms.get(m[1] as string)
+    if (form === undefined) return NOT_FOUND
+    const body = json(ctx)
+    const requests = (body.requests as Record<string, unknown>[] | undefined) ?? []
+    for (const req of requests) applyFormRequest(form, req)
+    form.revision += 1
+    touchNative(form.formId)
+    return [200, { form: fmtForm(form), replies: requests.map(() => ({})) }]
+  }
+
+  m = /^\/v1\/forms\/([^/:]+)\/responses$/.exec(path)
+  if (m !== null && method === 'GET') {
+    const form = state.forms.get(m[1] as string)
+    if (form === undefined) return NOT_FOUND
+    return [200, { responses: form.responses }]
+  }
+
+  m = /^\/v1\/forms\/([^/:]+)\/responses\/([^/:]+)$/.exec(path)
+  if (m !== null && method === 'GET') {
+    const form = state.forms.get(m[1] as string)
+    const found = form?.responses.find((r) => r.responseId === m?.[2])
+    if (found === undefined) return NOT_FOUND
+    return [200, found]
+  }
+
+  return null
 }
 
 function rangeLabelFor(range: A1Range, requested: string): string {

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -2279,27 +2279,41 @@ function zoneOffsetMs(instant: number, timeZone: string): number {
   return asUtc - instant
 }
 
-// Midnight local to `timeZone` on a floating date, as an absolute instant.
+// A wall-clock reading resolved in `timeZone`, as an absolute instant.
 // Two passes because the offset itself depends on the instant: on a DST
 // boundary the first guess lands in the wrong offset and corrects on retry.
-function zonedMidnight(date: string, timeZone: string): number {
-  const [y, mo, d] = date.split('-').map(Number)
-  const guess = Date.UTC(y as number, (mo as number) - 1, d as number)
+function wallClockMs(naive: string, timeZone: string): number {
+  const guess = Date.parse(`${naive}Z`)
   const once = guess - zoneOffsetMs(guess, timeZone)
   return guess - zoneOffsetMs(once, timeZone)
 }
 
+function zonedMidnight(date: string, timeZone: string): number {
+  return wallClockMs(`${date}T00:00:00`, timeZone)
+}
+
+// An offset is mandatory on dateTime UNLESS the slot names its own zone, so
+// a bare wall clock here is a zoned event rather than an error. Date.parse
+// would read it in the SERVER's local zone, which is neither.
+const HAS_OFFSET = /(?:Z|[+-]\d{2}:?\d{2})$/
+
+function slotMs(slot: EventTime, fallbackTz: string): number | null {
+  if (slot.dateTime !== undefined) {
+    if (HAS_OFFSET.test(slot.dateTime)) return Date.parse(slot.dateTime)
+    return wallClockMs(slot.dateTime, slot.timeZone ?? fallbackTz)
+  }
+  if (slot.date !== undefined) return zonedMidnight(slot.date, fallbackTz)
+  return null
+}
+
 function eventStartMs(ev: CalendarEvent, tz: string): number {
-  if (ev.start.dateTime !== undefined) return Date.parse(ev.start.dateTime)
-  return zonedMidnight(ev.start.date as string, tz)
+  return slotMs(ev.start, tz) ?? 0
 }
 
 // An all-day event's end.date is EXCLUSIVE, so a single-day event spans
 // start=D, end=D+1 and its instant end is midnight opening the next day.
 function eventEndMs(ev: CalendarEvent, tz: string): number {
-  if (ev.end.dateTime !== undefined) return Date.parse(ev.end.dateTime)
-  if (ev.end.date !== undefined) return zonedMidnight(ev.end.date, tz)
-  return eventStartMs(ev, tz)
+  return slotMs(ev.end, tz) ?? eventStartMs(ev, tz)
 }
 
 function calendarOr404(id: string): CalendarEntry | null {

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -197,6 +197,28 @@ interface FormDoc {
   revision: number
 }
 
+// A secondary calendar and a form carrying responses are both harness state
+// rather than anything the API can mint: you own every calendar you create,
+// so a reader one is by definition shared with you, and the Forms API has no
+// method that submits a response at all. Both therefore ride /reset, the same
+// out-of-band channel the pinned epoch already uses.
+interface SeedCalendar {
+  id: string
+  summary: string
+  timeZone?: string
+  accessRole?: string
+  hidden?: boolean
+  events?: Record<string, unknown>[]
+}
+
+interface SeedForm {
+  title: string
+  documentTitle?: string
+  description?: string
+  items?: Record<string, unknown>[]
+  responses?: Record<string, unknown>[]
+}
+
 // Non-UTC on purpose: a UTC default would hide exactly the day-bucketing
 // bugs this mock exists to catch. /reset can pin a different one.
 const DEFAULT_CALENDAR_TZ = 'Asia/Hong_Kong'
@@ -1782,8 +1804,17 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
   }
   if (method === 'POST' && path === '/reset') {
     const body =
-      ctx.body.length > 0 ? (json(ctx) as { epoch?: string; calendarTimeZone?: string }) : {}
+      ctx.body.length > 0
+        ? (json(ctx) as {
+            epoch?: string
+            calendarTimeZone?: string
+            calendars?: SeedCalendar[]
+            forms?: SeedForm[]
+          })
+        : {}
     state = new GwsState(body.epoch, body.calendarTimeZone)
+    if (body.calendars !== undefined) seedCalendars(body.calendars)
+    if (body.forms !== undefined) seedForms(body.forms)
     return [200, { ok: true }]
   }
 
@@ -2412,6 +2443,69 @@ function readEventTimes(
   return { start, end }
 }
 
+function makeEvent(body: Record<string, unknown>): CalendarEvent | null {
+  const times = readEventTimes(body)
+  if (times === null) return null
+  const now = state.now()
+  return {
+    id: state.nextEventId(),
+    status: 'confirmed',
+    summary: body.summary as string | undefined,
+    description: body.description as string | undefined,
+    location: body.location as string | undefined,
+    attendees: body.attendees as Record<string, unknown>[] | undefined,
+    start: times.start,
+    end: times.end,
+    created: now,
+    updated: now,
+  }
+}
+
+function seedCalendars(entries: SeedCalendar[]): void {
+  for (const entry of entries) {
+    state.calendars.set(entry.id, {
+      id: entry.id,
+      summary: entry.summary,
+      timeZone: entry.timeZone ?? DEFAULT_CALENDAR_TZ,
+      accessRole: entry.accessRole ?? 'owner',
+      ...(entry.hidden === true ? { hidden: true } : {}),
+    })
+    const bucket = eventsOf(entry.id)
+    for (const raw of entry.events ?? []) {
+      const ev = makeEvent(raw)
+      if (ev === null) throw new Error(`seed event needs a start and an end: ${JSON.stringify(raw)}`)
+      bucket.set(ev.id, ev)
+    }
+  }
+}
+
+function seedForms(entries: SeedForm[]): void {
+  for (const entry of entries) {
+    // Through the Drive table for the same reason forms.create is: the
+    // formId IS the Drive file id, and a seeded form has to be findable
+    // the one way an agent can find one.
+    const item = createDriveItem(
+      entry.documentTitle ?? entry.title,
+      FORM_MIME,
+      [],
+      Buffer.alloc(0),
+      state.nextId('form'),
+    )
+    state.forms.set(item.id, {
+      formId: item.id,
+      title: entry.title,
+      documentTitle: entry.documentTitle ?? entry.title,
+      ...(entry.description === undefined ? {} : { description: entry.description }),
+      items: (entry.items ?? []).map((raw) => ({
+        itemId: state.nextId('item'),
+        ...(raw as Omit<FormItem, 'itemId'>),
+      })),
+      responses: entry.responses ?? [],
+      revision: 1,
+    })
+  }
+}
+
 function routeCalendar(ctx: Ctx): [number, object | Buffer | null, string?] | null {
   const { method, path, query } = ctx
   const base = '/calendar/v3'
@@ -2454,23 +2548,9 @@ function routeCalendar(ctx: Ctx): [number, object | Buffer | null, string?] | nu
       if (cal.accessRole !== 'owner' && cal.accessRole !== 'writer') {
         return googleError(403, 'You need to have writer access.', 'PERMISSION_DENIED')
       }
-      const body = json(ctx)
-      const times = readEventTimes(body)
-      if (times === null) {
+      const ev = makeEvent(json(ctx))
+      if (ev === null) {
         return googleError(400, 'Missing end time.', 'INVALID_ARGUMENT')
-      }
-      const now = state.now()
-      const ev: CalendarEvent = {
-        id: state.nextEventId(),
-        status: 'confirmed',
-        summary: body.summary as string | undefined,
-        description: body.description as string | undefined,
-        location: body.location as string | undefined,
-        attendees: body.attendees as Record<string, unknown>[] | undefined,
-        start: times.start,
-        end: times.end,
-        created: now,
-        updated: now,
       }
       eventsOf(cal.id).set(ev.id, ev)
       return [200, fmtEvent(cal, ev)]

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -1296,6 +1296,7 @@
       "apps": "google-apps/v1",
       "mail": "gmail/v1",
       "calendar": "calendar/v1",
+      "forms": "forms/v1",
       "clis": [
         "gws"
       ],

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -1295,6 +1295,7 @@
       "epoch": "2026-02-01T00:00:00Z",
       "apps": "google-apps/v1",
       "mail": "gmail/v1",
+      "calendar": "calendar/v1",
       "clis": [
         "gws"
       ],

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -1209,6 +1209,32 @@
       ]
     },
     {
+      "id": "gcal",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "service": "gws",
+      "facet": "cli",
+      "epoch": "2026-02-01T00:00:00Z",
+      "calendar": "calendar/v1",
+      "mounts": [
+        {
+          "path": "/cal",
+          "resource": "gcal",
+          "backend": "gcal"
+        },
+        {
+          "path": "/scratch",
+          "resource": "ram",
+          "backend": "ram"
+        }
+      ],
+      "clis": [
+        "gws"
+      ]
+    },
+    {
       "id": "gmail",
       "hosts": [
         "python",

--- a/python/mirage/accessor/gcal.py
+++ b/python/mirage/accessor/gcal.py
@@ -15,6 +15,7 @@
 from datetime import date, datetime
 
 from mirage.accessor.base import Accessor
+from mirage.core.gcal.day import zone
 from mirage.core.google._client import TokenManager
 from mirage.resource.gcal.config import GCalConfig
 
@@ -26,15 +27,22 @@ class GCalAccessor(Accessor):
         self.config = config
         self.token_manager = token_manager
 
-    def today(self) -> date:
+    def today(self, tz: str) -> date:
         """The day the default listing window centres on.
+
+        Taken in the mount's bucketing zone rather than the host's: the two
+        disagree for several hours a day, so a window centred on the wrong
+        one shifts the whole listing by a day around either midnight.
 
         A method rather than a module-level call so a test can pin it and so
         a long-lived mount does not freeze its window at import time.
 
+        Args:
+            tz (str): the mount-wide bucketing zone.
+
         Returns:
-            date: today in the mount's bucketing zone, or the pinned day.
+            date: today in that zone, or the pinned day.
         """
         if self.config.today:
             return date.fromisoformat(self.config.today)
-        return datetime.now().date()
+        return datetime.now(zone(tz)).date()

--- a/python/mirage/accessor/gcal.py
+++ b/python/mirage/accessor/gcal.py
@@ -1,0 +1,40 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from datetime import date, datetime
+
+from mirage.accessor.base import Accessor
+from mirage.core.google._client import TokenManager
+from mirage.resource.gcal.config import GCalConfig
+
+
+class GCalAccessor(Accessor):
+
+    def __init__(self, config: GCalConfig,
+                 token_manager: TokenManager) -> None:
+        self.config = config
+        self.token_manager = token_manager
+
+    def today(self) -> date:
+        """The day the default listing window centres on.
+
+        A method rather than a module-level call so a test can pin it and so
+        a long-lived mount does not freeze its window at import time.
+
+        Returns:
+            date: today in the mount's bucketing zone, or the pinned day.
+        """
+        if self.config.today:
+            return date.fromisoformat(self.config.today)
+        return datetime.now().date()

--- a/python/mirage/commands/builtin/gcal/__init__.py
+++ b/python/mirage/commands/builtin/gcal/__init__.py
@@ -1,0 +1,25 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.builtin.gcal.io import IO as _IO
+from mirage.commands.builtin.gcal.rm import rm
+from mirage.commands.builtin.generic_bind import make_generic_commands
+
+COMMANDS = [
+    *make_generic_commands(
+        "gcal",
+        _IO,
+    ),
+    rm,
+]

--- a/python/mirage/commands/builtin/gcal/io.py
+++ b/python/mirage/commands/builtin/gcal/io.py
@@ -1,0 +1,32 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from functools import partial
+
+from mirage.commands.builtin.generic_bind import CommandIO
+from mirage.commands.builtin.utils.wrap import stream_from_bytes
+from mirage.core.gcal.read import read as _read
+from mirage.core.gcal.readdir import readdir as _readdir
+from mirage.core.gcal.stat import stat as _stat
+
+IO = CommandIO(
+    readdir=_readdir,
+    read_bytes=_read,
+    read_stream=partial(stream_from_bytes, _read),
+    stat=_stat,
+    is_mounted=lambda a: True,
+    local=False,
+)
+
+resolve_glob = IO.resolve_glob

--- a/python/mirage/commands/builtin/gcal/rm.py
+++ b/python/mirage/commands/builtin/gcal/rm.py
@@ -1,0 +1,19 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.builtin.gcal.io import resolve_glob
+from mirage.commands.builtin.generic.rm_command import make_rm
+from mirage.core.gcal.unlink import unlink
+
+rm = make_rm(resource="gcal", glob_fn=resolve_glob, unlink=unlink)

--- a/python/mirage/commands/cli/builtin/gws/__init__.py
+++ b/python/mirage/commands/cli/builtin/gws/__init__.py
@@ -109,6 +109,16 @@ GWS = CLISpec(
             subcommands=api_groups("slides"),
         ),
         CLISpec(
+            name="calendar",
+            description="Google calendar API commands",
+            subcommands=api_groups("calendar"),
+        ),
+        CLISpec(
+            name="forms",
+            description="Google forms API commands",
+            subcommands=api_groups("forms"),
+        ),
+        CLISpec(
             name="gmail",
             description="Google gmail API commands",
             subcommands=api_groups("gmail") + (

--- a/python/mirage/commands/cli/builtin/gws/api.py
+++ b/python/mirage/commands/cli/builtin/gws/api.py
@@ -17,6 +17,7 @@ import json as json_lib
 from collections.abc import Awaitable, Callable
 from enum import Enum, auto
 from typing import Any
+from urllib.parse import quote
 
 from mirage.cache.context import invalidate_after_write
 from mirage.commands.cli.builtin.gws.methods import (GWS_METHODS,
@@ -95,7 +96,14 @@ def fill_path(template: str, params: dict[str,
         name = path[start + 1:end]
         if name not in query:
             raise UsageError(f"--params must contain {name}")
-        path = path[:start] + str(query.pop(name)) + path[end + 1:]
+        # Percent-encode the value: a Discovery path parameter is one
+        # segment, and several real ids carry characters that change what
+        # the URL means. A Google holiday calendar id
+        # ("en.usa#holiday@group.v.calendar.google.com") is the sharp case,
+        # since "#" opens a fragment and the request would reach
+        # /calendars/en.usa instead.
+        path = path[:start] + quote(str(query.pop(name)),
+                                    safe="") + path[end + 1:]
     return path, query
 
 

--- a/python/mirage/commands/cli/builtin/gws/methods.py
+++ b/python/mirage/commands/cli/builtin/gws/methods.py
@@ -15,8 +15,9 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from mirage.core.google._client import (TokenManager, docs_base, drive_base,
-                                        gmail_base, sheets_base, slides_base)
+from mirage.core.google._client import (TokenManager, calendar_base, docs_base,
+                                        drive_base, forms_base, gmail_base,
+                                        sheets_base, slides_base)
 
 # The official gws CLI generates one command per Discovery method and
 # speaks raw API resources: `--params` carries path/query parameters,
@@ -147,6 +148,53 @@ GWS_METHODS: tuple[GwsMethod, ...] = (
               "/users/{userId}/messages/{id}/trash"),
     GwsMethod("gmail", "users messages attachments", "get", "GET",
               "/users/{userId}/messages/{messageId}/attachments/{id}"),
+    GwsMethod("calendar", "calendarList", "list", "GET",
+              "/users/me/calendarList"),
+    GwsMethod("calendar", "calendars", "get", "GET",
+              "/calendars/{calendarId}"),
+    GwsMethod("calendar", "events", "list", "GET",
+              "/calendars/{calendarId}/events"),
+    GwsMethod("calendar", "events", "get", "GET",
+              "/calendars/{calendarId}/events/{eventId}"),
+    GwsMethod("calendar",
+              "events",
+              "insert",
+              "POST",
+              "/calendars/{calendarId}/events",
+              needs_body=True),
+    GwsMethod("calendar",
+              "events",
+              "patch",
+              "PATCH",
+              "/calendars/{calendarId}/events/{eventId}",
+              needs_body=True),
+    GwsMethod("calendar", "events", "delete", "DELETE",
+              "/calendars/{calendarId}/events/{eventId}"),
+    GwsMethod("calendar",
+              "freebusy",
+              "query",
+              "POST",
+              "/freeBusy",
+              needs_body=True),
+    GwsMethod("forms",
+              "forms",
+              "create",
+              "POST",
+              "/forms",
+              needs_body=True,
+              placement="relocate",
+              id_field="formId"),
+    GwsMethod("forms", "forms", "get", "GET", "/forms/{formId}"),
+    GwsMethod("forms",
+              "forms",
+              "batchUpdate",
+              "POST",
+              "/forms/{formId}:batchUpdate",
+              needs_body=True),
+    GwsMethod("forms", "forms responses", "list", "GET",
+              "/forms/{formId}/responses"),
+    GwsMethod("forms", "forms responses", "get", "GET",
+              "/forms/{formId}/responses/{responseId}"),
 )
 
 
@@ -166,4 +214,6 @@ SERVICE_BASES: dict[str, Callable[[TokenManager], str]] = {
     "sheets": sheets_base,
     "slides": slides_base,
     "gmail": gmail_base,
+    "calendar": calendar_base,
+    "forms": forms_base,
 }

--- a/python/mirage/core/gcal/__init__.py
+++ b/python/mirage/core/gcal/__init__.py
@@ -1,0 +1,13 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========

--- a/python/mirage/core/gcal/_client.py
+++ b/python/mirage/core/gcal/_client.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from urllib.parse import quote
+
 from mirage.core.google._client import (CALENDAR_API_BASE, TokenManager,
                                         calendar_base, google_delete,
                                         google_get)
@@ -98,8 +100,12 @@ async def list_events(
     Returns:
         list[dict]: events.list items.
     """
+    # The id is one path segment and several real ones are not URL-safe: a
+    # holiday calendar is "en.usa#holiday@group.v.calendar.google.com", and
+    # an unencoded "#" opens a fragment, so the request would reach
+    # /calendars/en.usa instead.
     url = (f"{calendar_base(token_manager)}/calendars/"
-           f"{calendar_id}/events")
+           f"{quote(calendar_id, safe='')}/events")
     params = {
         "timeMin": time_min,
         "timeMax": time_max,
@@ -138,5 +144,6 @@ async def delete_event(token_manager: TokenManager, calendar_id: str,
         event_id (str): the event id.
     """
     url = (f"{calendar_base(token_manager)}/calendars/"
-           f"{calendar_id}/events/{event_id}")
+           f"{quote(calendar_id, safe='')}/events/"
+           f"{quote(event_id, safe='')}")
     await google_delete(token_manager, url)

--- a/python/mirage/core/gcal/_client.py
+++ b/python/mirage/core/gcal/_client.py
@@ -1,0 +1,142 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.core.google._client import (CALENDAR_API_BASE, TokenManager,
+                                        calendar_base, google_delete,
+                                        google_get)
+from mirage.types import JsonValue
+
+__all__ = [
+    "CALENDAR_API_BASE",
+    "TokenManager",
+    "calendar_base",
+    "google_delete",
+    "google_get",
+    "list_calendars",
+    "list_events",
+    "delete_event",
+]
+
+MAX_PAGES = 50
+
+
+async def list_calendars(
+        token_manager: TokenManager,
+        min_access_role: str | None = None) -> list[dict[str, JsonValue]]:
+    """List the account's calendars.
+
+    showHidden is left at its default (false) so the mount shows what the
+    Calendar UI shows; a subscribed holiday calendar the user hid stays out.
+
+    Args:
+        token_manager (TokenManager): the mount's OAuth handle.
+        min_access_role (str | None): keep only calendars at or above this
+            role, e.g. "writer" for ones the agent can schedule into.
+
+    Returns:
+        list[dict]: calendarList entries.
+    """
+    url = f"{calendar_base(token_manager)}/users/me/calendarList"
+    params: dict[str, str] = {}
+    if min_access_role:
+        params["minAccessRole"] = min_access_role
+    items: list[dict[str, JsonValue]] = []
+    token: str | None = None
+    for _ in range(MAX_PAGES):
+        page = dict(params)
+        if token:
+            page["pageToken"] = token
+        data = await google_get(token_manager, url, params=page)
+        if not isinstance(data, dict):
+            break
+        rows = data.get("items")
+        if isinstance(rows, list):
+            items.extend(r for r in rows if isinstance(r, dict))
+        nxt = data.get("nextPageToken")
+        if not isinstance(nxt, str) or not nxt:
+            break
+        token = nxt
+    return items
+
+
+async def list_events(
+    token_manager: TokenManager,
+    calendar_id: str,
+    time_min: str,
+    time_max: str,
+    time_zone: str | None = None,
+) -> list[dict[str, JsonValue]]:
+    """List a calendar's events overlapping a time window.
+
+    timeMin bounds an event's END and timeMax its START, both exclusive, so
+    the pair is an overlap query: a multi-day or midnight-crossing event is
+    returned by every day window it touches, with no extra request.
+
+    singleEvents expands a recurring series into its instances, which is what
+    makes a day directory well defined; without it the series' own record
+    would stand in for every occurrence.
+
+    Args:
+        token_manager (TokenManager): the mount's OAuth handle.
+        calendar_id (str): the calendar id, or "primary".
+        time_min (str): RFC3339 lower bound, offset mandatory.
+        time_max (str): RFC3339 upper bound, offset mandatory.
+        time_zone (str | None): zone the response renders times in; Google
+            defaults it to the calendar's own.
+
+    Returns:
+        list[dict]: events.list items.
+    """
+    url = (f"{calendar_base(token_manager)}/calendars/"
+           f"{calendar_id}/events")
+    params = {
+        "timeMin": time_min,
+        "timeMax": time_max,
+        "singleEvents": "true",
+        "orderBy": "startTime",
+        "maxResults": "2500",
+    }
+    if time_zone:
+        params["timeZone"] = time_zone
+    items: list[dict[str, JsonValue]] = []
+    token: str | None = None
+    for _ in range(MAX_PAGES):
+        page = dict(params)
+        if token:
+            page["pageToken"] = token
+        data = await google_get(token_manager, url, params=page)
+        if not isinstance(data, dict):
+            break
+        rows = data.get("items")
+        if isinstance(rows, list):
+            items.extend(r for r in rows if isinstance(r, dict))
+        nxt = data.get("nextPageToken")
+        if not isinstance(nxt, str) or not nxt:
+            break
+        token = nxt
+    return items
+
+
+async def delete_event(token_manager: TokenManager, calendar_id: str,
+                       event_id: str) -> None:
+    """Delete one event.
+
+    Args:
+        token_manager (TokenManager): the mount's OAuth handle.
+        calendar_id (str): the calendar id, or "primary".
+        event_id (str): the event id.
+    """
+    url = (f"{calendar_base(token_manager)}/calendars/"
+           f"{calendar_id}/events/{event_id}")
+    await google_delete(token_manager, url)

--- a/python/mirage/core/gcal/day.py
+++ b/python/mirage/core/gcal/day.py
@@ -1,0 +1,213 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import logging
+import re
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from mirage.types import JsonValue
+
+logger = logging.getLogger(__name__)
+
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+DEFAULT_TZ = "UTC"
+# The rolling window a bare readdir of a calendar reports. A calendar is
+# unbounded in both directions and the API offers no descending startTime
+# order, so a full listing means paging to the end; the window is stated in
+# the mount prompt rather than applied silently, and any date glob escapes it.
+WINDOW_BACK_DAYS = 30
+WINDOW_AHEAD_DAYS = 90
+
+
+def zone(tz: str) -> ZoneInfo:
+    """Resolve an IANA zone name, falling back to UTC when unknown.
+
+    Args:
+        tz (str): IANA time zone name.
+
+    Returns:
+        ZoneInfo: the resolved zone.
+    """
+    try:
+        return ZoneInfo(tz)
+    except (ZoneInfoNotFoundError, ValueError):
+        # A calendar can name a zone this platform's tzdata does not carry.
+        # Failing the whole listing over it would let one bad calendar hide
+        # every other one, so fall back loudly and keep going.
+        logger.debug("gcal: unknown time zone %r, bucketing in %s", tz,
+                     DEFAULT_TZ)
+        return ZoneInfo(DEFAULT_TZ)
+
+
+def local_midnight(day: str, tz: str) -> datetime:
+    """The instant at which a local calendar day begins.
+
+    Args:
+        day (str): a floating date, ``YYYY-MM-DD``.
+        tz (str): IANA time zone name.
+
+    Returns:
+        datetime: tz-aware datetime at 00:00 local.
+    """
+    parts = [int(p) for p in day.split("-")]
+    return datetime(parts[0], parts[1], parts[2], tzinfo=zone(tz))
+
+
+def day_bounds(day: str, tz: str) -> tuple[str, str]:
+    """The RFC3339 timeMin/timeMax pair covering one local day.
+
+    Computed as consecutive local midnights rather than start + 24h: a local
+    day is 23 or 25 hours on the two DST transitions each year, and adding a
+    fixed day would drop or double an hour of events.
+
+    Args:
+        day (str): a floating date, ``YYYY-MM-DD``.
+        tz (str): IANA time zone name.
+
+    Returns:
+        tuple[str, str]: (timeMin, timeMax) as RFC3339 with offsets.
+    """
+    start = local_midnight(day, tz)
+    nxt = (start.date() + timedelta(days=1)).isoformat()
+    return start.isoformat(), local_midnight(nxt, tz).isoformat()
+
+
+def window_bounds(today: date, tz: str) -> tuple[str, str]:
+    """The RFC3339 pair for the default listing window around a day.
+
+    Args:
+        today (date): the day the window is centred on.
+        tz (str): IANA time zone name.
+
+    Returns:
+        tuple[str, str]: (timeMin, timeMax) as RFC3339 with offsets.
+    """
+    lo = (today - timedelta(days=WINDOW_BACK_DAYS)).isoformat()
+    hi = (today + timedelta(days=WINDOW_AHEAD_DAYS)).isoformat()
+    return day_bounds(lo, tz)[0], day_bounds(hi, tz)[1]
+
+
+def is_all_day(slot: dict[str, JsonValue]) -> bool:
+    """Whether an event time slot is a floating all-day date.
+
+    Args:
+        slot (dict): an event's ``start`` or ``end`` object.
+    """
+    return "date" in slot and "dateTime" not in slot
+
+
+def slot_instant(slot: dict[str, JsonValue], tz: str) -> datetime | None:
+    """Resolve one event time slot to an absolute instant.
+
+    Args:
+        slot (dict): an event's ``start`` or ``end`` object.
+        tz (str): the bucketing zone, used only for a floating date.
+
+    Returns:
+        datetime | None: tz-aware instant, or None when the slot is empty.
+    """
+    raw = slot.get("dateTime")
+    if isinstance(raw, str) and raw:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    day = slot.get("date")
+    if isinstance(day, str) and DATE_RE.match(day):
+        return local_midnight(day, tz)
+    return None
+
+
+def event_span(event: dict[str, JsonValue],
+               tz: str) -> tuple[datetime, datetime] | None:
+    """The absolute [start, end) span of an event.
+
+    An all-day event's ``end.date`` is exclusive, so a one-day event is
+    ``start=D, end=D+1`` and its span closes at the midnight opening the
+    next day. That is the same convention the instant carries, so no
+    adjustment is applied here.
+
+    Args:
+        event (dict): an events.list item.
+        tz (str): the bucketing zone.
+
+    Returns:
+        tuple[datetime, datetime] | None: the span, or None if unparseable.
+    """
+    start_slot = event.get("start")
+    end_slot = event.get("end")
+    if not isinstance(start_slot, dict) or not isinstance(end_slot, dict):
+        return None
+    start = slot_instant(start_slot, tz)
+    if start is None:
+        return None
+    end = slot_instant(end_slot, tz)
+    if end is None or end < start:
+        end = start
+    return start, end
+
+
+def days_covered(span: tuple[datetime, datetime], tz: str) -> list[str]:
+    """Every local day an event's span touches.
+
+    The end is exclusive, so an event closing exactly at local midnight does
+    not reach into the following day; a zero-length event still occupies the
+    day it starts on.
+
+    Args:
+        span (tuple): the (start, end) instants.
+        tz (str): the bucketing zone.
+
+    Returns:
+        list[str]: ``YYYY-MM-DD`` days in ascending order.
+    """
+    zi = zone(tz)
+    first = span[0].astimezone(zi).date()
+    last = span[1].astimezone(zi).date()
+    if span[1] > span[0] and span[1].astimezone(
+            zi).time() == datetime.min.time():
+        last = last - timedelta(days=1)
+    if last < first:
+        last = first
+    out: list[str] = []
+    cur = first
+    while cur <= last:
+        out.append(cur.isoformat())
+        cur = cur + timedelta(days=1)
+    return out
+
+
+def clamped_hhmm(span: tuple[datetime, datetime], day: str, tz: str) -> str:
+    """The ``HHMM-HHMM`` label for an event as seen on one local day.
+
+    Times are clamped to the day, so an event running through it reads
+    ``0000-2400`` rather than repeating times that belong to another day.
+    ``2400`` is how an end at the next local midnight is spelled, since
+    ``0000`` there would sort before the start.
+
+    Args:
+        span (tuple): the (start, end) instants.
+        day (str): the local day being rendered, ``YYYY-MM-DD``.
+        tz (str): the bucketing zone.
+
+    Returns:
+        str: e.g. ``0900-1030``.
+    """
+    lo = local_midnight(day, tz)
+    hi = local_midnight((lo.date() + timedelta(days=1)).isoformat(), tz)
+    zi = zone(tz)
+    start = max(span[0], lo).astimezone(zi)
+    end = min(span[1], hi).astimezone(zi)
+    head = f"{start.hour:02d}{start.minute:02d}"
+    if end >= hi:
+        return f"{head}-2400"
+    return f"{head}-{end.hour:02d}{end.minute:02d}"

--- a/python/mirage/core/gcal/day.py
+++ b/python/mirage/core/gcal/day.py
@@ -99,6 +99,24 @@ def window_bounds(today: date, tz: str) -> tuple[str, str]:
     return day_bounds(lo, tz)[0], day_bounds(hi, tz)[1]
 
 
+def valid_day(day: str) -> bool:
+    """Whether a string is a real calendar date, not merely date-shaped.
+
+    ``2026-02-30`` matches the shape and is not a day; letting it through
+    made stat report a directory that every later call raised ValueError on.
+
+    Args:
+        day (str): the candidate date.
+    """
+    if not DATE_RE.match(day):
+        return False
+    try:
+        date.fromisoformat(day)
+    except ValueError:
+        return False
+    return True
+
+
 def is_all_day(slot: dict[str, JsonValue]) -> bool:
     """Whether an event time slot is a floating all-day date.
 
@@ -120,7 +138,17 @@ def slot_instant(slot: dict[str, JsonValue], tz: str) -> datetime | None:
     """
     raw = slot.get("dateTime")
     if isinstance(raw, str) and raw:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        stamp = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if stamp.tzinfo is not None:
+            return stamp
+        # Google requires an offset on dateTime UNLESS the slot names its
+        # own zone, so a naive stamp here is a zoned event, not an error.
+        # Leaving it naive made it uncomparable with the aware local
+        # midnights every bucketing call comes from (TypeError), and using
+        # the host zone would silently move the event.
+        declared = slot.get("timeZone")
+        zone_name = declared if isinstance(declared, str) and declared else tz
+        return stamp.replace(tzinfo=zone(zone_name))
     day = slot.get("date")
     if isinstance(day, str) and DATE_RE.match(day):
         return local_midnight(day, tz)

--- a/python/mirage/core/gcal/read.py
+++ b/python/mirage/core/gcal/read.py
@@ -1,0 +1,77 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+import logging
+
+from mirage.accessor.gcal import GCalAccessor
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.gcal._client import list_events
+from mirage.core.gcal.day import day_bounds
+from mirage.core.gcal.readdir import (bucket_zone, calendar_index,
+                                      calendar_payload, normalize)
+from mirage.resource.gcal.event_entry import parse_event_filename
+from mirage.types import PathSpec
+from mirage.utils.errors import enoent
+
+logger = logging.getLogger(__name__)
+
+
+async def read(
+    accessor: GCalAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = NULL_INDEX,
+) -> bytes:
+    """Read one calendar.json or one event's raw API payload.
+
+    The event file holds the events.list item unmodified: the directory name
+    and the HHMM segment are a view, while the payload is the truth an
+    absolute-instant comparison has to be made against.
+
+    Args:
+        accessor (GCalAccessor): the mount's accessor.
+        path (PathSpec): the file to read.
+        index (IndexCacheStore): the mount's index cache.
+
+    Returns:
+        bytes: the rendered file.
+    """
+    prefix, key, virtual_key = normalize(path)
+    parts = key.split("/")
+    if len(parts) < 2:
+        raise IsADirectoryError(path.virtual)
+
+    calendars = await calendar_index(accessor)
+    entry = calendars.get(parts[0])
+    if entry is None:
+        raise enoent(path.virtual)
+    tz = bucket_zone(accessor, calendars)
+
+    if len(parts) == 2 and parts[1] == "calendar.json":
+        return calendar_payload(entry, tz)
+
+    if len(parts) != 3:
+        raise enoent(path.virtual)
+
+    cal_id = entry.get("id")
+    if not isinstance(cal_id, str):
+        raise enoent(path.virtual)
+    event_id, _ = parse_event_filename(parts[2])
+    time_min, time_max = day_bounds(parts[1], tz)
+    for event in await list_events(accessor.token_manager, cal_id, time_min,
+                                   time_max, tz):
+        if event.get("id") == event_id:
+            return json.dumps(event, ensure_ascii=False,
+                              separators=(",", ":")).encode()
+    raise enoent(path.virtual)

--- a/python/mirage/core/gcal/readdir.py
+++ b/python/mirage/core/gcal/readdir.py
@@ -1,0 +1,290 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+from datetime import date, timedelta
+
+from mirage.accessor.gcal import GCalAccessor
+from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
+from mirage.core.gcal._client import list_calendars, list_events
+from mirage.core.gcal.day import (DATE_RE, WINDOW_AHEAD_DAYS, WINDOW_BACK_DAYS,
+                                  clamped_hhmm, day_bounds, days_covered,
+                                  event_span, window_bounds)
+from mirage.core.google.date_glob import glob_to_date_range
+from mirage.resource.gcal.event_entry import (CALENDAR_FILE, PRIMARY_DIR,
+                                              event_title,
+                                              make_calendar_dirname,
+                                              make_event_filename)
+from mirage.types import JsonValue, PathSpec
+from mirage.utils.errors import enoent
+from mirage.utils.key_prefix import mount_prefix_of
+
+CALENDAR_DIR = "gcal/calendar_dir"
+CALENDAR_JSON = "gcal/calendar_json"
+DAY_DIR = "gcal/day_dir"
+EVENT = "gcal/event"
+FREE_BUSY_ROLE = "freeBusyReader"
+
+
+def calendar_payload(entry: dict[str, JsonValue], tz: str) -> bytes:
+    """Render the per-calendar metadata file.
+
+    Args:
+        entry (dict): the calendarList entry.
+        tz (str): the mount-wide bucketing zone.
+
+    Returns:
+        bytes: the rendered ``calendar.json``.
+    """
+    body = {
+        "id": entry.get("id"),
+        "summary": entry.get("summary"),
+        "accessRole": entry.get("accessRole"),
+        "primary": bool(entry.get("primary")),
+        "calendarTimeZone": entry.get("timeZone"),
+        # The zone the day directories are bucketed in, which is mount-wide
+        # and therefore not always this calendar's own.
+        "bucketTimeZone": tz,
+    }
+    return json.dumps(body, ensure_ascii=False, separators=(",", ":")).encode()
+
+
+def normalize(path: PathSpec) -> tuple[str, str, str]:
+    """Split a path into (mount prefix, mount-relative key, virtual key).
+
+    Args:
+        path (PathSpec): the path being listed.
+
+    Returns:
+        tuple[str, str, str]: prefix, key, virtual key.
+    """
+    prefix = mount_prefix_of(path.virtual, path.resource_path)
+    raw = path.directory if path.pattern else path.virtual
+    if prefix and raw.startswith(prefix):
+        rest = raw[len(prefix):]
+        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
+            raw = rest or "/"
+    key = raw.strip("/")
+    virtual_key = prefix + "/" + key if key else prefix or "/"
+    return prefix, key, virtual_key
+
+
+async def calendar_index(
+        accessor: GCalAccessor) -> dict[str, dict[str, JsonValue]]:
+    """Map each calendar's directory name to its calendarList entry.
+
+    Args:
+        accessor (GCalAccessor): the mount's accessor.
+
+    Returns:
+        dict[str, dict]: directory name to entry.
+    """
+    rows = await list_calendars(accessor.token_manager,
+                                accessor.config.min_access_role)
+    out: dict[str, dict[str, JsonValue]] = {}
+    for row in rows:
+        cal_id = row.get("id")
+        if not isinstance(cal_id, str) or not cal_id:
+            continue
+        summary = row.get("summary")
+        name = make_calendar_dirname(
+            summary if isinstance(summary, str) else cal_id,
+            cal_id,
+            primary=bool(row.get("primary")))
+        out[name] = row
+    return out
+
+
+def bucket_zone(accessor: GCalAccessor,
+                calendars: dict[str, dict[str, JsonValue]]) -> str:
+    """The one zone every day directory on this mount is bucketed in.
+
+    Defaults to the primary calendar's zone, matching how the Calendar UI
+    draws its grid: bucketing each calendar in its own zone would make the
+    same directory name mean different 24-hour windows on different
+    calendars, so a cross-calendar free/busy comparison would be wrong.
+
+    Args:
+        accessor (GCalAccessor): the mount's accessor.
+        calendars (dict): the calendar index.
+
+    Returns:
+        str: an IANA zone name.
+    """
+    if accessor.config.time_zone:
+        return accessor.config.time_zone
+    primary = calendars.get(PRIMARY_DIR)
+    if primary is not None:
+        tz = primary.get("timeZone")
+        if isinstance(tz, str) and tz:
+            return tz
+    for entry in calendars.values():
+        tz = entry.get("timeZone")
+        if isinstance(tz, str) and tz:
+            return tz
+    return "UTC"
+
+
+def day_span(pattern: str | None, today: date,
+             tz: str) -> tuple[str, str, date, date]:
+    """The listing window, honouring a date glob when one was typed.
+
+    A bare readdir reports a rolling window around today because a calendar
+    is unbounded in both directions and the API offers no descending
+    startTime order. A glob escapes it by pushing its own bounds down.
+
+    Args:
+        pattern (str | None): the glob as typed, or None.
+        today (date): the day the default window centres on.
+        tz (str): the bucketing zone.
+
+    Returns:
+        tuple[str, str, date, date]: timeMin, timeMax, first day, last day.
+    """
+    span = glob_to_date_range(pattern)
+    if span is not None:
+        last = span[1] - timedelta(days=1)
+        return day_bounds(span[0].isoformat(),
+                          tz)[0], day_bounds(last.isoformat(),
+                                             tz)[1], span[0], last
+    lo, hi = window_bounds(today, tz)
+    return (lo, hi, today - timedelta(days=WINDOW_BACK_DAYS),
+            today + timedelta(days=WINDOW_AHEAD_DAYS))
+
+
+def event_entries(events: list[dict[str, JsonValue]], day: str, tz: str,
+                  free_busy: bool) -> list[tuple[str, IndexEntry]]:
+    """Build the index entries for one day directory.
+
+    Args:
+        events (list): events overlapping the day.
+        day (str): the local day, ``YYYY-MM-DD``.
+        tz (str): the bucketing zone.
+        free_busy (bool): whether the calendar hides event details.
+
+    Returns:
+        list[tuple[str, IndexEntry]]: (filename, entry) pairs.
+    """
+    rows: list[tuple[str, IndexEntry]] = []
+    for event in events:
+        event_id = event.get("id")
+        if not isinstance(event_id, str) or not event_id:
+            continue
+        span = event_span(event, tz)
+        if span is None or day not in days_covered(span, tz):
+            continue
+        summary = event.get("summary")
+        title = event_title(summary if isinstance(summary, str) else None,
+                            free_busy=free_busy)
+        name = make_event_filename(event_id, clamped_hhmm(span, day, tz),
+                                   title)
+        updated = event.get("updated")
+        payload = json.dumps(event, ensure_ascii=False,
+                             separators=(",", ":")).encode()
+        rows.append(
+            (name,
+             IndexEntry(
+                 id=event_id,
+                 name=title,
+                 resource_type=EVENT,
+                 remote_time=updated if isinstance(updated, str) else "",
+                 vfs_name=name,
+                 size=len(payload),
+             )))
+    return rows
+
+
+async def readdir(
+    accessor: GCalAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = NULL_INDEX,
+) -> list[str]:
+    """List one level of the calendar tree.
+
+    Args:
+        accessor (GCalAccessor): the mount's accessor.
+        path (PathSpec): the directory being listed.
+        index (IndexCacheStore): the mount's index cache.
+
+    Returns:
+        list[str]: virtual paths of the directory's children.
+    """
+    prefix, key, virtual_key = normalize(path)
+    calendars = await calendar_index(accessor)
+    tz = bucket_zone(accessor, calendars)
+
+    if not key:
+        entries = [(name,
+                    IndexEntry(id=str(entry.get("id") or name),
+                               name=name,
+                               resource_type=CALENDAR_DIR,
+                               vfs_name=name))
+                   for name, entry in sorted(calendars.items())]
+        await index.set_dir(virtual_key, entries)
+        return [f"{prefix}/{name}" for name, _ in entries]
+
+    parts = key.split("/")
+    entry = calendars.get(parts[0])
+    if entry is None or len(parts) > 2:
+        raise enoent(path.virtual)
+    cal_id = entry.get("id")
+    if not isinstance(cal_id, str):
+        raise enoent(path.virtual)
+    free_busy = entry.get("accessRole") == FREE_BUSY_ROLE
+
+    if len(parts) == 1:
+        time_min, time_max, first, last = day_span(path.pattern,
+                                                   accessor.today(), tz)
+        events = await list_events(accessor.token_manager, cal_id, time_min,
+                                   time_max, tz)
+        seen: set[str] = set()
+        for event in events:
+            span = event_span(event, tz)
+            if span is None:
+                continue
+            for day in days_covered(span, tz):
+                if first.isoformat() <= day <= last.isoformat():
+                    seen.add(day)
+        rows: list[tuple[str, IndexEntry]] = [
+            (CALENDAR_FILE,
+             IndexEntry(id=f"{cal_id}:calendar",
+                        name=CALENDAR_FILE,
+                        resource_type=CALENDAR_JSON,
+                        vfs_name=CALENDAR_FILE,
+                        size=len(calendar_payload(entry, tz))))
+        ]
+        for day in sorted(seen):
+            rows.append((day,
+                         IndexEntry(id=f"{cal_id}:{day}",
+                                    name=day,
+                                    resource_type=DAY_DIR,
+                                    vfs_name=day)))
+        if path.pattern:
+            # A globbed listing is a filtered view, not the directory: caching
+            # it as the directory would pin a short listing until it expires.
+            for name, row in rows:
+                await index.put(f"{virtual_key}/{name}", row)
+        else:
+            await index.set_dir(virtual_key, rows)
+        return [f"{prefix}/{key}/{name}" for name, _ in rows]
+
+    day = parts[1]
+    if not DATE_RE.match(day):
+        raise enoent(path.virtual)
+    time_min, time_max = day_bounds(day, tz)
+    events = await list_events(accessor.token_manager, cal_id, time_min,
+                               time_max, tz)
+    rows = event_entries(events, day, tz, free_busy)
+    await index.set_dir(virtual_key, rows)
+    return [f"{prefix}/{key}/{name}" for name, _ in rows]

--- a/python/mirage/core/gcal/readdir.py
+++ b/python/mirage/core/gcal/readdir.py
@@ -18,9 +18,9 @@ from datetime import date, timedelta
 from mirage.accessor.gcal import GCalAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
 from mirage.core.gcal._client import list_calendars, list_events
-from mirage.core.gcal.day import (DATE_RE, WINDOW_AHEAD_DAYS, WINDOW_BACK_DAYS,
+from mirage.core.gcal.day import (WINDOW_AHEAD_DAYS, WINDOW_BACK_DAYS,
                                   clamped_hhmm, day_bounds, days_covered,
-                                  event_span, window_bounds)
+                                  event_span, valid_day, window_bounds)
 from mirage.core.google.date_glob import glob_to_date_range
 from mirage.resource.gcal.event_entry import (CALENDAR_FILE, PRIMARY_DIR,
                                               event_title,
@@ -245,7 +245,7 @@ async def readdir(
 
     if len(parts) == 1:
         time_min, time_max, first, last = day_span(path.pattern,
-                                                   accessor.today(), tz)
+                                                   accessor.today(tz), tz)
         events = await list_events(accessor.token_manager, cal_id, time_min,
                                    time_max, tz)
         seen: set[str] = set()
@@ -280,7 +280,7 @@ async def readdir(
         return [f"{prefix}/{key}/{name}" for name, _ in rows]
 
     day = parts[1]
-    if not DATE_RE.match(day):
+    if not valid_day(day):
         raise enoent(path.virtual)
     time_min, time_max = day_bounds(day, tz)
     events = await list_events(accessor.token_manager, cal_id, time_min,

--- a/python/mirage/core/gcal/stat.py
+++ b/python/mirage/core/gcal/stat.py
@@ -1,0 +1,93 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import logging
+
+from mirage.accessor.gcal import GCalAccessor
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.gcal.day import DATE_RE
+from mirage.core.gcal.readdir import (CALENDAR_JSON, EVENT, calendar_index,
+                                      normalize, readdir)
+from mirage.types import FileStat, FileType, PathSpec
+from mirage.utils.errors import enoent
+from mirage.utils.key_prefix import mount_key
+
+logger = logging.getLogger(__name__)
+
+
+async def stat(
+    accessor: GCalAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = NULL_INDEX,
+) -> FileStat:
+    """Stat one node of the calendar tree.
+
+    A well-formed day directory resolves whether or not it holds an event:
+    the range query over that day is positive proof of what is there, so an
+    event-free day is an empty directory rather than a miss. Only a
+    malformed date, or one under a calendar that does not exist, is ENOENT.
+
+    Args:
+        accessor (GCalAccessor): the mount's accessor.
+        path (PathSpec): the path to stat.
+        index (IndexCacheStore): the mount's index cache.
+
+    Returns:
+        FileStat: the node's stat row.
+    """
+    prefix, key, virtual_key = normalize(path)
+    if not key:
+        return FileStat(name="/", type=FileType.DIRECTORY)
+
+    result = await index.get(virtual_key)
+    if result.entry is None:
+        parent_virtual = virtual_key.rsplit("/", 1)[0] or "/"
+        try:
+            await readdir(
+                accessor,
+                PathSpec(virtual=parent_virtual,
+                         directory=parent_virtual,
+                         resource_path=mount_key(parent_virtual, prefix)),
+                index=index,
+            )
+        except FileNotFoundError as exc:
+            logger.debug("gcal stat populate failed for %s: %s",
+                         parent_virtual, exc)
+        result = await index.get(virtual_key)
+
+    if result.entry is None:
+        parts = key.split("/")
+        if len(parts) == 2 and DATE_RE.match(parts[1]):
+            # Outside the default window, or a day with nothing on it. Ask
+            # the calendar list rather than the index: the index only knows
+            # the calendar once the ROOT has been listed, which a stat of a
+            # day two levels down never triggers.
+            if parts[0] not in await calendar_index(accessor):
+                raise enoent(path.virtual)
+            return FileStat(name=parts[1], type=FileType.DIRECTORY)
+        raise enoent(path.virtual)
+
+    entry = result.entry
+    if entry.resource_type in (EVENT, CALENDAR_JSON):
+        return FileStat(
+            name=entry.vfs_name,
+            type=FileType.JSON,
+            modified=entry.remote_time,
+            size=entry.size,
+            extra={
+                "event_id": entry.id,
+                **entry.extra
+            },
+        )
+    return FileStat(name=entry.vfs_name, type=FileType.DIRECTORY)

--- a/python/mirage/core/gcal/stat.py
+++ b/python/mirage/core/gcal/stat.py
@@ -16,7 +16,7 @@ import logging
 
 from mirage.accessor.gcal import GCalAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.gcal.day import DATE_RE
+from mirage.core.gcal.day import valid_day
 from mirage.core.gcal.readdir import (CALENDAR_JSON, EVENT, calendar_index,
                                       normalize, readdir)
 from mirage.types import FileStat, FileType, PathSpec
@@ -68,7 +68,7 @@ async def stat(
 
     if result.entry is None:
         parts = key.split("/")
-        if len(parts) == 2 and DATE_RE.match(parts[1]):
+        if len(parts) == 2 and valid_day(parts[1]):
             # Outside the default window, or a day with nothing on it. Ask
             # the calendar list rather than the index: the index only knows
             # the calendar once the ROOT has been listed, which a stat of a

--- a/python/mirage/core/gcal/unlink.py
+++ b/python/mirage/core/gcal/unlink.py
@@ -1,0 +1,57 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.gcal import GCalAccessor
+from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.gcal._client import delete_event
+from mirage.core.gcal.readdir import calendar_index, normalize
+from mirage.resource.gcal.event_entry import parse_event_filename
+from mirage.types import PathSpec
+from mirage.utils.errors import enoent
+
+
+async def unlink(
+    accessor: GCalAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = NULL_INDEX,
+) -> None:
+    """Delete the event a path names.
+
+    The path carries the event id, so no read is needed first: rm resolves
+    through the name the listing already produced.
+
+    Args:
+        accessor (GCalAccessor): the mount's accessor.
+        path (PathSpec): the event file to remove.
+        index (IndexCacheStore): the mount's index cache.
+    """
+    prefix, key, virtual_key = normalize(path)
+    parts = key.split("/")
+    if len(parts) != 3:
+        raise IsADirectoryError(path.virtual)
+    calendars = await calendar_index(accessor)
+    entry = calendars.get(parts[0])
+    if entry is None:
+        raise enoent(path.virtual)
+    role = entry.get("accessRole")
+    if role not in ("owner", "writer"):
+        raise PermissionError(path.virtual)
+    cal_id = entry.get("id")
+    if not isinstance(cal_id, str):
+        raise enoent(path.virtual)
+    event_id, _ = parse_event_filename(parts[2])
+    await delete_event(accessor.token_manager, cal_id, event_id)
+    await index.invalidate_dir(virtual_key.rsplit("/", 1)[0] or "/")
+    await invalidate_after_unlink(path)

--- a/python/mirage/core/google/_client.py
+++ b/python/mirage/core/google/_client.py
@@ -28,6 +28,8 @@ DOCS_API_BASE = "https://docs.googleapis.com/v1"
 SLIDES_API_BASE = "https://slides.googleapis.com/v1"
 SHEETS_API_BASE = "https://sheets.googleapis.com/v4"
 GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1"
+CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
+FORMS_API_BASE = "https://forms.googleapis.com/v1"
 DRIVE_UPLOAD_BASE = "https://www.googleapis.com/upload/drive/v3"
 TOKEN_BUFFER_SECONDS = 300
 
@@ -117,6 +119,16 @@ def sheets_base(token_manager: "TokenManager") -> str:
 def gmail_base(token_manager: "TokenManager") -> str:
     base = token_manager.config.api_base
     return f"{base}/gmail/v1" if base else GMAIL_API_BASE
+
+
+def calendar_base(token_manager: "TokenManager") -> str:
+    base = token_manager.config.api_base
+    return f"{base}/calendar/v3" if base else CALENDAR_API_BASE
+
+
+def forms_base(token_manager: "TokenManager") -> str:
+    base = token_manager.config.api_base
+    return f"{base}/v1" if base else FORMS_API_BASE
 
 
 async def refresh_access_token(config: GoogleConfig, ) -> tuple[str, int]:

--- a/python/mirage/core/google/date_glob.py
+++ b/python/mirage/core/google/date_glob.py
@@ -22,6 +22,35 @@ def _iso(d: date) -> str:
 
 
 def glob_to_modified_range(pattern: str | None) -> tuple[str, str] | None:
+    """Translate a date-prefixed glob into an RFC3339 modifiedTime range.
+
+    Args:
+        pattern (str | None): the glob as typed, or None.
+
+    Returns:
+        tuple[str, str] | None: (start, end) in UTC, or None when the glob
+        does not start with a date prefix.
+    """
+    span = glob_to_date_range(pattern)
+    if span is None:
+        return None
+    return _iso(span[0]), _iso(span[1])
+
+
+def glob_to_date_range(pattern: str | None) -> tuple[date, date] | None:
+    """Translate a date-prefixed glob into a half-open range of dates.
+
+    Kept separate from ``glob_to_modified_range`` because a caller bucketing
+    in a named time zone has to build its own bounds from the dates; UTC
+    instants would silently shift the window by the zone's offset.
+
+    Args:
+        pattern (str | None): the glob as typed, or None.
+
+    Returns:
+        tuple[date, date] | None: (start, end) with end exclusive, or None
+        when the glob does not start with a date prefix.
+    """
     if not pattern:
         return None
     meta_index = -1
@@ -58,4 +87,4 @@ def glob_to_modified_range(pattern: str | None) -> tuple[str, str] | None:
             return None
     except ValueError:
         return None
-    return _iso(start), _iso(end)
+    return start, end

--- a/python/mirage/ops/gcal/__init__.py
+++ b/python/mirage/ops/gcal/__init__.py
@@ -1,0 +1,19 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.builtin.gcal.io import IO
+from mirage.ops.gcal.read import read
+from mirage.ops.generic import make_generic_ops
+
+OPS = [*make_generic_ops("gcal", IO, overrides={"read"}), read]

--- a/python/mirage/ops/gcal/read.py
+++ b/python/mirage/ops/gcal/read.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.gcal import GCalAccessor
+from mirage.core.gcal.read import read as core_read
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("read", resource=["gcal"], filetype=".gcal.json")
+async def read(accessor: GCalAccessor, path: PathSpec, *, index,
+               **kwargs) -> bytes:
+    return await core_read(accessor, path, index)

--- a/python/mirage/resource/gcal/__init__.py
+++ b/python/mirage/resource/gcal/__init__.py
@@ -1,0 +1,25 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.resource.gcal.config import GCalConfig
+from mirage.resource.gcal.event_entry import make_event_filename
+
+__all__ = ["GCalConfig", "make_event_filename", "GCalResource"]
+
+
+def __getattr__(name: str):
+    if name == "GCalResource":
+        from mirage.resource.gcal.gcal import GCalResource
+        return GCalResource
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/mirage/resource/gcal/config.py
+++ b/python/mirage/resource/gcal/config.py
@@ -1,0 +1,28 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.core.google.config import GoogleConfig
+
+
+class GCalConfig(GoogleConfig):
+    # One zone for the whole mount, not one per calendar: the Calendar UI
+    # draws its whole grid in the primary zone, and per-calendar bucketing
+    # would make the same day directory name mean different 24-hour windows
+    # on different calendars. Defaults to the primary calendar's zone.
+    time_zone: str | None = None
+    # Keep only calendars at or above this accessRole, e.g. "writer" for
+    # ones the agent can actually schedule into.
+    min_access_role: str | None = None
+    # Pin the day the rolling window centres on; test and snapshot use.
+    today: str | None = None

--- a/python/mirage/resource/gcal/event_entry.py
+++ b/python/mirage/resource/gcal/event_entry.py
@@ -1,0 +1,142 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.utils.naming import make_id_name
+from mirage.utils.sanitize import NAME_MAX_BYTES, sanitize_name, truncate_bytes
+
+EVENT_SUFFIX = ".gcal.json"
+CALENDAR_FILE = "calendar.json"
+PRIMARY_DIR = "primary"
+# "HHMM-HHMM"
+HHMM_LEN = 9
+UNTITLED = "untitled"
+# A freeBusyReader calendar returns availability with no summary at all, so
+# there is no title to sanitize and "busy" is the honest rendering.
+BUSY = "busy"
+
+
+def event_title(summary: str | None, *, free_busy: bool = False) -> str:
+    """Pick the title segment for an event filename.
+
+    Args:
+        summary (str | None): the event's summary, absent when the calendar
+            is only readable as free/busy.
+        free_busy (bool): whether the calendar's accessRole hides details.
+
+    Returns:
+        str: a sanitized, non-empty title segment.
+    """
+    if summary is not None and summary.strip():
+        return sanitize_name(summary)
+    return BUSY if free_busy else UNTITLED
+
+
+def make_event_filename(event_id: str, hhmm: str, title: str) -> str:
+    """Build an event filename: id first, then the day-local times, then title.
+
+    The id leads so that trimming the title can never make two events collide
+    and so ``ls <idprefix>*`` addresses one event. Google event ids are 5-1024
+    characters by spec (26 in practice), so the title takes whatever of the
+    255-byte NAME_MAX is left rather than a fixed character count.
+
+    Args:
+        event_id (str): the Calendar API event id, embedded verbatim.
+        hhmm (str): the day-clamped ``HHMM-HHMM`` label.
+        title (str): an already-sanitized title segment.
+
+    Returns:
+        str: e.g. ``la9i1t9...__0900-1030_PhD_Defense.gcal.json``.
+    """
+    fixed = len(event_id.encode()) + len("__") + len(hhmm) + len("_") + len(
+        EVENT_SUFFIX)
+    trimmed = truncate_bytes(title, NAME_MAX_BYTES - fixed).rstrip("_")
+    if not trimmed:
+        # The title is what gives, never the id: trimming the id would make
+        # the name stop addressing the event, which is the whole reason it
+        # leads. An id long enough that even this form overflows NAME_MAX is
+        # therefore unnameable rather than silently mangled. The spec permits
+        # one (ids run 5-1024 chars) but only a caller-supplied id from
+        # events.import can be that long; Google's own are 26.
+        return f"{event_id}__{hhmm}{EVENT_SUFFIX}"
+    return f"{event_id}__{hhmm}_{trimmed}{EVENT_SUFFIX}"
+
+
+def parse_event_filename(name: str) -> tuple[str, str]:
+    """Recover (event_id, hhmm) from an event filename.
+
+    Splitting on the first ``__`` is safe because a Google event id is
+    base32hex and can hold neither an underscore nor a separator, while a
+    title routinely holds both.
+
+    Args:
+        name (str): the filename as rendered.
+
+    Raises:
+        FileNotFoundError: when the name is not an event filename.
+
+    Returns:
+        tuple[str, str]: the event id and the ``HHMM-HHMM`` label.
+    """
+    if not name.endswith(EVENT_SUFFIX):
+        raise FileNotFoundError(name)
+    raw = name[:-len(EVENT_SUFFIX)]
+    event_id, sep, rest = raw.partition("__")
+    if not sep or not event_id or len(rest) < HHMM_LEN:
+        raise FileNotFoundError(name)
+    return event_id, rest[:HHMM_LEN]
+
+
+def make_calendar_dirname(summary: str,
+                          calendar_id: str,
+                          *,
+                          primary: bool = False) -> str:
+    """Build the directory name for one calendar.
+
+    The primary calendar is spelled ``primary`` because that is the stable
+    alias every Calendar API call accepts, and its summary is only the
+    account's own email address.
+
+    Args:
+        summary (str): the calendar's title.
+        calendar_id (str): the calendar id, embedded verbatim.
+        primary (bool): whether this is the account's primary calendar.
+
+    Returns:
+        str: ``primary`` or ``Title__<calendarId>``.
+    """
+    if primary:
+        return PRIMARY_DIR
+    return make_id_name(summary, calendar_id)
+
+
+def parse_calendar_dirname(name: str) -> str:
+    """Recover the calendar id a directory name addresses.
+
+    Args:
+        name (str): the directory name as rendered.
+
+    Raises:
+        FileNotFoundError: when the name carries no calendar id.
+
+    Returns:
+        str: the calendar id, or ``primary`` for the primary alias.
+    """
+    if name == PRIMARY_DIR:
+        return PRIMARY_DIR
+    # rpartition, not partition: a calendar id holds "@" and "." but the
+    # sanitized title before it may itself contain "__".
+    _, sep, calendar_id = name.rpartition("__")
+    if not sep or not calendar_id:
+        raise FileNotFoundError(name)
+    return calendar_id

--- a/python/mirage/resource/gcal/gcal.py
+++ b/python/mirage/resource/gcal/gcal.py
@@ -1,0 +1,61 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Any
+
+from mirage.accessor.gcal import GCalAccessor
+from mirage.core.gcal.readdir import readdir
+from mirage.core.google._client import TokenManager
+from mirage.resource.base import BaseResource
+from mirage.resource.gcal.config import GCalConfig
+from mirage.resource.gcal.prompt import PROMPT, WRITE_PROMPT
+from mirage.types import ResourceName
+from mirage.utils.glob_walk import make_resolve_glob
+
+_resolve_glob = make_resolve_glob(readdir)
+
+
+class GCalResource(BaseResource):
+
+    accessor: GCalAccessor
+    name: str = ResourceName.GCAL
+    caches_reads: bool = True
+    # Shorter than the other Google mounts: a calendar is edited by other
+    # people and a day-long index would keep serving a schedule that has
+    # already moved.
+    index_ttl: float = 300
+    PROMPT: str = PROMPT
+    WRITE_PROMPT: str = WRITE_PROMPT
+
+    def __init__(self, config: GCalConfig) -> None:
+        super().__init__()
+        self.config = config
+        self._token_manager = TokenManager(config)
+        self.accessor = GCalAccessor(self.config, self._token_manager)
+        from mirage.commands.builtin.gcal import COMMANDS
+        from mirage.ops.gcal import OPS as GCAL_VFS_OPS
+
+        for fn in COMMANDS:
+            self.register(fn)
+        for fn in GCAL_VFS_OPS:
+            self.register_op(fn)
+
+    async def resolve_glob(self, paths, prefix: str = ""):
+        return await _resolve_glob(self.accessor, paths, index=self._index)
+
+    def get_state(self) -> dict[str, Any]:
+        return self.config_state(self.config)
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        pass

--- a/python/mirage/resource/gcal/gcal.py
+++ b/python/mirage/resource/gcal/gcal.py
@@ -15,8 +15,10 @@
 from typing import Any
 
 from mirage.accessor.gcal import GCalAccessor
+from mirage.commands.builtin.gcal import COMMANDS
 from mirage.core.gcal.readdir import readdir
 from mirage.core.google._client import TokenManager
+from mirage.ops.gcal import OPS as GCAL_VFS_OPS
 from mirage.resource.base import BaseResource
 from mirage.resource.gcal.config import GCalConfig
 from mirage.resource.gcal.prompt import PROMPT, WRITE_PROMPT
@@ -43,9 +45,6 @@ class GCalResource(BaseResource):
         self.config = config
         self._token_manager = TokenManager(config)
         self.accessor = GCalAccessor(self.config, self._token_manager)
-        from mirage.commands.builtin.gcal import COMMANDS
-        from mirage.ops.gcal import OPS as GCAL_VFS_OPS
-
         for fn in COMMANDS:
             self.register(fn)
         for fn in GCAL_VFS_OPS:

--- a/python/mirage/resource/gcal/prompt.py
+++ b/python/mirage/resource/gcal/prompt.py
@@ -1,0 +1,58 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+PROMPT = """Google Calendar is mounted as one directory per calendar, one
+directory per local day, and one JSON file per event.
+
+    /<mount>/primary/calendar.json
+    /<mount>/primary/2026-08-11/<eventId>__0900-1030_Team_Standup.gcal.json
+    /<mount>/Engineering__team@group.calendar.google.com/2026-08-11/...
+
+Reading the tree:
+
+- `ls <mount>/` lists the calendars. The primary one is always spelled
+  `primary`; every other directory ends in `__<calendarId>`.
+- `ls <mount>/primary/` lists ONLY the days that have an event, and ONLY
+  within a rolling window around today (30 days back, 90 forward). This is
+  a window, not the whole calendar. To look outside it, glob a date:
+  `ls <mount>/primary/2025-12-*` pushes its own range down to the API.
+- Any well-formed date resolves even when it holds nothing, so
+  `ls <mount>/primary/2027-03-04/` succeeds and prints nothing. An empty
+  listing means the day is free, not that the day is missing.
+- A file name is `<eventId>__<HHMM-HHMM>_<Title>.gcal.json`. The times are
+  clamped to that day, so an event running through it reads `0000-2400`.
+  A multi-day event appears under every day it covers.
+- `cat` an event for the unmodified Calendar API payload, including
+  attendees, description, location and the original start/end with offsets.
+- `calendar.json` carries the calendar's accessRole and, in
+  `bucketTimeZone`, the zone the day directories are bucketed in. That zone
+  is mount-wide, so every calendar's `2026-08-11/` covers the same 24 hours.
+- On a calendar shared as free/busy only, Google returns no titles at all,
+  so events render as `busy`.
+
+Acting on it:
+
+- `rm` an event file to delete that event.
+- Everything else goes through the `gws calendar` CLI, which takes the ids
+  the tree renders:
+  `gws calendar events insert --params '{"calendarId":"primary"}' --json ...`
+  `gws calendar events patch --params '{"calendarId":"primary","eventId":"..."}'`
+  `gws calendar freebusy query --json '{"timeMin":...,"timeMax":...,"items":[{"id":"primary"}]}'`
+- A written event must carry an explicit UTC offset or timeZone; an
+  ambiguous local time is not interpreted for you.
+"""
+
+WRITE_PROMPT = """Deleting an event file removes it from the calendar for
+every attendee. Creating and editing events goes through `gws calendar`.
+"""

--- a/python/mirage/resource/registry.py
+++ b/python/mirage/resource/registry.py
@@ -120,6 +120,9 @@ REGISTRY: dict[str, ResourceEntry] = {
     "linear":
     ResourceEntry("mirage.resource.linear:LinearResource",
                   "mirage.resource.linear:LinearConfig"),
+    "gcal":
+    ResourceEntry("mirage.resource.gcal:GCalResource",
+                  "mirage.resource.gcal:GCalConfig"),
     "gdocs":
     ResourceEntry("mirage.resource.gdocs:GDocsResource",
                   "mirage.resource.gdocs:GDocsConfig"),

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -375,6 +375,7 @@ class ResourceName(str, Enum):
     RAM = "ram"
     GITHUB = "github"
     LINEAR = "linear"
+    GCAL = "gcal"
     GDOCS = "gdocs"
     GSHEETS = "gsheets"
     GSLIDES = "gslides"

--- a/python/mirage/utils/sanitize.py
+++ b/python/mirage/utils/sanitize.py
@@ -17,6 +17,31 @@ import re
 UNSAFE_CHARS = re.compile(r"[^\w\s\-.]")
 MULTI_UNDERSCORE = re.compile(r"_+")
 MAX_LEN = 100
+# POSIX NAME_MAX on ext4 and APFS alike, and it counts BYTES. Truncating by
+# characters is the same number only for ASCII: a 100-character CJK title is
+# 300 bytes.
+NAME_MAX_BYTES = 255
+
+
+def truncate_bytes(text: str, budget: int) -> str:
+    """Trim a string to fit a byte budget without splitting a character.
+
+    Args:
+        text (str): the string to trim.
+        budget (int): maximum length in UTF-8 bytes.
+
+    Returns:
+        str: ``text`` unchanged when it already fits, else the longest
+        prefix whose UTF-8 encoding is at most ``budget`` bytes.
+    """
+    if budget <= 0:
+        return ""
+    raw = text.encode("utf-8")
+    if len(raw) <= budget:
+        return text
+    # errors="ignore" drops the partial sequence the cut may have left,
+    # which is exactly the trailing character that did not fit.
+    return raw[:budget].decode("utf-8", errors="ignore")
 
 
 def sanitize_name(name: str) -> str:

--- a/python/tests/commands/cli/builtin/gws/test_api.py
+++ b/python/tests/commands/cli/builtin/gws/test_api.py
@@ -314,3 +314,19 @@ async def test_an_explicitly_empty_parents_array_is_still_the_callers():
                           flags={"json": '{"name": "n", "parents": []}'}))
     assert post.await_args.args[2] == {"name": "n", "parents": []}
     assert "supportsAllDrives" not in post.await_args.args[1]
+
+
+def test_fill_path_percent_encodes_a_reserved_character():
+    # A Google holiday calendar id carries "#", which opens a URL fragment:
+    # unencoded, the request reached /calendars/en.usa and 404'd.
+    path, query = fill_path(
+        "/calendars/{calendarId}/events",
+        {"calendarId": "en.usa#holiday@group.v.calendar.google.com"})
+    assert path == ("/calendars/en.usa%23holiday%40group.v.calendar."
+                    "google.com/events")
+    assert query == {}
+
+
+def test_fill_path_leaves_an_ordinary_id_addressable():
+    path, _ = fill_path("/files/{fileId}", {"fileId": "1AbC-_dEf"})
+    assert path == "/files/1AbC-_dEf"

--- a/python/tests/commands/cli/builtin/gws/test_tree.py
+++ b/python/tests/commands/cli/builtin/gws/test_tree.py
@@ -32,8 +32,9 @@ def leaf(*path: str):
 def test_tree_lists_every_service():
     assert GWS.name == "gws"
     assert GWS.config_model is GoogleConfig
-    assert [g.name for g in GWS.subcommands
-            ] == ["drive", "sheets", "docs", "slides", "gmail"]
+    assert [g.name for g in GWS.subcommands] == [
+        "drive", "sheets", "docs", "slides", "calendar", "forms", "gmail"
+    ]
 
 
 def test_passthroughs_nest_by_discovery_resource():
@@ -60,6 +61,29 @@ def test_writes_follow_http_semantics():
     assert leaf("drive", "files", "delete").write
     assert leaf("sheets", "spreadsheets", "batchUpdate").write
     assert not leaf("gmail", "triage").write
+
+
+def test_calendar_passthroughs_nest_by_discovery_resource():
+    assert [v.name for v in leaf("calendar").subcommands
+            ] == ["calendarList", "calendars", "events", "freebusy"]
+    assert [v.name for v in leaf("calendar", "events").subcommands
+            ] == ["list", "get", "insert", "patch", "delete"]
+    assert not leaf("calendar", "events", "list").write
+    assert leaf("calendar", "events", "insert").write
+    assert leaf("calendar", "events", "delete").write
+    # freebusy.query is a POST that mutates nothing, but write follows the
+    # HTTP verb everywhere else in the tree and a second rule would be worse.
+    assert leaf("calendar", "freebusy", "query").write
+
+
+def test_forms_passthroughs_nest_by_discovery_resource():
+    assert [v.name for v in leaf("forms").subcommands] == ["forms"]
+    assert [v.name for v in leaf("forms", "forms").subcommands
+            ] == ["create", "get", "batchUpdate", "responses"]
+    assert [v.name for v in leaf("forms", "forms", "responses").subcommands
+            ] == ["list", "get"]
+    assert not leaf("forms", "forms", "get").write
+    assert leaf("forms", "forms", "create").write
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/gcal/conftest.py
+++ b/python/tests/core/gcal/conftest.py
@@ -1,0 +1,160 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from datetime import datetime
+
+import pytest
+
+from mirage.accessor.gcal import GCalAccessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.core.gcal.day import event_span
+from mirage.core.google._client import TokenManager
+from mirage.resource.gcal.config import GCalConfig
+
+HK = "Asia/Hong_Kong"
+
+PRIMARY = {
+    "id": "integ@example.com",
+    "summary": "Integ User",
+    "timeZone": HK,
+    "accessRole": "owner",
+    "primary": True,
+}
+TEAM = {
+    "id": "team@group.calendar.google.com",
+    "summary": "Engineering",
+    "timeZone": "America/Los_Angeles",
+    "accessRole": "reader",
+}
+SHARED = {
+    "id": "busy@group.calendar.google.com",
+    "summary": "Exec",
+    "timeZone": HK,
+    "accessRole": "freeBusyReader",
+}
+
+
+def timed(event_id: str, summary: str, start: str, end: str) -> dict:
+    return {
+        "id": event_id,
+        "status": "confirmed",
+        "summary": summary,
+        "start": {
+            "dateTime": start
+        },
+        "end": {
+            "dateTime": end
+        },
+        "updated": "2026-08-01T00:00:00.000Z",
+    }
+
+
+def all_day(event_id: str, summary: str, start: str, end: str) -> dict:
+    return {
+        "id": event_id,
+        "status": "confirmed",
+        "summary": summary,
+        "start": {
+            "date": start
+        },
+        "end": {
+            "date": end
+        },
+        "updated": "2026-08-01T00:00:00.000Z",
+    }
+
+
+EVENTS = [
+    timed("aaaa1", "PhD Defense", "2026-08-11T09:00:00+08:00",
+          "2026-08-11T10:30:00+08:00"),
+    timed("bbbb2", "Committee Meeting", "2026-08-11T15:00:00+08:00",
+          "2026-08-11T16:00:00+08:00"),
+    timed("cccc3", "Conference", "2026-08-10T09:00:00+08:00",
+          "2026-08-13T17:00:00+08:00"),
+    all_day("dddd4", "Public Holiday", "2026-08-11", "2026-08-12"),
+    timed("eeee5", "Last Year", "2025-01-05T09:00:00+08:00",
+          "2025-01-05T10:00:00+08:00"),
+]
+
+
+class FakeCalendarApi:
+
+    def __init__(self, calendars: list[dict], events: list[dict]) -> None:
+        self.calendars = calendars
+        self.events = events
+        self.listed: list[tuple[str, str, str]] = []
+        self.deleted: list[tuple[str, str]] = []
+
+    async def list_calendars(self, token_manager, min_access_role=None):
+        if not min_access_role:
+            return list(self.calendars)
+        return [
+            c for c in self.calendars if c["accessRole"] == min_access_role
+        ]
+
+    async def list_events(self,
+                          token_manager,
+                          calendar_id,
+                          time_min,
+                          time_max,
+                          time_zone=None):
+        self.listed.append((calendar_id, time_min, time_max))
+        lo = datetime.fromisoformat(time_min)
+        hi = datetime.fromisoformat(time_max)
+        free_busy = calendar_id == SHARED["id"]
+        out = []
+        for event in self.events:
+            span = event_span(event, time_zone or HK)
+            if span is None:
+                continue
+            # timeMin bounds the END and timeMax the START, both exclusive.
+            if span[1] <= lo or span[0] >= hi:
+                continue
+            if free_busy:
+                # What Google actually returns for a freeBusyReader role:
+                # availability with no summary, description or location.
+                event = {
+                    k: v
+                    for k, v in event.items()
+                    if k not in ("summary", "description", "location")
+                }
+            out.append(event)
+        return out
+
+    async def delete_event(self, token_manager, calendar_id, event_id):
+        self.deleted.append((calendar_id, event_id))
+
+
+@pytest.fixture
+def api(monkeypatch):
+    fake = FakeCalendarApi([PRIMARY, TEAM, SHARED], EVENTS)
+    for module in ("readdir", "read", "unlink"):
+        mod = __import__(f"mirage.core.gcal.{module}", fromlist=["x"])
+        for name in ("list_calendars", "list_events", "delete_event"):
+            if hasattr(mod, name):
+                monkeypatch.setattr(mod, name, getattr(fake, name))
+    return fake
+
+
+@pytest.fixture
+def accessor():
+    config = GCalConfig(client_id="cid",
+                        refresh_token="rt",
+                        today="2026-08-11")
+    return GCalAccessor(config, TokenManager(config))
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()

--- a/python/tests/core/gcal/test_client.py
+++ b/python/tests/core/gcal/test_client.py
@@ -33,8 +33,7 @@ def token_manager():
     return TokenManager(GCalConfig(client_id="cid", refresh_token="rt"))
 
 
-async def test_list_events_encodes_the_calendar_id(monkeypatch,
-                                                   token_manager):
+async def test_list_events_encodes_the_calendar_id(monkeypatch, token_manager):
     seen: list[str] = []
 
     async def fake_get(tm, url, params=None):
@@ -50,8 +49,8 @@ async def test_list_events_encodes_the_calendar_id(monkeypatch,
     assert parsed.path.endswith(f"/calendars/{HOLIDAY}/events")
 
 
-async def test_delete_event_encodes_both_path_segments(
-        monkeypatch, token_manager):
+async def test_delete_event_encodes_both_path_segments(monkeypatch,
+                                                       token_manager):
     seen: list[str] = []
 
     async def fake_delete(tm, url):

--- a/python/tests/core/gcal/test_client.py
+++ b/python/tests/core/gcal/test_client.py
@@ -1,0 +1,64 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+import yarl
+
+import mirage.core.gcal._client as client_mod
+from mirage.core.gcal._client import delete_event, list_events
+from mirage.core.google._client import TokenManager
+from mirage.resource.gcal.config import GCalConfig
+
+pytestmark = pytest.mark.asyncio
+
+# A subscribed holiday calendar's real id. "#" opens a URL fragment and "@"
+# is only legal in a userinfo segment, so an unencoded id would send the
+# request to /calendars/en.usa with the rest dropped as a fragment.
+HOLIDAY = "en.usa#holiday@group.v.calendar.google.com"
+
+
+@pytest.fixture
+def token_manager():
+    return TokenManager(GCalConfig(client_id="cid", refresh_token="rt"))
+
+
+async def test_list_events_encodes_the_calendar_id(monkeypatch,
+                                                   token_manager):
+    seen: list[str] = []
+
+    async def fake_get(tm, url, params=None):
+        seen.append(url)
+        return {}
+
+    monkeypatch.setattr(client_mod, "google_get", fake_get)
+    await list_events(token_manager, HOLIDAY, "2026-08-11T00:00:00+08:00",
+                      "2026-08-12T00:00:00+08:00")
+    assert "%23holiday%40group" in seen[0]
+    parsed = yarl.URL(seen[0])
+    assert parsed.fragment == ""
+    assert parsed.path.endswith(f"/calendars/{HOLIDAY}/events")
+
+
+async def test_delete_event_encodes_both_path_segments(
+        monkeypatch, token_manager):
+    seen: list[str] = []
+
+    async def fake_delete(tm, url):
+        seen.append(url)
+
+    monkeypatch.setattr(client_mod, "google_delete", fake_delete)
+    await delete_event(token_manager, HOLIDAY, "evt#1")
+    parsed = yarl.URL(seen[0])
+    assert parsed.fragment == ""
+    assert parsed.path.endswith(f"/calendars/{HOLIDAY}/events/evt#1")

--- a/python/tests/core/gcal/test_day.py
+++ b/python/tests/core/gcal/test_day.py
@@ -16,7 +16,8 @@ from datetime import date, datetime
 
 from mirage.core.gcal.day import (DEFAULT_TZ, clamped_hhmm, day_bounds,
                                   days_covered, event_span, is_all_day,
-                                  local_midnight, window_bounds, zone)
+                                  local_midnight, slot_instant, valid_day,
+                                  window_bounds, zone)
 
 HK = "Asia/Hong_Kong"
 LA = "America/Los_Angeles"
@@ -152,3 +153,46 @@ def test_clamped_hhmm_spells_an_all_day_event_as_the_full_day():
     span = event_span(_all_day("2026-08-11", "2026-08-12"), HK)
     assert span is not None
     assert clamped_hhmm(span, "2026-08-11", HK) == "0000-2400"
+
+
+def test_valid_day_rejects_a_date_shaped_non_date():
+    # Regex-shaped but impossible: letting it through made stat report a
+    # directory that every later call raised ValueError on.
+    assert valid_day("2026-02-11")
+    assert not valid_day("2026-02-30")
+    assert not valid_day("2026-13-01")
+    assert not valid_day("not-a-date")
+
+
+def test_zone_less_datetime_uses_the_slots_declared_zone():
+    # Google requires an offset on dateTime UNLESS the slot names a zone.
+    slot = {"dateTime": "2026-08-11T09:00:00", "timeZone": "Asia/Hong_Kong"}
+    got = slot_instant(slot, "UTC")
+    assert got is not None and got.tzinfo is not None
+    assert got == datetime.fromisoformat("2026-08-11T01:00:00+00:00")
+
+
+def test_zone_less_datetime_without_a_declared_zone_uses_the_bucket_zone():
+    got = slot_instant({"dateTime": "2026-08-11T09:00:00"}, HK)
+    assert got is not None
+    assert got == datetime.fromisoformat("2026-08-11T01:00:00+00:00")
+
+
+def test_a_zone_less_event_buckets_without_raising():
+    # A naive instant here used to reach clamped_hhmm and blow up comparing
+    # against the aware local midnights ("can't compare offset-naive and
+    # offset-aware datetimes").
+    event = {
+        "start": {
+            "dateTime": "2026-08-11T09:00:00",
+            "timeZone": HK
+        },
+        "end": {
+            "dateTime": "2026-08-11T10:30:00",
+            "timeZone": HK
+        },
+    }
+    span = event_span(event, "UTC")
+    assert span is not None
+    assert days_covered(span, HK) == ["2026-08-11"]
+    assert clamped_hhmm(span, "2026-08-11", HK) == "0900-1030"

--- a/python/tests/core/gcal/test_day.py
+++ b/python/tests/core/gcal/test_day.py
@@ -1,0 +1,154 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from datetime import date, datetime
+
+from mirage.core.gcal.day import (DEFAULT_TZ, clamped_hhmm, day_bounds,
+                                  days_covered, event_span, is_all_day,
+                                  local_midnight, window_bounds, zone)
+
+HK = "Asia/Hong_Kong"
+LA = "America/Los_Angeles"
+
+
+def _timed(start: str, end: str) -> dict:
+    return {"start": {"dateTime": start}, "end": {"dateTime": end}}
+
+
+def _all_day(start: str, end: str) -> dict:
+    return {"start": {"date": start}, "end": {"date": end}}
+
+
+def test_unknown_zone_falls_back_to_utc():
+    assert str(zone("Not/AZone")) == DEFAULT_TZ
+    assert str(zone(HK)) == HK
+
+
+def test_day_bounds_are_consecutive_local_midnights():
+    lo, hi = day_bounds("2026-08-11", HK)
+    assert lo == "2026-08-11T00:00:00+08:00"
+    assert hi == "2026-08-12T00:00:00+08:00"
+
+
+def test_day_bounds_span_25_hours_on_a_dst_fall_back():
+    # America/Los_Angeles leaves DST on 2026-11-01, making that local day 25
+    # hours. Adding a fixed 24h would drop the repeated hour's events.
+    lo, hi = day_bounds("2026-11-01", LA)
+    delta = datetime.fromisoformat(hi) - datetime.fromisoformat(lo)
+    assert delta.total_seconds() == 25 * 3600
+
+
+def test_day_bounds_span_23_hours_on_a_dst_spring_forward():
+    lo, hi = day_bounds("2026-03-08", LA)
+    delta = datetime.fromisoformat(hi) - datetime.fromisoformat(lo)
+    assert delta.total_seconds() == 23 * 3600
+
+
+def test_window_bounds_bracket_the_day():
+    lo, hi = window_bounds(date(2026, 8, 11), HK)
+    assert lo == "2026-07-12T00:00:00+08:00"
+    assert hi == "2026-11-10T00:00:00+08:00"
+
+
+def test_is_all_day_reads_the_slot_shape():
+    assert is_all_day({"date": "2026-08-11"})
+    assert not is_all_day({"dateTime": "2026-08-11T09:00:00+08:00"})
+
+
+def test_event_span_parses_offsets_and_z():
+    span = event_span(
+        _timed("2026-08-11T09:00:00+08:00", "2026-08-11T02:30:00Z"), HK)
+    assert span is not None
+    assert span[0] == datetime.fromisoformat("2026-08-11T01:00:00+00:00")
+    assert span[1] == datetime.fromisoformat("2026-08-11T02:30:00+00:00")
+
+
+def test_event_span_reads_all_day_dates_in_the_bucketing_zone():
+    span = event_span(_all_day("2026-08-11", "2026-08-12"), HK)
+    assert span is not None
+    assert span[0] == local_midnight("2026-08-11", HK)
+    assert span[1] == local_midnight("2026-08-12", HK)
+
+
+def test_event_span_is_none_without_usable_slots():
+    assert event_span({"start": {}, "end": {}}, HK) is None
+    assert event_span({"start": "nope", "end": {}}, HK) is None
+
+
+def test_single_day_all_day_event_covers_one_day_only():
+    # end.date is EXCLUSIVE, so start=D end=D+1 is a one-day event and must
+    # not leak into D+1's directory.
+    span = event_span(_all_day("2026-08-11", "2026-08-12"), HK)
+    assert span is not None
+    assert days_covered(span, HK) == ["2026-08-11"]
+
+
+def test_multi_day_all_day_event_covers_each_day():
+    span = event_span(_all_day("2026-08-11", "2026-08-14"), HK)
+    assert span is not None
+    assert days_covered(span, HK) == ["2026-08-11", "2026-08-12", "2026-08-13"]
+
+
+def test_timed_event_covers_every_day_it_spans():
+    span = event_span(
+        _timed("2026-08-10T09:00:00+08:00", "2026-08-13T17:00:00+08:00"), HK)
+    assert span is not None
+    assert days_covered(
+        span, HK) == ["2026-08-10", "2026-08-11", "2026-08-12", "2026-08-13"]
+
+
+def test_event_ending_exactly_at_midnight_stops_at_the_day_it_started():
+    span = event_span(
+        _timed("2026-08-11T23:00:00+08:00", "2026-08-12T00:00:00+08:00"), HK)
+    assert span is not None
+    assert days_covered(span, HK) == ["2026-08-11"]
+
+
+def test_zero_length_event_still_occupies_its_day():
+    span = event_span(
+        _timed("2026-08-11T09:00:00+08:00", "2026-08-11T09:00:00+08:00"), HK)
+    assert span is not None
+    assert days_covered(span, HK) == ["2026-08-11"]
+
+
+def test_bucketing_zone_decides_the_day():
+    # 20:00 in Los Angeles on Aug 11 is 03:00Z on Aug 12: bucketed in the
+    # calendar's zone it is Aug 11, bucketed in UTC it would be Aug 12.
+    span = event_span(
+        _timed("2026-08-11T20:00:00-07:00", "2026-08-11T21:00:00-07:00"), LA)
+    assert span is not None
+    assert days_covered(span, LA) == ["2026-08-11"]
+    assert days_covered(span, "UTC") == ["2026-08-12"]
+
+
+def test_clamped_hhmm_reports_local_times():
+    span = event_span(
+        _timed("2026-08-11T09:00:00+08:00", "2026-08-11T10:30:00+08:00"), HK)
+    assert span is not None
+    assert clamped_hhmm(span, "2026-08-11", HK) == "0900-1030"
+
+
+def test_clamped_hhmm_clamps_a_spanning_event_to_the_whole_day():
+    span = event_span(
+        _timed("2026-08-10T09:00:00+08:00", "2026-08-13T17:00:00+08:00"), HK)
+    assert span is not None
+    assert clamped_hhmm(span, "2026-08-10", HK) == "0900-2400"
+    assert clamped_hhmm(span, "2026-08-11", HK) == "0000-2400"
+    assert clamped_hhmm(span, "2026-08-13", HK) == "0000-1700"
+
+
+def test_clamped_hhmm_spells_an_all_day_event_as_the_full_day():
+    span = event_span(_all_day("2026-08-11", "2026-08-12"), HK)
+    assert span is not None
+    assert clamped_hhmm(span, "2026-08-11", HK) == "0000-2400"

--- a/python/tests/core/gcal/test_read.py
+++ b/python/tests/core/gcal/test_read.py
@@ -1,0 +1,82 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+
+import pytest
+
+from mirage.core.gcal.read import read
+from mirage.types import PathSpec
+
+pytestmark = pytest.mark.asyncio
+
+EVENT = "/primary/2026-08-11/aaaa1__0900-1030_PhD_Defense.gcal.json"
+
+
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.lstrip("/"))
+
+
+async def test_event_reads_the_unmodified_api_payload(api, accessor, index):
+    body = json.loads(await read(accessor, spec(EVENT), index))
+    assert body["id"] == "aaaa1"
+    assert body["summary"] == "PhD Defense"
+    # The original offset survives: the directory name is a view, the
+    # payload is what an absolute-instant comparison is made against.
+    assert body["start"]["dateTime"] == "2026-08-11T09:00:00+08:00"
+
+
+async def test_calendar_json_carries_the_bucket_zone_and_role(
+        api, accessor, index):
+    body = json.loads(await read(accessor, spec("/primary/calendar.json"),
+                                 index))
+    assert body["id"] == "integ@example.com"
+    assert body["accessRole"] == "owner"
+    assert body["primary"] is True
+    assert body["bucketTimeZone"] == "Asia/Hong_Kong"
+
+
+async def test_calendar_json_states_the_mount_wide_zone_not_the_calendars(
+        api, accessor, index):
+    # The reader calendar is America/Los_Angeles, but its day directories are
+    # bucketed mount-wide so every calendar's 2026-08-11 is the same window.
+    path = "/Engineering__team@group.calendar.google.com/calendar.json"
+    body = json.loads(await read(accessor, spec(path), index))
+    assert body["calendarTimeZone"] == "America/Los_Angeles"
+    assert body["bucketTimeZone"] == "Asia/Hong_Kong"
+
+
+async def test_reading_a_directory_raises(api, accessor, index):
+    with pytest.raises(IsADirectoryError):
+        await read(accessor, spec("/primary"), index)
+
+
+async def test_unknown_calendar_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await read(accessor, spec("/nope/calendar.json"), index)
+
+
+async def test_unknown_event_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await read(accessor,
+                   spec("/primary/2026-08-11/zzzz9__0000-0100_Nope.gcal.json"),
+                   index)
+
+
+async def test_a_name_that_is_not_an_event_file_is_enoent(
+        api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await read(accessor, spec("/primary/2026-08-11/notes.txt"), index)

--- a/python/tests/core/gcal/test_readdir.py
+++ b/python/tests/core/gcal/test_readdir.py
@@ -140,6 +140,20 @@ async def test_malformed_date_is_enoent(api, accessor, index):
         await readdir(accessor, spec("/primary/not-a-date"), index)
 
 
+async def test_date_shaped_but_impossible_date_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await readdir(accessor, spec("/primary/2026-02-30"), index)
+
+
+async def test_the_window_is_centred_in_the_bucket_zone(api, accessor, index):
+    # today is pinned, so this asserts the zone reaches the accessor at all;
+    # the bounds carry the bucket zone's offset rather than the host's.
+    await readdir(accessor, spec("/primary"), index)
+    _, time_min, time_max = api.listed[-1]
+    assert time_min.endswith("+08:00")
+    assert time_max.endswith("+08:00")
+
+
 async def test_too_deep_a_path_is_enoent(api, accessor, index):
     with pytest.raises(FileNotFoundError):
         await readdir(accessor, spec("/primary/2026-08-11/x/y"), index)

--- a/python/tests/core/gcal/test_readdir.py
+++ b/python/tests/core/gcal/test_readdir.py
@@ -1,0 +1,152 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.core.gcal.readdir import bucket_zone, calendar_index, readdir
+from mirage.types import PathSpec
+
+pytestmark = pytest.mark.asyncio
+
+HK = "Asia/Hong_Kong"
+
+
+def spec(virtual: str, pattern: str | None = None) -> PathSpec:
+    directory = (virtual.rsplit("/", 1)[0] or "/") if pattern else virtual
+    return PathSpec(virtual=virtual,
+                    directory=directory,
+                    resource_path=virtual.lstrip("/"),
+                    pattern=pattern)
+
+
+def names(paths: list[str]) -> list[str]:
+    return [p.rsplit("/", 1)[-1] for p in paths]
+
+
+async def test_root_lists_one_directory_per_calendar(api, accessor, index):
+    out = await readdir(accessor, spec("/"), index)
+    assert names(out) == [
+        "Engineering__team@group.calendar.google.com",
+        "Exec__busy@group.calendar.google.com",
+        "primary",
+    ]
+
+
+async def test_primary_keeps_its_alias_and_others_carry_the_id(
+        api, accessor, index):
+    calendars = await calendar_index(accessor)
+    assert calendars["primary"]["id"] == "integ@example.com"
+    assert (calendars["Engineering__team@group.calendar.google.com"]["id"] ==
+            "team@group.calendar.google.com")
+
+
+async def test_bucket_zone_defaults_to_the_primary_calendar(api, accessor):
+    calendars = await calendar_index(accessor)
+    # Not the reader calendar's America/Los_Angeles: one zone mount-wide.
+    assert bucket_zone(accessor, calendars) == HK
+
+
+async def test_bucket_zone_honours_an_explicit_override(api, accessor):
+    accessor.config = accessor.config.model_copy(
+        update={"time_zone": "Europe/Berlin"})
+    calendars = await calendar_index(accessor)
+    assert bucket_zone(accessor, calendars) == "Europe/Berlin"
+
+
+async def test_calendar_lists_only_days_holding_events(api, accessor, index):
+    out = await readdir(accessor, spec("/primary"), index)
+    assert names(out) == [
+        "calendar.json",
+        "2026-08-10",
+        "2026-08-11",
+        "2026-08-12",
+        "2026-08-13",
+    ]
+
+
+async def test_calendar_listing_omits_days_outside_the_window(
+        api, accessor, index):
+    out = names(await readdir(accessor, spec("/primary"), index))
+    # 2025-01-05 exists but sits far outside the -30/+90 day window.
+    assert "2025-01-05" not in out
+
+
+async def test_a_date_glob_escapes_the_default_window(api, accessor, index):
+    out = await readdir(accessor, spec("/primary/2025-01-*", "2025-01-*"),
+                        index)
+    assert "2025-01-05" in names(out)
+    listed = api.listed[-1]
+    assert listed[1].startswith("2025-01-01")
+    assert listed[2].startswith("2025-02-01")
+
+
+async def test_day_lists_one_file_per_overlapping_event(api, accessor, index):
+    out = names(await readdir(accessor, spec("/primary/2026-08-11"), index))
+    assert out == [
+        "aaaa1__0900-1030_PhD_Defense.gcal.json",
+        "bbbb2__1500-1600_Committee_Meeting.gcal.json",
+        "cccc3__0000-2400_Conference.gcal.json",
+        "dddd4__0000-2400_Public_Holiday.gcal.json",
+    ]
+
+
+async def test_a_multi_day_event_appears_under_every_day_it_covers(
+        api, accessor, index):
+    for day, hhmm in (("2026-08-10", "0900-2400"), ("2026-08-11", "0000-2400"),
+                      ("2026-08-12", "0000-2400"), ("2026-08-13",
+                                                    "0000-1700")):
+        out = names(await readdir(accessor, spec(f"/primary/{day}"), index))
+        assert f"cccc3__{hhmm}_Conference.gcal.json" in out
+
+
+async def test_an_all_day_event_does_not_leak_past_its_exclusive_end(
+        api, accessor, index):
+    out = names(await readdir(accessor, spec("/primary/2026-08-12"), index))
+    assert not any("Public_Holiday" in n for n in out)
+
+
+async def test_a_day_with_no_events_lists_empty(api, accessor, index):
+    assert await readdir(accessor, spec("/primary/2027-03-04"), index) == []
+
+
+async def test_free_busy_calendar_renders_events_without_titles(
+        api, accessor, index):
+    out = names(await readdir(
+        accessor, spec("/Exec__busy@group.calendar.google.com/2026-08-11"),
+        index))
+    # The real API sends no summary on such a calendar; the fixture keeps
+    # one, so this asserts the accessRole is what decides the rendering.
+    assert all(n.endswith("_busy.gcal.json") for n in out)
+
+
+async def test_unknown_calendar_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await readdir(accessor, spec("/nope"), index)
+
+
+async def test_malformed_date_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await readdir(accessor, spec("/primary/not-a-date"), index)
+
+
+async def test_too_deep_a_path_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await readdir(accessor, spec("/primary/2026-08-11/x/y"), index)
+
+
+async def test_min_access_role_filters_the_calendar_list(api, accessor, index):
+    accessor.config = accessor.config.model_copy(
+        update={"min_access_role": "owner"})
+    out = names(await readdir(accessor, spec("/"), index))
+    assert out == ["primary"]

--- a/python/tests/core/gcal/test_stat.py
+++ b/python/tests/core/gcal/test_stat.py
@@ -61,6 +61,14 @@ async def test_malformed_date_is_enoent(api, accessor, index):
         await stat(accessor, spec("/primary/not-a-date"), index)
 
 
+async def test_date_shaped_but_impossible_date_is_enoent(api, accessor, index):
+    # Shape alone used to be enough, so stat reported a directory that
+    # readdir then raised ValueError on.
+    for bad in ("2026-02-30", "2026-13-01"):
+        with pytest.raises(FileNotFoundError):
+            await stat(accessor, spec(f"/primary/{bad}"), index)
+
+
 async def test_event_reports_json_with_a_rendered_size(api, accessor, index):
     row = await stat(
         accessor,

--- a/python/tests/core/gcal/test_stat.py
+++ b/python/tests/core/gcal/test_stat.py
@@ -1,0 +1,84 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.core.gcal.stat import stat
+from mirage.types import FileType, PathSpec
+
+pytestmark = pytest.mark.asyncio
+
+
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.lstrip("/"))
+
+
+async def test_root_is_a_directory(api, accessor, index):
+    row = await stat(accessor, spec("/"), index)
+    assert row.type is FileType.DIRECTORY
+
+
+async def test_calendar_is_a_directory(api, accessor, index):
+    row = await stat(accessor, spec("/primary"), index)
+    assert row.type is FileType.DIRECTORY
+    assert row.name == "primary"
+
+
+async def test_day_holding_events_is_a_directory(api, accessor, index):
+    row = await stat(accessor, spec("/primary/2026-08-11"), index)
+    assert row.type is FileType.DIRECTORY
+
+
+async def test_event_free_day_still_resolves_as_a_directory(
+        api, accessor, index):
+    # The range query over that day is positive proof of what is there, so
+    # an empty day is an empty directory rather than ENOENT.
+    row = await stat(accessor, spec("/primary/2027-03-04"), index)
+    assert row.type is FileType.DIRECTORY
+    assert row.name == "2027-03-04"
+
+
+async def test_day_under_an_unknown_calendar_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, spec("/nope/2027-03-04"), index)
+
+
+async def test_malformed_date_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, spec("/primary/not-a-date"), index)
+
+
+async def test_event_reports_json_with_a_rendered_size(api, accessor, index):
+    row = await stat(
+        accessor,
+        spec("/primary/2026-08-11/aaaa1__0900-1030_PhD_Defense.gcal.json"),
+        index)
+    assert row.type is FileType.JSON
+    assert row.extra["event_id"] == "aaaa1"
+    # Size is the rendered payload's byte length, never a source-side number.
+    assert row.size is not None and row.size > 0
+
+
+async def test_calendar_json_reports_json(api, accessor, index):
+    row = await stat(accessor, spec("/primary/calendar.json"), index)
+    assert row.type is FileType.JSON
+
+
+async def test_unknown_event_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor,
+                   spec("/primary/2026-08-11/zzzz9__0000-0100_Nope.gcal.json"),
+                   index)

--- a/python/tests/core/gcal/test_unlink.py
+++ b/python/tests/core/gcal/test_unlink.py
@@ -1,0 +1,70 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.core.gcal.unlink import unlink
+from mirage.types import PathSpec
+
+pytestmark = pytest.mark.asyncio
+
+EVENT = "/primary/2026-08-11/aaaa1__0900-1030_PhD_Defense.gcal.json"
+
+
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.lstrip("/"))
+
+
+async def test_unlink_deletes_the_event_the_name_carries(api, accessor, index):
+    await unlink(accessor, spec(EVENT), index)
+    assert api.deleted == [("integ@example.com", "aaaa1")]
+
+
+async def test_unlink_needs_no_read_first(api, accessor, index):
+    # The id comes off the filename, so deleting costs one API call.
+    await unlink(accessor, spec(EVENT), index)
+    assert api.listed == []
+
+
+async def test_unlink_refuses_a_directory(api, accessor, index):
+    with pytest.raises(IsADirectoryError):
+        await unlink(accessor, spec("/primary/2026-08-11"), index)
+    assert api.deleted == []
+
+
+async def test_unlink_refuses_a_read_only_calendar(api, accessor, index):
+    path = ("/Engineering__team@group.calendar.google.com/2026-08-11/"
+            "aaaa1__0900-1030_PhD_Defense.gcal.json")
+    # accessRole reader: refuse at the mount rather than surfacing a 403
+    # from inside the API after the call has already gone out.
+    with pytest.raises(PermissionError):
+        await unlink(accessor, spec(path), index)
+    assert api.deleted == []
+
+
+async def test_unlink_refuses_a_free_busy_calendar(api, accessor, index):
+    path = ("/Exec__busy@group.calendar.google.com/2026-08-11/"
+            "aaaa1__0900-1030_busy.gcal.json")
+    with pytest.raises(PermissionError):
+        await unlink(accessor, spec(path), index)
+    assert api.deleted == []
+
+
+async def test_unlink_on_an_unknown_calendar_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await unlink(accessor,
+                     spec("/nope/2026-08-11/aaaa1__0900-1030_X.gcal.json"),
+                     index)

--- a/python/tests/core/google/test_client.py
+++ b/python/tests/core/google/test_client.py
@@ -13,11 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 # yapf: disable
-from mirage.core.google._client import (DOCS_API_BASE, DRIVE_API_BASE,
-                                        DRIVE_UPLOAD_BASE, GMAIL_API_BASE,
+from mirage.core.google._client import (CALENDAR_API_BASE, DOCS_API_BASE,
+                                        DRIVE_API_BASE, DRIVE_UPLOAD_BASE,
+                                        FORMS_API_BASE, GMAIL_API_BASE,
                                         SHEETS_API_BASE, SLIDES_API_BASE,
-                                        TOKEN_URL, TokenManager, docs_base,
-                                        drive_base, drive_upload_base,
+                                        TOKEN_URL, TokenManager, calendar_base,
+                                        docs_base, drive_base,
+                                        drive_upload_base, forms_base,
                                         gmail_base, google_error_message,
                                         sheets_base, slides_base, token_url)
 # yapf: enable
@@ -42,6 +44,8 @@ def test_bases_default_to_real_google_hosts():
     assert slides_base(tm) == SLIDES_API_BASE
     assert sheets_base(tm) == SHEETS_API_BASE
     assert gmail_base(tm) == GMAIL_API_BASE
+    assert calendar_base(tm) == CALENDAR_API_BASE
+    assert forms_base(tm) == FORMS_API_BASE
     assert token_url(tm.config) == TOKEN_URL
 
 
@@ -53,6 +57,8 @@ def test_api_base_override_rewrites_every_service():
     assert slides_base(tm) == "http://127.0.0.1:19999/v1"
     assert sheets_base(tm) == "http://127.0.0.1:19999/v4"
     assert gmail_base(tm) == "http://127.0.0.1:19999/gmail/v1"
+    assert calendar_base(tm) == "http://127.0.0.1:19999/calendar/v3"
+    assert forms_base(tm) == "http://127.0.0.1:19999/v1"
     assert token_url(tm.config) == "http://127.0.0.1:19999/token"
 
 

--- a/python/tests/resource/gcal/test_event_entry.py
+++ b/python/tests/resource/gcal/test_event_entry.py
@@ -1,0 +1,106 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.resource.gcal.event_entry import (PRIMARY_DIR, event_title,
+                                              make_calendar_dirname,
+                                              make_event_filename,
+                                              parse_calendar_dirname,
+                                              parse_event_filename)
+from mirage.utils.sanitize import NAME_MAX_BYTES
+
+EVENT_ID = "la9i1t995acovthi3f761chla0"
+
+
+def test_filename_leads_with_the_id():
+    name = make_event_filename(EVENT_ID, "0900-1030", "PhD_Defense")
+    assert name == f"{EVENT_ID}__0900-1030_PhD_Defense.gcal.json"
+    assert parse_event_filename(name) == (EVENT_ID, "0900-1030")
+
+
+def test_filename_round_trips_a_title_holding_underscores():
+    name = make_event_filename(EVENT_ID, "1500-1600", "A__B_C")
+    assert parse_event_filename(name) == (EVENT_ID, "1500-1600")
+
+
+def test_filename_rejects_a_non_event_name():
+    with pytest.raises(FileNotFoundError):
+        parse_event_filename("notes.txt")
+    with pytest.raises(FileNotFoundError):
+        parse_event_filename("noseparator.gcal.json")
+    with pytest.raises(FileNotFoundError):
+        parse_event_filename(f"{EVENT_ID}__090.gcal.json")
+
+
+def test_long_ascii_title_is_trimmed_to_name_max():
+    name = make_event_filename(EVENT_ID, "0900-1030", "a" * 400)
+    assert len(name.encode()) <= NAME_MAX_BYTES
+    assert parse_event_filename(name) == (EVENT_ID, "0900-1030")
+
+
+def test_long_cjk_title_is_trimmed_by_bytes_not_characters():
+    # 3 bytes per character: a character-counted budget would overflow
+    # NAME_MAX, which is the bug gdocs' sanitize_title still has.
+    name = make_event_filename(EVENT_ID, "0900-1030", "会" * 200)
+    raw = name.encode()
+    assert len(raw) <= NAME_MAX_BYTES
+    assert raw.decode() == name
+    assert parse_event_filename(name) == (EVENT_ID, "0900-1030")
+
+
+def test_title_is_dropped_when_a_long_id_leaves_no_room():
+    # 234 is the widest id that still names an event: the title is squeezed
+    # out entirely and id + separators + suffix lands exactly on NAME_MAX.
+    long_id = "v" * 234
+    name = make_event_filename(long_id, "0900-1030", "Some_Title")
+    assert len(name.encode()) == NAME_MAX_BYTES
+    assert name == f"{long_id}__0900-1030.gcal.json"
+    assert parse_event_filename(name) == (long_id, "0900-1030")
+
+
+def test_an_id_too_long_to_name_keeps_the_id_rather_than_truncating_it():
+    # The title is what gives, never the id: a trimmed id would stop
+    # addressing the event. Real Google ids are 26 chars, so this only
+    # arises for a caller-supplied events.import id.
+    long_id = "v" * (NAME_MAX_BYTES - 20)
+    name = make_event_filename(long_id, "0900-1030", "Some Title")
+    assert len(name.encode()) > NAME_MAX_BYTES
+    assert parse_event_filename(name) == (long_id, "0900-1030")
+
+
+def test_event_title_falls_back_by_access_role():
+    assert event_title("Standup") == "Standup"
+    assert event_title(None) == "untitled"
+    assert event_title("   ") == "untitled"
+    assert event_title(None, free_busy=True) == "busy"
+
+
+def test_primary_calendar_keeps_its_alias():
+    assert make_calendar_dirname("integ@example.com",
+                                 "integ@example.com",
+                                 primary=True) == PRIMARY_DIR
+    assert parse_calendar_dirname(PRIMARY_DIR) == PRIMARY_DIR
+
+
+def test_calendar_dirname_embeds_the_id_verbatim():
+    cal_id = "en.usa#holiday@group.v.calendar.google.com"
+    name = make_calendar_dirname("US Holidays", cal_id)
+    assert name == f"US_Holidays__{cal_id}"
+    assert parse_calendar_dirname(name) == cal_id
+
+
+def test_calendar_dirname_rejects_a_name_without_an_id():
+    with pytest.raises(FileNotFoundError):
+        parse_calendar_dirname("Engineering")

--- a/scripts/google_oauth.py
+++ b/scripts/google_oauth.py
@@ -39,6 +39,9 @@ SCOPES = [
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/presentations",
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/forms.body",
+    "https://www.googleapis.com/auth/forms.responses.readonly",
 ]
 
 

--- a/spec/python/general/awk.json
+++ b/spec/python/general/awk.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/base64.json
+++ b/spec/python/general/base64.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/basename.json
+++ b/spec/python/general/basename.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/cat.json
+++ b/spec/python/general/cat.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/cmp.json
+++ b/spec/python/general/cmp.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/column.json
+++ b/spec/python/general/column.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/comm.json
+++ b/spec/python/general/comm.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/cut.json
+++ b/spec/python/general/cut.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/diff.json
+++ b/spec/python/general/diff.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/dirname.json
+++ b/spec/python/general/dirname.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/du.json
+++ b/spec/python/general/du.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/expand.json
+++ b/spec/python/general/expand.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/file.json
+++ b/spec/python/general/file.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/find.json
+++ b/spec/python/general/find.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/fmt.json
+++ b/spec/python/general/fmt.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/fold.json
+++ b/spec/python/general/fold.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/grep.json
+++ b/spec/python/general/grep.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/head.json
+++ b/spec/python/general/head.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/join.json
+++ b/spec/python/general/join.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/jq.json
+++ b/spec/python/general/jq.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/look.json
+++ b/spec/python/general/look.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/ls.json
+++ b/spec/python/general/ls.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/md5.json
+++ b/spec/python/general/md5.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/md5sum.json
+++ b/spec/python/general/md5sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/nl.json
+++ b/spec/python/general/nl.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/numfmt.json
+++ b/spec/python/general/numfmt.json
@@ -49,6 +49,12 @@
         "has_provision": false,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": false,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/od.json
+++ b/spec/python/general/od.json
@@ -49,6 +49,12 @@
         "has_provision": false,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": false,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/paste.json
+++ b/spec/python/general/paste.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/readlink.json
+++ b/spec/python/general/readlink.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/realpath.json
+++ b/spec/python/general/realpath.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/rev.json
+++ b/spec/python/general/rev.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/rg.json
+++ b/spec/python/general/rg.json
@@ -49,6 +49,12 @@
         "has_provision": false,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/rm.json
+++ b/spec/python/general/rm.json
@@ -25,6 +25,12 @@
         "has_provision": true,
         "has_write": true
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": false,
+        "has_write": true
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -113,6 +119,7 @@
       "databricks_volume",
       "disk",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "gridfs",

--- a/spec/python/general/sed.json
+++ b/spec/python/general/sed.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/sha1sum.json
+++ b/spec/python/general/sha1sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/sha256sum.json
+++ b/spec/python/general/sha256sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/sha384sum.json
+++ b/spec/python/general/sha384sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/sha512sum.json
+++ b/spec/python/general/sha512sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/shuf.json
+++ b/spec/python/general/shuf.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/sort.json
+++ b/spec/python/general/sort.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/stat.json
+++ b/spec/python/general/stat.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/strings.json
+++ b/spec/python/general/strings.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/tac.json
+++ b/spec/python/general/tac.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/tail.json
+++ b/spec/python/general/tail.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/tr.json
+++ b/spec/python/general/tr.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/tree.json
+++ b/spec/python/general/tree.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/tsort.json
+++ b/spec/python/general/tsort.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/unexpand.json
+++ b/spec/python/general/unexpand.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/uniq.json
+++ b/spec/python/general/uniq.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/wc.json
+++ b/spec/python/general/wc.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -231,6 +237,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/xxd.json
+++ b/spec/python/general/xxd.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/zcat.json
+++ b/spec/python/general/zcat.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/general/zgrep.json
+++ b/spec/python/general/zgrep.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -225,6 +231,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/python/resources.json
+++ b/spec/python/resources.json
@@ -96,6 +96,14 @@
       "storage_id": false,
       "supports_snapshot": false
     },
+    "gcal": {
+      "caches_reads": true,
+      "index_ttl": 300,
+      "sizes_always_known": false,
+      "statfs": false,
+      "storage_id": false,
+      "supports_snapshot": false
+    },
     "gcs": {
       "caches_reads": true,
       "index_ttl": 600,
@@ -552,6 +560,18 @@
       ]
     },
     "email": {
+      "local": false,
+      "max_du_entries": 10000,
+      "max_glob_matches": 10000,
+      "slots": [
+        "is_mounted",
+        "read_bytes",
+        "read_stream",
+        "readdir",
+        "stat"
+      ]
+    },
+    "gcal": {
       "local": false,
       "max_du_entries": 10000,
       "max_glob_matches": 10000,
@@ -1043,6 +1063,7 @@
     "disk",
     "dropbox",
     "email",
+    "gcal",
     "gdocs",
     "gdrive",
     "github",
@@ -1085,6 +1106,7 @@
     "disk",
     "dropbox",
     "email",
+    "gcal",
     "gcs",
     "gdocs",
     "gdrive",

--- a/spec/typescript/browser/general/awk.json
+++ b/spec/typescript/browser/general/awk.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/base64.json
+++ b/spec/typescript/browser/general/base64.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/basename.json
+++ b/spec/typescript/browser/general/basename.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/cat.json
+++ b/spec/typescript/browser/general/cat.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/cmp.json
+++ b/spec/typescript/browser/general/cmp.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/column.json
+++ b/spec/typescript/browser/general/column.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/comm.json
+++ b/spec/typescript/browser/general/comm.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/cut.json
+++ b/spec/typescript/browser/general/cut.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/diff.json
+++ b/spec/typescript/browser/general/diff.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/dirname.json
+++ b/spec/typescript/browser/general/dirname.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/du.json
+++ b/spec/typescript/browser/general/du.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/expand.json
+++ b/spec/typescript/browser/general/expand.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/file.json
+++ b/spec/typescript/browser/general/file.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/find.json
+++ b/spec/typescript/browser/general/find.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/fmt.json
+++ b/spec/typescript/browser/general/fmt.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/fold.json
+++ b/spec/typescript/browser/general/fold.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/grep.json
+++ b/spec/typescript/browser/general/grep.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/head.json
+++ b/spec/typescript/browser/general/head.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/join.json
+++ b/spec/typescript/browser/general/join.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/jq.json
+++ b/spec/typescript/browser/general/jq.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/look.json
+++ b/spec/typescript/browser/general/look.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/ls.json
+++ b/spec/typescript/browser/general/ls.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/md5.json
+++ b/spec/typescript/browser/general/md5.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/md5sum.json
+++ b/spec/typescript/browser/general/md5sum.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/nl.json
+++ b/spec/typescript/browser/general/nl.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/numfmt.json
+++ b/spec/typescript/browser/general/numfmt.json
@@ -37,6 +37,12 @@
         "has_provision": false,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": false,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/od.json
+++ b/spec/typescript/browser/general/od.json
@@ -37,6 +37,12 @@
         "has_provision": false,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": false,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/paste.json
+++ b/spec/typescript/browser/general/paste.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/readlink.json
+++ b/spec/typescript/browser/general/readlink.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/realpath.json
+++ b/spec/typescript/browser/general/realpath.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/rev.json
+++ b/spec/typescript/browser/general/rev.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/rg.json
+++ b/spec/typescript/browser/general/rg.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/rm.json
+++ b/spec/typescript/browser/general/rm.json
@@ -19,6 +19,12 @@
         "has_provision": true,
         "has_write": true
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": false,
+        "has_write": true
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -82,6 +88,7 @@
       "box",
       "databricks_volume",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "gsheets",

--- a/spec/typescript/browser/general/sed.json
+++ b/spec/typescript/browser/general/sed.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/sha1sum.json
+++ b/spec/typescript/browser/general/sha1sum.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/sha256sum.json
+++ b/spec/typescript/browser/general/sha256sum.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/sha384sum.json
+++ b/spec/typescript/browser/general/sha384sum.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/sha512sum.json
+++ b/spec/typescript/browser/general/sha512sum.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/shuf.json
+++ b/spec/typescript/browser/general/shuf.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/sort.json
+++ b/spec/typescript/browser/general/sort.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/stat.json
+++ b/spec/typescript/browser/general/stat.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/strings.json
+++ b/spec/typescript/browser/general/strings.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/tac.json
+++ b/spec/typescript/browser/general/tac.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/tail.json
+++ b/spec/typescript/browser/general/tail.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/tr.json
+++ b/spec/typescript/browser/general/tr.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/tree.json
+++ b/spec/typescript/browser/general/tree.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/tsort.json
+++ b/spec/typescript/browser/general/tsort.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/unexpand.json
+++ b/spec/typescript/browser/general/unexpand.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/uniq.json
+++ b/spec/typescript/browser/general/uniq.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/wc.json
+++ b/spec/typescript/browser/general/wc.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -193,6 +199,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/xxd.json
+++ b/spec/typescript/browser/general/xxd.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/zcat.json
+++ b/spec/typescript/browser/general/zcat.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/general/zgrep.json
+++ b/spec/typescript/browser/general/zgrep.json
@@ -37,6 +37,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -187,6 +193,7 @@
       "dify",
       "discord",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/browser/resources.json
+++ b/spec/typescript/browser/resources.json
@@ -73,6 +73,14 @@
       "supports_snapshot": false
     },
     "email": null,
+    "gcal": {
+      "caches_reads": true,
+      "index_ttl": 300,
+      "sizes_always_known": false,
+      "statfs": false,
+      "storage_id": false,
+      "supports_snapshot": false
+    },
     "gcs": {
       "caches_reads": true,
       "index_ttl": 600,
@@ -426,6 +434,18 @@
         "stat",
         "unlink",
         "write"
+      ]
+    },
+    "gcal": {
+      "local": false,
+      "max_du_entries": 10000,
+      "max_glob_matches": 10000,
+      "slots": [
+        "is_mounted",
+        "read_bytes",
+        "read_stream",
+        "readdir",
+        "stat"
       ]
     },
     "gdocs": {
@@ -803,6 +823,7 @@
     "dify",
     "discord",
     "dropbox",
+    "gcal",
     "gdocs",
     "gdrive",
     "github",
@@ -839,6 +860,7 @@
     "discord",
     "dropbox",
     "email",
+    "gcal",
     "gcs",
     "gdocs",
     "gdrive",

--- a/spec/typescript/node/general/awk.json
+++ b/spec/typescript/node/general/awk.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/base64.json
+++ b/spec/typescript/node/general/base64.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/basename.json
+++ b/spec/typescript/node/general/basename.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/cat.json
+++ b/spec/typescript/node/general/cat.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/cmp.json
+++ b/spec/typescript/node/general/cmp.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/column.json
+++ b/spec/typescript/node/general/column.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/comm.json
+++ b/spec/typescript/node/general/comm.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/cut.json
+++ b/spec/typescript/node/general/cut.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/diff.json
+++ b/spec/typescript/node/general/diff.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/dirname.json
+++ b/spec/typescript/node/general/dirname.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/du.json
+++ b/spec/typescript/node/general/du.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/expand.json
+++ b/spec/typescript/node/general/expand.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/file.json
+++ b/spec/typescript/node/general/file.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/find.json
+++ b/spec/typescript/node/general/find.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/fmt.json
+++ b/spec/typescript/node/general/fmt.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/fold.json
+++ b/spec/typescript/node/general/fold.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/grep.json
+++ b/spec/typescript/node/general/grep.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/head.json
+++ b/spec/typescript/node/general/head.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/join.json
+++ b/spec/typescript/node/general/join.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/jq.json
+++ b/spec/typescript/node/general/jq.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/look.json
+++ b/spec/typescript/node/general/look.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/ls.json
+++ b/spec/typescript/node/general/ls.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/md5.json
+++ b/spec/typescript/node/general/md5.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/md5sum.json
+++ b/spec/typescript/node/general/md5sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/nl.json
+++ b/spec/typescript/node/general/nl.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/numfmt.json
+++ b/spec/typescript/node/general/numfmt.json
@@ -49,6 +49,12 @@
         "has_provision": false,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": false,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/od.json
+++ b/spec/typescript/node/general/od.json
@@ -49,6 +49,12 @@
         "has_provision": false,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": false,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/paste.json
+++ b/spec/typescript/node/general/paste.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/readlink.json
+++ b/spec/typescript/node/general/readlink.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/realpath.json
+++ b/spec/typescript/node/general/realpath.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/rev.json
+++ b/spec/typescript/node/general/rev.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/rg.json
+++ b/spec/typescript/node/general/rg.json
@@ -49,6 +49,12 @@
         "has_provision": false,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/rm.json
+++ b/spec/typescript/node/general/rm.json
@@ -25,6 +25,12 @@
         "has_provision": true,
         "has_write": true
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": false,
+        "has_write": true
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -131,6 +137,7 @@
       "databricks_volume",
       "disk",
       "dropbox",
+      "gcal",
       "gdocs",
       "gdrive",
       "gridfs",

--- a/spec/typescript/node/general/sed.json
+++ b/spec/typescript/node/general/sed.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/sha1sum.json
+++ b/spec/typescript/node/general/sha1sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/sha256sum.json
+++ b/spec/typescript/node/general/sha256sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/sha384sum.json
+++ b/spec/typescript/node/general/sha384sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/sha512sum.json
+++ b/spec/typescript/node/general/sha512sum.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/shuf.json
+++ b/spec/typescript/node/general/shuf.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/sort.json
+++ b/spec/typescript/node/general/sort.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/stat.json
+++ b/spec/typescript/node/general/stat.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/strings.json
+++ b/spec/typescript/node/general/strings.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/tac.json
+++ b/spec/typescript/node/general/tac.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/tail.json
+++ b/spec/typescript/node/general/tail.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/tr.json
+++ b/spec/typescript/node/general/tr.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/tree.json
+++ b/spec/typescript/node/general/tree.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/tsort.json
+++ b/spec/typescript/node/general/tsort.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/unexpand.json
+++ b/spec/typescript/node/general/unexpand.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/uniq.json
+++ b/spec/typescript/node/general/uniq.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/wc.json
+++ b/spec/typescript/node/general/wc.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -249,6 +255,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/xxd.json
+++ b/spec/typescript/node/general/xxd.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/zcat.json
+++ b/spec/typescript/node/general/zcat.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/general/zgrep.json
+++ b/spec/typescript/node/general/zgrep.json
@@ -49,6 +49,12 @@
         "has_provision": true,
         "has_write": false
       },
+      "gcal": {
+        "filetypes": [],
+        "has_aggregate": false,
+        "has_provision": true,
+        "has_write": false
+      },
       "gdocs": {
         "filetypes": [],
         "has_aggregate": false,
@@ -243,6 +249,7 @@
       "disk",
       "dropbox",
       "email",
+      "gcal",
       "gdocs",
       "gdrive",
       "github",

--- a/spec/typescript/node/resources.json
+++ b/spec/typescript/node/resources.json
@@ -96,6 +96,14 @@
       "storage_id": false,
       "supports_snapshot": false
     },
+    "gcal": {
+      "caches_reads": true,
+      "index_ttl": 300,
+      "sizes_always_known": false,
+      "statfs": false,
+      "storage_id": false,
+      "supports_snapshot": false
+    },
     "gcs": {
       "caches_reads": true,
       "index_ttl": 600,
@@ -550,6 +558,18 @@
       ]
     },
     "email": {
+      "local": false,
+      "max_du_entries": 10000,
+      "max_glob_matches": 10000,
+      "slots": [
+        "is_mounted",
+        "read_bytes",
+        "read_stream",
+        "readdir",
+        "stat"
+      ]
+    },
+    "gcal": {
       "local": false,
       "max_du_entries": 10000,
       "max_glob_matches": 10000,
@@ -1035,6 +1055,7 @@
     "disk",
     "dropbox",
     "email",
+    "gcal",
     "gdocs",
     "gdrive",
     "github",
@@ -1080,6 +1101,7 @@
     "disk",
     "dropbox",
     "email",
+    "gcal",
     "gcs",
     "gdocs",
     "gdrive",

--- a/typescript/packages/browser/src/index.ts
+++ b/typescript/packages/browser/src/index.ts
@@ -269,6 +269,13 @@ export {
   type GmailConfig,
   type GmailConfigRedacted,
 } from './resource/gmail/config.ts'
+export { GCalResource, type GCalResourceState } from './resource/gcal/gcal.ts'
+export {
+  normalizeGCalConfig,
+  redactGCalConfig,
+  type GCalConfig,
+  type GCalConfigRedacted,
+} from './resource/gcal/config.ts'
 export {
   buildResource,
   knownResources,

--- a/typescript/packages/browser/src/resource/gcal/config.ts
+++ b/typescript/packages/browser/src/resource/gcal/config.ts
@@ -1,0 +1,20 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export {
+  normalizeGoogleConfig as normalizeGCalConfig,
+  redactGoogleConfig as redactGCalConfig,
+  type GoogleConfig as GCalConfig,
+  type GoogleConfigRedacted as GCalConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/browser/src/resource/gcal/gcal.ts
+++ b/typescript/packages/browser/src/resource/gcal/gcal.ts
@@ -1,0 +1,121 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mountKey, mountPrefixOf } from '@struktoai/mirage-core'
+import {
+  type FileStat,
+  GCAL_COMMANDS,
+  GCAL_PROMPT,
+  GCAL_WRITE_PROMPT,
+  GCAL_OPS,
+  GCalAccessor,
+  type IndexCacheStore,
+  PathSpec,
+  RAMIndexCacheStore,
+  type RegisteredCommand,
+  type RegisteredOp,
+  type Resource,
+  ResourceName,
+  TokenManager,
+  gcalRead,
+  gcalReaddir,
+  makeResolveGlob,
+  gcalStat,
+} from '@struktoai/mirage-core'
+import { redactGCalConfig, type GCalConfig, type GCalConfigRedacted } from './config.ts'
+
+const gcalResolveGlob = makeResolveGlob(gcalReaddir)
+
+export interface GCalResourceState {
+  type: string
+  config: GCalConfigRedacted
+}
+
+export class GCalResource implements Resource {
+  readonly kind: string = ResourceName.GCAL
+  readonly cachesReads: boolean = true
+  // Shorter than the other Google mounts: a calendar is edited by other
+  // people and a day-long index would keep serving a schedule that has
+  // already moved.
+  readonly indexTtl: number = 300
+  readonly prompt: string = GCAL_PROMPT
+  readonly writePrompt: string = GCAL_WRITE_PROMPT
+  readonly config: GCalConfig
+  readonly accessor: GCalAccessor
+  readonly index: IndexCacheStore
+
+  constructor(config: GCalConfig) {
+    this.config = config
+    const tm = new TokenManager(config)
+    this.accessor = new GCalAccessor({ tokenManager: tm, config })
+    this.index = new RAMIndexCacheStore({ ttl: 300 })
+  }
+
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  commands(): readonly RegisteredCommand[] {
+    return GCAL_COMMANDS
+  }
+
+  ops(): readonly RegisteredOp[] {
+    return GCAL_OPS
+  }
+
+  readFile(p: PathSpec): Promise<Uint8Array> {
+    return gcalRead(this.accessor, p, this.index)
+  }
+
+  readdir(p: PathSpec): Promise<string[]> {
+    return gcalReaddir(this.accessor, p, this.index)
+  }
+
+  stat(p: PathSpec): Promise<FileStat> {
+    return gcalStat(this.accessor, p, this.index)
+  }
+
+  glob(paths: readonly PathSpec[], prefix = ''): Promise<PathSpec[]> {
+    const effective =
+      prefix !== ''
+        ? paths.map((p) =>
+            mountPrefixOf(p.virtual, p.resourcePath) !== ''
+              ? p
+              : new PathSpec({
+                  virtual: p.virtual,
+                  directory: p.directory,
+                  ...(p.pattern !== null ? { pattern: p.pattern } : {}),
+                  resolved: p.resolved,
+                  resourcePath: mountKey(p.virtual, prefix),
+                }),
+          )
+        : paths
+    return gcalResolveGlob(this.accessor, effective, this.index)
+  }
+
+  getState(): Promise<GCalResourceState> {
+    return Promise.resolve({
+      type: this.kind,
+      config: redactGCalConfig(this.config),
+    })
+  }
+
+  loadState(_state: GCalResourceState): Promise<void> {
+    return Promise.resolve()
+  }
+}

--- a/typescript/packages/browser/src/resource/registry.ts
+++ b/typescript/packages/browser/src/resource/registry.ts
@@ -336,6 +336,11 @@ const REGISTRY: Record<string, ResourceFactory> = {
     const { normalizeGitHubCIConfig } = await import('./github_ci/config.ts')
     return new GitHubCIResource(normalizeGitHubCIConfig(config))
   },
+  gcal: async (config) => {
+    const { GCalResource } = await import('./gcal/gcal.ts')
+    const { normalizeGCalConfig } = await import('./gcal/config.ts')
+    return new GCalResource(normalizeGCalConfig(config))
+  },
   gdocs: async (config) => {
     const { GDocsResource } = await import('./gdocs/gdocs.ts')
     const { normalizeGDocsConfig } = await import('./gdocs/config.ts')

--- a/typescript/packages/core/src/accessor/gcal.ts
+++ b/typescript/packages/core/src/accessor/gcal.ts
@@ -1,0 +1,43 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { localDate } from '../core/gcal/day.ts'
+import type { GoogleConfig } from '../core/google/config.ts'
+import type { TokenManager } from '../core/google/_client.ts'
+import { GoogleApiAccessor } from './google_api.ts'
+
+export class GCalAccessor extends GoogleApiAccessor {
+  readonly config: GoogleConfig
+
+  constructor(opts: { tokenManager: TokenManager; config: GoogleConfig }) {
+    super(opts)
+    this.config = opts.config
+  }
+
+  /**
+   * The day the default listing window centres on, `YYYY-MM-DD`.
+   *
+   * Taken in the mount's bucketing zone rather than the host's: the two
+   * disagree for several hours a day, so a window centred on the wrong one
+   * shifts the whole listing by a day around either midnight.
+   *
+   * A method rather than a module-level call so a test can pin it and so a
+   * long-lived mount does not freeze its window at construction time.
+   */
+  today(tz: string): string {
+    const pinned = this.config.today
+    if (pinned !== undefined && pinned !== '') return pinned
+    return localDate(Date.now(), tz)
+  }
+}

--- a/typescript/packages/core/src/commands/builtin/gcal/index.ts
+++ b/typescript/packages/core/src/commands/builtin/gcal/index.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { GCalAccessor } from '../../../accessor/gcal.ts'
+import { ResourceName } from '../../../types.ts'
+import type { RegisteredCommand } from '../../config.ts'
+import { makeGenericCommands } from '../generic_bind/index.ts'
+import { GCAL_IO } from './io.ts'
+import { GCAL_RM } from './rm.ts'
+
+// Calendar verbs and API passthroughs live in the gws CLI
+// (commands/cli/builtin/gws), installed by name; the mount only serves the
+// filesystem surface, and rm is the one mutation a path can express.
+export const GCAL_COMMANDS: readonly RegisteredCommand[] = [
+  ...makeGenericCommands<GCalAccessor>(ResourceName.GCAL, GCAL_IO),
+  ...GCAL_RM,
+]

--- a/typescript/packages/core/src/commands/builtin/gcal/io.ts
+++ b/typescript/packages/core/src/commands/builtin/gcal/io.ts
@@ -1,0 +1,29 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { GCalAccessor } from '../../../accessor/gcal.ts'
+import { read as gcalRead } from '../../../core/gcal/read.ts'
+import { readdir as gcalReaddir } from '../../../core/gcal/readdir.ts'
+import { stat as gcalStat } from '../../../core/gcal/stat.ts'
+import type { CommandIO } from '../generic_bind/index.ts'
+import { streamFromBytes } from '../utils/wrap.ts'
+
+export const GCAL_IO: CommandIO<GCalAccessor> = {
+  readdir: gcalReaddir,
+  readBytes: gcalRead,
+  readStream: (a, p, i) => streamFromBytes(gcalRead, a, p, i),
+  stat: gcalStat,
+  isMounted: () => true,
+  local: false,
+}

--- a/typescript/packages/core/src/commands/builtin/gcal/rm.ts
+++ b/typescript/packages/core/src/commands/builtin/gcal/rm.ts
@@ -1,0 +1,20 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { unlink } from '../../../core/gcal/unlink.ts'
+import { ResourceName } from '../../../types.ts'
+import { makeRm } from '../generic/rm_command.ts'
+import { GCAL_IO } from './io.ts'
+
+export const GCAL_RM = makeRm(ResourceName.GCAL, GCAL_IO, unlink)

--- a/typescript/packages/core/src/commands/builtin/generic/rm_command.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/rm_command.ts
@@ -1,0 +1,89 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { IndexCacheStore } from '../../../cache/index/store.ts'
+import { IOResult, type ByteSource } from '../../../io/types.ts'
+import type { PathSpec, ResourceNameValue } from '../../../types.ts'
+import type { Accessor } from '../../../accessor/base.ts'
+import { fsStrerror, isFsError } from '../../../utils/errors.ts'
+import { command, type CommandFnResult, type CommandOpts, type RegisteredCommand } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
+import { resolveGlobOf, type CommandIO } from '../generic_bind/index.ts'
+import { formatRecords } from '../utils/output.ts'
+
+const ENC = new TextEncoder()
+
+type UnlinkFn<A> = (accessor: A, path: PathSpec, index?: IndexCacheStore) => Promise<void>
+
+/**
+ * Build a backend's `rm` from its glob resolver and its unlink.
+ *
+ * Every API-backed mount spells the same GNU behaviour: report the operand
+ * it could not remove, keep removing the rest, and exit 1 if any failed.
+ */
+export function makeRm<A extends Accessor>(
+  resource: ResourceNameValue,
+  io: CommandIO<A>,
+  unlink: UnlinkFn<A>,
+): RegisteredCommand[] {
+  const resolveGlob = resolveGlobOf(io)
+  return command({
+    name: 'rm',
+    resource,
+    spec: specOf('rm'),
+    write: true,
+    fn: async (
+      accessor: A,
+      paths: PathSpec[],
+      _texts: string[],
+      opts: CommandOpts,
+    ): Promise<CommandFnResult> => {
+      if (paths.length === 0) {
+        return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('rm: missing operand\n') })]
+      }
+      const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
+      const fl = new FlagView(opts.flags, specOf('rm'))
+      const force = fl.asBool('f')
+      const verbose = fl.asBool('v')
+      const verboseParts: string[] = []
+      const errors: string[] = []
+      const writes: Record<string, Uint8Array> = {}
+      for (const p of resolved) {
+        try {
+          await unlink(accessor, p, opts.index ?? undefined)
+        } catch (err) {
+          const code = (err as { code?: string }).code
+          if (force && code === 'ENOENT') continue
+          if (!isFsError(err)) throw err
+          // GNU rm reports the operand and keeps removing the rest.
+          errors.push(`rm: cannot remove '${p.virtual}': ${String(fsStrerror(err))}`)
+          continue
+        }
+        writes[p.mountPath] = new Uint8Array()
+        if (verbose) verboseParts.push(`removed '${p.virtual}'`)
+      }
+      const output: ByteSource | null = verbose ? formatRecords(verboseParts) : null
+      const stderr = errors.length > 0 ? ENC.encode(errors.join('\n') + '\n') : undefined
+      return [
+        output,
+        new IOResult({
+          writes,
+          exitCode: errors.length > 0 ? 1 : 0,
+          ...(stderr !== undefined ? { stderr } : {}),
+        }),
+      ]
+    },
+  })
+}

--- a/typescript/packages/core/src/commands/builtin/generic/rm_command.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/rm_command.ts
@@ -14,10 +14,15 @@
 
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { PathSpec, ResourceNameValue } from '../../../types.ts'
+import type { PathSpec, ResourceName } from '../../../types.ts'
 import type { Accessor } from '../../../accessor/base.ts'
 import { fsStrerror, isFsError } from '../../../utils/errors.ts'
-import { command, type CommandFnResult, type CommandOpts, type RegisteredCommand } from '../../config.ts'
+import {
+  command,
+  type CommandFnResult,
+  type CommandOpts,
+  type RegisteredCommand,
+} from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { FlagView } from '../../spec/types.ts'
 import { resolveGlobOf, type CommandIO } from '../generic_bind/index.ts'
@@ -34,7 +39,7 @@ type UnlinkFn<A> = (accessor: A, path: PathSpec, index?: IndexCacheStore) => Pro
  * it could not remove, keep removing the rest, and exit 1 if any failed.
  */
 export function makeRm<A extends Accessor>(
-  resource: ResourceNameValue,
+  resource: ResourceName,
   io: CommandIO<A>,
   unlink: UnlinkFn<A>,
 ): RegisteredCommand[] {

--- a/typescript/packages/core/src/commands/cli/builtin/gws/api.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/api.ts
@@ -87,7 +87,13 @@ export function fillPath(
     const end = path.indexOf('}', start)
     const name = path.slice(start + 1, end)
     if (!(name in params)) throw new Error(`--params must contain ${name}`)
-    path = path.slice(0, start) + String(params[name]) + path.slice(end + 1)
+    // Percent-encode the value: a Discovery path parameter is one segment,
+    // and several real ids carry characters that change what the URL means.
+    // A Google holiday calendar id
+    // ("en.usa#holiday@group.v.calendar.google.com") is the sharp case,
+    // since "#" opens a fragment and the request would reach
+    // /calendars/en.usa instead.
+    path = path.slice(0, start) + encodeURIComponent(String(params[name])) + path.slice(end + 1)
     consumed.add(name)
   }
   const query = Object.fromEntries(Object.entries(params).filter(([k]) => !consumed.has(k)))

--- a/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
@@ -162,6 +162,17 @@ describe('gws tree', () => {
 })
 
 describe('gws api passthrough', () => {
+  it('fillPath percent-encodes a reserved character', () => {
+    // A Google holiday calendar id carries '#', which opens a URL fragment:
+    // unencoded, the request reached /calendars/en.usa and 404'd.
+    const [path, query] = fillPath('/calendars/{calendarId}/events', {
+      calendarId: 'en.usa#holiday@group.v.calendar.google.com',
+    })
+    expect(path).toBe('/calendars/en.usa%23holiday%40group.v.calendar.google.com/events')
+    expect(query).toEqual({})
+    expect(fillPath('/files/{fileId}', { fileId: '1AbC-_dEf' })[0]).toBe('/files/1AbC-_dEf')
+  })
+
   it('fillPath substitutes and leaves query params', () => {
     const [path, query] = fillPath('/files/{fileId}/permissions', { fileId: 'f1', pageSize: 5 })
     expect(path).toBe('/files/f1/permissions')

--- a/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
@@ -69,6 +69,8 @@ describe('gws tree', () => {
       'sheets',
       'docs',
       'slides',
+      'calendar',
+      'forms',
       'gmail',
     ])
     expect(cliSpecFor('gws')).toBe(GWS)
@@ -108,6 +110,44 @@ describe('gws tree', () => {
     expect(leaf('docs', 'write').write).toBe(true)
     expect(leaf('drive', 'files', 'list').write).toBe(false)
     expect(leaf('drive', 'files', 'delete').write).toBe(true)
+  })
+
+  it('nests calendar passthroughs by discovery resource', () => {
+    expect(leaf('calendar').subcommands.map((v) => v.name)).toEqual([
+      'calendarList',
+      'calendars',
+      'events',
+      'freebusy',
+    ])
+    expect(leaf('calendar', 'events').subcommands.map((v) => v.name)).toEqual([
+      'list',
+      'get',
+      'insert',
+      'patch',
+      'delete',
+    ])
+    expect(leaf('calendar', 'events', 'list').write).toBe(false)
+    expect(leaf('calendar', 'events', 'insert').write).toBe(true)
+    expect(leaf('calendar', 'events', 'delete').write).toBe(true)
+    // freebusy.query is a POST that mutates nothing, but write follows the
+    // HTTP verb everywhere else in the tree and a second rule would be worse.
+    expect(leaf('calendar', 'freebusy', 'query').write).toBe(true)
+  })
+
+  it('nests forms passthroughs by discovery resource', () => {
+    expect(leaf('forms').subcommands.map((v) => v.name)).toEqual(['forms'])
+    expect(leaf('forms', 'forms').subcommands.map((v) => v.name)).toEqual([
+      'create',
+      'get',
+      'batchUpdate',
+      'responses',
+    ])
+    expect(leaf('forms', 'forms', 'responses').subcommands.map((v) => v.name)).toEqual([
+      'list',
+      'get',
+    ])
+    expect(leaf('forms', 'forms', 'get').write).toBe(false)
+    expect(leaf('forms', 'forms', 'create').write).toBe(true)
   })
 
   it('accepts and preserves a refreshFn callback at install time', () => {

--- a/typescript/packages/core/src/commands/cli/builtin/gws/index.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/index.ts
@@ -127,6 +127,16 @@ export const GWS = new CLISpec({
       subcommands: apiGroups('slides'),
     }),
     new CLISpec({
+      name: 'calendar',
+      description: 'Google calendar API commands',
+      subcommands: apiGroups('calendar'),
+    }),
+    new CLISpec({
+      name: 'forms',
+      description: 'Google forms API commands',
+      subcommands: apiGroups('forms'),
+    }),
+    new CLISpec({
       name: 'gmail',
       description: 'Google gmail API commands',
       subcommands: [

--- a/typescript/packages/core/src/commands/cli/builtin/gws/methods.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/methods.ts
@@ -14,8 +14,10 @@
 
 import type { TokenManager } from '../../../../core/google/_client.ts'
 import {
+  calendarBase,
   docsBase,
   driveBase,
+  formsBase,
   gmailBase,
   sheetsBase,
   slidesBase,
@@ -28,7 +30,7 @@ import {
 // (sheets read/write/append, docs write, the gmail helpers) stay
 // hand-written beside them in the tree.
 
-export type GwsService = 'drive' | 'docs' | 'sheets' | 'slides' | 'gmail'
+export type GwsService = 'drive' | 'docs' | 'sheets' | 'slides' | 'gmail' | 'calendar' | 'forms'
 
 export interface GwsMethod {
   service: GwsService
@@ -231,6 +233,104 @@ export const GWS_METHODS: readonly GwsMethod[] = [
     http: 'GET',
     path: '/users/{userId}/messages/{messageId}/attachments/{id}',
   },
+  {
+    service: 'calendar',
+    resource: 'calendarList',
+    method: 'list',
+    http: 'GET',
+    path: '/users/me/calendarList',
+  },
+  {
+    service: 'calendar',
+    resource: 'calendars',
+    method: 'get',
+    http: 'GET',
+    path: '/calendars/{calendarId}',
+  },
+  {
+    service: 'calendar',
+    resource: 'events',
+    method: 'list',
+    http: 'GET',
+    path: '/calendars/{calendarId}/events',
+  },
+  {
+    service: 'calendar',
+    resource: 'events',
+    method: 'get',
+    http: 'GET',
+    path: '/calendars/{calendarId}/events/{eventId}',
+  },
+  {
+    service: 'calendar',
+    resource: 'events',
+    method: 'insert',
+    http: 'POST',
+    path: '/calendars/{calendarId}/events',
+    needsBody: true,
+  },
+  {
+    service: 'calendar',
+    resource: 'events',
+    method: 'patch',
+    http: 'PATCH',
+    path: '/calendars/{calendarId}/events/{eventId}',
+    needsBody: true,
+  },
+  {
+    service: 'calendar',
+    resource: 'events',
+    method: 'delete',
+    http: 'DELETE',
+    path: '/calendars/{calendarId}/events/{eventId}',
+  },
+  {
+    service: 'calendar',
+    resource: 'freebusy',
+    method: 'query',
+    http: 'POST',
+    path: '/freeBusy',
+    needsBody: true,
+  },
+  {
+    service: 'forms',
+    resource: 'forms',
+    method: 'create',
+    http: 'POST',
+    path: '/forms',
+    needsBody: true,
+    placement: 'relocate',
+    idField: 'formId',
+  },
+  {
+    service: 'forms',
+    resource: 'forms',
+    method: 'get',
+    http: 'GET',
+    path: '/forms/{formId}',
+  },
+  {
+    service: 'forms',
+    resource: 'forms',
+    method: 'batchUpdate',
+    http: 'POST',
+    path: '/forms/{formId}:batchUpdate',
+    needsBody: true,
+  },
+  {
+    service: 'forms',
+    resource: 'forms responses',
+    method: 'list',
+    http: 'GET',
+    path: '/forms/{formId}/responses',
+  },
+  {
+    service: 'forms',
+    resource: 'forms responses',
+    method: 'get',
+    http: 'GET',
+    path: '/forms/{formId}/responses/{responseId}',
+  },
 ]
 
 export function gwsMethodDescription(m: GwsMethod): string {
@@ -243,4 +343,6 @@ export const SERVICE_BASES: Record<GwsService, (tm: TokenManager) => string> = {
   sheets: sheetsBase,
   slides: slidesBase,
   gmail: gmailBase,
+  calendar: calendarBase,
+  forms: formsBase,
 }

--- a/typescript/packages/core/src/core/gcal/client.ts
+++ b/typescript/packages/core/src/core/gcal/client.ts
@@ -1,0 +1,113 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { JsonValue } from '../../types.ts'
+import { calendarBase, googleDelete, googleGet, type TokenManager } from '../google/_client.ts'
+
+const MAX_PAGES = 50
+
+function rows(data: unknown): Record<string, JsonValue>[] {
+  if (typeof data !== 'object' || data === null) return []
+  const items = (data as Record<string, unknown>).items
+  if (!Array.isArray(items)) return []
+  return items.filter(
+    (r): r is Record<string, JsonValue> => typeof r === 'object' && r !== null && !Array.isArray(r),
+  )
+}
+
+function nextToken(data: unknown): string | null {
+  if (typeof data !== 'object' || data === null) return null
+  const next = (data as Record<string, unknown>).nextPageToken
+  return typeof next === 'string' && next !== '' ? next : null
+}
+
+/**
+ * List the account's calendars.
+ *
+ * showHidden is left at its default (false) so the mount shows what the
+ * Calendar UI shows; a subscribed holiday calendar the user hid stays out.
+ */
+export async function listCalendars(
+  tokenManager: TokenManager,
+  minAccessRole?: string,
+): Promise<Record<string, JsonValue>[]> {
+  const url = `${calendarBase(tokenManager)}/users/me/calendarList`
+  const base: Record<string, string> = {}
+  if (minAccessRole !== undefined && minAccessRole !== '') base.minAccessRole = minAccessRole
+  const items: Record<string, JsonValue>[] = []
+  let token: string | null = null
+  for (let i = 0; i < MAX_PAGES; i += 1) {
+    const page = token !== null ? { ...base, pageToken: token } : base
+    const data = await googleGet(tokenManager, url, page)
+    items.push(...rows(data))
+    token = nextToken(data)
+    if (token === null) break
+  }
+  return items
+}
+
+/**
+ * List a calendar's events overlapping a time window.
+ *
+ * timeMin bounds an event's END and timeMax its START, both exclusive, so
+ * the pair is an overlap query: a multi-day or midnight-crossing event is
+ * returned by every day window it touches, with no extra request.
+ *
+ * singleEvents expands a recurring series into its instances, which is what
+ * makes a day directory well defined; without it the series' own record
+ * would stand in for every occurrence.
+ */
+export async function listEvents(
+  tokenManager: TokenManager,
+  calendarId: string,
+  timeMin: string,
+  timeMax: string,
+  timeZone?: string,
+): Promise<Record<string, JsonValue>[]> {
+  // The id is one path segment and several real ones are not URL-safe: a
+  // holiday calendar is "en.usa#holiday@group.v.calendar.google.com", and an
+  // unencoded "#" opens a fragment, so the request would reach
+  // /calendars/en.usa instead.
+  const url = `${calendarBase(tokenManager)}/calendars/${encodeURIComponent(calendarId)}/events`
+  const base: Record<string, string> = {
+    timeMin,
+    timeMax,
+    singleEvents: 'true',
+    orderBy: 'startTime',
+    maxResults: '2500',
+  }
+  if (timeZone !== undefined && timeZone !== '') base.timeZone = timeZone
+  const items: Record<string, JsonValue>[] = []
+  let token: string | null = null
+  for (let i = 0; i < MAX_PAGES; i += 1) {
+    const page = token !== null ? { ...base, pageToken: token } : base
+    const data = await googleGet(tokenManager, url, page)
+    items.push(...rows(data))
+    token = nextToken(data)
+    if (token === null) break
+  }
+  return items
+}
+
+/** Delete one event. */
+export async function deleteEvent(
+  tokenManager: TokenManager,
+  calendarId: string,
+  eventId: string,
+): Promise<void> {
+  const url =
+    `${calendarBase(tokenManager)}/calendars/${encodeURIComponent(calendarId)}` +
+    `/events/${encodeURIComponent(eventId)}`
+  await googleDelete(tokenManager, url)
+}

--- a/typescript/packages/core/src/core/gcal/day.test.ts
+++ b/typescript/packages/core/src/core/gcal/day.test.ts
@@ -38,6 +38,12 @@ function allDay(start: string, end: string): Record<string, JsonValue> {
   return { start: { date: start }, end: { date: end } }
 }
 
+function spanOf(event: Record<string, JsonValue>, tz: string): [number, number] {
+  const span = eventSpan(event, tz)
+  if (span === null) throw new Error('expected a parseable span')
+  return span
+}
+
 describe('gcal day bucketing', () => {
   it('falls back to UTC for an unknown zone', () => {
     expect(zone('Not/AZone').resolvedOptions().timeZone).toBe('UTC')
@@ -104,62 +110,53 @@ describe('gcal day bucketing', () => {
   it('covers one day only for a single-day all-day event', () => {
     // end.date is EXCLUSIVE, so start=D end=D+1 is a one-day event and must
     // not leak into D+1's directory.
-    const span = eventSpan(allDay('2026-08-11', '2026-08-12'), HK)
-    expect(daysCovered(span as [number, number], HK)).toEqual(['2026-08-11'])
+    const span = spanOf(allDay('2026-08-11', '2026-08-12'), HK)
+    expect(daysCovered(span, HK)).toEqual(['2026-08-11'])
   })
 
   it('covers each day of a multi-day all-day event', () => {
-    const span = eventSpan(allDay('2026-08-11', '2026-08-14'), HK)
-    expect(daysCovered(span as [number, number], HK)).toEqual([
-      '2026-08-11',
-      '2026-08-12',
-      '2026-08-13',
-    ])
+    const span = spanOf(allDay('2026-08-11', '2026-08-14'), HK)
+    expect(daysCovered(span, HK)).toEqual(['2026-08-11', '2026-08-12', '2026-08-13'])
   })
 
   it('covers every day a timed event spans', () => {
-    const span = eventSpan(timed('2026-08-10T09:00:00+08:00', '2026-08-13T17:00:00+08:00'), HK)
-    expect(daysCovered(span as [number, number], HK)).toEqual([
-      '2026-08-10',
-      '2026-08-11',
-      '2026-08-12',
-      '2026-08-13',
-    ])
+    const span = spanOf(timed('2026-08-10T09:00:00+08:00', '2026-08-13T17:00:00+08:00'), HK)
+    expect(daysCovered(span, HK)).toEqual(['2026-08-10', '2026-08-11', '2026-08-12', '2026-08-13'])
   })
 
   it('stops at the starting day when it ends exactly at midnight', () => {
-    const span = eventSpan(timed('2026-08-11T23:00:00+08:00', '2026-08-12T00:00:00+08:00'), HK)
-    expect(daysCovered(span as [number, number], HK)).toEqual(['2026-08-11'])
+    const span = spanOf(timed('2026-08-11T23:00:00+08:00', '2026-08-12T00:00:00+08:00'), HK)
+    expect(daysCovered(span, HK)).toEqual(['2026-08-11'])
   })
 
   it('still occupies a day for a zero-length event', () => {
-    const span = eventSpan(timed('2026-08-11T09:00:00+08:00', '2026-08-11T09:00:00+08:00'), HK)
-    expect(daysCovered(span as [number, number], HK)).toEqual(['2026-08-11'])
+    const span = spanOf(timed('2026-08-11T09:00:00+08:00', '2026-08-11T09:00:00+08:00'), HK)
+    expect(daysCovered(span, HK)).toEqual(['2026-08-11'])
   })
 
   it('lets the bucketing zone decide the day', () => {
     // 20:00 in Los Angeles on Aug 11 is 03:00Z on Aug 12: bucketed in the
     // calendar's zone it is Aug 11, in UTC it would be Aug 12.
-    const span = eventSpan(timed('2026-08-11T20:00:00-07:00', '2026-08-11T21:00:00-07:00'), LA)
-    expect(daysCovered(span as [number, number], LA)).toEqual(['2026-08-11'])
-    expect(daysCovered(span as [number, number], 'UTC')).toEqual(['2026-08-12'])
+    const span = spanOf(timed('2026-08-11T20:00:00-07:00', '2026-08-11T21:00:00-07:00'), LA)
+    expect(daysCovered(span, LA)).toEqual(['2026-08-11'])
+    expect(daysCovered(span, 'UTC')).toEqual(['2026-08-12'])
   })
 
   it('reports local times in the HHMM label', () => {
-    const span = eventSpan(timed('2026-08-11T09:00:00+08:00', '2026-08-11T10:30:00+08:00'), HK)
-    expect(clampedHhmm(span as [number, number], '2026-08-11', HK)).toBe('0900-1030')
+    const span = spanOf(timed('2026-08-11T09:00:00+08:00', '2026-08-11T10:30:00+08:00'), HK)
+    expect(clampedHhmm(span, '2026-08-11', HK)).toBe('0900-1030')
   })
 
   it('clamps a spanning event to the whole day', () => {
-    const span = eventSpan(timed('2026-08-10T09:00:00+08:00', '2026-08-13T17:00:00+08:00'), HK)
-    expect(clampedHhmm(span as [number, number], '2026-08-10', HK)).toBe('0900-2400')
-    expect(clampedHhmm(span as [number, number], '2026-08-11', HK)).toBe('0000-2400')
-    expect(clampedHhmm(span as [number, number], '2026-08-13', HK)).toBe('0000-1700')
+    const span = spanOf(timed('2026-08-10T09:00:00+08:00', '2026-08-13T17:00:00+08:00'), HK)
+    expect(clampedHhmm(span, '2026-08-10', HK)).toBe('0900-2400')
+    expect(clampedHhmm(span, '2026-08-11', HK)).toBe('0000-2400')
+    expect(clampedHhmm(span, '2026-08-13', HK)).toBe('0000-1700')
   })
 
   it('spells an all-day event as the full day', () => {
-    const span = eventSpan(allDay('2026-08-11', '2026-08-12'), HK)
-    expect(clampedHhmm(span as [number, number], '2026-08-11', HK)).toBe('0000-2400')
+    const span = spanOf(allDay('2026-08-11', '2026-08-12'), HK)
+    expect(clampedHhmm(span, '2026-08-11', HK)).toBe('0000-2400')
   })
 
   it('rejects a date-shaped non-date', () => {

--- a/typescript/packages/core/src/core/gcal/day.test.ts
+++ b/typescript/packages/core/src/core/gcal/day.test.ts
@@ -1,0 +1,173 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import type { JsonValue } from '../../types.ts'
+import {
+  clampedHhmm,
+  dayBounds,
+  daysCovered,
+  eventSpan,
+  isAllDay,
+  localMidnight,
+  slotInstant,
+  validDay,
+  windowBounds,
+  zone,
+} from './day.ts'
+
+const HK = 'Asia/Hong_Kong'
+const LA = 'America/Los_Angeles'
+
+function timed(start: string, end: string): Record<string, JsonValue> {
+  return { start: { dateTime: start }, end: { dateTime: end } }
+}
+
+function allDay(start: string, end: string): Record<string, JsonValue> {
+  return { start: { date: start }, end: { date: end } }
+}
+
+describe('gcal day bucketing', () => {
+  it('falls back to UTC for an unknown zone', () => {
+    expect(zone('Not/AZone').resolvedOptions().timeZone).toBe('UTC')
+    expect(zone(HK).resolvedOptions().timeZone).toBe(HK)
+  })
+
+  it('builds day bounds from consecutive local midnights', () => {
+    expect(dayBounds('2026-08-11', HK)).toEqual([
+      '2026-08-11T00:00:00+08:00',
+      '2026-08-12T00:00:00+08:00',
+    ])
+  })
+
+  it('spans 25 hours on a DST fall back', () => {
+    // America/Los_Angeles leaves DST on 2026-11-01, making that local day
+    // 25 hours. Adding a fixed 24h would drop the repeated hour's events.
+    const [lo, hi] = dayBounds('2026-11-01', LA)
+    expect(Date.parse(hi) - Date.parse(lo)).toBe(25 * 3600 * 1000)
+  })
+
+  it('spans 23 hours on a DST spring forward', () => {
+    const [lo, hi] = dayBounds('2026-03-08', LA)
+    expect(Date.parse(hi) - Date.parse(lo)).toBe(23 * 3600 * 1000)
+  })
+
+  it('brackets the day with the default window', () => {
+    expect(windowBounds('2026-08-11', HK)).toEqual([
+      '2026-07-12T00:00:00+08:00',
+      '2026-11-10T00:00:00+08:00',
+    ])
+  })
+
+  it('reads the slot shape for all-day', () => {
+    expect(isAllDay({ date: '2026-08-11' })).toBe(true)
+    expect(isAllDay({ dateTime: '2026-08-11T09:00:00+08:00' })).toBe(false)
+  })
+
+  it('parses offsets and Z', () => {
+    const span = eventSpan(timed('2026-08-11T09:00:00+08:00', '2026-08-11T02:30:00Z'), HK)
+    expect(span).not.toBeNull()
+    expect(span?.[0]).toBe(Date.parse('2026-08-11T01:00:00Z'))
+    expect(span?.[1]).toBe(Date.parse('2026-08-11T02:30:00Z'))
+  })
+
+  it('attaches the declared zone to a zone-less dateTime', () => {
+    // Google requires an offset UNLESS the slot names its own zone, so a
+    // bare wall clock is a zoned event, not an error. Reading it in the
+    // host zone would silently move the event.
+    const at = slotInstant({ dateTime: '2026-08-11T09:00:00', timeZone: HK }, 'UTC')
+    expect(at).toBe(Date.parse('2026-08-11T01:00:00Z'))
+  })
+
+  it('reads all-day dates in the bucketing zone', () => {
+    const span = eventSpan(allDay('2026-08-11', '2026-08-12'), HK)
+    expect(span?.[0]).toBe(localMidnight('2026-08-11', HK))
+    expect(span?.[1]).toBe(localMidnight('2026-08-12', HK))
+  })
+
+  it('returns null without usable slots', () => {
+    expect(eventSpan({ start: {}, end: {} }, HK)).toBeNull()
+    expect(eventSpan({ start: 'nope', end: {} }, HK)).toBeNull()
+  })
+
+  it('covers one day only for a single-day all-day event', () => {
+    // end.date is EXCLUSIVE, so start=D end=D+1 is a one-day event and must
+    // not leak into D+1's directory.
+    const span = eventSpan(allDay('2026-08-11', '2026-08-12'), HK)
+    expect(daysCovered(span as [number, number], HK)).toEqual(['2026-08-11'])
+  })
+
+  it('covers each day of a multi-day all-day event', () => {
+    const span = eventSpan(allDay('2026-08-11', '2026-08-14'), HK)
+    expect(daysCovered(span as [number, number], HK)).toEqual([
+      '2026-08-11',
+      '2026-08-12',
+      '2026-08-13',
+    ])
+  })
+
+  it('covers every day a timed event spans', () => {
+    const span = eventSpan(timed('2026-08-10T09:00:00+08:00', '2026-08-13T17:00:00+08:00'), HK)
+    expect(daysCovered(span as [number, number], HK)).toEqual([
+      '2026-08-10',
+      '2026-08-11',
+      '2026-08-12',
+      '2026-08-13',
+    ])
+  })
+
+  it('stops at the starting day when it ends exactly at midnight', () => {
+    const span = eventSpan(timed('2026-08-11T23:00:00+08:00', '2026-08-12T00:00:00+08:00'), HK)
+    expect(daysCovered(span as [number, number], HK)).toEqual(['2026-08-11'])
+  })
+
+  it('still occupies a day for a zero-length event', () => {
+    const span = eventSpan(timed('2026-08-11T09:00:00+08:00', '2026-08-11T09:00:00+08:00'), HK)
+    expect(daysCovered(span as [number, number], HK)).toEqual(['2026-08-11'])
+  })
+
+  it('lets the bucketing zone decide the day', () => {
+    // 20:00 in Los Angeles on Aug 11 is 03:00Z on Aug 12: bucketed in the
+    // calendar's zone it is Aug 11, in UTC it would be Aug 12.
+    const span = eventSpan(timed('2026-08-11T20:00:00-07:00', '2026-08-11T21:00:00-07:00'), LA)
+    expect(daysCovered(span as [number, number], LA)).toEqual(['2026-08-11'])
+    expect(daysCovered(span as [number, number], 'UTC')).toEqual(['2026-08-12'])
+  })
+
+  it('reports local times in the HHMM label', () => {
+    const span = eventSpan(timed('2026-08-11T09:00:00+08:00', '2026-08-11T10:30:00+08:00'), HK)
+    expect(clampedHhmm(span as [number, number], '2026-08-11', HK)).toBe('0900-1030')
+  })
+
+  it('clamps a spanning event to the whole day', () => {
+    const span = eventSpan(timed('2026-08-10T09:00:00+08:00', '2026-08-13T17:00:00+08:00'), HK)
+    expect(clampedHhmm(span as [number, number], '2026-08-10', HK)).toBe('0900-2400')
+    expect(clampedHhmm(span as [number, number], '2026-08-11', HK)).toBe('0000-2400')
+    expect(clampedHhmm(span as [number, number], '2026-08-13', HK)).toBe('0000-1700')
+  })
+
+  it('spells an all-day event as the full day', () => {
+    const span = eventSpan(allDay('2026-08-11', '2026-08-12'), HK)
+    expect(clampedHhmm(span as [number, number], '2026-08-11', HK)).toBe('0000-2400')
+  })
+
+  it('rejects a date-shaped non-date', () => {
+    // Regex-shaped but impossible: letting it through made stat report a
+    // directory that every later call then failed on.
+    expect(validDay('2026-02-30')).toBe(false)
+    expect(validDay('2026-13-01')).toBe(false)
+    expect(validDay('not-a-date')).toBe(false)
+    expect(validDay('2026-02-28')).toBe(true)
+  })
+})

--- a/typescript/packages/core/src/core/gcal/day.ts
+++ b/typescript/packages/core/src/core/gcal/day.ts
@@ -201,10 +201,7 @@ export function slotInstant(slot: Record<string, JsonValue>, tz: string): number
  * day. That is the same convention the instant carries, so no adjustment is
  * applied here.
  */
-export function eventSpan(
-  event: Record<string, JsonValue>,
-  tz: string,
-): [number, number] | null {
+export function eventSpan(event: Record<string, JsonValue>, tz: string): [number, number] | null {
   const startSlot = event.start
   const endSlot = event.end
   if (typeof startSlot !== 'object' || startSlot === null || Array.isArray(startSlot)) return null

--- a/typescript/packages/core/src/core/gcal/day.ts
+++ b/typescript/packages/core/src/core/gcal/day.ts
@@ -1,0 +1,257 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { JsonValue } from '../../types.ts'
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const DEFAULT_TZ = 'UTC'
+// The rolling window a bare readdir of a calendar reports. A calendar is
+// unbounded in both directions and the API offers no descending startTime
+// order, so a full listing means paging to the end; the window is stated in
+// the mount prompt rather than applied silently, and any date glob escapes it.
+export const WINDOW_BACK_DAYS = 30
+export const WINDOW_AHEAD_DAYS = 90
+
+const DAY_MS = 86_400_000
+
+// An offset is mandatory on dateTime UNLESS the slot names its own zone, so
+// a bare wall clock is a zoned event rather than an error.
+const HAS_OFFSET = /(?:Z|[+-]\d{2}:?\d{2})$/
+
+const formatters = new Map<string, Intl.DateTimeFormat>()
+
+/**
+ * Resolve an IANA zone name, falling back to UTC when unknown.
+ *
+ * A calendar can name a zone this platform's ICU data does not carry.
+ * Failing the whole listing over it would let one bad calendar hide every
+ * other one, so fall back and keep going.
+ */
+export function zone(tz: string): Intl.DateTimeFormat {
+  const cached = formatters.get(tz)
+  if (cached !== undefined) return cached
+  let made: Intl.DateTimeFormat
+  try {
+    made = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  } catch {
+    made = zone(DEFAULT_TZ)
+  }
+  formatters.set(tz, made)
+  return made
+}
+
+interface WallClock {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+}
+
+/** The wall-clock reading an instant has in a zone. */
+function wallParts(instant: number, tz: string): WallClock {
+  const parts = zone(tz).formatToParts(new Date(instant))
+  const get = (t: string): number => Number(parts.find((p) => p.type === t)?.value ?? '0')
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    // Intl renders midnight as hour 24 under hour12:false in some ICU
+    // versions, which would push the date a day forward.
+    hour: get('hour') % 24,
+    minute: get('minute'),
+    second: get('second'),
+  }
+}
+
+/** A zone's UTC offset in milliseconds at one instant. */
+function zoneOffsetMs(instant: number, tz: string): number {
+  const w = wallParts(instant, tz)
+  return Date.UTC(w.year, w.month - 1, w.day, w.hour, w.minute, w.second) - instant
+}
+
+/**
+ * A wall-clock reading resolved in a zone, as an absolute instant.
+ *
+ * Two passes because the offset itself depends on the instant: on a DST
+ * boundary the first guess lands on the wrong side of the transition.
+ */
+function wallClockMs(naive: string, tz: string): number {
+  const guess = Date.parse(`${naive}Z`)
+  const once = guess - zoneOffsetMs(guess, tz)
+  return guess - zoneOffsetMs(once, tz)
+}
+
+/** The instant at which a local calendar day begins. */
+export function localMidnight(day: string, tz: string): number {
+  return wallClockMs(`${day}T00:00:00`, tz)
+}
+
+function pad(value: number, width: number): string {
+  return String(value).padStart(width, '0')
+}
+
+/** The `YYYY-MM-DD` a day-count offset lands on, in floating date space. */
+export function shiftDay(day: string, days: number): string {
+  const at = Date.parse(`${day}T00:00:00Z`) + days * DAY_MS
+  return new Date(at).toISOString().slice(0, 10)
+}
+
+/** The local date an instant falls on, `YYYY-MM-DD`. */
+export function localDate(instant: number, tz: string): string {
+  const w = wallParts(instant, tz)
+  return `${pad(w.year, 4)}-${pad(w.month, 2)}-${pad(w.day, 2)}`
+}
+
+/** An instant as RFC3339 in one zone, offset included. */
+function rfc3339(instant: number, tz: string): string {
+  const w = wallParts(instant, tz)
+  const offset = zoneOffsetMs(instant, tz) / 60_000
+  const sign = offset < 0 ? '-' : '+'
+  const abs = Math.abs(offset)
+  const head =
+    `${pad(w.year, 4)}-${pad(w.month, 2)}-${pad(w.day, 2)}` +
+    `T${pad(w.hour, 2)}:${pad(w.minute, 2)}:${pad(w.second, 2)}`
+  return `${head}${sign}${pad(Math.floor(abs / 60), 2)}:${pad(abs % 60, 2)}`
+}
+
+/**
+ * The RFC3339 timeMin/timeMax pair covering one local day.
+ *
+ * Computed as consecutive local midnights rather than start + 24h: a local
+ * day is 23 or 25 hours on the two DST transitions each year, and adding a
+ * fixed day would drop or double an hour of events.
+ */
+export function dayBounds(day: string, tz: string): [string, string] {
+  const start = localMidnight(day, tz)
+  const next = localMidnight(shiftDay(day, 1), tz)
+  return [rfc3339(start, tz), rfc3339(next, tz)]
+}
+
+/** The RFC3339 pair for the default listing window around a day. */
+export function windowBounds(today: string, tz: string): [string, string] {
+  const lo = shiftDay(today, -WINDOW_BACK_DAYS)
+  const hi = shiftDay(today, WINDOW_AHEAD_DAYS)
+  return [dayBounds(lo, tz)[0], dayBounds(hi, tz)[1]]
+}
+
+/**
+ * Whether a string is a real calendar date, not merely date-shaped.
+ *
+ * `2026-02-30` matches the shape and is not a day; letting it through made
+ * stat report a directory that every later call then failed on.
+ */
+export function validDay(day: string): boolean {
+  if (!DATE_RE.test(day)) return false
+  const at = Date.parse(`${day}T00:00:00Z`)
+  if (Number.isNaN(at)) return false
+  return new Date(at).toISOString().slice(0, 10) === day
+}
+
+/** Whether an event time slot is a floating all-day date. */
+export function isAllDay(slot: Record<string, JsonValue>): boolean {
+  return slot.date !== undefined && slot.dateTime === undefined
+}
+
+/**
+ * Resolve one event time slot to an absolute instant.
+ *
+ * A dateTime with no offset is a zoned event, not an error: Google requires
+ * an offset unless the slot names its own zone. Reading it in the host zone
+ * would silently move the event.
+ */
+export function slotInstant(slot: Record<string, JsonValue>, tz: string): number | null {
+  const raw = slot.dateTime
+  if (typeof raw === 'string' && raw !== '') {
+    if (HAS_OFFSET.test(raw)) return Date.parse(raw)
+    const declared = slot.timeZone
+    return wallClockMs(raw, typeof declared === 'string' && declared !== '' ? declared : tz)
+  }
+  const day = slot.date
+  if (typeof day === 'string' && DATE_RE.test(day)) return localMidnight(day, tz)
+  return null
+}
+
+/**
+ * The absolute [start, end) span of an event.
+ *
+ * An all-day event's `end.date` is exclusive, so a one-day event is
+ * `start=D, end=D+1` and its span closes at the midnight opening the next
+ * day. That is the same convention the instant carries, so no adjustment is
+ * applied here.
+ */
+export function eventSpan(
+  event: Record<string, JsonValue>,
+  tz: string,
+): [number, number] | null {
+  const startSlot = event.start
+  const endSlot = event.end
+  if (typeof startSlot !== 'object' || startSlot === null || Array.isArray(startSlot)) return null
+  if (typeof endSlot !== 'object' || endSlot === null || Array.isArray(endSlot)) return null
+  const start = slotInstant(startSlot as Record<string, JsonValue>, tz)
+  if (start === null) return null
+  let end = slotInstant(endSlot as Record<string, JsonValue>, tz)
+  if (end === null || end < start) end = start
+  return [start, end]
+}
+
+/**
+ * Every local day an event's span touches.
+ *
+ * The end is exclusive, so an event closing exactly at local midnight does
+ * not reach into the following day; a zero-length event still occupies the
+ * day it starts on.
+ */
+export function daysCovered(span: [number, number], tz: string): string[] {
+  const first = localDate(span[0], tz)
+  let last = localDate(span[1], tz)
+  if (span[1] > span[0] && localMidnight(last, tz) === span[1]) last = shiftDay(last, -1)
+  if (last < first) last = first
+  const out: string[] = []
+  let cur = first
+  while (cur <= last) {
+    out.push(cur)
+    cur = shiftDay(cur, 1)
+  }
+  return out
+}
+
+/**
+ * The `HHMM-HHMM` label for an event as seen on one local day.
+ *
+ * Times are clamped to the day, so an event running through it reads
+ * `0000-2400` rather than repeating times that belong to another day.
+ * `2400` is how an end at the next local midnight is spelled, since `0000`
+ * there would sort before the start.
+ */
+export function clampedHhmm(span: [number, number], day: string, tz: string): string {
+  const lo = localMidnight(day, tz)
+  const hi = localMidnight(shiftDay(day, 1), tz)
+  const start = wallParts(Math.max(span[0], lo), tz)
+  const head = `${pad(start.hour, 2)}${pad(start.minute, 2)}`
+  const endAt = Math.min(span[1], hi)
+  if (endAt >= hi) return `${head}-2400`
+  const end = wallParts(endAt, tz)
+  return `${head}-${pad(end.hour, 2)}${pad(end.minute, 2)}`
+}

--- a/typescript/packages/core/src/core/gcal/read.ts
+++ b/typescript/packages/core/src/core/gcal/read.ts
@@ -1,0 +1,58 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { GCalAccessor } from '../../accessor/gcal.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { CALENDAR_FILE, parseEventFilename } from '../../resource/gcal/event_entry.ts'
+import type { PathSpec } from '../../types.ts'
+import { eisdir, enoent } from '../../utils/errors.ts'
+import { dayBounds } from './day.ts'
+import { listEvents } from './client.ts'
+import { bucketZone, calendarIndex, calendarPayload, normalize } from './readdir.ts'
+
+const ENC = new TextEncoder()
+
+/**
+ * Read one calendar.json or one event's raw API payload.
+ *
+ * The event file holds the events.list item unmodified: the directory name
+ * and the HHMM segment are a view, while the payload is the truth an
+ * absolute-instant comparison has to be made against.
+ */
+export async function read(
+  accessor: GCalAccessor,
+  path: PathSpec,
+  _index?: IndexCacheStore,
+): Promise<Uint8Array> {
+  const [, key] = normalize(path)
+  const parts = key === '' ? [] : key.split('/')
+  if (parts.length < 2) throw eisdir(path.virtual)
+
+  const calendars = await calendarIndex(accessor)
+  const entry = calendars.get(parts[0] as string)
+  if (entry === undefined) throw enoent(path.virtual)
+  const tz = bucketZone(accessor, calendars)
+
+  if (parts.length === 2 && parts[1] === CALENDAR_FILE) return calendarPayload(entry, tz)
+  if (parts.length !== 3) throw enoent(path.virtual)
+
+  const calId = entry.id
+  if (typeof calId !== 'string') throw enoent(path.virtual)
+  const [eventId] = parseEventFilename(parts[2] as string)
+  const [timeMin, timeMax] = dayBounds(parts[1] as string, tz)
+  for (const event of await listEvents(accessor.tokenManager, calId, timeMin, timeMax, tz)) {
+    if (event.id === eventId) return ENC.encode(JSON.stringify(event))
+  }
+  throw enoent(path.virtual)
+}

--- a/typescript/packages/core/src/core/gcal/read.ts
+++ b/typescript/packages/core/src/core/gcal/read.ts
@@ -37,20 +37,21 @@ export async function read(
 ): Promise<Uint8Array> {
   const [, key] = normalize(path)
   const parts = key === '' ? [] : key.split('/')
+  const [calName = '', day = '', file = ''] = parts
   if (parts.length < 2) throw eisdir(path.virtual)
 
   const calendars = await calendarIndex(accessor)
-  const entry = calendars.get(parts[0] as string)
+  const entry = calendars.get(calName)
   if (entry === undefined) throw enoent(path.virtual)
   const tz = bucketZone(accessor, calendars)
 
-  if (parts.length === 2 && parts[1] === CALENDAR_FILE) return calendarPayload(entry, tz)
+  if (parts.length === 2 && day === CALENDAR_FILE) return calendarPayload(entry, tz)
   if (parts.length !== 3) throw enoent(path.virtual)
 
   const calId = entry.id
   if (typeof calId !== 'string') throw enoent(path.virtual)
-  const [eventId] = parseEventFilename(parts[2] as string)
-  const [timeMin, timeMax] = dayBounds(parts[1] as string, tz)
+  const [eventId] = parseEventFilename(file)
+  const [timeMin, timeMax] = dayBounds(day, tz)
   for (const event of await listEvents(accessor.tokenManager, calId, timeMin, timeMax, tz)) {
     if (event.id === eventId) return ENC.encode(JSON.stringify(event))
   }

--- a/typescript/packages/core/src/core/gcal/readdir.ts
+++ b/typescript/packages/core/src/core/gcal/readdir.ts
@@ -199,7 +199,8 @@ export async function readdir(
   }
 
   const parts = key.split('/')
-  const entry = calendars.get(parts[0] as string)
+  const [calName = '', day = ''] = parts
+  const entry = calendars.get(calName)
   if (entry === undefined || parts.length > 2) throw enoent(path.virtual)
   const calId = entry.id
   if (typeof calId !== 'string') throw enoent(path.virtual)
@@ -251,7 +252,6 @@ export async function readdir(
     return rows.map(([name]) => `${prefix}/${key}/${name}`)
   }
 
-  const day = parts[1] as string
   if (!validDay(day)) throw enoent(path.virtual)
   const [timeMin, timeMax] = dayBounds(day, tz)
   const events = await listEvents(accessor.tokenManager, calId, timeMin, timeMax, tz)

--- a/typescript/packages/core/src/core/gcal/readdir.ts
+++ b/typescript/packages/core/src/core/gcal/readdir.ts
@@ -1,0 +1,261 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { GCalAccessor } from '../../accessor/gcal.ts'
+import { IndexEntry } from '../../cache/index/config.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import {
+  CALENDAR_FILE,
+  PRIMARY_DIR,
+  eventTitle,
+  makeCalendarDirname,
+  makeEventFilename,
+} from '../../resource/gcal/event_entry.ts'
+import type { JsonValue, PathSpec } from '../../types.ts'
+import { enoent } from '../../utils/errors.ts'
+import { mountPrefixOf } from '../../utils/key_prefix.ts'
+import { globToDateRange } from '../google/date_glob.ts'
+import {
+  WINDOW_AHEAD_DAYS,
+  WINDOW_BACK_DAYS,
+  clampedHhmm,
+  dayBounds,
+  daysCovered,
+  eventSpan,
+  shiftDay,
+  validDay,
+  windowBounds,
+} from './day.ts'
+import { listCalendars, listEvents } from './client.ts'
+
+const CALENDAR_DIR = 'gcal/calendar_dir'
+export const CALENDAR_JSON = 'gcal/calendar_json'
+const DAY_DIR = 'gcal/day_dir'
+export const EVENT = 'gcal/event'
+const FREE_BUSY_ROLE = 'freeBusyReader'
+
+const ENC = new TextEncoder()
+
+export type CalendarEntryRow = Record<string, JsonValue>
+
+/** Render the per-calendar metadata file. */
+export function calendarPayload(entry: CalendarEntryRow, tz: string): Uint8Array {
+  return ENC.encode(
+    JSON.stringify({
+      id: entry.id ?? null,
+      summary: entry.summary ?? null,
+      accessRole: entry.accessRole ?? null,
+      primary: entry.primary === true,
+      calendarTimeZone: entry.timeZone ?? null,
+      // The zone the day directories are bucketed in, which is mount-wide
+      // and therefore not always this calendar's own.
+      bucketTimeZone: tz,
+    }),
+  )
+}
+
+/** Split a path into `[mount prefix, mount-relative key, virtual key]`. */
+export function normalize(path: PathSpec): [string, string, string] {
+  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
+  const key = (path.pattern !== null ? path.dir : path).resourcePath
+  const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
+  return [prefix, key, virtualKey]
+}
+
+/** Map each calendar's directory name to its calendarList entry. */
+export async function calendarIndex(
+  accessor: GCalAccessor,
+): Promise<Map<string, CalendarEntryRow>> {
+  const rows = await listCalendars(accessor.tokenManager, accessor.config.minAccessRole)
+  const out = new Map<string, CalendarEntryRow>()
+  for (const row of rows) {
+    const calId = row.id
+    if (typeof calId !== 'string' || calId === '') continue
+    const summary = row.summary
+    const name = makeCalendarDirname(
+      typeof summary === 'string' ? summary : calId,
+      calId,
+      row.primary === true,
+    )
+    out.set(name, row)
+  }
+  return out
+}
+
+/**
+ * The one zone every day directory on this mount is bucketed in.
+ *
+ * Defaults to the primary calendar's zone, matching how the Calendar UI
+ * draws its grid: bucketing each calendar in its own zone would make the
+ * same directory name mean different 24-hour windows on different
+ * calendars, so a cross-calendar free/busy comparison would be wrong.
+ */
+export function bucketZone(
+  accessor: GCalAccessor,
+  calendars: Map<string, CalendarEntryRow>,
+): string {
+  const pinned = accessor.config.timeZone
+  if (pinned !== undefined && pinned !== '') return pinned
+  const primary = calendars.get(PRIMARY_DIR)
+  if (primary !== undefined) {
+    const tz = primary.timeZone
+    if (typeof tz === 'string' && tz !== '') return tz
+  }
+  for (const entry of calendars.values()) {
+    const tz = entry.timeZone
+    if (typeof tz === 'string' && tz !== '') return tz
+  }
+  return 'UTC'
+}
+
+/**
+ * The listing window, honouring a date glob when one was typed.
+ *
+ * A bare readdir reports a rolling window around today because a calendar
+ * is unbounded in both directions and the API offers no descending
+ * startTime order. A glob escapes it by pushing its own bounds down.
+ */
+function daySpan(
+  pattern: string | null,
+  today: string,
+  tz: string,
+): [string, string, string, string] {
+  const span = globToDateRange(pattern)
+  if (span !== null) {
+    const last = shiftDay(span[1], -1)
+    return [dayBounds(span[0], tz)[0], dayBounds(last, tz)[1], span[0], last]
+  }
+  const [lo, hi] = windowBounds(today, tz)
+  return [lo, hi, shiftDay(today, -WINDOW_BACK_DAYS), shiftDay(today, WINDOW_AHEAD_DAYS)]
+}
+
+/** Build the index entries for one day directory. */
+function eventEntries(
+  events: CalendarEntryRow[],
+  day: string,
+  tz: string,
+  freeBusy: boolean,
+): [string, IndexEntry][] {
+  const rows: [string, IndexEntry][] = []
+  for (const event of events) {
+    const eventId = event.id
+    if (typeof eventId !== 'string' || eventId === '') continue
+    const span = eventSpan(event, tz)
+    if (span === null || !daysCovered(span, tz).includes(day)) continue
+    const summary = event.summary
+    const title = eventTitle(typeof summary === 'string' ? summary : null, freeBusy)
+    const name = makeEventFilename(eventId, clampedHhmm(span, day, tz), title)
+    const updated = event.updated
+    rows.push([
+      name,
+      new IndexEntry({
+        id: eventId,
+        name: title,
+        resourceType: EVENT,
+        remoteTime: typeof updated === 'string' ? updated : '',
+        vfsName: name,
+        size: ENC.encode(JSON.stringify(event)).length,
+      }),
+    ])
+  }
+  return rows
+}
+
+/** List one level of the calendar tree. */
+export async function readdir(
+  accessor: GCalAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<string[]> {
+  const [prefix, key, virtualKey] = normalize(path)
+  const calendars = await calendarIndex(accessor)
+  const tz = bucketZone(accessor, calendars)
+
+  if (key === '') {
+    const entries: [string, IndexEntry][] = [...calendars.entries()]
+      .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+      .map(([name, entry]) => [
+        name,
+        new IndexEntry({
+          id: typeof entry.id === 'string' && entry.id !== '' ? entry.id : name,
+          name,
+          resourceType: CALENDAR_DIR,
+          vfsName: name,
+        }),
+      ])
+    if (index !== undefined) await index.setDir(virtualKey, entries)
+    return entries.map(([name]) => `${prefix}/${name}`)
+  }
+
+  const parts = key.split('/')
+  const entry = calendars.get(parts[0] as string)
+  if (entry === undefined || parts.length > 2) throw enoent(path.virtual)
+  const calId = entry.id
+  if (typeof calId !== 'string') throw enoent(path.virtual)
+  const freeBusy = entry.accessRole === FREE_BUSY_ROLE
+
+  if (parts.length === 1) {
+    const [timeMin, timeMax, first, last] = daySpan(path.pattern, accessor.today(tz), tz)
+    const events = await listEvents(accessor.tokenManager, calId, timeMin, timeMax, tz)
+    const seen = new Set<string>()
+    for (const event of events) {
+      const span = eventSpan(event, tz)
+      if (span === null) continue
+      for (const day of daysCovered(span, tz)) {
+        if (day >= first && day <= last) seen.add(day)
+      }
+    }
+    const rows: [string, IndexEntry][] = [
+      [
+        CALENDAR_FILE,
+        new IndexEntry({
+          id: `${calId}:calendar`,
+          name: CALENDAR_FILE,
+          resourceType: CALENDAR_JSON,
+          vfsName: CALENDAR_FILE,
+          size: calendarPayload(entry, tz).length,
+        }),
+      ],
+    ]
+    for (const day of [...seen].sort()) {
+      rows.push([
+        day,
+        new IndexEntry({
+          id: `${calId}:${day}`,
+          name: day,
+          resourceType: DAY_DIR,
+          vfsName: day,
+        }),
+      ])
+    }
+    if (index !== undefined) {
+      if (path.pattern !== null) {
+        // A globbed listing is a filtered view, not the directory: caching
+        // it as the directory would pin a short listing until it expires.
+        for (const [name, row] of rows) await index.put(`${virtualKey}/${name}`, row)
+      } else {
+        await index.setDir(virtualKey, rows)
+      }
+    }
+    return rows.map(([name]) => `${prefix}/${key}/${name}`)
+  }
+
+  const day = parts[1] as string
+  if (!validDay(day)) throw enoent(path.virtual)
+  const [timeMin, timeMax] = dayBounds(day, tz)
+  const events = await listEvents(accessor.tokenManager, calId, timeMin, timeMax, tz)
+  const rows = eventEntries(events, day, tz, freeBusy)
+  if (index !== undefined) await index.setDir(virtualKey, rows)
+  return rows.map(([name]) => `${prefix}/${key}/${name}`)
+}

--- a/typescript/packages/core/src/core/gcal/stat.ts
+++ b/typescript/packages/core/src/core/gcal/stat.ts
@@ -1,0 +1,84 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { GCalAccessor } from '../../accessor/gcal.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { FileStat, FileType, PathSpec } from '../../types.ts'
+import { enoent } from '../../utils/errors.ts'
+import { mountKey } from '../../utils/key_prefix.ts'
+import { validDay } from './day.ts'
+import { CALENDAR_JSON, EVENT, calendarIndex, normalize, readdir } from './readdir.ts'
+
+/**
+ * Stat one node of the calendar tree.
+ *
+ * A well-formed day directory resolves whether or not it holds an event:
+ * the range query over that day is positive proof of what is there, so an
+ * event-free day is an empty directory rather than a miss. Only a malformed
+ * date, or one under a calendar that does not exist, is ENOENT.
+ */
+export async function stat(
+  accessor: GCalAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<FileStat> {
+  const [prefix, key, virtualKey] = normalize(path)
+  if (key === '') return new FileStat({ name: '/', type: FileType.DIRECTORY })
+
+  let entry = index !== undefined ? (await index.get(virtualKey)).entry : null
+  if (entry === null || entry === undefined) {
+    const parentVirtual = virtualKey.slice(0, virtualKey.lastIndexOf('/')) || '/'
+    try {
+      await readdir(
+        accessor,
+        new PathSpec({
+          virtual: parentVirtual,
+          directory: parentVirtual,
+          resourcePath: mountKey(parentVirtual, prefix),
+        }),
+        index,
+      )
+    } catch {
+      // A parent that cannot be listed just leaves the miss below to
+      // decide; the calendar probe there is the authority.
+      entry = null
+    }
+    entry = index !== undefined ? (await index.get(virtualKey)).entry : null
+  }
+
+  if (entry === null || entry === undefined) {
+    const parts = key.split('/')
+    if (parts.length === 2 && validDay(parts[1] as string)) {
+      // Outside the default window, or a day with nothing on it. Ask the
+      // calendar list rather than the index: the index only knows the
+      // calendar once the ROOT has been listed, which a stat of a day two
+      // levels down never triggers.
+      const calendars = await calendarIndex(accessor)
+      if (!calendars.has(parts[0] as string)) throw enoent(path.virtual)
+      return new FileStat({ name: parts[1] as string, type: FileType.DIRECTORY })
+    }
+    throw enoent(path.virtual)
+  }
+
+  if (entry.resourceType === EVENT || entry.resourceType === CALENDAR_JSON) {
+    return new FileStat({
+      name: entry.vfsName,
+      type: FileType.JSON,
+      modified: entry.remoteTime,
+      size: entry.size,
+      extra: { event_id: entry.id, ...entry.extra },
+    })
+  }
+  return new FileStat({ name: entry.vfsName, type: FileType.DIRECTORY })
+}

--- a/typescript/packages/core/src/core/gcal/stat.ts
+++ b/typescript/packages/core/src/core/gcal/stat.ts
@@ -59,14 +59,15 @@ export async function stat(
 
   if (entry === null || entry === undefined) {
     const parts = key.split('/')
-    if (parts.length === 2 && validDay(parts[1] as string)) {
+    const [calName = '', day = ''] = parts
+    if (parts.length === 2 && validDay(day)) {
       // Outside the default window, or a day with nothing on it. Ask the
       // calendar list rather than the index: the index only knows the
       // calendar once the ROOT has been listed, which a stat of a day two
       // levels down never triggers.
       const calendars = await calendarIndex(accessor)
-      if (!calendars.has(parts[0] as string)) throw enoent(path.virtual)
-      return new FileStat({ name: parts[1] as string, type: FileType.DIRECTORY })
+      if (!calendars.has(calName)) throw enoent(path.virtual)
+      return new FileStat({ name: day, type: FileType.DIRECTORY })
     }
     throw enoent(path.virtual)
   }

--- a/typescript/packages/core/src/core/gcal/tree.test.ts
+++ b/typescript/packages/core/src/core/gcal/tree.test.ts
@@ -1,0 +1,346 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GCalAccessor } from '../../accessor/gcal.ts'
+import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
+import { FileType, PathSpec, type JsonValue } from '../../types.ts'
+import { TokenManager } from '../google/_client.ts'
+import { eventSpan } from './day.ts'
+
+const HK = 'Asia/Hong_Kong'
+
+const PRIMARY = {
+  id: 'integ@example.com',
+  summary: 'Integ User',
+  timeZone: HK,
+  accessRole: 'owner',
+  primary: true,
+}
+const TEAM = {
+  id: 'team@group.calendar.google.com',
+  summary: 'Engineering',
+  timeZone: 'America/Los_Angeles',
+  accessRole: 'reader',
+}
+const SHARED = {
+  id: 'busy@group.calendar.google.com',
+  summary: 'Exec',
+  timeZone: HK,
+  accessRole: 'freeBusyReader',
+}
+
+function timed(
+  id: string,
+  summary: string,
+  start: string,
+  end: string,
+): Record<string, JsonValue> {
+  return {
+    id,
+    status: 'confirmed',
+    summary,
+    start: { dateTime: start },
+    end: { dateTime: end },
+    updated: '2026-08-01T00:00:00.000Z',
+  }
+}
+
+function allDay(
+  id: string,
+  summary: string,
+  start: string,
+  end: string,
+): Record<string, JsonValue> {
+  return {
+    id,
+    status: 'confirmed',
+    summary,
+    start: { date: start },
+    end: { date: end },
+    updated: '2026-08-01T00:00:00.000Z',
+  }
+}
+
+const EVENTS: Record<string, JsonValue>[] = [
+  timed('aaaa1', 'PhD Defense', '2026-08-11T09:00:00+08:00', '2026-08-11T10:30:00+08:00'),
+  timed('bbbb2', 'Committee Meeting', '2026-08-11T15:00:00+08:00', '2026-08-11T16:00:00+08:00'),
+  timed('cccc3', 'Conference', '2026-08-10T09:00:00+08:00', '2026-08-13T17:00:00+08:00'),
+  allDay('dddd4', 'Public Holiday', '2026-08-11', '2026-08-12'),
+  timed('eeee5', 'Last Year', '2025-01-05T09:00:00+08:00', '2025-01-05T10:00:00+08:00'),
+]
+
+const listed: [string, string, string][] = []
+const deleted: [string, string][] = []
+
+vi.mock('./client.ts', () => ({
+  listCalendars: (_tm: unknown, minAccessRole?: string) => {
+    const all = [PRIMARY, TEAM, SHARED]
+    if (minAccessRole === undefined || minAccessRole === '') return Promise.resolve(all)
+    return Promise.resolve(all.filter((c) => c.accessRole === minAccessRole))
+  },
+  listEvents: (
+    _tm: unknown,
+    calendarId: string,
+    timeMin: string,
+    timeMax: string,
+    timeZone?: string,
+  ) => {
+    listed.push([calendarId, timeMin, timeMax])
+    const lo = Date.parse(timeMin)
+    const hi = Date.parse(timeMax)
+    const freeBusy = calendarId === SHARED.id
+    const out: Record<string, JsonValue>[] = []
+    for (const event of EVENTS) {
+      const span = eventSpan(event, timeZone ?? HK)
+      if (span === null) continue
+      // timeMin bounds the END and timeMax the START, both exclusive.
+      if (span[1] <= lo || span[0] >= hi) continue
+      if (freeBusy) {
+        // What Google actually returns for a freeBusyReader role:
+        // availability with no summary, description or location.
+        const { summary: _s, description: _d, location: _l, ...rest } = event
+        out.push(rest)
+        continue
+      }
+      out.push(event)
+    }
+    return Promise.resolve(out)
+  },
+  deleteEvent: (_tm: unknown, calendarId: string, eventId: string) => {
+    deleted.push([calendarId, eventId])
+    return Promise.resolve()
+  },
+}))
+
+const { readdir, bucketZone, calendarIndex } = await import('./readdir.ts')
+const { stat } = await import('./stat.ts')
+const { read } = await import('./read.ts')
+const { unlink } = await import('./unlink.ts')
+
+function spec(virtual: string, pattern?: string): PathSpec {
+  const directory = pattern !== undefined ? virtual.slice(0, virtual.lastIndexOf('/')) || '/' : virtual
+  return new PathSpec({
+    virtual,
+    directory,
+    resourcePath: virtual.replace(/^\//, ''),
+    ...(pattern !== undefined ? { pattern } : {}),
+  })
+}
+
+function names(paths: string[]): string[] {
+  return paths.map((p) => p.slice(p.lastIndexOf('/') + 1))
+}
+
+function makeAccessor(overrides: Record<string, string> = {}): GCalAccessor {
+  const config = {
+    clientId: 'cid',
+    refreshToken: 'rt',
+    today: '2026-08-11',
+    ...overrides,
+  }
+  return new GCalAccessor({ tokenManager: new TokenManager(config), config })
+}
+
+let accessor: GCalAccessor
+let index: RAMIndexCacheStore
+
+beforeEach(() => {
+  accessor = makeAccessor()
+  index = new RAMIndexCacheStore()
+  listed.length = 0
+  deleted.length = 0
+})
+
+describe('gcal readdir', () => {
+  it('lists one directory per calendar at the root', async () => {
+    expect(names(await readdir(accessor, spec('/'), index))).toEqual([
+      'Engineering__team@group.calendar.google.com',
+      'Exec__busy@group.calendar.google.com',
+      'primary',
+    ])
+  })
+
+  it('keeps the primary alias and carries the id on the others', async () => {
+    const calendars = await calendarIndex(accessor)
+    expect(calendars.get('primary')?.id).toBe('integ@example.com')
+    expect(calendars.get('Engineering__team@group.calendar.google.com')?.id).toBe(
+      'team@group.calendar.google.com',
+    )
+  })
+
+  it('defaults the bucket zone to the primary calendar', async () => {
+    // Not the reader calendar's America/Los_Angeles: one zone mount-wide.
+    expect(bucketZone(accessor, await calendarIndex(accessor))).toBe(HK)
+  })
+
+  it('honours an explicit bucket zone override', async () => {
+    const pinned = makeAccessor({ timeZone: 'Europe/Berlin' })
+    expect(bucketZone(pinned, await calendarIndex(pinned))).toBe('Europe/Berlin')
+  })
+
+  it('lists only days holding events', async () => {
+    expect(names(await readdir(accessor, spec('/primary'), index))).toEqual([
+      'calendar.json',
+      '2026-08-10',
+      '2026-08-11',
+      '2026-08-12',
+      '2026-08-13',
+    ])
+  })
+
+  it('omits days outside the window', async () => {
+    // 2025-01-05 exists but sits far outside the -30/+90 day window.
+    expect(names(await readdir(accessor, spec('/primary'), index))).not.toContain('2025-01-05')
+  })
+
+  it('escapes the default window with a date glob', async () => {
+    const out = names(await readdir(accessor, spec('/primary/2025-01-*', '2025-01-*'), index))
+    expect(out).toContain('2025-01-05')
+    const last = listed[listed.length - 1] as [string, string, string]
+    expect(last[1].startsWith('2025-01-01')).toBe(true)
+    expect(last[2].startsWith('2025-02-01')).toBe(true)
+  })
+
+  it('lists one file per overlapping event', async () => {
+    expect(names(await readdir(accessor, spec('/primary/2026-08-11'), index))).toEqual([
+      'aaaa1__0900-1030_PhD_Defense.gcal.json',
+      'bbbb2__1500-1600_Committee_Meeting.gcal.json',
+      'cccc3__0000-2400_Conference.gcal.json',
+      'dddd4__0000-2400_Public_Holiday.gcal.json',
+    ])
+  })
+
+  it('shows a multi-day event under every day it covers', async () => {
+    const cases: [string, string][] = [
+      ['2026-08-10', '0900-2400'],
+      ['2026-08-11', '0000-2400'],
+      ['2026-08-12', '0000-2400'],
+      ['2026-08-13', '0000-1700'],
+    ]
+    for (const [day, hhmm] of cases) {
+      const out = names(await readdir(accessor, spec(`/primary/${day}`), index))
+      expect(out).toContain(`cccc3__${hhmm}_Conference.gcal.json`)
+    }
+  })
+
+  it('does not leak an all-day event past its exclusive end', async () => {
+    const out = names(await readdir(accessor, spec('/primary/2026-08-12'), index))
+    expect(out.some((n) => n.includes('Public_Holiday'))).toBe(false)
+  })
+
+  it('lists a day with no events as empty', async () => {
+    expect(await readdir(accessor, spec('/primary/2027-03-04'), index)).toEqual([])
+  })
+
+  it('renders a free/busy calendar without titles', async () => {
+    const out = names(
+      await readdir(accessor, spec('/Exec__busy@group.calendar.google.com/2026-08-11'), index),
+    )
+    expect(out.length).toBeGreaterThan(0)
+    expect(out.every((n) => n.endsWith('_busy.gcal.json'))).toBe(true)
+  })
+
+  it('is ENOENT for an unknown calendar, a bad date and too deep a path', async () => {
+    await expect(readdir(accessor, spec('/nope'), index)).rejects.toThrow()
+    await expect(readdir(accessor, spec('/primary/not-a-date'), index)).rejects.toThrow()
+    await expect(readdir(accessor, spec('/primary/2026-02-30'), index)).rejects.toThrow()
+    await expect(readdir(accessor, spec('/primary/2026-08-11/x/y'), index)).rejects.toThrow()
+  })
+
+  it('centres the window in the bucket zone', async () => {
+    await readdir(accessor, spec('/primary'), index)
+    const last = listed[listed.length - 1] as [string, string, string]
+    expect(last[1].endsWith('+08:00')).toBe(true)
+    expect(last[2].endsWith('+08:00')).toBe(true)
+  })
+})
+
+describe('gcal stat', () => {
+  it('reports directories and event files', async () => {
+    expect((await stat(accessor, spec('/'), index)).type).toBe(FileType.DIRECTORY)
+    expect((await stat(accessor, spec('/primary'), index)).type).toBe(FileType.DIRECTORY)
+    expect((await stat(accessor, spec('/primary/2026-08-11'), index)).type).toBe(
+      FileType.DIRECTORY,
+    )
+    const row = await stat(
+      accessor,
+      spec('/primary/2026-08-11/aaaa1__0900-1030_PhD_Defense.gcal.json'),
+      index,
+    )
+    expect(row.type).toBe(FileType.JSON)
+    expect(row.extra.event_id).toBe('aaaa1')
+    expect(row.size).toBeGreaterThan(0)
+  })
+
+  it('resolves an event-free day as an empty directory', async () => {
+    // The range query over that day is positive proof of what is there, so
+    // an empty day is an empty directory rather than ENOENT.
+    const row = await stat(accessor, spec('/primary/2027-03-04'), index)
+    expect(row.type).toBe(FileType.DIRECTORY)
+  })
+
+  it('is ENOENT for an impossible date or an unknown calendar', async () => {
+    await expect(stat(accessor, spec('/primary/2026-02-30'), index)).rejects.toThrow()
+    await expect(stat(accessor, spec('/nope/2027-03-04'), index)).rejects.toThrow()
+  })
+})
+
+describe('gcal read', () => {
+  it('renders calendar.json with the mount-wide bucket zone', async () => {
+    const body = JSON.parse(
+      new TextDecoder().decode(await read(accessor, spec('/primary/calendar.json'), index)),
+    ) as Record<string, unknown>
+    expect(body.id).toBe('integ@example.com')
+    expect(body.accessRole).toBe('owner')
+    expect(body.bucketTimeZone).toBe(HK)
+  })
+
+  it('serves the unmodified API payload for an event', async () => {
+    const body = JSON.parse(
+      new TextDecoder().decode(
+        await read(
+          accessor,
+          spec('/primary/2026-08-11/aaaa1__0900-1030_PhD_Defense.gcal.json'),
+          index,
+        ),
+      ),
+    ) as Record<string, unknown>
+    expect(body.id).toBe('aaaa1')
+    expect(body.summary).toBe('PhD Defense')
+    expect(body.start).toEqual({ dateTime: '2026-08-11T09:00:00+08:00' })
+  })
+})
+
+describe('gcal unlink', () => {
+  it('deletes the event the path names', async () => {
+    await unlink(
+      accessor,
+      spec('/primary/2026-08-11/aaaa1__0900-1030_PhD_Defense.gcal.json'),
+      index,
+    )
+    expect(deleted).toEqual([['integ@example.com', 'aaaa1']])
+  })
+
+  it('refuses a calendar the account cannot write', async () => {
+    await expect(
+      unlink(
+        accessor,
+        spec('/Engineering__team@group.calendar.google.com/2026-08-11/aaaa1__0900-1030_X.gcal.json'),
+        index,
+      ),
+    ).rejects.toThrow()
+    expect(deleted).toEqual([])
+  })
+})

--- a/typescript/packages/core/src/core/gcal/tree.test.ts
+++ b/typescript/packages/core/src/core/gcal/tree.test.ts
@@ -41,12 +41,7 @@ const SHARED = {
   accessRole: 'freeBusyReader',
 }
 
-function timed(
-  id: string,
-  summary: string,
-  start: string,
-  end: string,
-): Record<string, JsonValue> {
+function timed(id: string, summary: string, start: string, end: string): Record<string, JsonValue> {
   return {
     id,
     status: 'confirmed',
@@ -110,7 +105,10 @@ vi.mock('./client.ts', () => ({
       if (freeBusy) {
         // What Google actually returns for a freeBusyReader role:
         // availability with no summary, description or location.
-        const { summary: _s, description: _d, location: _l, ...rest } = event
+        const rest: Record<string, JsonValue> = {}
+        for (const [k, v] of Object.entries(event)) {
+          if (k !== 'summary' && k !== 'description' && k !== 'location') rest[k] = v
+        }
         out.push(rest)
         continue
       }
@@ -130,13 +128,20 @@ const { read } = await import('./read.ts')
 const { unlink } = await import('./unlink.ts')
 
 function spec(virtual: string, pattern?: string): PathSpec {
-  const directory = pattern !== undefined ? virtual.slice(0, virtual.lastIndexOf('/')) || '/' : virtual
+  const directory =
+    pattern !== undefined ? virtual.slice(0, virtual.lastIndexOf('/')) || '/' : virtual
   return new PathSpec({
     virtual,
     directory,
     resourcePath: virtual.replace(/^\//, ''),
     ...(pattern !== undefined ? { pattern } : {}),
   })
+}
+
+function lastListed(): [string, string, string] {
+  const last = listed[listed.length - 1]
+  if (last === undefined) throw new Error('no events.list call was made')
+  return last
 }
 
 function names(paths: string[]): string[] {
@@ -208,7 +213,7 @@ describe('gcal readdir', () => {
   it('escapes the default window with a date glob', async () => {
     const out = names(await readdir(accessor, spec('/primary/2025-01-*', '2025-01-*'), index))
     expect(out).toContain('2025-01-05')
-    const last = listed[listed.length - 1] as [string, string, string]
+    const last = lastListed()
     expect(last[1].startsWith('2025-01-01')).toBe(true)
     expect(last[2].startsWith('2025-02-01')).toBe(true)
   })
@@ -261,7 +266,7 @@ describe('gcal readdir', () => {
 
   it('centres the window in the bucket zone', async () => {
     await readdir(accessor, spec('/primary'), index)
-    const last = listed[listed.length - 1] as [string, string, string]
+    const last = lastListed()
     expect(last[1].endsWith('+08:00')).toBe(true)
     expect(last[2].endsWith('+08:00')).toBe(true)
   })
@@ -271,9 +276,7 @@ describe('gcal stat', () => {
   it('reports directories and event files', async () => {
     expect((await stat(accessor, spec('/'), index)).type).toBe(FileType.DIRECTORY)
     expect((await stat(accessor, spec('/primary'), index)).type).toBe(FileType.DIRECTORY)
-    expect((await stat(accessor, spec('/primary/2026-08-11'), index)).type).toBe(
-      FileType.DIRECTORY,
-    )
+    expect((await stat(accessor, spec('/primary/2026-08-11'), index)).type).toBe(FileType.DIRECTORY)
     const row = await stat(
       accessor,
       spec('/primary/2026-08-11/aaaa1__0900-1030_PhD_Defense.gcal.json'),
@@ -337,7 +340,9 @@ describe('gcal unlink', () => {
     await expect(
       unlink(
         accessor,
-        spec('/Engineering__team@group.calendar.google.com/2026-08-11/aaaa1__0900-1030_X.gcal.json'),
+        spec(
+          '/Engineering__team@group.calendar.google.com/2026-08-11/aaaa1__0900-1030_X.gcal.json',
+        ),
         index,
       ),
     ).rejects.toThrow()

--- a/typescript/packages/core/src/core/gcal/unlink.ts
+++ b/typescript/packages/core/src/core/gcal/unlink.ts
@@ -1,0 +1,52 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { GCalAccessor } from '../../accessor/gcal.ts'
+import { invalidateAfterUnlink } from '../../cache/context.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { parseEventFilename } from '../../resource/gcal/event_entry.ts'
+import type { PathSpec } from '../../types.ts'
+import { eacces, eisdir, enoent } from '../../utils/errors.ts'
+import { deleteEvent } from './client.ts'
+import { calendarIndex, normalize } from './readdir.ts'
+
+const WRITABLE_ROLES = new Set(['owner', 'writer'])
+
+/**
+ * Delete the event a path names.
+ *
+ * The path carries the event id, so no read is needed first: rm resolves
+ * through the name the listing already produced.
+ */
+export async function unlink(
+  accessor: GCalAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<void> {
+  const [, key, virtualKey] = normalize(path)
+  const parts = key === '' ? [] : key.split('/')
+  if (parts.length !== 3) throw eisdir(path.virtual)
+  const calendars = await calendarIndex(accessor)
+  const entry = calendars.get(parts[0] as string)
+  if (entry === undefined) throw enoent(path.virtual)
+  const role = entry.accessRole
+  if (typeof role !== 'string' || !WRITABLE_ROLES.has(role)) throw eacces(path.virtual)
+  const calId = entry.id
+  if (typeof calId !== 'string') throw enoent(path.virtual)
+  const [eventId] = parseEventFilename(parts[2] as string)
+  await deleteEvent(accessor.tokenManager, calId, eventId)
+  const parentDir = virtualKey.slice(0, virtualKey.lastIndexOf('/')) || '/'
+  if (index !== undefined) await index.invalidateDir(parentDir)
+  await invalidateAfterUnlink(virtualKey)
+}

--- a/typescript/packages/core/src/core/gcal/unlink.ts
+++ b/typescript/packages/core/src/core/gcal/unlink.ts
@@ -36,15 +36,16 @@ export async function unlink(
 ): Promise<void> {
   const [, key, virtualKey] = normalize(path)
   const parts = key === '' ? [] : key.split('/')
+  const [calName = '', , file = ''] = parts
   if (parts.length !== 3) throw eisdir(path.virtual)
   const calendars = await calendarIndex(accessor)
-  const entry = calendars.get(parts[0] as string)
+  const entry = calendars.get(calName)
   if (entry === undefined) throw enoent(path.virtual)
   const role = entry.accessRole
   if (typeof role !== 'string' || !WRITABLE_ROLES.has(role)) throw eacces(path.virtual)
   const calId = entry.id
   if (typeof calId !== 'string') throw enoent(path.virtual)
-  const [eventId] = parseEventFilename(parts[2] as string)
+  const [eventId] = parseEventFilename(file)
   await deleteEvent(accessor.tokenManager, calId, eventId)
   const parentDir = virtualKey.slice(0, virtualKey.lastIndexOf('/')) || '/'
   if (index !== undefined) await index.invalidateDir(parentDir)

--- a/typescript/packages/core/src/core/google/_client.test.ts
+++ b/typescript/packages/core/src/core/google/_client.test.ts
@@ -15,14 +15,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DOCS_API_BASE,
+  CALENDAR_API_BASE,
   DRIVE_API_BASE,
+  FORMS_API_BASE,
   DRIVE_UPLOAD_BASE,
   SHEETS_API_BASE,
   SLIDES_API_BASE,
   TOKEN_URL,
   TokenManager,
   docsBase,
+  calendarBase,
   driveBase,
+  formsBase,
   driveUploadBase,
   refreshAccessToken,
   sheetsBase,
@@ -145,6 +149,8 @@ describe('api base helpers', () => {
     expect(docsBase(tm)).toBe(DOCS_API_BASE)
     expect(slidesBase(tm)).toBe(SLIDES_API_BASE)
     expect(sheetsBase(tm)).toBe(SHEETS_API_BASE)
+    expect(calendarBase(tm)).toBe(CALENDAR_API_BASE)
+    expect(formsBase(tm)).toBe(FORMS_API_BASE)
     expect(tokenUrl(tm.config)).toBe(TOKEN_URL)
   })
 
@@ -159,6 +165,8 @@ describe('api base helpers', () => {
     expect(docsBase(tm)).toBe('http://127.0.0.1:19999/v1')
     expect(slidesBase(tm)).toBe('http://127.0.0.1:19999/v1')
     expect(sheetsBase(tm)).toBe('http://127.0.0.1:19999/v4')
+    expect(calendarBase(tm)).toBe('http://127.0.0.1:19999/calendar/v3')
+    expect(formsBase(tm)).toBe('http://127.0.0.1:19999/v1')
     expect(tokenUrl(tm.config)).toBe('http://127.0.0.1:19999/token')
   })
 })

--- a/typescript/packages/core/src/core/google/_client.ts
+++ b/typescript/packages/core/src/core/google/_client.ts
@@ -21,6 +21,8 @@ export const SLIDES_API_BASE = 'https://slides.googleapis.com/v1'
 export const SHEETS_API_BASE = 'https://sheets.googleapis.com/v4'
 export const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1'
 export const DRIVE_UPLOAD_BASE = 'https://www.googleapis.com/upload/drive/v3'
+export const CALENDAR_API_BASE = 'https://www.googleapis.com/calendar/v3'
+export const FORMS_API_BASE = 'https://forms.googleapis.com/v1'
 export const TOKEN_BUFFER_SECONDS = 300
 
 export function tokenUrl(config: GoogleConfig): string {
@@ -55,6 +57,16 @@ export function sheetsBase(tokenManager: TokenManager): string {
 export function gmailBase(tokenManager: TokenManager): string {
   const base = tokenManager.config.apiBase
   return base !== undefined ? `${base}/gmail/v1` : GMAIL_API_BASE
+}
+
+export function calendarBase(tokenManager: TokenManager): string {
+  const base = tokenManager.config.apiBase
+  return base !== undefined ? `${base}/calendar/v3` : CALENDAR_API_BASE
+}
+
+export function formsBase(tokenManager: TokenManager): string {
+  const base = tokenManager.config.apiBase
+  return base !== undefined ? `${base}/v1` : FORMS_API_BASE
 }
 
 export class GoogleApiError extends Error {

--- a/typescript/packages/core/src/core/google/config.ts
+++ b/typescript/packages/core/src/core/google/config.ts
@@ -33,6 +33,18 @@ export interface GoogleConfig {
   // Drive-only: scope the mount to this folder ID instead of the Drive
   // root, the s3 key_prefix analog. Other Google backends ignore it.
   folderId?: string
+  // Calendar-only. One zone for the whole mount, not one per calendar: the
+  // Calendar UI draws its whole grid in the primary zone, and per-calendar
+  // bucketing would make the same day directory name mean different
+  // 24-hour windows on different calendars. Defaults to the primary
+  // calendar's zone.
+  timeZone?: string
+  // Calendar-only: keep only calendars at or above this accessRole, e.g.
+  // "writer" for ones the agent can actually schedule into.
+  minAccessRole?: string
+  // Calendar-only: pin the day the rolling window centres on; test and
+  // snapshot use.
+  today?: string
 }
 
 export interface GoogleConfigRedacted {
@@ -41,6 +53,9 @@ export interface GoogleConfigRedacted {
   refreshToken: '<REDACTED>'
   apiBase?: string
   folderId?: string
+  timeZone?: string
+  minAccessRole?: string
+  today?: string
 }
 
 export const GoogleConfigSchema = z.object({
@@ -49,6 +64,9 @@ export const GoogleConfigSchema = z.object({
   refreshToken: secretStr(),
   apiBase: z.string().optional(),
   folderId: z.string().optional(),
+  timeZone: z.string().optional(),
+  minAccessRole: z.string().optional(),
+  today: z.string().optional(),
 })
 
 export function redactGoogleConfig(config: GoogleConfig): GoogleConfigRedacted {
@@ -63,6 +81,8 @@ export function normalizeGoogleConfig(input: Record<string, unknown>): GoogleCon
       refresh_token: 'refreshToken',
       api_base: 'apiBase',
       folder_id: 'folderId',
+      time_zone: 'timeZone',
+      min_access_role: 'minAccessRole',
     },
   }) as unknown as GoogleConfig
 }

--- a/typescript/packages/core/src/core/google/date_glob.ts
+++ b/typescript/packages/core/src/core/google/date_glob.ts
@@ -14,16 +14,16 @@
 
 import { GLOB_CHARS } from '../../utils/glob_walk.ts'
 
-function iso(year: number, month: number, day: number): string {
+function day(year: number, month: number, date: number): string {
   const mm = String(month).padStart(2, '0')
-  const dd = String(day).padStart(2, '0')
-  return `${String(year)}-${mm}-${dd}T00:00:00Z`
+  const dd = String(date).padStart(2, '0')
+  return `${String(year)}-${mm}-${dd}`
 }
 
-function isValidDate(year: number, month: number, day: number): boolean {
-  if (month < 1 || month > 12 || day < 1) return false
-  const d = new Date(Date.UTC(year, month - 1, day))
-  return d.getUTCFullYear() === year && d.getUTCMonth() === month - 1 && d.getUTCDate() === day
+function isValidDate(year: number, month: number, date: number): boolean {
+  if (month < 1 || month > 12 || date < 1) return false
+  const d = new Date(Date.UTC(year, month - 1, date))
+  return d.getUTCFullYear() === year && d.getUTCMonth() === month - 1 && d.getUTCDate() === date
 }
 
 function parseFixedInt(s: string | undefined, expectedLength: number): number | null {
@@ -31,7 +31,14 @@ function parseFixedInt(s: string | undefined, expectedLength: number): number | 
   return Number.parseInt(s, 10)
 }
 
-export function globToModifiedRange(pattern: string | null | undefined): [string, string] | null {
+/**
+ * Translate a date-prefixed glob into a half-open range of floating dates.
+ *
+ * Kept separate from `globToModifiedRange` because a caller bucketing in a
+ * named time zone has to build its own bounds from the dates; UTC instants
+ * would silently shift the window by the zone's offset.
+ */
+export function globToDateRange(pattern: string | null | undefined): [string, string] | null {
   if (!pattern) return null
   let metaIndex = -1
   for (const ch of GLOB_CHARS) {
@@ -44,28 +51,34 @@ export function globToModifiedRange(pattern: string | null | undefined): [string
   if (parts.length === 1) {
     const year = parseFixedInt(parts[0], 4)
     if (year === null) return null
-    return [iso(year, 1, 1), iso(year + 1, 1, 1)]
+    return [day(year, 1, 1), day(year + 1, 1, 1)]
   }
   if (parts.length === 2) {
     const year = parseFixedInt(parts[0], 4)
     const month = parseFixedInt(parts[1], 2)
     if (year === null || month === null) return null
     if (!isValidDate(year, month, 1)) return null
-    if (month === 12) return [iso(year, month, 1), iso(year + 1, 1, 1)]
-    return [iso(year, month, 1), iso(year, month + 1, 1)]
+    if (month === 12) return [day(year, month, 1), day(year + 1, 1, 1)]
+    return [day(year, month, 1), day(year, month + 1, 1)]
   }
   if (parts.length === 3) {
     const year = parseFixedInt(parts[0], 4)
     const month = parseFixedInt(parts[1], 2)
-    const day = parseFixedInt(parts[2], 2)
-    if (year === null || month === null || day === null) return null
-    if (!isValidDate(year, month, day)) return null
-    const start = new Date(Date.UTC(year, month - 1, day))
-    const next = new Date(start.getTime() + 86400000)
+    const date = parseFixedInt(parts[2], 2)
+    if (year === null || month === null || date === null) return null
+    if (!isValidDate(year, month, date)) return null
+    const next = new Date(Date.UTC(year, month - 1, date) + 86400000)
     return [
-      iso(year, month, day),
-      iso(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate()),
+      day(year, month, date),
+      day(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate()),
     ]
   }
   return null
+}
+
+/** Translate a date-prefixed glob into an RFC3339 modifiedTime range. */
+export function globToModifiedRange(pattern: string | null | undefined): [string, string] | null {
+  const span = globToDateRange(pattern)
+  if (span === null) return null
+  return [`${span[0]}T00:00:00Z`, `${span[1]}T00:00:00Z`]
 }

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1008,6 +1008,33 @@ export {
   listAllFiles as googleDriveListAllFiles,
   listFiles as googleDriveListFiles,
 } from './core/google/drive.ts'
+export { GCalAccessor } from './accessor/gcal.ts'
+export { GCAL_COMMANDS } from './commands/builtin/gcal/index.ts'
+export { GCAL_OPS } from './ops/gcal/index.ts'
+export { read as gcalRead } from './core/gcal/read.ts'
+export { readdir as gcalReaddir } from './core/gcal/readdir.ts'
+export { stat as gcalStat } from './core/gcal/stat.ts'
+export { unlink as gcalUnlink } from './core/gcal/unlink.ts'
+export {
+  deleteEvent as gcalDeleteEvent,
+  listCalendars as gcalListCalendars,
+  listEvents as gcalListEvents,
+} from './core/gcal/client.ts'
+export {
+  clampedHhmm as gcalClampedHhmm,
+  dayBounds as gcalDayBounds,
+  daysCovered as gcalDaysCovered,
+  eventSpan as gcalEventSpan,
+  validDay as gcalValidDay,
+  windowBounds as gcalWindowBounds,
+} from './core/gcal/day.ts'
+export { GCAL_PROMPT, GCAL_WRITE_PROMPT } from './resource/gcal/prompt.ts'
+export {
+  makeCalendarDirname as gcalMakeCalendarDirname,
+  makeEventFilename as gcalMakeEventFilename,
+  parseCalendarDirname as gcalParseCalendarDirname,
+  parseEventFilename as gcalParseEventFilename,
+} from './resource/gcal/event_entry.ts'
 export { GDocsAccessor } from './accessor/gdocs.ts'
 export { GDOCS_COMMANDS } from './commands/builtin/gdocs/index.ts'
 export { GDOCS_OPS } from './ops/gdocs/index.ts'

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -962,9 +962,11 @@ export {
 export { listAnnotations as githubCiListAnnotations } from './core/github_ci/annotations.ts'
 export { GITHUB_CI_PROMPT } from './resource/github_ci/prompt.ts'
 export {
+  CALENDAR_API_BASE,
   DOCS_API_BASE,
   DRIVE_API_BASE,
   DRIVE_UPLOAD_BASE,
+  FORMS_API_BASE,
   GMAIL_API_BASE,
   GoogleApiError,
   SHEETS_API_BASE,
@@ -972,9 +974,11 @@ export {
   TOKEN_BUFFER_SECONDS,
   TOKEN_URL,
   TokenManager,
+  calendarBase,
   docsBase,
   driveBase,
   driveUploadBase,
+  formsBase,
   gmailBase,
   sheetsBase,
   slidesBase,

--- a/typescript/packages/core/src/ops/gcal/index.ts
+++ b/typescript/packages/core/src/ops/gcal/index.ts
@@ -1,0 +1,26 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { GCAL_IO } from '../../commands/builtin/gcal/io.ts'
+import { ResourceName } from '../../types.ts'
+import { makeGenericOps } from '../generic/factory.ts'
+import type { RegisteredOp } from '../registry.ts'
+import { readOp } from './read.ts'
+
+// The only read is the rendered filetype op, so the factory's plain read is
+// suppressed via overrides.
+export const GCAL_OPS: readonly RegisteredOp[] = [
+  ...makeGenericOps(ResourceName.GCAL, GCAL_IO, { overrides: new Set(['read']) }),
+  readOp,
+]

--- a/typescript/packages/core/src/ops/gcal/read.ts
+++ b/typescript/packages/core/src/ops/gcal/read.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { GCalAccessor } from '../../accessor/gcal.ts'
+import { read as coreRead } from '../../core/gcal/read.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import type { OpKwargs, RegisteredOp } from '../registry.ts'
+
+export const readOp: RegisteredOp = {
+  name: 'read',
+  resource: ResourceName.GCAL,
+  filetype: '.gcal.json',
+  write: false,
+  fn: (accessor: GCalAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+    return coreRead(accessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/resource/gcal/event_entry.test.ts
+++ b/typescript/packages/core/src/resource/gcal/event_entry.test.ts
@@ -1,0 +1,109 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { NAME_MAX_BYTES } from '../../utils/sanitize.ts'
+import {
+  PRIMARY_DIR,
+  eventTitle,
+  makeCalendarDirname,
+  makeEventFilename,
+  parseCalendarDirname,
+  parseEventFilename,
+} from './event_entry.ts'
+
+const EVENT_ID = 'la9i1t995acovthi3f761chla0'
+const UTF8 = new TextEncoder()
+
+function byteLength(value: string): number {
+  return UTF8.encode(value).length
+}
+
+describe('gcal event entry naming', () => {
+  it('leads with the id', () => {
+    const name = makeEventFilename(EVENT_ID, '0900-1030', 'PhD_Defense')
+    expect(name).toBe(`${EVENT_ID}__0900-1030_PhD_Defense.gcal.json`)
+    expect(parseEventFilename(name)).toEqual([EVENT_ID, '0900-1030'])
+  })
+
+  it('round trips a title holding underscores', () => {
+    const name = makeEventFilename(EVENT_ID, '1500-1600', 'A__B_C')
+    expect(parseEventFilename(name)).toEqual([EVENT_ID, '1500-1600'])
+  })
+
+  it('rejects a non-event name', () => {
+    expect(() => parseEventFilename('notes.txt')).toThrow()
+    expect(() => parseEventFilename('noseparator.gcal.json')).toThrow()
+    expect(() => parseEventFilename(`${EVENT_ID}__090.gcal.json`)).toThrow()
+  })
+
+  it('trims a long ascii title to NAME_MAX', () => {
+    const name = makeEventFilename(EVENT_ID, '0900-1030', 'a'.repeat(400))
+    expect(byteLength(name)).toBeLessThanOrEqual(NAME_MAX_BYTES)
+    expect(parseEventFilename(name)).toEqual([EVENT_ID, '0900-1030'])
+  })
+
+  it('trims a long CJK title by bytes, not characters', () => {
+    // 3 bytes per character: a character-counted budget would overflow
+    // NAME_MAX, which is the bug gdocs' sanitizeTitle still has.
+    const name = makeEventFilename(EVENT_ID, '0900-1030', '会'.repeat(200))
+    expect(byteLength(name)).toBeLessThanOrEqual(NAME_MAX_BYTES)
+    expect(name).not.toContain('�')
+    expect(parseEventFilename(name)).toEqual([EVENT_ID, '0900-1030'])
+  })
+
+  it('drops the title when a long id leaves no room', () => {
+    // 234 is the widest id that still names an event: the title is
+    // squeezed out entirely and id + separators + suffix lands exactly on
+    // NAME_MAX.
+    const longId = 'v'.repeat(234)
+    const name = makeEventFilename(longId, '0900-1030', 'Some_Title')
+    expect(byteLength(name)).toBe(NAME_MAX_BYTES)
+    expect(name).toBe(`${longId}__0900-1030.gcal.json`)
+    expect(parseEventFilename(name)).toEqual([longId, '0900-1030'])
+  })
+
+  it('keeps an id too long to name rather than truncating it', () => {
+    // The title is what gives, never the id: a trimmed id would stop
+    // addressing the event. Real Google ids are 26 chars, so this only
+    // arises for a caller-supplied events.import id.
+    const longId = 'v'.repeat(NAME_MAX_BYTES - 20)
+    const name = makeEventFilename(longId, '0900-1030', 'Some Title')
+    expect(byteLength(name)).toBeGreaterThan(NAME_MAX_BYTES)
+    expect(parseEventFilename(name)).toEqual([longId, '0900-1030'])
+  })
+
+  it('falls back by access role', () => {
+    expect(eventTitle('Standup')).toBe('Standup')
+    expect(eventTitle(null)).toBe('untitled')
+    expect(eventTitle('   ')).toBe('untitled')
+    expect(eventTitle(null, true)).toBe('busy')
+  })
+
+  it('keeps the primary alias', () => {
+    expect(makeCalendarDirname('integ@example.com', 'integ@example.com', true)).toBe(PRIMARY_DIR)
+    expect(parseCalendarDirname(PRIMARY_DIR)).toBe(PRIMARY_DIR)
+  })
+
+  it('embeds the calendar id verbatim', () => {
+    const calId = 'en.usa#holiday@group.v.calendar.google.com'
+    const name = makeCalendarDirname('US Holidays', calId)
+    expect(name).toBe(`US_Holidays__${calId}`)
+    expect(parseCalendarDirname(name)).toBe(calId)
+  })
+
+  it('rejects a calendar dirname without an id', () => {
+    expect(() => parseCalendarDirname('Engineering')).toThrow()
+  })
+})

--- a/typescript/packages/core/src/resource/gcal/event_entry.ts
+++ b/typescript/packages/core/src/resource/gcal/event_entry.ts
@@ -14,7 +14,12 @@
 
 import { enoent } from '../../utils/errors.ts'
 import { makeIdName } from '../../utils/naming.ts'
-import { NAME_MAX_BYTES, sanitizeName, truncateBytes } from '../../utils/sanitize.ts'
+import {
+  NAME_MAX_BYTES,
+  sanitizeName,
+  stripTrailingUnderscores,
+  truncateBytes,
+} from '../../utils/sanitize.ts'
 
 const EVENT_SUFFIX = '.gcal.json'
 export const CALENDAR_FILE = 'calendar.json'
@@ -44,7 +49,7 @@ export function eventTitle(summary: string | null, freeBusy = false): string {
  */
 export function makeEventFilename(eventId: string, hhmm: string, title: string): string {
   const fixed = UTF8.encode(eventId).length + 2 + hhmm.length + 1 + EVENT_SUFFIX.length
-  const trimmed = truncateBytes(title, NAME_MAX_BYTES - fixed).replace(/_+$/u, '')
+  const trimmed = stripTrailingUnderscores(truncateBytes(title, NAME_MAX_BYTES - fixed))
   if (trimmed === '') {
     // The title is what gives, never the id: trimming the id would make the
     // name stop addressing the event, which is the whole reason it leads. An

--- a/typescript/packages/core/src/resource/gcal/event_entry.ts
+++ b/typescript/packages/core/src/resource/gcal/event_entry.ts
@@ -1,0 +1,99 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { enoent } from '../../utils/errors.ts'
+import { makeIdName } from '../../utils/naming.ts'
+import { NAME_MAX_BYTES, sanitizeName, truncateBytes } from '../../utils/sanitize.ts'
+
+const EVENT_SUFFIX = '.gcal.json'
+export const CALENDAR_FILE = 'calendar.json'
+export const PRIMARY_DIR = 'primary'
+// "HHMM-HHMM"
+const HHMM_LEN = 9
+const UNTITLED = 'untitled'
+// A freeBusyReader calendar returns availability with no summary at all, so
+// there is no title to sanitize and "busy" is the honest rendering.
+const BUSY = 'busy'
+
+const UTF8 = new TextEncoder()
+
+/** Pick the title segment for an event filename. */
+export function eventTitle(summary: string | null, freeBusy = false): string {
+  if (summary !== null && summary.trim() !== '') return sanitizeName(summary)
+  return freeBusy ? BUSY : UNTITLED
+}
+
+/**
+ * Build an event filename: id first, then the day-local times, then title.
+ *
+ * The id leads so that trimming the title can never make two events collide
+ * and so `ls <idprefix>*` addresses one event. Google event ids are 5-1024
+ * characters by spec (26 in practice), so the title takes whatever of the
+ * 255-byte NAME_MAX is left rather than a fixed character count.
+ */
+export function makeEventFilename(eventId: string, hhmm: string, title: string): string {
+  const fixed = UTF8.encode(eventId).length + 2 + hhmm.length + 1 + EVENT_SUFFIX.length
+  const trimmed = truncateBytes(title, NAME_MAX_BYTES - fixed).replace(/_+$/u, '')
+  if (trimmed === '') {
+    // The title is what gives, never the id: trimming the id would make the
+    // name stop addressing the event, which is the whole reason it leads. An
+    // id long enough that even this form overflows NAME_MAX is therefore
+    // unnameable rather than silently mangled. The spec permits one (ids run
+    // 5-1024 chars) but only a caller-supplied id from events.import can be
+    // that long; Google's own are 26.
+    return `${eventId}__${hhmm}${EVENT_SUFFIX}`
+  }
+  return `${eventId}__${hhmm}_${trimmed}${EVENT_SUFFIX}`
+}
+
+/**
+ * Recover `[eventId, hhmm]` from an event filename.
+ *
+ * Splitting on the first `__` is safe because a Google event id is base32hex
+ * and can hold neither an underscore nor a separator, while a title
+ * routinely holds both.
+ */
+export function parseEventFilename(name: string): [string, string] {
+  if (!name.endsWith(EVENT_SUFFIX)) throw enoent(name)
+  const raw = name.slice(0, -EVENT_SUFFIX.length)
+  const idx = raw.indexOf('__')
+  if (idx <= 0) throw enoent(name)
+  const rest = raw.slice(idx + 2)
+  if (rest.length < HHMM_LEN) throw enoent(name)
+  return [raw.slice(0, idx), rest.slice(0, HHMM_LEN)]
+}
+
+/**
+ * Build the directory name for one calendar.
+ *
+ * The primary calendar is spelled `primary` because that is the stable alias
+ * every Calendar API call accepts, and its summary is only the account's own
+ * email address.
+ */
+export function makeCalendarDirname(summary: string, calendarId: string, primary = false): string {
+  if (primary) return PRIMARY_DIR
+  return makeIdName(summary, calendarId)
+}
+
+/** Recover the calendar id a directory name addresses. */
+export function parseCalendarDirname(name: string): string {
+  if (name === PRIMARY_DIR) return PRIMARY_DIR
+  // lastIndexOf, not indexOf: a calendar id holds "@" and "." but the
+  // sanitized title before it may itself contain "__".
+  const idx = name.lastIndexOf('__')
+  if (idx === -1) throw enoent(name)
+  const calendarId = name.slice(idx + 2)
+  if (calendarId === '') throw enoent(name)
+  return calendarId
+}

--- a/typescript/packages/core/src/resource/gcal/prompt.ts
+++ b/typescript/packages/core/src/resource/gcal/prompt.ts
@@ -1,0 +1,58 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export const GCAL_PROMPT = `Google Calendar is mounted as one directory per calendar, one
+directory per local day, and one JSON file per event.
+
+    /<mount>/primary/calendar.json
+    /<mount>/primary/2026-08-11/<eventId>__0900-1030_Team_Standup.gcal.json
+    /<mount>/Engineering__team@group.calendar.google.com/2026-08-11/...
+
+Reading the tree:
+
+- \`ls <mount>/\` lists the calendars. The primary one is always spelled
+  \`primary\`; every other directory ends in \`__<calendarId>\`.
+- \`ls <mount>/primary/\` lists ONLY the days that have an event, and ONLY
+  within a rolling window around today (30 days back, 90 forward). This is
+  a window, not the whole calendar. To look outside it, glob a date:
+  \`ls <mount>/primary/2025-12-*\` pushes its own range down to the API.
+- Any well-formed date resolves even when it holds nothing, so
+  \`ls <mount>/primary/2027-03-04/\` succeeds and prints nothing. An empty
+  listing means the day is free, not that the day is missing.
+- A file name is \`<eventId>__<HHMM-HHMM>_<Title>.gcal.json\`. The times are
+  clamped to that day, so an event running through it reads \`0000-2400\`.
+  A multi-day event appears under every day it covers.
+- \`cat\` an event for the unmodified Calendar API payload, including
+  attendees, description, location and the original start/end with offsets.
+- \`calendar.json\` carries the calendar's accessRole and, in
+  \`bucketTimeZone\`, the zone the day directories are bucketed in. That zone
+  is mount-wide, so every calendar's \`2026-08-11/\` covers the same 24 hours.
+- On a calendar shared as free/busy only, Google returns no titles at all,
+  so events render as \`busy\`.
+
+Acting on it:
+
+- \`rm\` an event file to delete that event.
+- Everything else goes through the \`gws calendar\` CLI, which takes the ids
+  the tree renders:
+  \`gws calendar events insert --params '{"calendarId":"primary"}' --json ...\`
+  \`gws calendar events patch --params '{"calendarId":"primary","eventId":"..."}'\`
+  \`gws calendar freebusy query --json '{"timeMin":...,"timeMax":...,"items":[{"id":"primary"}]}'\`
+- A written event must carry an explicit UTC offset or timeZone; an
+  ambiguous local time is not interpreted for you.
+`
+
+export const GCAL_WRITE_PROMPT = `Deleting an event file removes it from the calendar for
+every attendee. Creating and editing events goes through \`gws calendar\`.
+`

--- a/typescript/packages/core/src/types.test.ts
+++ b/typescript/packages/core/src/types.test.ts
@@ -106,6 +106,7 @@ describe('ResourceName', () => {
       'disk',
       'dropbox',
       'email',
+      'gcal',
       'gcs',
       'gdocs',
       'gdrive',

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -16,6 +16,11 @@ import type { IndexCacheStore } from './cache/index/store.ts'
 import type { FindOptions } from './resource/base.ts'
 import { rstripSlash, stripSlash } from './utils/slash.ts'
 
+// Any value that survives a JSON round trip: what a decoded payload holds,
+// what jq evaluates over, what an API field hands back. The mirror of
+// python's mirage.types.JsonValue.
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [k: string]: JsonValue }
+
 export const MountMode = Object.freeze({
   READ: 'read',
   WRITE: 'write',
@@ -225,6 +230,7 @@ export const ResourceName = Object.freeze({
   RAM: 'ram',
   GITHUB: 'github',
   LINEAR: 'linear',
+  GCAL: 'gcal',
   GDOCS: 'gdocs',
   GSHEETS: 'gsheets',
   GSLIDES: 'gslides',

--- a/typescript/packages/core/src/utils/sanitize.ts
+++ b/typescript/packages/core/src/utils/sanitize.ts
@@ -22,7 +22,7 @@ const MAX_LEN = 100
 export const NAME_MAX_BYTES = 255
 
 const UTF8 = new TextEncoder()
-const UTF8_LOSSY = new TextDecoder('utf-8')
+const UTF8_DECODER = new TextDecoder('utf-8')
 
 /**
  * Trim a string to fit a byte budget without splitting a character.
@@ -34,9 +34,21 @@ export function truncateBytes(text: string, budget: number): string {
   if (budget <= 0) return ''
   const raw = UTF8.encode(text)
   if (raw.length <= budget) return text
-  // The decoder replaces the partial sequence the cut may have left with
-  // U+FFFD, which is exactly the trailing character that did not fit.
-  return UTF8_LOSSY.decode(raw.slice(0, budget)).replace(/�+$/u, '')
+  // Cut on a character boundary by walking back over continuation bytes
+  // (0b10xxxxxx), so the slice never ends mid-sequence and the decoder has
+  // nothing to replace. Decoding first and stripping U+FFFD afterwards
+  // needs an anchored `+` quantifier, which backtracks polynomially on an
+  // input the calendar controls.
+  let end = budget
+  while (end > 0 && ((raw[end] ?? 0) & 0xc0) === 0x80) end -= 1
+  return UTF8_DECODER.decode(raw.slice(0, end))
+}
+
+/** Trim trailing underscores, linearly. python's `str.rstrip("_")`. */
+export function stripTrailingUnderscores(value: string): string {
+  let end = value.length
+  while (end > 0 && value[end - 1] === '_') end -= 1
+  return value.slice(0, end)
 }
 
 export function stripUnderscores(value: string): string {

--- a/typescript/packages/core/src/utils/sanitize.ts
+++ b/typescript/packages/core/src/utils/sanitize.ts
@@ -16,6 +16,28 @@
 const UNSAFE_CHARS = /[^\p{L}\p{N}_\s\-.]/gu
 const MULTI_UNDERSCORE = /_+/g
 const MAX_LEN = 100
+// POSIX NAME_MAX on ext4 and APFS alike, and it counts BYTES. Truncating by
+// characters is the same number only for ASCII: a 100-character CJK title is
+// 300 bytes.
+export const NAME_MAX_BYTES = 255
+
+const UTF8 = new TextEncoder()
+const UTF8_LOSSY = new TextDecoder('utf-8')
+
+/**
+ * Trim a string to fit a byte budget without splitting a character.
+ *
+ * Returns `text` unchanged when it already fits, else the longest prefix
+ * whose UTF-8 encoding is at most `budget` bytes.
+ */
+export function truncateBytes(text: string, budget: number): string {
+  if (budget <= 0) return ''
+  const raw = UTF8.encode(text)
+  if (raw.length <= budget) return text
+  // The decoder replaces the partial sequence the cut may have left with
+  // U+FFFD, which is exactly the trailing character that did not fit.
+  return UTF8_LOSSY.decode(raw.slice(0, budget)).replace(/�+$/u, '')
+}
 
 export function stripUnderscores(value: string): string {
   let start = 0

--- a/typescript/packages/node/src/index.ts
+++ b/typescript/packages/node/src/index.ts
@@ -384,6 +384,13 @@ export {
   type GmailConfig,
   type GmailConfigRedacted,
 } from './resource/gmail/config.ts'
+export { GCalResource, type GCalResourceState } from './resource/gcal/gcal.ts'
+export {
+  normalizeGCalConfig,
+  redactGCalConfig,
+  type GCalConfig,
+  type GCalConfigRedacted,
+} from './resource/gcal/config.ts'
 export { EmailResource, type EmailResourceState } from './resource/email/email.ts'
 export {
   buildEmailConfig,

--- a/typescript/packages/node/src/resource/gcal/config.ts
+++ b/typescript/packages/node/src/resource/gcal/config.ts
@@ -1,0 +1,20 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export {
+  normalizeGoogleConfig as normalizeGCalConfig,
+  redactGoogleConfig as redactGCalConfig,
+  type GoogleConfig as GCalConfig,
+  type GoogleConfigRedacted as GCalConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/node/src/resource/gcal/gcal.ts
+++ b/typescript/packages/node/src/resource/gcal/gcal.ts
@@ -65,10 +65,6 @@ export class GCalResource extends BaseResource implements Resource {
     return Promise.resolve()
   }
 
-  close(): Promise<void> {
-    return Promise.resolve()
-  }
-
   commands(): readonly RegisteredCommand[] {
     return GCAL_COMMANDS
   }

--- a/typescript/packages/node/src/resource/gcal/gcal.ts
+++ b/typescript/packages/node/src/resource/gcal/gcal.ts
@@ -1,0 +1,120 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import {
+  BaseResource,
+  GCAL_COMMANDS,
+  GCAL_PROMPT,
+  GCAL_OPS,
+  GCAL_WRITE_PROMPT,
+  GCalAccessor,
+  PathSpec,
+  ResourceName,
+  TokenManager,
+  gcalRead,
+  gcalReaddir,
+  makeResolveGlob,
+  gcalStat,
+  mountKey,
+  mountPrefixOf,
+  type FileStat,
+  type RegisteredCommand,
+  type RegisteredOp,
+  type Resource,
+} from '@struktoai/mirage-core'
+import { redactGCalConfig, type GCalConfig, type GCalConfigRedacted } from './config.ts'
+
+const gcalResolveGlob = makeResolveGlob(gcalReaddir)
+
+export interface GCalResourceState {
+  type: string
+  config: GCalConfigRedacted
+}
+
+export class GCalResource extends BaseResource implements Resource {
+  readonly kind: string = ResourceName.GCAL
+  readonly cachesReads: boolean = true
+  // Shorter than the other Google mounts: a calendar is edited by other
+  // people and a day-long index would keep serving a schedule that has
+  // already moved.
+  override readonly indexTtl: number = 300
+  readonly prompt: string = GCAL_PROMPT
+  readonly writePrompt: string = GCAL_WRITE_PROMPT
+  readonly config: GCalConfig
+  readonly accessor: GCalAccessor
+
+  constructor(config: GCalConfig) {
+    super()
+    this.config = config
+    const tm = new TokenManager(config)
+    this.accessor = new GCalAccessor({ tokenManager: tm, config })
+  }
+
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  commands(): readonly RegisteredCommand[] {
+    return GCAL_COMMANDS
+  }
+
+  ops(): readonly RegisteredOp[] {
+    return GCAL_OPS
+  }
+
+  readFile(p: PathSpec): Promise<Uint8Array> {
+    return gcalRead(this.accessor, p, this.index)
+  }
+
+  readdir(p: PathSpec): Promise<string[]> {
+    return gcalReaddir(this.accessor, p, this.index)
+  }
+
+  stat(p: PathSpec): Promise<FileStat> {
+    return gcalStat(this.accessor, p, this.index)
+  }
+
+  glob(paths: readonly PathSpec[], prefix = ''): Promise<PathSpec[]> {
+    const effective =
+      prefix !== ''
+        ? paths.map((p) =>
+            mountPrefixOf(p.virtual, p.resourcePath) !== ''
+              ? p
+              : new PathSpec({
+                  virtual: p.virtual,
+                  directory: p.directory,
+                  ...(p.pattern !== null ? { pattern: p.pattern } : {}),
+                  resolved: p.resolved,
+                  resourcePath: mountKey(p.virtual, prefix),
+                }),
+          )
+        : paths
+    return gcalResolveGlob(this.accessor, effective, this.index)
+  }
+
+  getState(): Promise<GCalResourceState> {
+    return Promise.resolve({
+      type: this.kind,
+      config: redactGCalConfig(this.config),
+    })
+  }
+
+  loadState(_state: GCalResourceState): Promise<void> {
+    return Promise.resolve()
+  }
+}

--- a/typescript/packages/node/src/resource/registry.ts
+++ b/typescript/packages/node/src/resource/registry.ts
@@ -237,6 +237,11 @@ const REGISTRY: Record<string, ResourceFactory> = {
     const { normalizeGitHubCIConfig } = await import('./github_ci/config.ts')
     return new GitHubCIResource(normalizeGitHubCIConfig(config))
   },
+  gcal: async (config) => {
+    const { GCalResource } = await import('./gcal/gcal.ts')
+    const { normalizeGCalConfig } = await import('./gcal/config.ts')
+    return new GCalResource(normalizeGCalConfig(config))
+  },
   gdocs: async (config) => {
     const { GDocsResource } = await import('./gdocs/gdocs.ts')
     const { normalizeGDocsConfig } = await import('./gdocs/config.ts')


### PR DESCRIPTION
## Summary

- `gws calendar`: calendarList.list, calendars.get, events list/get/insert/patch/delete, freebusy.query
- `gws forms`: forms create/get/batchUpdate, responses list/get
- `routeCalendar` + `routeForms` in the integ GWS mock; `/reset` takes `calendarTimeZone` (defaults `Asia/Hong_Kong`, non-UTC so day-bucketing bugs surface)
- calendar/forms OAuth scopes in `scripts/google_oauth.py`

Both services go in as rows in the existing Discovery table, so this is wiring plus a base function each. No mount yet; that is the follow-up.

Two mock details that are deliberate: event ids are minted as 26-char base32hex because that is the real shape and a future gcal mount will put them in filenames, and a form is created through the Drive table so `formId == Drive file id` holds in the mock as it does on real Google.

## Test plan

- `pre-commit run --all-files` clean and idempotent
- python: 13194 passed, 0 failed
- typescript: all 7 packages green
- Exercised live against the mock through a real Workspace: overlap querying (a multi-day event lists under every day it spans), all-day `end.date` exclusivity, zoned midnight, `orderBy=startTime`, freeBusy, `q` search, 204 delete, and finding a form's id via `gws drive files list`