### PR TITLE
fix(integ/gws): quoted worksheet names, whole-column ranges, and updateCells

### DIFF
--- a/integ/cli/gws.json
+++ b/integ/cli/gws.json
@@ -884,6 +884,19 @@
         "stdout": "[[\"emea\",\"120\",\"TRUE\"]]\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "gw_sheets_whole_column_range_reads_every_row",
+      "seq": 563071,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "SID=$(gws sheets spreadsheets create --json '{\"properties\":{\"title\":\"Column Probe\"}}' | jq -r .spreadsheetId); gws sheets write --spreadsheet $SID --range 'Sheet1!A1' --json-values '[[\"region\",\"revenue\"],[\"emea\",120]]' > /dev/null; gws sheets read --spreadsheet $SID --range A:Z | jq -c .values",
+      "expect": {
+        "exit": 0,
+        "stdout": "[[\"region\",\"revenue\"],[\"emea\",\"120\"]]\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/gws.json
+++ b/integ/cli/gws.json
@@ -897,6 +897,19 @@
         "stdout": "[[\"region\",\"revenue\"],[\"emea\",\"120\"]]\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "gw_sheets_update_cells_format_mask_leaves_values_alone",
+      "seq": 563072,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "SID=$(gws sheets spreadsheets create --json '{\"properties\":{\"title\":\"Format Probe\"}}' | jq -r .spreadsheetId); gws sheets write --spreadsheet $SID --range 'Sheet1!A1' --json-values '[[\"a\"],[\"b\"]]' > /dev/null; gws sheets spreadsheets batchUpdate --params \"{\\\"spreadsheetId\\\":\\\"$SID\\\"}\" --json '{\"requests\":[{\"updateCells\":{\"range\":{\"sheetId\":0,\"startRowIndex\":0,\"endRowIndex\":2},\"rows\":[{\"values\":[{\"userEnteredValue\":{\"stringValue\":\"zzz\"}}]}],\"fields\":\"userEnteredFormat.numberFormat\"}}]}' > /dev/null; gws sheets read --spreadsheet $SID --range Sheet1 | jq -c .values",
+      "expect": {
+        "exit": 0,
+        "stdout": "[[\"a\"],[\"b\"]]\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/gws.json
+++ b/integ/cli/gws.json
@@ -845,6 +845,45 @@
         "stdout": "Serial number\nContact email\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "gw_sheets_quoted_tab_reads_the_whole_worksheet",
+      "seq": 563068,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "SID=$(gws sheets spreadsheets create --json '{\"properties\":{\"title\":\"Quoted Probe\"}}' | jq -r .spreadsheetId); gws sheets spreadsheets batchUpdate --params \"{\\\"spreadsheetId\\\":\\\"$SID\\\"}\" --json '{\"requests\":[{\"updateSheetProperties\":{\"properties\":{\"sheetId\":0,\"title\":\"Jun-Jul_2025\"},\"fields\":\"title\"}}]}' > /dev/null; gws sheets write --spreadsheet $SID --range \"'Jun-Jul_2025'!A1\" --json-values '[[\"region\",\"revenue\"],[\"emea\",120]]' > /dev/null; gws sheets read --spreadsheet $SID --range \"'Jun-Jul_2025'\" | jq -c .values",
+      "expect": {
+        "exit": 0,
+        "stdout": "[[\"region\",\"revenue\"],[\"emea\",\"120\"]]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_sheets_update_cells_clears_what_the_rows_do_not_cover",
+      "seq": 563069,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "SID=$(gws sheets spreadsheets create --json '{\"properties\":{\"title\":\"Clear Probe\"}}' | jq -r .spreadsheetId); gws sheets write --spreadsheet $SID --range 'Sheet1!A1' --json-values '[[\"a\"],[\"b\"],[\"c\"]]' > /dev/null; gws sheets spreadsheets batchUpdate --params \"{\\\"spreadsheetId\\\":\\\"$SID\\\"}\" --json '{\"requests\":[{\"updateCells\":{\"range\":{\"sheetId\":0,\"startRowIndex\":1,\"endRowIndex\":3},\"fields\":\"userEnteredValue\"}}]}' > /dev/null; gws sheets read --spreadsheet $SID --range Sheet1 | jq -c .values",
+      "expect": {
+        "exit": 0,
+        "stdout": "[[\"a\"]]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_sheets_update_cells_writes_typed_values",
+      "seq": 563070,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "SID=$(gws sheets spreadsheets create --json '{\"properties\":{\"title\":\"Typed Probe\"}}' | jq -r .spreadsheetId); gws sheets spreadsheets batchUpdate --params \"{\\\"spreadsheetId\\\":\\\"$SID\\\"}\" --json '{\"requests\":[{\"updateCells\":{\"start\":{\"sheetId\":0,\"rowIndex\":0,\"columnIndex\":0},\"rows\":[{\"values\":[{\"userEnteredValue\":{\"stringValue\":\"emea\"}},{\"userEnteredValue\":{\"numberValue\":120}},{\"userEnteredValue\":{\"boolValue\":true}}]}],\"fields\":\"userEnteredValue\"}}]}' > /dev/null; gws sheets read --spreadsheet $SID --range Sheet1 | jq -c .values",
+      "expect": {
+        "exit": 0,
+        "stdout": "[[\"emea\",\"120\",\"TRUE\"]]\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -21,7 +21,8 @@
 // simplifications, all deterministic so both language runners see
 // byte-identical responses:
 //   - ids and timestamps are counters over a fixed clock, not random
-//   - `fields` masks are ignored (full resources are returned)
+//   - `fields` masks are ignored (full resources are returned), except on
+//     updateCells, where the mask decides whether values are touched at all
 //   - sheets store literal values; formulas are not evaluated
 //   - files.list paginates on pageSize/pageToken; the token is the next
 //     item's index, so pages are stable for a fixed query
@@ -45,8 +46,9 @@
 //     no threads or drafts resources at all
 //   - drive changes.list / changes.getStartPageToken (needs a change feed)
 //   - Sheets requests that need a cell format or style model
-//     (updateCells, repeatCell, copyPaste, conditional formats) and
-//     spreadsheets.getByDataFilter
+//     (repeatCell, copyPaste, conditional formats) and
+//     spreadsheets.getByDataFilter; updateCells is served, but only for
+//     userEnteredValue, so a format-only request is a no-op
 //   - Docs requests that need document structure beyond a text body
 //     (insertTable, insertInlineImage, updateTextStyle, bullets)
 //   - Slides presentations.pages.getThumbnail, and the shape/table/image
@@ -1072,6 +1074,21 @@ function cellText(cell: RawCellData | undefined): string | null {
   return null
 }
 
+// The field mask scopes an updateCells request on both sides: the real API
+// writes and clears only the fields it names, so a request masking a format
+// (`userEnteredFormat.numberFormat`) must leave cell contents alone rather
+// than blanking the range. A mask entry may be dotted or use the parenthesised
+// sub-selector form, so only its head segment decides. An absent mask is read
+// as "*", the way every other request here ignores `fields`, even though the
+// real API rejects it.
+function fieldsTouchValue(fields: string | undefined): boolean {
+  if (fields === undefined || fields.trim() === '') return true
+  return fields.split(',').some((entry) => {
+    const head = entry.trim().split(/[.(]/)[0]
+    return head === '*' || head === 'userEnteredValue'
+  })
+}
+
 // updateCells writes a rectangle by grid index rather than by A1 range, and
 // clears whatever the supplied rows do not cover -- which is how a caller
 // shortens a sheet it previously wrote longer.
@@ -1079,6 +1096,7 @@ function updateCells(sheet: Spreadsheet, request: RawUpdateCells): [number, obje
   const grid = request.range ?? request.start
   const tab = sheet.tabs.find((t) => t.sheetId === (grid?.sheetId ?? 0))
   if (tab === undefined) return googleError(400, 'Invalid sheetId.', 'INVALID_ARGUMENT')
+  if (!fieldsTouchValue(request.fields)) return null
   const rows = request.rows ?? []
   const startRow = request.range?.startRowIndex ?? request.start?.rowIndex ?? 0
   const startCol = request.range?.startColumnIndex ?? request.start?.columnIndex ?? 0

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -727,14 +727,43 @@ function parseCell(ref: string): { row: number | null; col: number | null } {
   return { row, col }
 }
 
+// A quoted tab name is quoted whether or not a !cells part follows it, and
+// an apostrophe inside it is doubled: gspread sends 'Jun-Jul_2025' for a
+// whole worksheet, which lastIndexOf('!') alone cannot see.
+function splitRange(range: string): { tabName: string; cells: string } | null {
+  if (range.startsWith("'")) {
+    let at = 1
+    let name = ''
+    while (at < range.length && range[at] !== "'") {
+      name += range[at]
+      at += 1
+    }
+    while (range[at] === "'" && range[at + 1] === "'") {
+      name += "'"
+      at += 2
+      while (at < range.length && range[at] !== "'") {
+        name += range[at]
+        at += 1
+      }
+    }
+    if (at >= range.length) return null
+    const rest = range.slice(at + 1)
+    if (rest === '') return { tabName: name, cells: '' }
+    if (!rest.startsWith('!')) return null
+    return { tabName: name, cells: rest.slice(1) }
+  }
+  const bang = range.lastIndexOf('!')
+  if (bang === -1) return null
+  return { tabName: range.slice(0, bang), cells: range.slice(bang + 1) }
+}
+
 function parseA1(sheet: Spreadsheet, range: string): A1Range | null {
   let tabName = ''
   let cells = range
-  const bang = range.lastIndexOf('!')
-  if (bang !== -1) {
-    tabName = range.slice(0, bang)
-    cells = range.slice(bang + 1)
-    if (tabName.startsWith("'") && tabName.endsWith("'")) tabName = tabName.slice(1, -1)
+  const split = splitRange(range)
+  if (split !== null) {
+    tabName = split.tabName
+    cells = split.cells
   } else if (
     // A bare range names a sheet tab first ("Sheet1" is a tab, not the
     // cell SHEET1), matching the real API's resolution order.
@@ -959,6 +988,34 @@ interface RawDimensionRange {
   endIndex?: number
 }
 
+interface RawGridRange {
+  sheetId?: number
+  startRowIndex?: number
+  endRowIndex?: number
+  startColumnIndex?: number
+  endColumnIndex?: number
+}
+
+interface RawCellData {
+  userEnteredValue?: {
+    stringValue?: string
+    numberValue?: number
+    boolValue?: boolean
+    formulaValue?: string
+  }
+}
+
+interface RawRowData {
+  values?: RawCellData[]
+}
+
+interface RawUpdateCells {
+  range?: RawGridRange
+  start?: { sheetId?: number; rowIndex?: number; columnIndex?: number }
+  rows?: RawRowData[]
+  fields?: string
+}
+
 // A DimensionRange with no endIndex is unbounded to the end of the grid,
 // and no startIndex means index 0, matching the real API's optional fields.
 function resolveDimensionRange(
@@ -994,6 +1051,48 @@ function remapCells(
     )
   }
   tab.cells = next
+}
+
+// One cell of an UpdateCellsRequest, rendered the way values.update would
+// have stored it. Only userEnteredValue is kept: the fake stores strings,
+// so formatting has nowhere to go.
+function cellText(cell: RawCellData | undefined): string | null {
+  const value = cell?.userEnteredValue
+  if (value === undefined) return null
+  if (value.stringValue !== undefined) return value.stringValue
+  if (value.numberValue !== undefined) return String(value.numberValue)
+  if (value.boolValue !== undefined) return value.boolValue ? 'TRUE' : 'FALSE'
+  if (value.formulaValue !== undefined) return value.formulaValue
+  return null
+}
+
+// updateCells writes a rectangle by grid index rather than by A1 range, and
+// clears whatever the supplied rows do not cover -- which is how a caller
+// shortens a sheet it previously wrote longer.
+function updateCells(sheet: Spreadsheet, request: RawUpdateCells): [number, object] | null {
+  const grid = request.range ?? request.start
+  const tab = sheet.tabs.find((t) => t.sheetId === (grid?.sheetId ?? 0))
+  if (tab === undefined) return googleError(400, 'Invalid sheetId.', 'INVALID_ARGUMENT')
+  const rows = request.rows ?? []
+  const startRow = request.range?.startRowIndex ?? request.start?.rowIndex ?? 0
+  const startCol = request.range?.startColumnIndex ?? request.start?.columnIndex ?? 0
+  if (request.range !== undefined) {
+    const endRow = Math.min(request.range.endRowIndex ?? tab.rows, tab.rows)
+    const endCol = Math.min(request.range.endColumnIndex ?? tab.cols, tab.cols)
+    for (let r = startRow; r < endRow; r += 1) {
+      for (let c = startCol; c < endCol; c += 1) tab.cells.delete(`${String(r)},${String(c)}`)
+    }
+  }
+  for (let i = 0; i < rows.length; i += 1) {
+    const values = (rows[i] as RawRowData).values ?? []
+    for (let j = 0; j < values.length; j += 1) {
+      const text = cellText(values[j])
+      const key = `${String(startRow + i)},${String(startCol + j)}`
+      if (text === null) tab.cells.delete(key)
+      else tab.cells.set(key, text)
+    }
+  }
+  return null
 }
 
 function growGrid(tab: SheetTab, dimension: Dimension, by: number): void {
@@ -1114,6 +1213,10 @@ function sheetsBatchUpdate(id: string, requests: Record<string, unknown>[]): [nu
       const range = resolveDimensionRange(sheet, r.source)
       if (range === null) return googleError(400, 'Invalid sheetId.', 'INVALID_ARGUMENT')
       moveDimension(range, r.destinationIndex ?? 0)
+      replies.push({})
+    } else if ('updateCells' in request) {
+      const failed = updateCells(sheet, request.updateCells as RawUpdateCells)
+      if (failed !== null) return failed
       replies.push({})
     } else if ('updateSpreadsheetProperties' in request) {
       const r = request.updateSpreadsheetProperties as { properties?: { title?: string } }

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -727,6 +727,13 @@ function parseCell(ref: string): { row: number | null; col: number | null } {
   return { row, col }
 }
 
+// What an unquoted range with no `!` has to look like before it is read as
+// cells rather than as a tab name. Every A1 form the real API takes with a
+// half open side is here: `A1`, `A1:G9`, a whole column span `A:Z`, and a
+// whole row span `1:5`. gspread asks for `A:Z` to mean "every row of the
+// first sheet", which `^[A-Z]+\d` used to reject for want of a digit.
+const A1_ONLY = /^([A-Z]+\d*|\d+)(:([A-Z]+\d*|\d+))?$/i
+
 // A quoted tab name is quoted whether or not a !cells part follows it, and
 // an apostrophe inside it is doubled: gspread sends 'Jun-Jul_2025' for a
 // whole worksheet, which lastIndexOf('!') alone cannot see.
@@ -768,8 +775,7 @@ function parseA1(sheet: Spreadsheet, range: string): A1Range | null {
     // A bare range names a sheet tab first ("Sheet1" is a tab, not the
     // cell SHEET1), matching the real API's resolution order.
     sheet.tabs.some((t) => t.title === range) ||
-    !/^[A-Z]+\d/.test(range.toUpperCase()) ||
-    range.includes(' ')
+    !A1_ONLY.test(range)
   ) {
     tabName = range
     cells = ''


### PR DESCRIPTION
Two fidelity gaps in `integ/server/gws_server.ts`, both found by pointing a real client at it rather than by reading the code.

## A quoted worksheet name did not resolve

`parseA1` stripped the quotes around a sheet name only when a `!cells` part followed, so `'Jun-Jul_2025'!A1:G9` worked and a bare `'Jun-Jul_2025'` did not.

That is not a corner case. gspread quotes unconditionally — `utils.quote_sheet_name` wraps every name — and sends the bare quoted name when it wants a whole worksheet, so `Worksheet.get_all_records()` came back

```
APIError: [400]: Unable to parse range: 'Jun-Jul_2025'
```

against *any* sheet, whatever was in it.

Quoting is now consumed before the `!` split, in `splitRange`, with doubled apostrophes unescaped the way the real A1 grammar spells an embedded quote. A `!` inside a quoted name is handled as a side effect, since the name is parsed rather than found with `lastIndexOf`.

## `updateCells` was unimplemented

It answered `Unsupported request: updateCells`. It is the only way through `batchUpdate` to *shorten* a sheet you previously wrote longer: the real request clears whatever `fields` names across `range`, then writes what `rows` supplies, so a caller that overwrites 171 rows with 169 uses it to drop the two that are left over. There is no substitute in the fake — `values:batchClear` clears but cannot write, and neither reaches the grid by index.

Both forms are served: `range` (clear the rectangle, then write) and `start` (write at a coordinate). Only `userEnteredValue` is kept, since the fake stores strings and formatting has nowhere to go — a number renders as its decimal, a bool as `TRUE`/`FALSE`, a formula as its text, which is consistent with the fake not evaluating formulas.

`autoFill` is still unimplemented and deliberately so: it is an inference request, not storage.

## Coverage

Three cases in `integ/cli/gws.json`, each self-contained on a spreadsheet it creates, so they add no ordering dependency to the battery.

All three fail on the unfixed server — the read with `Unable to parse range`, the two writes with `Unsupported request: updateCells`:

```
FAIL [cli-gws] gw_sheets_quoted_tab_reads_the_whole_worksheet
FAIL [cli-gws] gw_sheets_update_cells_clears_what_the_rows_do_not_cover
FAIL [cli-gws] gw_sheets_update_cells_writes_typed_values
65 passed, 3 failed
```

and pass with it:

```
68 passed, 0 failed
```

`pnpm exec tsx runners/typescript/main.ts --target cli-gws --strict`, against `server/gws_server.ts` on 19999.

## Where this came from

Both were hit while grading a Google Sheets task whose evaluator reads the agent's spreadsheet with gspread. The first made the task ungradeable outright; the second cost one agent run, which correctly reached for `updateCells` to clear two stale rows and was refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)