### PR TITLE
fix: GNU byte pins across tail, split, numfmt, sed, cp and find (#609 T1-F)

### DIFF
--- a/integ/unix/numfmt/suffixes.json
+++ b/integ/unix/numfmt/suffixes.json
@@ -1,0 +1,67 @@
+{
+  "cases": [
+    {
+      "id": "numfmt_to_none_prints_every_digit",
+      "seq": 960020,
+      "note": "GNU 9.7 renders --to=none in fixed notation; this used to print 1e+24 in TypeScript.",
+      "targets": ["ram", "disk"],
+      "command": "numfmt --from=si 1Y",
+      "expect": {
+        "exit": 0,
+        "stdout": "1000000000000000000000000\n",
+        "stderr": ""
+      },
+      "flags": ["from"]
+    },
+    {
+      "id": "numfmt_to_none_keeps_input_precision",
+      "seq": 960021,
+      "note": "GNU 9.7 echoes an unscaled value at the precision it was typed with.",
+      "targets": ["ram", "disk"],
+      "command": "numfmt 1.000",
+      "expect": {
+        "exit": 0,
+        "stdout": "1.000\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "numfmt_iec_refuses_a_byte_suffix",
+      "seq": 960022,
+      "note": "GNU 9.7 takes one unit letter and nothing after it, so 1KiB is not a kilobyte; both languages used to accept it.",
+      "targets": ["ram", "disk"],
+      "command": "numfmt --from=iec 1KiB",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "numfmt: invalid suffix in input '1KiB': 'iB'\n"
+      },
+      "flags": ["from"]
+    },
+    {
+      "id": "numfmt_iec_i_demands_its_i",
+      "seq": 960023,
+      "note": "GNU 9.7 requires the trailing i under --from=iec-i.",
+      "targets": ["ram", "disk"],
+      "command": "numfmt --from=iec-i 1K",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "numfmt: missing 'i' suffix in input: '1K' (e.g Ki/Mi/Gi)\n"
+      },
+      "flags": ["from"]
+    },
+    {
+      "id": "numfmt_no_from_points_at_from",
+      "seq": 960024,
+      "note": "GNU 9.7 names --from when the suffix is a real unit but no scaling was requested.",
+      "targets": ["ram", "disk"],
+      "command": "numfmt 1K",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "numfmt: rejecting suffix in input: '1K' (consider using --from)\n"
+      }
+    }
+  ]
+}

--- a/integ/unix/sed/usage.json
+++ b/integ/unix/sed/usage.json
@@ -1,0 +1,74 @@
+{
+  "cases": [
+    {
+      "id": "sed_missing_script",
+      "seq": 960030,
+      "note": "GNU 9.7 prints its usage block and exits 1; mirage names the problem in one line. Run on every backend so a wrapper cannot grow its own spelling again.",
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "sed",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "sed: missing script\n"
+      }
+    },
+    {
+      "id": "sed_no_input_files",
+      "seq": 960031,
+      "note": "GNU 9.7's spelling and exit 4 for -i with no operands; mirage reuses them with no stdin either, having no terminal to read.",
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "sed 's/a/b/'",
+      "expect": {
+        "exit": 4,
+        "stdout": "",
+        "stderr": "sed: no input files\n"
+      }
+    }
+  ]
+}

--- a/integ/unix/split/separator.json
+++ b/integ/unix/split/separator.json
@@ -1,0 +1,43 @@
+{
+  "cases": [
+    {
+      "id": "split_separator_multi_char_refused",
+      "seq": 960010,
+      "note": "GNU 9.7 refuses a separator longer than one byte rather than taking its first byte.",
+      "targets": ["ram", "disk"],
+      "command": "mkdir -p /data/sepm && printf 'a\\nb\\n' > /data/sepm/in && split --separator=XY /data/sepm/in /data/sepm/s",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "split: multi-character separator 'XY'\n"
+      },
+      "flags": ["separator"]
+    },
+    {
+      "id": "split_separator_empty_refused",
+      "seq": 960011,
+      "note": "GNU 9.7 reports an explicitly empty --separator instead of falling back to newline.",
+      "targets": ["ram", "disk"],
+      "command": "mkdir -p /data/sepe && printf 'a\\nb\\n' > /data/sepe/in && split --separator='' /data/sepe/in /data/sepe/s",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "split: empty record separator\n"
+      },
+      "flags": ["separator"]
+    },
+    {
+      "id": "split_separator_nul_escape",
+      "seq": 960012,
+      "note": "GNU 9.7 reads the two-character spelling \\0 as a NUL separator; each record keeps its terminator, so 3 NUL-terminated records at 2 per file are 4 bytes then 2. The default newline separator would see one 6-byte record.",
+      "targets": ["ram", "disk"],
+      "command": "mkdir -p /data/sepn && printf 'a\\0b\\0c\\0' > /data/sepn/in && split --lines 2 --separator='\\0' /data/sepn/in /data/sepn/s && wc -c < /data/sepn/saa && wc -c < /data/sepn/sab",
+      "expect": {
+        "exit": 0,
+        "stdout": "4\n2\n",
+        "stderr": ""
+      },
+      "flags": ["separator", "lines"]
+    }
+  ]
+}

--- a/integ/unix/tail/c_offsets.json
+++ b/integ/unix/tail/c_offsets.json
@@ -1,0 +1,145 @@
+{
+  "note": "GNU coreutils 9.7 pins for `tail -c`'s sign grammar, docker debian:stable-slim. `-c -N` counts back from the end exactly like `-c N`; `-c +N` counts forward from byte N, 1-indexed, so `+1` is the whole file and a `+N` past the end is empty.",
+  "cases": [
+    {
+      "id": "tail_c_negative_is_last_n",
+      "seq": 960000,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "tail -c -3 /data/a.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "az\n",
+        "stderr": ""
+      },
+      "flags": ["c"]
+    },
+    {
+      "id": "tail_c_plus_counts_from_the_start",
+      "seq": 960001,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "tail -c +3 /data/a.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "llo\nworld\nfoo\nbar\nbaz\n",
+        "stderr": ""
+      },
+      "flags": ["c"]
+    },
+    {
+      "id": "tail_c_plus_one_is_the_whole_file",
+      "seq": 960002,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "tail -c +1 /data/a.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "hello\nworld\nfoo\nbar\nbaz\n",
+        "stderr": ""
+      },
+      "flags": ["c"]
+    },
+    {
+      "id": "tail_c_plus_past_the_end_is_empty",
+      "seq": 960003,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "tail -c +99 /data/a.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      "flags": ["c"]
+    }
+  ]
+}

--- a/python/mirage/commands/builtin/generic/cp.py
+++ b/python/mirage/commands/builtin/generic/cp.py
@@ -615,7 +615,12 @@ async def _mirror_dirs(
     if strategy.mkdir is None:
         return True
     mounts = [src_base, *await strategy.find(src, type="d")]
-    for entry_mount in sorted(set(mounts), key=len):
+    # Shortest first so a parent is created before its children. The name is
+    # the tiebreak because `sorted` is stable and set iteration over strings
+    # is PYTHONHASHSEED-dependent, so sibling directories of equal length
+    # used to come out in a different order run to run -- and in a different
+    # order from TypeScript, whose Set keeps insertion order.
+    for entry_mount in sorted(set(mounts), key=lambda p: (len(p), p)):
         entry_dst = mounted_path(target,
                                  dst_base + entry_mount[len(src_base):])
         if lines is not None:

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -1,6 +1,5 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import datetime, timezone
 
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.find_eval import (FindArgs, FindEntry, PredNode,
@@ -15,7 +14,7 @@ from mirage.commands.builtin.utils.output import format_records
 from mirage.io.types import ByteSource, IOResult
 from mirage.ops.types import LinkView, StatPath
 from mirage.types import FileStat, FileType, FindType, PathSpec
-from mirage.utils.dates import iso_timestamp
+from mirage.utils.dates import iso_timestamp, matches_mtime
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
 from mirage.utils.path import respell_raw
 
@@ -93,15 +92,12 @@ async def apply_mtime_filter(
             s = await stat(spec)
         except (FileNotFoundError, ValueError):
             continue
-        if s.modified is None:
-            continue
-        mod_ts = datetime.fromisoformat(
-            s.modified).replace(tzinfo=timezone.utc).timestamp()
-        if mtime_min is not None and mod_ts < mtime_min:
-            continue
-        if mtime_max is not None and mod_ts > mtime_max:
-            continue
-        filtered.append(r)
+        # `matches_mtime` is the same helper the rest of this file already
+        # uses. Parsing inline instead stamped UTC over an offset the
+        # backend actually reported, moving the entry by that offset, and
+        # let a malformed timestamp raise out of the walk.
+        if matches_mtime(s.modified, mtime_min, mtime_max):
+            filtered.append(r)
     return filtered
 
 

--- a/python/mirage/commands/builtin/generic/numfmt.py
+++ b/python/mirage/commands/builtin/generic/numfmt.py
@@ -1,49 +1,167 @@
 import re
-from decimal import ROUND_HALF_EVEN, ROUND_UP, Decimal, InvalidOperation
+from decimal import ROUND_HALF_EVEN, ROUND_UP, Context, Decimal
 
 from mirage.commands.builtin.utils.lines import split_lines
 from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.errors import UsageError
 from mirage.io.types import ByteSource, IOResult
 
 _SUFFIX_ORDER = ("", "K", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q")
 # SI spells kilo lowercase; every larger unit and all of IEC stay uppercase.
 _SI_DISPLAY = ("", "k", *_SUFFIX_ORDER[2:])
 _FIRST_FIELD_RE = re.compile(r"(\s*)(\S+)([\s\S]*)")
+# GNU accepts no leading '+' and no bare trailing '.', and it reads no
+# exponent: `1e3` is a number followed by the unknown suffix 'e3'.
+_NUMBER_RE = re.compile(r"(-?(?:[0-9]*\.[0-9]+|[0-9]+))(.*)", re.DOTALL)
+# Only kilo has a lowercase spelling; every larger unit is uppercase-only.
+_UNIT_EXPONENTS = {
+    "K": 1,
+    "k": 1,
+    **{
+        u: i
+        for i, u in enumerate(_SUFFIX_ORDER) if i >= 2
+    },
+}
 
 
-def _parse_number(value: str, from_mode: str) -> Decimal:
-    match = re.fullmatch(r"([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+))([A-Za-z]*)",
-                         value)
-    if match is None:
-        raise InvalidOperation(value)
-    number = Decimal(match.group(1))
-    suffix = match.group(2)
-    if not suffix or from_mode == "none":
-        return number
-    normalized = suffix.removesuffix("i").removesuffix("B").upper()
-    if normalized not in _SUFFIX_ORDER:
-        raise InvalidOperation(value)
-    exponent = _SUFFIX_ORDER.index(normalized)
-    base = 1000 if from_mode == "si" else 1024
-    return number * (Decimal(base)**exponent)
+def _context_for(text: str) -> Context:
+    """A decimal context wide enough to hold this field exactly.
+
+    A field's significant digits can never exceed its own length and the
+    largest ``--from`` multiplier (1024**10) adds 31 more, so the string
+    length plus a fixed margin is a safe and cheap upper bound. The default
+    28-digit context is not: it rounds ``1024**10`` on the way in, and
+    quantizing a thirty-digit result under it raises InvalidOperation
+    instead of printing ``numfmt --from=si 1Q``.
+
+    Args:
+        text (str): the input field, as typed.
+    """
+    return Context(prec=len(text) + 64, rounding=ROUND_UP)
 
 
-def _format_number(number: Decimal, to_mode: str, grouping: bool) -> str:
+def _suffix_error(value: str, junk: str) -> UsageError:
+    """GNU's two shapes of suffix complaint, exit 2 either way.
+
+    An unusable first character quotes only the whole field; a usable unit
+    followed by junk quotes the field and then the junk (pinned against
+    coreutils 9.7).
+
+    Args:
+        value (str): the whole input field, as typed.
+        junk (str): the unusable tail, or "" for the whole-field shape.
+    """
+    if not junk:
+        return UsageError(f"numfmt: invalid suffix in input: '{value}'", 2)
+    return UsageError(f"numfmt: invalid suffix in input '{value}': '{junk}'",
+                      2)
+
+
+def _scale_of(value: str, suffix: str, from_mode: str) -> tuple[int, int]:
+    """Read a unit suffix as a (base, exponent) pair for ``--from``.
+
+    Each mode spells the same units differently: si and iec take the bare
+    letter, iec-i requires the trailing 'i', and auto takes either and lets
+    the 'i' pick base 1024. Nothing may follow (pinned against coreutils
+    9.7), which is why `1KiB` is refused everywhere -- it used to be read
+    as a kilobyte in both languages.
+
+    Args:
+        value (str): the whole input field, for the error messages.
+        suffix (str): everything after the digits; never empty.
+        from_mode (str): one of ``si``, ``iec``, ``iec-i`` or ``auto``.
+    """
+    exponent = _UNIT_EXPONENTS.get(suffix[0])
+    if exponent is None:
+        raise _suffix_error(value, "")
+    tail = suffix[1:]
+    if from_mode == "iec-i":
+        if not tail:
+            raise UsageError(
+                f"numfmt: missing 'i' suffix in input: '{value}' "
+                "(e.g Ki/Mi/Gi)", 2)
+        if tail[0] != "i":
+            raise _suffix_error(value, tail)
+        if tail[1:]:
+            raise _suffix_error(value, tail[1:])
+        return 1024, exponent
+    if from_mode == "auto":
+        base = 1024 if tail[:1] == "i" else 1000
+        rest = tail[1:] if base == 1024 else tail
+        if rest:
+            raise _suffix_error(value, rest)
+        return base, exponent
+    if tail:
+        raise _suffix_error(value, tail)
+    return (1000 if from_mode == "si" else 1024), exponent
+
+
+def _parse_number(value: str, from_mode: str) -> tuple[Decimal, int]:
+    """Read one input field as an exact value plus its --to=none precision.
+
+    GNU prints an unscaled value back at the precision it was typed with
+    (``1.000`` stays ``1.000``) and a scaled one as a whole number rounded
+    away from zero (``1.0005K`` is ``1001``), so the decimal count travels
+    with the value. A unit that is spelled correctly but unusable because
+    no ``--from`` was given is reported as such, which is why the unit
+    letter is checked before the mode is. Deliberate divergence: GNU calls
+    a second decimal point an invalid suffix in some spellings and an
+    invalid number in others (``1.5.5`` against ``1..5``); mirage calls
+    every trailing decimal point an invalid number.
+
+    Args:
+        value (str): the whole input field, as typed.
+        from_mode (str): one of ``none``, ``si``, ``iec``, ``iec-i``,
+            ``auto``.
+    """
+    match = _NUMBER_RE.fullmatch(value)
+    if match is None or (match.group(2).startswith(".")
+                         and "." not in match.group(1)):
+        raise UsageError(f"numfmt: invalid number: '{value}'", 2)
+    digits, suffix = match.group(1), match.group(2)
+    number = Decimal(digits)
+    _, _, fraction = digits.partition(".")
+    if not suffix:
+        return number, len(fraction)
+    if suffix[0] not in _UNIT_EXPONENTS:
+        raise _suffix_error(value, "")
+    if from_mode == "none":
+        raise UsageError(
+            f"numfmt: rejecting suffix in input: '{value}' "
+            "(consider using --from)", 2)
+    base, exponent = _scale_of(value, suffix, from_mode)
+    ctx = _context_for(value)
+    return ctx.multiply(number, ctx.power(Decimal(base), exponent)), 0
+
+
+def _format_number(number: Decimal, to_mode: str, grouping: bool,
+                   decimals: int) -> str:
     """Render a value the way GNU numfmt does for the given --to mode.
 
     GNU rounds away from zero, keeping one decimal only while the scaled
     value is below 10. That rounding can push a value back over the base
     (999.4 -> 1000 -> 1.0k), so the unit is re-checked afterwards. The final
     render goes through printf, which rounds half-even, which is why an
-    unscaled 2.5 prints as 2.
+    unscaled 2.5 prints as 2. --to=none instead keeps the precision the
+    value was parsed with and rounds away from zero there, always in fixed
+    notation -- ``1Y`` is a twenty-five digit number, never ``1e+24``.
+    Deliberate divergence: GNU reads the input into a long double first, so
+    a value it cannot hold exactly rounds up on the way out (``1.10`` prints
+    as ``1.11`` while ``1.20`` and ``1.30`` do not); mirage keeps the value
+    exact, as it already does for printf.
 
     Args:
         number (Decimal): Value to render, already --from scaled.
         to_mode (str): One of ``none``, ``si``, ``iec`` or ``iec-i``.
         grouping (bool): Whether to group thousands.
+        decimals (int): Decimal places for ``--to=none``.
     """
     if to_mode == "none":
-        return format(number.normalize(), ",f" if grouping else "f")
+        number = number.quantize(Decimal(1).scaleb(-decimals),
+                                 rounding=ROUND_UP,
+                                 context=_context_for(str(number)))
+        return format(number,
+                      f",.{decimals}f" if grouping else f".{decimals}f")
     base = Decimal(1000 if to_mode == "si" else 1024)
     display = _SI_DISPLAY if to_mode == "si" else _SUFFIX_ORDER
     power = 0
@@ -67,8 +185,8 @@ def _format_number(number: Decimal, to_mode: str, grouping: bool) -> str:
 
 def _convert_field(value: str, to_mode: str, from_mode: str, suffix: str,
                    grouping: bool) -> str:
-    number = _parse_number(value.removesuffix(suffix), from_mode)
-    return _format_number(number, to_mode, grouping) + suffix
+    number, decimals = _parse_number(value.removesuffix(suffix), from_mode)
+    return _format_number(number, to_mode, grouping, decimals) + suffix
 
 
 def _convert_line(line: str, to_mode: str, from_mode: str, suffix: str,

--- a/python/mirage/commands/builtin/generic/sed.py
+++ b/python/mirage/commands/builtin/generic/sed.py
@@ -1,7 +1,9 @@
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from mirage.commands.builtin.sed_helper import (_execute_program,
+from mirage.commands.builtin.sed_helper import (SED_NO_INPUT_EXIT,
+                                                SED_NO_INPUT_FILES,
+                                                _execute_program,
                                                 _parse_one_command,
                                                 _parse_program)
 from mirage.commands.builtin.utils.stream import _read_stdin_async
@@ -125,7 +127,8 @@ async def sed(
 
     raw = await _read_stdin_async(stdin)
     if raw is None:
-        raise ValueError("sed: usage: sed EXPRESSION path")
+        return None, IOResult(exit_code=SED_NO_INPUT_EXIT,
+                              stderr=f"{SED_NO_INPUT_FILES}\n".encode())
     text = raw.decode(errors="replace")
     result = _execute_program(text,
                               commands,

--- a/python/mirage/commands/builtin/generic/split.py
+++ b/python/mirage/commands/builtin/generic/split.py
@@ -100,6 +100,35 @@ def parse_suffix_start(value: str, hex_mode: bool, suffix_len: int) -> int:
     return start
 
 
+def parse_separator(value: str | None) -> bytes:
+    """GNU ``split -t`` record separator: exactly one byte, or ``\\0``.
+
+    GNU reads the value as one byte and refuses every other length rather
+    than truncating to the first: an empty value is an empty record
+    separator and anything longer is a multi-character one, with the
+    two-character spelling ``\\0`` carved out as the only way to write a
+    NUL on a command line. The length is counted in bytes, so a lone
+    non-ASCII character is multi-character too (pinned against coreutils
+    9.7). Deliberate divergence, matching truncate: GNU's quotearg escapes
+    control characters in the message and mirage quotes the raw value. Not
+    covered: GNU also refuses two ``-t`` flags naming different characters,
+    which needs a list-valued flag the spec does not have.
+
+    Args:
+        value (str | None): the raw flag value, or None when unset.
+    """
+    if value is None:
+        return b"\n"
+    if value == "\\0":
+        return b"\0"
+    encoded = value.encode()
+    if not encoded:
+        raise UsageError("split: empty record separator", 1)
+    if len(encoded) > 1:
+        raise UsageError(f"split: multi-character separator '{value}'", 1)
+    return encoded
+
+
 _ALPHA_SUFFIXES = "abcdefghijklmnopqrstuvwxyz"
 _NUMERIC_SUFFIXES = "0123456789"
 _HEX_SUFFIXES = "0123456789abcdef"

--- a/python/mirage/commands/builtin/generic/tail.py
+++ b/python/mirage/commands/builtin/generic/tail.py
@@ -14,7 +14,25 @@ async def tail(
     n: int | None = None,
     c: int | None = None,
     from_line: int | None = None,
+    from_byte: int | None = None,
 ) -> AsyncIterator[bytes]:
+    if from_byte is not None:
+        # GNU counts `-c +N` from byte N, 1-indexed, so +0 and +1 both mean
+        # the whole file.
+        skip = max(0, from_byte - 1)
+        skipped = 0
+        async for chunk in ensure_stream(src):
+            if skipped >= skip:
+                yield chunk
+                continue
+            remaining = skip - skipped
+            if len(chunk) <= remaining:
+                skipped += len(chunk)
+                continue
+            yield chunk[remaining:]
+            skipped = skip
+        return
+
     if from_line is not None:
         start = max(1, from_line)
         skip = start - 1
@@ -80,6 +98,7 @@ def tail_multi(
     n: int | None = None,
     c: int | None = None,
     from_line: int | None = None,
+    from_byte: int | None = None,
     show_headers: bool = False,
 ) -> AsyncIterator[bytes]:
     """Run tail over multiple already-resolved paths.
@@ -104,6 +123,7 @@ def tail_multi(
                        n=n,
                        c=c,
                        from_line=from_line,
+                       from_byte=from_byte,
                        show_headers=show_headers)
 
 
@@ -114,6 +134,7 @@ async def _tail_multi(
     n: int | None = None,
     c: int | None = None,
     from_line: int | None = None,
+    from_byte: int | None = None,
     show_headers: bool = False,
 ) -> AsyncIterator[bytes]:
     for i, p in enumerate(paths):
@@ -125,5 +146,9 @@ async def _tail_multi(
         source = read(p)
         if inspect.isawaitable(source):
             source = await source
-        async for chunk in tail(source, n=n, c=c, from_line=from_line):
+        async for chunk in tail(source,
+                                n=n,
+                                c=c,
+                                from_line=from_line,
+                                from_byte=from_byte):
             yield chunk

--- a/python/mirage/commands/builtin/generic_bind/builders/sed.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/sed.py
@@ -21,6 +21,7 @@ from mirage.commands.builtin.generic.sed import sed as generic_sed
 from mirage.commands.builtin.generic_bind.adapter import (Builder, CommandIO,
                                                           bound_op)
 from mirage.commands.builtin.generic_bind.provision import make_sed_provision
+from mirage.commands.builtin.sed_helper import SED_MISSING_SCRIPT
 from mirage.commands.spec.types import FlagValue
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -108,7 +109,8 @@ async def sed(
         script_parts.append(texts[0])
     script = "\n".join(script_parts) if script_parts else None
     if script is None:
-        raise ValueError("sed: usage: sed EXPRESSION [path]")
+        return None, IOResult(exit_code=1,
+                              stderr=f"{SED_MISSING_SCRIPT}\n".encode())
     # The default stream-to-stdout path is read-only and works on every
     # backend; only in-place editing needs a write op (#382).
     if i and ops.write is None:

--- a/python/mirage/commands/builtin/generic_bind/builders/split.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/split.py
@@ -16,11 +16,6 @@ from functools import partial
 
 from mirage.accessor.base import Accessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.commands.builtin.generic.split import (parse_bytes_value,
-                                                   parse_chunks_value,
-                                                   parse_lines_value,
-                                                   parse_suffix_length,
-                                                   parse_suffix_start)
 from mirage.commands.builtin.generic.split import split as generic_split
 from mirage.commands.builtin.generic_bind.adapter import (Builder, CommandIO,
                                                           Operation, bound_op)
@@ -30,6 +25,10 @@ from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagValue, FlagView
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
+
+from mirage.commands.builtin.generic.split import (  # isort: skip
+    parse_bytes_value, parse_chunks_value, parse_lines_value, parse_separator,
+    parse_suffix_length, parse_suffix_start)
 
 
 async def split(
@@ -81,7 +80,7 @@ async def split(
         hex_suffix=hex_value is not None,
         suffix_start=suffix_start,
         additional_suffix=fl.as_str("additional_suffix") or "",
-        separator=(fl.as_str("separator") or "\n").encode())
+        separator=parse_separator(fl.as_str("separator")))
 
 
 BUILDER = Builder('split',

--- a/python/mirage/commands/builtin/generic_bind/builders/tail.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/tail.py
@@ -20,7 +20,7 @@ from mirage.commands.builtin.generic.tail import tail_multi
 from mirage.commands.builtin.generic_bind.adapter import (Builder, CommandIO,
                                                           bound_op)
 from mirage.commands.builtin.generic_bind.builders.common import split_readable
-from mirage.commands.builtin.tail_helper import _parse_n, number_flag_error
+from mirage.commands.builtin.tail_helper import number_flag_error, parse_counts
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -42,15 +42,7 @@ async def tail(
     num_err = number_flag_error("tail", n, c)
     if num_err is not None:
         return None, IOResult(exit_code=1, stderr=num_err.encode())
-    n_int: int | None = None
-    from_line: int | None = None
-    if n is not None:
-        lines, plus_mode = _parse_n(n)
-        if plus_mode:
-            from_line = lines
-        else:
-            n_int = lines
-    c_int = int(c) if c is not None else None
+    counts = parse_counts(n, c)
     if paths and ops.is_mounted(accessor):
         paths = await ops.resolve_glob(accessor, paths, index)
         show_headers = (v or len(paths) > 1) and not q
@@ -60,13 +52,17 @@ async def tail(
             return None, io
         return tail_multi(paths,
                           read=bound_op(ops.read_stream, accessor, index),
-                          n=n_int,
-                          c=c_int,
-                          from_line=from_line,
+                          n=counts.lines,
+                          c=counts.byte_count,
+                          from_line=counts.from_line,
+                          from_byte=counts.from_byte,
                           show_headers=show_headers), io
     source = _resolve_source(stdin, "tail: missing operand")
-    return generic_tail(source, n=n_int, c=c_int,
-                        from_line=from_line), IOResult()
+    return generic_tail(source,
+                        n=counts.lines,
+                        c=counts.byte_count,
+                        from_line=counts.from_line,
+                        from_byte=counts.from_byte), IOResult()
 
 
 BUILDER = Builder('tail', tail, None, False, header_aggregate, read=True)

--- a/python/mirage/commands/builtin/mongodb/tail.py
+++ b/python/mirage/commands/builtin/mongodb/tail.py
@@ -18,7 +18,7 @@ from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.generic.tail import tail_multi
 from mirage.commands.builtin.generic_bind.adapter import bound_op
 from mirage.commands.builtin.mongodb.io import resolve_glob
-from mirage.commands.builtin.tail_helper import _parse_n
+from mirage.commands.builtin.tail_helper import parse_counts
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -45,15 +45,7 @@ async def tail(
     index: IndexCacheStore,
     **_extra: FlagValue,
 ) -> tuple[ByteSource | None, IOResult]:
-    n_int: int | None = None
-    from_line: int | None = None
-    if n is not None:
-        lines, plus_mode = _parse_n(n)
-        if plus_mode:
-            from_line = lines
-        else:
-            n_int = lines
-    c_int = int(c) if c is not None else None
+    counts = parse_counts(n, c)
     if paths:
         paths = await resolve_glob(accessor, paths, index=index)
         if (follow and len(paths) == 1
@@ -61,8 +53,9 @@ async def tail(
             return watch_stream(accessor, paths[0], index), IOResult()
         # Collections fetch only the last N documents server-side (sort by
         # primary key descending + limit) instead of reading everything.
-        n_eff = n_int if n_int is not None else 10
-        if (len(paths) == 1 and c_int is None and from_line is None
+        n_eff = counts.lines if counts.lines is not None else 10
+        if (len(paths) == 1 and counts.byte_count is None
+                and counts.from_byte is None and counts.from_line is None
                 and n_eff > 0
                 and detect_scope(paths[0]).level == ScopeLevel.DOCUMENTS):
             data = await read_tail(accessor, paths[0], n_eff, index)
@@ -71,10 +64,14 @@ async def tail(
         show_headers = (v or len(paths) > 1) and not q
         return tail_multi(paths,
                           read=bound_op(mongodb_read, accessor, index),
-                          n=n_int,
-                          c=c_int,
-                          from_line=from_line,
+                          n=counts.lines,
+                          c=counts.byte_count,
+                          from_line=counts.from_line,
+                          from_byte=counts.from_byte,
                           show_headers=show_headers), IOResult()
     source = _resolve_source(stdin, "tail: missing operand")
-    return generic_tail(source, n=n_int, c=c_int,
-                        from_line=from_line), IOResult()
+    return generic_tail(source,
+                        n=counts.lines,
+                        c=counts.byte_count,
+                        from_line=counts.from_line,
+                        from_byte=counts.from_byte), IOResult()

--- a/python/mirage/commands/builtin/postgres/tail.py
+++ b/python/mirage/commands/builtin/postgres/tail.py
@@ -20,7 +20,7 @@ from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.generic.tail import tail_multi
 from mirage.commands.builtin.generic_bind.adapter import bound_op
 from mirage.commands.builtin.postgres.io import resolve_glob
-from mirage.commands.builtin.tail_helper import _parse_n
+from mirage.commands.builtin.tail_helper import parse_counts
 from mirage.commands.builtin.utils.paths import has_unresolved_glob
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
@@ -46,21 +46,14 @@ async def tail(
     index: IndexCacheStore,
     **_extra: FlagValue,
 ) -> tuple[ByteSource | None, IOResult]:
-    n_int: int | None = None
-    from_line: int | None = None
-    if n is not None:
-        lines, plus_mode = _parse_n(n)
-        if plus_mode:
-            from_line = lines
-        else:
-            n_int = lines
-    c_int = int(c) if c is not None else None
+    counts = parse_counts(n, c)
     if paths:
         scope = detect_scope(paths[0])
         if (len(paths) == 1 and not has_unresolved_glob(paths)
                 and isinstance(scope, PostgresEntityRowsScope)
-                and c_int is None and n_int is not None):
-            limit = min(n_int, accessor.config.default_row_limit)
+                and counts.byte_count is None and counts.from_byte is None
+                and counts.lines is not None):
+            limit = min(counts.lines, accessor.config.default_row_limit)
             pool = await accessor.pool()
             async with pool.acquire() as conn:
                 total = await _client.count_rows(conn, scope.schema,
@@ -72,23 +65,31 @@ async def tail(
                                                 limit=limit,
                                                 offset=offset)
             if not rows:
-                return generic_tail(b"", n=n_int, c=c_int,
-                                    from_line=from_line), IOResult()
+                return generic_tail(b"",
+                                    n=counts.lines,
+                                    c=counts.byte_count,
+                                    from_line=counts.from_line,
+                                    from_byte=counts.from_byte), IOResult()
             jsonl = "\n".join(
                 orjson.dumps(r, default=str).decode() for r in rows) + "\n"
             return generic_tail(jsonl.encode(),
-                                n=n_int,
-                                c=c_int,
-                                from_line=from_line), IOResult()
+                                n=counts.lines,
+                                c=counts.byte_count,
+                                from_line=counts.from_line,
+                                from_byte=counts.from_byte), IOResult()
 
         paths = await resolve_glob(accessor, paths, index=index)
         show_headers = (v or len(paths) > 1) and not q
         return tail_multi(paths,
                           read=bound_op(postgres_read, accessor, index),
-                          n=n_int,
-                          c=c_int,
-                          from_line=from_line,
+                          n=counts.lines,
+                          c=counts.byte_count,
+                          from_line=counts.from_line,
+                          from_byte=counts.from_byte,
                           show_headers=show_headers), IOResult()
     source = _resolve_source(stdin, "tail: missing operand")
-    return generic_tail(source, n=n_int, c=c_int,
-                        from_line=from_line), IOResult()
+    return generic_tail(source,
+                        n=counts.lines,
+                        c=counts.byte_count,
+                        from_line=counts.from_line,
+                        from_byte=counts.from_byte), IOResult()

--- a/python/mirage/commands/builtin/sed_helper.py
+++ b/python/mirage/commands/builtin/sed_helper.py
@@ -16,6 +16,17 @@ import re
 from typing import Any
 
 _SIMPLE_CMDS = frozenset("dDpPhHgGxNq")
+# GNU answers a missing script with its whole thirty-nine line usage block
+# and exit 1; mirage names the problem in one line instead, because the
+# block is GNU's own prose and reproducing it buys a mirage user nothing.
+# `no input files` and its exit 4 are GNU's exact spelling for `sed -i`
+# with no operands, and mirage reuses them when there is no stdin either --
+# it has no terminal for GNU's blocking read to reach. Both live here so
+# the generic and its builder cannot drift apart again; there used to be
+# four spellings across the two languages.
+SED_MISSING_SCRIPT = "sed: missing script"
+SED_NO_INPUT_FILES = "sed: no input files"
+SED_NO_INPUT_EXIT = 4
 
 
 def _apply_repl(m: "re.Match[str]", repl: str) -> str:

--- a/python/mirage/commands/builtin/tail_helper.py
+++ b/python/mirage/commands/builtin/tail_helper.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import re
+from dataclasses import dataclass
 
 _NUMBER_RE = re.compile(r"^[+-]?[0-9]+$")
 
@@ -32,3 +33,45 @@ def _parse_n(n: str | None) -> tuple[int, bool]:
     if n.startswith("+"):
         return int(n[1:]), True
     return int(n), False
+
+
+@dataclass(frozen=True, slots=True)
+class TailCounts:
+    lines: int | None = None
+    from_line: int | None = None
+    byte_count: int | None = None
+    from_byte: int | None = None
+
+
+def parse_counts(n: str | None, c: str | None) -> TailCounts:
+    """Split tail's ``-n``/``-c`` values by which end they count from.
+
+    GNU gives both flags the same sign grammar: a leading ``+`` counts
+    forward from the start of the input, 1-indexed, so ``+0`` and ``+1``
+    both mean the whole thing; any other spelling counts back from the
+    end. Every caller used to apply that grammar to ``-n`` and take the
+    absolute value of ``-c``, which silently turned ``tail -c +3`` into
+    the last three bytes -- so the split lives here, once, beside the
+    parser it is built from.
+
+    Args:
+        n (str | None): the raw ``-n`` value, or None when unset.
+        c (str | None): the raw ``-c`` value, or None when unset.
+    """
+    lines: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        count, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = count
+        else:
+            lines = count
+    byte_count: int | None = None
+    from_byte: int | None = None
+    if c is not None:
+        count, plus_mode = _parse_n(c)
+        if plus_mode:
+            from_byte = count
+        else:
+            byte_count = count
+    return TailCounts(lines, from_line, byte_count, from_byte)

--- a/python/tests/commands/builtin/gdrive/test_sed.py
+++ b/python/tests/commands/builtin/gdrive/test_sed.py
@@ -183,5 +183,9 @@ async def test_sed_in_place_writes_back(accessor, index):
 
 @pytest.mark.asyncio
 async def test_sed_missing_expression(accessor, index):
-    with pytest.raises(ValueError, match="sed: usage"):
-        await sed(accessor, [], index=index)
+    # A missing script is reported, not raised: GNU exits 1 with a message,
+    # and the TypeScript twin has always returned an IOResult here.
+    out, io = await sed(accessor, [], index=index)
+    assert out is None
+    assert io.exit_code == 1
+    assert io.stderr == b"sed: missing script\n"

--- a/python/tests/commands/builtin/generic/test_find.py
+++ b/python/tests/commands/builtin/generic/test_find.py
@@ -1,6 +1,6 @@
 import asyncio
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
 import pytest
@@ -181,6 +181,49 @@ async def test_apply_mtime_filter_drops_entries_with_no_modified_time():
         return FileStat(name="a.txt",
                         size=1,
                         modified=None,
+                        type=FileType.TEXT)
+
+    out = await apply_mtime_filter(
+        ["/a.txt"],
+        mtime_min=1.0,
+        mtime_max=None,
+        stat=stat,
+    )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_apply_mtime_filter_honours_a_reported_utc_offset():
+    """A backend that reports +09:00 means +09:00, not UTC.
+
+    Stamping UTC over the offset moved the entry nine hours, which is
+    enough to push it out of a window it belongs in.
+    """
+    moment = datetime(2025, 6, 1, 12, 0, tzinfo=timezone(timedelta(hours=9)))
+
+    async def stat(_spec: PathSpec) -> FileStat:
+        return FileStat(name="a.txt",
+                        size=1,
+                        modified=moment.isoformat(),
+                        type=FileType.TEXT)
+
+    out = await apply_mtime_filter(
+        ["/a.txt"],
+        mtime_min=moment.timestamp() - 60,
+        mtime_max=moment.timestamp() + 60,
+        stat=stat,
+    )
+    assert out == ["/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_apply_mtime_filter_drops_a_malformed_timestamp():
+    """An unparseable stamp drops the entry instead of raising out of find."""
+
+    async def stat(_spec: PathSpec) -> FileStat:
+        return FileStat(name="a.txt",
+                        size=1,
+                        modified="not-a-date",
                         type=FileType.TEXT)
 
     out = await apply_mtime_filter(

--- a/python/tests/commands/builtin/generic/test_numfmt.py
+++ b/python/tests/commands/builtin/generic/test_numfmt.py
@@ -1,0 +1,172 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.commands.builtin.generic.numfmt import numfmt
+from mirage.commands.errors import UsageError
+
+
+async def run(value: str, **kwargs: str | bool) -> str:
+    out, _ = await numfmt(value, **kwargs)
+    assert out is not None
+    return bytes(out).decode().rstrip("\n")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("value", "from_mode", "expected"), [
+    ("1Y", "si", "1000000000000000000000000"),
+    ("1Q", "si", "1000000000000000000000000000000"),
+    ("1Y", "iec", "1208925819614629174706176"),
+    ("1Q", "iec", "1267650600228229401496703205376"),
+    ("1.5Y", "si", "1500000000000000000000000"),
+    ("1.5Y", "iec", "1813388729421943762059264"),
+    ("12345678901234567890123456789", "none", "12345678901234567890123456789"),
+])
+async def test_to_none_prints_every_digit(value, from_mode, expected):
+    # This used to render through a double in TypeScript, which printed
+    # '1e+24', and through a 28-digit decimal context in Python, which
+    # could not hold 1024**10 at all.
+    assert await run(value, from_mode=from_mode) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("value", "expected"), [
+    ("1", "1"),
+    ("1.000", "1.000"),
+    ("1.100", "1.100"),
+    ("1.20", "1.20"),
+    ("0.10", "0.10"),
+    ("00012", "12"),
+    ("-1", "-1"),
+])
+async def test_to_none_keeps_the_precision_it_was_given(value, expected):
+    # GNU echoes an unscaled value at the precision it was typed with.
+    # Deliberate divergence: GNU reads through a long double, so '1.10'
+    # comes back as '1.11' while '1.20' and '1.30' do not.
+    assert await run(value) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("value", "expected"), [
+    ("1.5K", "1500"),
+    ("1.500K", "1500"),
+    (".5K", "500"),
+    ("1.0005K", "1001"),
+    ("1.0000005K", "1001"),
+    ("0.0015K", "2"),
+    ("1.23456789K", "1235"),
+    ("-1.5K", "-1500"),
+    ("-0.0015K", "-2"),
+])
+async def test_a_scaled_value_is_a_whole_number_rounded_away_from_zero(
+        value, expected):
+    assert await run(value, from_mode="si") == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("value", "from_mode", "expected"), [
+    ("1K", "si", "1000"),
+    ("1k", "si", "1000"),
+    ("1K", "iec", "1024"),
+    ("1k", "iec", "1024"),
+    ("1Ki", "iec-i", "1024"),
+    ("1K", "auto", "1000"),
+    ("1Ki", "auto", "1024"),
+    ("1ki", "auto", "1024"),
+    ("1M", "auto", "1000000"),
+    ("1Mi", "auto", "1048576"),
+])
+async def test_each_from_mode_spells_its_units_its_own_way(
+        value, from_mode, expected):
+    assert await run(value, from_mode=from_mode) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("value", "from_mode", "message"), [
+    ("1KiB", "iec", "numfmt: invalid suffix in input '1KiB': 'iB'"),
+    ("1Ki", "iec", "numfmt: invalid suffix in input '1Ki': 'i'"),
+    ("1KB", "iec", "numfmt: invalid suffix in input '1KB': 'B'"),
+    ("1kB", "si", "numfmt: invalid suffix in input '1kB': 'B'"),
+    ("1KiB", "auto", "numfmt: invalid suffix in input '1KiB': 'B'"),
+    ("1kI", "auto", "numfmt: invalid suffix in input '1kI': 'I'"),
+    ("1KiB", "iec-i", "numfmt: invalid suffix in input '1KiB': 'B'"),
+    ("1Z9", "si", "numfmt: invalid suffix in input '1Z9': '9'"),
+    ("1Kx", "si", "numfmt: invalid suffix in input '1Kx': 'x'"),
+    ("1KK", "si", "numfmt: invalid suffix in input '1KK': 'K'"),
+])
+async def test_a_unit_followed_by_junk_names_the_junk(value, from_mode,
+                                                      message):
+    # '1KiB' used to read as a kilobyte in both languages: TypeScript
+    # stripped a trailing 'iB' with a regex and Python removed 'i' then 'B'.
+    with pytest.raises(UsageError) as exc:
+        await run(value, from_mode=from_mode)
+    assert str(exc.value) == message
+    assert exc.value.exit_code == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("value", "from_mode", "message"), [
+    ("1m", "si", "numfmt: invalid suffix in input: '1m'"),
+    ("1g", "si", "numfmt: invalid suffix in input: '1g'"),
+    ("1J", "si", "numfmt: invalid suffix in input: '1J'"),
+    ("1i", "auto", "numfmt: invalid suffix in input: '1i'"),
+    ("1i", "iec-i", "numfmt: invalid suffix in input: '1i'"),
+    ("1e3", "none", "numfmt: invalid suffix in input: '1e3'"),
+    ("0x10", "none", "numfmt: invalid suffix in input: '0x10'"),
+    ("1.5.5", "si", "numfmt: invalid suffix in input: '1.5.5'"),
+])
+async def test_an_unusable_first_character_quotes_only_the_field(
+        value, from_mode, message):
+    # Only kilo has a lowercase spelling, so '1m' and '1g' are not units;
+    # both languages used to upper-case the suffix and accept them.
+    with pytest.raises(UsageError) as exc:
+        await run(value, from_mode=from_mode)
+    assert str(exc.value) == message
+    assert exc.value.exit_code == 2
+
+
+@pytest.mark.asyncio
+async def test_iec_i_demands_its_i():
+    with pytest.raises(UsageError) as exc:
+        await run("1K", from_mode="iec-i")
+    assert str(exc.value) == (
+        "numfmt: missing 'i' suffix in input: '1K' (e.g Ki/Mi/Gi)")
+    assert exc.value.exit_code == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["1K", "1k", "1Ki", "1KiB", "1Kx", "1.5K"])
+async def test_a_real_unit_without_from_points_at_from(value):
+    with pytest.raises(UsageError) as exc:
+        await run(value)
+    assert str(exc.value) == (f"numfmt: rejecting suffix in input: '{value}' "
+                              "(consider using --from)")
+    assert exc.value.exit_code == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("value", "from_mode"), [
+    ("abc", "si"),
+    ("abc", "none"),
+    ("+1", "si"),
+    ("1.", "none"),
+    ("1.x", "si"),
+])
+async def test_bad_numbers_report_the_number(value, from_mode):
+    # GNU reads no leading '+', no bare trailing '.' and no exponent.
+    with pytest.raises(UsageError) as exc:
+        await run(value, from_mode=from_mode)
+    assert str(exc.value) == f"numfmt: invalid number: '{value}'"
+    assert exc.value.exit_code == 2

--- a/python/tests/commands/builtin/generic/test_sed.py
+++ b/python/tests/commands/builtin/generic/test_sed.py
@@ -146,10 +146,16 @@ async def test_sed_n_suppress_with_p():
 
 
 @pytest.mark.asyncio
-async def test_sed_no_paths_no_stdin_raises():
+async def test_sed_no_paths_no_stdin_reports_no_input_files():
+    # GNU's spelling and exit code for `sed -i` with no operands; mirage
+    # reuses them when there is no stdin either, having no terminal to
+    # read. This used to raise on the Python side and return exit 1 with a
+    # different message on the TypeScript side.
     rb, wb, _ = _make_backend({})
-    with pytest.raises(ValueError, match="usage"):
-        await sed([], "s/a/b/", read_bytes=rb, write_bytes=wb)
+    out, io = await sed([], "s/a/b/", read_bytes=rb, write_bytes=wb)
+    assert out is None
+    assert io.exit_code == 4
+    assert io.stderr == b"sed: no input files\n"
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/generic/test_split.py
+++ b/python/tests/commands/builtin/generic/test_split.py
@@ -15,12 +15,11 @@
 import pytest
 
 from mirage.commands.builtin.generic import split as split_generic
-from mirage.commands.builtin.generic.split import (parse_bytes_value,
-                                                   parse_chunks_value,
-                                                   parse_lines_value,
-                                                   parse_suffix_length,
-                                                   parse_suffix_start)
 from mirage.commands.errors import UsageError
+
+from mirage.commands.builtin.generic.split import (  # isort: skip
+    parse_bytes_value, parse_chunks_value, parse_lines_value, parse_separator,
+    parse_suffix_length, parse_suffix_start)
 
 _TRY = "\nTry 'split --help' for more information."
 _ALPHA_SUFFIXES = split_generic._ALPHA_SUFFIXES
@@ -116,6 +115,35 @@ def test_suffix_length_rejects_junk_but_allows_zero():
     with pytest.raises(UsageError) as exc:
         parse_suffix_length("1k")
     assert str(exc.value) == "split: invalid suffix length: '1k'"
+
+
+def test_separator_takes_one_byte_and_the_nul_spelling():
+    # `\0` is the only escape GNU reads, and it is two characters on the
+    # command line; everything else is taken literally, so a lone backslash
+    # and a digit zero are ordinary separators.
+    assert parse_separator(None) == b"\n"
+    assert parse_separator("\\0") == b"\0"
+    assert parse_separator("X") == b"X"
+    assert parse_separator("0") == b"0"
+    assert parse_separator("\\") == b"\\"
+
+
+@pytest.mark.parametrize("value", ["XY", "abc", "\\n", "\\t", "é"])
+def test_separator_rejects_multi_byte_values(value):
+    # This used to keep the whole byte string as the separator, splitting on
+    # 'XY' where GNU refuses to run at all. 'é' is one character but two
+    # UTF-8 bytes, and GNU counts bytes.
+    with pytest.raises(UsageError) as exc:
+        parse_separator(value)
+    assert str(exc.value) == f"split: multi-character separator '{value}'"
+    assert exc.value.exit_code == 1
+
+
+def test_separator_rejects_an_empty_value():
+    with pytest.raises(UsageError) as exc:
+        parse_separator("")
+    assert str(exc.value) == "split: empty record separator"
+    assert exc.value.exit_code == 1
 
 
 def test_suffix_names_auto_lengthen_like_gnu():

--- a/python/tests/commands/builtin/generic/test_tail.py
+++ b/python/tests/commands/builtin/generic/test_tail.py
@@ -238,3 +238,47 @@ async def test_tail_from_line_emits_chunks_incrementally_after_skip():
 
     chunks = [c async for c in tail(src(), from_line=3)]
     assert chunks == [b"c", b"\nd\n", b"e\n"]
+
+
+@pytest.mark.asyncio
+async def test_tail_from_byte_starts_at_that_byte():
+    """GNU `tail -c +3` emits from byte 3 to EOF, 1-indexed."""
+    out = await _drain(tail(b"abcdefghij", from_byte=3))
+    assert out == b"cdefghij"
+
+
+@pytest.mark.asyncio
+async def test_tail_from_byte_one_and_zero_are_the_whole_input():
+    assert await _drain(tail(b"abcdefghij", from_byte=1)) == b"abcdefghij"
+    assert await _drain(tail(b"abcdefghij", from_byte=0)) == b"abcdefghij"
+
+
+@pytest.mark.asyncio
+async def test_tail_from_byte_past_the_end_emits_nothing():
+    out = await _drain(tail(b"abcdefghij", from_byte=99))
+    assert out == b""
+
+
+@pytest.mark.asyncio
+async def test_tail_from_byte_skips_across_chunk_boundaries():
+
+    async def src():
+        yield b"ab"
+        yield b"cd"
+        yield b"ef"
+
+    chunks = [c async for c in tail(src(), from_byte=4)]
+    assert b"".join(chunks) == b"def"
+
+
+@pytest.mark.asyncio
+async def test_tail_from_byte_passes_later_chunks_through_untouched():
+    """Once the skip is satisfied, chunks are yielded without rebuffering."""
+
+    async def src():
+        yield b"abc"
+        yield b"defgh"
+        yield b"ij"
+
+    chunks = [c async for c in tail(src(), from_byte=3)]
+    assert chunks == [b"c", b"defgh", b"ij"]

--- a/python/tests/commands/builtin/test_tail_helper.py
+++ b/python/tests/commands/builtin/test_tail_helper.py
@@ -1,0 +1,39 @@
+from mirage.commands.builtin.tail_helper import parse_counts
+
+
+def test_bare_count_counts_back_from_the_end():
+    counts = parse_counts("3", None)
+    assert counts.lines == 3
+    assert counts.from_line is None
+
+
+def test_leading_plus_counts_forward_for_lines():
+    counts = parse_counts("+3", None)
+    assert counts.from_line == 3
+    assert counts.lines is None
+
+
+def test_leading_plus_counts_forward_for_bytes():
+    """GNU `tail -c +3` starts at byte 3; taking abs() gave the LAST three."""
+    counts = parse_counts(None, "+3")
+    assert counts.from_byte == 3
+    assert counts.byte_count is None
+
+
+def test_negative_bytes_still_count_back_from_the_end():
+    counts = parse_counts(None, "-3")
+    assert counts.byte_count == -3
+    assert counts.from_byte is None
+
+
+def test_unset_flags_stay_none_so_the_generic_picks_its_default():
+    counts = parse_counts(None, None)
+    assert counts == parse_counts(None, None)
+    assert (counts.lines, counts.from_line, counts.byte_count,
+            counts.from_byte) == (None, None, None, None)
+
+
+def test_both_flags_are_parsed_independently():
+    counts = parse_counts("+2", "5")
+    assert counts.from_line == 2
+    assert counts.byte_count == 5

--- a/typescript/packages/core/src/commands/builtin/generic/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cp.ts
@@ -527,7 +527,13 @@ async function mirrorDirs(
 ): Promise<boolean> {
   if (strategy.mkdir === undefined) return true
   const mounts = [srcBase, ...(await strategy.find(src, { type: 'd' }))]
-  const unique = [...new Set(mounts)].sort((a, b) => a.length - b.length)
+  // Shortest first so a parent is created before its children, then by name:
+  // sorting on length alone leaves equal-length siblings in whatever order
+  // the Set happened to hold, which is insertion order here and hash order in
+  // Python. Same key on both sides, same output.
+  const unique = [...new Set(mounts)].sort(
+    (a, b) => a.length - b.length || (a < b ? -1 : a > b ? 1 : 0),
+  )
   for (const entryMount of unique) {
     const entryDst = mountedPath(target, dstBase + entryMount.slice(srcBase.length))
     if (lines !== undefined) {

--- a/typescript/packages/core/src/commands/builtin/generic/find.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.test.ts
@@ -19,7 +19,7 @@ import type { FindOptions } from '../../../resource/base.ts'
 import { FileType, PathSpec, type FileStat } from '../../../types.ts'
 import type { CommandOpts } from '../../config.ts'
 import type { LinkView } from '../../../ops/types.ts'
-import { findGeneric } from './find.ts'
+import { findGeneric, linkResults } from './find.ts'
 
 const DEC = new TextDecoder()
 
@@ -294,6 +294,52 @@ describe('generic command find', () => {
     await expect(findGeneric([spec('/limited')], [], makeOpts(), fakeFind)).rejects.toThrow(
       'rate limited',
     )
+  })
+
+  describe('-mtime reads timestamps through modifiedTs', () => {
+    function linkViewOf(modified: string | null): LinkView {
+      const st = { name: 'l', size: 1, type: FileType.TEXT, modified } as FileStat
+      return {
+        statAt: () => null,
+        children: () => [],
+        subtree: () => [['/l', st]],
+        resolve: (p: string) => p,
+        exists: () => Promise.resolve(true),
+        targetStat: () => Promise.resolve(null),
+      }
+    }
+
+    async function withMtime(modified: string | null): Promise<string[]> {
+      return linkResults(
+        linkViewOf(modified),
+        '/',
+        '',
+        '',
+        { op: 'true' },
+        null,
+        null,
+        null,
+        null,
+        0,
+        Number.MAX_SAFE_INTEGER,
+        false,
+      )
+    }
+
+    it('drops a malformed timestamp instead of keeping it', async () => {
+      // Date.parse('nonsense') is NaN, and every NaN comparison is false,
+      // so both window checks passed and the entry survived — where Python
+      // drops it. modifiedTs returns null for the same input.
+      expect(await withMtime('not-a-date')).toEqual([])
+    })
+
+    it('keeps an entry whose timestamp is inside the window', async () => {
+      expect(await withMtime('2025-06-01T12:00:00Z')).toEqual(['/l'])
+    })
+
+    it('reads a date-only stamp as midnight UTC rather than NaN', async () => {
+      expect(await withMtime('2025-06-01')).toEqual(['/l'])
+    })
   })
 
   it.each([

--- a/typescript/packages/core/src/commands/builtin/generic/find.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.ts
@@ -201,7 +201,11 @@ export async function linkResults(
     if (minSize !== null && size < minSize) continue
     if (maxSize !== null && size > maxSize) continue
     if (mtimeMin !== null || mtimeMax !== null) {
-      const ts = st.modified !== null ? Date.parse(st.modified) / 1000 : null
+      // `modifiedTs` is the helper the rest of this file uses. A bare
+      // Date.parse gives NaN for a date-only or malformed stamp, which the
+      // `=== null` guard below does not catch, so every comparison came out
+      // false and the entry was kept -- where Python drops it.
+      const ts = modifiedTs(st.modified)
       if (ts === null) continue
       if (mtimeMin !== null && ts < mtimeMin) continue
       if (mtimeMax !== null && ts > mtimeMax) continue

--- a/typescript/packages/core/src/commands/builtin/generic/numfmt.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/numfmt.test.ts
@@ -1,0 +1,153 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+import { describe, expect, it } from 'vitest'
+
+import type { CommandOpts } from '../../config.ts'
+import { UsageError } from '../../errors.ts'
+import { numfmtGeneric } from './numfmt.ts'
+
+const DEC = new TextDecoder()
+
+async function run(value: string, flags: CommandOpts['flags'] = {}): Promise<string> {
+  const opts = {
+    stdin: null,
+    flags,
+    filetypeFns: null,
+    cwd: '/',
+    resource: { kind: 'ram' } as never,
+  } as CommandOpts
+  const result = await numfmtGeneric([value], opts)
+  return DEC.decode(result?.[0] as Uint8Array).replace(/\n$/, '')
+}
+
+describe('numfmt --to=none rendering', () => {
+  // This used to render through String(double), which printed '1e+24'.
+  it.each([
+    ['1Y', 'si', '1000000000000000000000000'],
+    ['1Q', 'si', '1000000000000000000000000000000'],
+    ['1Y', 'iec', '1208925819614629174706176'],
+    ['1Q', 'iec', '1267650600228229401496703205376'],
+    ['1.5Y', 'si', '1500000000000000000000000'],
+    ['1.5Y', 'iec', '1813388729421943762059264'],
+    ['12345678901234567890123456789', 'none', '12345678901234567890123456789'],
+  ])('prints every digit of %s in %s', async (value, from, expected) => {
+    expect(await run(value, { from })).toBe(expected)
+  })
+
+  // GNU echoes an unscaled value at the precision it was typed with.
+  // Deliberate divergence: GNU reads through a long double, so '1.10' comes
+  // back as '1.11' while '1.20' and '1.30' do not.
+  it.each([
+    ['1', '1'],
+    ['1.000', '1.000'],
+    ['1.100', '1.100'],
+    ['1.20', '1.20'],
+    ['0.10', '0.10'],
+    ['00012', '12'],
+    ['-1', '-1'],
+  ])('keeps the precision %s was given', async (value, expected) => {
+    expect(await run(value)).toBe(expected)
+  })
+
+  it.each([
+    ['1.5K', '1500'],
+    ['1.500K', '1500'],
+    ['.5K', '500'],
+    ['1.0005K', '1001'],
+    ['1.0000005K', '1001'],
+    ['0.0015K', '2'],
+    ['1.23456789K', '1235'],
+    ['-1.5K', '-1500'],
+    ['-0.0015K', '-2'],
+  ])('rounds the scaled %s away from zero to a whole number', async (value, expected) => {
+    expect(await run(value, { from: 'si' })).toBe(expected)
+  })
+})
+
+describe('numfmt --from suffixes', () => {
+  it.each([
+    ['1K', 'si', '1000'],
+    ['1k', 'si', '1000'],
+    ['1K', 'iec', '1024'],
+    ['1k', 'iec', '1024'],
+    ['1Ki', 'iec-i', '1024'],
+    ['1K', 'auto', '1000'],
+    ['1Ki', 'auto', '1024'],
+    ['1ki', 'auto', '1024'],
+    ['1M', 'auto', '1000000'],
+    ['1Mi', 'auto', '1048576'],
+  ])('reads %s under --from=%s', async (value, from, expected) => {
+    expect(await run(value, { from })).toBe(expected)
+  })
+
+  // '1KiB' used to read as a kilobyte: the suffix went through
+  // .replace(/i?B$/, '').replace(/i$/, '') before the unit lookup.
+  it.each([
+    ['1KiB', 'iec', "numfmt: invalid suffix in input '1KiB': 'iB'"],
+    ['1Ki', 'iec', "numfmt: invalid suffix in input '1Ki': 'i'"],
+    ['1KB', 'iec', "numfmt: invalid suffix in input '1KB': 'B'"],
+    ['1kB', 'si', "numfmt: invalid suffix in input '1kB': 'B'"],
+    ['1KiB', 'auto', "numfmt: invalid suffix in input '1KiB': 'B'"],
+    ['1kI', 'auto', "numfmt: invalid suffix in input '1kI': 'I'"],
+    ['1KiB', 'iec-i', "numfmt: invalid suffix in input '1KiB': 'B'"],
+    ['1Z9', 'si', "numfmt: invalid suffix in input '1Z9': '9'"],
+    ['1Kx', 'si', "numfmt: invalid suffix in input '1Kx': 'x'"],
+    ['1KK', 'si', "numfmt: invalid suffix in input '1KK': 'K'"],
+  ])('names the junk after the unit in %s', async (value, from, message) => {
+    await expect(run(value, { from })).rejects.toThrow(new UsageError(message, 2))
+  })
+
+  // Only kilo has a lowercase spelling, so '1m' and '1g' are not units;
+  // both languages used to upper-case the suffix and accept them.
+  it.each([
+    ['1m', 'si', "numfmt: invalid suffix in input: '1m'"],
+    ['1g', 'si', "numfmt: invalid suffix in input: '1g'"],
+    ['1J', 'si', "numfmt: invalid suffix in input: '1J'"],
+    ['1i', 'auto', "numfmt: invalid suffix in input: '1i'"],
+    ['1i', 'iec-i', "numfmt: invalid suffix in input: '1i'"],
+    ['1e3', 'none', "numfmt: invalid suffix in input: '1e3'"],
+    ['0x10', 'none', "numfmt: invalid suffix in input: '0x10'"],
+    ['1.5.5', 'si', "numfmt: invalid suffix in input: '1.5.5'"],
+  ])('quotes only the field for the unusable %s', async (value, from, message) => {
+    await expect(run(value, { from })).rejects.toThrow(new UsageError(message, 2))
+  })
+
+  it('demands the i under --from=iec-i', async () => {
+    await expect(run('1K', { from: 'iec-i' })).rejects.toThrow(
+      new UsageError("numfmt: missing 'i' suffix in input: '1K' (e.g Ki/Mi/Gi)", 2),
+    )
+  })
+
+  it.each([['1K'], ['1k'], ['1Ki'], ['1KiB'], ['1Kx'], ['1.5K']])(
+    'points %s at --from when none was given',
+    async (value) => {
+      await expect(run(value)).rejects.toThrow(
+        new UsageError(`numfmt: rejecting suffix in input: '${value}' (consider using --from)`, 2),
+      )
+    },
+  )
+
+  // GNU reads no leading '+', no bare trailing '.' and no exponent.
+  it.each([
+    ['abc', 'si'],
+    ['abc', 'none'],
+    ['+1', 'si'],
+    ['1.', 'none'],
+    ['1.x', 'si'],
+  ])('reports %s as an invalid number', async (value, from) => {
+    await expect(run(value, { from })).rejects.toThrow(
+      new UsageError(`numfmt: invalid number: '${value}'`, 2),
+    )
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
@@ -2,6 +2,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize } from '../../../io/types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { UsageError } from '../../errors.ts'
 import { resolveSource } from '../utils/stream.ts'
 
 const ENC = new TextEncoder()
@@ -9,16 +10,117 @@ const DEC = new TextDecoder('utf-8', { fatal: false })
 const SUFFIXES = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'] as const
 // SI spells kilo lowercase; every larger unit and all of IEC stay uppercase.
 const SI_DISPLAY: readonly string[] = ['', 'k', ...SUFFIXES.slice(2)]
+// Only kilo has a lowercase spelling; every larger unit is uppercase-only.
+const UNIT_EXPONENTS: Readonly<Record<string, number>> = Object.freeze({
+  K: 1,
+  k: 1,
+  M: 2,
+  G: 3,
+  T: 4,
+  P: 5,
+  E: 6,
+  Z: 7,
+  Y: 8,
+  R: 9,
+  Q: 10,
+})
+// GNU accepts no leading '+' and no bare trailing '.', and it reads no
+// exponent: `1e3` is a number followed by the unknown suffix 'e3'.
+const NUMBER_RE = /^(-?(?:[0-9]*\.[0-9]+|[0-9]+))([\s\S]*)$/
 
-function parseNumber(value: string, fromMode: string): number {
-  const match = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([A-Za-z]*)$/.exec(value)
-  if (match === null) throw new Error(`numfmt: invalid number: '${value}'`)
-  const number = Number(match[1])
-  const suffix = (match[2] ?? '').replace(/i?B$/, '').replace(/i$/, '').toUpperCase()
-  if (suffix === '' || fromMode === 'none') return number
-  const exponent = SUFFIXES.indexOf(suffix as (typeof SUFFIXES)[number])
-  if (exponent < 0) throw new Error(`numfmt: invalid suffix in input: '${value}'`)
-  return number * (fromMode === 'si' ? 1000 : 1024) ** exponent
+// A value carried exactly, as digits / 10**scale, so that `--to=none` can
+// print every digit of `1Y` rather than the `1e+24` a double renders.
+interface Parsed {
+  digits: bigint
+  scale: number
+  decimals: number
+}
+
+// GNU's two shapes of suffix complaint, exit 2 either way. An unusable
+// first character quotes only the whole field; a usable unit followed by
+// junk quotes the field and then the junk (pinned against coreutils 9.7).
+function suffixError(value: string, junk: string): UsageError {
+  if (junk === '') return new UsageError(`numfmt: invalid suffix in input: '${value}'`, 2)
+  return new UsageError(`numfmt: invalid suffix in input '${value}': '${junk}'`, 2)
+}
+
+// Each --from mode spells the same units differently: si and iec take the
+// bare letter, iec-i requires the trailing 'i', and auto takes either and
+// lets the 'i' pick base 1024. Nothing may follow (pinned against coreutils
+// 9.7), which is why `1KiB` is refused everywhere -- it used to be read as
+// a kilobyte in both languages.
+function scaleOf(value: string, suffix: string, fromMode: string): [number, number] {
+  const exponent = UNIT_EXPONENTS[suffix[0] ?? '']
+  if (exponent === undefined) throw suffixError(value, '')
+  const tail = suffix.slice(1)
+  if (fromMode === 'iec-i') {
+    if (tail === '') {
+      throw new UsageError(`numfmt: missing 'i' suffix in input: '${value}' (e.g Ki/Mi/Gi)`, 2)
+    }
+    if (!tail.startsWith('i')) throw suffixError(value, tail)
+    if (tail.length > 1) throw suffixError(value, tail.slice(1))
+    return [1024, exponent]
+  }
+  if (fromMode === 'auto') {
+    const base = tail.startsWith('i') ? 1024 : 1000
+    const rest = base === 1024 ? tail.slice(1) : tail
+    if (rest !== '') throw suffixError(value, rest)
+    return [base, exponent]
+  }
+  if (tail !== '') throw suffixError(value, tail)
+  return [fromMode === 'si' ? 1000 : 1024, exponent]
+}
+
+// GNU prints an unscaled value back at the precision it was typed with
+// (`1.000` stays `1.000`) and a scaled one as a whole number rounded away
+// from zero (`1.0005K` is `1001`), so the decimal count travels with the
+// value. A unit that is spelled correctly but unusable because no --from
+// was given is reported as such, which is why the unit letter is checked
+// before the mode is. Deliberate divergence: GNU calls a second decimal
+// point an invalid suffix in some spellings and an invalid number in
+// others (`1.5.5` against `1..5`); mirage calls every trailing decimal
+// point an invalid number.
+function parseNumber(value: string, fromMode: string): Parsed {
+  const match = NUMBER_RE.exec(value)
+  const head = match?.[1] ?? ''
+  const rest = match?.[2] ?? ''
+  if (match === null || (rest.startsWith('.') && !head.includes('.'))) {
+    throw new UsageError(`numfmt: invalid number: '${value}'`, 2)
+  }
+  const dot = head.indexOf('.')
+  const fraction = dot < 0 ? '' : head.slice(dot + 1)
+  const digits = BigInt(dot < 0 ? head : head.slice(0, dot) + fraction)
+  if (rest === '') return { digits, scale: fraction.length, decimals: fraction.length }
+  if (UNIT_EXPONENTS[rest[0] ?? ''] === undefined) throw suffixError(value, '')
+  if (fromMode === 'none') {
+    throw new UsageError(`numfmt: rejecting suffix in input: '${value}' (consider using --from)`, 2)
+  }
+  const [base, exponent] = scaleOf(value, rest, fromMode)
+  return {
+    digits: digits * BigInt(base) ** BigInt(exponent),
+    scale: fraction.length,
+    decimals: 0,
+  }
+}
+
+// Round digits/10**scale away from zero at `places` decimals, returning the
+// result scaled by 10**places. BigInt division truncates toward zero, so a
+// non-zero remainder is what pushes the magnitude up.
+function roundAway(digits: bigint, scale: number, places: number): bigint {
+  if (scale <= places) return digits * 10n ** BigInt(places - scale)
+  const divisor = 10n ** BigInt(scale - places)
+  const quotient = digits / divisor
+  if (digits % divisor === 0n) return quotient
+  return digits < 0n ? quotient - 1n : quotient + 1n
+}
+
+function fixed(scaled: bigint, places: number, grouping: boolean): string {
+  const negative = scaled < 0n
+  const text = (negative ? -scaled : scaled).toString().padStart(places + 1, '0')
+  const whole = text.slice(0, text.length - places)
+  const grouped = grouping ? whole.replace(/\B(?=(\d{3})+(?!\d))/g, ',') : whole
+  const fraction = places > 0 ? `.${text.slice(text.length - places)}` : ''
+  return (negative ? '-' : '') + grouped + fraction
 }
 
 // Round away from zero at `places` decimals. Snapping to 15 significant digits
@@ -47,14 +149,20 @@ function toFixedHalfEven(value: number, places: number): string {
 
 // GNU rounds away from zero, keeping one decimal only while the scaled value
 // is below 10. That rounding can push a value back over the base
-// (999.4 -> 1000 -> 1.0k), so the unit is re-checked afterwards.
-function formatNumber(value: number, toMode: string, grouping: boolean): string {
+// (999.4 -> 1000 -> 1.0k), so the unit is re-checked afterwards. --to=none
+// instead keeps the precision the value was parsed with and rounds away
+// from zero there, always in fixed notation -- `1Y` is a twenty-five digit
+// number, never `1e+24`. Deliberate divergence: GNU reads the input into a
+// long double first, so a value it cannot hold exactly rounds up on the way
+// out (`1.10` prints as `1.11` while `1.20` and `1.30` do not); mirage
+// keeps the value exact, as it already does for printf.
+function formatNumber(parsed: Parsed, toMode: string, grouping: boolean): string {
   if (toMode === 'none') {
-    return grouping ? value.toLocaleString('en-US', { maximumFractionDigits: 20 }) : String(value)
+    return fixed(roundAway(parsed.digits, parsed.scale, parsed.decimals), parsed.decimals, grouping)
   }
   const base = toMode === 'si' ? 1000 : 1024
   const display = toMode === 'si' ? SI_DISPLAY : SUFFIXES
-  let number = value
+  let number = Number(parsed.digits) / 10 ** parsed.scale
   let power = 0
   while (Math.abs(number) >= base && power < display.length - 1) {
     number /= base

--- a/typescript/packages/core/src/commands/builtin/generic/sed.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/sed.test.ts
@@ -1,0 +1,70 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+import { describe, expect, it } from 'vitest'
+
+import { materialize } from '../../../io/types.ts'
+import type { CommandOpts } from '../../config.ts'
+import { sedGeneric } from './sed.ts'
+
+const DEC = new TextDecoder()
+
+async function runSed(
+  texts: string[],
+  flags: CommandOpts['flags'] = {},
+  stdin: Uint8Array | null = null,
+): Promise<{ exitCode: number; stderr: string }> {
+  const opts = {
+    stdin,
+    flags,
+    filetypeFns: null,
+    cwd: '/',
+    resource: { kind: 'ram' } as never,
+  } as CommandOpts
+  const result = await sedGeneric(
+    [],
+    texts,
+    opts,
+    () => {
+      throw new Error('no operands; nothing to stream')
+    },
+    () => Promise.resolve(),
+  )
+  if (result === null) throw new Error('sed returned nothing')
+  const io = result[1]
+  const stderr = io.stderr === null ? '' : DEC.decode(await materialize(io.stderr))
+  return { exitCode: io.exitCode, stderr }
+}
+
+describe('sed usage reporting', () => {
+  it('names a missing script and exits 1', async () => {
+    // GNU answers this with its whole usage block, also exit 1. Python used
+    // to raise ValueError('sed: usage: sed EXPRESSION [path]') here.
+    expect(await runSed([])).toEqual({ exitCode: 1, stderr: 'sed: missing script\n' })
+  })
+
+  it('reports no input files with GNU exit 4 when there is nothing to read', async () => {
+    // GNU's spelling and exit code for `sed -i` with no operands; mirage
+    // reuses them when there is no stdin either, having no terminal to
+    // read. This used to be 'sed: missing operand' with exit 1 here and
+    // ValueError('sed: usage: sed EXPRESSION path') in Python.
+    expect(await runSed(['s/a/b/'])).toEqual({ exitCode: 4, stderr: 'sed: no input files\n' })
+  })
+
+  it('reports no input files for -i with no operands too', async () => {
+    expect(await runSed(['s/a/b/'], { i: true })).toEqual({
+      exitCode: 4,
+      stderr: 'sed: no input files\n',
+    })
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/sed.ts
@@ -19,7 +19,15 @@ import { fsErrorLine, isFsError } from '../../../utils/errors.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
-import { executeProgram, parseOneCommand, parseProgram, type SedCommand } from '../sed_helper.ts'
+import {
+  executeProgram,
+  parseOneCommand,
+  parseProgram,
+  SED_MISSING_SCRIPT,
+  SED_NO_INPUT_EXIT,
+  SED_NO_INPUT_FILES,
+  type SedCommand,
+} from '../sed_helper.ts'
 import { readStdinAsync } from '../utils/stream.ts'
 
 const ENC = new TextEncoder()
@@ -56,7 +64,7 @@ export async function sedGeneric(
   if (!flagScript && texts[0] !== undefined) scriptParts.push(texts[0])
   const script = scriptParts.length > 0 ? scriptParts.join('\n') : undefined
   if (script === undefined) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('sed: missing script\n') })]
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${SED_MISSING_SCRIPT}\n`) })]
   }
   const suppress = fl.asBool('n')
   const inPlace = fl.asBool('i')
@@ -185,7 +193,13 @@ export async function sedGeneric(
 
   const raw = await readStdinAsync(opts.stdin)
   if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('sed: missing operand\n') })]
+    return [
+      null,
+      new IOResult({
+        exitCode: SED_NO_INPUT_EXIT,
+        stderr: ENC.encode(`${SED_NO_INPUT_FILES}\n`),
+      }),
+    ]
   }
   const text = DEC.decode(raw)
   const result = executeProgram(text, commands, suppress, extended)

--- a/typescript/packages/core/src/commands/builtin/generic/split.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/split.test.ts
@@ -90,6 +90,37 @@ describe('split flag values', () => {
     expect(hex.xf0).toBeUndefined()
   })
 
+  it('reads -t as one byte and keeps it on every record', async () => {
+    // `\0` is the only escape GNU reads, and it is two characters on the
+    // command line; everything else is literal, so a lone backslash and a
+    // digit zero are ordinary separators. Each record keeps its terminator.
+    const nul = await runSplit({ separator: '\\0', lines: '2' }, 'a\0b\0c\0')
+    expect(nul.xaa).toBe('a\0b\0')
+    expect(nul.xab).toBe('c\0')
+    const digit = await runSplit({ separator: '0', lines: '2' }, 'a0b0c0')
+    expect(digit.xaa).toBe('a0b0')
+    const backslash = await runSplit({ separator: '\\', lines: '2' }, 'a\\b\\c\\')
+    expect(backslash.xaa).toBe('a\\b\\')
+  })
+
+  it.each([['XY'], ['abc'], ['\\n'], ['\\t'], ['é']])(
+    'refuses the multi-byte separator %j instead of taking its first byte',
+    async (separator) => {
+      // This used to encode the value and keep byte 0, so `-t XY` split on
+      // 'X' where GNU refuses to run at all. 'é' is one character but two
+      // UTF-8 bytes, and GNU counts bytes.
+      await expect(runSplit({ separator })).rejects.toThrow(
+        new UsageError(`split: multi-character separator '${separator}'`, 1),
+      )
+    },
+  )
+
+  it('refuses an empty separator', async () => {
+    await expect(runSplit({ separator: '' })).rejects.toThrow(
+      new UsageError('split: empty record separator', 1),
+    )
+  })
+
   it('exhausts an explicit width instead of wrapping onto earlier chunks', async () => {
     // GNU keeps the chunks already written and fails on the next name.
     const sink: Record<string, string> = {}

--- a/typescript/packages/core/src/commands/builtin/generic/split.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/split.ts
@@ -104,6 +104,27 @@ function parseSuffixStart(value: string, hexMode: boolean, suffixLen: number): n
   return start
 }
 
+// GNU reads -t as one byte and refuses every other length rather than
+// truncating to the first: an empty value is an empty record separator and
+// anything longer is a multi-character one, with the two-character spelling
+// `\0` carved out as the only way to write a NUL on a command line. The
+// length is counted in bytes, so a lone non-ASCII character is
+// multi-character too (pinned against coreutils 9.7). Deliberate
+// divergence, matching truncate: GNU's quotearg escapes control characters
+// in the message and mirage quotes the raw value. Not covered: GNU also
+// refuses two -t flags naming different characters, which needs a
+// list-valued flag the spec does not have.
+function parseSeparator(value: string | undefined): number {
+  if (value === undefined) return 0x0a
+  if (value === '\\0') return 0
+  const encoded = ENC.encode(value)
+  if (encoded.byteLength === 0) throw new UsageError('split: empty record separator', 1)
+  if (encoded.byteLength > 1) {
+    throw new UsageError(`split: multi-character separator '${value}'`, 1)
+  }
+  return encoded[0] ?? 0x0a
+}
+
 const ALPHA_SUFFIXES = 'abcdefghijklmnopqrstuvwxyz'
 const NUMERIC_SUFFIXES = '0123456789'
 const HEX_SUFFIXES = '0123456789abcdef'
@@ -261,12 +282,7 @@ export async function splitGeneric(
         ? parseSuffixStart(hexValue, true, suffixLen)
         : 0
   const additionalSuffix = fl.asStr('additional_suffix') ?? ''
-  const separator =
-    separatorValue === '\\0'
-      ? 0
-      : typeof separatorValue === 'string'
-        ? (ENC.encode(separatorValue)[0] ?? 0x0a)
-        : 0x0a
+  const separator = parseSeparator(separatorValue)
   const linesPerFile =
     linesFlag !== null ? parseLinesValue(linesFlag) : bFlag === null && nFlag === null ? 1000 : 0
   const byteLimit = bFlag !== null ? parseBytesValue(bFlag) : 0

--- a/typescript/packages/core/src/commands/builtin/generic/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tail.ts
@@ -18,13 +18,28 @@ import { cacheAwareStreamEager } from '../../../cache/read_through.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
-import { countNewlines, numberFlagError, parseN, tailBytes } from '../tail_helper.ts'
+import {
+  countNewlines,
+  numberFlagError,
+  parseCounts,
+  tailBytes,
+  type TailCounts,
+} from '../tail_helper.ts'
 import { fsErrorLine, isFsError } from '../../../utils/errors.ts'
 import { readStdinAsync } from '../utils/stream.ts'
 
 const ENC = new TextEncoder()
 
 type Stream = (p: PathSpec) => AsyncIterable<Uint8Array>
+
+// Whether this operand's whole content is what tail emits, which is what
+// makes it worth handing to the file cache. Counting from the start is
+// never treated as a full read, matching what `-n +N` has always done.
+function readsEverything(counts: TailCounts, raw: Uint8Array): boolean {
+  if (counts.fromByte !== null || counts.fromLine !== null) return false
+  if (counts.byteCount !== null) return counts.byteCount >= raw.byteLength
+  return (counts.lines ?? 10) >= countNewlines(raw)
+}
 
 function concat(chunks: Uint8Array[]): Uint8Array {
   let total = 0
@@ -52,8 +67,7 @@ export async function tailGeneric(
   if (numErr !== null) return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(numErr) })]
   const qFlag = fl.asBool('q')
   const vFlag = fl.asBool('v')
-  const [lines, plusMode] = parseN(nRaw)
-  const bytesMode = cRaw !== null ? Number.parseInt(cRaw, 10) : null
+  const counts = parseCounts(nRaw, cRaw)
 
   if (paths.length > 0) {
     const chunks: Uint8Array[] = []
@@ -77,13 +91,8 @@ export async function tailGeneric(
         chunks.push(ENC.encode(header))
       }
       printed += 1
-      if (bytesMode !== null) {
-        chunks.push(bytesMode === 0 ? new Uint8Array(0) : raw.slice(-bytesMode))
-        if (bytesMode >= raw.byteLength) cache.push(p.virtual)
-      } else {
-        chunks.push(tailBytes(raw, lines, null, plusMode))
-        if (!plusMode && lines >= countNewlines(raw)) cache.push(p.virtual)
-      }
+      chunks.push(tailBytes(raw, counts))
+      if (readsEverything(counts, raw)) cache.push(p.virtual)
     }
     const io = new IOResult({
       cache,
@@ -98,9 +107,5 @@ export async function tailGeneric(
   if (raw === null) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('tail: missing operand\n') })]
   }
-  if (bytesMode !== null) {
-    const out: ByteSource = bytesMode === 0 ? new Uint8Array(0) : raw.slice(-bytesMode)
-    return [out, new IOResult()]
-  }
-  return [tailBytes(raw, lines, null, plusMode), new IOResult()]
+  return [tailBytes(raw, counts), new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tail.ts
@@ -20,6 +20,7 @@ import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import {
   countNewlines,
+  normalizeCounts,
   numberFlagError,
   parseCounts,
   tailBytes,
@@ -35,7 +36,8 @@ type Stream = (p: PathSpec) => AsyncIterable<Uint8Array>
 // Whether this operand's whole content is what tail emits, which is what
 // makes it worth handing to the file cache. Counting from the start is
 // never treated as a full read, matching what `-n +N` has always done.
-function readsEverything(counts: TailCounts, raw: Uint8Array): boolean {
+function readsEverything(rawCounts: TailCounts, raw: Uint8Array): boolean {
+  const counts = normalizeCounts(rawCounts)
   if (counts.fromByte !== null || counts.fromLine !== null) return false
   if (counts.byteCount !== null) return counts.byteCount >= raw.byteLength
   return (counts.lines ?? 10) >= countNewlines(raw)

--- a/typescript/packages/core/src/commands/builtin/ram/tail/tail.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/tail/tail.test.ts
@@ -93,6 +93,36 @@ describe('tail', () => {
     expect(await runTail(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { c: '0' })).toBe('')
   })
 
+  it('-c -N counts back from the end, like -c N', async () => {
+    // This used to drop the FIRST N bytes: the raw signed value went into
+    // raw.slice(-bytesMode), so a leading '-' flipped the slice around.
+    const resource = new RAMResource()
+    resource.store.files.set('/tmp/f.txt', ENC.encode('abcdefghij'))
+    expect(await runTail(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { c: '-3' })).toBe('hij')
+  })
+
+  it('-c +N counts forward from byte N', async () => {
+    const resource = new RAMResource()
+    resource.store.files.set('/tmp/f.txt', ENC.encode('abcdefghij'))
+    expect(await runTail(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { c: '+3' })).toBe(
+      'cdefghij',
+    )
+  })
+
+  it('-c +1 and -c +0 are the whole file', async () => {
+    const resource = new RAMResource()
+    resource.store.files.set('/tmp/f.txt', ENC.encode('abcdefghij'))
+    const path = [PathSpec.fromStrPath('/tmp/f.txt')]
+    expect(await runTail(resource, path, { c: '+1' })).toBe('abcdefghij')
+    expect(await runTail(resource, path, { c: '+0' })).toBe('abcdefghij')
+  })
+
+  it('-c +N past the end returns empty', async () => {
+    const resource = new RAMResource()
+    resource.store.files.set('/tmp/f.txt', ENC.encode('abcdefghij'))
+    expect(await runTail(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { c: '+99' })).toBe('')
+  })
+
   it('empty file', async () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', new Uint8Array())

--- a/typescript/packages/core/src/commands/builtin/sed_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/sed_helper.ts
@@ -14,6 +14,18 @@
 
 const SIMPLE_CMDS = new Set(['d', 'D', 'p', 'P', 'h', 'H', 'g', 'G', 'x', 'N', 'q'])
 
+// GNU answers a missing script with its whole thirty-nine line usage block
+// and exit 1; mirage names the problem in one line instead, because the
+// block is GNU's own prose and reproducing it buys a mirage user nothing.
+// `no input files` and its exit 4 are GNU's exact spelling for `sed -i`
+// with no operands, and mirage reuses them when there is no stdin either --
+// it has no terminal for GNU's blocking read to reach. Both live here so
+// the generic and its builder cannot drift apart again; there used to be
+// four spellings across the two languages.
+export const SED_MISSING_SCRIPT = 'sed: missing script'
+export const SED_NO_INPUT_FILES = 'sed: no input files'
+export const SED_NO_INPUT_EXIT = 4
+
 type SedAddr = ['line', string] | ['last', ''] | ['regex', string]
 
 export interface SedCommand {

--- a/typescript/packages/core/src/commands/builtin/tail_helper.test.ts
+++ b/typescript/packages/core/src/commands/builtin/tail_helper.test.ts
@@ -1,0 +1,85 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { parseCounts, tailBytes } from './tail_helper.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+function run(data: string, n: string | null, c: string | null): string {
+  return DEC.decode(tailBytes(ENC.encode(data), parseCounts(n, c)))
+}
+
+describe('parseCounts', () => {
+  it('sends a bare count to the count-back-from-the-end slot', () => {
+    expect(parseCounts('3', null)).toEqual({
+      lines: 3,
+      fromLine: null,
+      byteCount: null,
+      fromByte: null,
+    })
+  })
+
+  it('sends a leading + to the count-forward slot, for bytes too', () => {
+    // The byte half is the fix: `-c +3` used to be parsed as the plain
+    // number 3 and served as the LAST three bytes.
+    expect(parseCounts(null, '+3').fromByte).toBe(3)
+    expect(parseCounts(null, '+3').byteCount).toBeNull()
+  })
+
+  it('leaves an unset flag null so the caller picks its own default', () => {
+    expect(parseCounts(null, null)).toEqual({
+      lines: null,
+      fromLine: null,
+      byteCount: null,
+      fromByte: null,
+    })
+  })
+})
+
+describe('tailBytes', () => {
+  it('-c N and -c -N both take the last N bytes', () => {
+    expect(run('abcdefghij', null, '3')).toBe('hij')
+    expect(run('abcdefghij', null, '-3')).toBe('hij')
+  })
+
+  it('-c +N starts at byte N, 1-indexed', () => {
+    expect(run('abcdefghij', null, '+3')).toBe('cdefghij')
+    expect(run('abcdefghij', null, '+1')).toBe('abcdefghij')
+    expect(run('abcdefghij', null, '+0')).toBe('abcdefghij')
+    expect(run('abcdefghij', null, '+99')).toBe('')
+  })
+
+  it('-c 0 is empty but a count past the end is the whole file', () => {
+    expect(run('abcdefghij', null, '0')).toBe('')
+    expect(run('abcdefghij', null, '99')).toBe('abcdefghij')
+  })
+
+  it('falls back to the last 10 lines when neither flag is set', () => {
+    const body = Array.from({ length: 20 }, (_, i) => `line${String(i + 1)}`).join('\n')
+    expect(run(body, null, null).split('\n')).toHaveLength(10)
+  })
+
+  it('keeps the line behaviour it already had', () => {
+    expect(run('a\nb\nc\nd\ne\n', '3', null)).toBe('c\nd\ne\n')
+    expect(run('a\nb\nc\nd\ne\n', '-3', null)).toBe('c\nd\ne\n')
+    expect(run('a\nb\nc\nd\ne\n', '+2', null)).toBe('b\nc\nd\ne\n')
+    expect(run('a\nb\nc\n', '0', null)).toBe('')
+  })
+
+  it('lets -c win over -n, as GNU does', () => {
+    expect(run('abcdefghij', '2', '3')).toBe('hij')
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/tail_helper.test.ts
+++ b/typescript/packages/core/src/commands/builtin/tail_helper.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { parseCounts, tailBytes } from './tail_helper.ts'
+import { normalizeCounts, parseCounts, tailBytes, type TailCounts } from './tail_helper.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder()
@@ -21,6 +21,30 @@ const DEC = new TextDecoder()
 function run(data: string, n: string | null, c: string | null): string {
   return DEC.decode(tailBytes(ENC.encode(data), parseCounts(n, c)))
 }
+
+describe('normalizeCounts', () => {
+  // A TailCounts is a plain object, so anything reaching tailBytes from
+  // outside TypeScript can leave fields undefined. `undefined !== null` is
+  // true, so a bare guard used to take the count-forward branch and return
+  // `slice(NaN)` -- the whole input, silently.
+  it('reads a missing field as unset rather than as a count', () => {
+    expect(normalizeCounts({ lines: 2 } as unknown as TailCounts)).toEqual({
+      lines: 2,
+      fromLine: null,
+      byteCount: null,
+      fromByte: null,
+    })
+  })
+
+  it.each([
+    [{ lines: 2 }, 'd\ne\n'],
+    [{}, 'a\nb\nc\nd\ne\n'],
+    [{ byteCount: 3 }, '\ne\n'],
+  ])('serves %j as its own kind of tail, not as the whole input', (partial, expected) => {
+    const data = ENC.encode('a\nb\nc\nd\ne\n')
+    expect(DEC.decode(tailBytes(data, partial as TailCounts))).toBe(expected)
+  })
+})
 
 describe('parseCounts', () => {
   it('sends a bare count to the count-back-from-the-end slot', () => {

--- a/typescript/packages/core/src/commands/builtin/tail_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/tail_helper.ts
@@ -26,6 +26,25 @@ export interface TailCounts {
 }
 
 /**
+ * Fill in whatever a caller left off a `TailCounts`.
+ *
+ * The struct is a plain object, so a caller that omits a field — or a
+ * JavaScript one that passes something else entirely — supplies undefined,
+ * and a bare `!== null` test waves that straight into the first branch,
+ * where `slice(NaN)` quietly returns the whole input. Python's twin is a
+ * dataclass whose four fields all default to None and has no such hole;
+ * reading every field through `?? null` gives this side the same floor.
+ */
+export function normalizeCounts(counts: TailCounts): TailCounts {
+  return {
+    lines: counts.lines ?? null,
+    fromLine: counts.fromLine ?? null,
+    byteCount: counts.byteCount ?? null,
+    fromByte: counts.fromByte ?? null,
+  }
+}
+
+/**
  * Split tail's `-n`/`-c` values by which end they count from.
  *
  * GNU gives both flags the same sign grammar: a leading `+` counts forward
@@ -67,7 +86,8 @@ export function numberFlagError(
   return null
 }
 
-export function tailBytes(data: Uint8Array, counts: TailCounts): Uint8Array {
+export function tailBytes(data: Uint8Array, rawCounts: TailCounts): Uint8Array {
+  const counts = normalizeCounts(rawCounts)
   if (counts.fromByte !== null) {
     // GNU counts `-c +N` from byte N, 1-indexed, so +0 and +1 both mean the
     // whole input.

--- a/typescript/packages/core/src/commands/builtin/tail_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/tail_helper.ts
@@ -18,6 +18,39 @@ export function parseN(n: string | null): [number, boolean] {
   return [Number.parseInt(n, 10), false]
 }
 
+export interface TailCounts {
+  lines: number | null
+  fromLine: number | null
+  byteCount: number | null
+  fromByte: number | null
+}
+
+/**
+ * Split tail's `-n`/`-c` values by which end they count from.
+ *
+ * GNU gives both flags the same sign grammar: a leading `+` counts forward
+ * from the start of the input, 1-indexed, so `+0` and `+1` both mean the
+ * whole thing; any other spelling counts back from the end. Every caller
+ * used to apply that grammar to `-n` and take the absolute value of `-c`,
+ * which silently turned `tail -c +3` into the last three bytes — so the
+ * split lives here, once, beside the parser it is built from. Mirrors
+ * Python's `parse_counts`.
+ */
+export function parseCounts(nRaw: string | null, cRaw: string | null): TailCounts {
+  const counts: TailCounts = { lines: null, fromLine: null, byteCount: null, fromByte: null }
+  if (nRaw !== null) {
+    const [count, plusMode] = parseN(nRaw)
+    if (plusMode) counts.fromLine = count
+    else counts.lines = count
+  }
+  if (cRaw !== null) {
+    const [count, plusMode] = parseN(cRaw)
+    if (plusMode) counts.fromByte = count
+    else counts.byteCount = count
+  }
+  return counts
+}
+
 // GNU-style validation for head/tail -n/-c. Mirrors Python's int() raising on
 // a non-numeric value; returns the error line (with the bad value) or null.
 export function numberFlagError(
@@ -34,14 +67,14 @@ export function numberFlagError(
   return null
 }
 
-export function tailBytes(
-  data: Uint8Array,
-  lines: number,
-  bytesMode: number | null = null,
-  plusMode = false,
-): Uint8Array {
-  if (bytesMode !== null) {
-    const targetBytes = Math.abs(bytesMode)
+export function tailBytes(data: Uint8Array, counts: TailCounts): Uint8Array {
+  if (counts.fromByte !== null) {
+    // GNU counts `-c +N` from byte N, 1-indexed, so +0 and +1 both mean the
+    // whole input.
+    return data.slice(Math.max(0, counts.fromByte - 1))
+  }
+  if (counts.byteCount !== null) {
+    const targetBytes = Math.abs(counts.byteCount)
     if (targetBytes === 0) return new Uint8Array(0)
     const start = Math.max(0, data.byteLength - targetBytes)
     return data.slice(start)
@@ -50,10 +83,10 @@ export function tailBytes(
   const trimmed =
     parts.length > 0 && parts[parts.length - 1]?.byteLength === 0 ? parts.slice(0, -1) : parts
   let selected: Uint8Array[]
-  if (plusMode) {
-    selected = trimmed.slice(Math.max(0, lines - 1))
+  if (counts.fromLine !== null) {
+    selected = trimmed.slice(Math.max(0, counts.fromLine - 1))
   } else {
-    const targetLines = Math.abs(lines)
+    const targetLines = Math.abs(counts.lines ?? 10)
     if (targetLines === 0) return new Uint8Array(0)
     selected = trimmed.slice(-targetLines)
   }

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -394,7 +394,13 @@ export {
   sortLines,
   splitSortLines,
 } from './commands/builtin/sort_helper.ts'
-export { countNewlines, parseN, tailBytes } from './commands/builtin/tail_helper.ts'
+export {
+  countNewlines,
+  parseCounts,
+  parseN,
+  tailBytes,
+  type TailCounts,
+} from './commands/builtin/tail_helper.ts'
 export { AsyncLineIterator } from './io/async_line_iterator.ts'
 export { readStdinAsync, resolveSource, wrapBytes } from './commands/builtin/utils/stream.ts'
 export { formatLsLong, humanSize } from './commands/builtin/utils/formatting.ts'

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -396,6 +396,7 @@ export {
 } from './commands/builtin/sort_helper.ts'
 export {
   countNewlines,
+  normalizeCounts,
   parseCounts,
   parseN,
   tailBytes,


### PR DESCRIPTION
Six of the eight T1-F rows from the cleanup plan. Every row was re-pinned against `debian:stable-slim` (coreutils 9.7, sed 4.9) before it was touched, and that changed the plan: **four rows were wrong in both languages, not one**, two were substantially larger than recorded, and one (`tar --exclude`) turned out to be already fixed and is dropped.

## The rows

**`tail -c` takes the same sign grammar as `-n`.** TypeScript did `raw.slice(-bytesMode)`, so `-c -3` dropped the *first* three bytes; Python's `abs(c)` turned `-c +3` into the last three. The audit called Python correct — it isn't. Both now route `-c` through one shared `parse_counts`/`parseCounts`, which is the actual fix: the sign grammar was hand-written at three Python call sites (the generic binder plus the mongodb and postgres wrappers) and they had drifted apart. TS's `tailBytes` already had the right last-N logic and the generic simply never reached it for `-c`.

**`split -t` is one byte, or the two-character spelling `\0`.** TypeScript took `ENC.encode(sep)[0]`; Python kept the whole byte string. So `split -t XY` split on `X` in one tree and on `XY` in the other, where GNU refuses to run at all (`split: multi-character separator 'XY'`, exit 1). An empty `--separator=` is now reported rather than silently falling back to newline. Length is counted in bytes, so a lone non-ASCII character is multi-character too.

**`numfmt` needed both halves of its row plus more.**
- `--to=none` renders in fixed notation from an exact value: `--from=si 1Y` prints twenty-five digits instead of TypeScript's `1e+24`, and `--from=iec 1Q` prints at all — Python's default 28-digit decimal context could not hold `1024**10` and raised. An unscaled value keeps the precision it was typed with (`1.000` stays `1.000`); a scaled one is a whole number rounded away from zero (`1.0005K` → `1001`).
- The suffix grammar is now GNU's: one unit letter, lowercase accepted only for kilo, with the trailing `i` required under `iec-i`, optional under `auto` (and selecting base 1024), and refused elsewhere. `1KiB` used to read as a kilobyte in **both** trees — TS stripped it with `/i?B$/`, Python with `.removesuffix("i").removesuffix("B")`. `--from=auto 1K` was 1024 on both sides where GNU gives 1000.
- Errors now carry GNU's four message shapes and **exit 2**, instead of `Error` in TS and a raw `decimal.InvalidOperation` in Python.

**`sed`'s missing-script and no-input paths had four spellings** across the two languages, and Python *raised* where TypeScript returned exit 1. Both now share two constants in `sed_helper`, return an `IOResult`, and use GNU's `sed: no input files` with its exit 4. GNU's 39-line usage block is deliberately **not** reproduced — it is GNU's own prose, and one line says the same thing.

**`cp -rv`** ordered sibling directories by length alone, which leaves equal-length names in `PYTHONHASHSEED` order in Python and Set-insertion order in TS. Both key on `(len, path)` now.

**`find -mtime`** parsed timestamps inline on both sides instead of using the helper each tree already had. Python stamped UTC over a real reported offset (a `+09:00` backend read nine hours off) and let a malformed value raise out of the walk; TypeScript's bare `Date.parse` produced a `NaN` that slipped past the `=== null` guard, so every comparison came out false and the entry was **kept** where Python dropped it.

## Deliberate divergences, documented in place

- The `split` message quotes the raw separator; GNU's `quotearg` escapes control characters (`'\\n'` for a literal backslash-n). This matches the choice already recorded for `truncate`.
- GNU reads `numfmt` input into a long double, so a value it cannot hold exactly rounds up on the way out — `1.10` prints as `1.11` while `1.20` and `1.30` round-trip. mirage keeps the value exact, as it already does for `printf`.
- GNU distinguishes an invalid *suffix* from an invalid *number* inconsistently for a second decimal point (`1.5.5` against `1..5`); mirage calls every trailing decimal point an invalid number.
- GNU also refuses two `-t` flags naming different characters. That needs a list-valued flag the spec does not have; noted in the code, not implemented.

## Verification

- **4695 integ cases pass on `ram` and `disk` under both runners**, including 13 new cases across `integ/unix/{tail,split,numfmt,sed}/`. The two `sed` usage cases run on all 22 targets so a backend wrapper cannot grow its own spelling again.
- New unit suites mirror 1:1: `test_numfmt.py` / `numfmt.test.ts` are 63 tests each, both driven from the same docker-pinned table.
- `pnpm -r typecheck` clean, `pnpm -r test` green (core 7361, browser 182, node 2120), full `pytest` green, `check_spec_parity.py` 93/93.

## Out of scope, filed separately

Found while pinning `split -t '\0'`: `commands/builtin/utils/escapes.{py,ts}` is used only by `tr` and **both sides diverge from GNU tr**, in different ways. GNU reads `\NNN` octal (no leading zero), and an unknown escape drops the backslash. Python's helper is a regex over eight named escapes and passes everything else through unchanged, so `tr '\0' '-'` silently does nothing; TypeScript's is the *echo* reader, with `\0NNN` and a `\xHH` GNU tr does not have. Not in this PR.

The remaining T1-F rows — `wc -w`/`-L` (much larger than recorded: `-L` is terminal-column geometry, not code points) and #370's astral sort order across 40+ TS `.sort()` sites — each get their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)