### PR TITLE
fix(paths): absolute operands keep their typed spelling — unblocks cd -P and as-typed echo

### DIFF
--- a/integ/resources/chroma/ops.json
+++ b/integ/resources/chroma/ops.json
@@ -516,7 +516,7 @@
       "command": "du /knowledge/",
       "expect": {
         "exit": 0,
-        "stdout": "354\t/knowledge/guides\n306\t/knowledge/policies\n712\t/knowledge\n",
+        "stdout": "354\t/knowledge/guides\n306\t/knowledge/policies\n712\t/knowledge/\n",
         "stderr": ""
       }
     },

--- a/integ/resources/mongodb/ls.json
+++ b/integ/resources/mongodb/ls.json
@@ -74,7 +74,7 @@
       "command": "tree -L 3 /mongodb/mirage_integ/",
       "expect": {
         "exit": 0,
-        "stdout": "/mongodb/mirage_integ\n|-- collections\n|   |-- authors\n|   |   |-- documents.jsonl\n|   |   `-- schema.json\n|   |-- books\n|   |   |-- documents.jsonl\n|   |   `-- schema.json\n|   `-- system.views\n|       |-- documents.jsonl\n|       `-- schema.json\n|-- database.json\n`-- views\n    `-- recent_books\n        |-- documents.jsonl\n        `-- schema.json\n\n7 directories, 9 files\n",
+        "stdout": "/mongodb/mirage_integ/\n|-- collections\n|   |-- authors\n|   |   |-- documents.jsonl\n|   |   `-- schema.json\n|   |-- books\n|   |   |-- documents.jsonl\n|   |   `-- schema.json\n|   `-- system.views\n|       |-- documents.jsonl\n|       `-- schema.json\n|-- database.json\n`-- views\n    `-- recent_books\n        |-- documents.jsonl\n        `-- schema.json\n\n7 directories, 9 files\n",
         "stderr": ""
       }
     }

--- a/integ/resources/notion/ops.json
+++ b/integ/resources/notion/ops.json
@@ -360,7 +360,7 @@
       "command": "du /notion/pages/",
       "expect": {
         "exit": 0,
-        "stdout": "1466\t/notion/pages/Notes__bbbb2222-3333-4444-5555-666677778888\n1087\t/notion/pages/Project_Roadmap__aaaa1111-2222-3333-4444-555566667777/Q1_Goals__cccc1111-2222-3333-4444-555566667777\n4341\t/notion/pages/Project_Roadmap__aaaa1111-2222-3333-4444-555566667777\n5807\t/notion/pages\n",
+        "stdout": "1466\t/notion/pages/Notes__bbbb2222-3333-4444-5555-666677778888\n1087\t/notion/pages/Project_Roadmap__aaaa1111-2222-3333-4444-555566667777/Q1_Goals__cccc1111-2222-3333-4444-555566667777\n4341\t/notion/pages/Project_Roadmap__aaaa1111-2222-3333-4444-555566667777\n5807\t/notion/pages/\n",
         "stderr": ""
       }
     },
@@ -373,7 +373,7 @@
       "command": "du /notion/pages/Project_Roadmap__aaaa1111-2222-3333-4444-555566667777/",
       "expect": {
         "exit": 0,
-        "stdout": "1087\t/notion/pages/Project_Roadmap__aaaa1111-2222-3333-4444-555566667777/Q1_Goals__cccc1111-2222-3333-4444-555566667777\n4341\t/notion/pages/Project_Roadmap__aaaa1111-2222-3333-4444-555566667777\n",
+        "stdout": "1087\t/notion/pages/Project_Roadmap__aaaa1111-2222-3333-4444-555566667777/Q1_Goals__cccc1111-2222-3333-4444-555566667777\n4341\t/notion/pages/Project_Roadmap__aaaa1111-2222-3333-4444-555566667777/\n",
         "stderr": ""
       }
     },

--- a/integ/resources/postgres/ls.json
+++ b/integ/resources/postgres/ls.json
@@ -74,7 +74,7 @@
       "command": "tree -L 3 /pg/public/",
       "expect": {
         "exit": 0,
-        "stdout": "/pg/public\n|-- tables\n|   |-- authors\n|   |   |-- rows.jsonl\n|   |   |-- schema.json\n|   |   `-- semantic.json\n|   `-- books\n|       |-- rows.jsonl\n|       |-- schema.json\n|       `-- semantic.json\n`-- views\n    `-- recent_books\n        |-- rows.jsonl\n        |-- schema.json\n        `-- semantic.json\n\n6 directories, 9 files\n",
+        "stdout": "/pg/public/\n|-- tables\n|   |-- authors\n|   |   |-- rows.jsonl\n|   |   |-- schema.json\n|   |   `-- semantic.json\n|   `-- books\n|       |-- rows.jsonl\n|       |-- schema.json\n|       `-- semantic.json\n`-- views\n    `-- recent_books\n        |-- rows.jsonl\n        |-- schema.json\n        `-- semantic.json\n\n6 directories, 9 files\n",
         "stderr": ""
       }
     }

--- a/integ/resources/qdrant/ops.json
+++ b/integ/resources/qdrant/ops.json
@@ -334,7 +334,7 @@
       "command": "du /db/",
       "expect": {
         "exit": 0,
-        "stdout": "84\t/db/cat/big\n86\t/db/cat/small\n170\t/db/cat\n82\t/db/dog/big\n88\t/db/dog/small\n170\t/db/dog\n340\t/db\n",
+        "stdout": "84\t/db/cat/big\n86\t/db/cat/small\n170\t/db/cat\n82\t/db/dog/big\n88\t/db/dog/small\n170\t/db/dog\n340\t/db/\n",
         "stderr": ""
       }
     },

--- a/integ/resources/slack/find.json
+++ b/integ/resources/slack/find.json
@@ -9,7 +9,7 @@
       "command": "find /slack/channels/eng-agents__C8/2026-02-06/",
       "expect": {
         "exit": 0,
-        "stdout": "/slack/channels/eng-agents__C8/2026-02-06\n/slack/channels/eng-agents__C8/2026-02-06/chat.jsonl\n/slack/channels/eng-agents__C8/2026-02-06/files\n/slack/channels/eng-agents__C8/2026-02-06/files/model_eval_results__F7.csv\n",
+        "stdout": "/slack/channels/eng-agents__C8/2026-02-06/\n/slack/channels/eng-agents__C8/2026-02-06/chat.jsonl\n/slack/channels/eng-agents__C8/2026-02-06/files\n/slack/channels/eng-agents__C8/2026-02-06/files/model_eval_results__F7.csv\n",
         "stderr": ""
       }
     },

--- a/integ/resources/slack/ls.json
+++ b/integ/resources/slack/ls.json
@@ -101,7 +101,7 @@
       "expect": {
         "exit": 2,
         "stdout": "",
-        "stderr": "ls: cannot access '/slack/channels/product-reply__C6': No such file or directory\n"
+        "stderr": "ls: cannot access '/slack/channels/product-reply__C6/': No such file or directory\n"
       }
     }
   ]

--- a/integ/resources/slack/tree.json
+++ b/integ/resources/slack/tree.json
@@ -9,7 +9,7 @@
       "command": "tree /slack/channels/eng-agents__C8/2026-02-06/",
       "expect": {
         "exit": 0,
-        "stdout": "/slack/channels/eng-agents__C8/2026-02-06\n|-- chat.jsonl\n`-- files\n    `-- model_eval_results__F7.csv\n\n2 directories, 2 files\n",
+        "stdout": "/slack/channels/eng-agents__C8/2026-02-06/\n|-- chat.jsonl\n`-- files\n    `-- model_eval_results__F7.csv\n\n2 directories, 2 files\n",
         "stderr": ""
       }
     }

--- a/integ/server/jaeger_seed.py
+++ b/integ/server/jaeger_seed.py
@@ -188,6 +188,31 @@ def post_spans(host: str) -> None:
             raise RuntimeError(f"OTLP push failed: HTTP {response.status}")
 
 
+async def push_when_ready(otlp_host: str) -> None:
+    """Push the fixture spans, retrying until the receiver is listening.
+
+    Args:
+        otlp_host (str): OTLP HTTP base URL.
+
+    Raises:
+        RuntimeError: the receiver never accepted the batch.
+    """
+    last = ""
+    for _ in range(POLL_ATTEMPTS):
+        try:
+            post_spans(otlp_host)
+            return
+        except OSError as exc:
+            # Same reason `query` catches OSError rather than URLError:
+            # a booting container's docker-proxy accepts the connection
+            # and resets it, which reaches us as a raw ConnectionResetError.
+            last = str(exc)
+            print(f"otlp not ready: {exc}", file=sys.stderr)
+            await asyncio.sleep(POLL_DELAY)
+    raise RuntimeError(
+        f"OTLP receiver at {otlp_host} never accepted the batch: {last}")
+
+
 def query(query_host: str, path: str) -> dict:
     """Call the Jaeger query API.
 
@@ -242,7 +267,11 @@ async def seed(query_host: str, otlp_host: str) -> None:
         if query(query_host, "/api/services"):
             break
         await asyncio.sleep(POLL_DELAY)
-    post_spans(otlp_host)
+    # The query API answering says nothing about the OTLP receiver: they are
+    # separate ports on the same container, bound at different times, so the
+    # push meets the same half-open docker-proxy socket `query` already
+    # guards against. Poll the port we actually need by retrying the push.
+    await push_when_ready(otlp_host)
     await wait_for_services(query_host)
     print(f"JAEGER_URL={query_host}")
 

--- a/integ/unix/arch/traversal.json
+++ b/integ/unix/arch/traversal.json
@@ -95,6 +95,38 @@
         "stdout": "./\ndeep/\ndeep/g.txt\n",
         "stderr": "tar: Removing leading `..' from member names\ntar: Removing leading `../' from member names\n"
       }
+    },
+    {
+      "id": "arch_tar_announces_a_prefix_it_cannot_archive",
+      "seq": 960091,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tmiss2/sub && (cd /data/tmiss2 && tar -c -f /data/tmiss2.tar sub/../missing)",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "tar: Removing leading `sub/../' from member names\ntar: sub/../missing: Cannot stat: No such file or directory\ntar: Exiting with failure status due to previous errors\n"
+      }
+    },
+    {
+      "id": "arch_tar_keeps_notices_in_operand_order",
+      "seq": 960092,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tord/sub && echo o | tee /data/tord/file.txt > /dev/null && (cd /data/tord/sub && tar -c -f /data/tord.tar missing ../file.txt)",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "tar: missing: Cannot stat: No such file or directory\ntar: Removing leading `../' from member names\ntar: Exiting with failure status due to previous errors\n"
+      }
     }
   ]
 }

--- a/integ/unix/arch/traversal.json
+++ b/integ/unix/arch/traversal.json
@@ -1,0 +1,100 @@
+{
+  "cases": [
+    {
+      "id": "arch_tar_drops_an_absolute_dotdot_prefix",
+      "seq": 960068,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/ttrav/sub && echo trav | tee /data/ttrav/g.txt > /dev/null && tar -c -f /data/ttrav.tar /data/ttrav/sub/../g.txt && tar -t -f /data/ttrav.tar",
+      "expect": {
+        "exit": 0,
+        "stdout": "g.txt\n",
+        "stderr": "tar: Removing leading `/data/ttrav/sub/../' from member names\n"
+      }
+    },
+    {
+      "id": "arch_tar_drops_a_relative_dotdot_prefix",
+      "seq": 960069,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/ttrav2/sub && echo trav2 | tee /data/ttrav2/g.txt > /dev/null && (cd /data/ttrav2 && tar -c -f /data/ttrav2.tar sub/../g.txt) && tar -t -f /data/ttrav2.tar",
+      "expect": {
+        "exit": 0,
+        "stdout": "g.txt\n",
+        "stderr": "tar: Removing leading `sub/../' from member names\n"
+      }
+    },
+    {
+      "id": "arch_tar_keeps_a_dot_slash_operand",
+      "seq": 960070,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tdot && echo dot | tee /data/tdot/g.txt > /dev/null && (cd /data/tdot && tar -c -f /data/tdot.tar ./g.txt) && tar -t -f /data/tdot.tar",
+      "expect": {
+        "exit": 0,
+        "stdout": "./g.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "arch_tar_names_each_dropped_prefix_once",
+      "seq": 960071,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tmix/sub && echo m1 | tee /data/tmix/a.txt > /dev/null && echo m2 | tee /data/tmix/b.txt > /dev/null && tar -c -f /data/tmix.tar /data/tmix/a.txt /data/tmix/sub/../b.txt && tar -t -f /data/tmix.tar",
+      "expect": {
+        "exit": 0,
+        "stdout": "data/tmix/a.txt\nb.txt\n",
+        "stderr": "tar: Removing leading `/' from member names\ntar: Removing leading `/data/tmix/sub/../' from member names\n"
+      }
+    },
+    {
+      "id": "arch_zip_keeps_a_dotdot_member_name",
+      "seq": 960072,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/ztrav/sub && echo z | tee /data/ztrav/g.txt > /dev/null && (cd /data/ztrav && zip -q /data/ztrav.zip sub/../g.txt) && unzip -l /data/ztrav.zip | tail -n 1 | awk '{print $2}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "sub/../g.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "arch_tar_owes_two_notices_for_a_bare_dotdot",
+      "seq": 960086,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs"
+      ],
+      "command": "mkdir -p /data/tdd/sub/deep && echo dd | tee /data/tdd/sub/deep/g.txt > /dev/null && (cd /data/tdd/sub/deep && tar -c -f /data/tdd.tar ..) && tar -t -f /data/tdd.tar",
+      "expect": {
+        "exit": 0,
+        "stdout": "./\ndeep/\ndeep/g.txt\n",
+        "stderr": "tar: Removing leading `..' from member names\ntar: Removing leading `../' from member names\n"
+      }
+    }
+  ]
+}

--- a/integ/unix/sym/cdmode.json
+++ b/integ/unix/sym/cdmode.json
@@ -27,7 +27,7 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "mkdir -p /data/lkd/real && echo x > /data/lkd/real/f.txt && ln -s /data/lkd/real /data/lkp",
+      "command": "ln -s /data/disptree/d /data/lkp",
       "expect": {
         "exit": 0,
         "stdout": "",
@@ -98,7 +98,7 @@
       "command": "(cd -P /data/lkp/.. && pwd)",
       "expect": {
         "exit": 0,
-        "stdout": "/data/lkd\n",
+        "stdout": "/data/disptree\n",
         "stderr": ""
       }
     },
@@ -163,7 +163,7 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "rm /data/lkp && rm -r /data/lkd",
+      "command": "rm /data/lkp",
       "expect": {
         "exit": 0,
         "stdout": "",

--- a/integ/unix/sym/cdmode.json
+++ b/integ/unix/sym/cdmode.json
@@ -1,0 +1,174 @@
+{
+  "cases": [
+    {
+      "id": "sym_cd_mode_setup",
+      "seq": 637,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/lkd/real && ln -s /data/lkd/real /data/lkp",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sym_cd_logical_dotdot",
+      "seq": 638,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "(cd -L /data/lkp/.. && pwd)",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sym_cd_physical_dotdot",
+      "seq": 639,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "(cd -P /data/lkp/.. && pwd)",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/lkd\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sym_cd_default_is_logical",
+      "seq": 640,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "(cd /data/lkp/.. && pwd)",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sym_cd_mode_cleanup",
+      "seq": 641,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "rm /data/lkp && rm -r /data/lkd",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/unix/sym/cdmode.json
+++ b/integ/unix/sym/cdmode.json
@@ -27,7 +27,7 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "mkdir -p /data/lkd/real && ln -s /data/lkd/real /data/lkp",
+      "command": "mkdir -p /data/lkd/real && echo x > /data/lkd/real/f.txt && ln -s /data/lkd/real /data/lkp",
       "expect": {
         "exit": 0,
         "stdout": "",

--- a/python/mirage/commands/builtin/generic/tar/__init__.py
+++ b/python/mirage/commands/builtin/generic/tar/__init__.py
@@ -1,7 +1,8 @@
 from mirage.commands.builtin.generic.tar.constants import (READ_MODES,
                                                            WRITE_MODES)
 from mirage.commands.builtin.generic.tar.create import (excluded, member_name,
-                                                        plan_create, pruned)
+                                                        plan_create, pruned,
+                                                        strip_prefix)
 from mirage.commands.builtin.generic.tar.tar import tar
 from mirage.commands.builtin.generic.tar.types import (CompressionSuffix,
                                                        CreateResult, Member,
@@ -19,5 +20,6 @@ __all__ = [
     "member_name",
     "plan_create",
     "pruned",
+    "strip_prefix",
     "tar",
 ]

--- a/python/mirage/commands/builtin/generic/tar/create.py
+++ b/python/mirage/commands/builtin/generic/tar/create.py
@@ -124,6 +124,24 @@ def removing_leading(prefix: str) -> str:
     return f"tar: Removing leading `{prefix}' from member names"
 
 
+def _announce_prefix(prefix: str, dropped: list[str],
+                     notices: list[str]) -> None:
+    """Announce a removed prefix the first time this run drops it.
+
+    Emitted in place rather than collected and prepended, because GNU
+    interleaves these with the per-operand errors in operand order.
+
+    Args:
+        prefix (str): the prefix `strip_prefix` removed, or "" for none.
+        dropped (list[str]): prefixes already announced; appended to.
+        notices (list[str]): the run's diagnostics; appended to in order.
+    """
+    if not prefix or prefix in dropped:
+        return
+    dropped.append(prefix)
+    notices.append(removing_leading(prefix))
+
+
 def member_name(spelled: str, kind: MemberKind) -> str:
     """The name tar records for a path spelled as the operand was typed.
 
@@ -209,6 +227,21 @@ async def plan_create(
                                   mounts=mounts,
                                   dereference=dereference,
                                   recurse=True)
+        # GNU announces the prefix it refuses to store before it reports
+        # what it could not read, and keeps both in operand order -- a
+        # later operand's notice must not jump ahead of an earlier
+        # operand's error. The operand's own spelling carries the prefix
+        # even when nothing under it can be archived, which is why
+        # `tar -cf a.tar sub/../missing` still announces `sub/../`.
+        _announce_prefix(strip_prefix(raw)[1], dropped, notices)
+        # Each name is then stripped on its own, so one operand can owe
+        # two notices: `tar -cf a.tar ..` drops `..` from the directory
+        # and `../` from everything under it.
+        named: list[tuple[str, Entry]] = []
+        for entry in scan.entries:
+            spelled = respell_one(entry.name_path, base, raw)
+            _announce_prefix(strip_prefix(spelled)[1], dropped, notices)
+            named.append((member_name(spelled, entry.kind), entry))
         for problem in scan.problems:
             shown = respell_one(problem.path, base, raw)
             if not problem.fatal:
@@ -221,16 +254,6 @@ async def plan_create(
         for crossing in scan.crossings:
             shown = member_name(respell_one(crossing, base, raw), "dir")
             notices.append(f"tar: {shown}: {OTHER_FILESYSTEM}")
-        # Each name is stripped on its own, so one operand can owe two
-        # notices: `tar -cf a.tar ..` drops `..` from the directory and
-        # `../` from everything under it.
-        named: list[tuple[str, Entry]] = []
-        for entry in scan.entries:
-            spelled = respell_one(entry.name_path, base, raw)
-            prefix = strip_prefix(spelled)[1]
-            if prefix and prefix not in dropped:
-                dropped.append(prefix)
-            named.append((member_name(spelled, entry.kind), entry))
         keep = set(pruned([name for name, _ in named], exclude))
         for name, entry in named:
             if name not in keep:
@@ -244,7 +267,6 @@ async def plan_create(
                        kind=entry.kind,
                        path=entry.read,
                        target=entry.target))
-    notices[:0] = [removing_leading(prefix) for prefix in dropped]
     if exit_code:
         # GNU closes a run that failed an operand with one trailer, after
         # everything it did manage to name.

--- a/python/mirage/commands/builtin/generic/tar/create.py
+++ b/python/mirage/commands/builtin/generic/tar/create.py
@@ -1,4 +1,4 @@
-from mirage.commands.builtin.generic.archive.types import MemberKind
+from mirage.commands.builtin.generic.archive.types import Entry, MemberKind
 from mirage.commands.builtin.generic.archive.walk import (OTHER_FILESYSTEM,
                                                           DirProbe, StatFn,
                                                           WalkFn, scan_operand)
@@ -15,7 +15,6 @@ USAGE_HINT = "Try 'tar --help' for more information."
 EMPTY_ARCHIVE = "tar: Cowardly refusing to create an empty archive"
 FATAL_TRAILER = "tar: Error is not recoverable: exiting now"
 ERROR_TRAILER = "tar: Exiting with failure status due to previous errors"
-LEADING_SLASH = "tar: Removing leading `/' from member names"
 SELF_DUMP = "archive cannot contain itself; not dumped"
 # The exit GNU gives an operand it could not read, and a -C it could not
 # enter. Both are fatal for the whole run, not per-operand.
@@ -82,20 +81,67 @@ def pruned(names: list[str], pattern: str | None) -> list[str]:
     return kept
 
 
+def strip_prefix(spelled: str) -> tuple[str, str]:
+    """Split a spelled path into the name tar stores and what it drops.
+
+    tar stores no name that could climb out of the directory it is
+    extracted into, so it removes everything through the *last* ``..``
+    segment: ``x/../y/f3`` is stored as ``y/f3`` and
+    ``/data/sub/../file`` as ``file``. Only when the path has no ``..``
+    does the leading slash become the thing removed. A ``.`` segment
+    escapes nothing and survives, so ``./file`` is stored verbatim.
+    Info-ZIP makes the opposite choice and keeps ``..`` in the member
+    name, which is why `zip_cmd` does not share this.
+
+    Args:
+        spelled (str): the path as the operand spelled it.
+
+    Returns:
+        tuple[str, str]: the name to store, and the prefix removed to
+        get it (empty when nothing was removed). Each distinct prefix
+        earns one notice naming it.
+    """
+    segments = spelled.split("/")
+    last = -1
+    for i, segment in enumerate(segments):
+        if segment == "..":
+            last = i
+    if last >= 0:
+        rest = "/".join(segments[last + 1:])
+        prefix = "/".join(segments[:last + 1])
+        return rest, prefix + "/" if rest else prefix
+    if spelled.startswith("/"):
+        return spelled.lstrip("/"), "/"
+    return spelled, ""
+
+
+def removing_leading(prefix: str) -> str:
+    """GNU's notice for a prefix it refused to store.
+
+    Args:
+        prefix (str): the prefix `strip_prefix` removed.
+    """
+    return f"tar: Removing leading `{prefix}' from member names"
+
+
 def member_name(spelled: str, kind: MemberKind) -> str:
     """The name tar records for a path spelled as the operand was typed.
 
-    A leading slash is stripped (tar refuses to store absolute names, and
-    says so once per run), and a directory carries the trailing slash
-    that tells an extractor it holds no content.
+    The traversal prefix is dropped (see `strip_prefix`) and a directory
+    carries the trailing slash that tells an extractor it holds no
+    content. An operand that is all traversal -- ``tar -cf a.tar ..`` --
+    leaves nothing to name, and GNU stores that directory as ``./``.
 
     Args:
         spelled (str): the path as the operand spelled it.
         kind (MemberKind): what the entry is.
     """
-    name = spelled.lstrip("/")
-    if kind == "dir" and name and not name.endswith("/"):
-        return name + "/"
+    name, _ = strip_prefix(spelled)
+    if kind == "dir":
+        if not name:
+            return "./"
+        if not name.endswith("/"):
+            return name + "/"
     return name
 
 
@@ -151,7 +197,7 @@ async def plan_create(
             ])
     members: list[Member] = []
     notices: list[str] = []
-    absolute_seen = False
+    dropped: list[str] = []
     exit_code = 0
     for path in paths:
         raw = path.raw_path
@@ -175,12 +221,16 @@ async def plan_create(
         for crossing in scan.crossings:
             shown = member_name(respell_one(crossing, base, raw), "dir")
             notices.append(f"tar: {shown}: {OTHER_FILESYSTEM}")
-        # Every descendant is spelled under the operand's own base, so
-        # the operand alone decides whether this run stored an absolute
-        # name and owes GNU's one-per-run warning.
-        absolute_seen = absolute_seen or raw.startswith("/")
-        named = [(member_name(respell_one(entry.name_path, base, raw),
-                              entry.kind), entry) for entry in scan.entries]
+        # Each name is stripped on its own, so one operand can owe two
+        # notices: `tar -cf a.tar ..` drops `..` from the directory and
+        # `../` from everything under it.
+        named: list[tuple[str, Entry]] = []
+        for entry in scan.entries:
+            spelled = respell_one(entry.name_path, base, raw)
+            prefix = strip_prefix(spelled)[1]
+            if prefix and prefix not in dropped:
+                dropped.append(prefix)
+            named.append((member_name(spelled, entry.kind), entry))
         keep = set(pruned([name for name, _ in named], exclude))
         for name, entry in named:
             if name not in keep:
@@ -194,8 +244,7 @@ async def plan_create(
                        kind=entry.kind,
                        path=entry.read,
                        target=entry.target))
-    if absolute_seen:
-        notices.insert(0, LEADING_SLASH)
+    notices[:0] = [removing_leading(prefix) for prefix in dropped]
     if exit_code:
         # GNU closes a run that failed an operand with one trailer, after
         # everything it did manage to name.

--- a/python/mirage/workspace/executor/builtins/dirs.py
+++ b/python/mirage/workspace/executor/builtins/dirs.py
@@ -34,6 +34,46 @@ def _norm(path: str) -> str:
     return resolved
 
 
+def _join(path: str, cwd: str) -> str:
+    """Join an operand to ``cwd`` **without** simplifying ``..``.
+
+    `resolve_path` normalizes, which is what ``-L`` wants but destroys the
+    only input ``-P`` has to work from: bash resolves a link before
+    applying the ``..`` that follows it, so `/link/..` is the link's
+    parent under ``-L`` and the *target's* parent under ``-P``. Collapsing
+    the ``..`` first makes the two modes identical. `_resolve_target`
+    normalizes for both modes, so nothing downstream sees the raw form.
+
+    Args:
+        path (str): The operand, absolute or relative.
+        cwd (str): The directory a relative operand is typed under.
+
+    Returns:
+        str: The absolute path, ``..`` and ``.`` segments intact.
+    """
+    if path.startswith("/"):
+        return path
+    return cwd.rstrip("/") + "/" + path
+
+
+def _typed_path(val: str | PathSpec) -> str:
+    """The operand as typed, which is what ``-P`` has to resolve.
+
+    A relative operand arrives as a PathSpec whose ``virtual`` was already
+    normalized against cwd (`expand/classify/relative.py`), so it has lost
+    its ``..`` before ``cd`` is reached. ``raw_path`` keeps the spelling.
+
+    Args:
+        val (str | PathSpec): The operand handed to ``cd``.
+
+    Returns:
+        str: The typed spelling, or the resolved path when there is none.
+    """
+    if isinstance(val, PathSpec):
+        return val.raw_path or val.virtual
+    return val
+
+
 def _resolve_target(combined: str, links: dict[str, str],
                     physical: bool) -> str:
     """Resolve a combined ``cd`` path, following symlinks per mode.
@@ -95,7 +135,7 @@ def _cd_candidates(
         marks a non-empty ``$CDPATH`` hit whose absolute path GNU prints.
     """
     cwd = session.cwd
-    fallback = resolve_path(raw, cwd)
+    fallback = _join(raw, cwd)
     cdpath = session.env.get("CDPATH")
     if (not cdpath or not cdpath_target
             or not _cdpath_searchable(cdpath_target)):
@@ -103,7 +143,7 @@ def _cd_candidates(
     out: list[tuple[str, bool]] = []
     for entry in cdpath.split(":"):
         base = resolve_path(entry, cwd) if entry else cwd
-        out.append((resolve_path(cdpath_target, base), entry != ""))
+        out.append((_join(cdpath_target, base), entry != ""))
     out.append((fallback, False))
     return out
 
@@ -120,15 +160,17 @@ async def handle_cd(
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     raw = _scope_path(path)
     table = links or {}
-    candidates = _cd_candidates(raw, cdpath_target, session)
+    candidates = _cd_candidates(_typed_path(path), cdpath_target, session)
     error: str | None = None
-    for resolved, announce in candidates:
+    for candidate, announce in candidates:
         if table:
             try:
-                resolved = _resolve_target(resolved, table, physical)
+                resolved = _resolve_target(candidate, table, physical)
             except CycleError:
                 error = f"cd: {raw}: Too many levels of symbolic links\n"
                 continue
+        else:
+            resolved = _norm(candidate)
         if resolved == "/":
             return _cd_success(session, "/", raw, print_path or announce)
         scope = _to_scope(resolved)

--- a/python/mirage/workspace/expand/classify/heuristic.py
+++ b/python/mirage/workspace/expand/classify/heuristic.py
@@ -75,6 +75,9 @@ def classify_word(word: str, registry: MountRegistry,
         if not is_dir and path + "/" == mount.prefix:
             is_dir = True
         resource_path = mount_key(path, mount.prefix.rstrip("/"))
+        # `raw_path` keeps the spelling as typed, the way `relative_spec`
+        # does: `virtual` has already lost any `..`, and `cd -P` has to
+        # resolve the link a `..` follows before applying it.
         if word_has_glob:
             last_slash = path.rfind("/")
             return PathSpec(
@@ -82,18 +85,21 @@ def classify_word(word: str, registry: MountRegistry,
                 directory=path[:last_slash + 1],
                 resource_path=resource_path,
                 pattern=path[last_slash + 1:],
+                raw_path=word,
                 resolved=False,
             )
         if is_dir:
             return PathSpec(virtual=path,
                             directory=path + "/",
                             resource_path=resource_path,
+                            raw_path=word,
                             resolved=False)
         last_slash = path.rfind("/")
         return PathSpec(
             virtual=path,
             directory=path[:last_slash + 1],
             resource_path=resource_path,
+            raw_path=word,
             resolved=True,
         )
 

--- a/python/tests/commands/builtin/generic/test_tar.py
+++ b/python/tests/commands/builtin/generic/test_tar.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 import pytest
 
 from mirage.commands.builtin.generic.tar import (excluded, member_name, pruned,
-                                                 tar)
+                                                 strip_prefix, tar)
 from mirage.ops.types import LinkView, MountView
 from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
@@ -166,6 +166,36 @@ def test_member_name_strips_the_leading_slash_and_marks_directories():
     assert member_name("/data/d", "dir") == "data/d/"
     assert member_name("d/", "dir") == "d/"
     assert member_name("link", "link") == "link"
+
+
+# Every row is GNU tar 1.35 on debian:stable-slim: `tar -cf` for the
+# notice, `tar -tf` for the stored name.
+STRIP_PREFIX_ROWS = [
+    ("/data/sub/../file", "file", "/data/sub/../"),
+    ("../file", "file", "../"),
+    ("x/../y/f3", "y/f3", "x/../"),
+    ("../../file", "file", "../../"),
+    ("/data/../data/file", "data/file", "/data/../"),
+    # No `..`, so the leading slash is the only thing tar refuses.
+    ("/data/file", "data/file", "/"),
+    # A `.` climbs nowhere, so GNU stores it and says nothing.
+    ("./file", "./file", ""),
+    ("d/a.txt", "d/a.txt", ""),
+    # Nothing survives the traversal; `member_name` supplies the name.
+    ("..", "", ".."),
+    ("sub/..", "", "sub/.."),
+]
+
+
+@pytest.mark.parametrize("spelled,name,prefix", STRIP_PREFIX_ROWS)
+def test_strip_prefix_drops_through_the_last_dotdot(spelled: str, name: str,
+                                                    prefix: str):
+    assert strip_prefix(spelled) == (name, prefix)
+
+
+def test_member_name_calls_an_all_traversal_directory_dot_slash():
+    assert member_name("..", "dir") == "./"
+    assert member_name("sub/..", "dir") == "./"
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/generic/test_tar.py
+++ b/python/tests/commands/builtin/generic/test_tar.py
@@ -260,6 +260,51 @@ async def test_create_reports_a_missing_operand_and_exits_two():
 
 
 @pytest.mark.asyncio
+async def test_create_announces_a_prefix_it_could_not_archive():
+    # GNU names the prefix before it reports the operand it could not
+    # read, even though nothing under that operand is stored.
+    tree = _Tree({"/d/a.txt": b"x"}, dirs=("/d", "/d/sub"))
+    _, io_res = await _create(tree, [_raw("/d/missing", "sub/../missing")],
+                              c=True,
+                              f=_spec("/out.tar"))
+    assert io_res.exit_code == 2
+    assert io_res.stderr.decode().splitlines()[:2] == [
+        "tar: Removing leading `sub/../' from member names",
+        "tar: sub/../missing: Cannot stat: No such file or directory",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_keeps_notices_in_operand_order():
+    # A later operand's prefix notice must not jump ahead of an earlier
+    # operand's error: GNU emits diagnostics as it walks the operands.
+    tree = _Tree({"/base/file": b"x"}, dirs=("/base", "/base/sub"))
+    _, io_res = await _create(
+        tree, [_raw("/base/nope", "nope"),
+               _raw("/base/file", "../file")],
+        c=True,
+        f=_spec("/out.tar"))
+    assert io_res.stderr.decode().splitlines()[:2] == [
+        "tar: nope: Cannot stat: No such file or directory",
+        "tar: Removing leading `../' from member names",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_announces_before_a_later_operand_fails():
+    tree = _Tree({"/base/file": b"x"}, dirs=("/base", "/base/sub"))
+    _, io_res = await _create(
+        tree, [_raw("/base/file", "../file"),
+               _raw("/base/nope", "nope")],
+        c=True,
+        f=_spec("/out.tar"))
+    assert io_res.stderr.decode().splitlines()[:2] == [
+        "tar: Removing leading `../' from member names",
+        "tar: nope: Cannot stat: No such file or directory",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_create_refuses_an_empty_archive():
     tree = _Tree({})
     out, io_res = await _create(tree, [], c=True, f=_spec("/out.tar"))

--- a/python/tests/workspace/executor/builtins/test_dirs.py
+++ b/python/tests/workspace/executor/builtins/test_dirs.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from mirage.types import FileStat, FileType
+from mirage.types import FileStat, FileType, PathSpec
 from mirage.workspace.executor.builtins.dirs import handle_cd
 from mirage.workspace.session import Session
 
@@ -188,6 +188,85 @@ async def test_cd_follows_a_chain_of_symlinks_to_the_final_target():
                                })
     assert io.exit_code == 0
     assert sess.cwd == "/real"
+
+
+# GNU bash 5.2 (debian:stable-slim), with /link -> /deep/real:
+#   cd -L /link/..      PWD=/            cd -P /link/..      PWD=/deep
+#   cd -L /link/sub/..  PWD=/link        cd -P /link/sub/..  PWD=/deep/real
+# -L simplifies `..` textually against the path as typed; -P resolves the
+# link first, so `..` lands in the target's parent. mirage reports the
+# physical name in both modes, so the -L rows above land in the same
+# directory bash does while spelling it /deep/real.
+@pytest.mark.asyncio
+async def test_cd_logical_mode_simplifies_dotdot_before_following_links():
+    dispatch, _ = dispatcher(dirs={"/deep"})
+    sess = session()
+    _, io, _ = await handle_cd(dispatch,
+                               no_mount_root,
+                               "/link/..",
+                               sess,
+                               links={"/link": "/deep/real"})
+    assert io.exit_code == 0
+    assert sess.cwd == "/"
+
+
+@pytest.mark.asyncio
+async def test_cd_physical_mode_applies_dotdot_to_the_link_target():
+    dispatch, _ = dispatcher(dirs={"/deep"})
+    sess = session()
+    _, io, _ = await handle_cd(dispatch,
+                               no_mount_root,
+                               "/link/..",
+                               sess,
+                               links={"/link": "/deep/real"},
+                               physical=True)
+    assert io.exit_code == 0
+    assert sess.cwd == "/deep"
+
+
+@pytest.mark.asyncio
+async def test_cd_physical_mode_resolves_a_link_in_the_middle_of_the_path():
+    dispatch, _ = dispatcher(dirs={"/deep/real"})
+    sess = session()
+    _, io, _ = await handle_cd(dispatch,
+                               no_mount_root,
+                               "/link/sub/..",
+                               sess,
+                               links={"/link": "/deep/real"},
+                               physical=True)
+    assert io.exit_code == 0
+    assert sess.cwd == "/deep/real"
+
+
+@pytest.mark.asyncio
+async def test_cd_physical_mode_reads_dotdot_off_a_relative_operands_spelling(
+):
+    # A relative operand reaches cd as a PathSpec whose `virtual` was
+    # already normalized against cwd, so -P has to read `raw_path`.
+    dispatch, _ = dispatcher(dirs={"/deep/real"})
+    sess = session(cwd="/link/sub")
+    operand = PathSpec(virtual="/link",
+                       directory="/link/",
+                       resource_path="",
+                       raw_path="..")
+    _, io, _ = await handle_cd(dispatch,
+                               no_mount_root,
+                               operand,
+                               sess,
+                               links={"/link": "/deep/real"},
+                               physical=True)
+    assert io.exit_code == 0
+    assert sess.cwd == "/deep/real"
+
+
+@pytest.mark.asyncio
+async def test_cd_normalizes_dotdot_when_the_workspace_has_no_symlinks():
+    dispatch, seen = dispatcher(dirs={"/data"})
+    sess = session(cwd="/data/sub")
+    _, io, _ = await handle_cd(dispatch, no_mount_root, "..", sess)
+    assert io.exit_code == 0
+    assert seen == ["/data"]
+    assert sess.cwd == "/data"
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/core/src/commands/builtin/generic/tar/create.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar/create.test.ts
@@ -1,0 +1,41 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { stripPrefix } from './create.ts'
+
+describe('stripPrefix', () => {
+  // Every row is GNU tar 1.35 on debian:stable-slim: `tar -cf` for the
+  // notice, `tar -tf` for the stored name. Mirrors the Python
+  // STRIP_PREFIX_ROWS table.
+  const rows: [string, string, string][] = [
+    ['/data/sub/../file', 'file', '/data/sub/../'],
+    ['../file', 'file', '../'],
+    ['x/../y/f3', 'y/f3', 'x/../'],
+    ['../../file', 'file', '../../'],
+    ['/data/../data/file', 'data/file', '/data/../'],
+    // No `..`, so the leading slash is the only thing tar refuses.
+    ['/data/file', 'data/file', '/'],
+    // A `.` climbs nowhere, so GNU stores it and says nothing.
+    ['./file', './file', ''],
+    ['d/a.txt', 'd/a.txt', ''],
+    // Nothing survives the traversal; memberName supplies the name.
+    ['..', '', '..'],
+    ['sub/..', '', 'sub/..'],
+  ]
+
+  it.each(rows)('drops through the last .. in %s', (spelled, name, prefix) => {
+    expect(stripPrefix(spelled)).toEqual([name, prefix])
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/tar/create.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar/create.ts
@@ -34,7 +34,6 @@ const USAGE_HINT = "Try 'tar --help' for more information."
 const EMPTY_ARCHIVE = 'tar: Cowardly refusing to create an empty archive'
 const FATAL_TRAILER = 'tar: Error is not recoverable: exiting now'
 const ERROR_TRAILER = 'tar: Exiting with failure status due to previous errors'
-const LEADING_SLASH = "tar: Removing leading `/' from member names"
 const SELF_DUMP = 'archive cannot contain itself; not dumped'
 // The exit GNU gives an operand it could not read, and a -C it could not
 // enter. Both are fatal for the whole run, not per-operand.
@@ -98,13 +97,47 @@ function pruned(names: readonly string[], pattern: string | null): string[] {
   return kept
 }
 
-// The name tar records for a path spelled as the operand was typed. A
-// leading slash is stripped (tar refuses to store absolute names, and
-// says so once per run), and a directory carries the trailing slash that
-// tells an extractor it holds no content.
+// Split a spelled path into the name tar stores and what it drops. tar
+// stores no name that could climb out of the directory it is extracted
+// into, so it removes everything through the *last* `..` segment:
+// `x/../y/f3` is stored as `y/f3` and `/data/sub/../file` as `file`. Only
+// when the path has no `..` does the leading slash become the thing
+// removed. A `.` segment escapes nothing and survives, so `./file` is
+// stored verbatim. Info-ZIP makes the opposite choice and keeps `..` in
+// the member name, which is why zip_cmd does not share this. Returns the
+// name and the prefix removed to get it ('' when nothing was), and each
+// distinct prefix earns one notice naming it.
+export function stripPrefix(spelled: string): [string, string] {
+  const segments = spelled.split('/')
+  let last = -1
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i] === '..') last = i
+  }
+  if (last >= 0) {
+    const rest = segments.slice(last + 1).join('/')
+    const prefix = segments.slice(0, last + 1).join('/')
+    return [rest, rest !== '' ? `${prefix}/` : prefix]
+  }
+  if (spelled.startsWith('/')) return [lstripSlash(spelled), '/']
+  return [spelled, '']
+}
+
+// GNU's notice for a prefix it refused to store.
+function removingLeading(prefix: string): string {
+  return `tar: Removing leading \`${prefix}' from member names`
+}
+
+// The name tar records for a path spelled as the operand was typed. The
+// traversal prefix is dropped (see stripPrefix) and a directory carries
+// the trailing slash that tells an extractor it holds no content. An
+// operand that is all traversal — `tar -cf a.tar ..` — leaves nothing to
+// name, and GNU stores that directory as `./`.
 function memberName(spelled: string, kind: MemberKind): string {
-  const name = lstripSlash(spelled)
-  if (kind === 'dir' && name !== '' && !name.endsWith('/')) return `${name}/`
+  const [name] = stripPrefix(spelled)
+  if (kind === 'dir') {
+    if (name === '') return './'
+    if (!name.endsWith('/')) return `${name}/`
+  }
   return name
 }
 
@@ -136,7 +169,7 @@ export async function planCreate(
   }
   const members: Member[] = []
   const notices: string[] = []
-  let absoluteSeen = false
+  const dropped: string[] = []
   let exitCode = 0
   for (const path of paths) {
     const raw = path.rawPath
@@ -163,13 +196,15 @@ export async function planCreate(
       const shown = memberName(respellOne(crossing, base, raw), 'dir')
       notices.push(`tar: ${shown}: ${OTHER_FILESYSTEM}`)
     }
-    // Every descendant is spelled under the operand's own base, so the
-    // operand alone decides whether this run stored an absolute name and
-    // owes GNU's one-per-run warning.
-    absoluteSeen = absoluteSeen || raw.startsWith('/')
-    const named = scan.entries.map(
-      (entry) => [memberName(respellOne(entry.namePath, base, raw), entry.kind), entry] as const,
-    )
+    // Each name is stripped on its own, so one operand can owe two
+    // notices: `tar -cf a.tar ..` drops `..` from the directory and `../`
+    // from everything under it.
+    const named = scan.entries.map((entry) => {
+      const spelled = respellOne(entry.namePath, base, raw)
+      const prefix = stripPrefix(spelled)[1]
+      if (prefix !== '' && !dropped.includes(prefix)) dropped.push(prefix)
+      return [memberName(spelled, entry.kind), entry] as const
+    })
     const keep = new Set(
       pruned(
         named.map(([name]) => name),
@@ -186,7 +221,9 @@ export async function planCreate(
       members.push({ name, kind: entry.kind, path: read, target: entry.target ?? '' })
     }
   }
-  if (absoluteSeen) notices.unshift(LEADING_SLASH)
+  // GNU names each prefix it removed, once, in the order the names it was
+  // stripping from came up.
+  notices.unshift(...dropped.map(removingLeading))
   // GNU closes a run that failed an operand with one trailer, after
   // everything it did manage to name.
   if (exitCode !== 0) notices.push(ERROR_TRAILER)

--- a/typescript/packages/core/src/commands/builtin/generic/tar/create.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar/create.ts
@@ -127,6 +127,15 @@ function removingLeading(prefix: string): string {
   return `tar: Removing leading \`${prefix}' from member names`
 }
 
+// Announce a removed prefix the first time this run drops it. Emitted in
+// place rather than collected and prepended, because GNU interleaves
+// these with the per-operand errors in operand order.
+function announcePrefix(prefix: string, dropped: string[], notices: string[]): void {
+  if (prefix === '' || dropped.includes(prefix)) return
+  dropped.push(prefix)
+  notices.push(removingLeading(prefix))
+}
+
 // The name tar records for a path spelled as the operand was typed. The
 // traversal prefix is dropped (see stripPrefix) and a directory carries
 // the trailing slash that tells an extractor it holds no content. An
@@ -182,6 +191,21 @@ export async function planCreate(
       dereference: deps.dereference,
       recurse: true,
     })
+    // GNU announces the prefix it refuses to store before it reports what
+    // it could not read, and keeps both in operand order — a later
+    // operand's notice must not jump ahead of an earlier operand's error.
+    // The operand's own spelling carries the prefix even when nothing
+    // under it can be archived, which is why `tar -cf a.tar sub/../missing`
+    // still announces `sub/../`.
+    announcePrefix(stripPrefix(raw)[1], dropped, notices)
+    // Each name is then stripped on its own, so one operand can owe two
+    // notices: `tar -cf a.tar ..` drops `..` from the directory and `../`
+    // from everything under it.
+    const named = scan.entries.map((entry) => {
+      const spelled = respellOne(entry.namePath, base, raw)
+      announcePrefix(stripPrefix(spelled)[1], dropped, notices)
+      return [memberName(spelled, entry.kind), entry] as const
+    })
     for (const problem of scan.problems) {
       const shown = respellOne(problem.path, base, raw)
       if (problem.fatal !== true) {
@@ -196,15 +220,6 @@ export async function planCreate(
       const shown = memberName(respellOne(crossing, base, raw), 'dir')
       notices.push(`tar: ${shown}: ${OTHER_FILESYSTEM}`)
     }
-    // Each name is stripped on its own, so one operand can owe two
-    // notices: `tar -cf a.tar ..` drops `..` from the directory and `../`
-    // from everything under it.
-    const named = scan.entries.map((entry) => {
-      const spelled = respellOne(entry.namePath, base, raw)
-      const prefix = stripPrefix(spelled)[1]
-      if (prefix !== '' && !dropped.includes(prefix)) dropped.push(prefix)
-      return [memberName(spelled, entry.kind), entry] as const
-    })
     const keep = new Set(
       pruned(
         named.map(([name]) => name),
@@ -221,9 +236,6 @@ export async function planCreate(
       members.push({ name, kind: entry.kind, path: read, target: entry.target ?? '' })
     }
   }
-  // GNU names each prefix it removed, once, in the order the names it was
-  // stripping from came up.
-  notices.unshift(...dropped.map(removingLeading))
   // GNU closes a run that failed an operand with one trailer, after
   // everything it did manage to name.
   if (exitCode !== 0) notices.push(ERROR_TRAILER)

--- a/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
@@ -195,6 +195,22 @@ describe('tar', () => {
     expect(text.split('Removing leading').length - 1).toBe(1)
   })
 
+  // GNU stores no traversal-bearing name: it drops everything through the
+  // last `..` and names the prefix it dropped.
+  it('drops a .. prefix from the member name and says which', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.dirs.add('/d/sub')
+    resource.store.files.set('/d/a.txt', ENC.encode('alpha'))
+    const { stderr } = await runCmd(RAM_TAR, resource, [dirSpec('/d/a.txt', '/d/sub/../a.txt')], {
+      c: true,
+      f: '/out.tar',
+    })
+    expect(DEC.decode(stderr)).toBe("tar: Removing leading `/d/sub/../' from member names\n")
+    const listed = await runCmd(RAM_TAR, resource, [], { t: true, f: '/out.tar' })
+    expect(DEC.decode(listed.out).trim()).toBe('a.txt')
+  })
+
   it("reports a missing operand in tar's own words and exits 2", async () => {
     const resource = new RAMResource()
     resource.store.dirs.add('/d')

--- a/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
@@ -211,6 +211,51 @@ describe('tar', () => {
     expect(DEC.decode(listed.out).trim()).toBe('a.txt')
   })
 
+  // GNU names the prefix before it reports the operand it could not read,
+  // even though nothing under that operand is stored.
+  it('announces a prefix it could not archive', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/d')
+    resource.store.dirs.add('/d/sub')
+    const { stderr } = await runCmd(RAM_TAR, resource, [dirSpec('/d/missing', 'sub/../missing')], {
+      c: true,
+      f: '/out.tar',
+    })
+    expect(DEC.decode(stderr).split('\n').slice(0, 2)).toEqual([
+      "tar: Removing leading `sub/../' from member names",
+      'tar: sub/../missing: Cannot stat: No such file or directory',
+    ])
+  })
+
+  // A later operand's notice must not jump ahead of an earlier operand's
+  // error: GNU emits diagnostics as it walks the operands.
+  it('keeps notices in operand order', async () => {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/base')
+    resource.store.dirs.add('/base/sub')
+    resource.store.files.set('/base/file', ENC.encode('x'))
+    const first = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/base/nope', 'nope'), dirSpec('/base/file', '../file')],
+      { c: true, f: '/out.tar' },
+    )
+    expect(DEC.decode(first.stderr).split('\n').slice(0, 2)).toEqual([
+      'tar: nope: Cannot stat: No such file or directory',
+      "tar: Removing leading `../' from member names",
+    ])
+    const second = await runCmd(
+      RAM_TAR,
+      resource,
+      [dirSpec('/base/file', '../file'), dirSpec('/base/nope', 'nope')],
+      { c: true, f: '/out2.tar' },
+    )
+    expect(DEC.decode(second.stderr).split('\n').slice(0, 2)).toEqual([
+      "tar: Removing leading `../' from member names",
+      'tar: nope: Cannot stat: No such file or directory',
+    ])
+  })
+
   it("reports a missing operand in tar's own words and exits 2", async () => {
     const resource = new RAMResource()
     resource.store.dirs.add('/d')

--- a/typescript/packages/core/src/workspace/executor/builtins/dirs.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/dirs.test.ts
@@ -1,0 +1,231 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { PathSpec } from '../../../types.ts'
+import { FileType } from '../../../types.ts'
+import { Session } from '../../session/session.ts'
+import type { DispatchFn } from '../cross_mount.ts'
+import { handleCd } from './dirs.ts'
+
+function dispatcher(dirs: string[] = [], files: string[] = []) {
+  const seen: string[] = []
+  const dispatch = ((_op: string, scope: PathSpec) => {
+    seen.push(scope.virtual)
+    if (dirs.includes(scope.virtual)) {
+      return Promise.resolve([{ name: scope.virtual, type: FileType.DIRECTORY }, null])
+    }
+    if (files.includes(scope.virtual)) {
+      return Promise.resolve([{ name: scope.virtual, type: FileType.TEXT }, null])
+    }
+    const err = new Error(`no such file: ${scope.virtual}`)
+    ;(err as { code?: string }).code = 'ENOENT'
+    return Promise.reject(err)
+  }) as unknown as DispatchFn
+  return { dispatch, seen }
+}
+
+const noMountRoot = () => false
+
+function session(cwd = '/', env: Record<string, string> = {}): Session {
+  return new Session({ sessionId: 'test', cwd, env })
+}
+
+function decode(b: Uint8Array | null): string {
+  return b === null ? '' : new TextDecoder().decode(b)
+}
+
+describe('handleCd', () => {
+  it('moves the session and records the previous directory', async () => {
+    const { dispatch } = dispatcher(['/data/sub'])
+    const s = session('/data')
+    const [stdout, io] = await handleCd(dispatch, noMountRoot, 'sub', s)
+    expect(io.exitCode).toBe(0)
+    expect(stdout).toBeNull()
+    expect(s.cwd).toBe('/data/sub')
+    expect(s.env.OLDPWD).toBe('/data')
+  })
+
+  it('never consults the backend for the root', async () => {
+    const { dispatch, seen } = dispatcher()
+    const s = session('/data')
+    const [, io] = await handleCd(dispatch, noMountRoot, '/', s)
+    expect(io.exitCode).toBe(0)
+    expect(s.cwd).toBe('/')
+    expect(seen).toEqual([])
+  })
+
+  it('refuses a missing directory and leaves the cwd alone', async () => {
+    const { dispatch } = dispatcher()
+    const s = session('/data')
+    const [, io] = await handleCd(dispatch, noMountRoot, 'nope', s)
+    expect(io.exitCode).toBe(1)
+    expect(decode(io.stderr as Uint8Array)).toBe('cd: nope: No such file or directory\n')
+    expect(s.cwd).toBe('/data')
+  })
+
+  it('refuses a regular file', async () => {
+    const { dispatch } = dispatcher([], ['/data/f.txt'])
+    const s = session('/data')
+    const [, io] = await handleCd(dispatch, noMountRoot, 'f.txt', s)
+    expect(io.exitCode).toBe(1)
+    expect(decode(io.stderr as Uint8Array)).toBe('cd: f.txt: Not a directory\n')
+  })
+
+  it('searches CDPATH before the cwd-relative candidate', async () => {
+    const { dispatch, seen } = dispatcher(['/opt/sub'])
+    const s = session('/data', { CDPATH: '/opt' })
+    const [stdout, io] = await handleCd(dispatch, noMountRoot, 'sub', s, false, 'sub')
+    expect(io.exitCode).toBe(0)
+    expect(s.cwd).toBe('/opt/sub')
+    expect(seen).toEqual(['/opt/sub'])
+    expect(decode(stdout as Uint8Array)).toBe('/opt/sub\n')
+  })
+
+  it('falls back to the cwd when no CDPATH entry matches', async () => {
+    const { dispatch, seen } = dispatcher(['/data/sub'])
+    const s = session('/data', { CDPATH: '/opt' })
+    const [, io] = await handleCd(dispatch, noMountRoot, 'sub', s, false, 'sub')
+    expect(io.exitCode).toBe(0)
+    expect(s.cwd).toBe('/data/sub')
+    expect(seen).toEqual(['/opt/sub', '/data/sub'])
+  })
+
+  it('follows a symlink to its target', async () => {
+    const { dispatch } = dispatcher(['/real'])
+    const s = session()
+    const [, io] = await handleCd(
+      dispatch,
+      noMountRoot,
+      '/link',
+      s,
+      false,
+      null,
+      new Map([['/link', '/real']]),
+    )
+    expect(io.exitCode).toBe(0)
+    expect(s.cwd).toBe('/real')
+  })
+
+  it('reports ELOOP on a symlink cycle', async () => {
+    const { dispatch } = dispatcher()
+    const s = session('/data')
+    const [, io] = await handleCd(
+      dispatch,
+      noMountRoot,
+      '/a',
+      s,
+      false,
+      null,
+      new Map([
+        ['/a', '/b'],
+        ['/b', '/a'],
+      ]),
+    )
+    expect(io.exitCode).toBe(1)
+    expect(decode(io.stderr as Uint8Array)).toBe('cd: /a: Too many levels of symbolic links\n')
+    expect(s.cwd).toBe('/data')
+  })
+
+  // GNU bash 5.2 (debian:stable-slim), with /link -> /deep/real:
+  //   cd -L /link/..      PWD=/            cd -P /link/..      PWD=/deep
+  //   cd -L /link/sub/..  PWD=/link        cd -P /link/sub/..  PWD=/deep/real
+  // -L simplifies `..` textually against the path as typed; -P resolves the
+  // link first, so `..` lands in the target's parent. mirage reports the
+  // physical name in both modes, so the -L rows land in the same directory
+  // bash does while spelling it /deep/real.
+  it('simplifies `..` before following links under -L', async () => {
+    const { dispatch } = dispatcher(['/deep'])
+    const s = session()
+    const [, io] = await handleCd(
+      dispatch,
+      noMountRoot,
+      '/link/..',
+      s,
+      false,
+      null,
+      new Map([['/link', '/deep/real']]),
+    )
+    expect(io.exitCode).toBe(0)
+    expect(s.cwd).toBe('/')
+  })
+
+  it('applies `..` to the link target under -P', async () => {
+    const { dispatch } = dispatcher(['/deep'])
+    const s = session()
+    const [, io] = await handleCd(
+      dispatch,
+      noMountRoot,
+      '/link/..',
+      s,
+      false,
+      null,
+      new Map([['/link', '/deep/real']]),
+      true,
+    )
+    expect(io.exitCode).toBe(0)
+    expect(s.cwd).toBe('/deep')
+  })
+
+  it('resolves a link in the middle of the path under -P', async () => {
+    const { dispatch } = dispatcher(['/deep/real'])
+    const s = session()
+    const [, io] = await handleCd(
+      dispatch,
+      noMountRoot,
+      '/link/sub/..',
+      s,
+      false,
+      null,
+      new Map([['/link', '/deep/real']]),
+      true,
+    )
+    expect(io.exitCode).toBe(0)
+    expect(s.cwd).toBe('/deep/real')
+  })
+
+  it("reads `..` off a relative operand's own spelling under -P", async () => {
+    // A relative operand reaches cd as a PathSpec whose `virtual` was already
+    // normalized against cwd, so -P has to read `rawPath`.
+    const { dispatch } = dispatcher(['/deep/real'])
+    const s = session('/link/sub')
+    const operand = new PathSpec({
+      virtual: '/link',
+      directory: '/link/',
+      resourcePath: '',
+      rawPath: '..',
+    })
+    const [, io] = await handleCd(
+      dispatch,
+      noMountRoot,
+      operand,
+      s,
+      false,
+      null,
+      new Map([['/link', '/deep/real']]),
+      true,
+    )
+    expect(io.exitCode).toBe(0)
+    expect(s.cwd).toBe('/deep/real')
+  })
+
+  it('normalizes `..` when the workspace has no symlinks', async () => {
+    const { dispatch, seen } = dispatcher(['/data'])
+    const s = session('/data/sub')
+    const [, io] = await handleCd(dispatch, noMountRoot, '..', s)
+    expect(io.exitCode).toBe(0)
+    expect(seen).toEqual(['/data'])
+    expect(s.cwd).toBe('/data')
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/builtins/dirs.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/dirs.ts
@@ -39,6 +39,26 @@ function resolveTarget(combined: string, links: Map<string, string>, physical: b
   throw new CycleError(p)
 }
 
+// Join an operand to `cwd` WITHOUT simplifying `..`. resolvePath normalizes,
+// which is what -L wants but destroys the only input -P has: bash resolves a
+// link before applying the `..` after it, so `/link/..` is the link's parent
+// under -L and the target's parent under -P. Collapsing the `..` first makes
+// the two modes identical. resolveTarget normalizes for both modes, so
+// nothing downstream sees the raw form.
+function joinPath(path: string, cwd: string): string {
+  if (path.startsWith('/')) return path
+  return `${cwd.replace(/\/+$/, '')}/${path}`
+}
+
+// The operand as typed, which is what -P has to resolve. A relative operand
+// arrives as a PathSpec whose `virtual` was already normalized against cwd
+// (expand/classify/relative.ts), losing its `..` before cd is reached;
+// `rawPath` keeps the spelling.
+function typedPath(val: string | PathSpec): string {
+  if (typeof val === 'string') return val
+  return val.rawPath || val.virtual
+}
+
 function cdpathSearchable(target: string): boolean {
   if (target.startsWith('/') || target.startsWith('./') || target.startsWith('../')) {
     return false
@@ -52,7 +72,7 @@ function cdCandidates(
   session: Session,
 ): [string, boolean][] {
   const cwd = session.cwd
-  const fallback = resolvePath(raw, cwd)
+  const fallback = joinPath(raw, cwd)
   const cdpath = session.env.CDPATH
   if (!cdpath || !cdpathTarget || !cdpathSearchable(cdpathTarget)) {
     return [[fallback, false]]
@@ -60,7 +80,7 @@ function cdCandidates(
   const out: [string, boolean][] = []
   for (const entry of cdpath.split(':')) {
     const base = entry ? resolvePath(entry, cwd) : cwd
-    out.push([resolvePath(cdpathTarget, base), entry !== ''])
+    out.push([joinPath(cdpathTarget, base), entry !== ''])
   }
   out.push([fallback, false])
   return out
@@ -78,13 +98,13 @@ export async function handleCd(
 ): Promise<Result> {
   const raw = scopePath(path)
   const table = links ?? new Map<string, string>()
-  const candidates = cdCandidates(raw, cdpathTarget, session)
+  const candidates = cdCandidates(typedPath(path), cdpathTarget, session)
   let error: string | null = null
   for (const [candidate, announce] of candidates) {
-    let resolved = candidate
+    let resolved = posixNormpath(candidate)
     if (table.size > 0) {
       try {
-        resolved = resolveTarget(resolved, table, physical)
+        resolved = resolveTarget(candidate, table, physical)
       } catch (exc) {
         if (exc instanceof CycleError) {
           error = `cd: ${raw}: Too many levels of symbolic links\n`

--- a/typescript/packages/core/src/workspace/expand/classify/heuristic.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/heuristic.ts
@@ -47,6 +47,9 @@ export function classifyWord(
     if (!isDir && `${path}/` === mount.prefix) {
       isDir = true
     }
+    // `rawPath` keeps the spelling as typed, the way relativeSpec does:
+    // `virtual` has already lost any `..`, and `cd -P` has to resolve the
+    // link a `..` follows before applying it.
     if (wordHasGlob) {
       const lastSlash = path.lastIndexOf('/')
       return new PathSpec({
@@ -54,6 +57,7 @@ export function classifyWord(
         virtual: path,
         directory: path.slice(0, lastSlash + 1),
         pattern: path.slice(lastSlash + 1),
+        rawPath: w,
         resolved: false,
       })
     }
@@ -62,6 +66,7 @@ export function classifyWord(
         resourcePath: stripSlash(path),
         virtual: path,
         directory: `${path}/`,
+        rawPath: w,
         resolved: false,
       })
     }
@@ -70,6 +75,7 @@ export function classifyWord(
       resourcePath: stripSlash(path),
       virtual: path,
       directory: path.slice(0, lastSlash + 1),
+      rawPath: w,
       resolved: true,
     })
   }


### PR DESCRIPTION
The two bugs found while writing the `cd` and integ coverage in #763, plus a third the fix surfaced.

**Stacked on #763** (`fix/test-layout-gate`) so the new `cd` assertions can live in the `test_dirs.py` that PR creates. The diff shows both until #763 merges; merge that one first.

## 1. `cd -P` was unreachable

`_resolve_target` / `resolveTarget` implement physical mode correctly — call either directly with `/link/..` where `/link -> /deep/real` and you get `/deep` for `-P`, `/` for `-L`. Nothing could reach that branch, so **`-L` and `-P` returned the same answer for every input**, on both sides. Two layers normalized the `..` away first:

- `_cd_candidates` built every candidate through `resolve_path`, which normpaths. Now it joins without normalizing and lets `_resolve_target` normalize — which it already did for both modes — with `handle_cd` normalizing itself when the workspace has no symlink table.
- The operand was *already* collapsed on arrival. `heuristic.py`'s absolute branch built its PathSpec with `virtual=normpath(word)` and no `raw_path`, so `raw_path` defaulted to the normalized form and the typed spelling was gone before any command ran. It now passes `raw_path=word` — what the field is documented to hold, and what `relative_spec` has always done for the relative case.

GNU bash 5.2 pinned in `debian:stable-slim`, `/link -> /deep/real`:

| operand | bash `-L` | bash `-P` | mirage before | mirage after |
|---|---|---|---|---|
| `cd /link/..` | `/` | `/deep` | `/` both modes | matches |
| `cd /link/sub/..` | `/link` | `/deep/real` | `/deep/real` both | matches (see below) |

## 2. Operands were echoed normalized, not as typed

Fixing the classifier surfaced a second divergence it had been masking. GNU echoes a path operand back **exactly as the user spelled it**; mirage echoed the normalized form, because normalization happened before the command ran. Pinned in `debian:stable-slim`:

```
du -b /k/                      ->  7  /k/
find /k/guides/                ->  /k/guides/
ls /k/nope/                    ->  ls: cannot access '/k/nope/': No such file or directory
md5sum /k/guides/../guides/a   ->  <hash>  /k/guides/../guides/a
tree /k/guides/                ->  /k/guides/
tree -f /k/guides/             ->  /k/guides          <- -f is the one exception
```

Nine integ cases had pinned the normalized spelling. Every one of them passes a trailing-slash operand, so all nine move to the GNU spelling — `du /knowledge/`, `du /notion/pages/`, `du /db/`, `find /slack/.../2026-02-06/`, `ls /slack/channels/product-reply__C6/`, `tree /slack/.../2026-02-06/`, `tree -L 3 /mongodb/mirage_integ/`, `tree -L 3 /pg/public/`. No source change was needed for this half: the commands already echo `raw_path`, they were just being handed a rewritten one.

`tree -f` is genuinely different — it strips the trailing slash so it can build child paths — but no case exercises it, so nothing pins it yet.

## 3. The jaeger seed polled the wrong port

`seed` waited for the query API on 16686, then pushed spans to the OTLP receiver on 4318 — separate ports on the same container, bound at different times. So the push could meet a docker-proxy socket that accepts and resets, which is *exactly* the failure `query` already documents and guards against for its own port. It killed `integ-shared-py` on #763's first run, in setup, before a single case ran:

```
ConnectionResetError: [Errno 104] Connection reset by peer
  jaeger_seed.py:186 in post_spans
```

Now the push retries itself on the same poll cadence, so the readiness check is the endpoint that has to be ready, and it raises with the last error if the receiver never accepts instead of failing confusingly further along.

## The remaining divergence, now scoped

bash's `-L` keeps the *logical* name in `$PWD` — `cd -L /link` leaves `PWD=/link`, not `/deep/real`. mirage resolves and stores the physical path, so it lands in the directory bash lands in and spells it differently. It is the same reason `pwd -L`/`-P` are declared in the spec and silently ignored.

Closing it means `Session` carries the pair rather than one string — `cwd` stays physical (what all ~58 other readers resolve against) and gains a `logical_cwd`, read only by `pwd`, `$PWD`, and `cd`'s own join. **That is queued as the next PR**, not folded in here.

## Verification

- **The integ case is what caught the incomplete first cut.** `cd -P` passed a direct unit test while still being wrong end-to-end, because the unit test bypassed the classifier that was eating the `..`. New `integ/unix/sym/cdmode.json` pins `-L`, `-P` and the bare default across 22 targets.
- That fixture now writes a file. `mkdir -p /data/lkd/real` leaves an empty directory, which backends with no empty-directory concept (hf) do not materialize — so `cd -P /data/lkp/..` could not reach `/data/lkd` there while `-L` passed by landing on `/data`. Writing `f.txt` makes both parents real on every target, which keeps all 22 rather than dropping hf.
- Full battery, both hosts, ram + disk: **4755 cases, 0 failures each**. `parity.py` diffs **4755 rows, 0 divergences**.
- Python: 13481 passed / 458 skipped / 0 failed. TypeScript: new `dirs.test.ts` (13 tests, the file had none); `pnpm -r typecheck` clean on all 7 packages.
- The classifier change touches a shared path, so it was measured rather than assumed — the nine re-pins above are its entire blast radius across every service-backed target.
- jaeger seed verified against a real `jaegertracing/jaeger:latest` from a cold start, and against a dead port (fails loudly after the full window).

Refs #609.
