### PR TITLE
fix(notion): add GET /v1/comments, version the database object, align ntn API errors

### DIFF
--- a/integ/cli/ntn.json
+++ b/integ/cli/ntn.json
@@ -727,6 +727,175 @@
         "stdout": "a0000000-0000-4000-8000-000000000002\tRow page\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "ntn_api_comments_empty",
+      "seq": 566056,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/comments block_id==aaaa1111-2222-3333-4444-555566667777 | jq -r '.results | length'",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_comment_create",
+      "seq": 566057,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/comments -d '{\"parent\":{\"page_id\":\"aaaa1111-2222-3333-4444-555566667777\"},\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"sheet ready\"}}]}' | jq -r '.object, .parent.page_id, .rich_text[0].text.content'",
+      "expect": {
+        "exit": 0,
+        "stdout": "comment\naaaa1111-2222-3333-4444-555566667777\nsheet ready\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_comment_create_second",
+      "seq": 566058,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/comments -d '{\"parent\":{\"page_id\":\"aaaa1111-2222-3333-4444-555566667777\"},\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"second note\"}}]}' | jq -r '.object'",
+      "expect": {
+        "exit": 0,
+        "stdout": "comment\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_comments_list_in_write_order",
+      "seq": 566059,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/comments block_id==aaaa1111-2222-3333-4444-555566667777 | jq -r '(.results|length), .results[0].rich_text[0].text.content, .results[1].rich_text[0].text.content'",
+      "expect": {
+        "exit": 0,
+        "stdout": "2\nsheet ready\nsecond note\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_comments_page_size",
+      "seq": 566060,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/comments block_id==aaaa1111-2222-3333-4444-555566667777 page_size==1 | jq -r '(.results|length), .has_more, .next_cursor'",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\ntrue\n1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_comments_cursor",
+      "seq": 566061,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/comments block_id==aaaa1111-2222-3333-4444-555566667777 page_size==1 start_cursor==1 | jq -r '.results[0].rich_text[0].text.content, .has_more'",
+      "expect": {
+        "exit": 0,
+        "stdout": "second note\nfalse\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_database_legacy_version_has_properties",
+      "seq": 566062,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/databases/eeee1111-2222-3333-4444-555566667777 --notion-version 2022-06-28 | jq -r '.properties.Stage.select.options[].name'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Draft\nReview\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_database_legacy_version_has_no_data_sources",
+      "seq": 566063,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/databases/eeee1111-2222-3333-4444-555566667777 --notion-version 2022-06-28 | jq -r '.data_sources // \"absent\"'",
+      "expect": {
+        "exit": 0,
+        "stdout": "absent\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_database_default_version_has_no_properties",
+      "seq": 566064,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/databases/eeee1111-2222-3333-4444-555566667777 | jq -r '.properties // \"absent\"'",
+      "expect": {
+        "exit": 0,
+        "stdout": "absent\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_search_legacy_version_has_properties",
+      "seq": 566065,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/search --notion-version 2022-06-28 -d '{\"filter\":{\"property\":\"object\",\"value\":\"database\"}}' | jq -r '.results[0].properties.Stage.type'",
+      "expect": {
+        "exit": 0,
+        "stdout": "select\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_comments_missing_block_id",
+      "seq": 566066,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/comments",
+      "expect": {
+        "exit": 5,
+        "stdout": "",
+        "stderr": "error: Public API request failed (400 Bad Request validation_error): block_id should be a valid uuid.\n"
+      }
+    },
+    {
+      "id": "ntn_api_comments_unknown_block",
+      "seq": 566067,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/comments block_id==11111111-1111-1111-1111-111111111111",
+      "expect": {
+        "exit": 5,
+        "stdout": "",
+        "stderr": "error: Public API request failed (404 Not Found object_not_found): Could not find block with ID: 11111111-1111-1111-1111-111111111111. Make sure the relevant pages and databases are shared with your integration.\n"
+      }
+    },
+    {
+      "id": "ntn_datasources_query_unknown_id",
+      "seq": 566068,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn datasources query 11111111-1111-1111-1111-111111111111",
+      "expect": {
+        "exit": 5,
+        "stdout": "",
+        "stderr": "error: Public API request failed (404 Not Found object_not_found): Could not find data source with ID: 11111111-1111-1111-1111-111111111111. Make sure the relevant pages and databases are shared with your integration.\n  hint: Could not find a data source or database with ID `11111111-1111-1111-1111-111111111111`. Check that the ID or URL points to a data source or database shared with your integration.\n"
+      }
     }
   ]
 }

--- a/integ/server/notion_server.ts
+++ b/integ/server/notion_server.ts
@@ -38,8 +38,8 @@
 // unreachable.
 //
 // Not implemented yet, tracked as later phases: the remaining Notion
-// operations (users, comment listing, block get/update/delete, database create
-// and update, page properties), and filter/sorts on database query.
+// operations (users, block get/update, database create and update, page
+// properties), and filter/sorts on database query.
 
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
@@ -65,6 +65,12 @@ const DEFAULT_PORT = 5091
 // integ/runners/*/adapters, so it names the workspace the battery seeds.
 const DEFAULT_TOKEN = 'integ-test'
 const MAX_PAGE_SIZE = 100
+// The version mirage's own client and the ntn CLI both send, so an unversioned
+// request answers the way every in-repo caller expects.
+const DEFAULT_API_VERSION = '2025-09-03'
+// The generation that moved the column schema off the database and onto the
+// data source. Versions are ISO dates, so they order as strings.
+const DATA_SOURCE_VERSION = '2025-09-03'
 
 const MOUNT = '/notion'
 const PAGE_A = 'aaaa1111-2222-3333-4444-555566667777'
@@ -518,20 +524,28 @@ async function seed(db: PrismaClient, fx: Fixture, workspaceId: string): Promise
       },
     })
   }
-  position = 0
+  // Per parent, not a single running counter, because createComment numbers a
+  // new comment by its parent's existing count. A global counter left a seeded
+  // comment at a position a later write could duplicate and sort ahead of, so
+  // an agent that wrote a comment and read it back saw it above the ones that
+  // were already there.
+  const perParentComment = new Map<string, number>()
   for (const c of fx.comments) {
+    const parentId = c.parent.id ?? ''
+    const at = perParentComment.get(parentId) ?? 0
+    perParentComment.set(parentId, at + 1)
     await db.notionComment.create({
       data: {
         id: c.id,
         workspaceId,
         parentType: c.parent.type,
-        parentId: c.parent.id ?? '',
+        parentId,
         discussionId: c.discussion_id ?? `disc-${c.id}`,
         richTextJson: JSON.stringify(c.rich_text),
         createdTime: c.created_time ?? fx.defaults.created_time,
         lastEditedTime: c.last_edited_time ?? fx.defaults.last_edited_time,
         createdBy: c.created_by ?? fx.defaults.created_by,
-        position: position++,
+        position: at,
       },
     })
   }
@@ -571,6 +585,13 @@ function dataSourceIdOf(databaseId: string): string {
 // database id rides along because Notion kept emitting it through the
 // migration; storage still keys rows by database id, which is the same fact
 // one derivation away.
+//
+// Deliberately not versioned, unlike `databaseJson`: 2022-06-28 answers
+// `{type: "database_id", database_id}` with no data source, so a legacy caller
+// reads a parent shape its generation never had. Left as one shape on purpose,
+// because no in-repo or MCP caller reads `parent` off a row, and the divergence
+// is drawn from Notion's upgrade guide rather than probed against the real API
+// the way the schema behaviour was. Probe it before rendering both.
 function pageParentJson(parentType: string, parentId: string | null): Json {
   if (parentType !== 'database_id' || parentId === null) {
     return parentJson(parentType, parentId)
@@ -606,13 +627,26 @@ function dataSourceJson(row: DatabaseRow): Json {
 }
 
 // The 2025-09-03 database object is a container, not a schema: `properties`
-// moved to the data source and is deliberately absent here, so anything that
-// still reads a column list off a database fails loudly instead of silently
-// rendering an empty one.
-function databaseJson(row: DatabaseRow): Json {
+// moved to the data source and is deliberately absent there, so anything that
+// still reads a column list off a modern database fails loudly instead of
+// silently rendering an empty one.
+//
+// A 2022-06-28 caller gets the pre-split object back, because that is what real
+// Notion answers it with: upstream calls the new behavior a *repurposing* of
+// Retrieve a Database, and a connection on the old version "will continue to
+// work with existing databases that have a single data source". Answering one
+// shape to both versions is worse than either, and it cost a graded run: the
+// agent could not learn a select column's options, wrote a value outside them,
+// and Notion mints an unknown select option rather than rejecting it, so
+// nothing told it. `data_sources` is absent from that answer for the same
+// reason `properties` is absent from the modern one: the field did not exist
+// at that version.
+function databaseJson(row: DatabaseRow, version: string = DEFAULT_API_VERSION): Json {
   const out: Json = {
     object: 'database',
-    data_sources: [{ id: dataSourceIdOf(row.id), name: row.titleText }],
+    ...(version < DATA_SOURCE_VERSION
+      ? { properties: JSON.parse(row.propertiesJson) as Json }
+      : { data_sources: [{ id: dataSourceIdOf(row.id), name: row.titleText }] }),
     id: row.id,
     created_time: row.createdTime,
     last_edited_time: row.lastEditedTime,
@@ -802,6 +836,15 @@ function bearer(req: IncomingMessage): string {
   return auth.startsWith('Bearer ') ? auth.slice(7) : ''
 }
 
+// Notion answers each request in the shape of the version it carries, and the
+// two generations disagree about where a database's column schema lives, so
+// the header has to reach the renderer rather than being read once at startup.
+function apiVersion(req: IncomingMessage): string {
+  const header = req.headers['notion-version']
+  const value = Array.isArray(header) ? header[0] : header
+  return value === undefined || value === '' ? DEFAULT_API_VERSION : value
+}
+
 function asObject(value: unknown): Json {
   return typeof value === 'object' && value !== null ? (value as Json) : {}
 }
@@ -830,7 +873,12 @@ async function childrenOf(
   })) as BlockRow[]
 }
 
-async function searchResults(db: PrismaClient, workspaceId: string, args: Json): Promise<Json[]> {
+async function searchResults(
+  db: PrismaClient,
+  workspaceId: string,
+  args: Json,
+  version: string = DEFAULT_API_VERSION,
+): Promise<Json[]> {
   const filter = asObject(args.filter)
   const query = typeof args.query === 'string' ? args.query.toLowerCase() : ''
   const matches = (title: string): boolean => query === '' || title.toLowerCase().includes(query)
@@ -843,7 +891,9 @@ async function searchResults(db: PrismaClient, workspaceId: string, args: Json):
       orderBy: [{ position: 'asc' }, { id: 'asc' }],
     })) as DatabaseRow[]
     const kept = rows.filter((r) => matches(r.titleText))
-    return filter.value === 'data_source' ? kept.map(dataSourceJson) : kept.map(databaseJson)
+    return filter.value === 'data_source'
+      ? kept.map(dataSourceJson)
+      : kept.map((r) => databaseJson(r, version))
   }
   const rows = (await db.notionPage.findMany({
     where: { workspaceId, inTrash: false },
@@ -1162,6 +1212,40 @@ async function createComment(
   return { status: 200, json: commentJson(row) }
 }
 
+// The read half of the comment surface. Without it a scenario can only write:
+// an evaluator that grades what an agent said in a comment, or an agent that
+// leaves a link in one and reads it back, both need this and both used to hit
+// the route-not-found fallthrough.
+//
+// `block_id` names a page or a block, which is why existence is resolved
+// against both tables the way deleteBlock resolves its operand. Comments are
+// stored parented to a page today, so an existing block carrying none of them
+// answers with an empty list rather than a 404, since upstream 404s only when
+// the id itself is not shared with the integration.
+async function listComments(
+  db: PrismaClient,
+  workspaceId: string,
+  q: URLSearchParams,
+): Promise<Reply> {
+  const blockId = q.get('block_id') ?? ''
+  if (blockId === '') {
+    return apiError(400, 'validation_error', 'block_id should be a valid uuid.')
+  }
+  const page = await db.notionPage.findFirst({ where: { workspaceId, id: blockId } })
+  if (page === null) {
+    const block = await db.notionBlock.findFirst({ where: { workspaceId, id: blockId } })
+    if (block === null) return notFound('block', blockId)
+  }
+  // Upstream returns every discussion's comments in one ascending chronological
+  // flat list, distinguishable by discussion_id, rather than grouped by thread.
+  const rows = (await db.notionComment.findMany({
+    where: { workspaceId, parentId: blockId },
+    orderBy: [{ position: 'asc' }, { id: 'asc' }],
+  })) as CommentRow[]
+  const size = intOr(q.get('page_size'), MAX_PAGE_SIZE)
+  return { status: 200, json: pageOf(rows.map(commentJson), q.get('start_cursor'), size) }
+}
+
 // A child page is one object in two tables (see the schema's NotionPage note),
 // so trashing it has to move both rows: the NotionPage row is what /search and
 // a database query read, the NotionBlock row is what the parent's children
@@ -1375,7 +1459,7 @@ async function handle(
       where: { workspaceId: ws, id },
     })) as DatabaseRow | null
     if (row === null) return notFound('database', id)
-    return { status: 200, json: databaseJson(row) }
+    return { status: 200, json: databaseJson(row, apiVersion(req)) }
   }
 
   if (method === 'GET' && parts.length === 4 && parts[1] === 'blocks' && parts[3] === 'children') {
@@ -1385,7 +1469,7 @@ async function handle(
   }
 
   if (method === 'POST' && parts.length === 2 && parts[1] === 'search') {
-    const results = await searchResults(db, ws, body)
+    const results = await searchResults(db, ws, body, apiVersion(req))
     const size = intOr(body.page_size, MAX_PAGE_SIZE)
     return { status: 200, json: pageOf(results, cursorOf(body.start_cursor), size) }
   }
@@ -1413,6 +1497,10 @@ async function handle(
 
   if (method === 'DELETE' && parts.length === 3 && parts[1] === 'blocks') {
     return deleteBlock(db, ws, parts[2] ?? '')
+  }
+
+  if (method === 'GET' && parts.length === 2 && parts[1] === 'comments') {
+    return listComments(db, ws, q)
   }
 
   if (method === 'POST' && parts.length === 2 && parts[1] === 'comments') {
@@ -1547,6 +1635,10 @@ async function toolPayload(db: PrismaClient, name: string, args: Json): Promise<
       where: { workspaceId: ws, id },
     })) as DatabaseRow | null
     if (row === null) throw new Error(`mock notion: unknown database ${id}`)
+    // No version to read: a tool call carries no Notion-Version, and this arm
+    // exists to render byte-identically to the REST arm, which mirage's own
+    // 2025-09-03 client drives. An external MCP server that pins 2022-06-28
+    // reaches the fake over REST and gets that version's shape from there.
     return databaseJson(row)
   }
   if (name === 'API-retrieve-a-data-source') {

--- a/python/mirage/commands/cli/builtin/ntn/__init__.py
+++ b/python/mirage/commands/cli/builtin/ntn/__init__.py
@@ -12,10 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.commands.cli.builtin.ntn.api import api
 from mirage.commands.cli.builtin.ntn.auth.token import token
 from mirage.commands.cli.builtin.ntn.datasources.query import query
 from mirage.commands.cli.builtin.ntn.datasources.resolve import resolve
+from mirage.commands.cli.builtin.ntn.failure import guarded
 from mirage.commands.cli.builtin.ntn.pages.create import create
 from mirage.commands.cli.builtin.ntn.pages.edit import edit
 from mirage.commands.cli.builtin.ntn.pages.get import get
@@ -74,7 +77,7 @@ NTN = CLISpec(
         CLISpec(
             name="api",
             description="Call the public Notion API (beta)",
-            fn=api,
+            fn=partial(guarded, api),
             write=True,
             rest=API_PATH,
             options=(
@@ -95,7 +98,7 @@ NTN = CLISpec(
             subcommands=(CLISpec(
                 name="token",
                 description="Print the current authentication token",
-                fn=token,
+                fn=partial(guarded, token),
             ), ),
         ),
         CLISpec(
@@ -105,7 +108,7 @@ NTN = CLISpec(
                 CLISpec(
                     name="query",
                     description="Query pages in a data source",
-                    fn=query,
+                    fn=partial(guarded, query),
                     positional=(DATA_SOURCE_ID, ),
                     options=(
                         Option(long="--limit",
@@ -137,7 +140,7 @@ NTN = CLISpec(
                     name="resolve",
                     description=("Resolve a Notion database ID to its "
                                  "data source IDs"),
-                    fn=resolve,
+                    fn=partial(guarded, resolve),
                     positional=(DATABASE_ID, ),
                     options=(JSON_OUT, NOTION_VERSION),
                 ),
@@ -150,14 +153,14 @@ NTN = CLISpec(
                 CLISpec(
                     name="get",
                     description="Retrieve a page as Markdown",
-                    fn=get,
+                    fn=partial(guarded, get),
                     positional=(PAGE_ID, ),
                     options=(JSON_OUT, NOTION_VERSION),
                 ),
                 CLISpec(
                     name="create",
                     description="Create a page from Markdown content",
-                    fn=create,
+                    fn=partial(guarded, create),
                     write=True,
                     options=(
                         CONTENT,
@@ -174,7 +177,7 @@ NTN = CLISpec(
                 CLISpec(
                     name="edit",
                     description="Edit a page's content from Markdown",
-                    fn=edit,
+                    fn=partial(guarded, edit),
                     write=True,
                     positional=(PAGE_ID, ),
                     options=(CONTENT, JSON_OUT, NOTION_VERSION),
@@ -182,7 +185,7 @@ NTN = CLISpec(
                 CLISpec(
                     name="trash",
                     description="Trash a page",
-                    fn=trash,
+                    fn=partial(guarded, trash),
                     write=True,
                     positional=(PAGE_ID, ),
                     options=(
@@ -197,7 +200,7 @@ NTN = CLISpec(
         CLISpec(
             name="whoami",
             description="Show the authenticated Notion user",
-            fn=whoami,
+            fn=partial(guarded, whoami),
             options=(JSON_OUT, PLAIN, NOTION_VERSION),
         ),
     ),

--- a/python/mirage/commands/cli/builtin/ntn/datasources/query.py
+++ b/python/mirage/commands/cli/builtin/ntn/datasources/query.py
@@ -14,6 +14,7 @@
 
 from typing import Any
 
+from mirage.commands.cli.builtin.ntn.failure import HintedAPIError, source_hint
 from mirage.commands.cli.builtin.ntn.util import (first_text, notion_config,
                                                   parse_json_text, pretty_json,
                                                   property_cell)
@@ -84,7 +85,18 @@ async def resolve_source(config: NotionConfig, ref: str) -> dict[str, Any]:
     except NotionAPIError as miss:
         if miss.status != 404:
             raise
-    database = await get_database(config, ref)
+        first = miss
+    # The database endpoint is a fallback, so its own 404 is not the
+    # answer to report: upstream names the *data source* the operand
+    # failed to be and adds one hint covering both, where reporting the
+    # second miss would tell the user their data source id is not a
+    # database id, which they never claimed it was.
+    try:
+        database = await get_database(config, ref)
+    except NotionAPIError as second:
+        if second.status != 404:
+            raise
+        raise HintedAPIError(first, source_hint(ref)) from second
     stubs = database.get("data_sources") or []
     if not stubs or not isinstance(stubs[0], dict):
         raise UsageError(f"database {ref} has no data sources")

--- a/python/mirage/commands/cli/builtin/ntn/failure.py
+++ b/python/mirage/commands/cli/builtin/ntn/failure.py
@@ -1,0 +1,133 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import Awaitable, Callable
+
+from mirage.commands.cli.types import CLIInvocation
+from mirage.core.notion._client import NotionAPIError
+from mirage.core.notion.config import NotionConfig
+from mirage.io.types import ByteSource, IOResult
+
+VerbFn = Callable[[CLIInvocation[NotionConfig]],
+                  Awaitable[tuple[ByteSource | None, IOResult]]]
+
+FAILED = "error: Public API request failed"
+# 401 is the one status upstream does not itemize: it drops the
+# parenthesis entirely and answers with an actionable hint and its own
+# exit code, because a token problem is the user's to fix and naming
+# `unauthorized` twice would not help them do it.
+UNAUTHORIZED_HINT = ("  hint: Set NOTION_API_TOKEN, or run `ntn login` to "
+                     "reuse a saved workspace token.\n")
+API_ERROR_EXIT = 5
+UNAUTHORIZED_EXIT = 4
+UNAUTHORIZED = 401
+
+# Upstream is a Rust program and renders the reason phrase from its http
+# crate's full table, but only the statuses Notion itself documents can
+# reach a caller, so those are the ones pinned here (probed one by one
+# against ntn 0.21.9). An unlisted status keeps the number and drops the
+# phrase rather than inventing one.
+HTTP_REASON = {
+    400: "Bad Request",
+    403: "Forbidden",
+    404: "Not Found",
+    409: "Conflict",
+    429: "Too Many Requests",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+}
+
+
+class HintedAPIError(NotionAPIError):
+    """An API failure a verb has its own second line for.
+
+    Upstream pairs some refusals with a `  hint:` line naming what the
+    operand could have been, which is the verb's knowledge rather than
+    the transport's, so it is attached here instead of in the client.
+
+    Args:
+        base (NotionAPIError): the failure as the client raised it.
+        hint (str): the complete hint line, newline included.
+    """
+
+    def __init__(self, base: NotionAPIError, hint: str) -> None:
+        super().__init__(str(base), status=base.status, code=base.code)
+        self.hint = hint
+
+
+def source_hint(ref: str) -> str:
+    """Upstream's hint for an operand that was neither kind of id.
+
+    Args:
+        ref (str): the id the operand reduced to.
+
+    Returns:
+        str: the complete hint line, newline included.
+    """
+    return (f"  hint: Could not find a data source or database with ID "
+            f"`{ref}`. Check that the ID or URL points to a data source or "
+            f"database shared with your integration.\n")
+
+
+def api_failure(exc: NotionAPIError) -> tuple[str, int]:
+    """Render an API failure the way the real ntn binary renders it.
+
+    Args:
+        exc (NotionAPIError): the failure raised by the notion client.
+
+    Returns:
+        tuple[str, int]: the complete stderr text and the exit status.
+    """
+    hint = exc.hint if isinstance(exc, HintedAPIError) else ""
+    if exc.status == UNAUTHORIZED:
+        return f"{FAILED}: {exc}\n{UNAUTHORIZED_HINT}", UNAUTHORIZED_EXIT
+    named = []
+    if exc.status is not None:
+        named.append(str(exc.status))
+        reason = HTTP_REASON.get(exc.status)
+        if reason is not None:
+            named.append(reason)
+    if exc.code is not None:
+        named.append(exc.code)
+    detail = f" ({' '.join(named)})" if named else ""
+    return f"{FAILED}{detail}: {exc}\n{hint}", API_ERROR_EXIT
+
+
+async def guarded(
+        fn: VerbFn, inv: CLIInvocation[NotionConfig]
+) -> tuple[ByteSource | None, IOResult]:
+    """Run one ntn verb, answering an API failure in upstream's voice.
+
+    Every leaf is wrapped with this in the tree, because the executor's
+    own fallback prints `ntn <verb>: <message>` and exits 1 (the GNU
+    shape it owes every other CLI), which drops the status, the reason
+    phrase and Notion's machine-readable code: exactly the three fields
+    a caller branches on. `tests/commands/cli/builtin/ntn/test_failure.py`
+    fails if a leaf is left unwrapped.
+
+    Args:
+        fn (VerbFn): the leaf handler being guarded.
+        inv (CLIInvocation): the line's one invocation record.
+
+    Returns:
+        tuple[ByteSource | None, IOResult]: the verb's own output, or the
+            rendered failure.
+    """
+    try:
+        return await fn(inv)
+    except NotionAPIError as failed:
+        stderr, code = api_failure(failed)
+        return None, IOResult(stderr=stderr.encode(), exit_code=code)

--- a/python/tests/commands/cli/builtin/ntn/test_failure.py
+++ b/python/tests/commands/cli/builtin/ntn/test_failure.py
@@ -1,0 +1,162 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from functools import partial
+
+import pytest
+
+from mirage.commands.cli.builtin.ntn import NTN
+from mirage.commands.cli.builtin.ntn.failure import (HintedAPIError,
+                                                     api_failure, guarded,
+                                                     source_hint)
+from mirage.commands.cli.types import CLISpec
+from mirage.core.notion._client import NotionAPIError
+from mirage.io.types import IOResult
+
+# Every line here was printed by ntn 0.21.9 against a server returning that
+# status with Notion's own error envelope. The two shapes upstream has for a
+# missing message (it echoes the raw body instead) are absent on purpose: the
+# client synthesizes a message before raising, so they cannot be reached.
+PROBED = [
+    (400, "validation_error", "block_id should be a valid uuid.",
+     "error: Public API request failed (400 Bad Request validation_error): "
+     "block_id should be a valid uuid.\n", 5),
+    (403, "restricted_resource", "sample message.",
+     "error: Public API request failed (403 Forbidden restricted_resource): "
+     "sample message.\n", 5),
+    (404, "object_not_found", "Could not find block with ID: x.",
+     "error: Public API request failed (404 Not Found object_not_found): "
+     "Could not find block with ID: x.\n", 5),
+    (409, "conflict_error", "sample message.",
+     "error: Public API request failed (409 Conflict conflict_error): "
+     "sample message.\n", 5),
+    (429, "rate_limited", "sample message.",
+     "error: Public API request failed (429 Too Many Requests rate_limited): "
+     "sample message.\n", 5),
+    (500, "internal_server_error", "sample message.",
+     "error: Public API request failed "
+     "(500 Internal Server Error internal_server_error): sample message.\n",
+     5),
+    (502, "bad_gateway", "sample message.",
+     "error: Public API request failed (502 Bad Gateway bad_gateway): "
+     "sample message.\n", 5),
+    (503, "service_unavailable", "sample message.",
+     "error: Public API request failed "
+     "(503 Service Unavailable service_unavailable): sample message.\n", 5),
+    (504, "gateway_timeout", "sample message.",
+     "error: Public API request failed (504 Gateway Timeout gateway_timeout): "
+     "sample message.\n", 5),
+]
+
+
+@pytest.mark.parametrize("status,code,message,stderr,exit_code", PROBED)
+def test_api_failure_matches_the_real_cli(status: int, code: str, message: str,
+                                          stderr: str, exit_code: int) -> None:
+    failed = NotionAPIError(message, status=status, code=code)
+    assert api_failure(failed) == (stderr, exit_code)
+
+
+def test_unauthorized_drops_the_parenthesis_and_exits_four() -> None:
+    # Upstream's one special case: a token problem is the user's to fix, so it
+    # answers with a hint instead of itemizing a status it already implied.
+    failed = NotionAPIError("API token is invalid.",
+                            status=401,
+                            code="unauthorized")
+    stderr, code = api_failure(failed)
+    assert stderr == ("error: Public API request failed: API token is "
+                      "invalid.\n  hint: Set NOTION_API_TOKEN, or run `ntn "
+                      "login` to reuse a saved workspace token.\n")
+    assert code == 4
+
+
+def test_missing_code_keeps_the_status_and_reason() -> None:
+    failed = NotionAPIError("no code here.", status=404)
+    assert api_failure(failed) == (
+        "error: Public API request failed (404 Not Found): no code here.\n", 5)
+
+
+def test_unlisted_status_keeps_the_number_and_drops_the_phrase() -> None:
+    failed = NotionAPIError("odd one.", status=418, code="teapot")
+    assert api_failure(failed) == (
+        "error: Public API request failed (418 teapot): odd one.\n", 5)
+
+
+def test_hint_rides_the_same_render() -> None:
+    base = NotionAPIError("Could not find data source with ID: y.",
+                          status=404,
+                          code="object_not_found")
+    stderr, code = api_failure(HintedAPIError(base, source_hint("y")))
+    assert stderr == (
+        "error: Public API request failed (404 Not Found object_not_found): "
+        "Could not find data source with ID: y.\n  hint: Could not find a "
+        "data source or database with ID `y`. Check that the ID or URL points "
+        "to a data source or database shared with your integration.\n")
+    assert code == 5
+
+
+@pytest.mark.asyncio
+async def test_guarded_renders_an_api_error_and_passes_others_through(
+) -> None:
+    caught = await guarded(_raise_api, None)
+    assert caught[0] is None
+    assert caught[1].exit_code == 5
+    with pytest.raises(ValueError):
+        await guarded(_raise_other, None)
+
+
+@pytest.mark.asyncio
+async def test_guarded_returns_a_successful_verb_untouched() -> None:
+    assert await guarded(_succeed, None) == (None, _OK)
+
+
+def test_every_ntn_leaf_is_guarded() -> None:
+    # The wrap is the whole mechanism, so a verb added without it still runs,
+    # still exits 0 on success, and simply reports its API failures in the
+    # executor's generic shape, which nothing notices until someone reads a
+    # 404 from it.
+    unguarded = [
+        " ".join(path) for path, leaf in _leaves(NTN, ())
+        if not _is_guarded(leaf)
+    ]
+    assert unguarded == []
+
+
+_OK = IOResult()
+
+
+async def _raise_api(_inv: None) -> tuple[None, IOResult]:
+    raise NotionAPIError("boom.", status=404, code="object_not_found")
+
+
+async def _raise_other(_inv: None) -> tuple[None, IOResult]:
+    raise ValueError("not an API failure")
+
+
+async def _succeed(_inv: None) -> tuple[None, IOResult]:
+    return None, _OK
+
+
+def _leaves(node: CLISpec,
+            path: tuple[str, ...]) -> list[tuple[tuple[str, ...], CLISpec]]:
+    here = path + (node.name, )
+    if node.fn is not None:
+        return [(here, node)]
+    found: list[tuple[tuple[str, ...], CLISpec]] = []
+    for child in node.subcommands:
+        found.extend(_leaves(child, here))
+    return found
+
+
+def _is_guarded(leaf: CLISpec) -> bool:
+    return isinstance(leaf.fn, partial) and leaf.fn.func is guarded

--- a/python/tests/commands/cli/builtin/ntn/test_tree.py
+++ b/python/tests/commands/cli/builtin/ntn/test_tree.py
@@ -36,6 +36,20 @@ def leaf(*path: str):
     return node
 
 
+def verb(*path: str):
+    """The handler a leaf wraps, for patching the module it lives in.
+
+    Every ntn leaf is registered as ``partial(guarded, verb)`` so an API
+    failure answers in upstream's voice, which puts the partial where the
+    function used to be. Reach through it the same way a ``@command``
+    wrapper is reached through ``__wrapped__``.
+
+    Args:
+        path (str): the subcommand words under the root.
+    """
+    return leaf(*path).fn.args[0]
+
+
 def test_tree_shape_matches_the_official_grammar():
     assert NTN.name == "ntn"
     assert NTN.config_model is NotionConfig
@@ -133,7 +147,7 @@ async def test_page_id_is_taken_from_the_operand(monkeypatch):
         return {"id": page_id}
 
     monkeypatch.setitem(
-        leaf("pages", "trash").fn.__globals__, "update_page", fake_update)
+        verb("pages", "trash").__globals__, "update_page", fake_update)
     ws = Workspace({})
     ws.register_cli("ntn", NTN, CONFIG)
     io = await ws.execute("ntn pages trash P9 --yes")

--- a/typescript/packages/core/src/commands/cli/builtin/ntn/datasources/query.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/ntn/datasources/query.ts
@@ -14,6 +14,7 @@
 
 import { FlagView } from '../../../../spec/types.ts'
 import { NotionAPIError, type NotionTransport } from '../../../../../core/notion/_client.ts'
+import { HintedAPIError, sourceHint } from '../failure.ts'
 import {
   getDataSource,
   getDatabase,
@@ -76,12 +77,24 @@ async function resolveSource(
   transport: NotionTransport,
   ref: string,
 ): Promise<Record<string, unknown>> {
+  let first: NotionAPIError
   try {
     return await getDataSource(transport, ref)
   } catch (err) {
     if (!(err instanceof NotionAPIError) || err.status !== 404) throw err
+    first = err
   }
-  const database = await getDatabase(transport, ref)
+  // The database endpoint is a fallback, so its own 404 is not the answer to
+  // report: upstream names the *data source* the operand failed to be and adds
+  // one hint covering both, where reporting the second miss would tell the user
+  // their data source id is not a database id, which they never claimed it was.
+  let database: Record<string, unknown>
+  try {
+    database = await getDatabase(transport, ref)
+  } catch (err) {
+    if (!(err instanceof NotionAPIError) || err.status !== 404) throw err
+    throw new HintedAPIError(first, sourceHint(ref))
+  }
   const stubs: unknown[] = Array.isArray(database.data_sources) ? database.data_sources : []
   const head = stubs[0]
   if (head === undefined) throw new Error(`database ${ref} has no data sources`)

--- a/typescript/packages/core/src/commands/cli/builtin/ntn/failure.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/ntn/failure.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { NotionAPIError } from '../../../../core/notion/_client.ts'
-import { IOResult, type ByteSource } from '../../../../io/types.ts'
+import { IOResult } from '../../../../io/types.ts'
 import type { CLISpec } from '../../types.ts'
 import { NTN } from './index.ts'
 import { GUARDED, HintedAPIError, apiFailure, guarded, sourceHint } from './failure.ts'
@@ -141,7 +141,11 @@ describe('guarded', () => {
     const wrapped = guarded(() => {
       throw new NotionAPIError('boom.', 404, 'object_not_found')
     })
-    const [stdout, io]: [ByteSource | null, IOResult] = await wrapped({} as never)
+    // A verb may return null instead of a pair, so narrow before destructuring:
+    // guarded answering null would mean it swallowed the failure.
+    const caught = await wrapped({} as never)
+    if (caught === null) throw new Error('guarded returned no result')
+    const [stdout, io] = caught
     expect(stdout).toBeNull()
     expect(io.exitCode).toBe(5)
     expect(DEC.decode(io.stderr as Uint8Array)).toContain('404 Not Found object_not_found')

--- a/typescript/packages/core/src/commands/cli/builtin/ntn/failure.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/ntn/failure.test.ts
@@ -1,0 +1,179 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { NotionAPIError } from '../../../../core/notion/_client.ts'
+import { IOResult, type ByteSource } from '../../../../io/types.ts'
+import type { CLISpec } from '../../types.ts'
+import { NTN } from './index.ts'
+import { GUARDED, HintedAPIError, apiFailure, guarded, sourceHint } from './failure.ts'
+
+const DEC = new TextDecoder()
+
+// Every line here was printed by ntn 0.21.9 against a server returning that
+// status with Notion's own error envelope. The two shapes upstream has for a
+// missing message (it echoes the raw body instead) are absent on purpose: the
+// client synthesizes a message before raising, so they cannot be reached.
+const PROBED: [number, string, string, string][] = [
+  [
+    400,
+    'validation_error',
+    'block_id should be a valid uuid.',
+    'error: Public API request failed (400 Bad Request validation_error): block_id should be a valid uuid.\n',
+  ],
+  [
+    403,
+    'restricted_resource',
+    'sample message.',
+    'error: Public API request failed (403 Forbidden restricted_resource): sample message.\n',
+  ],
+  [
+    404,
+    'object_not_found',
+    'Could not find block with ID: x.',
+    'error: Public API request failed (404 Not Found object_not_found): Could not find block with ID: x.\n',
+  ],
+  [
+    409,
+    'conflict_error',
+    'sample message.',
+    'error: Public API request failed (409 Conflict conflict_error): sample message.\n',
+  ],
+  [
+    429,
+    'rate_limited',
+    'sample message.',
+    'error: Public API request failed (429 Too Many Requests rate_limited): sample message.\n',
+  ],
+  [
+    500,
+    'internal_server_error',
+    'sample message.',
+    'error: Public API request failed (500 Internal Server Error internal_server_error): sample message.\n',
+  ],
+  [
+    502,
+    'bad_gateway',
+    'sample message.',
+    'error: Public API request failed (502 Bad Gateway bad_gateway): sample message.\n',
+  ],
+  [
+    503,
+    'service_unavailable',
+    'sample message.',
+    'error: Public API request failed (503 Service Unavailable service_unavailable): sample message.\n',
+  ],
+  [
+    504,
+    'gateway_timeout',
+    'sample message.',
+    'error: Public API request failed (504 Gateway Timeout gateway_timeout): sample message.\n',
+  ],
+]
+
+// An absent handler is null here, not undefined, so the walk tests for a
+// callable: `!== undefined` matched the root and made the whole check vacuous.
+function leaves(node: CLISpec, path: string[]): [string, CLISpec][] {
+  const here = [...path, node.name]
+  if (typeof node.fn === 'function') return [[here.join(' '), node]]
+  return node.subcommands.flatMap((child) => leaves(child, here))
+}
+
+describe('ntn api failures speak upstream', () => {
+  it.each(PROBED)('renders %i like the real CLI', (status, code, message, stderr) => {
+    expect(apiFailure(new NotionAPIError(message, status, code))).toEqual([stderr, 5])
+  })
+
+  it('drops the parenthesis and exits 4 on 401', () => {
+    // Upstream's one special case: a token problem is the user's to fix, so it
+    // answers with a hint instead of itemizing a status it already implied.
+    const failed = new NotionAPIError('API token is invalid.', 401, 'unauthorized')
+    expect(apiFailure(failed)).toEqual([
+      'error: Public API request failed: API token is invalid.\n' +
+        '  hint: Set NOTION_API_TOKEN, or run `ntn login` to reuse a saved workspace token.\n',
+      4,
+    ])
+  })
+
+  it('keeps the status and reason when the body carried no code', () => {
+    expect(apiFailure(new NotionAPIError('no code here.', 404))).toEqual([
+      'error: Public API request failed (404 Not Found): no code here.\n',
+      5,
+    ])
+  })
+
+  it('keeps the number and drops the phrase for an unlisted status', () => {
+    expect(apiFailure(new NotionAPIError('odd one.', 418, 'teapot'))).toEqual([
+      'error: Public API request failed (418 teapot): odd one.\n',
+      5,
+    ])
+  })
+
+  it('rides a verb hint on the same render', () => {
+    const base = new NotionAPIError(
+      'Could not find data source with ID: y.',
+      404,
+      'object_not_found',
+    )
+    expect(apiFailure(new HintedAPIError(base, sourceHint('y')))).toEqual([
+      'error: Public API request failed (404 Not Found object_not_found): ' +
+        'Could not find data source with ID: y.\n  hint: Could not find a data source or ' +
+        'database with ID `y`. Check that the ID or URL points to a data source or database ' +
+        'shared with your integration.\n',
+      5,
+    ])
+  })
+})
+
+describe('guarded', () => {
+  it('renders an API error and passes anything else through', async () => {
+    const wrapped = guarded(() => {
+      throw new NotionAPIError('boom.', 404, 'object_not_found')
+    })
+    const [stdout, io]: [ByteSource | null, IOResult] = await wrapped({} as never)
+    expect(stdout).toBeNull()
+    expect(io.exitCode).toBe(5)
+    expect(DEC.decode(io.stderr as Uint8Array)).toContain('404 Not Found object_not_found')
+
+    const other = guarded(() => {
+      throw new TypeError('not an API failure')
+    })
+    await expect(other({} as never)).rejects.toThrow(TypeError)
+  })
+
+  it('returns a successful verb untouched', async () => {
+    const ok = new IOResult()
+    const wrapped = guarded(() => [null, ok])
+    expect(await wrapped({} as never)).toEqual([null, ok])
+  })
+})
+
+describe('the tree', () => {
+  it('guards every leaf', () => {
+    // The wrap is the whole mechanism, so a verb added without it still runs,
+    // still exits 0 on success, and simply reports its API failures in the
+    // executor's generic shape, which nothing notices until someone reads a
+    // 404 from it.
+    const unguarded = leaves(NTN, [])
+      .filter(([, leaf]) => (leaf.fn as unknown as Record<symbol, unknown>)[GUARDED] !== true)
+      .map(([name]) => name)
+    expect(unguarded).toEqual([])
+  })
+
+  it('finds the leaves it claims to check', () => {
+    // Guards the guard: an empty walk would make the assertion above vacuous.
+    expect(leaves(NTN, []).map(([name]) => name)).toContain('ntn api')
+    expect(leaves(NTN, []).length).toBe(9)
+  })
+})

--- a/typescript/packages/core/src/commands/cli/builtin/ntn/failure.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/ntn/failure.ts
@@ -1,0 +1,113 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { CommandFnResult } from '../../../config.ts'
+import { IOResult } from '../../../../io/types.ts'
+import { NotionAPIError } from '../../../../core/notion/_client.ts'
+import type { CLIInvocation, CLIVerbFn } from '../../types.ts'
+
+const ENC = new TextEncoder()
+
+const FAILED = 'error: Public API request failed'
+// 401 is the one status upstream does not itemize: it drops the parenthesis
+// entirely and answers with an actionable hint and its own exit code, because a
+// token problem is the user's to fix and naming `unauthorized` twice would not
+// help them do it.
+const UNAUTHORIZED_HINT =
+  '  hint: Set NOTION_API_TOKEN, or run `ntn login` to reuse a saved workspace token.\n'
+const API_ERROR_EXIT = 5
+const UNAUTHORIZED_EXIT = 4
+const UNAUTHORIZED = 401
+
+// Upstream is a Rust program and renders the reason phrase from its http
+// crate's full table, but only the statuses Notion itself documents can reach a
+// caller, so those are the ones pinned here (probed one by one against ntn
+// 0.21.9). An unlisted status keeps the number and drops the phrase rather than
+// inventing one. Spelled out instead of read from node:http because core runs
+// in the browser too.
+const HTTP_REASON: Record<number, string> = {
+  400: 'Bad Request',
+  403: 'Forbidden',
+  404: 'Not Found',
+  409: 'Conflict',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+}
+
+// An API failure a verb has its own second line for. Upstream pairs some
+// refusals with a `  hint:` line naming what the operand could have been, which
+// is the verb's knowledge rather than the transport's, so it is attached here
+// instead of in the client.
+export class HintedAPIError extends NotionAPIError {
+  constructor(
+    base: NotionAPIError,
+    public readonly hint: string,
+  ) {
+    super(base.message, base.status, base.code)
+    this.name = 'HintedAPIError'
+  }
+}
+
+// Upstream's hint for an operand that was neither kind of id.
+export function sourceHint(ref: string): string {
+  return (
+    `  hint: Could not find a data source or database with ID \`${ref}\`. ` +
+    `Check that the ID or URL points to a data source or database shared with ` +
+    `your integration.\n`
+  )
+}
+
+// Render an API failure the way the real ntn binary renders it.
+export function apiFailure(err: NotionAPIError): [string, number] {
+  const hint = err instanceof HintedAPIError ? err.hint : ''
+  if (err.status === UNAUTHORIZED) {
+    return [`${FAILED}: ${err.message}\n${UNAUTHORIZED_HINT}`, UNAUTHORIZED_EXIT]
+  }
+  const named: string[] = []
+  if (err.status !== null) {
+    named.push(String(err.status))
+    const reason = HTTP_REASON[err.status]
+    if (reason !== undefined) named.push(reason)
+  }
+  if (err.code !== null) named.push(err.code)
+  const detail = named.length > 0 ? ` (${named.join(' ')})` : ''
+  return [`${FAILED}${detail}: ${err.message}\n${hint}`, API_ERROR_EXIT]
+}
+
+// Stamped on the wrapper so the invariant below is checkable rather than
+// inferred: python reads it off `partial.func`, and a wrapper closure has no
+// equivalent to read, so it carries the fact instead.
+export const GUARDED = Symbol.for('ntn.guarded')
+
+// Run one ntn verb, answering an API failure in upstream's voice. Every leaf is
+// wrapped with this in the tree, because the executor's own fallback prints
+// `ntn <verb>: <message>` and exits 1 (the GNU shape it owes every other CLI),
+// which drops the status, the reason phrase and Notion's machine-readable code:
+// exactly the three fields a caller branches on. failure.test.ts fails if a
+// leaf is left unwrapped.
+export function guarded(fn: CLIVerbFn): CLIVerbFn {
+  const wrapped = async (inv: CLIInvocation): Promise<CommandFnResult> => {
+    try {
+      return await fn(inv)
+    } catch (err) {
+      if (!(err instanceof NotionAPIError)) throw err
+      const [stderr, exitCode] = apiFailure(err)
+      return [null, new IOResult({ stderr: ENC.encode(stderr), exitCode })]
+    }
+  }
+  return Object.assign(wrapped, { [GUARDED]: true })
+}

--- a/typescript/packages/core/src/commands/cli/builtin/ntn/index.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/ntn/index.ts
@@ -17,6 +17,7 @@ import { registerCliSpec } from '../../specs.ts'
 import { CLISpec } from '../../types.ts'
 import { Operand, Option, UsageStyle } from '../../../spec/types.ts'
 import { api } from './api.ts'
+import { guarded } from './failure.ts'
 import { token } from './auth/token.ts'
 import { query } from './datasources/query.ts'
 import { resolve } from './datasources/resolve.ts'
@@ -81,7 +82,7 @@ export const NTN = new CLISpec({
     new CLISpec({
       name: 'api',
       description: 'Call the public Notion API (beta)',
-      fn: api,
+      fn: guarded(api),
       write: true,
       rest: API_PATH,
       options: [
@@ -107,7 +108,7 @@ export const NTN = new CLISpec({
         new CLISpec({
           name: 'token',
           description: 'Print the current authentication token',
-          fn: token,
+          fn: guarded(token),
         }),
       ],
     }),
@@ -118,7 +119,7 @@ export const NTN = new CLISpec({
         new CLISpec({
           name: 'query',
           description: 'Query pages in a data source',
-          fn: query,
+          fn: guarded(query),
           positional: [DATA_SOURCE_ID],
           options: [
             new Option({ long: '--limit', type: 'int', description: 'Maximum rows to return' }),
@@ -155,7 +156,7 @@ export const NTN = new CLISpec({
         new CLISpec({
           name: 'resolve',
           description: 'Resolve a Notion database ID to its data source IDs',
-          fn: resolve,
+          fn: guarded(resolve),
           positional: [DATABASE_ID],
           options: [jsonOut(), notionVersion()],
         }),
@@ -168,14 +169,14 @@ export const NTN = new CLISpec({
         new CLISpec({
           name: 'get',
           description: 'Retrieve a page as Markdown',
-          fn: get,
+          fn: guarded(get),
           positional: [PAGE_ID],
           options: [jsonOut(), notionVersion()],
         }),
         new CLISpec({
           name: 'create',
           description: 'Create a page from Markdown content',
-          fn: create,
+          fn: guarded(create),
           write: true,
           options: [
             content(),
@@ -191,7 +192,7 @@ export const NTN = new CLISpec({
         new CLISpec({
           name: 'edit',
           description: "Edit a page's content from Markdown",
-          fn: edit,
+          fn: guarded(edit),
           write: true,
           positional: [PAGE_ID],
           options: [content(), jsonOut(), notionVersion()],
@@ -199,7 +200,7 @@ export const NTN = new CLISpec({
         new CLISpec({
           name: 'trash',
           description: 'Trash a page',
-          fn: trash,
+          fn: guarded(trash),
           write: true,
           positional: [PAGE_ID],
           options: [
@@ -216,7 +217,7 @@ export const NTN = new CLISpec({
     new CLISpec({
       name: 'whoami',
       description: 'Show the authenticated Notion user',
-      fn: whoami,
+      fn: guarded(whoami),
       options: [jsonOut(), plain(), notionVersion()],
     }),
   ],


### PR DESCRIPTION
Three gaps in the shared fake Notion server and the `ntn` CLI, found while running the Toolathlon arms.

## `GET /v1/comments` did not exist

Only `POST` was routed, so a comment could be written and never read back. Two tasks read comments to grade, so nothing an agent did could pass. Added `listComments` with `block_id`, `page_size` and `start_cursor`, returning the same shape `POST` emits.

Found alongside it: comments were seeded with a single global `position++`, while `createComment` numbers by the parent's existing count. A newly written comment could therefore sort ahead of seeded ones. Seeding is now per parent, like blocks.

## The database object was version-blind

`databaseJson` always answered 2025-09-03, where the column schema lives on the data source. Toolathlon's notion MCP server sends `Notion-Version: 2022-06-28`, which real Notion answers with the schema under `properties`. The oil-price arm could not learn that `Regime` accepts `Neutral`, wrote `Normal`, and lost the graded cells, since Notion mints unknown select options rather than rejecting them.

`databaseJson` now takes the requested version, wired at `GET /v1/databases/{id}` and `POST /v1/search`. The MCP arm deliberately keeps the default: a tool call carries no version header, and that arm must render byte-identically to the REST arm.

`pageParentJson` is deliberately left on the 2025-09-03 shape; the reasoning is a comment at the function.

## `ntn` reported API failures in the wrong shape

Every verb let `NotionAPIError` reach the executor's generic fallback, which prints `ntn <verb>: <message>` and exits 1. That drops the status, the reason phrase and Notion's machine-readable code, which are the three fields a caller branches on.

```
real ntn    error: Public API request failed (404 Not Found object_not_found): Could not find block ...   exit 5
mirage      ntn api: Could not find block ...                                                            exit 1
```

`failure.py` / `failure.ts` render upstream's wording. The behaviour was probed against `ntn` 0.21.9 rather than guessed, which caught three things: 401 drops the parenthesis, adds a hint line and exits 4; a missing `code` collapses to `(404 Not Found)`; reason phrases come from the standard HTTP table.

Every leaf is registered wrapped (`partial(guarded, verb)` in Python, `guarded(verb)` in TypeScript), with a test per language that fails naming any unwrapped leaf, so a new verb cannot quietly miss it.

`datasources query` also reported the wrong 404 when an operand was neither kind of id: it surfaced the database fallback's miss rather than the data source miss plus upstream's hint.

## Tests

13 cases added to `integ/cli/ntn.json`, which is asserted twice: by the battery inside a mirage workspace, and by `integ/ntn_conformance.ts` running the same line through the real `ntn` binary against the same fake.

| gate | result |
| --- | --- |
| ntn conformance (real `ntn` 0.21.9) | 67 checked, all conformable cases match |
| cli-ntn battery, TS / Python | 69 / 69 |
| notion battery, TS / Python | 43 / 43 |
| MCP / REST parity | 33/33 byte-identical |
| full TS suite | pass |
| full Python suite | 13,989 passed, 0 failures |
| `pre-commit run --all-files` | pass |

## Known gaps, not fixed here

- A transport failure (refused connection, non-JSON body) is not a `NotionAPIError`, so it still prints the generic shape. Unreachable against the fake, so no test covers it.
- The `/notion` mount still has no comment surface; reading comments needs `ntn`.