### PR TITLE
fix(himalaya): file the sender's own copy of a sent message

### DIFF
--- a/docs/python/cli/himalaya.mdx
+++ b/docs/python/cli/himalaya.mdx
@@ -28,6 +28,37 @@ ws.register_cli("himalaya", HIMALAYA, config.model_dump())
 Two installs under different names are two accounts. In YAML, the same
 install rides the `clis:` section; see the [CLI overview](/python/cli/index).
 
+## Sent copies
+
+Sending is SMTP and keeps no record of itself, so the copy in your own
+Sent mailbox is a second, separate IMAP `APPEND` that mail clients make
+on your behalf. mirage makes it too, `\Seen`, on every `--send`.
+
+Which mailbox it lands in is asked, not guessed: a server that
+implements RFC 6154 tags one of its mailboxes `\Sent` in its folder
+listing, which is `[Gmail]/Sent Mail` on Gmail and `Sent Items` on
+Exchange. Set `sent_folder` to pin a name and skip the probe, or
+`save_copy=False` to file nothing.
+
+```python
+config = EmailConfig(
+    imap_host="imap.example.com",
+    smtp_host="smtp.example.com",
+    username="agent@example.com",
+    password="app-password",
+    save_copy=True,      # the default
+    sent_folder="Sent",  # unset asks the server
+)
+```
+
+`--save <MAILBOX>` overrides both for one line, and on its own (without
+`--send`) it files the message without sending it, which is how a draft
+is written. The two failure modes differ on purpose: a copy that fails
+*after* a successful send is a warning on stderr and exit 0, because
+the mail is already gone and a non-zero exit invites a retry that would
+send it twice; a `--save` that sends nothing fails loudly, because
+nothing happened yet.
+
 ## Verbs
 
 The verbs follow the [himalaya](https://github.com/pimalaya/himalaya)
@@ -126,6 +157,7 @@ himalaya message compose --to you@example.org --subject Report --body 'see attac
 | `--attach`      | no       | Attachment file path, repeatable               |
 | `--signature`   | no       | Signature appended after a `-- ` line          |
 | `--send`        | no       | Send through SMTP instead of writing to stdout |
+| `--save`        | no       | File a copy in this mailbox (see above)        |
 
 ### `himalaya message send`
 
@@ -134,8 +166,14 @@ is the sink a composer chain feeds.
 
 ```bash
 himalaya message send < message.eml
+himalaya message send --save Sent < message.eml
 himalaya message compose --to you@example.org --subject Hi --body yo | himalaya message send
 ```
+
+| Option    | Required | Description                            |
+| --------- | -------- | -------------------------------------- |
+| `<ID>`    | no       | The message itself, inline             |
+| `--save`  | no       | File a copy in this mailbox            |
 
 ### `himalaya message reply`
 
@@ -177,9 +215,15 @@ Deliberate gaps, all of which fail loudly rather than silently:
   download`, `mailbox` and the protocol-specific subgroups (`imap`,
   `jmap`, `gmail`, `msgraph`, `smtp`) are not implemented. An unknown
   verb exits 1 with git's wording.
-- `--save <MAILBOX>` is absent because the email backend has no IMAP
-  `APPEND`, and `message read --seen` is absent because the mount is
-  read-only and never flips `\Seen`.
+- `message read --seen` is absent because the mount is read-only and
+  never flips `\Seen`.
+- The account-level sent copy is mirage's own, and defaults on. Upstream
+  v2 files a copy only when `--save <MAILBOX>` names one; a mirage agent
+  that never learned the flag still leaves the record a human sender
+  would. Turn it off with `save_copy` per account.
+- Resolving the sent mailbox from the server's RFC 6154 `\Sent` tag is
+  ahead of upstream, whose own IMAP backend still pins `INBOX` alone
+  while it waits on `LIST RETURN (SPECIAL-USE)` support in io-imap.
 - `envelope list` renders JSON, not a table, so its table flags
   (`--max-width`, `--recipient`, `--has-attachment`) do not exist.
 - Body and signature files (`--body-file`, `--signature-file`) are

--- a/docs/typescript/cli/himalaya.mdx
+++ b/docs/typescript/cli/himalaya.mdx
@@ -25,6 +25,37 @@ ws.registerCli('himalaya', HIMALAYA, config)
 Two installs under different names are two accounts. In YAML, the same
 install rides the `clis:` section; see the [CLI overview](/typescript/cli/index).
 
+## Sent copies
+
+Sending is SMTP and keeps no record of itself, so the copy in your own
+Sent mailbox is a second, separate IMAP `APPEND` that mail clients make
+on your behalf. mirage makes it too, `\Seen`, on every `--send`.
+
+Which mailbox it lands in is asked, not guessed: a server that
+implements RFC 6154 tags one of its mailboxes `\Sent` in its folder
+listing, which is `[Gmail]/Sent Mail` on Gmail and `Sent Items` on
+Exchange. Set `sentFolder` to pin a name and skip the probe, or
+`saveCopy=False` to file nothing.
+
+```ts
+const config = {
+  imapHost: 'imap.example.com',
+  smtpHost: 'smtp.example.com',
+  username: 'agent@example.com',
+  password: 'app-password',
+  saveCopy: true, // the default
+  sentFolder: 'Sent', // unset asks the server
+}
+```
+
+`--save <MAILBOX>` overrides both for one line, and on its own (without
+`--send`) it files the message without sending it, which is how a draft
+is written. The two failure modes differ on purpose: a copy that fails
+*after* a successful send is a warning on stderr and exit 0, because
+the mail is already gone and a non-zero exit invites a retry that would
+send it twice; a `--save` that sends nothing fails loudly, because
+nothing happened yet.
+
 ## Verbs
 
 The verbs follow the [himalaya](https://github.com/pimalaya/himalaya)
@@ -123,6 +154,7 @@ himalaya message compose --to you@example.org --subject Report --body 'see attac
 | `--attach`      | no       | Attachment file path, repeatable               |
 | `--signature`   | no       | Signature appended after a `-- ` line          |
 | `--send`        | no       | Send through SMTP instead of writing to stdout |
+| `--save`        | no       | File a copy in this mailbox (see above)        |
 
 ### `himalaya message send`
 
@@ -131,8 +163,14 @@ is the sink a composer chain feeds.
 
 ```bash
 himalaya message send < message.eml
+himalaya message send --save Sent < message.eml
 himalaya message compose --to you@example.org --subject Hi --body yo | himalaya message send
 ```
+
+| Option    | Required | Description                            |
+| --------- | -------- | -------------------------------------- |
+| `<ID>`    | no       | The message itself, inline             |
+| `--save`  | no       | File a copy in this mailbox            |
 
 ### `himalaya message reply`
 
@@ -174,9 +212,15 @@ Deliberate gaps, all of which fail loudly rather than silently:
   download`, `mailbox` and the protocol-specific subgroups (`imap`,
   `jmap`, `gmail`, `msgraph`, `smtp`) are not implemented. An unknown
   verb exits 1 with git's wording.
-- `--save <MAILBOX>` is absent because the email backend has no IMAP
-  `APPEND`, and `message read --seen` is absent because the mount is
-  read-only and never flips `\Seen`.
+- `message read --seen` is absent because the mount is read-only and
+  never flips `\Seen`.
+- The account-level sent copy is mirage's own, and defaults on. Upstream
+  v2 files a copy only when `--save <MAILBOX>` names one; a mirage agent
+  that never learned the flag still leaves the record a human sender
+  would. Turn it off with `saveCopy` per account.
+- Resolving the sent mailbox from the server's RFC 6154 `\Sent` tag is
+  ahead of upstream, whose own IMAP backend still pins `INBOX` alone
+  while it waits on `LIST RETURN (SPECIAL-USE)` support in io-imap.
 - `envelope list` renders JSON, not a table, so its table flags
   (`--max-width`, `--recipient`, `--has-attachment`) do not exist.
 - Body and signature files (`--body-file`, `--signature-file`) are

--- a/integ/cli/himalaya.json
+++ b/integ/cli/himalaya.json
@@ -885,6 +885,88 @@
         "stdout": "From: integ@example.com\r\nTo: integ@example.com\r\nSubject: =?utf-8?b?UsOpc3Vtw6kgZMOpdGFpbGzDqQ==?=\r\nContent-Type: text/plain; charset=\"utf-8\"\r\nContent-Transfer-Encoding: 8bit\r\nMIME-Version: 1.0\r\n\r\nnaïve résumé body\r\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "hm_send_files_the_senders_own_copy",
+      "seq": 562118,
+      "targets": [
+        "cli-himalaya"
+      ],
+      "clear_cache": true,
+      "command": "grep -rl 'sent from the cli facet' /mail/Sent | wc -l | tr -d ' '",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hm_save_without_send_files_a_draft",
+      "seq": 562119,
+      "targets": [
+        "cli-himalaya"
+      ],
+      "command": "himalaya message compose --to integ@example.com --subject 'Draft probe' --body 'never sent' --save Archive | jq -r .status",
+      "expect": {
+        "exit": 0,
+        "stdout": "saved\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hm_save_without_send_lands_in_the_named_mailbox",
+      "seq": 562120,
+      "targets": [
+        "cli-himalaya"
+      ],
+      "clear_cache": true,
+      "command": "grep -rl 'never sent' /mail/Archive | wc -l | tr -d ' '",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hm_save_without_send_reached_no_recipient",
+      "seq": 562121,
+      "targets": [
+        "cli-himalaya"
+      ],
+      "clear_cache": true,
+      "command": "grep -rl 'never sent' /mail/INBOX | wc -l | tr -d ' '",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hm_save_names_the_mailbox_for_a_sent_copy",
+      "seq": 562122,
+      "targets": [
+        "cli-himalaya"
+      ],
+      "command": "himalaya message compose --to integ@example.com --subject 'Filed probe' --body 'filed elsewhere' --send --save Archive | jq -r .status",
+      "expect": {
+        "exit": 0,
+        "stdout": "sent\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hm_save_beat_the_default_sent_mailbox",
+      "seq": 562123,
+      "targets": [
+        "cli-himalaya"
+      ],
+      "clear_cache": true,
+      "command": "grep -rl 'filed elsewhere' /mail/Archive | wc -l | tr -d ' '",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/resources/email/basic.json
+++ b/integ/resources/email/basic.json
@@ -10,7 +10,7 @@
       "command": "ls /mail",
       "expect": {
         "exit": 0,
-        "stdout": "Archive\nINBOX\n",
+        "stdout": "Archive\nINBOX\nSent\n",
         "stderr": ""
       }
     },
@@ -389,6 +389,20 @@
       ],
       "clear_cache": true,
       "command": "find /mail/INBOX -name 'Fwd_*' | wc -l",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "em_send_keeps_a_copy_in_sent",
+      "seq": 540027,
+      "targets": [
+        "email"
+      ],
+      "clear_cache": true,
+      "command": "find /mail/Sent -name 'Ship_update*' | wc -l",
       "expect": {
         "exit": 0,
         "stdout": "1\n",

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -118,6 +118,7 @@ EMAIL_SMTP_PORT = int(os.environ.get("EMAIL_SMTP_PORT", "3025"))
 EMAIL_API_PORT = int(os.environ.get("EMAIL_API_PORT", "8080"))
 EMAIL_USERNAME = "integ@example.com"
 EMAIL_PASSWORD = "secret"
+EMAIL_SENT_FOLDER = "Sent"
 # Doubles as the workspace id on the fake notion server.
 NOTION_TOKEN = "integ-test"
 MONGODB_URI = os.environ.get("MONGODB_URI", "mongodb://localhost:27017")
@@ -738,7 +739,12 @@ class EmailService:
         # before the workspace opens, not backend code.
         imap = imaplib.IMAP4(host, EMAIL_IMAP_PORT)
         imap.login(EMAIL_USERNAME, EMAIL_PASSWORD)
-        known = {"INBOX"}
+        # GreenMail hands a new account nothing but an INBOX, where every
+        # real provider ships a sent mailbox already made. himalaya files
+        # a copy of each sent message into one, so create it here rather
+        # than leave the copy with nowhere to land.
+        imap.create(EMAIL_SENT_FOLDER)
+        known = {"INBOX", EMAIL_SENT_FOLDER}
         for entry in entries:
             folder = entry["folder"]
             if folder not in known:

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -363,6 +363,7 @@ const EMAIL_SMTP_PORT = Number(process.env.EMAIL_SMTP_PORT ?? '3025')
 const EMAIL_API_PORT = Number(process.env.EMAIL_API_PORT ?? '8080')
 const EMAIL_USERNAME = 'integ@example.com'
 const EMAIL_PASSWORD = 'secret'
+const EMAIL_SENT_FOLDER = 'Sent'
 // Doubles as the workspace id on the fake notion server.
 const NOTION_TOKEN = 'integ-test'
 
@@ -388,7 +389,12 @@ async function openEmail(target: Target): Promise<Open> {
       logger: false,
     })
     await imap.connect()
-    const known = new Set(['INBOX'])
+    // GreenMail hands a new account nothing but an INBOX, where every
+    // real provider ships a sent mailbox already made. himalaya files a
+    // copy of each sent message into one, so create it here rather than
+    // leave the copy with nowhere to land.
+    await imap.mailboxCreate(EMAIL_SENT_FOLDER)
+    const known = new Set(['INBOX', EMAIL_SENT_FOLDER])
     for (const entry of entries) {
       const folder = entry.folder ?? 'INBOX'
       if (!known.has(folder)) {

--- a/python/mirage/commands/cli/builtin/himalaya/__init__.py
+++ b/python/mirage/commands/cli/builtin/himalaya/__init__.py
@@ -43,6 +43,15 @@ PAGE_SIZE = Option(short="-s",
                    type="int",
                    description="Maximum envelopes per page")
 
+# Upstream v2 spells the sent copy as an explicit mailbox on every verb
+# that produces a message, so `--save` alone files it without sending and
+# `--save` with `--send` does both, naming the mailbox the account's
+# save_copy would otherwise resolve on its own.
+SAVE = Option(long="--save",
+              type="str",
+              metavar="MAILBOX",
+              description="Append a copy of the message to this mailbox")
+
 # The built-in flag composer, shared verbatim by compose, reply and
 # forward: upstream flattens the same clap struct into all three.
 COMPOSER: tuple[Option, ...] = (
@@ -76,6 +85,7 @@ COMPOSER: tuple[Option, ...] = (
            description="Signature appended after a '-- ' line"),
     Option(long="--send",
            description="Send through SMTP instead of writing MIME to stdout"),
+    SAVE,
 )
 QUOTING: tuple[Option, ...] = (
     Option(short="-P",
@@ -152,6 +162,7 @@ HIMALAYA = CLISpec(
                     description="Send a raw RFC 5322 message",
                     fn=send,
                     write=True,
+                    options=(SAVE, ),
                     rest=ID,
                 ),
                 CLISpec(

--- a/python/mirage/commands/cli/builtin/himalaya/deliver.py
+++ b/python/mirage/commands/cli/builtin/himalaya/deliver.py
@@ -82,8 +82,9 @@ async def save_sent_copy(config: EmailConfig,
                                      flags=SEEN_FLAG)
         if response.result != "OK":
             detail = " ".join(
-                line.decode(errors="replace") if isinstance(
-                    line, (bytes, bytearray)) else str(line)
+                line.decode(
+                    errors="replace") if isinstance(line, (
+                        bytes, bytearray)) else str(line)
                 for line in (response.lines or []))
             raise ValueError(f"{folder}: {detail or response.result}")
     finally:

--- a/python/mirage/commands/cli/builtin/himalaya/deliver.py
+++ b/python/mirage/commands/cli/builtin/himalaya/deliver.py
@@ -1,0 +1,135 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import logging
+from email.message import Message
+
+from mirage.accessor.email import EmailAccessor
+from mirage.commands.cli.builtin.himalaya.smtp import send_raw
+from mirage.core.email._client import list_folder_entries, quote_mailbox
+from mirage.core.email.config import EmailConfig
+
+logger = logging.getLogger(__name__)
+
+SENT_ATTRIBUTE = "\\sent"
+DEFAULT_SENT_FOLDER = "Sent"
+SEEN_FLAG = "\\Seen"
+
+
+async def resolve_sent_folder(accessor: EmailAccessor,
+                              configured: str | None) -> str:
+    """Name the mailbox a sent copy belongs in.
+
+    IMAP never standardized that name: it is ``Sent`` on most servers,
+    ``Sent Items`` on Exchange and ``[Gmail]/Sent Mail`` on Gmail. A
+    server that implements RFC 6154 tags the right one \\Sent in its
+    LIST reply, so asking beats guessing; upstream himalaya has no
+    probe and falls back on its folder.alias.sent, which is what the
+    configured name is here.
+
+    Args:
+        accessor (EmailAccessor): the logged-in account.
+        configured (str | None): sent_folder, when the deployment
+            pinned one. It wins, so a server whose tag is wrong stays
+            correctable.
+
+    Returns:
+        str: the mailbox name to append into.
+    """
+    if configured:
+        return configured
+    for name, attributes in await list_folder_entries(accessor):
+        if any(attr.lower() == SENT_ATTRIBUTE for attr in attributes):
+            return name
+    return DEFAULT_SENT_FOLDER
+
+
+async def save_sent_copy(config: EmailConfig,
+                         raw: bytes,
+                         folder: str | None = None) -> str:
+    """APPEND a message to a mailbox, seen, the way upstream saves one.
+
+    Args:
+        config (EmailConfig): the account.
+        raw (bytes): the same RFC 5322 bytes SMTP carried.
+        folder (str | None): the mailbox --save named. None resolves the
+            account's sent mailbox instead.
+
+    Returns:
+        str: the mailbox the copy landed in.
+
+    Raises:
+        ValueError: the server refused the APPEND.
+    """
+    accessor = EmailAccessor(config)
+    try:
+        folder = folder or await resolve_sent_folder(accessor,
+                                                     config.sent_folder)
+        imap = await accessor.get_imap()
+        response = await imap.append(raw,
+                                     mailbox=quote_mailbox(folder),
+                                     flags=SEEN_FLAG)
+        if response.result != "OK":
+            detail = " ".join(
+                line.decode(errors="replace") if isinstance(
+                    line, (bytes, bytearray)) else str(line)
+                for line in (response.lines or []))
+            raise ValueError(f"{folder}: {detail or response.result}")
+    finally:
+        await accessor.close()
+    return folder
+
+
+async def deliver(config: EmailConfig,
+                  raw: bytes,
+                  save: str | None = None) -> tuple[Message, str]:
+    """Send a message over SMTP, then file the sender's own copy.
+
+    Two conversations with two servers: SMTP hands the message to the
+    recipient's side and keeps no record, so the copy in the sender's
+    Sent mailbox is a separate IMAP APPEND that every mail client makes
+    on its own. Upstream v2 spells that APPEND as ``--save <MAILBOX>``
+    and does nothing without it; mirage keeps the account-level
+    ``save_copy`` on top, defaulted on, so an agent that never learned
+    the flag still leaves the record a human sender would.
+
+    The other deliberate divergence is the failure arm. Upstream
+    propagates, which fails the command after the mail has already left;
+    here the APPEND failure is reported on stderr and the verb still
+    succeeds, because a non-zero exit invites a retry that sends the
+    message twice. Nothing is swallowed: the reason is logged and
+    printed. A ``--save`` that sends nothing does not go through here at
+    all, precisely because nothing happened yet and failing is safe.
+
+    Args:
+        config (EmailConfig): the account.
+        raw (bytes): the complete RFC 5322 message.
+        save (str | None): the mailbox --save named, if any.
+
+    Returns:
+        tuple[Message, str]: the parsed message, and a warning line for
+            stderr which is empty when there is nothing to report.
+    """
+    message = await send_raw(config, raw)
+    if save is None and not config.save_copy:
+        return message, ""
+    try:
+        await save_sent_copy(config, raw, save)
+    except Exception as exc:
+        # Every failure mode is caught on purpose: the message is
+        # already delivered by this point, so no fault of the copy may
+        # turn into a failed send.
+        logger.warning("sent copy not saved: %s", exc)
+        return message, f"himalaya: sent copy not saved: {exc}\n"
+    return message, ""

--- a/python/mirage/commands/cli/builtin/himalaya/send.py
+++ b/python/mirage/commands/cli/builtin/himalaya/send.py
@@ -14,8 +14,9 @@
 
 import json
 
-from mirage.commands.cli.builtin.himalaya.smtp import send_raw
+from mirage.commands.cli.builtin.himalaya.deliver import deliver
 from mirage.commands.cli.types import CLIInvocation
+from mirage.commands.spec.types import FlagView
 from mirage.core.email.config import EmailConfig
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult, materialize
@@ -31,7 +32,8 @@ async def send(
     if not raw.strip():
         raise ValueError("no message provided: pass it as an argument "
                          "or pipe it via standard input")
-    message = await send_raw(inv.config, raw)
+    message, warning = await deliver(inv.config, raw,
+                                     FlagView(inv.flags).as_str("save"))
     result = {
         "status": "sent",
         "to": message["To"],
@@ -39,4 +41,5 @@ async def send(
     }
     out = json.dumps(result, ensure_ascii=False,
                      separators=(",", ":")).encode()
-    return yield_bytes(out), IOResult()
+    return yield_bytes(out), IOResult(
+        stderr=warning.encode() if warning else None)

--- a/python/mirage/commands/cli/builtin/himalaya/util.py
+++ b/python/mirage/commands/cli/builtin/himalaya/util.py
@@ -20,7 +20,8 @@ from mirage.commands.cli.builtin.himalaya.builder import (Attachment, Compose,
                                                           Source, build,
                                                           read_body,
                                                           split_addresses)
-from mirage.commands.cli.builtin.himalaya.smtp import send_raw
+from mirage.commands.cli.builtin.himalaya.deliver import (deliver,
+                                                          save_sent_copy)
 from mirage.commands.cli.types import CLIVerbOpts
 from mirage.commands.spec.types import FlagView
 from mirage.core.email.config import EmailConfig
@@ -117,9 +118,26 @@ async def route(
     # (or into `message send`), so serialize with the SMTP policy rather
     # than the LF-only default.
     raw = message.as_bytes(policy=SMTP)
+    save = fl.as_str("save")
     if not fl.as_bool("send"):
-        return yield_bytes(raw), IOResult()
-    await send_raw(config, raw)
+        if save is None:
+            return yield_bytes(raw), IOResult()
+        # --save without --send files the message and sends nothing, so
+        # a refused APPEND means nothing happened at all and may fail
+        # loudly: there is no delivered message a retry could duplicate.
+        folder = await save_sent_copy(config, raw, save)
+        out = json.dumps(
+            {
+                "status": "saved",
+                "mailbox": folder,
+                "to": message["To"],
+                "subject": message["Subject"],
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode()
+        return yield_bytes(out), IOResult()
+    _, warning = await deliver(config, raw, save)
     result = {
         "status": "sent",
         "to": message["To"],
@@ -127,4 +145,5 @@ async def route(
     }
     out = json.dumps(result, ensure_ascii=False,
                      separators=(",", ":")).encode()
-    return yield_bytes(out), IOResult()
+    return yield_bytes(out), IOResult(
+        stderr=warning.encode() if warning else None)

--- a/python/mirage/core/email/_client.py
+++ b/python/mirage/core/email/_client.py
@@ -30,6 +30,69 @@ INTERNAL_DATE_RE = re.compile(r'INTERNALDATE "([^"]*)"')
 FETCH_ITEMS = "(UID FLAGS INTERNALDATE BODY.PEEK[])"
 
 
+def quote_mailbox(folder: str) -> str:
+    """Spell a mailbox name as an IMAP quoted string.
+
+    aioimaplib joins a command's arguments with spaces exactly as
+    given, so a bare mailbox name containing one arrives as two
+    arguments and the server reads only the first word. That is not
+    exotic: the sent mailbox is ``Sent Items`` on Exchange and
+    ``[Gmail]/Sent Mail`` on Gmail.
+
+    Args:
+        folder (str): the mailbox name as the server listed it.
+
+    Returns:
+        str: the name wrapped in quotes, with quotes and backslashes
+            escaped per RFC 3501's quoted-string rules.
+    """
+    escaped = folder.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def parse_folder_line(line: str | bytes) -> tuple[str, tuple[str, ...]] | None:
+    """Read one LIST response line as a name and its attributes.
+
+    A line looks like ``(\\HasNoChildren \\Sent) "/" "Sent"``: the
+    parenthesized attributes come first, so they can be read without
+    knowing anything about the name that follows.
+
+    Args:
+        line (str | bytes): one line of the LIST response.
+
+    Returns:
+        tuple[str, tuple[str, ...]] | None: the mailbox name and its
+            attributes, or None for a line that is not a mailbox (the
+            trailing "LIST completed" among them).
+    """
+    if isinstance(line, (bytes, bytearray)):
+        line = bytes(line).decode(errors="replace")
+    if '"' not in line:
+        return None
+    parts = line.rsplit('"', 2)
+    if len(parts) < 2:
+        return None
+    attributes: tuple[str, ...] = ()
+    if "(" in line:
+        start = line.index("(")
+        end = line.find(")", start)
+        if end != -1:
+            attributes = tuple(line[start + 1:end].split())
+    return parts[-2], attributes
+
+
+async def list_folder_entries(
+        accessor: EmailAccessor) -> list[tuple[str, tuple[str, ...]]]:
+    imap = await accessor.get_imap()
+    response = await imap.list('""', "*")
+    entries: list[tuple[str, tuple[str, ...]]] = []
+    for line in response.lines:
+        parsed = parse_folder_line(line)
+        if parsed is not None:
+            entries.append(parsed)
+    return entries
+
+
 async def select_folder(imap: aioimaplib.IMAP4_SSL, folder: str) -> None:
     """Select a mailbox, failing loudly when it does not exist.
 
@@ -45,23 +108,13 @@ async def select_folder(imap: aioimaplib.IMAP4_SSL, folder: str) -> None:
     Raises:
         FileNotFoundError: the server refused the mailbox.
     """
-    response = await imap.select(folder)
+    response = await imap.select(quote_mailbox(folder))
     if response.result != "OK":
         raise FileNotFoundError(f"no such mailbox {folder!r}")
 
 
 async def list_folders(accessor: EmailAccessor) -> list[str]:
-    imap = await accessor.get_imap()
-    response = await imap.list('""', "*")
-    folders: list[str] = []
-    for line in response.lines:
-        if isinstance(line, (bytes, bytearray)):
-            line = bytes(line).decode(errors="replace")
-        if '"' in line:
-            parts = line.rsplit('"', 2)
-            if len(parts) >= 2:
-                folders.append(parts[-2])
-    return folders
+    return [name for name, _ in await list_folder_entries(accessor)]
 
 
 async def list_message_uids(

--- a/python/mirage/core/email/_client.py
+++ b/python/mirage/core/email/_client.py
@@ -50,12 +50,40 @@ def quote_mailbox(folder: str) -> str:
     return f'"{escaped}"'
 
 
+def read_quoted(text: str) -> tuple[str, str]:
+    """Read one RFC 3501 quoted string off the front of ``text``.
+
+    Args:
+        text (str): a fragment whose first character is the opening
+            quote.
+
+    Returns:
+        tuple[str, str]: the unescaped contents, and whatever follows
+            the closing quote with leading spaces dropped.
+    """
+    chars: list[str] = []
+    index = 1
+    while index < len(text):
+        char = text[index]
+        if char == "\\" and index + 1 < len(text):
+            chars.append(text[index + 1])
+            index += 2
+            continue
+        if char == '"':
+            return "".join(chars), text[index + 1:].lstrip()
+        chars.append(char)
+        index += 1
+    return "".join(chars), ""
+
+
 def parse_folder_line(line: str | bytes) -> tuple[str, tuple[str, ...]] | None:
     """Read one LIST response line as a name and its attributes.
 
-    A line looks like ``(\\HasNoChildren \\Sent) "/" "Sent"``: the
-    parenthesized attributes come first, so they can be read without
-    knowing anything about the name that follows.
+    The grammar is ``(attrs) delimiter mailbox``, and the mailbox is an
+    astring: a quoted string on most servers but a bare atom whenever
+    the name needs no quoting, which is legal and which some servers
+    emit. Splitting on quotes reads the delimiter as the name for the
+    atom form, so the three tokens are walked in order instead.
 
     Args:
         line (str | bytes): one line of the LIST response.
@@ -67,18 +95,24 @@ def parse_folder_line(line: str | bytes) -> tuple[str, tuple[str, ...]] | None:
     """
     if isinstance(line, (bytes, bytearray)):
         line = bytes(line).decode(errors="replace")
-    if '"' not in line:
+    text = line.strip()
+    # An untagged LIST line always opens with its attribute list, which
+    # is what tells it apart from the completion line.
+    if not text.startswith("("):
         return None
-    parts = line.rsplit('"', 2)
-    if len(parts) < 2:
+    end = text.find(")")
+    if end == -1:
         return None
-    attributes: tuple[str, ...] = ()
-    if "(" in line:
-        start = line.index("(")
-        end = line.find(")", start)
-        if end != -1:
-            attributes = tuple(line[start + 1:end].split())
-    return parts[-2], attributes
+    attributes = tuple(text[1:end].split())
+    rest = text[end + 1:].lstrip()
+    if rest.startswith('"'):
+        _, rest = read_quoted(rest)
+    elif rest[:3].upper() == "NIL":
+        rest = rest[3:].lstrip()
+    if not rest:
+        return None
+    name = read_quoted(rest)[0] if rest.startswith('"') else rest.split()[0]
+    return (name, attributes) if name else None
 
 
 async def list_folder_entries(

--- a/python/mirage/core/email/config.py
+++ b/python/mirage/core/email/config.py
@@ -24,3 +24,8 @@ class EmailConfig(BaseModel):
     password: SecretStr
     use_ssl: bool = True
     max_messages: int = 200
+    # Upstream himalaya's message.send.save-copy, whose default is true
+    # since pimalaya/himalaya#536. sent_folder is its folder.alias.sent:
+    # unset means ask the server for its \Sent mailbox.
+    save_copy: bool = True
+    sent_folder: str | None = None

--- a/python/tests/commands/cli/builtin/himalaya/test_compose.py
+++ b/python/tests/commands/cli/builtin/himalaya/test_compose.py
@@ -49,11 +49,19 @@ def ops_with_files() -> CLIVerbOpts:
 def sent(monkeypatch):
     seen: dict = {}
 
-    async def fake_send_raw(config, raw):
+    async def fake_deliver(config, raw, save=None):
         seen["raw"] = raw
-        return BytesParser(policy=default_policy).parsebytes(raw)
+        seen["save"] = save
+        return BytesParser(policy=default_policy).parsebytes(raw), ""
 
-    monkeypatch.setattr(util_module, "send_raw", fake_send_raw)
+    async def fake_save(config, raw, folder=None):
+        if seen.get("refuse"):
+            raise ValueError(f"{folder}: [TRYCREATE] No such mailbox")
+        seen["saved"] = (raw, folder)
+        return folder or "Sent"
+
+    monkeypatch.setattr(util_module, "deliver", fake_deliver)
+    monkeypatch.setattr(util_module, "save_sent_copy", fake_save)
     return seen
 
 
@@ -202,4 +210,53 @@ async def test_attach_outside_a_workspace_is_refused(sent):
                               "yo",
                               "attach":
                               [PathSpec.from_str_path("/scratch/note.txt")],
+                          }))
+
+
+@pytest.mark.asyncio
+async def test_save_rides_along_to_the_delivery(sent):
+    await compose(
+        CLIInvocation(CONFIG,
+                      flags={
+                          "to": "a@b.com",
+                          "body": "yo",
+                          "send": True,
+                          "save": "Drafts",
+                      }))
+    assert sent["save"] == "Drafts"
+
+
+@pytest.mark.asyncio
+async def test_save_without_send_files_the_message_and_sends_nothing(sent):
+    out, io = await compose(
+        CLIInvocation(CONFIG,
+                      flags={
+                          "to": "a@b.com",
+                          "subject": "Draft it",
+                          "body": "yo",
+                          "save": "Drafts",
+                      }))
+    assert io.exit_code == 0
+    assert "raw" not in sent
+    assert sent["saved"][1] == "Drafts"
+    assert json.loads(await materialize(out)) == {
+        "status": "saved",
+        "mailbox": "Drafts",
+        "to": "a@b.com",
+        "subject": "Draft it",
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_refused_save_without_send_fails_loudly(sent):
+    # Nothing was sent, so there is no delivered message a retry could
+    # duplicate: this one is an error, not a warning.
+    sent["refuse"] = True
+    with pytest.raises(ValueError, match="Drafts: .*TRYCREATE"):
+        await compose(
+            CLIInvocation(CONFIG,
+                          flags={
+                              "to": "a@b.com",
+                              "body": "yo",
+                              "save": "Drafts",
                           }))

--- a/python/tests/commands/cli/builtin/himalaya/test_deliver.py
+++ b/python/tests/commands/cli/builtin/himalaya/test_deliver.py
@@ -1,0 +1,208 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from email.parser import BytesParser
+from email.policy import default as default_policy
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mirage.accessor.email import EmailAccessor
+from mirage.commands.cli.builtin.himalaya.deliver import (deliver,
+                                                          resolve_sent_folder,
+                                                          save_sent_copy)
+from mirage.core.email.config import EmailConfig
+
+RAW = b"From: me@example.com\r\nTo: a@b.com\r\nSubject: Hi\r\n\r\nyo"
+
+GMAIL_LINES = [
+    b'(\\HasNoChildren) "/" "INBOX"',
+    b'(\\HasNoChildren \\Sent) "/" "[Gmail]/Sent Mail"',
+    b'(\\HasNoChildren \\Trash) "/" "[Gmail]/Trash"',
+]
+PLAIN_LINES = [
+    b'(\\HasNoChildren) "/" "INBOX"',
+    b'(\\HasNoChildren) "/" "Archive"',
+]
+
+
+def config(**overrides) -> EmailConfig:
+    return EmailConfig(imap_host="h",
+                       smtp_host="h",
+                       username="u",
+                       password="p",
+                       **overrides)
+
+
+def fake_imap(lines: list[bytes], append_result: str = "OK"):
+    imap = AsyncMock()
+    listing = MagicMock()
+    listing.lines = lines
+    imap.list.return_value = listing
+    appended = MagicMock()
+    appended.result = append_result
+    appended.lines = [b"[TRYCREATE] No such mailbox"]
+    imap.append.return_value = appended
+    return imap
+
+
+@pytest.fixture
+def imap(monkeypatch):
+    state: dict = {"lines": PLAIN_LINES, "append_result": "OK"}
+
+    async def fake_get_imap(self):
+        client = state.setdefault(
+            "client", fake_imap(state["lines"], state["append_result"]))
+        return client
+
+    async def fake_close(self):
+        state["closed"] = True
+
+    monkeypatch.setattr(EmailAccessor, "get_imap", fake_get_imap)
+    monkeypatch.setattr(EmailAccessor, "close", fake_close)
+    return state
+
+
+@pytest.fixture
+def smtp(monkeypatch):
+    seen: dict = {}
+
+    async def fake_send_raw(cfg, raw):
+        seen["raw"] = raw
+        return BytesParser(policy=default_policy).parsebytes(raw)
+
+    monkeypatch.setitem(deliver.__globals__, "send_raw", fake_send_raw)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_the_server_names_its_own_sent_mailbox(imap):
+    imap["lines"] = GMAIL_LINES
+    accessor = EmailAccessor(config())
+    assert await resolve_sent_folder(accessor, None) == "[Gmail]/Sent Mail"
+
+
+@pytest.mark.asyncio
+async def test_a_server_with_no_tag_falls_back_to_sent(imap):
+    accessor = EmailAccessor(config())
+    assert await resolve_sent_folder(accessor, None) == "Sent"
+
+
+@pytest.mark.asyncio
+async def test_a_configured_folder_beats_the_servers_tag(imap):
+    imap["lines"] = GMAIL_LINES
+    accessor = EmailAccessor(config())
+    assert await resolve_sent_folder(accessor, "Archive") == "Archive"
+
+
+@pytest.mark.asyncio
+async def test_a_configured_folder_is_taken_without_asking(imap):
+    accessor = EmailAccessor(config())
+    assert await resolve_sent_folder(accessor, "Archive") == "Archive"
+    assert "client" not in imap
+
+
+@pytest.mark.asyncio
+async def test_the_copy_is_appended_seen_and_the_mailbox_is_quoted(imap):
+    imap["lines"] = GMAIL_LINES
+    assert await save_sent_copy(config(), RAW) == "[Gmail]/Sent Mail"
+    # A mailbox name holding a space is two arguments unless it is
+    # quoted, and both Gmail's and Exchange's hold one.
+    imap["client"].append.assert_awaited_once_with(
+        RAW, mailbox='"[Gmail]/Sent Mail"', flags="\\Seen")
+    assert imap["closed"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_refused_append_names_the_mailbox(imap):
+    imap["append_result"] = "NO"
+    with pytest.raises(ValueError, match="Sent: .*TRYCREATE"):
+        await save_sent_copy(config(), RAW)
+    assert imap["closed"] is True
+
+
+@pytest.mark.asyncio
+async def test_deliver_sends_then_saves(imap, smtp):
+    message, warning = await deliver(config(), RAW)
+    assert smtp["raw"] == RAW
+    assert message["Subject"] == "Hi"
+    assert warning == ""
+    imap["client"].append.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_save_copy_off_sends_and_touches_no_mailbox(imap, smtp):
+    _, warning = await deliver(config(save_copy=False), RAW)
+    assert smtp["raw"] == RAW
+    assert warning == ""
+    assert "client" not in imap
+
+
+@pytest.mark.asyncio
+async def test_a_failed_copy_warns_but_the_send_still_counts(imap, smtp):
+    imap["append_result"] = "NO"
+    message, warning = await deliver(config(), RAW)
+    # The message is already on the wire, so the copy's failure is
+    # reported rather than raised: a non-zero exit invites a retry that
+    # would send it a second time.
+    assert smtp["raw"] == RAW
+    assert message["Subject"] == "Hi"
+    assert warning.startswith("himalaya: sent copy not saved: Sent:")
+    assert warning.endswith("\n")
+
+
+@pytest.mark.asyncio
+async def test_a_broken_connection_warns_rather_than_raising(monkeypatch,
+                                                             smtp):
+
+    async def fake_get_imap(self):
+        raise ConnectionError("IMAP login failed for u on h")
+
+    async def fake_close(self):
+        return None
+
+    monkeypatch.setattr(EmailAccessor, "get_imap", fake_get_imap)
+    monkeypatch.setattr(EmailAccessor, "close", fake_close)
+    _, warning = await deliver(config(), RAW)
+    assert warning == ("himalaya: sent copy not saved: "
+                       "IMAP login failed for u on h\n")
+
+
+@pytest.mark.asyncio
+async def test_save_names_the_mailbox_and_skips_resolution(imap):
+    imap["lines"] = GMAIL_LINES
+    assert await save_sent_copy(config(), RAW, "Drafts") == "Drafts"
+    imap["client"].append.assert_awaited_once_with(RAW,
+                                                   mailbox='"Drafts"',
+                                                   flags="\\Seen")
+    imap["client"].list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_save_beats_the_accounts_own_sent_mailbox(imap, smtp):
+    imap["lines"] = GMAIL_LINES
+    _, warning = await deliver(config(), RAW, "Drafts")
+    assert warning == ""
+    imap["client"].append.assert_awaited_once_with(RAW,
+                                                   mailbox='"Drafts"',
+                                                   flags="\\Seen")
+
+
+@pytest.mark.asyncio
+async def test_save_files_a_copy_even_with_save_copy_off(imap, smtp):
+    # --save is the user asking on this one line, so the account-level
+    # switch does not veto it.
+    _, warning = await deliver(config(save_copy=False), RAW, "Drafts")
+    assert warning == ""
+    imap["client"].append.assert_awaited_once()

--- a/python/tests/commands/cli/builtin/himalaya/test_deliver.py
+++ b/python/tests/commands/cli/builtin/himalaya/test_deliver.py
@@ -163,8 +163,8 @@ async def test_a_failed_copy_warns_but_the_send_still_counts(imap, smtp):
 
 
 @pytest.mark.asyncio
-async def test_a_broken_connection_warns_rather_than_raising(monkeypatch,
-                                                             smtp):
+async def test_a_broken_connection_warns_rather_than_raising(
+        monkeypatch, smtp):
 
     async def fake_get_imap(self):
         raise ConnectionError("IMAP login failed for u on h")

--- a/python/tests/commands/cli/builtin/himalaya/test_forward.py
+++ b/python/tests/commands/cli/builtin/himalaya/test_forward.py
@@ -50,15 +50,15 @@ def patched(monkeypatch):
         seen["args"] = (folder, uid)
         return ORIGINAL
 
-    async def fake_send_raw(config, raw):
+    async def fake_deliver(config, raw, save=None):
         seen["raw"] = raw
-        return BytesParser(policy=default_policy).parsebytes(raw)
+        return BytesParser(policy=default_policy).parsebytes(raw), ""
 
     async def fake_close(self):
         seen["closed"] = True
 
     monkeypatch.setitem(forward.__globals__, "fetch_message", fake_fetch)
-    monkeypatch.setattr(util_module, "send_raw", fake_send_raw)
+    monkeypatch.setattr(util_module, "deliver", fake_deliver)
     monkeypatch.setattr(EmailAccessor, "close", fake_close)
     return seen
 

--- a/python/tests/commands/cli/builtin/himalaya/test_reply.py
+++ b/python/tests/commands/cli/builtin/himalaya/test_reply.py
@@ -54,15 +54,15 @@ def patched(monkeypatch):
         seen["args"] = (folder, uid)
         return ORIGINAL
 
-    async def fake_send_raw(config, raw):
+    async def fake_deliver(config, raw, save=None):
         seen["raw"] = raw
-        return BytesParser(policy=default_policy).parsebytes(raw)
+        return BytesParser(policy=default_policy).parsebytes(raw), ""
 
     async def fake_close(self):
         seen["closed"] = True
 
     monkeypatch.setitem(reply.__globals__, "fetch_message", fake_fetch)
-    monkeypatch.setattr(util_module, "send_raw", fake_send_raw)
+    monkeypatch.setattr(util_module, "deliver", fake_deliver)
     monkeypatch.setattr(EmailAccessor, "close", fake_close)
     return seen
 

--- a/python/tests/commands/cli/builtin/himalaya/test_send.py
+++ b/python/tests/commands/cli/builtin/himalaya/test_send.py
@@ -31,11 +31,13 @@ RAW = b"From: me@example.com\nTo: a@b.com\nSubject: Hi\n\nyo"
 def sent(monkeypatch):
     seen: dict = {}
 
-    async def fake_send_raw(config, raw):
+    async def fake_deliver(config, raw, save=None):
         seen["raw"] = raw
-        return BytesParser(policy=default_policy).parsebytes(raw)
+        seen["save"] = save
+        message = BytesParser(policy=default_policy).parsebytes(raw)
+        return message, seen.get("warning", "")
 
-    monkeypatch.setitem(send.__globals__, "send_raw", fake_send_raw)
+    monkeypatch.setitem(send.__globals__, "deliver", fake_deliver)
     return seen
 
 
@@ -69,3 +71,30 @@ async def test_an_empty_message_is_refused_before_smtp(sent):
     with pytest.raises(ValueError, match="no message provided"):
         await send(CLIInvocation(CONFIG, stdin=b"   \n "))
     assert "raw" not in sent
+
+
+@pytest.mark.asyncio
+async def test_a_clean_send_writes_nothing_to_stderr(sent):
+    _, io = await send(CLIInvocation(CONFIG, stdin=RAW))
+    assert io.stderr is None
+
+
+@pytest.mark.asyncio
+async def test_an_unsaved_copy_reaches_stderr_without_failing_the_verb(sent):
+    sent["warning"] = "himalaya: sent copy not saved: Sent: NO\n"
+    out, io = await send(CLIInvocation(CONFIG, stdin=RAW))
+    assert io.exit_code == 0
+    assert await materialize(io.stderr) == sent["warning"].encode()
+    assert json.loads(await materialize(out))["status"] == "sent"
+
+
+@pytest.mark.asyncio
+async def test_save_names_the_mailbox_for_the_copy(sent):
+    await send(CLIInvocation(CONFIG, stdin=RAW, flags={"save": "Drafts"}))
+    assert sent["save"] == "Drafts"
+
+
+@pytest.mark.asyncio
+async def test_without_save_the_account_resolves_its_own_mailbox(sent):
+    await send(CLIInvocation(CONFIG, stdin=RAW))
+    assert sent["save"] is None

--- a/python/tests/commands/cli/builtin/himalaya/test_tree.py
+++ b/python/tests/commands/cli/builtin/himalaya/test_tree.py
@@ -94,11 +94,11 @@ async def test_installed_tree_composes_mime_without_sending():
 async def test_the_write_alias_reaches_compose(monkeypatch):
     sent = {}
 
-    async def fake_send_raw(config, raw):
+    async def fake_deliver(config, raw, save=None):
         sent["raw"] = raw
-        return BytesParser(policy=default_policy).parsebytes(raw)
+        return BytesParser(policy=default_policy).parsebytes(raw), ""
 
-    monkeypatch.setattr(util_module, "send_raw", fake_send_raw)
+    monkeypatch.setattr(util_module, "deliver", fake_deliver)
     ws = Workspace({})
     ws.register_cli("himalaya", HIMALAYA, CONFIG)
     io = await ws.execute(

--- a/python/tests/core/email/test_client.py
+++ b/python/tests/core/email/test_client.py
@@ -18,7 +18,9 @@ import pytest
 
 from mirage.accessor.email import EmailAccessor
 from mirage.core.email._client import (fetch_headers, fetch_message,
-                                       list_folders, list_message_uids)
+                                       list_folder_entries, list_folders,
+                                       list_message_uids, parse_folder_line,
+                                       quote_mailbox, select_folder)
 from mirage.core.email.config import EmailConfig
 
 MESSAGE = (b"From: alice@example.com\r\n"
@@ -65,6 +67,52 @@ async def test_list_folders(accessor):
     assert "INBOX" in folders
     assert "Sent" in folders
     assert "Drafts" in folders
+
+
+@pytest.mark.asyncio
+async def test_list_folder_entries_reports_special_use_attributes(accessor):
+    mock_imap = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.lines = [
+        b'(\\HasNoChildren) "/" "INBOX"',
+        b'(\\HasNoChildren \\Sent) "/" "[Gmail]/Sent Mail"',
+        b"LIST completed",
+    ]
+    mock_imap.list.return_value = mock_response
+    accessor._imap = mock_imap
+    accessor._imap.protocol = True
+
+    entries = await list_folder_entries(accessor)
+    assert entries == [
+        ("INBOX", ("\\HasNoChildren", )),
+        ("[Gmail]/Sent Mail", ("\\HasNoChildren", "\\Sent")),
+    ]
+
+
+def test_parse_folder_line_skips_the_completion_line():
+    assert parse_folder_line(b"LIST completed") is None
+
+
+def test_parse_folder_line_reads_a_name_holding_a_paren():
+    assert parse_folder_line(b'(\\HasNoChildren) "/" "Notes (old)"') == (
+        "Notes (old)", ("\\HasNoChildren", ))
+
+
+def test_quote_mailbox_wraps_and_escapes():
+    assert quote_mailbox("Sent Items") == '"Sent Items"'
+    assert quote_mailbox('od"d') == '"od\\"d"'
+    assert quote_mailbox("back\\slash") == '"back\\\\slash"'
+
+
+@pytest.mark.asyncio
+async def test_select_quotes_a_mailbox_holding_a_space():
+    mock_imap = AsyncMock()
+    selected = MagicMock()
+    selected.result = "OK"
+    mock_imap.select.return_value = selected
+
+    await select_folder(mock_imap, "[Gmail]/Sent Mail")
+    mock_imap.select.assert_awaited_once_with('"[Gmail]/Sent Mail"')
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/email/test_client.py
+++ b/python/tests/core/email/test_client.py
@@ -98,6 +98,29 @@ def test_parse_folder_line_reads_a_name_holding_a_paren():
         "Notes (old)", ("\\HasNoChildren", ))
 
 
+def test_parse_folder_line_reads_an_atom_mailbox():
+    # A mailbox is an astring, so a name needing no quoting may arrive
+    # bare. Splitting on quotes reads the delimiter as the name here.
+    assert parse_folder_line(b'(\\HasNoChildren \\Sent) "/" Sent') == (
+        "Sent", ("\\HasNoChildren", "\\Sent"))
+
+
+def test_parse_folder_line_reads_an_atom_after_a_nil_delimiter():
+    assert parse_folder_line(b"(\\HasNoChildren) NIL INBOX") == ("INBOX", (
+        "\\HasNoChildren", ))
+
+
+def test_parse_folder_line_unescapes_a_quoted_name():
+    assert parse_folder_line(b'(\\HasNoChildren) "/" "od\\"d"') == ('od"d', (
+        "\\HasNoChildren", ))
+
+
+def test_an_atom_sent_mailbox_survives_into_resolution():
+    # The whole point of the parse: this used to answer "/", which the
+    # sent copy would then have tried to APPEND into.
+    assert parse_folder_line(b'(\\Sent) "/" Sent')[0] == "Sent"
+
+
 def test_quote_mailbox_wraps_and_escapes():
     assert quote_mailbox("Sent Items") == '"Sent Items"'
     assert quote_mailbox('od"d') == '"od\\"d"'

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/deliver.test.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/deliver.test.ts
@@ -35,6 +35,7 @@ const PLAIN = [
 
 const listMock = vi.fn()
 const appendMock = vi.fn()
+let closeSpy: ReturnType<typeof vi.spyOn>
 
 function config(overrides: Partial<EmailConfig> = {}): EmailConfig {
   return {
@@ -61,7 +62,7 @@ beforeEach(() => {
     list: listMock,
     append: appendMock,
   } as unknown as Awaited<ReturnType<EmailAccessor['getImap']>>)
-  vi.spyOn(EmailAccessor.prototype, 'close').mockResolvedValue()
+  closeSpy = vi.spyOn(EmailAccessor.prototype, 'close').mockResolvedValue()
 })
 
 describe('resolveSentFolder', () => {
@@ -86,13 +87,13 @@ describe('saveSentCopy', () => {
     listMock.mockResolvedValue(GMAIL)
     expect(await saveSentCopy(config(), RAW)).toBe('[Gmail]/Sent Mail')
     expect(appendMock).toHaveBeenCalledWith('[Gmail]/Sent Mail', Buffer.from(RAW), ['\\Seen'])
-    expect(EmailAccessor.prototype.close).toHaveBeenCalled()
+    expect(closeSpy).toHaveBeenCalled()
   })
 
   it('names the mailbox when the server refuses', async () => {
     appendMock.mockResolvedValue(false)
     await expect(saveSentCopy(config(), RAW)).rejects.toThrow('Sent: the server refused')
-    expect(EmailAccessor.prototype.close).toHaveBeenCalled()
+    expect(closeSpy).toHaveBeenCalled()
   })
 })
 

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/deliver.test.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/deliver.test.ts
@@ -1,0 +1,148 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EmailAccessor } from '../../../../accessor/email.ts'
+import type { EmailConfig } from '../../../../core/email/config.ts'
+import { deliver, resolveSentFolder, saveSentCopy } from './deliver.ts'
+
+const sendRawMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./smtp.ts', () => ({ sendRaw: sendRawMock }))
+
+const RAW = new TextEncoder().encode('From: me@x\r\nTo: a@b.com\r\nSubject: Hi\r\n\r\nyo')
+
+const GMAIL = [
+  { pathAsListed: 'INBOX', specialUse: undefined },
+  { pathAsListed: '[Gmail]/Sent Mail', specialUse: '\\Sent' },
+  { pathAsListed: '[Gmail]/Trash', specialUse: '\\Trash' },
+]
+const PLAIN = [
+  { pathAsListed: 'INBOX', specialUse: undefined },
+  { pathAsListed: 'Archive', specialUse: undefined },
+]
+
+const listMock = vi.fn()
+const appendMock = vi.fn()
+
+function config(overrides: Partial<EmailConfig> = {}): EmailConfig {
+  return {
+    imapHost: 'h',
+    imapPort: 993,
+    smtpHost: 'h',
+    smtpPort: 587,
+    username: 'u',
+    password: 'p',
+    useSsl: false,
+    maxMessages: 200,
+    saveCopy: true,
+    sentFolder: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  listMock.mockResolvedValue(PLAIN)
+  appendMock.mockResolvedValue({ destination: 'Sent' })
+  sendRawMock.mockResolvedValue({ to: [{ name: '', email: 'a@b.com' }], subject: 'Hi' })
+  vi.spyOn(EmailAccessor.prototype, 'getImap').mockResolvedValue({
+    list: listMock,
+    append: appendMock,
+  } as unknown as Awaited<ReturnType<EmailAccessor['getImap']>>)
+  vi.spyOn(EmailAccessor.prototype, 'close').mockResolvedValue()
+})
+
+describe('resolveSentFolder', () => {
+  it('takes the mailbox the server tags \\Sent', async () => {
+    listMock.mockResolvedValue(GMAIL)
+    expect(await resolveSentFolder(new EmailAccessor(config()), null)).toBe('[Gmail]/Sent Mail')
+  })
+
+  it('falls back to Sent when the server tags nothing', async () => {
+    expect(await resolveSentFolder(new EmailAccessor(config()), null)).toBe('Sent')
+  })
+
+  it('lets a configured folder win, without asking the server', async () => {
+    listMock.mockResolvedValue(GMAIL)
+    expect(await resolveSentFolder(new EmailAccessor(config()), 'Archive')).toBe('Archive')
+    expect(listMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('saveSentCopy', () => {
+  it('appends the message seen, and closes the accessor', async () => {
+    listMock.mockResolvedValue(GMAIL)
+    expect(await saveSentCopy(config(), RAW)).toBe('[Gmail]/Sent Mail')
+    expect(appendMock).toHaveBeenCalledWith('[Gmail]/Sent Mail', Buffer.from(RAW), ['\\Seen'])
+    expect(EmailAccessor.prototype.close).toHaveBeenCalled()
+  })
+
+  it('names the mailbox when the server refuses', async () => {
+    appendMock.mockResolvedValue(false)
+    await expect(saveSentCopy(config(), RAW)).rejects.toThrow('Sent: the server refused')
+    expect(EmailAccessor.prototype.close).toHaveBeenCalled()
+  })
+})
+
+describe('deliver', () => {
+  it('sends, then saves', async () => {
+    const { parsed, warning } = await deliver(config(), RAW)
+    expect(sendRawMock).toHaveBeenCalledWith(expect.anything(), RAW)
+    expect(parsed.subject).toBe('Hi')
+    expect(warning).toBe('')
+    expect(appendMock).toHaveBeenCalledOnce()
+  })
+
+  it('sends and touches no mailbox when saveCopy is off', async () => {
+    const { warning } = await deliver(config({ saveCopy: false }), RAW)
+    expect(sendRawMock).toHaveBeenCalledOnce()
+    expect(warning).toBe('')
+    expect(appendMock).not.toHaveBeenCalled()
+  })
+
+  it('warns rather than raising when the copy fails', async () => {
+    // The message is already on the wire, so a failed copy must not
+    // become a failed send: a non-zero exit invites a retry that would
+    // send it a second time.
+    appendMock.mockRejectedValue(new Error('Sent: over quota'))
+    const { parsed, warning } = await deliver(config(), RAW)
+    expect(parsed.subject).toBe('Hi')
+    expect(warning).toBe('himalaya: sent copy not saved: Sent: over quota\n')
+  })
+
+  it('files into the mailbox --save names, over the account default', async () => {
+    listMock.mockResolvedValue(GMAIL)
+    const { warning } = await deliver(config(), RAW, 'Drafts')
+    expect(warning).toBe('')
+    expect(appendMock).toHaveBeenCalledWith('Drafts', Buffer.from(RAW), ['\\Seen'])
+    expect(listMock).not.toHaveBeenCalled()
+  })
+
+  it('honours --save even when saveCopy is off', async () => {
+    // --save is the user asking on this one line, so the account-level
+    // switch does not veto it.
+    const { warning } = await deliver(config({ saveCopy: false }), RAW, 'Drafts')
+    expect(warning).toBe('')
+    expect(appendMock).toHaveBeenCalledOnce()
+  })
+
+  it('warns when the account cannot be reached at all', async () => {
+    vi.spyOn(EmailAccessor.prototype, 'getImap').mockRejectedValue(
+      new Error('IMAP login failed for u on h'),
+    )
+    const { warning } = await deliver(config(), RAW)
+    expect(warning).toBe('himalaya: sent copy not saved: IMAP login failed for u on h\n')
+  })
+})

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/deliver.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/deliver.ts
@@ -1,0 +1,112 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { EmailAccessor } from '../../../../accessor/email.ts'
+import { listFolderEntries } from '../../../../core/email/_client.ts'
+import type { ParsedRfc822 } from '../../../../core/email/_parse.ts'
+import type { EmailConfig } from '../../../../core/email/config.ts'
+import { sendRaw } from './smtp.ts'
+
+const SENT_ATTRIBUTE = '\\sent'
+const DEFAULT_SENT_FOLDER = 'Sent'
+const SEEN_FLAG = '\\Seen'
+
+export interface Delivery {
+  parsed: ParsedRfc822
+  /** A line for stderr, empty when there is nothing to report. */
+  warning: string
+}
+
+/**
+ * Names the mailbox a sent copy belongs in.
+ *
+ * IMAP never standardized that name: it is `Sent` on most servers,
+ * `Sent Items` on Exchange and `[Gmail]/Sent Mail` on Gmail. A server
+ * that implements RFC 6154 tags the right one \Sent in its LIST reply,
+ * so asking beats guessing; upstream himalaya has no probe and falls
+ * back on its folder.alias.sent, which is the configured name here and
+ * wins so a server whose tag is wrong stays correctable.
+ */
+export async function resolveSentFolder(
+  accessor: EmailAccessor,
+  configured: string | null,
+): Promise<string> {
+  if (configured !== null && configured !== '') return configured
+  const entries = await listFolderEntries(accessor)
+  const tagged = entries.find((entry) => entry.specialUse?.toLowerCase() === SENT_ATTRIBUTE)
+  return tagged?.name ?? DEFAULT_SENT_FOLDER
+}
+
+/**
+ * APPENDs a message to a mailbox, seen, and answers with the mailbox it
+ * landed in. `named` is the mailbox --save gave; without one the
+ * account's own sent mailbox is resolved.
+ *
+ * Unlike python's, this path quotes nothing: imapflow builds the
+ * command from typed attributes, so a mailbox holding a space arrives
+ * as one argument on its own.
+ */
+export async function saveSentCopy(
+  config: EmailConfig,
+  raw: Uint8Array,
+  named: string | null = null,
+): Promise<string> {
+  const accessor = new EmailAccessor(config)
+  try {
+    const folder = named ?? (await resolveSentFolder(accessor, config.sentFolder))
+    const imap = await accessor.getImap()
+    const result = await imap.append(folder, Buffer.from(raw), [SEEN_FLAG])
+    if (result === false) throw new Error(`${folder}: the server refused the message`)
+    return folder
+  } finally {
+    await accessor.close()
+  }
+}
+
+/**
+ * Sends a message over SMTP, then files the sender's own copy.
+ *
+ * Two conversations with two servers: SMTP hands the message to the
+ * recipient's side and keeps no record, so the copy in the sender's
+ * Sent mailbox is a separate IMAP APPEND that every mail client makes
+ * on its own. Upstream v2 spells that APPEND as `--save <MAILBOX>` and
+ * does nothing without it; mirage keeps the account-level `saveCopy` on
+ * top, defaulted on, so an agent that never learned the flag still
+ * leaves the record a human sender would.
+ *
+ * The other deliberate divergence is the failure arm. Upstream
+ * propagates, which fails the command after the mail has already left;
+ * here the APPEND failure is reported on stderr and the verb still
+ * succeeds, because a non-zero exit invites a retry that sends the
+ * message twice. A `--save` that sends nothing does not go through here
+ * at all, precisely because nothing happened yet and failing is safe.
+ */
+export async function deliver(
+  config: EmailConfig,
+  raw: Uint8Array,
+  save: string | null = null,
+): Promise<Delivery> {
+  const parsed = await sendRaw(config, raw)
+  if (save === null && !config.saveCopy) return { parsed, warning: '' }
+  try {
+    await saveSentCopy(config, raw, save)
+  } catch (error) {
+    // Every failure mode is caught on purpose: the message is already
+    // delivered by this point, so no fault of the copy may turn into a
+    // failed send. Nothing is swallowed, the reason is printed.
+    const reason = error instanceof Error ? error.message : String(error)
+    return { parsed, warning: `himalaya: sent copy not saved: ${reason}\n` }
+  }
+  return { parsed, warning: '' }
+}

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/himalaya.test.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/himalaya.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   cliSpecFor,
   enoent,
@@ -22,6 +22,7 @@ import {
   type PathSpec,
 } from '@struktoai/mirage-core'
 import { EmailAccessor } from '../../../../accessor/email.ts'
+import type { EmailConfig } from '../../../../core/email/config.ts'
 import { messageJsonBytes } from '../../../../core/email/render.ts'
 import { Workspace } from '../../../../workspace.ts'
 import {
@@ -43,10 +44,13 @@ import { searchEnvelopes } from './search.ts'
 import { send } from './send.ts'
 
 const sendRawMock = vi.hoisted(() => vi.fn())
+const listFolderEntriesMock = vi.hoisted(() => vi.fn())
+const appendMock = vi.hoisted(() => vi.fn())
 
 vi.mock('./smtp.ts', () => ({ sendRaw: sendRawMock }))
 
 vi.mock('../../../../core/email/_client.ts', () => ({
+  listFolderEntries: listFolderEntriesMock,
   fetchRawMessage: vi.fn(() => Promise.resolve(new TextEncoder().encode('From: a@x\r\n\r\nbody'))),
   fetchMessage: vi.fn(() => Promise.resolve(ORIGINAL)),
   listMessageUids: vi.fn(() => Promise.resolve(['1', '2'])),
@@ -80,7 +84,7 @@ const HEADERS: Record<string, unknown> = {
   '2': { ...ORIGINAL, uid: '2', subject: 'alpha', date: 'Tue, 03 Feb 2026 10:00:00 +0000' },
 }
 
-const CONFIG = {
+const CONFIG: EmailConfig = {
   imapHost: 'h',
   imapPort: 993,
   smtpHost: 'h',
@@ -89,7 +93,25 @@ const CONFIG = {
   password: 'p',
   useSsl: false,
   maxMessages: 200,
+  saveCopy: true,
+  sentFolder: null,
 }
+
+// Every --send path now also files the sender's copy over IMAP, so the
+// account's IMAP side is stubbed for the whole file: without this the
+// verbs would reach for a real connection to host 'h'.
+beforeEach(() => {
+  listFolderEntriesMock.mockResolvedValue([
+    { name: 'INBOX', specialUse: null },
+    { name: 'Sent', specialUse: '\\Sent' },
+  ])
+  appendMock.mockReset()
+  appendMock.mockResolvedValue({ destination: 'Sent' })
+  vi.spyOn(EmailAccessor.prototype, 'getImap').mockResolvedValue({
+    append: appendMock,
+  } as unknown as Awaited<ReturnType<EmailAccessor['getImap']>>)
+  vi.spyOn(EmailAccessor.prototype, 'close').mockResolvedValue()
+})
 
 function leaf(...path: string[]) {
   let node = HIMALAYA
@@ -589,6 +611,106 @@ describe('himalaya verbs', () => {
       to: 'a@b.com',
       subject: 'Hi',
     })
+  })
+
+  it('send files the sender copy in the mailbox the server tags \\Sent', async () => {
+    sendRawMock.mockClear()
+    sendRawMock.mockResolvedValue({ to: [{ name: '', email: 'a@b.com' }], subject: 'Hi' })
+    const raw = new TextEncoder().encode('From: me@x\nTo: a@b.com\nSubject: Hi\n\nyo')
+    const [, io] = (await send({
+      config: CONFIG,
+      argv: [],
+      paths: [],
+      texts: [],
+      flags: {},
+      stdin: raw,
+      env: {},
+    })) as [Uint8Array, IOResult]
+    expect(appendMock).toHaveBeenCalledWith('Sent', Buffer.from(raw), ['\\Seen'])
+    expect(io.stderr).toBeNull()
+  })
+
+  it('send warns on stderr and still succeeds when the copy fails', async () => {
+    sendRawMock.mockClear()
+    sendRawMock.mockResolvedValue({ to: [{ name: '', email: 'a@b.com' }], subject: 'Hi' })
+    appendMock.mockRejectedValue(new Error('Sent: no such mailbox'))
+    const raw = new TextEncoder().encode('From: me@x\nTo: a@b.com\nSubject: Hi\n\nyo')
+    const [out, io] = (await send({
+      config: CONFIG,
+      argv: [],
+      paths: [],
+      texts: [],
+      flags: {},
+      stdin: raw,
+      env: {},
+    })) as [Uint8Array, IOResult]
+    // The message is already delivered, so the copy's failure is
+    // reported rather than raised.
+    expect(io.exitCode).toBe(0)
+    expect((JSON.parse(decode(await materialize(out))) as { status: string }).status).toBe('sent')
+    expect(decode(await materialize(io.stderr))).toBe(
+      'himalaya: sent copy not saved: Sent: no such mailbox\n',
+    )
+  })
+
+  it('compose --send files a copy too, and saveCopy off files none', async () => {
+    sendRawMock.mockClear()
+    sendRawMock.mockResolvedValue({ to: [{ name: '', email: 'a@b.com' }], subject: 'Hi' })
+    const compose = await import('./compose.ts').then((m) => m.compose)
+    const invocation = {
+      config: CONFIG,
+      argv: [],
+      paths: [],
+      texts: [],
+      flags: { to: 'a@b.com', subject: 'Hi', body: 'yo', send: true },
+      stdin: null,
+      env: {},
+    }
+    await compose(invocation)
+    expect(appendMock).toHaveBeenCalledTimes(1)
+    await compose({ ...invocation, config: { ...CONFIG, saveCopy: false } })
+    expect(appendMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('compose --save without --send files the message and sends nothing', async () => {
+    sendRawMock.mockClear()
+    const compose = await import('./compose.ts').then((m) => m.compose)
+    const [out, io] = (await compose({
+      config: CONFIG,
+      argv: [],
+      paths: [],
+      texts: [],
+      flags: { to: 'a@b.com', subject: 'Draft it', body: 'yo', save: 'Drafts' },
+      stdin: null,
+      env: {},
+    })) as [Uint8Array, IOResult]
+    expect(sendRawMock).not.toHaveBeenCalled()
+    expect(appendMock).toHaveBeenCalledWith('Drafts', expect.anything(), ['\\Seen'])
+    expect(JSON.parse(decode(await materialize(out)))).toEqual({
+      status: 'saved',
+      mailbox: 'Drafts',
+      to: 'a@b.com',
+      subject: 'Draft it',
+    })
+    expect(io.exitCode).toBe(0)
+  })
+
+  it('a refused --save without --send fails loudly', async () => {
+    // Nothing was sent, so there is no delivered message a retry could
+    // duplicate: this one is an error, not a warning.
+    appendMock.mockRejectedValue(new Error('Drafts: no such mailbox'))
+    const compose = await import('./compose.ts').then((m) => m.compose)
+    await expect(
+      compose({
+        config: CONFIG,
+        argv: [],
+        paths: [],
+        texts: [],
+        flags: { to: 'a@b.com', body: 'yo', save: 'Drafts' },
+        stdin: null,
+        env: {},
+      }),
+    ).rejects.toThrow('Drafts: no such mailbox')
   })
 
   it('send refuses an empty message before reaching SMTP', async () => {

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/index.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/index.ts
@@ -48,6 +48,17 @@ const PAGE_SIZE = new Option({
   description: 'Maximum envelopes per page',
 })
 
+// Upstream v2 spells the sent copy as an explicit mailbox on every verb
+// that produces a message, so `--save` alone files it without sending and
+// `--save` with `--send` does both, naming the mailbox the account's
+// saveCopy would otherwise resolve on its own.
+const SAVE = new Option({
+  long: '--save',
+  type: 'str',
+  metavar: 'MAILBOX',
+  description: 'Append a copy of the message to this mailbox',
+})
+
 // The built-in flag composer, shared verbatim by compose, reply and
 // forward: upstream flattens the same clap struct into all three.
 const COMPOSER = [
@@ -88,6 +99,7 @@ const COMPOSER = [
     long: '--send',
     description: 'Send through SMTP instead of writing MIME to stdout',
   }),
+  SAVE,
 ]
 
 const QUOTING = [
@@ -166,6 +178,7 @@ export const HIMALAYA = new CLISpec({
           description: 'Send a raw RFC 5322 message',
           fn: send,
           write: true,
+          options: [SAVE],
           rest: ID,
         }),
         new CLISpec({

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/send.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/send.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
+  FlagView,
   IOResult,
   materialize,
   type ByteSource,
@@ -20,7 +21,7 @@ import {
   type CommandFnResult,
 } from '@struktoai/mirage-core'
 import type { EmailConfig } from '../../../../core/email/config.ts'
-import { sendRaw } from './smtp.ts'
+import { deliver } from './deliver.ts'
 
 const ENC = new TextEncoder()
 
@@ -38,7 +39,12 @@ export async function send(inv: CLIInvocation): Promise<CommandFnResult> {
   if (new TextDecoder().decode(raw).trim() === '') {
     throw new Error('no message provided: pass it as an argument or pipe it via standard input')
   }
-  const parsed = await sendRaw(inv.config as EmailConfig, raw)
+  const fl = new FlagView(inv.flags)
+  const { parsed, warning } = await deliver(
+    inv.config as EmailConfig,
+    raw,
+    fl.asStr('save') ?? null,
+  )
   const result = {
     status: 'sent',
     to: parsed.to
@@ -47,5 +53,5 @@ export async function send(inv: CLIInvocation): Promise<CommandFnResult> {
     subject: parsed.subject,
   }
   const out: ByteSource = ENC.encode(JSON.stringify(result))
-  return [out, new IOResult()]
+  return [out, new IOResult({ stderr: warning === '' ? null : ENC.encode(warning) })]
 }

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/util.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/util.ts
@@ -22,11 +22,19 @@ import {
   type CommandFnResult,
   type FlagView,
 } from '@struktoai/mirage-core'
+import { parseRfc822, type ParsedRfc822 } from '../../../../core/email/_parse.ts'
 import type { EmailConfig } from '../../../../core/email/config.ts'
 import { build, readBody, splitAddresses, type Attachment, type Source } from './builder.ts'
-import { sendRaw } from './smtp.ts'
+import { deliver, saveSentCopy } from './deliver.ts'
 
 const ENC = new TextEncoder()
+
+/** The `to` field both outcomes report, spelled as the header reads. */
+function addressList(addresses: ParsedRfc822['to']): string {
+  return addresses
+    .map((entry) => (entry.name === '' ? entry.email : `${entry.name} <${entry.email}>`))
+    .join(', ')
+}
 
 /** The command's first operand, or a usage error. */
 export function firstText(texts: readonly string[], label: string): string {
@@ -102,14 +110,30 @@ export async function route(
     },
     source,
   )
-  if (!fl.asBool('send')) return [raw as ByteSource, new IOResult()]
-  const parsed = await sendRaw(config, raw)
+  const save = fl.asStr('save') ?? null
+  if (!fl.asBool('send')) {
+    if (save === null) return [raw as ByteSource, new IOResult()]
+    // --save without --send files the message and sends nothing, so a
+    // refused APPEND means nothing happened at all and may fail loudly:
+    // there is no delivered message a retry could duplicate.
+    const folder = await saveSentCopy(config, raw, save)
+    const filed = await parseRfc822(raw)
+    const saved = {
+      status: 'saved',
+      mailbox: folder,
+      to: addressList(filed.to),
+      subject: filed.subject,
+    }
+    return [ENC.encode(JSON.stringify(saved)) as ByteSource, new IOResult()]
+  }
+  const { parsed, warning } = await deliver(config, raw, save)
   const result = {
     status: 'sent',
-    to: parsed.to
-      .map((entry) => (entry.name === '' ? entry.email : `${entry.name} <${entry.email}>`))
-      .join(', '),
+    to: addressList(parsed.to),
     subject: parsed.subject,
   }
-  return [ENC.encode(JSON.stringify(result)) as ByteSource, new IOResult()]
+  return [
+    ENC.encode(JSON.stringify(result)) as ByteSource,
+    new IOResult({ stderr: warning === '' ? null : ENC.encode(warning) }),
+  ]
 }

--- a/typescript/packages/node/src/core/email/_client.ts
+++ b/typescript/packages/node/src/core/email/_client.ts
@@ -29,10 +29,20 @@ function internalDateOf(value: Date | string | undefined): string {
   return value.toISOString()
 }
 
-export async function listFolders(accessor: EmailAccessor): Promise<string[]> {
+export interface FolderEntry {
+  name: string
+  /** The RFC 6154 special-use attribute the server tagged it with. */
+  specialUse: string | null
+}
+
+export async function listFolderEntries(accessor: EmailAccessor): Promise<FolderEntry[]> {
   const imap = await accessor.getImap()
   const tree = await imap.list()
-  return tree.map((m) => m.pathAsListed)
+  return tree.map((m) => ({ name: m.pathAsListed, specialUse: m.specialUse ?? null }))
+}
+
+export async function listFolders(accessor: EmailAccessor): Promise<string[]> {
+  return (await listFolderEntries(accessor)).map((entry) => entry.name)
 }
 
 /**

--- a/typescript/packages/node/src/core/email/config.ts
+++ b/typescript/packages/node/src/core/email/config.ts
@@ -27,6 +27,13 @@ export interface EmailConfig {
   password: string
   useSsl: boolean
   maxMessages: number
+  /**
+   * Upstream himalaya's message.send.save-copy, whose default is true
+   * since pimalaya/himalaya#536.
+   */
+  saveCopy: boolean
+  /** Its folder.alias.sent: null means ask the server for its \Sent mailbox. */
+  sentFolder: string | null
 }
 
 export interface EmailConfigRedacted extends Omit<EmailConfig, 'password'> {
@@ -45,6 +52,8 @@ export const EmailConfigSchema = z.object({
   password: secretStr(),
   useSsl: z.boolean().default(true),
   maxMessages: z.number().default(200),
+  saveCopy: z.boolean().default(true),
+  sentFolder: z.string().nullable().default(null),
 })
 
 export function redactEmailConfig(config: EmailConfig): EmailConfigRedacted {
@@ -60,6 +69,8 @@ export interface EmailConfigInput {
   password: string
   useSsl?: boolean
   maxMessages?: number
+  saveCopy?: boolean
+  sentFolder?: string | null
 }
 
 export function buildEmailConfig(input: EmailConfigInput): EmailConfig {
@@ -72,6 +83,8 @@ export function buildEmailConfig(input: EmailConfigInput): EmailConfig {
     password: input.password,
     useSsl: input.useSsl ?? true,
     maxMessages: input.maxMessages ?? 200,
+    saveCopy: input.saveCopy ?? true,
+    sentFolder: input.sentFolder ?? null,
   }
 }
 
@@ -84,6 +97,8 @@ export function normalizeEmailConfig(input: Record<string, unknown>): EmailConfi
       smtp_port: 'smtpPort',
       use_ssl: 'useSsl',
       max_messages: 'maxMessages',
+      save_copy: 'saveCopy',
+      sent_folder: 'sentFolder',
     },
   })
   const built: EmailConfigInput = {
@@ -96,5 +111,7 @@ export function normalizeEmailConfig(input: Record<string, unknown>): EmailConfi
   if (typeof norm.smtpPort === 'number') built.smtpPort = norm.smtpPort
   if (typeof norm.useSsl === 'boolean') built.useSsl = norm.useSsl
   if (typeof norm.maxMessages === 'number') built.maxMessages = norm.maxMessages
+  if (typeof norm.saveCopy === 'boolean') built.saveCopy = norm.saveCopy
+  if (typeof norm.sentFolder === 'string') built.sentFolder = norm.sentFolder
   return buildEmailConfig(built)
 }


### PR DESCRIPTION
## The bug

`himalaya ... --send` opened one SMTP conversation and stopped. Mail was
genuinely delivered, but the sender's own Sent mailbox stayed empty.

A Sent folder is not produced by sending. SMTP keeps no record of itself;
the copy is a second, separate IMAP APPEND that every mail client makes on
your behalf. mirage did the first thing and not the second, at four call
sites: `message send`, plus the route `compose`, `reply` and `forward`
share.

Found by comparing benchmark arms: on the same task against the same
server, the emails-mcp arm left 7 messages in the sender's Sent and the
mirage arm left 0, while both delivered identically to recipients. A
grader reading recipient inboxes cannot tell the arms apart; one reading
the sender's Sent sees one arm that appears to have done nothing.

## What this does

Upstream v2.0.0 spells the copy as `--save <MAILBOX>`, having replaced
1.x's automatic `message.send.save-copy` config. Both are here, because
they answer different needs:

- **`--save <MAILBOX>`** on all four verbs, which is v2 parity. On its own,
  with no `--send`, it files the message without sending it, which is how
  a draft is written.
- **`save_copy`**, an account-level default that is **on**, and is mirage's
  own divergence from v2: an agent that never learned the flag still leaves
  the record a human sender would. `sent_folder` pins the mailbox.

The mailbox is asked for, not guessed. A server implementing RFC 6154 tags
one mailbox `\Sent` in its LIST reply (`[Gmail]/Sent Mail` on Gmail,
`Sent Items` on Exchange); failing that the configured name; failing that
`Sent`. That probe is ahead of upstream, whose v2 wizard notes IMAP pins
the reserved INBOX alone while it waits on `LIST RETURN (SPECIAL-USE)` in
io-imap.

## Failure policy

It splits on whether a send already happened, which is the main design
call to review:

| | outcome |
| --- | --- |
| copy fails after a successful send | warning on stderr, exit 0 |
| `--save` with no `--send` fails | fails loudly |

The message is already gone in the first case, so a non-zero exit invites a
retry that sends it twice. In the second nothing happened yet, so retrying
is safe. Upstream propagates in both.

## Two bugs found on the way

- **aioimaplib joins command arguments with spaces verbatim and quotes
  nothing**, so an unquoted mailbox holding a space arrives as two
  arguments and the server reads only the first word. That breaks on
  exactly the two providers above. `quote_mailbox` now covers the APPEND
  and the pre-existing `select_folder`, which had the same latent bug.
  imapflow needs none of it, building commands from typed attributes.
- **The TypeScript test CONFIG was an untyped literal**, so a new required
  field did not fail tsc and those tests passed vacuously through the
  `!saveCopy` early return. Annotated now, with a global beforeEach
  stubbing the accessor so no `--send` test reaches for a real connection.

## Verification

Against a live GreenMail, on both hosts:

- integ `email` 86 passed, `cli-himalaya` 74 passed, including six new cases
- confirmed on the wire that compose, reply, forward and send each land in
  Sent with `\Seen`, and that the LIST parser handles real output (empty
  attribute lists, `.` delimiter)
- Python suite exit 0, TypeScript node 2144 passed, pre-commit clean

GreenMail hands a new account nothing but an INBOX, where a real provider
ships a sent mailbox already made, so both integ seeders create one and the
`ls /mail` golden gains `Sent`.

Known gap: GreenMail advertises no special-use, so the `\Sent` probe's
happy path is covered by unit tests only.
