### PR TITLE
refactor(runtime): guest op surface parity and one Ops facade

### DIFF
--- a/integ/runtime/bridge.json
+++ b/integ/runtime/bridge.json
@@ -292,6 +292,209 @@
           }
         }
       ]
+    },
+    {
+      "id": "redis_guest_open_modes",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "monty",
+          "vfs"
+        ],
+        "mounts": {
+          "/redis": {
+            "resource": "redis"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/redis/notes.txt', 'w').close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": [
+              "create /redis/notes.txt"
+            ]
+          }
+        },
+        {
+          "command": "python3 -c \"f = open('/redis/notes.txt', 'a'); f.write('hey'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": [
+              "append /redis/notes.txt"
+            ]
+          }
+        },
+        {
+          "command": "cat /redis/notes.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "hey"
+          }
+        }
+      ]
+    },
+    {
+      "id": "redis_guest_open_modes_js",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "quickjs",
+          "vfs"
+        ],
+        "mounts": {
+          "/redis": {
+            "resource": "redis"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "js -e \"const f = std.open('/redis/notes.txt', 'w'); f.puts('hey'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": [
+              "create /redis/notes.txt"
+            ]
+          }
+        },
+        {
+          "command": "cat /redis/notes.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "hey"
+          }
+        }
+      ]
+    },
+    {
+      "id": "s3_guest_open_w",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "monty",
+          "vfs"
+        ],
+        "mounts": {
+          "/s3": {
+            "resource": "s3"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "rm -f /s3/report.txt"
+        },
+        {
+          "command": "python3 -c \"f = open('/s3/report.txt', 'w'); f.write('r1'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": [
+              "create /s3/report.txt"
+            ]
+          }
+        },
+        {
+          "command": "cat /s3/report.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "r1"
+          }
+        }
+      ]
+    },
+    {
+      "id": "s3_guest_open_w_js",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "quickjs",
+          "vfs"
+        ],
+        "mounts": {
+          "/s3": {
+            "resource": "s3"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "rm -f /s3/report.txt"
+        },
+        {
+          "command": "js -e \"const f = std.open('/s3/report.txt', 'w'); f.puts('r1'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": [
+              "create /s3/report.txt"
+            ]
+          }
+        },
+        {
+          "command": "cat /s3/report.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "r1"
+          }
+        }
+      ]
+    },
+    {
+      "id": "s3_facade_probes",
+      "world": {
+        "mounts": {
+          "/s3": {
+            "resource": "s3"
+          }
+        }
+      },
+      "steps": [
+        {
+          "s3_put": {
+            "key": "probe/x.txt",
+            "body": "payload"
+          }
+        },
+        {
+          "facade": {
+            "method": "is_dir",
+            "path": "/s3/probe"
+          },
+          "expect": {
+            "value": true
+          }
+        },
+        {
+          "facade": {
+            "method": "exists",
+            "path": "/s3/nope.txt"
+          },
+          "expect": {
+            "value": false
+          }
+        },
+        {
+          "facade": {
+            "method": "cat",
+            "path": "/s3/greeting.txt"
+          },
+          "expect": {
+            "value": "hello from s3\n",
+            "ops_contain": [
+              "read /s3/greeting.txt"
+            ]
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/cli.sh
+++ b/integ/runtime/cli.sh
@@ -8,10 +8,13 @@
 # command_limits, and the per-line --runtime argument.
 #
 # Cases whose steps need the SDK surface (add_runtime, rename, s3_put,
-# read_op) or a runner-local test runtime (echobox) or runner-local
-# code policies (world.policies) or non-ram mounts are skipped as
-# sdk-only. Expect semantics: exit and stdout are exact, stderr is a
-# containment check (the CLI owns its stderr framing).
+# read_op, facade — the last calls ws.ops directly) or a runner-local
+# test runtime (echobox) or runner-local code policies (world.policies)
+# or non-ram mounts are skipped as sdk-only. Expect semantics: exit and
+# stdout are exact, stderr is a containment check (the CLI owns its
+# stderr framing), and the SDK-side expectations (ops_contain,
+# ops_absent, value) are not checked because the op ledger has no CLI
+# door.
 #
 # A yaml file is any JSON document here: YAML is a superset of JSON,
 # so the driver emits the case world as JSON with jq and both loaders
@@ -52,7 +55,7 @@ cli_expressible() {
       | to_entries | all(.value.resource == "ram"))
     and (((.world.policies // []) | length) == 0)
     and (((.world.runtimes // []) | map(select(type == "object" and .name == "echobox")) | length) == 0)
-    and (((.steps // []) | map(select(has("add_runtime") or has("rename") or has("s3_put") or has("read_op"))) | length) == 0)
+    and (((.steps // []) | map(select(has("add_runtime") or has("rename") or has("s3_put") or has("read_op") or has("facade"))) | length) == 0)
   ' >/dev/null <<<"$case_json"
 }
 
@@ -128,10 +131,19 @@ run_case() {
   fi
 
   # Seed declared mount files through the shell (cat reads the piped
-  # stdin, the redirect writes the mount).
+  # stdin, the redirect writes the mount). A nested seed name needs its
+  # parent first: the redirect refuses a missing directory, and it
+  # refuses silently here, which reads as a file that was never
+  # declared (run.py and run.ts mkdir the parent the same way).
   local prefix name ok=0
   while IFS=$'\t' read -r prefix name; do
     [ -n "$prefix" ] || continue
+    case "$name" in
+      */*)
+        $cli execute -w "$wsid" -c "mkdir -p $prefix/${name%/*}" \
+          >/dev/null 2>&1 </dev/null
+        ;;
+    esac
     jq -j --arg p "$prefix" --arg n "$name" \
       '.world.mounts[$p].files[$n]' <<<"$case_json" \
       | $cli execute -w "$wsid" -c "cat > $prefix/$name" >/dev/null 2>&1

--- a/integ/runtime/guestops.json
+++ b/integ/runtime/guestops.json
@@ -1,0 +1,500 @@
+{
+  "suite": "guestops",
+  "cases": [
+    {
+      "id": "monty_w_creates_an_empty_file",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": { "seed.txt": "seed\n", "sub/inner.txt": "in\n" }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/data/new.txt', 'w').close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["create /data/new.txt"],
+            "ops_absent": ["write /data/new.txt", "append /data/new.txt"]
+          }
+        },
+        {
+          "command": "cat /data/new.txt",
+          "expect": { "exit": 0, "stdout": "" }
+        }
+      ]
+    },
+    {
+      "id": "monty_w_truncates_at_open",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": { "seed.txt": "seed\n" }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/data/seed.txt', 'w').close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["truncate /data/seed.txt"],
+            "ops_absent": ["create /data/seed.txt"]
+          }
+        },
+        {
+          "command": "cat /data/seed.txt",
+          "expect": { "exit": 0, "stdout": "" }
+        }
+      ]
+    },
+    {
+      "id": "monty_w_write_flushes_after_the_create",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"f = open('/data/out.txt', 'w'); f.write('hi'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["create /data/out.txt"]
+          }
+        },
+        {
+          "command": "cat /data/out.txt",
+          "expect": { "exit": 0, "stdout": "hi" }
+        }
+      ]
+    },
+    {
+      "id": "monty_a_creates_then_appends",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"f = open('/data/log.txt', 'a'); f.write('one\\n'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["create /data/log.txt", "append /data/log.txt"]
+          }
+        },
+        {
+          "command": "python3 -c \"f = open('/data/log.txt', 'a'); f.write('two\\n'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["append /data/log.txt"],
+            "ops_absent": ["create /data/log.txt", "truncate /data/log.txt"]
+          }
+        },
+        {
+          "command": "cat /data/log.txt",
+          "expect": { "exit": 0, "stdout": "one\ntwo\n" }
+        }
+      ]
+    },
+    {
+      "id": "monty_cannot_spell_exclusive",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/data/seed.txt', 'x')\"",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "exclusive creation mode is not supported"
+          }
+        }
+      ]
+    },
+    {
+      "id": "monty_cannot_spell_update",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/data/seed.txt', 'r+')\"",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "update modes ('+') are not yet supported"
+          }
+        }
+      ]
+    },
+    {
+      "id": "monty_refuses_a_bad_mode_word",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/data/seed.txt', 'rr')\"",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "must have exactly one of create/read/write/append mode"
+          }
+        }
+      ]
+    },
+    {
+      "id": "monty_iterdir_classifies_through_stat",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": { "seed.txt": "seed\n", "sub/inner.txt": "in\n" }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"from pathlib import Path; print(sorted(str(p).split('/')[-1] for p in Path('/data').iterdir()))\"",
+          "expect": { "exit": 0, "stdout": "['seed.txt', 'sub']\n" }
+        },
+        {
+          "command": "python3 -c \"from pathlib import Path; print(Path('/data/sub').is_dir(), Path('/data/seed.txt').is_file())\"",
+          "expect": { "exit": 0, "stdout": "True True\n" }
+        }
+      ]
+    },
+    {
+      "id": "monty_guest_reads_share_the_shell_ledger",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"print(open('/data/seed.txt').read().strip())\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "seed\n",
+            "ops_contain": ["read /data/seed.txt"]
+          }
+        }
+      ]
+    },
+    {
+      "id": "qjs_w_creates_an_empty_file",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["quickjs", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "js -e \"const f = std.open('/data/new.txt', 'w'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["create /data/new.txt"],
+            "ops_absent": ["write /data/new.txt"]
+          }
+        },
+        {
+          "command": "cat /data/new.txt",
+          "expect": { "exit": 0, "stdout": "" }
+        }
+      ]
+    },
+    {
+      "id": "qjs_w_truncates_at_open",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["quickjs", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "js -e \"const f = std.open('/data/seed.txt', 'w'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["truncate /data/seed.txt"],
+            "ops_absent": ["create /data/seed.txt"]
+          }
+        },
+        {
+          "command": "cat /data/seed.txt",
+          "expect": { "exit": 0, "stdout": "" }
+        }
+      ]
+    },
+    {
+      "id": "qjs_wx_refuses_an_existing_file",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["quickjs", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "js -e \"console.log(std.open('/data/seed.txt', 'wx') === null)\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "true\n",
+            "ops_absent": ["create /data/seed.txt", "truncate /data/seed.txt", "write /data/seed.txt"]
+          }
+        },
+        {
+          "command": "cat /data/seed.txt",
+          "expect": { "exit": 0, "stdout": "seed\n" }
+        }
+      ]
+    },
+    {
+      "id": "qjs_wx_creates_a_missing_file",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["quickjs", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "js -e \"const f = std.open('/data/fresh.txt', 'wx'); f.puts('fresh'); f.close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["create /data/fresh.txt"]
+          }
+        },
+        {
+          "command": "cat /data/fresh.txt",
+          "expect": { "exit": 0, "stdout": "fresh" }
+        }
+      ]
+    },
+    {
+      "id": "qjs_rplus_refuses_a_missing_file",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["quickjs", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "js -e \"console.log(std.open('/data/nope.txt', 'r+') === null)\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "true\n",
+            "ops_absent": ["create /data/nope.txt"]
+          }
+        }
+      ]
+    },
+    {
+      "id": "qjs_refuses_a_bad_mode_word",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["quickjs", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "js -e \"std.open('/data/seed.txt', 'rr')\"",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "invalid file mode"
+          }
+        }
+      ]
+    },
+    {
+      "id": "qjs_readdir_classifies_through_stat",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["quickjs", "vfs"],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": { "seed.txt": "seed\n", "sub/inner.txt": "in\n" }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "js -e \"const [names] = os.readdir('/data'); console.log(names.filter((n) => !n.startsWith('.')).sort().join(','))\"",
+          "expect": { "exit": 0, "stdout": "seed.txt,sub\n" }
+        },
+        {
+          "command": "js -e \"const [d] = os.stat('/data/sub'); const [f] = os.stat('/data/seed.txt'); console.log((d.mode & os.S_IFMT) === os.S_IFDIR, (f.mode & os.S_IFMT) === os.S_IFREG)\"",
+          "expect": { "exit": 0, "stdout": "true true\n" }
+        }
+      ]
+    },
+    {
+      "id": "pyodide_w_creates_an_empty_file",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["pyodide", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/data/new.txt', 'w').close()\"",
+          "expect": { "exit": 0 }
+        },
+        {
+          "command": "cat /data/new.txt",
+          "expect": { "exit": 0, "stdout": "" }
+        }
+      ]
+    },
+    {
+      "id": "pyodide_w_truncates_at_open",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["pyodide", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/data/seed.txt', 'w').close()\"",
+          "expect": { "exit": 0 }
+        },
+        {
+          "command": "cat /data/seed.txt",
+          "expect": { "exit": 0, "stdout": "" }
+        }
+      ]
+    },
+    {
+      "id": "pyodide_x_is_exclusive",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["pyodide", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/data/seed.txt', 'x')\"",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "FileExistsError"
+          }
+        },
+        {
+          "command": "python3 -c \"f = open('/data/fresh.txt', 'x'); f.write('fresh'); f.close()\"",
+          "expect": { "exit": 0 }
+        },
+        {
+          "command": "cat /data/fresh.txt",
+          "expect": { "exit": 0, "stdout": "fresh" }
+        }
+      ]
+    },
+    {
+      "id": "pyodide_rplus_refuses_a_missing_file",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["pyodide", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/data/nope.txt', 'r+')\"",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "FileNotFoundError"
+          }
+        }
+      ]
+    },
+    {
+      "id": "pyodide_listdir_classifies_through_stat",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["pyodide", "vfs"],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": { "seed.txt": "seed\n", "sub/inner.txt": "in\n" }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import os; print(sorted(os.listdir('/data'))); print(os.path.isdir('/data/sub'), os.path.isfile('/data/seed.txt'))\"",
+          "expect": { "exit": 0, "stdout": "['seed.txt', 'sub']\nTrue True\n" }
+        }
+      ]
+    },
+    {
+      "id": "facade_probes_answer_through_the_door",
+      "world": {
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": { "seed.txt": "seed\n", "sub/inner.txt": "in\n" }
+          }
+        }
+      },
+      "steps": [
+        {
+          "facade": { "method": "exists", "path": "/data/seed.txt" },
+          "expect": { "value": true }
+        },
+        {
+          "facade": { "method": "exists", "path": "/data/nope.txt" },
+          "expect": { "value": false }
+        },
+        {
+          "facade": { "method": "is_dir", "path": "/data/sub" },
+          "expect": { "value": true }
+        },
+        {
+          "facade": { "method": "is_file", "path": "/data/seed.txt" },
+          "expect": { "value": true }
+        },
+        {
+          "facade": { "method": "is_file", "path": "/data/sub" },
+          "expect": { "value": false }
+        },
+        {
+          "facade": { "method": "cat", "path": "/data/seed.txt" },
+          "expect": { "value": "seed\n", "ops_contain": ["read /data/seed.txt"] }
+        },
+        {
+          "facade": { "method": "list_files", "path": "/data" },
+          "expect": { "value": ["seed.txt"] }
+        }
+      ]
+    },
+    {
+      "id": "facade_append_lands_on_the_one_ledger",
+      "world": {
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "facade": { "method": "append", "path": "/data/seed.txt", "data": "more\n" },
+          "expect": { "ops_contain": ["append /data/seed.txt"] }
+        },
+        {
+          "command": "cat /data/seed.txt",
+          "expect": { "exit": 0, "stdout": "seed\nmore\n" }
+        }
+      ]
+    }
+  ]
+}

--- a/integ/runtime/run.py
+++ b/integ/runtime/run.py
@@ -358,11 +358,70 @@ async def _build_workspace(world: dict[str, Any], run_id: str) -> Workspace:
     ws = Workspace(mounts, mode=MountMode.EXEC, **kwargs)
     if "clis" in world:
         _install_clis(ws, world["clis"])
+    made_dirs: set[str] = set()
     for prefix, name, data in seeds:
+        # A nested seed needs its directory first: write refuses a
+        # missing parent (GNU dest-parent semantics), and the op-level
+        # mkdir creates the whole chain.
+        parent = f"{prefix}/{name.rpartition('/')[0]}"
+        if "/" in name and parent not in made_dirs:
+            await ws.dispatch("mkdir", PathSpec.from_str_path(parent))
+            made_dirs.add(parent)
         await ws.dispatch("write",
                           PathSpec.from_str_path(f"{prefix}/{name}"),
                           data=data)
     return ws
+
+
+def _check_ops(expect: dict[str, Any], seen: list[str]) -> list[str]:
+    """Ledger expectations for one step, against the ops it added.
+
+    Args:
+        expect (dict[str, Any]): the step's expect block; ``ops_contain``
+            and ``ops_absent`` hold ``"<op> <path>"`` strings.
+        seen (list[str]): the records the step appended, one
+            ``"<op> <path>"`` string per record, in arrival order.
+    """
+    problems = []
+    for entry in expect.get("ops_contain", []):
+        if entry not in seen:
+            problems.append(f"ledger missing {entry!r}: got {seen!r}")
+    for entry in expect.get("ops_absent", []):
+        if entry in seen:
+            problems.append(f"ledger must not hold {entry!r}: got {seen!r}")
+    return problems
+
+
+async def _run_facade(ws: Workspace, expect: dict[str, Any],
+                      spec: dict[str, Any]) -> list[str]:
+    """One facade step: call a typed Ops convenience and check its value.
+
+    Args:
+        ws (Workspace): the workspace under test.
+        expect (dict[str, Any]): ``value`` (JSON-comparable result) or
+            ``throws_contains``.
+        spec (dict[str, Any]): ``method`` (the python facade spelling,
+            e.g. ``is_dir``), ``path``, and ``data`` for ``append``.
+    """
+    method = getattr(ws.ops, spec["method"])
+    args: list[Any] = [spec["path"]]
+    if "data" in spec:
+        args.append(spec["data"].encode())
+    if "throws_contains" in expect:
+        try:
+            await method(*args)
+        except Exception as exc:
+            if expect["throws_contains"] in str(exc):
+                return []
+            return [
+                f"facade raised {exc!r}, expected "
+                f"{expect['throws_contains']!r} in the message"
+            ]
+        return ["facade: expected an error, none raised"]
+    value = await method(*args)
+    if "value" in expect and value != expect["value"]:
+        return [f"facade value {value!r}, expected {expect['value']!r}"]
+    return []
 
 
 def _check(case_id: str, label: str, expect: dict[str, Any], exit_code: int,
@@ -389,6 +448,14 @@ async def _run_step(ws: Workspace, case_id: str, index: int,
                     step: dict[str, Any]) -> list[str]:
     expect = step.get("expect", {})
     label = f"step[{index}]"
+    # The ledger slice this step adds: ws.ops.records is the one
+    # workspace-wide account, so the step's own ops are the tail.
+    ledger_before = len(ws.ops.records)
+    if "facade" in step:
+        problems = await _run_facade(ws, expect, step["facade"])
+        seen = [f"{r.op} {r.path}" for r in ws.ops.records[ledger_before:]]
+        problems.extend(_check_ops(expect, seen))
+        return [f"{case_id} {label}: {p}" for p in problems]
     if "s3_put" in step:
         put = step["s3_put"]
         _s3_client().put_object(Bucket=BUCKET,
@@ -452,7 +519,11 @@ async def _run_step(ws: Workspace, case_id: str, index: int,
     result = await ws.execute(command, **kwargs)
     stdout = await result.stdout_str()
     stderr = await result.stderr_str()
-    return _check(case_id, label, expect, result.exit_code, stdout, stderr)
+    problems = _check(case_id, label, expect, result.exit_code, stdout, stderr)
+    seen = [f"{r.op} {r.path}" for r in ws.ops.records[ledger_before:]]
+    problems.extend(f"{case_id} {label}: {p}"
+                    for p in _check_ops(expect, seen))
+    return problems
 
 
 async def _run_case(suite: str, case: dict[str, Any]) -> list[str]:

--- a/integ/runtime/run.ts
+++ b/integ/runtime/run.ts
@@ -62,6 +62,15 @@ interface Expect {
   throws_contains?: string;
   errno?: string;
   content?: string;
+  ops_contain?: string[];
+  ops_absent?: string[];
+  value?: unknown;
+}
+
+interface FacadeSpec {
+  method: string;
+  path: string;
+  data?: string;
 }
 
 interface Step {
@@ -72,6 +81,7 @@ interface Step {
   s3_put?: { key: string; body: string };
   rename?: { src: string; dst: string };
   read_op?: string;
+  facade?: FacadeSpec;
   expect?: Expect;
 }
 
@@ -398,7 +408,19 @@ async function buildWorkspace(world: World, runId: string): Promise<Workspace> {
     });
     ws.registerCli(name, spec, entry.config ?? null);
   }
+  const madeDirs = new Set<string>();
   for (const [prefix, name, content] of seeds) {
+    // A nested seed needs its directory first: write refuses a missing
+    // parent (GNU dest-parent semantics), and the op-level mkdir
+    // creates the whole chain.
+    const slash = name.lastIndexOf("/");
+    if (slash > 0) {
+      const dir = `${prefix}/${name.slice(0, slash)}`;
+      if (!madeDirs.has(dir)) {
+        await ws.dispatch("mkdir", dir, []);
+        madeDirs.add(dir);
+      }
+    }
     await ws.dispatch("write", `${prefix}/${name}`, [ENC.encode(content)]);
   }
   return ws;
@@ -431,9 +453,62 @@ function check(
   return problems.map((p) => `${caseId} ${label}: ${p}`);
 }
 
+function checkOps(expect: Expect, seen: string[]): string[] {
+  const problems: string[] = [];
+  for (const entry of expect.ops_contain ?? []) {
+    if (!seen.includes(entry)) {
+      problems.push(`ledger missing ${JSON.stringify(entry)}: got ${JSON.stringify(seen)}`);
+    }
+  }
+  for (const entry of expect.ops_absent ?? []) {
+    if (seen.includes(entry)) {
+      problems.push(`ledger must not hold ${JSON.stringify(entry)}: got ${JSON.stringify(seen)}`);
+    }
+  }
+  return problems;
+}
+
+// One facade step: call a typed Ops convenience (`ws.fs`) and check its
+// value. The JSON carries the python facade spelling (`is_dir`,
+// `list_files`); snakeToCamel maps it onto the TS method.
+async function runFacade(ws: Workspace, expect: Expect, spec: FacadeSpec): Promise<string[]> {
+  const facade = ws.fs as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>;
+  const method = facade[snakeToCamel(spec.method)];
+  if (method === undefined) return [`facade has no method ${spec.method}`];
+  const args: unknown[] = [spec.path];
+  if (spec.data !== undefined) args.push(ENC.encode(spec.data));
+  if (expect.throws_contains !== undefined) {
+    try {
+      await method.apply(ws.fs, args);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes(expect.throws_contains)) return [];
+      return [
+        `facade raised ${JSON.stringify(message)}, expected ` +
+          `${JSON.stringify(expect.throws_contains)} in the message`,
+      ];
+    }
+    return ["facade: expected an error, none raised"];
+  }
+  const value = await method.apply(ws.fs, args);
+  if (expect.value !== undefined && JSON.stringify(value ?? null) !== JSON.stringify(expect.value)) {
+    return [`facade value ${JSON.stringify(value ?? null)}, expected ${JSON.stringify(expect.value)}`];
+  }
+  return [];
+}
+
 async function runStep(ws: Workspace, caseId: string, index: number, step: Step): Promise<string[]> {
   const expect = step.expect ?? {};
   const label = `step[${index}]`;
+  // The ledger slice this step adds: ws.records delegates to the Ops
+  // facade's account, so the step's own ops are the tail.
+  const ledgerBefore = ws.records.length;
+  if (step.facade !== undefined) {
+    const problems = await runFacade(ws, expect, step.facade);
+    const seen = ws.records.slice(ledgerBefore).map((r) => `${r.op} ${r.path}`);
+    problems.push(...checkOps(expect, seen));
+    return problems.map((p) => `${caseId} ${label}: ${p}`);
+  }
   if (step.s3_put !== undefined) {
     await putS3(step.s3_put.key, step.s3_put.body);
     return [];
@@ -496,7 +571,10 @@ async function runStep(ws: Workspace, caseId: string, index: number, step: Step)
   const result = await ws.execute(command, options);
   const stdout = DEC.decode(result.stdout);
   const stderr = DEC.decode(result.stderr);
-  return check(caseId, label, expect, result.exitCode, stdout, stderr);
+  const problems = check(caseId, label, expect, result.exitCode, stdout, stderr);
+  const seen = ws.records.slice(ledgerBefore).map((r) => `${r.op} ${r.path}`);
+  problems.push(...checkOps(expect, seen).map((p) => `${caseId} ${label}: ${p}`));
+  return problems;
 }
 
 async function runCase(suite: string, testCase: Case): Promise<string[]> {

--- a/integ/runtime/wasi.json
+++ b/integ/runtime/wasi.json
@@ -87,6 +87,110 @@
           }
         }
       ]
+    },
+    {
+      "id": "open_modes_dispatch_the_establishing_op",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "seed.txt": "seed\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"open('/ram/new.txt', 'w').close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["create /ram/new.txt"],
+            "ops_absent": ["write /ram/new.txt"]
+          }
+        },
+        {
+          "command": "cat /ram/new.txt",
+          "expect": { "exit": 0, "stdout": "" }
+        },
+        {
+          "command": "python3 -c \"open('/ram/seed.txt', 'w').close()\"",
+          "expect": {
+            "exit": 0,
+            "ops_contain": ["truncate /ram/seed.txt"]
+          }
+        },
+        {
+          "command": "cat /ram/seed.txt",
+          "expect": { "exit": 0, "stdout": "" }
+        },
+        {
+          "command": "python3 -c \"open('/ram/new.txt', 'x')\"",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "FileExistsError"
+          }
+        },
+        {
+          "command": "python3 -c \"f = open('/ram/fresh.txt', 'x'); f.write('fresh'); f.close()\" && cat /ram/fresh.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "fresh",
+            "ops_contain": ["create /ram/fresh.txt"]
+          }
+        },
+        {
+          "command": "python3 -c \"open('/ram/nope.txt', 'r+')\"",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "FileNotFoundError"
+          }
+        },
+        {
+          "command": "python3 -c \"open('/ram/seed.txt', 'rr')\"",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "invalid mode: 'rr'"
+          }
+        }
+      ]
+    },
+    {
+      "id": "listdir_classifies_through_stat",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "seed.txt": "seed\n",
+              "sub/inner.txt": "in\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import os; print(sorted(os.listdir('/ram'))); print(os.path.isdir('/ram/sub'), os.path.isfile('/ram/seed.txt'))\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "['seed.txt', 'sub']\nTrue True\n"
+          }
+        }
+      ]
     }
   ]
 }

--- a/python/mirage/commands/builtin/generic_bind/builders/mkdir.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/mkdir.py
@@ -22,7 +22,7 @@ from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 from mirage.utils.errors import (FS_ERRORS, error_path, fs_strerror,
                                  operand_spelling)
-from mirage.utils.mode import DEFAULT_DIR_MODE, parse_mode
+from mirage.utils.mode import DEFAULT_DIR_MODE, parse_chmod
 
 
 async def mkdir(
@@ -44,7 +44,7 @@ async def mkdir(
     if mode_text is not None:
         # Symbolic clauses build on what mirage renders for a new
         # directory, since there is no umask to subtract from.
-        mode = parse_mode(mode_text, DEFAULT_DIR_MODE)
+        mode = parse_chmod(mode_text, DEFAULT_DIR_MODE)
         if mode is None:
             raise ValueError(f"mkdir: invalid mode '{mode_text}'")
         if ops.set_attrs is None:

--- a/python/mirage/core/disk/create.py
+++ b/python/mirage/core/disk/create.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
 from pathlib import Path
 
 import aiofiles
@@ -20,6 +21,7 @@ import aiofiles.os
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.disk.errors import disk_errors
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
@@ -32,8 +34,10 @@ def _resolve(root: Path, path: str) -> Path:
 
 async def create(accessor: DiskAccessor, path_spec: PathSpec) -> None:
     path = path_spec.mount_path
+    start_ms = int(time.monotonic() * 1000)
     p = _resolve(accessor.root, path)
     with disk_errors(path_spec.virtual):
         async with aiofiles.open(p, "wb") as f:
             await f.write(b"")
+    record("create", path, "disk", 0, start_ms)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/disk/truncate.py
+++ b/python/mirage/core/disk/truncate.py
@@ -12,12 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
 from pathlib import Path
 
 import aiofiles
 
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.context import invalidate_after_write
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
@@ -31,6 +33,7 @@ def _resolve(root: Path, path: str) -> Path:
 async def truncate(accessor: DiskAccessor, path_spec: PathSpec,
                    length: int) -> None:
     path = path_spec.mount_path
+    start_ms = int(time.monotonic() * 1000)
     p = _resolve(accessor.root, path)
     try:
         async with aiofiles.open(p, "rb") as f:
@@ -40,4 +43,5 @@ async def truncate(accessor: DiskAccessor, path_spec: PathSpec,
     result = data[:length].ljust(length, b"\0")
     async with aiofiles.open(p, "wb") as f:
         await f.write(result)
+    record("truncate", path, "disk", 0, start_ms)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/gridfs/create.py
+++ b/python/mirage/core/gridfs/create.py
@@ -12,14 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.gridfs import GridFSAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.gridfs._client import _key, bucket
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
 async def create(accessor: GridFSAccessor, path_spec: PathSpec) -> None:
     path = path_spec.mount_path
+    start_ms = int(time.monotonic() * 1000)
     config = accessor.config
     await bucket(accessor).upload_from_stream(_key(path, config), b"")
+    record("create", path, "gridfs", 0, start_ms)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/gridfs/truncate.py
+++ b/python/mirage/core/gridfs/truncate.py
@@ -12,15 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.gridfs import GridFSAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.gridfs._client import _key, bucket, latest_file
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
 async def truncate(accessor: GridFSAccessor, path_spec: PathSpec,
                    length: int) -> None:
     path = path_spec.mount_path
+    start_ms = int(time.monotonic() * 1000)
     config = accessor.config
     key = _key(path, config)
     doc = await latest_file(accessor, key)
@@ -35,4 +39,5 @@ async def truncate(accessor: GridFSAccessor, path_spec: PathSpec,
             await out.close()
     result = data[:length].ljust(length, b"\0")
     await bucket(accessor).upload_from_stream(key, result)
+    record("truncate", path, "gridfs", 0, start_ms)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/nextcloud/create.py
+++ b/python/mirage/core/nextcloud/create.py
@@ -1,10 +1,15 @@
+import time
+
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.context import invalidate_after_write
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
 async def create(accessor: NextcloudAccessor, path: PathSpec) -> None:
     key = path.mount_path.lstrip("/")
+    start_ms = int(time.monotonic() * 1000)
     op = accessor.operator()
     await op.write(key, b"")
+    record("create", path.virtual, "nextcloud", 0, start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/core/nextcloud/truncate.py
+++ b/python/mirage/core/nextcloud/truncate.py
@@ -1,13 +1,17 @@
+import time
+
 from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.context import invalidate_after_write
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
 async def truncate(accessor: NextcloudAccessor, path: PathSpec,
                    length: int) -> None:
     key = path.mount_path.lstrip("/")
+    start_ms = int(time.monotonic() * 1000)
     op = accessor.operator()
     try:
         data = bytes(await op.read(key))
@@ -15,4 +19,5 @@ async def truncate(accessor: NextcloudAccessor, path: PathSpec,
         data = b""
     result = data[:length].ljust(length, b"\0")
     await op.write(key, result)
+    record("truncate", path.virtual, "nextcloud", 0, start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/core/ram/create.py
+++ b/python/mirage/core/ram/create.py
@@ -12,18 +12,23 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.ram.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
+from mirage.observe.context import record
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
 
 async def create(accessor: RAMAccessor, path: PathSpec) -> None:
     store = accessor.store
+    start_ms = int(time.monotonic() * 1000)
     p = norm(path.mount_path)
     check_dest_parents(store, path, p)
     store.files[p] = b""
     store.modified[p] = now_iso()
+    record("create", path.mount_path, "ram", 0, start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/core/ram/truncate.py
+++ b/python/mirage/core/ram/truncate.py
@@ -12,15 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.timeutil import now_iso
+from mirage.observe.context import record
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
 
 async def truncate(accessor: RAMAccessor, path: PathSpec, length: int) -> None:
     store = accessor.store
+    start_ms = int(time.monotonic() * 1000)
     p = norm(path.mount_path)
     if p in store.files:
         data = store.files[p]
@@ -28,4 +32,5 @@ async def truncate(accessor: RAMAccessor, path: PathSpec, length: int) -> None:
         data = b""
     store.files[p] = data[:length].ljust(length, b"\0")
     store.modified[p] = now_iso()
+    record("truncate", path.mount_path, "ram", 0, start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/core/redis/create.py
+++ b/python/mirage/core/redis/create.py
@@ -12,18 +12,23 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.redis.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
+from mirage.observe.context import record
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
 
 async def create(accessor: RedisAccessor, path: PathSpec) -> None:
     store = accessor.store
+    start_ms = int(time.monotonic() * 1000)
     p = norm(path.mount_path)
     await check_dest_parents(store, path, p)
     await store.set_file(p, b"")
     await store.set_modified(p, now_iso())
+    record("create", path.mount_path, "redis", 0, start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/core/redis/truncate.py
+++ b/python/mirage/core/redis/truncate.py
@@ -12,9 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.timeutil import now_iso
+from mirage.observe.context import record
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
@@ -22,10 +25,12 @@ from mirage.utils.path import norm
 async def truncate(accessor: RedisAccessor, path: PathSpec,
                    length: int) -> None:
     store = accessor.store
+    start_ms = int(time.monotonic() * 1000)
     p = norm(path.mount_path)
     data = await store.get_file(p)
     if data is None:
         data = b""
     await store.set_file(p, data[:length].ljust(length, b"\0"))
     await store.set_modified(p, now_iso())
+    record("truncate", path.mount_path, "redis", 0, start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/core/s3/create.py
+++ b/python/mirage/core/s3/create.py
@@ -12,18 +12,23 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.s3._client import _client_kwargs, _key, async_session
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
 async def create(accessor: S3Accessor, path_spec: PathSpec) -> None:
     path = path_spec.mount_path
+    start_ms = int(time.monotonic() * 1000)
     config = accessor.config
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
         await client.put_object(Bucket=config.bucket,
                                 Key=_key(path, config),
                                 Body=b"")
+    record("create", path, "s3", 0, start_ms)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/s3/truncate.py
+++ b/python/mirage/core/s3/truncate.py
@@ -12,15 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.s3._client import _client_kwargs, _key, async_session
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
 async def truncate(accessor: S3Accessor, path_spec: PathSpec,
                    length: int) -> None:
     path = path_spec.mount_path
+    start_ms = int(time.monotonic() * 1000)
     config = accessor.config
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
@@ -38,4 +42,5 @@ async def truncate(accessor: S3Accessor, path_spec: PathSpec,
         await client.put_object(Bucket=config.bucket,
                                 Key=_key(path, config),
                                 Body=result)
+    record("truncate", path, "s3", 0, start_ms)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/sharepoint/create.py
+++ b/python/mirage/core/sharepoint/create.py
@@ -1,8 +1,11 @@
+import time
+
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.sharepoint._client import (graph_put_bytes, item_url,
                                             split_path)
 from mirage.core.sharepoint._resolver import resolve
+from mirage.observe.context import record
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -10,6 +13,7 @@ from mirage.utils.errors import enoent
 async def create(accessor: SharePointAccessor, path: PathSpec) -> None:
     virtual = path.virtual if isinstance(path, PathSpec) else path
     _, stripped = split_path(path)
+    start_ms = int(time.monotonic() * 1000)
     resolved = await resolve(accessor, path)
     if resolved.drive_id is None or resolved.item_path is None:
         raise enoent(virtual)
@@ -18,4 +22,5 @@ async def create(accessor: SharePointAccessor, path: PathSpec) -> None:
                    resolved.item_path,
                    action="/content")
     await graph_put_bytes(accessor.config, url, b"")
+    record("create", stripped, "sharepoint", 0, start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/core/ssh/create.py
+++ b/python/mirage/core/ssh/create.py
@@ -12,15 +12,20 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.ssh._client import _abs
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
 async def create(accessor: SSHAccessor, path: PathSpec) -> None:
     config = accessor.config
+    start_ms = int(time.monotonic() * 1000)
     sftp = await accessor.sftp()
     async with sftp.open(_abs(config, path.mount_path), "wb"):
         pass
+    record("create", path.mount_path, "ssh", 0, start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/core/ssh/truncate.py
+++ b/python/mirage/core/ssh/truncate.py
@@ -12,9 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
+
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.ssh._client import _abs
+from mirage.observe.context import record
 from mirage.types import PathSpec
 
 
@@ -22,6 +25,8 @@ async def truncate(accessor: SSHAccessor,
                    path: PathSpec,
                    length: int = 0) -> None:
     config = accessor.config
+    start_ms = int(time.monotonic() * 1000)
     sftp = await accessor.sftp()
     await sftp.truncate(_abs(config, path.mount_path), length)
+    record("truncate", path.mount_path, "ssh", 0, start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/observe/context.py
+++ b/python/mirage/observe/context.py
@@ -79,6 +79,30 @@ def active_recorder() -> Recorder | None:
     return _recorder.get()
 
 
+def set_active_recorder(rec: Recorder | None):
+    """Bind ``rec`` as the active Recorder for the current context.
+
+    The door for a caller that captured a recorder on one task and must
+    re-establish it on another (``RuntimeVFS`` re-binding the typed
+    line's ledger around a guest op that hopped threads). Returns the
+    token for :func:`reset_active_recorder`.
+
+    Args:
+        rec (Recorder | None): the recorder to bind; None binds the
+            unrecorded state.
+    """
+    return _recorder.set(rec)
+
+
+def reset_active_recorder(token) -> None:
+    """Restore the previous recorder after a :func:`set_active_recorder`.
+
+    Args:
+        token: The token returned by ``set_active_recorder``.
+    """
+    _recorder.reset(token)
+
+
 def push_mount_prefix(prefix: str) -> str:
     """Set the mount prefix on the active Recorder. Returns the previous
     prefix so callers can restore it.

--- a/python/mirage/ops/file.py
+++ b/python/mirage/ops/file.py
@@ -66,15 +66,18 @@ class MirageFile:
         self._closed = False
         self._dirty = False
         self._buf: io.BytesIO | io.StringIO | None = None
-        if self._facts.truncate:
-            self._run(self._ops.create(self._path))
-        elif self._facts.exclusive:
+        # Exclusivity outranks truncation: wx carries both facts, and
+        # testing truncate first would create over the existing file the
+        # mode promises to refuse.
+        if self._facts.exclusive:
             try:
                 self._run(self._ops.stat(self._path))
             except FileNotFoundError:
                 self._run(self._ops.create(self._path))
             else:
                 raise FileExistsError(self._path)
+        elif self._facts.truncate:
+            self._run(self._ops.create(self._path))
         elif self._facts.append:
             try:
                 self._run(self._ops.stat(self._path))

--- a/python/mirage/ops/file.py
+++ b/python/mirage/ops/file.py
@@ -22,22 +22,10 @@ from typing import Self, TypeVar
 
 from mirage.bridge.sync import run_async_from_sync
 from mirage.ops import Ops
+from mirage.runtime.handles.mode import parse_mode
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
-
-
-def _parse_mode(mode: str) -> tuple[str, bool, bool, bool]:
-    valid = set("rwaxbt+")
-    if (not mode or any(char not in valid for char in mode)
-            or sum(mode.count(char) for char in "rwax") != 1
-            or mode.count("+") > 1 or mode.count("b") > 1
-            or mode.count("t") > 1 or ("b" in mode and "t" in mode)):
-        raise ValueError(f"invalid mode: {mode!r}")
-    base = next(char for char in "rwax" if char in mode)
-    readable = base == "r" or "+" in mode
-    writable = base != "r" or "+" in mode
-    return base, "b" in mode, readable, writable
 
 
 class MirageFile:
@@ -57,8 +45,10 @@ class MirageFile:
         self._path = path
         self._mode = mode
         self._loop = loop
-        self._base_mode, self._binary, self._readable, self._writable = \
-            _parse_mode(mode)
+        self._facts = parse_mode(mode)
+        self._binary = self._facts.binary
+        self._readable = self._facts.readable
+        self._writable = self._facts.writable
         if self._binary:
             if encoding is not None:
                 raise ValueError(
@@ -76,16 +66,16 @@ class MirageFile:
         self._closed = False
         self._dirty = False
         self._buf: io.BytesIO | io.StringIO | None = None
-        if self._base_mode == "w":
+        if self._facts.truncate:
             self._run(self._ops.create(self._path))
-        elif self._base_mode == "x":
+        elif self._facts.exclusive:
             try:
                 self._run(self._ops.stat(self._path))
             except FileNotFoundError:
                 self._run(self._ops.create(self._path))
             else:
                 raise FileExistsError(self._path)
-        elif self._base_mode == "a":
+        elif self._facts.append:
             try:
                 self._run(self._ops.stat(self._path))
             except FileNotFoundError:
@@ -97,13 +87,13 @@ class MirageFile:
     def _load(self) -> io.BytesIO | io.StringIO:
         if self._buf is not None:
             return self._buf
-        if self._base_mode in ("w", "x"):
+        if self._facts.truncate or self._facts.exclusive:
             if self._binary:
                 self._buf = io.BytesIO()
             else:
                 self._buf = io.StringIO(newline=self._newline)
             return self._buf
-        if self._base_mode == "a":
+        if self._facts.append:
             data = self._run(self._ops.read(self._path))
             if self._binary:
                 self._buf = io.BytesIO(data)

--- a/python/mirage/ops/generic/factory.py
+++ b/python/mirage/ops/generic/factory.py
@@ -196,7 +196,7 @@ def make_generic_ops(
     there is deliberately no ``forward_index`` knob here, in either
     language. Every write path evicts the parent listing through
     :meth:`Dispatcher.invalidate_after_write`, and both VFS/FUSE
-    surfaces (:class:`Ops`, TypeScript's ``WorkspaceFS``) delegate to
+    surfaces (:class:`Ops` in both languages) delegate to
     that same dispatcher, so the door that populates a listing is the
     door that evicts it.
 

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -21,7 +21,8 @@ from mirage.io import OpReport
 from mirage.observe import OpRecord
 from mirage.ops.config import NO_FOLLOW_OPS, NamespaceLinks, OpsMount
 from mirage.runtime.types import DispatchFn
-from mirage.types import FileStat, MountMode, PathSpec
+from mirage.types import FileStat, FileType, MountMode, PathSpec
+from mirage.utils.errors import NoMountError
 from mirage.utils.path import owner_prefix
 
 
@@ -40,7 +41,7 @@ class Ops:
     second pipeline here would be a second door, and it drifted from
     the real one exactly as expected: it served no cache, saw no
     namespace structure, and fired the gates only when a caller
-    remembered to hand it policies. TypeScript's ``WorkspaceFS`` takes
+    remembered to hand it policies. TypeScript's ``Ops`` takes
     the same stance.
     """
 
@@ -295,6 +296,69 @@ class Ops:
 
     async def readdir(self, path: str) -> list[str]:
         return await self._call("readdir", path)
+
+    # The three probes below answer "is this path there?", so only a
+    # genuine missing path may read back as False: the typed registry
+    # miss (NoMountError) and the backend's own absence. An auth
+    # failure, a timeout, or a backend bug is not an answer to that
+    # question; swallowing it would let a caller act on a false
+    # "missing" (overwrite, recreate, skip). Mirrors the TS facade.
+    async def exists(self, path: str) -> bool:
+        """True when a stat answers for the path.
+
+        Args:
+            path (str): Virtual path.
+        """
+        try:
+            await self.stat(path)
+        except (FileNotFoundError, NoMountError):
+            return False
+        return True
+
+    async def is_dir(self, path: str) -> bool:
+        """True when the path stats as a directory.
+
+        Args:
+            path (str): Virtual path.
+        """
+        try:
+            st = await self.stat(path)
+        except (FileNotFoundError, NoMountError):
+            return False
+        return st.type == FileType.DIRECTORY
+
+    async def is_file(self, path: str) -> bool:
+        """True when the path stats as anything but a directory.
+
+        Args:
+            path (str): Virtual path.
+        """
+        try:
+            st = await self.stat(path)
+        except (FileNotFoundError, NoMountError):
+            return False
+        return st.type != FileType.DIRECTORY
+
+    async def cat(self, path: str) -> str:
+        """The file's content as text (the TS facade's ``cat``).
+
+        Args:
+            path (str): Virtual path.
+        """
+        data = await self.read(path)
+        return data.decode("utf-8", errors="replace")
+
+    async def list_files(self, path: str) -> list[str]:
+        """Basenames of the directory's files, directories dropped.
+
+        Args:
+            path (str): Virtual path.
+        """
+        files = []
+        for entry in await self.readdir(path):
+            if await self.is_file(entry):
+                files.append(entry.rstrip("/").rsplit("/", 1)[-1])
+        return files
 
     async def mkdir(self, path: str) -> None:
         await self._call("mkdir", path)

--- a/python/mirage/runtime/handles/constants.py
+++ b/python/mirage/runtime/handles/constants.py
@@ -12,19 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
+# The fopen mode alphabet: one base letter (r/w/a/x), at most one each
+# of +, b, t. parse_mode owns the rule; these tables are the vocabulary
+# it reads.
+MODE_CHARS = frozenset("rwaxbt+")
 
-from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.cache.context import invalidate_after_write
-from mirage.core.onedrive._client import graph_put_bytes, item_url, split_path
-from mirage.observe.context import record
-from mirage.types import PathSpec
-
-
-async def create(accessor: OneDriveAccessor, path: PathSpec) -> None:
-    _, stripped = split_path(path)
-    start_ms = int(time.monotonic() * 1000)
-    url = item_url(accessor.config, "/" + stripped, action="/content")
-    await graph_put_bytes(accessor.config, url, b"")
-    record("create", stripped, "onedrive", 0, start_ms)
-    await invalidate_after_write(path)
+# The legal base-letter sets: CPython's four plus C fopen's wx
+# (exclusive create), which CPython spells as a bare x.
+MODE_BASES = (frozenset("r"), frozenset("w"), frozenset("a"), frozenset("x"),
+              frozenset("wx"))

--- a/python/mirage/runtime/handles/mode.py
+++ b/python/mirage/runtime/handles/mode.py
@@ -14,6 +14,8 @@
 
 from dataclasses import dataclass
 
+_VALID = frozenset("rwaxbt+")
+
 
 @dataclass(frozen=True, slots=True)
 class OpenMode:
@@ -21,35 +23,63 @@ class OpenMode:
 
     One vocabulary for every dialect that opens by mode: quickjs's
     ``std.open`` and monty's ``path_open`` pass these strings verbatim,
-    and preview1's oflags/rights/fdflags translate onto the same five
-    facts in ``WasiFs.path_open``.
+    ``MirageFile`` takes one from embedding code, and preview1's
+    oflags/rights/fdflags translate onto the same facts in
+    ``WasiFs.path_open``.
 
     Args:
+        readable (bool): the handle may read (r, +).
         writable (bool): the handle may mutate its buffer (w, a, x, +).
         truncate (bool): opening discards existing content (w).
         append (bool): the position starts at the end (a).
         create (bool): a missing file is created (w, a, x).
         exclusive (bool): an existing file refuses the open (x).
+        binary (bool): the handle carries bytes, not text (b).
     """
 
+    readable: bool
     writable: bool
     truncate: bool
     append: bool
     create: bool
     exclusive: bool
+    binary: bool
+
+
+_BASES = ({"r"}, {"w"}, {"a"}, {"x"}, {"w", "x"})
 
 
 def parse_mode(mode: str) -> OpenMode:
-    """Read an fopen-style mode string into its five facts.
+    """Read an fopen-style mode string into its facts, validating it.
+
+    The rule is CPython's, the stricter of the two parsers this
+    replaced — one base, at most one each of ``+``, ``b``, ``t``, and
+    never ``b`` together with ``t`` — widened by one C-dialect
+    spelling: ``wx``, fopen's exclusive create, which CPython spells
+    as a bare ``x``. Both dialects open by mode through this one
+    parser, so it accepts the union. A guest engine that tolerates
+    looser spellings still (C fopen reads ``rr`` as ``r``) renders
+    this refusal in its own dialect at its own boundary.
 
     Args:
-        mode (str): the mode as the guest spelled it (``r``, ``w+b``,
-            ``a``, ...); unknown letters are ignored, matching fopen.
+        mode (str): the mode as the caller spelled it (``r``, ``w+b``,
+            ``a``, ``wx``, ...).
+
+    Raises:
+        ValueError: the mode does not parse, in CPython's own wording.
     """
+    if (not mode or any(char not in _VALID for char in mode)
+            or any(mode.count(char) > 1 for char in _VALID)
+            or ("b" in mode and "t" in mode)
+            or set(mode) & set("rwax") not in _BASES):
+        raise ValueError(f"invalid mode: {mode!r}")
+    plus = "+" in mode
     return OpenMode(
-        writable=any(c in mode for c in "wax+"),
+        readable="r" in mode or plus,
+        writable="r" not in mode or plus,
         truncate="w" in mode,
         append="a" in mode,
-        create=any(c in mode for c in "wax"),
+        create=any(char in mode for char in "wax"),
         exclusive="x" in mode,
+        binary="b" in mode,
     )

--- a/python/mirage/runtime/handles/mode.py
+++ b/python/mirage/runtime/handles/mode.py
@@ -69,8 +69,8 @@ def parse_mode(mode: str) -> OpenMode:
         ValueError: the mode does not parse, in CPython's own wording.
     """
     if (not mode or any(char not in _VALID for char in mode)
-            or any(mode.count(char) > 1 for char in _VALID)
-            or ("b" in mode and "t" in mode)
+            or any(mode.count(char) > 1
+                   for char in _VALID) or ("b" in mode and "t" in mode)
             or set(mode) & set("rwax") not in _BASES):
         raise ValueError(f"invalid mode: {mode!r}")
     plus = "+" in mode

--- a/python/mirage/runtime/handles/mode.py
+++ b/python/mirage/runtime/handles/mode.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass
 
-_VALID = frozenset("rwaxbt+")
+from mirage.runtime.handles.constants import MODE_BASES, MODE_CHARS
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,9 +46,6 @@ class OpenMode:
     binary: bool
 
 
-_BASES = ({"r"}, {"w"}, {"a"}, {"x"}, {"w", "x"})
-
-
 def parse_mode(mode: str) -> OpenMode:
     """Read an fopen-style mode string into its facts, validating it.
 
@@ -68,10 +65,10 @@ def parse_mode(mode: str) -> OpenMode:
     Raises:
         ValueError: the mode does not parse, in CPython's own wording.
     """
-    if (not mode or any(char not in _VALID for char in mode)
+    if (not mode or any(char not in MODE_CHARS for char in mode)
             or any(mode.count(char) > 1
-                   for char in _VALID) or ("b" in mode and "t" in mode)
-            or set(mode) & set("rwax") not in _BASES):
+                   for char in MODE_CHARS) or ("b" in mode and "t" in mode)
+            or set(mode) & set("rwax") not in MODE_BASES):
         raise ValueError(f"invalid mode: {mode!r}")
     plus = "+" in mode
     return OpenMode(

--- a/python/mirage/runtime/python/monty/osaccess.py
+++ b/python/mirage/runtime/python/monty/osaccess.py
@@ -168,9 +168,22 @@ class MirageOSAccess(OSAccess):
 
     def path_open(self, path: PurePosixPath, mode: str) -> MontyFileHandle:
         self._ensure_file(path)
-        if parse_mode(mode).writable:
+        facts = parse_mode(mode)
+        if facts.writable:
             self._ensure_dir(path.parent)
-        return super().path_open(path, mode)
+        existed = self._get_entry(path) is not None
+        handle = super().path_open(path, mode)
+        # The mode's open-time effect on the mount, the same
+        # establishing op quickjs's shim and wasi's path_open dispatch:
+        # 'w' truncates what exists and creates what does not, 'a'
+        # creates what does not. Without it a bare open/close never
+        # flushes (there is no delta), so the file either kept its old
+        # bytes or never existed at all.
+        if existed and facts.truncate:
+            self._vfs.truncate(str(path))
+        elif not existed and facts.create:
+            self._vfs.create(str(path))
+        return handle
 
     def path_read_text(self, path: PurePosixPath | MontyFileHandle) -> str:
         self._ensure_file(path_from_arg(path))

--- a/python/mirage/runtime/python/monty/osaccess.py
+++ b/python/mirage/runtime/python/monty/osaccess.py
@@ -69,7 +69,10 @@ class MirageOSAccess(OSAccess):
         return self._vfs.read(virtual)
 
     def _list_remote(self, virtual: str) -> list[str] | None:
-        return self._vfs.readdir(virtual)
+        entries = self._vfs.readdir(virtual)
+        if entries is None:
+            return None
+        return [entry.path for entry in entries]
 
     def _tree_bytes(self, path: PurePosixPath) -> bytes | None:
         entry = self._get_entry(path)

--- a/python/mirage/runtime/python/monty/vfs.py
+++ b/python/mirage/runtime/python/monty/vfs.py
@@ -79,6 +79,18 @@ class MontyVFS:
         self._core.append(virtual, data, whole)
         self._missing.discard(virtual)
 
+    def create(self, virtual: str) -> None:
+        if self._core is None:
+            return
+        self._core.create(virtual)
+        self._missing.discard(virtual)
+
+    def truncate(self, virtual: str) -> None:
+        if self._core is None:
+            return
+        self._core.truncate(virtual)
+        self._missing.discard(virtual)
+
     def mkdir(self, virtual: str, parents: bool) -> None:
         if self._core is None:
             return

--- a/python/mirage/runtime/python/monty/vfs.py
+++ b/python/mirage/runtime/python/monty/vfs.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.runtime.types import VFSEntry
 from mirage.runtime.vfs import RuntimeVFS
 
 
@@ -49,7 +50,7 @@ class MontyVFS:
             self._missing.add(virtual)
             return None
 
-    def readdir(self, virtual: str) -> list[str] | None:
+    def readdir(self, virtual: str) -> list[VFSEntry] | None:
         """The directory's entries, or None when it is not a directory."""
         if self._core is None:
             return None

--- a/python/mirage/runtime/types.py
+++ b/python/mirage/runtime/types.py
@@ -62,6 +62,32 @@ PrefixSource: TypeAlias = Callable[[], list[str]]
 
 
 @dataclass(frozen=True, slots=True)
+class VFSEntry:
+    """One directory entry as the mounts report it (TS ``VFSEntry``).
+
+    Resolved once at the door off the stat index the readdir just
+    populated, so no guest pays one stat per entry for a fact the door
+    already had.
+
+    Args:
+        path (str): the entry's virtual path, in the door's own
+            spelling (a backend that slash-marks directories keeps the
+            trailing slash).
+        size (int): rendered content bytes, 0 for directories and for
+            entries whose stat answered absent.
+        is_dir (bool): the entry is a directory.
+        is_link (bool): the entry is a namespace symlink. The TS
+            bridge marks it from its namespace; python rows carry
+            False until links enter dispatch (R8).
+    """
+
+    path: str
+    size: int
+    is_dir: bool
+    is_link: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class ScriptSource:
     """Script source arriving from a workspace config, not from code.
 

--- a/python/mirage/runtime/vfs.py
+++ b/python/mirage/runtime/vfs.py
@@ -18,6 +18,8 @@ from typing import Any, Callable
 
 from mirage.context import (get_current_session, reset_current_session,
                             set_current_session)
+from mirage.observe.context import (active_recorder, reset_active_recorder,
+                                    set_active_recorder)
 from mirage.runtime.errors import CrossMountError
 from mirage.runtime.handles import plan_flush
 from mirage.runtime.resolver import MountResolver
@@ -44,12 +46,14 @@ class RuntimeVFS:
     that caller. The hop cannot carry the launching task's contextvars:
     what travels is the calling thread's context, and the threads guest
     calls arrive on (monty's tokio workers, wasmtime's run thread) never
-    had the session bound. So the VFS captures the session on the
-    launching task at construction — every runtime builds one per run,
-    and monty builds one per eval — and re-binds it around each
-    dispatched op, the same bracket FUSE's ``MountCore`` puts around its
-    ops. Session mount modes are then enforced inside the op exactly as
-    they are for a shell command.
+    had the session bound. So the VFS captures the session and the op
+    recorder on the launching task at construction — every runtime
+    builds one per run, and monty builds one per eval — and re-binds
+    both around each dispatched op, the same bracket FUSE's
+    ``MountCore`` puts around its ops. Session mount modes are then
+    enforced inside the op exactly as they are for a shell command, and
+    a guest's file I/O lands on the typed line's ledger exactly as a
+    shell command's does.
 
     Args:
         dispatch (Callable): the workspace dispatch coroutine function.
@@ -67,6 +71,7 @@ class RuntimeVFS:
         self._resolver = resolver
         self._no_append: set[str] = set()
         self._session = get_current_session()
+        self._recorder = active_recorder()
 
     def _raw(self, op: str, path: str, **kwargs: Any) -> Any:
         coro = self._dispatch(op, PathSpec.from_str_path(path), **kwargs)
@@ -75,22 +80,27 @@ class RuntimeVFS:
         return result
 
     async def _bind_session(self, coro: Coroutine[Any, Any, Any]) -> Any:
-        """Run one dispatched op under the captured launch session.
+        """Run one dispatched op under the captured launch context.
 
-        Set inside the coroutine so the token lands on the event-loop
+        Set inside the coroutine so the tokens land on the event-loop
         task that executes the op, mirroring ``MountCore._bind_session``.
+        Binds the session (mount modes) and the op recorder (the typed
+        line's ledger) together: both were captured on the launching
+        task and both are invisible to the thread the guest called from.
 
         Args:
             coro (Coroutine): the dispatch coroutine to run under the
-                session.
+                session and recorder.
 
         Returns:
             Any: whatever the wrapped coroutine returns.
         """
         token = set_current_session(self._session)
+        rec_token = set_active_recorder(self._recorder)
         try:
             return await coro
         finally:
+            reset_active_recorder(rec_token)
             reset_current_session(token)
 
     def call(self, op: str, path: str, **kwargs: Any) -> Any:

--- a/python/mirage/runtime/vfs.py
+++ b/python/mirage/runtime/vfs.py
@@ -21,9 +21,11 @@ from mirage.context import (get_current_session, reset_current_session,
 from mirage.runtime.errors import CrossMountError
 from mirage.runtime.handles import plan_flush
 from mirage.runtime.resolver import MountResolver
+from mirage.runtime.types import VFSEntry
 from mirage.types import FileStat, PathSpec
 from mirage.utils.errors import OperationNotSupportedError
 from mirage.utils.path import norm
+from mirage.utils.stat_view import content_size, is_dir
 
 
 class RuntimeVFS:
@@ -149,8 +151,32 @@ class RuntimeVFS:
     def stat(self, path: str) -> FileStat:
         return self.call("stat", path)
 
-    def readdir(self, path: str) -> list[str]:
-        return list(self.call("readdir", path))
+    def readdir(self, path: str) -> list[VFSEntry]:
+        """List a directory as resolved entries (the TS bridge's shape).
+
+        A backend that slash-marks directories skips the stat; every
+        other entry is classified by the stat the readdir just
+        populated the index with, so the lookup is RAM, not another
+        API call. An entry that vanished between list and stat (or a
+        dangling link) rides as a size-0 file instead of failing the
+        whole listing: the guest's own open reports the miss.
+
+        Args:
+            path (str): guest-absolute virtual path.
+        """
+        entries: list[VFSEntry] = []
+        for raw in self.call("readdir", path):
+            if raw.endswith("/"):
+                entries.append(VFSEntry(path=raw, size=0, is_dir=True))
+                continue
+            try:
+                st = self.call("stat", raw)
+            except FileNotFoundError:
+                entries.append(VFSEntry(path=raw, size=0, is_dir=False))
+                continue
+            entries.append(
+                VFSEntry(path=raw, size=content_size(st), is_dir=is_dir(st)))
+        return entries
 
     def create(self, path: str) -> None:
         self.call("create", path)

--- a/python/mirage/runtime/wasm/vfs.py
+++ b/python/mirage/runtime/wasm/vfs.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from mirage.runtime.vfs import RuntimeVFS
-from mirage.runtime.wasm.abi import FT_DIR, FT_UNKNOWN
+from mirage.runtime.wasm.abi import FT_DIR, FT_REG
 from mirage.runtime.wasm.build import BuildDir
 from mirage.runtime.wasm.config import WasmFsConfig
 from mirage.runtime.wasm.constants import READONLY_HINT
@@ -220,8 +220,9 @@ class WasmVFS:
     def readdir(self, path: str) -> list[tuple[str, int]]:
         """List a guest directory as (name, preview1 filetype) pairs.
 
-        Core entries whose kind the backend does not report come back
-        FT_UNKNOWN; guests stat lazily when they care.
+        Core entries arrive kind-resolved (the door stats what the
+        backend does not slash-mark), so a guest's ``d_type`` is real
+        instead of FT_UNKNOWN paid off with one lazy stat per entry.
 
         Args:
             path (str): guest-absolute path.
@@ -234,14 +235,12 @@ class WasmVFS:
         return self._readdir_core(path)
 
     def _readdir_core(self, path: str) -> list[tuple[str, int]]:
-        names = self._core_call("readdir", path)
         entries: dict[str, int] = {}
-        for raw in names:
-            base = raw.rstrip("/").rsplit("/", 1)[-1]
+        for entry in self._require_core().readdir(path):
+            base = entry.path.rstrip("/").rsplit("/", 1)[-1]
             if not base:
                 continue
-            kind = FT_DIR if raw.endswith("/") else FT_UNKNOWN
-            entries[base] = kind
+            entries[base] = FT_DIR if entry.is_dir else FT_REG
         return sorted(entries.items())
 
     def _readdir_root(self) -> list[tuple[str, int]]:
@@ -249,7 +248,7 @@ class WasmVFS:
 
         The core's readdir already carries mount structure (the door
         merges child mounts and links), so no prefix synthesis happens
-        here; mount entries arrive kind-unknown and guests stat lazily,
+        here; mount entries arrive kind-resolved by the core listing,
         which the door also answers for structure-only directories.
         """
         entries: dict[str, int] = {}

--- a/python/mirage/utils/mode.py
+++ b/python/mirage/utils/mode.py
@@ -22,7 +22,7 @@ DEFAULT_DIR_MODE = 0o755
 DEFAULT_FILE_MODE = 0o644
 
 
-def parse_mode(text: str, current: int) -> int | None:
+def parse_chmod(text: str, current: int) -> int | None:
     """Parse a chmod MODE argument (octal or symbolic).
 
     Symbolic supports the common grammar: ``[ugoa...][+-=][rwx...]``
@@ -38,9 +38,9 @@ def parse_mode(text: str, current: int) -> int | None:
 
     Example::
 
-        parse_mode("644", 0)          -> 0o644
-        parse_mode("u+x", 0o644)      -> 0o744
-        parse_mode("a=r", 0o777)      -> 0o444
+        parse_chmod("644", 0)          -> 0o644
+        parse_chmod("u+x", 0o644)      -> 0o744
+        parse_chmod("a=r", 0o777)      -> 0o444
     """
     if text and all(c in "01234567" for c in text):
         value = int(text, 8)
@@ -68,4 +68,4 @@ def parse_mode(text: str, current: int) -> int | None:
     return mode
 
 
-__all__ = ["DEFAULT_DIR_MODE", "DEFAULT_FILE_MODE", "parse_mode"]
+__all__ = ["DEFAULT_DIR_MODE", "DEFAULT_FILE_MODE", "parse_chmod"]

--- a/python/mirage/workspace/executor/builtins/metadata.py
+++ b/python/mirage/workspace/executor/builtins/metadata.py
@@ -21,7 +21,8 @@ from mirage.io import IOResult
 from mirage.policy import PolicyDenied
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import FS_ERRORS, format_fs_error, fs_strerror
-from mirage.utils.mode import DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, parse_mode
+from mirage.utils.mode import (DEFAULT_DIR_MODE, DEFAULT_FILE_MODE,
+                              parse_chmod)
 from mirage.utils.path import CycleError, resolve_path
 from mirage.workspace.executor.builtins.shared import (Result, expand_operands,
                                                        fail, finish,
@@ -403,7 +404,7 @@ async def handle_chmod(
     if len(operands) < 2:
         return fail("chmod", "chmod: missing operand\n", 2)
     mode_text = operand_text(operands[0])
-    if parse_mode(mode_text, 0) is None:
+    if parse_chmod(mode_text, 0) is None:
         return fail("chmod", f"chmod: invalid mode: '{mode_text}'\n", 1)
 
     recursive = "R" in flags
@@ -426,7 +427,7 @@ async def handle_chmod(
             else:
                 current = (DEFAULT_DIR_MODE if path_stat.type
                            == FileType.DIRECTORY else DEFAULT_FILE_MODE)
-            new_mode = parse_mode(mode_text, current)
+            new_mode = parse_chmod(mode_text, current)
             if new_mode is None:
                 return fail("chmod", f"chmod: invalid mode: '{mode_text}'\n",
                             1)

--- a/python/mirage/workspace/executor/builtins/metadata.py
+++ b/python/mirage/workspace/executor/builtins/metadata.py
@@ -21,8 +21,7 @@ from mirage.io import IOResult
 from mirage.policy import PolicyDenied
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import FS_ERRORS, format_fs_error, fs_strerror
-from mirage.utils.mode import (DEFAULT_DIR_MODE, DEFAULT_FILE_MODE,
-                              parse_chmod)
+from mirage.utils.mode import DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, parse_chmod
 from mirage.utils.path import CycleError, resolve_path
 from mirage.workspace.executor.builtins.shared import (Result, expand_operands,
                                                        fail, finish,

--- a/python/tests/core/ram/test_create.py
+++ b/python/tests/core/ram/test_create.py
@@ -16,6 +16,7 @@ import pytest
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.core.ram.create import create
+from mirage.observe.context import RecordingScope
 from mirage.resource.ram.store import RAMStore
 from mirage.types import PathSpec
 
@@ -47,6 +48,23 @@ async def test_create_normalizes_path():
     a = RAMAccessor(s)
     await create(a, PathSpec.from_str_path("file.txt"))
     assert "/file.txt" in s.files
+
+
+@pytest.mark.asyncio
+async def test_create_records_its_own_op():
+    # A guest creating a file must land in the ledger as 'create', not
+    # as a zero-byte 'write' (the TS core's old shape) and not as
+    # nothing at all (this core's old shape): anything keyed on op
+    # names — policy, snapshots, integ truth — reads the same world in
+    # both languages.
+    s = RAMStore()
+    a = RAMAccessor(s)
+    scope = RecordingScope()
+    await create(a, PathSpec.from_str_path("/new.txt"))
+    scope.close()
+    assert [r.op for r in scope.records] == ["create"]
+    assert scope.records[0].bytes == 0
+    assert scope.records[0].source == "ram"
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/ram/test_truncate.py
+++ b/python/tests/core/ram/test_truncate.py
@@ -1,0 +1,55 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.accessor.ram import RAMAccessor
+from mirage.core.ram.truncate import truncate
+from mirage.observe.context import RecordingScope
+from mirage.resource.ram.store import RAMStore
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_truncate_to_zero_empties_the_file():
+    s = RAMStore()
+    a = RAMAccessor(s)
+    s.files["/t.txt"] = b"previous"
+    await truncate(a, PathSpec.from_str_path("/t.txt"), 0)
+    assert s.files["/t.txt"] == b""
+
+
+@pytest.mark.asyncio
+async def test_truncate_extends_with_nul_bytes():
+    s = RAMStore()
+    a = RAMAccessor(s)
+    s.files["/t.txt"] = b"ab"
+    await truncate(a, PathSpec.from_str_path("/t.txt"), 4)
+    assert s.files["/t.txt"] == b"ab\x00\x00"
+
+
+@pytest.mark.asyncio
+async def test_truncate_records_its_own_op():
+    # The op used to leave no record at all, so a guest's 'w' open on
+    # an existing file was invisible to the ledger while the same open
+    # on a missing file was not.
+    s = RAMStore()
+    a = RAMAccessor(s)
+    s.files["/t.txt"] = b"previous"
+    scope = RecordingScope()
+    await truncate(a, PathSpec.from_str_path("/t.txt"), 0)
+    scope.close()
+    assert [r.op for r in scope.records] == ["truncate"]
+    assert scope.records[0].bytes == 0
+    assert scope.records[0].source == "ram"

--- a/python/tests/ops/test_file.py
+++ b/python/tests/ops/test_file.py
@@ -161,13 +161,17 @@ class TestMirageFile:
         assert _read(ops, "/data/dir/f.txt") == b"visible"
         f.close()
 
-    def test_exclusive_mode_creates_once(self):
+    @pytest.mark.parametrize("mode", ["x", "wx"])
+    def test_exclusive_mode_creates_once(self, mode):
         ops, _ = make_ops_with_dir()
-        with MirageFile(ops, "/data/dir/f.txt", "x") as f:
+        with MirageFile(ops, "/data/dir/f.txt", mode) as f:
             f.write("new")
         assert _read(ops, "/data/dir/f.txt") == b"new"
         with pytest.raises(FileExistsError):
-            MirageFile(ops, "/data/dir/f.txt", "x")
+            MirageFile(ops, "/data/dir/f.txt", mode)
+        # wx carries the truncate fact too; exclusivity must win, so a
+        # refused open leaves the existing content untouched.
+        assert _read(ops, "/data/dir/f.txt") == b"new"
 
     def test_append_mode_creates_missing_file_on_open(self):
         ops, _ = make_ops_with_dir()

--- a/python/tests/ops/test_ops.py
+++ b/python/tests/ops/test_ops.py
@@ -463,3 +463,44 @@ class TestAttachedOpsOneDoor:
             assert await ws.ops.read("/a/y.txt") == b"body"
         finally:
             await ws.close()
+
+
+class TestProbesAndConveniences:
+    """The surface union with the TS facade (R7b).
+
+    Only a genuine missing path reads back False from the probes; an
+    auth failure or a backend bug propagates, since acting on a false
+    "missing" means overwriting or recreating data that is there.
+    """
+
+    def test_exists_answers_the_three_cases(self):
+        ops, _ = make_ops()
+        run(ops.write("/data/a.txt", b"x"))
+        run(ops.mkdir("/data/dir"))
+        assert run(ops.exists("/data/a.txt")) is True
+        assert run(ops.exists("/data/dir")) is True
+        assert run(ops.exists("/data/nope.txt")) is False
+        assert run(ops.exists("/nowhere/x.txt")) is False
+
+    def test_is_dir_and_is_file_split_on_the_stat_type(self):
+        ops, _ = make_ops()
+        run(ops.mkdir("/data/dir"))
+        run(ops.write("/data/dir/f.txt", b"x"))
+        assert run(ops.is_dir("/data/dir")) is True
+        assert run(ops.is_file("/data/dir")) is False
+        assert run(ops.is_file("/data/dir/f.txt")) is True
+        assert run(ops.is_dir("/data/dir/f.txt")) is False
+        assert run(ops.is_dir("/data/nope")) is False
+        assert run(ops.is_file("/data/nope")) is False
+
+    def test_cat_decodes_utf8(self):
+        ops, _ = make_ops()
+        run(ops.write("/data/a.txt", "héllo".encode()))
+        assert run(ops.cat("/data/a.txt")) == "héllo"
+
+    def test_list_files_keeps_files_only_as_basenames(self):
+        ops, _ = make_ops()
+        run(ops.mkdir("/data/dir"))
+        run(ops.write("/data/dir/a.txt", b"1"))
+        run(ops.mkdir("/data/dir/sub"))
+        assert run(ops.list_files("/data/dir")) == ["a.txt"]

--- a/python/tests/runtime/handles/test_constants.py
+++ b/python/tests/runtime/handles/test_constants.py
@@ -12,19 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
-from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.cache.context import invalidate_after_write
-from mirage.core.onedrive._client import graph_put_bytes, item_url, split_path
-from mirage.observe.context import record
-from mirage.types import PathSpec
+from mirage.runtime.handles.constants import MODE_BASES, MODE_CHARS
 
 
-async def create(accessor: OneDriveAccessor, path: PathSpec) -> None:
-    _, stripped = split_path(path)
-    start_ms = int(time.monotonic() * 1000)
-    url = item_url(accessor.config, "/" + stripped, action="/content")
-    await graph_put_bytes(accessor.config, url, b"")
-    record("create", stripped, "onedrive", 0, start_ms)
-    await invalidate_after_write(path)
+def test_every_base_spelling_draws_from_the_mode_alphabet():
+    for base in MODE_BASES:
+        assert base <= MODE_CHARS
+
+
+def test_the_bases_are_cpythons_four_plus_c_fopens_wx():
+    assert set(MODE_BASES) == {
+        frozenset("r"),
+        frozenset("w"),
+        frozenset("a"),
+        frozenset("x"),
+        frozenset("wx"),
+    }

--- a/python/tests/runtime/handles/test_mode.py
+++ b/python/tests/runtime/handles/test_mode.py
@@ -12,17 +12,65 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import pytest
+
 from mirage.runtime.handles.mode import parse_mode
 
 
-def test_parse_mode_reads_the_five_facts():
+def test_parse_mode_reads_the_facts():
     read = parse_mode("r")
     assert not read.writable and not read.create
+    assert read.readable and not read.binary
     update = parse_mode("r+b")
     assert update.writable and not update.truncate and not update.create
+    assert update.readable and update.binary
     write = parse_mode("w")
     assert write.writable and write.truncate and write.create
+    assert not write.readable
     append = parse_mode("a")
     assert append.writable and append.append and not append.truncate
+    assert not append.readable
     exclusive = parse_mode("x")
     assert exclusive.writable and exclusive.exclusive and exclusive.create
+    assert not exclusive.readable
+
+
+def test_plus_makes_every_base_readable_and_writable():
+    for spelling in ("r+", "w+", "a+", "x+"):
+        mode = parse_mode(spelling)
+        assert mode.readable, spelling
+        assert mode.writable, spelling
+
+
+def test_wx_is_c_fopen_exclusive_create():
+    # CPython spells exclusive creation as a bare 'x'; C fopen (and so
+    # qjs-wasi's std.open) spells it 'wx'. One parser serves both
+    # dialects, so both spellings answer the same facts.
+    mode = parse_mode("wx")
+    assert mode.exclusive and mode.create and mode.truncate
+    assert mode.writable and not mode.readable
+
+
+@pytest.mark.parametrize("bad", [
+    "",
+    "q",
+    "rw",
+    "rr",
+    "r++",
+    "rbb",
+    "rbt",
+    "wq",
+    "b",
+])
+def test_garbage_modes_raise_the_cpython_refusal(bad: str):
+    # One parser, the stricter half's rule: exactly one of rwax, at
+    # most one each of +, b, t, and never b with t. The message is
+    # CPython's own, so a guest and an embedder read the same refusal.
+    with pytest.raises(ValueError, match="invalid mode"):
+        parse_mode(bad)
+
+
+def test_text_flag_is_accepted_and_not_binary():
+    mode = parse_mode("rt")
+    assert not mode.binary
+    assert mode.readable

--- a/python/tests/runtime/python/monty/test_osaccess.py
+++ b/python/tests/runtime/python/monty/test_osaccess.py
@@ -32,6 +32,8 @@ class FakeDispatch:
         self.supports_append = supports_append
         self.writes: list[tuple[str, bytes]] = []
         self.appends: list[tuple[str, bytes]] = []
+        self.created: list[str] = []
+        self.truncated: list[str] = []
         self.unlinked: list[str] = []
         self.dirs: list[str] = []
         self.renamed: list[tuple[str, str]] = []
@@ -73,6 +75,14 @@ class FakeDispatch:
             data = kwargs["data"]
             self.files[virtual] = self.files.get(virtual, b"") + data
             self.appends.append((virtual, data))
+            return None, None
+        if op == "create":
+            self.files[virtual] = b""
+            self.created.append(virtual)
+            return None, None
+        if op == "truncate":
+            self.files[virtual] = b""
+            self.truncated.append(virtual)
             return None, None
         if op == "unlink":
             self.files.pop(virtual, None)
@@ -119,6 +129,54 @@ def test_monty_missing_virtual_file():
     result = asyncio.run(runtime.run(RunArgs(code="open('/s3/missing.txt')")))
     assert result.exit_code == 1
     assert b"FileNotFoundError" in result.stderr
+
+
+def test_monty_open_w_creates_a_missing_file_at_open():
+    # CPython's open('w') leaves an empty file even when nothing is
+    # written; before the establishing op fired at open, the file only
+    # ever reached the mount through a later flush, so a bare
+    # open/close left nothing behind. The seed keeps /s3 listable,
+    # which is what the fake calls an existing directory.
+    dispatch = FakeDispatch({"/s3/seed.txt": b"x"})
+    runtime = MontyRuntime()
+    runtime.attach(dispatch, PrefixResolver(lambda: []))
+    result = asyncio.run(
+        runtime.run(RunArgs(code="open('/s3/new.txt', 'w').close()")))
+    assert result.exit_code == 0
+    assert dispatch.created == ["/s3/new.txt"]
+    assert dispatch.files["/s3/new.txt"] == b""
+
+
+def test_monty_open_w_truncates_an_existing_file_at_open():
+    dispatch = FakeDispatch({"/s3/keep.txt": b"old-bytes"})
+    runtime = MontyRuntime()
+    runtime.attach(dispatch, PrefixResolver(lambda: []))
+    result = asyncio.run(
+        runtime.run(RunArgs(code="open('/s3/keep.txt', 'w').close()")))
+    assert result.exit_code == 0
+    assert dispatch.truncated == ["/s3/keep.txt"]
+    assert dispatch.files["/s3/keep.txt"] == b""
+
+
+def test_monty_open_a_creates_a_missing_file_at_open():
+    dispatch = FakeDispatch({"/s3/seed.txt": b"x"})
+    runtime = MontyRuntime()
+    runtime.attach(dispatch, PrefixResolver(lambda: []))
+    result = asyncio.run(
+        runtime.run(RunArgs(code="open('/s3/log.txt', 'a').close()")))
+    assert result.exit_code == 0
+    assert dispatch.created == ["/s3/log.txt"]
+
+
+def test_monty_open_r_establishes_nothing():
+    dispatch = FakeDispatch({"/s3/a.txt": b"x"})
+    runtime = MontyRuntime()
+    runtime.attach(dispatch, PrefixResolver(lambda: []))
+    result = asyncio.run(runtime.run(
+        RunArgs(code="open('/s3/a.txt').close()")))
+    assert result.exit_code == 0
+    assert dispatch.created == []
+    assert dispatch.truncated == []
 
 
 def test_monty_write_flushes_through_dispatch():

--- a/python/tests/runtime/python/monty/test_osaccess.py
+++ b/python/tests/runtime/python/monty/test_osaccess.py
@@ -18,6 +18,7 @@ import errno
 from mirage.runtime.python import MontyRuntime
 from mirage.runtime.resolver import PrefixResolver
 from mirage.runtime.types import RunArgs
+from mirage.types import FileStat, FileType
 from mirage.utils.errors import OperationNotSupportedError
 
 
@@ -42,12 +43,19 @@ class FakeDispatch:
             if virtual not in self.files:
                 raise FileNotFoundError(virtual)
             return self.files[virtual], None
+        if op == "stat":
+            if virtual in self.files:
+                return FileStat(name=virtual,
+                                size=len(self.files[virtual]),
+                                type=FileType.TEXT), None
+            raise FileNotFoundError(virtual)
         if op == "readdir":
+            # Full virtual paths, the door's own shape.
             prefix = virtual.rstrip("/") + "/"
             names = set()
             for p in self.files:
                 if p.startswith(prefix):
-                    names.add(p[len(prefix):].split("/")[0])
+                    names.add(prefix + p[len(prefix):].split("/")[0])
             if not names and virtual.rstrip("/") not in ("", "/"):
                 raise FileNotFoundError(virtual)
             return sorted(names), None

--- a/python/tests/runtime/python/monty/test_vfs.py
+++ b/python/tests/runtime/python/monty/test_vfs.py
@@ -15,6 +15,7 @@
 from mirage.runtime.python.monty.vfs import MontyVFS
 from mirage.runtime.resolver import PrefixResolver
 from mirage.runtime.vfs import RuntimeVFS
+from mirage.types import FileStat, FileType
 
 
 class CountingCore(RuntimeVFS):
@@ -37,10 +38,17 @@ class CountingCore(RuntimeVFS):
             if path not in self.files:
                 raise FileNotFoundError(path)
             return self.files[path]
+        if op == "stat":
+            if path not in self.files:
+                raise FileNotFoundError(path)
+            return FileStat(name=path,
+                            size=len(self.files[path]),
+                            type=FileType.TEXT)
         if op == "readdir":
+            # Full virtual paths, the door's own shape.
             prefix = path.rstrip("/") + "/"
             names = {
-                p[len(prefix):].split("/")[0]
+                prefix + p[len(prefix):].split("/")[0]
                 for p in self.files if p.startswith(prefix)
             }
             if not names:
@@ -114,7 +122,7 @@ def test_a_listing_miss_is_not_cached_because_a_directory_may_gain_entries():
     vfs = MontyVFS(core)
     assert vfs.readdir("/s3/d") is None
     core.files["/s3/d/a.txt"] = b"1"
-    assert vfs.readdir("/s3/d") == ["a.txt"]
+    assert [e.path for e in vfs.readdir("/s3/d")] == ["/s3/d/a.txt"]
 
 
 def test_an_unwired_view_answers_none_and_swallows_no_mutation():

--- a/python/tests/runtime/test_conformance_worlds.py
+++ b/python/tests/runtime/test_conformance_worlds.py
@@ -652,3 +652,88 @@ async def test_guest_resolves_relative_path_against_cwd(
         assert "top" in out
     finally:
         await ws.close()
+
+
+# ── Group 5: an exclusive open refuses an existing file (R7a) ──
+#
+# fopen's `x`: the open must fail on an existing file and leave it
+# untouched, and must create a missing one. CPython raises
+# FileExistsError, qjs-wasi's std.open returns null (EEXIST under the
+# hood), and the TS quickjs shim answers the same by consuming
+# `OpenMode.exclusive` (its twin pin lives in workspace_js_mount.test.ts).
+# monty has no spelling: it refuses mode 'x' outright ("exclusive
+# creation mode is not supported"), which is its own honest answer.
+
+
+def exclusive_world(runtime: str) -> Workspace:
+    """One mount, one existing file the exclusive open must not touch.
+
+    Args:
+        runtime (str): registry name of the guest runtime to attach.
+    """
+    return Workspace(
+        {"/w": _seed({"/keep.txt": b"keep"})},
+        mode=MountMode.EXEC,
+        runtimes=[runtime, "vfs"],
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime,line",
+    _guest_cases({
+        "wasi":
+        "python3 -c \"\ntry:\n    open('/w/keep.txt', 'x')\n"
+        "except FileExistsError:\n    print('refused')\"",
+        "quickjs":
+        "node -e \"console.log(std.open('/w/keep.txt', 'wx') === null "
+        "? 'refused' : 'OPENED')\"",
+    }),
+)
+async def test_guest_exclusive_open_refuses_existing(runtime: str, line: str):
+    """An exclusive open over an existing file refuses and leaves it be.
+
+    Args:
+        runtime (str): guest runtime under test.
+        line (str): the exclusive-open line in that runtime's idiom.
+    """
+    ws = exclusive_world(runtime)
+    try:
+        code, out, err = await _sh(ws, line)
+        assert code == 0, err
+        assert "refused" in out
+        code, out, _ = await _sh(ws, "cat /w/keep.txt")
+        assert code == 0
+        assert out == "keep"
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime,line",
+    _guest_cases({
+        "wasi":
+        "python3 -c \"f = open('/w/made.txt', 'x'); f.write('made'); "
+        "f.close()\"",
+        "quickjs":
+        "node -e \"const f = std.open('/w/made.txt', 'wx'); "
+        "f.puts('made'); f.close()\"",
+    }),
+)
+async def test_guest_exclusive_open_creates_missing(runtime: str, line: str):
+    """The same mode on a missing file creates it.
+
+    Args:
+        runtime (str): guest runtime under test.
+        line (str): the exclusive-create line in that runtime's idiom.
+    """
+    ws = exclusive_world(runtime)
+    try:
+        code, _, err = await _sh(ws, line)
+        assert code == 0, err
+        code, out, _ = await _sh(ws, "cat /w/made.txt")
+        assert code == 0
+        assert out == "made"
+    finally:
+        await ws.close()

--- a/python/tests/runtime/test_vfs.py
+++ b/python/tests/runtime/test_vfs.py
@@ -21,9 +21,34 @@ from mirage.context import (get_current_session, reset_current_session,
                             set_current_session)
 from mirage.runtime.errors import CrossMountError
 from mirage.runtime.resolver import PrefixResolver
+from mirage.runtime.types import VFSEntry
 from mirage.runtime.vfs import RuntimeVFS
+from mirage.types import FileStat, FileType
 from mirage.utils.errors import OperationNotSupportedError
 from mirage.workspace.session import Session
+
+
+class ListingVFS(RuntimeVFS):
+    """Core double for the readdir lifting: canned listing and stats."""
+
+    def __init__(self, listing, stats):
+        super().__init__(dispatch=None,
+                         loop=None,
+                         resolver=PrefixResolver(lambda: []))
+        self._listing = list(listing)
+        self._stats = dict(stats)
+        self.stat_calls = []
+
+    def _raw(self, op, path, **kwargs):
+        if op == "readdir":
+            return list(self._listing)
+        if op == "stat":
+            self.stat_calls.append(path)
+            st = self._stats.get(path)
+            if st is None:
+                raise FileNotFoundError(path)
+            return st
+        raise NotImplementedError(op)
 
 
 class RecordingVFS(RuntimeVFS):
@@ -98,6 +123,44 @@ def test_rename_within_one_mount_dispatches():
     op, path, kwargs = vfs.calls[0]
     assert (op, path) == ("rename", "/data/a.txt")
     assert kwargs["dst"].virtual == "/data/b.txt"
+
+
+def test_readdir_lifts_names_into_entries():
+    # The TS bridge resolves path/size/isDir once at the door, off the
+    # stat index the readdir just populated; python answered bare names
+    # and every consumer re-parsed the trailing-slash convention, paying
+    # one guest stat per entry for a fact the door already had.
+    vfs = ListingVFS(
+        listing=["/data/sub/", "/data/a.txt", "/data/ghost.txt"],
+        stats={
+            "/data/a.txt":
+            FileStat(name="a.txt", size=4, type=FileType.TEXT),
+        },
+    )
+    assert vfs.readdir("/data/") == [
+        VFSEntry(path="/data/sub/", size=0, is_dir=True),
+        VFSEntry(path="/data/a.txt", size=4, is_dir=False),
+        VFSEntry(path="/data/ghost.txt", size=0, is_dir=False),
+    ]
+    # A slash-marked directory skips the stat; a vanished entry (or a
+    # dangling link) rides as a size-0 file instead of failing the
+    # whole listing.
+    assert vfs.stat_calls == ["/data/a.txt", "/data/ghost.txt"]
+
+
+def test_readdir_stats_unmarked_directories():
+    # RAM-style backends mark nothing with a slash; dir-ness comes from
+    # the stat.
+    vfs = ListingVFS(
+        listing=["/data/sub"],
+        stats={
+            "/data/sub":
+            FileStat(name="sub", type=FileType.DIRECTORY),
+        },
+    )
+    assert vfs.readdir("/data/") == [
+        VFSEntry(path="/data/sub", size=0, is_dir=True),
+    ]
 
 
 def test_flush_ships_only_the_delta():

--- a/python/tests/runtime/test_vfs.py
+++ b/python/tests/runtime/test_vfs.py
@@ -133,8 +133,7 @@ def test_readdir_lifts_names_into_entries():
     vfs = ListingVFS(
         listing=["/data/sub/", "/data/a.txt", "/data/ghost.txt"],
         stats={
-            "/data/a.txt":
-            FileStat(name="a.txt", size=4, type=FileType.TEXT),
+            "/data/a.txt": FileStat(name="a.txt", size=4, type=FileType.TEXT),
         },
     )
     assert vfs.readdir("/data/") == [
@@ -154,8 +153,7 @@ def test_readdir_stats_unmarked_directories():
     vfs = ListingVFS(
         listing=["/data/sub"],
         stats={
-            "/data/sub":
-            FileStat(name="sub", type=FileType.DIRECTORY),
+            "/data/sub": FileStat(name="sub", type=FileType.DIRECTORY),
         },
     )
     assert vfs.readdir("/data/") == [

--- a/python/tests/runtime/test_vfs.py
+++ b/python/tests/runtime/test_vfs.py
@@ -14,11 +14,13 @@
 
 import asyncio
 import threading
+import time
 
 import pytest
 
 from mirage.context import (get_current_session, reset_current_session,
                             set_current_session)
+from mirage.observe.context import RecordingScope, record
 from mirage.runtime.errors import CrossMountError
 from mirage.runtime.resolver import PrefixResolver
 from mirage.runtime.types import VFSEntry
@@ -223,6 +225,47 @@ async def test_the_hop_rebinds_the_launch_session_on_a_bare_thread():
     worker.start()
     await asyncio.to_thread(worker.join)
     assert dispatch.sessions == [sess]
+
+
+class LedgerDispatch(RecordingDispatch):
+    """Emits an op event inside the dispatched op, like a backend core."""
+
+    async def __call__(self, op, path, **kwargs):
+        record(op, path.virtual, "ram", 7, int(time.monotonic() * 1000))
+        return await super().__call__(op, path, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_the_hop_rebinds_the_launch_recorder_on_a_bare_thread():
+    # The op ledger is contextvar state exactly like the session: the
+    # threads guest calls arrive on never had it, and the loop task
+    # run_coroutine_threadsafe schedules gets the loop's context, not
+    # the typed line's. Without the rebind a guest's file I/O never
+    # reaches ws.ops.records while the same op from a shell line does.
+    dispatch = LedgerDispatch()
+    scope = RecordingScope()
+    try:
+        vfs = RuntimeVFS(dispatch, asyncio.get_running_loop())
+        worker = threading.Thread(target=vfs.read, args=("/data/f.txt", ))
+        worker.start()
+        await asyncio.to_thread(worker.join)
+    finally:
+        scope.close()
+    assert [(r.op, r.path) for r in scope.records] == [("read", "/data/f.txt")]
+
+
+@pytest.mark.asyncio
+async def test_a_recorderless_launch_dispatches_unrecorded():
+    dispatch = LedgerDispatch()
+    vfs = RuntimeVFS(dispatch, asyncio.get_running_loop())
+    scope = RecordingScope()
+    try:
+        worker = threading.Thread(target=vfs.read, args=("/data/f.txt", ))
+        worker.start()
+        await asyncio.to_thread(worker.join)
+    finally:
+        scope.close()
+    assert scope.records == []
 
 
 @pytest.mark.asyncio

--- a/python/tests/runtime/wasm/test_vfs.py
+++ b/python/tests/runtime/wasm/test_vfs.py
@@ -21,7 +21,7 @@ import pytest
 from mirage.ops.namespace_view import merge_readdir
 from mirage.runtime.resolver import PrefixResolver
 from mirage.runtime.vfs import RuntimeVFS
-from mirage.runtime.wasm.abi import FT_DIR, FT_REG, FT_UNKNOWN
+from mirage.runtime.wasm.abi import FT_DIR, FT_REG
 from mirage.runtime.wasm.config import WasmFsConfig
 from mirage.runtime.wasm.types import GuestStat
 from mirage.runtime.wasm.vfs import WasmVFS
@@ -57,7 +57,10 @@ class FakeVFS(RuntimeVFS):
                                 size=len(self.files[path]),
                                 modified=self.modified,
                                 type=FileType.TEXT)
-            if path in self.dirs or path == "/":
+            # The real door answers a directory for a structure-only
+            # path (a mount prefix with no backend object behind it).
+            roots = {p.rstrip("/") or "/" for p in self.prefixes()}
+            if path in self.dirs or path == "/" or path in roots:
                 return FileStat(name=path, type=FileType.DIRECTORY)
             raise FileNotFoundError(path)
         if op == "read":
@@ -152,12 +155,15 @@ def test_stat_maps_filestat_fields():
     assert fs.stat_or_none("/data/nope") is None
 
 
-def test_readdir_bridge_marks_kind_from_trailing_slash():
+def test_readdir_bridge_resolves_kind_from_slash_or_stat():
+    # A slash-marked entry is a directory without a stat; an unmarked
+    # one is classified by the stat the same readdir populated, so a
+    # guest's d_type is real instead of FT_UNKNOWN.
     bridge = FakeVFS(files={"/data/f.txt": b""},
                      dirs={"/data/sub"},
                      prefixes=["/data/"])
     fs = WasmVFS(core=bridge)
-    assert fs.readdir("/data") == [("f.txt", FT_UNKNOWN), ("sub", FT_DIR)]
+    assert fs.readdir("/data") == [("f.txt", FT_REG), ("sub", FT_DIR)]
 
 
 def test_readdir_root_merges_host_bridge_and_mounts(tmp_path):
@@ -166,14 +172,14 @@ def test_readdir_root_merges_host_bridge_and_mounts(tmp_path):
     bridge = FakeVFS(files={"/root.txt": b""}, prefixes=["/data/", "/logs/"])
     fs = WasmVFS(WasmFsConfig(host_root=str(tmp_path)), bridge)
     # Mount entries arrive through the core readdir (the door merges
-    # them), so their kind is unknown here; guests stat lazily and the
-    # door answers a directory for a structure-only path.
+    # them) and resolve as directories through the door's stat, which
+    # answers for a structure-only path.
     assert fs.readdir("/") == [
-        ("data", FT_UNKNOWN),
+        ("data", FT_DIR),
         ("lib", FT_DIR),
-        ("logs", FT_UNKNOWN),
+        ("logs", FT_DIR),
         ("python.wasm", FT_REG),
-        ("root.txt", FT_UNKNOWN),
+        ("root.txt", FT_REG),
     ]
 
 

--- a/python/tests/utils/test_mode.py
+++ b/python/tests/utils/test_mode.py
@@ -12,38 +12,38 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.utils.mode import parse_mode
+from mirage.utils.mode import parse_chmod
 
 
-def test_parse_mode_octal():
-    assert parse_mode("644", 0) == 0o644
-    assert parse_mode("0", 0o777) == 0
-    assert parse_mode("7777", 0) == 0o7777
+def test_parse_chmod_octal():
+    assert parse_chmod("644", 0) == 0o644
+    assert parse_chmod("0", 0o777) == 0
+    assert parse_chmod("7777", 0) == 0o7777
 
 
-def test_parse_mode_octal_out_of_range():
-    assert parse_mode("77777", 0) is None
+def test_parse_chmod_octal_out_of_range():
+    assert parse_chmod("77777", 0) is None
 
 
-def test_parse_mode_symbolic_add():
-    assert parse_mode("u+x", 0o644) == 0o744
-    assert parse_mode("+x", 0o644) == 0o755
+def test_parse_chmod_symbolic_add():
+    assert parse_chmod("u+x", 0o644) == 0o744
+    assert parse_chmod("+x", 0o644) == 0o755
 
 
-def test_parse_mode_symbolic_remove():
-    assert parse_mode("go-r", 0o644) == 0o600
+def test_parse_chmod_symbolic_remove():
+    assert parse_chmod("go-r", 0o644) == 0o600
 
 
-def test_parse_mode_symbolic_assign():
-    assert parse_mode("a=r", 0o777) == 0o444
-    assert parse_mode("u=rwx,go=", 0o644) == 0o700
+def test_parse_chmod_symbolic_assign():
+    assert parse_chmod("a=r", 0o777) == 0o444
+    assert parse_chmod("u=rwx,go=", 0o644) == 0o700
 
 
-def test_parse_mode_symbolic_comma_clauses():
-    assert parse_mode("u+x,g-r", 0o644) == 0o704
+def test_parse_chmod_symbolic_comma_clauses():
+    assert parse_chmod("u+x,g-r", 0o644) == 0o704
 
 
-def test_parse_mode_invalid():
-    assert parse_mode("zz", 0o644) is None
-    assert parse_mode("u~x", 0o644) is None
-    assert parse_mode("u+q", 0o644) is None
+def test_parse_chmod_invalid():
+    assert parse_chmod("zz", 0o644) is None
+    assert parse_chmod("u~x", 0o644) is None
+    assert parse_chmod("u+q", 0o644) is None

--- a/spec/layout_exceptions.json
+++ b/spec/layout_exceptions.json
@@ -1,5 +1,5 @@
 {
-  "baseline": 310,
+  "baseline": 305,
   "baseline_reason": "Every divergence below the excused ones predates the gate and each needs its own decision, so --strict fails on a rise rather than demanding zero. Lower this number whenever a divergence is closed; the gate fails on a drop too, so an improvement cannot be silently spent. Items 31-37 of the cleanup plan are scoped from this report. The unit is one module, never one directory: a one-sided directory counts once per module inside it, so it cannot absorb new modules without moving the number. An excused directory is the deliberate exception -- it excuses its whole subtree, because the excuse is that there is no counterpart to mirror, which makes growth inside it expected rather than drift.",
   "directories": {
     "python_only": {
@@ -29,5 +29,13 @@
       "core/hf/du": "Same hf/hf_buckets alias as above."
     }
   },
-  "modules": {}
+  "modules": {
+    "ops": {
+      "python_only": {
+        "file": "MirageFile: a sync file object over the Ops facade for embedding python code (with open-style usage). An npm consumer holds promises, not file objects, so there is nothing to mirror.",
+        "open": "The open() constructor for MirageFile; same embedding convenience as ops/file.",
+        "os_patch": "Patches the host interpreter's builtins.open/os functions onto a workspace, a CPython-only trick with no npm analogue."
+      }
+    }
+  }
 }

--- a/typescript/packages/browser/src/core/opfs/truncate.ts
+++ b/typescript/packages/browser/src/core/opfs/truncate.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { PathSpec } from '@struktoai/mirage-core'
+import { ResourceName, record, type PathSpec } from '@struktoai/mirage-core'
 import type { OPFSAccessor } from '../../accessor/opfs.ts'
 import { destError, isNotFound, resolveFileHandle, toWritableChunk } from './utils.ts'
 
@@ -21,6 +21,7 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
+  const start = performance.now()
   const root = accessor.rootHandle
   const virtual = path.mountPath
   let handle: FileSystemFileHandle
@@ -46,4 +47,5 @@ export async function truncate(
   const writable = await handle.createWritable()
   await writable.write(toWritableChunk(out))
   await writable.close()
+  record('truncate', virtual, ResourceName.OPFS, 0, start)
 }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/mkdir.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/mkdir.ts
@@ -19,7 +19,7 @@ import {
   isFsError,
   operandSpelling,
 } from '../../../../utils/errors.ts'
-import { DEFAULT_DIR_MODE, parseMode } from '../../../../utils/mode.ts'
+import { DEFAULT_DIR_MODE, parseChmod } from '../../../../utils/mode.ts'
 import { specOf } from '../../../spec/builtins.ts'
 import { FlagView } from '../../../spec/types.ts'
 import { type Builder, resolveGlobOf } from '../adapter.ts'
@@ -51,7 +51,7 @@ export const MKDIR_BUILDER: Builder = {
     if (modeText !== null) {
       // Symbolic clauses build on what mirage renders for a new directory,
       // since there is no umask to subtract from.
-      mode = parseMode(modeText, DEFAULT_DIR_MODE)
+      mode = parseChmod(modeText, DEFAULT_DIR_MODE)
       if (mode === null) throw new Error(`mkdir: invalid mode '${modeText}'`)
       if (setAttrs === undefined) {
         throw new Error('mkdir: --mode is not supported on this backend')

--- a/typescript/packages/core/src/core/ram/create.ts
+++ b/typescript/packages/core/src/core/ram/create.ts
@@ -12,10 +12,23 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { record } from '../../observe/context.ts'
 import type { RAMAccessor } from '../../accessor/ram.ts'
-import type { PathSpec } from '../../types.ts'
-import { writeBytes } from './write.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
+import { norm, nowIso } from './utils.ts'
+import { invalidateAfterWrite } from '../../cache/context.ts'
+import { checkDestParents } from './dest.ts'
 
-export function create(accessor: RAMAccessor, path: PathSpec): Promise<void> {
-  return writeBytes(accessor, path, new Uint8Array())
+export async function create(accessor: RAMAccessor, path: PathSpec): Promise<void> {
+  // Not a delegation to writeBytes: that recorded the op as 'write',
+  // so a guest creating a file and one writing one were the same row
+  // in the ledger.
+  const start = performance.now()
+  const p = norm(path.mountPath)
+  checkDestParents(accessor, path, p)
+  accessor.store.files.set(p, new Uint8Array())
+  accessor.store.modified.set(p, nowIso())
+  record('create', p, ResourceName.RAM, 0, start)
+  await invalidateAfterWrite(path)
+  return Promise.resolve()
 }

--- a/typescript/packages/core/src/core/ram/truncate.ts
+++ b/typescript/packages/core/src/core/ram/truncate.ts
@@ -12,8 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { record } from '../../observe/context.ts'
 import type { RAMAccessor } from '../../accessor/ram.ts'
-import type { PathSpec } from '../../types.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
 import { norm, nowIso } from './utils.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
 
@@ -22,12 +23,14 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
+  const start = performance.now()
   const p = norm(path.mountPath)
   const existing = accessor.store.files.get(p) ?? new Uint8Array()
   const out = new Uint8Array(length)
   out.set(existing.subarray(0, Math.min(existing.byteLength, length)))
   accessor.store.files.set(p, out)
   accessor.store.modified.set(p, nowIso())
+  record('truncate', p, ResourceName.RAM, 0, start)
   await invalidateAfterWrite(path)
   return Promise.resolve()
 }

--- a/typescript/packages/core/src/core/s3/create.ts
+++ b/typescript/packages/core/src/core/s3/create.ts
@@ -12,14 +12,16 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { PathSpec } from '../../types.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
+import { record } from '../../observe/context.ts'
 import { loadS3Module, rawPathOf, s3Key, withClient } from './_client.ts'
 
 export async function create(accessor: S3Accessor, path: PathSpec): Promise<void> {
   const { PutObjectCommand } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
+  const start = performance.now()
   await withClient(accessor.config, async (client) => {
     await client.send(
       new PutObjectCommand({
@@ -29,5 +31,6 @@ export async function create(accessor: S3Accessor, path: PathSpec): Promise<void
       }),
     )
   })
+  record('create', path.virtual, ResourceName.S3, 0, start)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/core/src/core/s3/truncate.ts
+++ b/typescript/packages/core/src/core/s3/truncate.ts
@@ -13,8 +13,9 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { invalidateAfterWrite } from '../../cache/context.ts'
-import type { PathSpec } from '../../types.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
+import { record } from '../../observe/context.ts'
 import {
   isNotFoundError,
   loadS3Module,
@@ -32,6 +33,7 @@ export async function truncate(
   const { GetObjectCommand, PutObjectCommand } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
   const key = s3Key(raw, accessor.config)
+  const start = performance.now()
   await withClient(accessor.config, async (client) => {
     let existing: Uint8Array = new Uint8Array()
     try {
@@ -47,5 +49,6 @@ export async function truncate(
     // Remaining bytes are already zero-filled (Uint8Array default).
     await client.send(new PutObjectCommand({ Bucket: accessor.config.bucket, Key: key, Body: out }))
   })
+  record('truncate', path.virtual, ResourceName.S3, 0, start)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/core/src/core/s3/write.ts
+++ b/typescript/packages/core/src/core/s3/write.ts
@@ -13,13 +13,15 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { invalidateAfterWrite } from '../../cache/context.ts'
-import type { PathSpec } from '../../types.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
+import { record } from '../../observe/context.ts'
 import { loadS3Module, rawPathOf, s3Key, withClient } from './_client.ts'
 
 export async function write(accessor: S3Accessor, path: PathSpec, data: Uint8Array): Promise<void> {
   const { PutObjectCommand } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
+  const start = performance.now()
   await withClient(accessor.config, async (client) => {
     await client.send(
       new PutObjectCommand({
@@ -29,5 +31,6 @@ export async function write(accessor: S3Accessor, path: PathSpec, data: Uint8Arr
       }),
     )
   })
+  record('write', path.virtual, ResourceName.S3, data.byteLength, start)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -136,6 +136,7 @@ export {
   type RegisteredOp,
   registerOp,
 } from './ops/registry.ts'
+export { Ops } from './ops/ops.ts'
 export { RAM_OPS } from './ops/ram/index.ts'
 export { makeGenericOps } from './ops/generic/factory.ts'
 export { extractWriteData } from './ops/write_args.ts'

--- a/typescript/packages/core/src/ops/ops.test.ts
+++ b/typescript/packages/core/src/ops/ops.test.ts
@@ -76,6 +76,14 @@ describe('Ops', () => {
     expect(entries.sort()).toEqual(['/data/sub/x.txt', '/data/sub/y.txt'])
   })
 
+  it('append extends a file through the append op (the python facade has it too)', async () => {
+    const ws = mkWorkspace()
+    await ws.fs.writeFile('/data/log.txt', 'head')
+    await ws.fs.append('/data/log.txt', new TextEncoder().encode('-tail'))
+    expect(await ws.fs.readFileText('/data/log.txt')).toBe('head-tail')
+    expect(ws.records.map((r) => r.op)).toContain('append')
+  })
+
   it('exists returns true for existing files and dirs', async () => {
     const ws = mkWorkspace()
     await ws.fs.writeFile('/data/hi.txt', 'hi')

--- a/typescript/packages/core/src/ops/ops.test.ts
+++ b/typescript/packages/core/src/ops/ops.test.ts
@@ -15,14 +15,14 @@
 import { describe, expect, it } from 'vitest'
 import { runWithSession } from '../context/session_context.ts'
 import { LimitExceededError } from '../commands/builtin/utils/limit.ts'
-import { OpsRegistry } from '../ops/registry.ts'
+import { OpsRegistry } from './registry.ts'
 import type { Policy } from '../policy/base.ts'
 import { PolicyDenied, PolicyError } from '../policy/errors.ts'
 import type { Action, OpsContext, OpsResultContext } from '../policy/types.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { FileType, Limit, MountMode, OnExceed } from '../types.ts'
 import { enotdir } from '../utils/errors.ts'
-import { Workspace } from './workspace.ts'
+import { Workspace } from '../workspace/workspace.ts'
 
 const DEC = new TextDecoder()
 
@@ -52,7 +52,7 @@ function mkFailingStat(err: unknown): Workspace {
   return ws
 }
 
-describe('WorkspaceFS', () => {
+describe('Ops', () => {
   it('writeFile + readFile round-trips bytes', async () => {
     const ws = mkWorkspace()
     await ws.fs.writeFile('/data/a.txt', 'hello')
@@ -117,7 +117,7 @@ describe('WorkspaceFS', () => {
   })
 })
 
-describe('WorkspaceFS existence probes', () => {
+describe('Ops existence probes', () => {
   it('report false for a missing path', async () => {
     const ws = mkWorkspace()
     expect(await ws.fs.exists('/data/nope')).toBe(false)
@@ -149,7 +149,7 @@ describe('WorkspaceFS existence probes', () => {
 
 // The fs facade is an op door like the dispatcher: FUSE and programmatic
 // access read through it, so policy hooks must fire here too.
-describe('WorkspaceFS policy door', () => {
+describe('Ops policy door', () => {
   class SealReads implements Policy {
     preOps(ctx: OpsContext): Action | null {
       if (!ctx.write && ctx.path.virtual.endsWith('.sealed')) {
@@ -231,7 +231,7 @@ describe('WorkspaceFS policy door', () => {
 // The facade is not a second pipeline: it hands every op to the
 // dispatcher, so what the shell sees and what ws.fs sees cannot drift,
 // and each gate fires exactly once per op.
-describe('WorkspaceFS is one door with the dispatcher', () => {
+describe('Ops is one door with the dispatcher', () => {
   class CountPre implements Policy {
     readonly seen: string[] = []
     preOps(ctx: OpsContext): Action | null {
@@ -369,7 +369,7 @@ describe('WorkspaceFS is one door with the dispatcher', () => {
   })
 })
 
-describe('WorkspaceFS accounting survives the delegation', () => {
+describe('Ops accounting survives the delegation', () => {
   class DenyBigReads implements Policy {
     postOps(ctx: OpsResultContext): Action | null {
       if (ctx.op === 'read') return { kind: 'deny', message: 'too big\n' }
@@ -572,7 +572,7 @@ describe('a warm cache still answers a ranged read with the window', () => {
   })
 })
 
-describe('WorkspaceFS rename is bounded by the mount', () => {
+describe('Ops rename is bounded by the mount', () => {
   function mkTwoMounts(): Workspace {
     const a = new RAMResource()
     const b = new RAMResource()

--- a/typescript/packages/core/src/ops/ops.ts
+++ b/typescript/packages/core/src/ops/ops.ts
@@ -202,6 +202,16 @@ export class Ops {
     await this.through('write', path, [bytes])
   }
 
+  /**
+   * Append bytes to a file through the mount's append op (the python
+   * facade's `append`). No whole-file fallback here: that is
+   * RuntimeVFS's business, where a guest holds the full buffer; an
+   * embedder calling the facade gets the mount's real answer.
+   */
+  async append(path: string, data: Uint8Array): Promise<void> {
+    await this.through('append', path, [data])
+  }
+
   async readdir(path: string): Promise<string[]> {
     return ((await this.through('readdir', path)) as string[] | null) ?? []
   }

--- a/typescript/packages/core/src/ops/ops.ts
+++ b/typescript/packages/core/src/ops/ops.ts
@@ -14,12 +14,12 @@
 
 import { OpReport } from '../io/types.ts'
 import { OpRecord } from '../observe/record.ts'
-import { NO_FOLLOW_OPS, type NamespaceLinks } from '../ops/config.ts'
-import type { OpKwargs } from '../ops/registry.ts'
+import { NO_FOLLOW_OPS, type NamespaceLinks } from './config.ts'
+import type { OpKwargs } from './registry.ts'
 import type { FileStat } from '../types.ts'
 import { FileType, PathSpec } from '../types.ts'
 import { exdev, isMissingPath } from '../utils/errors.ts'
-import type { DispatchFn } from './executor/cross_mount.ts'
+import type { DispatchFn } from '../workspace/executor/cross_mount.ts'
 
 export type OpSink = (rec: OpRecord) => Promise<void>
 
@@ -48,17 +48,25 @@ function payloadBytes(result: unknown, args: readonly unknown[]): number {
  * same pipeline as a shell command: link follow, session grants,
  * admission policies, cache read-through, namespace structure, and
  * post-write invalidation all fire once, at that one door. The facade
- * keeps only what is its own: the typed surface and op recording
- * (`ws.records`, and the network/cache split derived from it). Mirrors
- * Python's `Ops` attached to a workspace.
+ * keeps only what is its own: the typed surface and the op ledger
+ * (`records`, with the network/cache split derived from it) — the
+ * ledger lives here, not on the workspace, which is what lets
+ * `MountCore` take one `Ops` instead of reaching through a whole
+ * `Workspace`. Mirrors Python's `Ops`.
  */
-export class WorkspaceFS {
+export class Ops {
   private readonly dispatch: DispatchFn
   private readonly sink: OpSink | null
   // Injected namespace seam (workspace wires it); FUSE reads `links`
   // for its symlink surface.
   readonly links: NamespaceLinks | null
   private readonly ownerOf: OwnerOf
+  /**
+   * The op ledger: every facade op lands here, and the executor
+   * appends each shell line's ops too, so this is the one
+   * workspace-wide account (python's `Ops.records`).
+   */
+  readonly records: OpRecord[] = []
 
   constructor(
     dispatch: DispatchFn,
@@ -72,6 +80,28 @@ export class WorkspaceFS {
     this.ownerOf = ownerOf
   }
 
+  /** Ops that moved bytes over the network, in arrival order. */
+  get networkRecords(): OpRecord[] {
+    return this.records.filter((r) => !r.isCache)
+  }
+
+  get networkBytes(): number {
+    let total = 0
+    for (const r of this.records) if (!r.isCache) total += r.bytes
+    return total
+  }
+
+  /** Ops a warm cache answered, in arrival order. */
+  get cacheRecords(): OpRecord[] {
+    return this.records.filter((r) => r.isCache)
+  }
+
+  get cacheBytes(): number {
+    let total = 0
+    for (const r of this.records) if (r.isCache) total += r.bytes
+    return total
+  }
+
   private async record(
     op: string,
     path: string,
@@ -79,17 +109,16 @@ export class WorkspaceFS {
     bytes: number,
     startMs: number,
   ): Promise<void> {
-    if (this.sink === null) return
-    await this.sink(
-      new OpRecord({
-        op,
-        path,
-        source,
-        bytes,
-        timestamp: Date.now(),
-        durationMs: Date.now() - startMs,
-      }),
-    )
+    const rec = new OpRecord({
+      op,
+      path,
+      source,
+      bytes,
+      timestamp: Date.now(),
+      durationMs: Date.now() - startMs,
+    })
+    this.records.push(rec)
+    if (this.sink !== null) await this.sink(rec)
   }
 
   /**

--- a/typescript/packages/core/src/runtime/conformance.test.ts
+++ b/typescript/packages/core/src/runtime/conformance.test.ts
@@ -49,7 +49,7 @@ const MONTY_OPEN_UNSUPPORTED =
 // has not seen starts from empty and the close-flush overwrites the
 // mount content the run never read.
 
-// The workspace bridge has no APPEND op, so every append close
+// The workspace bridge has no append op, so every append close
 // re-flushes the whole file: n appends ship O(n^2) bytes.
 
 interface Row {
@@ -519,16 +519,16 @@ function makeCountingBridge(seed: Record<string, string>): CountingBridge {
   const ops: [op: string, path: string, bytes: number][] = []
   const dispatch: BridgeDispatchFn = (op, path, bytes, dst) => {
     ops.push([op, path, bytes?.length ?? 0])
-    if (op === 'READ') {
+    if (op === 'read') {
       const hit = files.get(path)
       if (hit === undefined) return Promise.reject(new Error(`ENOENT ${path}`))
       return Promise.resolve(new Uint8Array(hit))
     }
-    if (op === 'WRITE') {
+    if (op === 'write') {
       files.set(path, bytes === undefined ? new Uint8Array() : new Uint8Array(bytes))
       return Promise.resolve(undefined)
     }
-    if (op === 'APPEND') {
+    if (op === 'append') {
       const base = files.get(path) ?? new Uint8Array()
       const tail = bytes ?? new Uint8Array()
       const next = new Uint8Array(base.length + tail.length)
@@ -537,7 +537,7 @@ function makeCountingBridge(seed: Record<string, string>): CountingBridge {
       files.set(path, next)
       return Promise.resolve(undefined)
     }
-    if (op === 'STAT') {
+    if (op === 'stat') {
       const hit = files.get(path)
       if (hit !== undefined) return Promise.resolve({ size: hit.length, isDir: false, mtimeMs: 0 })
       const dir = path.replace(/\/$/, '')
@@ -545,7 +545,7 @@ function makeCountingBridge(seed: Record<string, string>): CountingBridge {
       if (isDir) return Promise.resolve({ size: 0, isDir: true, mtimeMs: 0 })
       return Promise.reject(new Error(`ENOENT ${path}`))
     }
-    if (op === 'LIST') {
+    if (op === 'readdir') {
       const prefix = path.replace(/\/$/, '') + '/'
       const entries: { path: string; size: number; isDir: boolean }[] = []
       for (const [p, content] of files) {
@@ -555,15 +555,15 @@ function makeCountingBridge(seed: Record<string, string>): CountingBridge {
       }
       return Promise.resolve(entries)
     }
-    if (op === 'UNLINK') {
+    if (op === 'unlink') {
       files.delete(path)
       return Promise.resolve(undefined)
     }
-    if (op === 'MKDIR') {
+    if (op === 'mkdir') {
       dirs.add(path)
       return Promise.resolve(undefined)
     }
-    if (op === 'RMDIR') {
+    if (op === 'rmdir') {
       dirs.delete(path)
       return Promise.resolve(undefined)
     }
@@ -577,7 +577,7 @@ function makeCountingBridge(seed: Record<string, string>): CountingBridge {
   // Both spellings count: the question is how many bytes crossed the
   // transport, and a runtime that ships tails is exactly the one being
   // measured. Counting WRITE alone would score a working append as 0.
-  const isMutation = (op: string): boolean => op === 'WRITE' || op === 'APPEND'
+  const isMutation = (op: string): boolean => op === 'write' || op === 'append'
   const mutationBytes = () =>
     ops.filter(([op]) => isMutation(op)).reduce((total, [, , size]) => total + size, 0)
   const mutationOps = () =>

--- a/typescript/packages/core/src/runtime/conformance_worlds.test.ts
+++ b/typescript/packages/core/src/runtime/conformance_worlds.test.ts
@@ -18,6 +18,7 @@ import { RAMResource } from '../resource/ram/ram.ts'
 import { FileType, MountMode } from '../types.ts'
 import { getTestParser, stderrStr, stdoutStr } from '../workspace/fixtures/workspace_fixture.ts'
 import { Workspace } from '../workspace/workspace.ts'
+import { QuickJsRuntime } from './js/quickjs.ts'
 import { MontyRuntime } from './python/monty/index.ts'
 
 // One world, three surfaces, one door: the TS half of the conformance
@@ -381,4 +382,60 @@ describe('scoped world', () => {
       await ws.close()
     }
   })
+})
+
+// ── Group 5: an exclusive open refuses an existing file (R7a) ──
+//
+// The python half runs the same world over the real qjs-wasi engine
+// and CPython-wasm (test_conformance_worlds.py, guarded); this half
+// runs it over the synthesized quickjs shim, which consumes
+// `OpenMode.exclusive` for the refusal. monty has no spelling for the
+// fact: it refuses mode 'x' outright ("exclusive creation mode is not
+// supported").
+
+async function exclusiveWorld(): Promise<Workspace> {
+  const parser = await getTestParser()
+  const ops = new OpsRegistry()
+  const w = new RAMResource()
+  ops.registerResource(w)
+  const ws = new Workspace(
+    {},
+    { mode: MountMode.EXEC, ops, shellParser: parser, runtimes: [new QuickJsRuntime(), 'vfs'] },
+  )
+  ws.addMount('/w', w, MountMode.WRITE)
+  await ws.fs.writeFile('/w/keep.txt', 'keep')
+  return ws
+}
+
+describe('exclusive-open world', () => {
+  it("a js guest's 'wx' refuses an existing file and leaves it untouched", async () => {
+    const ws = await exclusiveWorld()
+    try {
+      const [code, out, err] = await run(
+        ws,
+        "js -e \"console.log(std.open('/w/keep.txt', 'wx') === null ? 'refused' : 'OPENED')\"",
+      )
+      expect(code, err).toBe(0)
+      expect(out).toContain('refused')
+      const [, keep] = await run(ws, 'cat /w/keep.txt')
+      expect(keep).toBe('keep')
+    } finally {
+      await ws.close()
+    }
+  }, 60_000)
+
+  it("a js guest's 'wx' creates a missing file", async () => {
+    const ws = await exclusiveWorld()
+    try {
+      const [code, , err] = await run(
+        ws,
+        "js -e \"const f = std.open('/w/made.txt', 'wx'); f.puts('made'); f.close()\"",
+      )
+      expect(code, err).toBe(0)
+      const [, made] = await run(ws, 'cat /w/made.txt')
+      expect(made).toBe('made')
+    } finally {
+      await ws.close()
+    }
+  }, 60_000)
 })

--- a/typescript/packages/core/src/runtime/handles/constants.ts
+++ b/typescript/packages/core/src/runtime/handles/constants.ts
@@ -12,15 +12,11 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { ResourceName, invalidateAfterWrite, record, type PathSpec } from '@struktoai/mirage-core'
-import type { GridFSAccessor } from '../../accessor/gridfs.ts'
-import { gridfsKey, rawPathOf } from './_client.ts'
-import { uploadBytes } from './write.ts'
+// The fopen mode alphabet: one base letter (r/w/a/x), at most one each
+// of +, b, t. parseMode owns the rule; these tables are the vocabulary
+// it reads.
+export const MODE_CHARS = 'rwaxbt+'
 
-export async function create(accessor: GridFSAccessor, path: PathSpec): Promise<void> {
-  const raw = rawPathOf(path)
-  const startMs = performance.now()
-  await uploadBytes(accessor, gridfsKey(raw, accessor.config), new Uint8Array(0))
-  record('create', path.virtual, ResourceName.GRIDFS, 0, startMs)
-  await invalidateAfterWrite(path)
-}
+// The legal base-letter spellings: CPython's four plus C fopen's wx
+// (exclusive create), which CPython spells as a bare x.
+export const MODE_BASES: readonly string[] = ['r', 'w', 'a', 'x', 'wx']

--- a/typescript/packages/core/src/runtime/handles/index.ts
+++ b/typescript/packages/core/src/runtime/handles/index.ts
@@ -13,6 +13,6 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 export { NO_WRITE, planFlush, type FlushKind } from './flush.ts'
-export { parseMode } from './mode.ts'
+export { parseMode, type OpenMode } from './mode.ts'
 export { FileHandle, mergeWrites } from './file_handle.ts'
 export { FileTable } from './file_table.ts'

--- a/typescript/packages/core/src/runtime/handles/mode.test.ts
+++ b/typescript/packages/core/src/runtime/handles/mode.test.ts
@@ -16,20 +16,58 @@ import { describe, expect, it } from 'vitest'
 import { parseMode } from './mode.ts'
 
 describe('parseMode', () => {
-  it('reads the five facts', () => {
+  it('reads the facts', () => {
     const read = parseMode('r')
     expect(read.writable).toBe(false)
     expect(read.create).toBe(false)
+    expect(read.readable).toBe(true)
+    expect(read.binary).toBe(false)
     const update = parseMode('r+b')
     expect(update.writable).toBe(true)
     expect(update.truncate).toBe(false)
     expect(update.create).toBe(false)
+    expect(update.readable).toBe(true)
+    expect(update.binary).toBe(true)
     const write = parseMode('w')
     expect(write.writable && write.truncate && write.create).toBe(true)
+    expect(write.readable).toBe(false)
     const append = parseMode('a')
     expect(append.append).toBe(true)
     expect(append.truncate).toBe(false)
     const exclusive = parseMode('x')
     expect(exclusive.exclusive && exclusive.create).toBe(true)
+    expect(exclusive.readable).toBe(false)
+  })
+
+  it('makes every base readable and writable under +', () => {
+    for (const spelling of ['r+', 'w+', 'a+', 'x+']) {
+      const mode = parseMode(spelling)
+      expect(mode.readable, spelling).toBe(true)
+      expect(mode.writable, spelling).toBe(true)
+    }
+  })
+
+  it("reads 'wx' as C fopen's exclusive create", () => {
+    // CPython spells exclusive creation as a bare 'x'; C fopen (and
+    // so qjs-wasi's std.open) spells it 'wx'. One parser serves both
+    // dialects, so both spellings answer the same facts.
+    const mode = parseMode('wx')
+    expect(mode.exclusive && mode.create && mode.truncate).toBe(true)
+    expect(mode.writable).toBe(true)
+    expect(mode.readable).toBe(false)
+  })
+
+  it('refuses garbage modes in CPython wording', () => {
+    // One parser, the stricter half's rule: exactly one of rwax, at
+    // most one each of +, b, t, and never b with t.
+    for (const bad of ['', 'q', 'rw', 'rr', 'r++', 'rbb', 'rbt', 'wq', 'b']) {
+      expect(() => parseMode(bad), bad).toThrow(/invalid mode/)
+    }
+  })
+
+  it('accepts the text flag and reads it as not binary', () => {
+    const mode = parseMode('rt')
+    expect(mode.binary).toBe(false)
+    expect(mode.readable).toBe(true)
   })
 })

--- a/typescript/packages/core/src/runtime/handles/mode.ts
+++ b/typescript/packages/core/src/runtime/handles/mode.ts
@@ -12,7 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-const VALID = 'rwaxbt+'
+import { MODE_BASES, MODE_CHARS } from './constants.ts'
+
+// Inside a character class every mode letter (and +) is literal.
+const INVALID_CHAR = new RegExp(`[^${MODE_CHARS}]`)
 
 /**
  * What an fopen-style mode string says about a handle.
@@ -38,8 +41,6 @@ export interface OpenMode {
   binary: boolean
 }
 
-const BASES = ['r', 'w', 'a', 'x', 'wx']
-
 /**
  * Read an fopen-style mode string into its facts, validating it.
  *
@@ -63,13 +64,13 @@ export function parseMode(mode: string): OpenMode {
   let bases = ''
   for (const char of 'rwax') if (mode.includes(char)) bases += char
   let duplicated = false
-  for (const char of VALID) if (count(char) > 1) duplicated = true
+  for (const char of MODE_CHARS) if (count(char) > 1) duplicated = true
   if (
     mode.length === 0 ||
-    /[^rwaxbt+]/.test(mode) ||
+    INVALID_CHAR.test(mode) ||
     duplicated ||
     (mode.includes('b') && mode.includes('t')) ||
-    !BASES.includes(bases)
+    !MODE_BASES.includes(bases)
   ) {
     throw new Error(`invalid mode: '${mode}'`)
   }

--- a/typescript/packages/core/src/runtime/handles/mode.ts
+++ b/typescript/packages/core/src/runtime/handles/mode.ts
@@ -12,14 +12,18 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+const VALID = new Set('rwaxbt+')
+
 /**
  * What an fopen-style mode string says about a handle.
  *
  * One vocabulary for every dialect that opens by mode: quickjs's
  * `std.open` passes these strings verbatim, and Python's preview1
- * oflags/rights/fdflags translate onto the same five facts.
+ * oflags/rights/fdflags translate onto the same facts.
  */
 export interface OpenMode {
+  /** The handle may read (r, +). */
+  readable: boolean
   /** The handle may mutate its buffer (w, a, x, +). */
   writable: boolean
   /** Opening discards existing content (w). */
@@ -30,21 +34,50 @@ export interface OpenMode {
   create: boolean
   /** An existing file refuses the open (x). */
   exclusive: boolean
+  /** The handle carries bytes, not text (b). */
+  binary: boolean
 }
 
+const BASES = ['r', 'w', 'a', 'x', 'wx']
+
 /**
- * Read an fopen-style mode string into its five facts.
+ * Read an fopen-style mode string into its facts, validating it.
+ *
+ * The rule is CPython's, the stricter of the two parsers this
+ * replaced — one base, at most one each of `+`, `b`, `t`, and never
+ * `b` together with `t` — widened by one C-dialect spelling: `wx`,
+ * fopen's exclusive create, which CPython spells as a bare `x`. Both
+ * dialects open by mode through this one parser, so it accepts the
+ * union. A guest engine that tolerates looser spellings still (C
+ * fopen reads `rr` as `r`) renders this refusal in its own dialect at
+ * its own boundary.
  *
  * Args:
- *   mode: the mode as the guest spelled it (`r`, `w+b`, `a`, ...);
- *     unknown letters are ignored, matching fopen.
+ *   mode: the mode as the caller spelled it (`r`, `w+b`, `a`, `wx`, ...).
+ *
+ * Throws:
+ *   Error: the mode does not parse, in CPython's own wording.
  */
 export function parseMode(mode: string): OpenMode {
+  const count = (char: string): number => mode.split(char).length - 1
+  const bases = [...'rwax'].filter((char) => mode.includes(char)).join('')
+  if (
+    mode.length === 0 ||
+    [...mode].some((char) => !VALID.has(char)) ||
+    [...VALID].some((char) => count(char) > 1) ||
+    (mode.includes('b') && mode.includes('t')) ||
+    !BASES.includes(bases)
+  ) {
+    throw new Error(`invalid mode: '${mode}'`)
+  }
+  const plus = mode.includes('+')
   return {
-    writable: /[wax+]/.test(mode),
+    readable: mode.includes('r') || plus,
+    writable: !mode.includes('r') || plus,
     truncate: mode.includes('w'),
     append: mode.includes('a'),
-    create: /[wax]/.test(mode),
+    create: [...'wax'].some((char) => mode.includes(char)),
     exclusive: mode.includes('x'),
+    binary: mode.includes('b'),
   }
 }

--- a/typescript/packages/core/src/runtime/handles/mode.ts
+++ b/typescript/packages/core/src/runtime/handles/mode.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-const VALID = new Set('rwaxbt+')
+const VALID = 'rwaxbt+'
 
 /**
  * What an fopen-style mode string says about a handle.
@@ -60,11 +60,14 @@ const BASES = ['r', 'w', 'a', 'x', 'wx']
  */
 export function parseMode(mode: string): OpenMode {
   const count = (char: string): number => mode.split(char).length - 1
-  const bases = [...'rwax'].filter((char) => mode.includes(char)).join('')
+  let bases = ''
+  for (const char of 'rwax') if (mode.includes(char)) bases += char
+  let duplicated = false
+  for (const char of VALID) if (count(char) > 1) duplicated = true
   if (
     mode.length === 0 ||
-    [...mode].some((char) => !VALID.has(char)) ||
-    [...VALID].some((char) => count(char) > 1) ||
+    /[^rwaxbt+]/.test(mode) ||
+    duplicated ||
     (mode.includes('b') && mode.includes('t')) ||
     !BASES.includes(bases)
   ) {
@@ -76,7 +79,7 @@ export function parseMode(mode: string): OpenMode {
     writable: !mode.includes('r') || plus,
     truncate: mode.includes('w'),
     append: mode.includes('a'),
-    create: [...'wax'].some((char) => mode.includes(char)),
+    create: /[wax]/.test(mode),
     exclusive: mode.includes('x'),
     binary: mode.includes('b'),
   }

--- a/typescript/packages/core/src/runtime/js/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/js/vfs.test.ts
@@ -1,0 +1,83 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { QuickJsRuntime } from './quickjs.ts'
+import { PrefixResolver } from '../resolver.ts'
+import type { BridgeDispatchFn, RunArgs } from '../types.ts'
+
+const DEC = new TextDecoder()
+
+interface StatProbeBridge {
+  dispatch: BridgeDispatchFn
+  ops: string[]
+}
+
+// A bridge whose stat answers with one canned rejection while the file's
+// content is real and readable, so the open ladder's reading of that
+// failure is the only thing under test. Real dispatch errors arrive
+// code-stamped (the workspace chokepoints classify them), so the canned
+// ones are too.
+function makeStatProbeBridge(statCode: string, content: string): StatProbeBridge {
+  const ops: string[] = []
+  const dispatch: BridgeDispatchFn = (op, path) => {
+    ops.push(op)
+    if (op === 'stat') {
+      return Promise.reject(Object.assign(new Error(`stat refused: ${path}`), { code: statCode }))
+    }
+    if (op === 'read') return Promise.resolve(new TextEncoder().encode(content))
+    return Promise.resolve(undefined)
+  }
+  return { dispatch, ops }
+}
+
+function runArgs(code: string): RunArgs {
+  return { code, args: [], env: {}, stdin: null }
+}
+
+const OPEN_APPEND_JS = `const f = std.open('/data/f.txt', 'a');
+console.log(f === null ? 'refused' : 'opened');
+if (f !== null) f.close();`
+
+// The open ladder treats a stat miss as "no file yet", which is what
+// lets create-capable modes establish one. Only a confirmed absence may
+// read that way: a transient backend failure or a policy denial on an
+// existing file must refuse the open, or 'a'/'w' would create over
+// content this open never saw.
+describe('quickjs std.open reads stat failures', () => {
+  it('a non-absence stat failure refuses the open and mutates nothing', async () => {
+    const bridge = makeStatProbeBridge('EIO', 'precious')
+    const rt = new QuickJsRuntime()
+    rt.attach(bridge.dispatch, new PrefixResolver(() => ['/data/']))
+    const result = await rt.run(runArgs(OPEN_APPEND_JS))
+    await rt.close()
+    expect(result.exitCode).toBe(0)
+    expect(DEC.decode(result.stdout)).toBe('refused\n')
+    expect(bridge.ops).not.toContain('create')
+    expect(bridge.ops).not.toContain('truncate')
+    expect(bridge.ops).not.toContain('write')
+    expect(bridge.ops).not.toContain('append')
+  }, 120_000)
+
+  it('a confirmed absence still lets a create-capable mode establish', async () => {
+    const bridge = makeStatProbeBridge('ENOENT', '')
+    const rt = new QuickJsRuntime()
+    rt.attach(bridge.dispatch, new PrefixResolver(() => ['/data/']))
+    const result = await rt.run(runArgs(OPEN_APPEND_JS))
+    await rt.close()
+    expect(result.exitCode).toBe(0)
+    expect(DEC.decode(result.stdout)).toBe('opened\n')
+    expect(bridge.ops).toContain('create')
+  }, 120_000)
+})

--- a/typescript/packages/core/src/runtime/js/vfs.ts
+++ b/typescript/packages/core/src/runtime/js/vfs.ts
@@ -15,7 +15,7 @@
 import { classify } from '../../errors/index.ts'
 import { WASI } from './wasi.ts'
 import { DIR_MODE, FILE_MODE } from '../../utils/stat_view.ts'
-import { FileHandle, FileTable, parseMode } from '../handles/index.ts'
+import { FileHandle, FileTable, parseMode, type OpenMode } from '../handles/index.ts'
 import type { RuntimeVFS, VFSStat } from '../vfs.ts'
 import type { QuickJSAsyncContext, QuickJSHandle } from 'quickjs-emscripten'
 import { compareCodePoints } from '../../utils/sort.ts'
@@ -54,6 +54,7 @@ function wasiErrno(err: unknown): number {
 export const MIRAGE_FS_BOOTSTRAP = `
 std.open = (path, mode) => {
   const fd = __mirage_open(String(path), String(mode === undefined ? 'r' : mode));
+  if (fd === -2) throw new TypeError('invalid file mode');
   if (fd < 0) return null;
   return {
     readAsString: (max) => __mirage_read(fd, max === undefined ? -1 : (max | 0)),
@@ -114,7 +115,18 @@ export function installMirageFs(ctx: QuickJSAsyncContext, vfs: RuntimeVFS | null
 
   defineAsync('__mirage_open', async (pathH, modeH) => {
     const path = ctx.getString(pathH)
-    const mode = parseMode(ctx.getString(modeH))
+    // The engine validates the mode before touching the filesystem
+    // (qjs-libc throws TypeError before any open); -2 tells the
+    // bootstrap to raise that refusal, since a host throw would not
+    // arrive typed. The shared parser is stricter than qjs-libc's
+    // character scan ('rr' passes strspn but not CPython's one-base
+    // rule); the strict answer is the one both guests can agree on.
+    let mode: OpenMode
+    try {
+      mode = parseMode(ctx.getString(modeH))
+    } catch {
+      return ctx.newNumber(-2)
+    }
     if (vfs === null || !underMount(path)) return ctx.newNumber(-1)
     let st: VFSStat | null = null
     try {

--- a/typescript/packages/core/src/runtime/js/vfs.ts
+++ b/typescript/packages/core/src/runtime/js/vfs.ts
@@ -116,26 +116,35 @@ export function installMirageFs(ctx: QuickJSAsyncContext, vfs: RuntimeVFS | null
     const path = ctx.getString(pathH)
     const mode = parseMode(ctx.getString(modeH))
     if (vfs === null || !underMount(path)) return ctx.newNumber(-1)
-    let buf: Uint8Array = new Uint8Array()
-    let existed = false
-    if (!mode.truncate) {
-      try {
-        buf = await vfs.read(path)
-        existed = true
-      } catch {
-        if (!mode.writable) return ctx.newNumber(-1)
-      }
+    let st: VFSStat | null = null
+    try {
+      st = await vfs.stat(path)
+    } catch {
+      st = null
     }
-    // Truncate or create writes through the mount at open, mirroring
-    // the Python runtime: this enforces write modes (a read-only mount
-    // or a read-narrowed session throws here, so the guest gets null)
-    // and establishes the file before the buffered writes.
-    if (mode.truncate || (mode.writable && !existed)) {
-      try {
-        await vfs.write(path, buf)
-      } catch {
-        return ctx.newNumber(-1)
+    // The same ladder as the python wasi host's path_open, so the two
+    // engines refuse the same opens: a directory, an exclusive open
+    // over an existing file (EEXIST in the real engine), and a missing
+    // file whose mode does not create.
+    if (st !== null && st.isDir) return ctx.newNumber(-1)
+    if (st !== null && mode.exclusive) return ctx.newNumber(-1)
+    if (st === null && !mode.create) return ctx.newNumber(-1)
+    // The establishing op goes through the mount at open as the op it
+    // is — create for a missing file, truncate for a discarded one —
+    // so write modes and a read-narrowed session refuse here (the
+    // guest gets null), the ledger records the real op, and a backend
+    // with a native truncate receives it.
+    let buf: Uint8Array = new Uint8Array()
+    try {
+      if (st === null) {
+        await vfs.create(path)
+      } else if (mode.truncate) {
+        await vfs.truncate(path)
+      } else {
+        buf = await vfs.read(path)
       }
+    } catch {
+      return ctx.newNumber(-1)
     }
     const fd = table.add(FileHandle.opened(path, buf, mode))
     return ctx.newNumber(fd)

--- a/typescript/packages/core/src/runtime/js/vfs.ts
+++ b/typescript/packages/core/src/runtime/js/vfs.ts
@@ -138,7 +138,7 @@ export function installMirageFs(ctx: QuickJSAsyncContext, vfs: RuntimeVFS | null
     // engines refuse the same opens: a directory, an exclusive open
     // over an existing file (EEXIST in the real engine), and a missing
     // file whose mode does not create.
-    if (st !== null && st.isDir) return ctx.newNumber(-1)
+    if (st?.isDir === true) return ctx.newNumber(-1)
     if (st !== null && mode.exclusive) return ctx.newNumber(-1)
     if (st === null && !mode.create) return ctx.newNumber(-1)
     // The establishing op goes through the mount at open as the op it

--- a/typescript/packages/core/src/runtime/js/vfs.ts
+++ b/typescript/packages/core/src/runtime/js/vfs.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { classify } from '../../errors/index.ts'
+import { isMissingPath } from '../../utils/errors.ts'
 import { WASI } from './wasi.ts'
 import { DIR_MODE, FILE_MODE } from '../../utils/stat_view.ts'
 import { FileHandle, FileTable, parseMode, type OpenMode } from '../handles/index.ts'
@@ -131,8 +132,13 @@ export function installMirageFs(ctx: QuickJSAsyncContext, vfs: RuntimeVFS | null
     let st: VFSStat | null = null
     try {
       st = await vfs.stat(path)
-    } catch {
-      st = null
+    } catch (err) {
+      // Only a confirmed absence reads as "no file yet" (the python
+      // host's stat_or_none makes the same distinction): a transient
+      // failure or a policy denial on an existing file must refuse the
+      // open, or a create-capable mode would create over content this
+      // open never saw.
+      if (!isMissingPath(err)) return ctx.newNumber(-1)
     }
     // The same ladder as the python wasi host's path_open, so the two
     // engines refuse the same opens: a directory, an exclusive open

--- a/typescript/packages/core/src/runtime/python/monty/osaccess.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/osaccess.test.ts
@@ -107,7 +107,7 @@ describe('MirageOSAccess path operations', () => {
 
   it('answers the exists family as booleans, never as a rejection', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'LIST' && path === '/ram/d/') {
+      if (op === 'readdir' && path === '/ram/d/') {
         return Promise.resolve([{ path: '/ram/d/a', size: 1, isDir: false }])
       }
       return Promise.reject(Object.assign(new Error('gone'), { code: 'ENOENT' }))

--- a/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
@@ -33,7 +33,7 @@ function makeBridge(seed: Record<string, Uint8Array>): {
   const writes: [string, Uint8Array][] = []
   const mutations: string[] = []
   const dispatch: BridgeDispatchFn = (op, path, bytes, dst) => {
-    if (op === 'READ') {
+    if (op === 'read') {
       const data = files.get(path)
       if (data === undefined) {
         // The real dispatcher rejects with coded fs errors (ENOENT et
@@ -42,18 +42,18 @@ function makeBridge(seed: Record<string, Uint8Array>): {
       }
       return Promise.resolve(data)
     }
-    if (op === 'WRITE') {
+    if (op === 'write') {
       const data = bytes ?? new Uint8Array()
       files.set(path, data)
       writes.push([path, data])
       return Promise.resolve(undefined)
     }
-    if (op === 'MKDIR' || op === 'RMDIR' || op === 'UNLINK') {
-      if (op === 'UNLINK') files.delete(path)
+    if (op === 'mkdir' || op === 'rmdir' || op === 'unlink') {
+      if (op === 'unlink') files.delete(path)
       mutations.push(`${op} ${path}`)
       return Promise.resolve(undefined)
     }
-    if (op === 'RENAME') {
+    if (op === 'rename') {
       const data = files.get(path)
       if (data !== undefined && dst !== undefined) {
         files.delete(path)
@@ -402,7 +402,7 @@ describe('MontyRuntime', () => {
     const failing =
       (code: string): BridgeDispatchFn =>
       (op, path) => {
-        if (op === 'LIST') return Promise.resolve([])
+        if (op === 'readdir') return Promise.resolve([])
         return Promise.reject(Object.assign(new Error(path), { code }))
       }
     const missing = await run(

--- a/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
@@ -59,7 +59,7 @@ function makeBridge(seed: Record<string, Uint8Array>): {
         files.delete(path)
         files.set(dst, data)
       }
-      mutations.push(`RENAME ${path} ${dst ?? ''}`)
+      mutations.push(`rename ${path} ${dst ?? ''}`)
       return Promise.resolve(undefined)
     }
     const prefix = path
@@ -272,7 +272,7 @@ describe('MontyRuntime', () => {
       "from pathlib import Path\nPath('/s3/sub').mkdir()\nPath('/s3/a.txt').unlink()\nPath('/s3/sub').rmdir()",
     )
     expect(result.exitCode).toBe(0)
-    expect(mutations).toEqual(['MKDIR /s3/sub', 'UNLINK /s3/a.txt', 'RMDIR /s3/sub'])
+    expect(mutations).toEqual(['mkdir /s3/sub', 'unlink /s3/a.txt', 'rmdir /s3/sub'])
     expect(files.has('/s3/a.txt')).toBe(false)
   }, 30_000)
 
@@ -284,7 +284,7 @@ describe('MontyRuntime', () => {
       "from pathlib import Path\nPath('/s3/a.txt').rename('/s3/b.txt')\nPath('/s3/b.txt').unlink()",
     )
     expect(result.exitCode).toBe(0)
-    expect(mutations).toEqual(['RENAME /s3/a.txt /s3/b.txt', 'UNLINK /s3/b.txt'])
+    expect(mutations).toEqual(['rename /s3/a.txt /s3/b.txt', 'unlink /s3/b.txt'])
     expect(files.has('/s3/b.txt')).toBe(false)
   }, 30_000)
 
@@ -293,7 +293,7 @@ describe('MontyRuntime', () => {
     const rt = make(dispatch)
     const result = await run(rt, "from pathlib import Path\nPath('/s3/a.txt').rename('/s3/b.txt')")
     expect(result.exitCode).toBe(0)
-    expect(mutations).toEqual(['RENAME /s3/a.txt /s3/b.txt'])
+    expect(mutations).toEqual(['rename /s3/a.txt /s3/b.txt'])
     expect(files.has('/s3/b.txt')).toBe(true)
   }, 30_000)
 
@@ -314,7 +314,7 @@ describe('MontyRuntime', () => {
     const rt = make(dispatch, () => ['/a/', '/b/'])
     const result = await run(rt, "from pathlib import Path\nPath('/a/f.txt').rename('/a/g.txt')")
     expect(result.exitCode).toBe(0)
-    expect(mutations).toEqual(['RENAME /a/f.txt /a/g.txt'])
+    expect(mutations).toEqual(['rename /a/f.txt /a/g.txt'])
   }, 30_000)
 
   it('a rename leaving the mount view never reaches the bridge', async () => {

--- a/typescript/packages/core/src/runtime/python/monty/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/vfs.test.ts
@@ -89,7 +89,7 @@ describe('MontyVFS values', () => {
       Promise.resolve([{ path: '/ram/d/a', size: 1, isDir: false }]),
     )
     const entries = await viewOn(dispatch).readdir('/ram/d')
-    expect(dispatch).toHaveBeenCalledWith('LIST', '/ram/d/')
+    expect(dispatch).toHaveBeenCalledWith('readdir', '/ram/d/')
     expect(entries).toHaveLength(1)
   })
 
@@ -106,7 +106,7 @@ describe('MontyVFS values', () => {
 describe('MontyVFS negative cache', () => {
   const listing = () =>
     vi.fn<BridgeDispatchFn>((op) => {
-      if (op === 'LIST') return Promise.resolve([{ path: '/ram/a', size: 1, isDir: false }])
+      if (op === 'readdir') return Promise.resolve([{ path: '/ram/a', size: 1, isDir: false }])
       return Promise.resolve(undefined)
     })
 
@@ -117,7 +117,7 @@ describe('MontyVFS negative cache', () => {
     const vfs = viewOn(dispatch)
     expect(await vfs.entryFor('/ram/nope')).toBeNull()
     expect(await vfs.entryFor('/ram/nope')).toBeNull()
-    expect(dispatch.mock.calls.filter((c) => c[0] === 'LIST')).toHaveLength(1)
+    expect(dispatch.mock.calls.filter((c) => c[0] === 'readdir')).toHaveLength(1)
   })
 
   it('answers a remembered absence from read without dispatching', async () => {
@@ -125,7 +125,7 @@ describe('MontyVFS negative cache', () => {
     const vfs = viewOn(dispatch)
     await vfs.entryFor('/ram/nope')
     await expect(vfs.read('/ram/nope')).rejects.toMatchObject({ name: 'FileNotFoundError' })
-    expect(dispatch.mock.calls.filter((c) => c[0] === 'READ')).toHaveLength(0)
+    expect(dispatch.mock.calls.filter((c) => c[0] === 'read')).toHaveLength(0)
   })
 
   it('forgets the absence once the path is written, so the guest sees its own write', async () => {
@@ -134,7 +134,7 @@ describe('MontyVFS negative cache', () => {
     expect(await vfs.entryFor('/ram/new.txt')).toBeNull()
     await vfs.write('/ram/new.txt', 'hi')
     await vfs.entryFor('/ram/new.txt')
-    expect(dispatch.mock.calls.filter((c) => c[0] === 'LIST')).toHaveLength(2)
+    expect(dispatch.mock.calls.filter((c) => c[0] === 'readdir')).toHaveLength(2)
   })
 
   it('remembers a path it removed, and forgets a rename destination', async () => {
@@ -142,7 +142,7 @@ describe('MontyVFS negative cache', () => {
     const vfs = viewOn(dispatch)
     await vfs.unlink('/ram/a')
     expect(await vfs.entryFor('/ram/a')).toBeNull()
-    expect(dispatch.mock.calls.filter((c) => c[0] === 'LIST')).toHaveLength(0)
+    expect(dispatch.mock.calls.filter((c) => c[0] === 'readdir')).toHaveLength(0)
     await vfs.rename('/ram/b', '/ram/a')
     expect(await vfs.entryFor('/ram/a')).toMatchObject({ isDir: false })
   })
@@ -169,7 +169,7 @@ describe('MontyVFS negative cache', () => {
     let down = true
     const dispatch = vi.fn<BridgeDispatchFn>((op) => {
       if (down) return Promise.reject(new Error('transport down'))
-      if (op === 'READ') return Promise.resolve(new TextEncoder().encode('back'))
+      if (op === 'read') return Promise.resolve(new TextEncoder().encode('back'))
       return Promise.resolve(undefined)
     })
     const vfs = viewOn(dispatch)

--- a/typescript/packages/core/src/runtime/python/mount.test.ts
+++ b/typescript/packages/core/src/runtime/python/mount.test.ts
@@ -29,11 +29,11 @@ function makeBridge(): {
     const entry: { op: string; path: string; bytes?: Uint8Array } =
       normalizedBytes !== undefined ? { op, path, bytes: normalizedBytes } : { op, path }
     calls.push(entry)
-    if (op === 'WRITE') {
+    if (op === 'write') {
       files.set(path, normalizedBytes ?? new Uint8Array())
       return Promise.resolve(undefined)
     }
-    if (op === 'APPEND') {
+    if (op === 'append') {
       const base = files.get(path) ?? new Uint8Array()
       const tail = normalizedBytes ?? new Uint8Array()
       const next = new Uint8Array(base.length + tail.length)
@@ -42,7 +42,7 @@ function makeBridge(): {
       files.set(path, next)
       return Promise.resolve(undefined)
     }
-    if (op === 'READ') return Promise.resolve(files.get(path) ?? new Uint8Array())
+    if (op === 'read') return Promise.resolve(files.get(path) ?? new Uint8Array())
     const prefix = path
     const entries: { path: string; size: number; isDir: boolean }[] = []
     const dirs = new Set<string>()
@@ -93,7 +93,7 @@ describe('PyodideRuntime mount visibility', () => {
       env: {},
       stdin: new Uint8Array(),
     })
-    const writes = calls.filter((c) => c.op === 'WRITE')
+    const writes = calls.filter((c) => c.op === 'write')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
     if (w0?.bytes === undefined) throw new Error('unreachable')
@@ -120,7 +120,7 @@ describe('PyodideRuntime mount visibility', () => {
       env: {},
       stdin: new Uint8Array(),
     })
-    expect(calls.filter((c) => c.op === 'WRITE')).toHaveLength(0)
+    expect(calls.filter((c) => c.op === 'write')).toHaveLength(0)
     await rt.close()
   }, 60_000)
 
@@ -144,7 +144,7 @@ describe('PyodideRuntime mount visibility', () => {
       stdin: new Uint8Array(),
     })
     expect(new TextDecoder().decode(result.stdout)).toContain('lazy')
-    expect(calls.some((c) => c.op === 'LIST' && c.path === '/ram/')).toBe(true)
+    expect(calls.some((c) => c.op === 'readdir' && c.path === '/ram/')).toBe(true)
     await rt.close()
   }, 60_000)
 
@@ -167,7 +167,7 @@ describe('PyodideRuntime mount visibility', () => {
         stdin: new Uint8Array(),
       })
       expect(result.exitCode).toBe(0)
-      expect(calls.filter((c) => c.op === 'WRITE')).toHaveLength(0)
+      expect(calls.filter((c) => c.op === 'write')).toHaveLength(0)
       expect(warnings.some((w) => w.includes("cannot serve a mount at '/'"))).toBe(true)
       // Reported once, not once per run.
       await rt.run({ code: 'pass', args: [], env: {}, stdin: new Uint8Array() })
@@ -201,8 +201,8 @@ describe('PyodideRuntime mount visibility', () => {
 
   it('a failed flush surfaces on stderr and flips a clean exit to 1', async () => {
     const dispatch: BridgeDispatchFn = (op) => {
-      if (op === 'WRITE') return Promise.reject(new Error('mount is read-only'))
-      if (op === 'READ') return Promise.resolve(new Uint8Array())
+      if (op === 'write') return Promise.reject(new Error('mount is read-only'))
+      if (op === 'read') return Promise.resolve(new Uint8Array())
       return Promise.resolve([])
     }
     const rt = new PyodideRuntime()
@@ -237,9 +237,9 @@ describe('PyodideRuntime mount visibility', () => {
     const attempted: string[] = []
     const dispatch: BridgeDispatchFn = (op, path) => {
       attempted.push(`${op} ${path}`)
-      if (op === 'WRITE') return Promise.reject(new Error('backend hiccup'))
-      if (op === 'READ') return Promise.resolve(new Uint8Array())
-      if (op === 'LIST') return Promise.resolve([])
+      if (op === 'write') return Promise.reject(new Error('backend hiccup'))
+      if (op === 'read') return Promise.resolve(new Uint8Array())
+      if (op === 'readdir') return Promise.resolve([])
       return Promise.resolve(undefined)
     }
     const rt = new PyodideRuntime()
@@ -256,7 +256,7 @@ describe('PyodideRuntime mount visibility', () => {
     })
     // The rename must not run: its prerequisite write never landed, so
     // replaying it could move a stale backend copy onto the destination.
-    expect(attempted.filter((c) => c.startsWith('RENAME'))).toHaveLength(0)
+    expect(attempted.filter((c) => c.startsWith('rename'))).toHaveLength(0)
     const stderr = new TextDecoder().decode(result.stderr ?? new Uint8Array())
     expect(stderr).toContain('failed to write /ram/tmp.txt')
     expect(stderr).toContain('skipped 1 later mutation(s)')
@@ -270,14 +270,14 @@ describe('PyodideRuntime mount visibility', () => {
     // content. Leaving it out of the guest's tree would read as absence,
     // and the append would then ship its tail as the whole file.
     const dispatch: BridgeDispatchFn = (op, path, bytes) => {
-      if (op === 'READ' && path === '/ram/log.txt') {
+      if (op === 'read' && path === '/ram/log.txt') {
         return Promise.reject(new Error('backend unavailable'))
       }
-      if (op === 'READ') return Promise.resolve(new Uint8Array())
-      if (op === 'LIST') {
+      if (op === 'read') return Promise.resolve(new Uint8Array())
+      if (op === 'readdir') {
         return Promise.resolve([{ path: '/ram/log.txt', size: 4, isDir: false }])
       }
-      if (op === 'WRITE' && bytes !== undefined) writes.push(new Uint8Array(bytes))
+      if (op === 'write' && bytes !== undefined) writes.push(new Uint8Array(bytes))
       return Promise.resolve(undefined)
     }
     const rt = new PyodideRuntime()

--- a/typescript/packages/core/src/runtime/python/nojspi.test.ts
+++ b/typescript/packages/core/src/runtime/python/nojspi.test.ts
@@ -36,8 +36,8 @@ describe('PyodideRuntime without JSPI', () => {
       // have to suspend, not ride an already-resolved promise
       await new Promise((resolve) => setTimeout(resolve, 1))
       calls.push(bytes ? { op, path, bytes: new Uint8Array(bytes) } : { op, path })
-      if (op === 'READ') return new Uint8Array()
-      if (op === 'LIST') return []
+      if (op === 'read') return new Uint8Array()
+      if (op === 'readdir') return []
       return undefined
     }
     const rt = new PyodideRuntime()
@@ -50,7 +50,7 @@ describe('PyodideRuntime without JSPI', () => {
     })
     expect(new TextDecoder().decode(result.stderr ?? new Uint8Array())).toBe('')
     expect(result.exitCode).toBe(0)
-    const writes = calls.filter((c) => c.op === 'WRITE')
+    const writes = calls.filter((c) => c.op === 'write')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
     if (w0?.bytes === undefined) throw new Error('unreachable')
@@ -65,8 +65,8 @@ describe('PyodideRuntime without JSPI', () => {
     ])
     const dispatch: BridgeDispatchFn = async (op, path) => {
       await new Promise((resolve) => setTimeout(resolve, 1))
-      if (op === 'READ') return files.get(path) ?? new Uint8Array()
-      if (op === 'LIST') {
+      if (op === 'read') return files.get(path) ?? new Uint8Array()
+      if (op === 'readdir') {
         const entries = []
         for (const [p, content] of files) {
           if (p.startsWith(path) && !p.slice(path.length).includes('/')) {
@@ -98,8 +98,8 @@ describe('PyodideRuntime without JSPI', () => {
     const dispatch: BridgeDispatchFn = async (op, path, _bytes, dst) => {
       await new Promise((resolve) => setTimeout(resolve, 1))
       calls.push(dst === undefined ? { op, path } : { op, path, dst })
-      if (op === 'READ') return new Uint8Array()
-      if (op === 'LIST') return []
+      if (op === 'read') return new Uint8Array()
+      if (op === 'readdir') return []
       return undefined
     }
     const rt = new PyodideRuntime()
@@ -119,13 +119,13 @@ describe('PyodideRuntime without JSPI', () => {
     })
     expect(new TextDecoder().decode(result.stderr ?? new Uint8Array())).toBe('')
     expect(result.exitCode).toBe(0)
-    const mutations = calls.filter((c) => c.op !== 'READ' && c.op !== 'LIST')
+    const mutations = calls.filter((c) => c.op !== 'read' && c.op !== 'readdir')
     expect(mutations).toEqual([
-      { op: 'MKDIR', path: '/ram/box' },
-      { op: 'WRITE', path: '/ram/box/f.txt' },
-      { op: 'RENAME', path: '/ram/box/f.txt', dst: '/ram/box/g.txt' },
-      { op: 'UNLINK', path: '/ram/box/g.txt' },
-      { op: 'RMDIR', path: '/ram/box' },
+      { op: 'mkdir', path: '/ram/box' },
+      { op: 'write', path: '/ram/box/f.txt' },
+      { op: 'rename', path: '/ram/box/f.txt', dst: '/ram/box/g.txt' },
+      { op: 'unlink', path: '/ram/box/g.txt' },
+      { op: 'rmdir', path: '/ram/box' },
     ])
     await rt.close()
   }, 60_000)
@@ -139,19 +139,19 @@ describe('PyodideRuntime without JSPI', () => {
     const writes: { path: string; text: string }[] = []
     const dispatch: BridgeDispatchFn = async (op, path, bytes) => {
       await new Promise((resolve) => setTimeout(resolve, 1))
-      if (op === 'READ') {
+      if (op === 'read') {
         const found = files.get(path)
         if (found === undefined) throw new Error(`no such file: ${path}`)
         return found
       }
-      if (op === 'LIST') {
+      if (op === 'readdir') {
         return [...files].map(([p, v]) => ({ path: p, size: v.length, isDir: false }))
       }
-      if (op === 'WRITE' && bytes !== undefined) {
+      if (op === 'write' && bytes !== undefined) {
         files.set(path, new Uint8Array(bytes))
         writes.push({ path, text: new TextDecoder().decode(bytes) })
       }
-      if (op === 'APPEND' && bytes !== undefined) {
+      if (op === 'append' && bytes !== undefined) {
         const base = files.get(path) ?? new Uint8Array()
         const next = new Uint8Array(base.length + bytes.length)
         next.set(base)

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -491,7 +491,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
    * that impossible without JSPI, which no shipping Node has and Safari
    * does not implement.
    *
-   * The cost is one LIST plus one READ per file per run. Narrowing that
+   * The cost is one readdir plus one read per file per run. Narrowing that
    * to what actually changed needs a per-entry change stamp the bridge
    * does not carry yet; until it does, correctness is the side to err on.
    *
@@ -523,7 +523,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       this.mounted.delete(prefix)
     }
     for (const prefix of [...wanted].sort((a, b) => a.length - b.length)) {
-      // Collect before touching the mount table: a failed LIST then
+      // Collect before touching the mount table: a failed readdir then
       // leaves the previous snapshot serving rather than an empty mount,
       // and the prefix retries on the next run.
       const seed = new MirageFsSeed()

--- a/typescript/packages/core/src/runtime/python/syspath.test.ts
+++ b/typescript/packages/core/src/runtime/python/syspath.test.ts
@@ -17,7 +17,7 @@ import { PrefixResolver } from '../resolver.ts'
 import { PyodideRuntime } from './pyodide.ts'
 import type { BridgeDispatchFn } from '../types.ts'
 
-const EMPTY_MOUNT: BridgeDispatchFn = (op) => Promise.resolve(op === 'LIST' ? [] : new Uint8Array())
+const EMPTY_MOUNT: BridgeDispatchFn = (op) => Promise.resolve(op === 'readdir' ? [] : new Uint8Array())
 
 function decode(bytes: Uint8Array | null | undefined): string {
   return bytes ? new TextDecoder().decode(bytes) : ''

--- a/typescript/packages/core/src/runtime/python/syspath.test.ts
+++ b/typescript/packages/core/src/runtime/python/syspath.test.ts
@@ -17,7 +17,8 @@ import { PrefixResolver } from '../resolver.ts'
 import { PyodideRuntime } from './pyodide.ts'
 import type { BridgeDispatchFn } from '../types.ts'
 
-const EMPTY_MOUNT: BridgeDispatchFn = (op) => Promise.resolve(op === 'readdir' ? [] : new Uint8Array())
+const EMPTY_MOUNT: BridgeDispatchFn = (op) =>
+  Promise.resolve(op === 'readdir' ? [] : new Uint8Array())
 
 function decode(bytes: Uint8Array | null | undefined): string {
   return bytes ? new TextDecoder().decode(bytes) : ''

--- a/typescript/packages/core/src/runtime/python/vfs/preload.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/preload.test.ts
@@ -43,15 +43,15 @@ function makeFakeFS(): FakeFS {
 describe('preloadInto', () => {
   it('creates the prefix directory and writes flat files', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'LIST' && path === '/ram/') {
+      if (op === 'readdir' && path === '/ram/') {
         return Promise.resolve([
           { path: '/ram/a.txt', size: 5, isDir: false },
           { path: '/ram/b.bin', size: 3, isDir: false },
         ])
       }
-      if (op === 'READ' && path === '/ram/a.txt')
+      if (op === 'read' && path === '/ram/a.txt')
         return Promise.resolve(new TextEncoder().encode('hello'))
-      if (op === 'READ' && path === '/ram/b.bin') return Promise.resolve(new Uint8Array([1, 2, 3]))
+      if (op === 'read' && path === '/ram/b.bin') return Promise.resolve(new Uint8Array([1, 2, 3]))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS()
@@ -65,11 +65,11 @@ describe('preloadInto', () => {
 
   it('recurses into subdirectories', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'LIST' && path === '/ram/')
+      if (op === 'readdir' && path === '/ram/')
         return Promise.resolve([{ path: '/ram/sub', size: 0, isDir: true }])
-      if (op === 'LIST' && path === '/ram/sub/')
+      if (op === 'readdir' && path === '/ram/sub/')
         return Promise.resolve([{ path: '/ram/sub/c.txt', size: 1, isDir: false }])
-      if (op === 'READ' && path === '/ram/sub/c.txt') return Promise.resolve(new Uint8Array([7]))
+      if (op === 'read' && path === '/ram/sub/c.txt') return Promise.resolve(new Uint8Array([7]))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS()
@@ -82,9 +82,9 @@ describe('preloadInto', () => {
 
   it('is idempotent: re-running overwrites with the mount content', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'LIST' && path === '/ram/')
+      if (op === 'readdir' && path === '/ram/')
         return Promise.resolve([{ path: '/ram/x', size: 1, isDir: false }])
-      if (op === 'READ' && path === '/ram/x') return Promise.resolve(new Uint8Array([42]))
+      if (op === 'read' && path === '/ram/x') return Promise.resolve(new Uint8Array([42]))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS()
@@ -97,9 +97,9 @@ describe('preloadInto', () => {
     expect(Array.from(x)).toEqual([42])
   })
 
-  it('handles empty mounts (LIST returns [])', async () => {
+  it('handles empty mounts (readdir returns [])', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op) =>
-      Promise.resolve(op === 'LIST' ? [] : new Uint8Array()),
+      Promise.resolve(op === 'readdir' ? [] : new Uint8Array()),
     )
     const fs = makeFakeFS()
     await preloadInto(fs, new RuntimeVFS(dispatch), '/ram/')
@@ -109,26 +109,26 @@ describe('preloadInto', () => {
 
   it('accepts a prefix without trailing slash and lists with one', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'LIST' && path === '/ram/') return Promise.resolve([])
+      if (op === 'readdir' && path === '/ram/') return Promise.resolve([])
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS()
     await preloadInto(fs, new RuntimeVFS(dispatch), '/ram')
     expect(fs._dirs.has('/ram')).toBe(true)
-    expect(dispatch).toHaveBeenCalledWith('LIST', '/ram/')
+    expect(dispatch).toHaveBeenCalledWith('readdir', '/ram/')
   })
 
   it('skips a single failing entry and still preloads the rest', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'LIST' && path === '/ram/') {
+      if (op === 'readdir' && path === '/ram/') {
         return Promise.resolve([
           { path: '/ram/ok.txt', size: 2, isDir: false },
           { path: '/ram/bad.txt', size: 4, isDir: false },
         ])
       }
-      if (op === 'READ' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([1, 2]))
-      if (op === 'READ' && path === '/ram/bad.txt') return Promise.reject(new Error('unreadable'))
+      if (op === 'read' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([1, 2]))
+      if (op === 'read' && path === '/ram/bad.txt') return Promise.reject(new Error('unreadable'))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS()
@@ -144,14 +144,14 @@ describe('preloadInto', () => {
   it('skips a failing subtree and still preloads sibling files', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'LIST' && path === '/ram/') {
+      if (op === 'readdir' && path === '/ram/') {
         return Promise.resolve([
           { path: '/ram/ok.txt', size: 1, isDir: false },
           { path: '/ram/bad', size: 0, isDir: true },
         ])
       }
-      if (op === 'READ' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([7]))
-      if (op === 'LIST' && path === '/ram/bad/') return Promise.reject(new Error('subtree fail'))
+      if (op === 'read' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([7]))
+      if (op === 'readdir' && path === '/ram/bad/') return Promise.reject(new Error('subtree fail'))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS()
@@ -164,7 +164,7 @@ describe('preloadInto', () => {
     warn.mockRestore()
   })
 
-  it('lets the top-level LIST error propagate', async () => {
+  it('lets the top-level readdir error propagate', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.reject(new Error('top-level boom')))
     const fs = makeFakeFS()
     await expect(preloadInto(fs, new RuntimeVFS(dispatch), '/ram/')).rejects.toThrow(
@@ -174,19 +174,19 @@ describe('preloadInto', () => {
 
   // A nested mount is served through its parent's walk (syncMounts
   // collapses to maximal prefixes), but it keeps the failure boundary it
-  // had as a top-level prefix: degrading its root LIST failure to an
+  // had as a top-level prefix: degrading its root readdir failure to an
   // empty directory would let syncMounts replace a healthy snapshot with
   // one where the nested mount reads as empty.
-  it('lets a nested mount root LIST failure fail the whole collection', async () => {
+  it('lets a nested mount root readdir failure fail the whole collection', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'LIST' && path === '/ram/') {
+      if (op === 'readdir' && path === '/ram/') {
         return Promise.resolve([
           { path: '/ram/ok.txt', size: 1, isDir: false },
           { path: '/ram/inner', size: 0, isDir: true },
         ])
       }
-      if (op === 'READ' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([7]))
-      if (op === 'LIST' && path === '/ram/inner/') return Promise.reject(new Error('inner boom'))
+      if (op === 'read' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([7]))
+      if (op === 'readdir' && path === '/ram/inner/') return Promise.reject(new Error('inner boom'))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS()

--- a/typescript/packages/core/src/runtime/python/vfs/preload.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/preload.ts
@@ -36,7 +36,7 @@ async function preloadEntry(fs: FSLike, vfs: RuntimeVFS, entry: VFSEntry): Promi
     const next = entry.path.endsWith('/') ? entry.path : entry.path + '/'
     if (vfs.mountOf(entry.path) === next) {
       // A nested mount served through its parent keeps the failure
-      // boundary it had as a top-level prefix: its root LIST failing
+      // boundary it had as a top-level prefix: its root readdir failing
       // must fail the whole collection, so syncMounts keeps the
       // previous healthy snapshot instead of replacing it with one
       // where this subtree reads as empty.

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
@@ -67,28 +67,28 @@ describe('MirageFs', () => {
     py = await loadPyodideRuntime()
     const dispatch: BridgeDispatchFn = (op, path, bytes, dst) => {
       calls.push(bytes ? { op, path, bytes: new Uint8Array(bytes) } : { op, path })
-      if (op === 'READ') {
+      if (op === 'read') {
         if (unreadable.has(path)) return Promise.reject(new Error('backend unavailable'))
         const found = store.get(path)
         if (found === undefined) return Promise.reject(new Error(`no such file: ${path}`))
         return Promise.resolve(found)
       }
-      if (op === 'WRITE' && bytes !== undefined) store.set(path, new Uint8Array(bytes))
-      if (op === 'APPEND' && bytes !== undefined) {
+      if (op === 'write' && bytes !== undefined) store.set(path, new Uint8Array(bytes))
+      if (op === 'append' && bytes !== undefined) {
         const base = store.get(path) ?? new Uint8Array()
         const next = new Uint8Array(base.length + bytes.length)
         next.set(base)
         next.set(bytes, base.length)
         store.set(path, next)
       }
-      if (op === 'UNLINK') store.delete(path)
-      if (op === 'RENAME' && dst !== undefined) {
+      if (op === 'unlink') store.delete(path)
+      if (op === 'rename' && dst !== undefined) {
         const moved = store.get(path)
         if (moved === undefined) return Promise.reject(new Error(`no such file: ${path}`))
         store.delete(path)
         store.set(dst, moved)
       }
-      if (op === 'LIST') {
+      if (op === 'readdir') {
         return Promise.resolve(
           [...store.keys()]
             .filter((k) => k.startsWith(path))
@@ -295,7 +295,7 @@ with open('${p}../escaped.txt', 'w') as f:
 `)
     await drain()
     expect([...store.keys()]).toEqual([])
-    expect(calls.filter((c) => c.op === 'WRITE')).toEqual([])
+    expect(calls.filter((c) => c.op === 'write')).toEqual([])
   })
 
   it('refuses to open a listed file the mount would not hand over', async () => {

--- a/typescript/packages/core/src/runtime/types.ts
+++ b/typescript/packages/core/src/runtime/types.ts
@@ -29,7 +29,7 @@ export type RuntimeLanguage = 'python' | 'js'
  * imports no workspace module (Python's DispatchFn in runtime/types).
  */
 export type BridgeDispatchFn = (
-  op: 'READ' | 'WRITE' | 'APPEND' | 'LIST' | 'STAT' | 'UNLINK' | 'MKDIR' | 'RMDIR' | 'RENAME',
+  op: 'read' | 'write' | 'append' | 'readdir' | 'stat' | 'unlink' | 'mkdir' | 'rmdir' | 'rename',
   path: string,
   bytes?: Uint8Array,
   dst?: string,

--- a/typescript/packages/core/src/runtime/types.ts
+++ b/typescript/packages/core/src/runtime/types.ts
@@ -29,7 +29,18 @@ export type RuntimeLanguage = 'python' | 'js'
  * imports no workspace module (Python's DispatchFn in runtime/types).
  */
 export type BridgeDispatchFn = (
-  op: 'read' | 'write' | 'append' | 'readdir' | 'stat' | 'unlink' | 'mkdir' | 'rmdir' | 'rename',
+  op:
+    | 'read'
+    | 'write'
+    | 'append'
+    | 'readdir'
+    | 'stat'
+    | 'create'
+    | 'truncate'
+    | 'unlink'
+    | 'mkdir'
+    | 'rmdir'
+    | 'rename',
   path: string,
   bytes?: Uint8Array,
   dst?: string,

--- a/typescript/packages/core/src/runtime/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/vfs.test.ts
@@ -86,9 +86,23 @@ describe('RuntimeVFS transport', () => {
     )
   })
 
-  it('throws TypeError when STAT returns a bad shape', async () => {
+  it('throws TypeError when stat returns a bad shape', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve({ size: 1 }))
     await expect(new RuntimeVFS(dispatch).stat('/x')).rejects.toThrow(TypeError)
+  })
+
+  it('forwards create and truncate as their own ops, never a write', async () => {
+    // The bridge used to lack both verbs, so quickjs faked them with
+    // write: the ledger recorded the wrong op and a backend with a
+    // native truncate got a whole-file write instead.
+    const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve(undefined))
+    const vfs = new RuntimeVFS(dispatch)
+    await vfs.create('/ram/new.txt')
+    await vfs.truncate('/ram/old.txt')
+    expect(dispatch.mock.calls.map((c) => [c[0], c[1]])).toEqual([
+      ['create', '/ram/new.txt'],
+      ['truncate', '/ram/old.txt'],
+    ])
   })
 })
 

--- a/typescript/packages/core/src/runtime/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/vfs.test.ts
@@ -22,26 +22,26 @@ import { PrefixResolver } from './resolver.ts'
 const enc = new TextEncoder()
 
 describe('RuntimeVFS transport', () => {
-  it('forwards read to dispatch READ and returns bytes', async () => {
+  it('forwards read to dispatch read and returns bytes', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve(new Uint8Array([1, 2, 3])))
     const out = await new RuntimeVFS(dispatch).read('/ram/x.txt')
-    expect(dispatch).toHaveBeenCalledWith('READ', '/ram/x.txt')
+    expect(dispatch).toHaveBeenCalledWith('read', '/ram/x.txt')
     expect(Array.from(out)).toEqual([1, 2, 3])
   })
 
-  it('forwards write to dispatch WRITE with bytes and resolves void', async () => {
+  it('forwards write to dispatch write with bytes and resolves void', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve(undefined))
     await new RuntimeVFS(dispatch).write('/ram/x.txt', new Uint8Array([9, 9]))
     const call = dispatch.mock.calls[0]
     if (call === undefined) throw new Error('unreachable')
     const [op, path, bytes] = call
     if (bytes === undefined) throw new Error('unreachable')
-    expect(op).toBe('WRITE')
+    expect(op).toBe('write')
     expect(path).toBe('/ram/x.txt')
     expect(Array.from(bytes)).toEqual([9, 9])
   })
 
-  it('forwards readdir to dispatch LIST and returns entries', async () => {
+  it('forwards readdir to dispatch readdir and returns entries', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() =>
       Promise.resolve([
         { path: '/ram/a.txt', size: 4, isDir: false },
@@ -58,28 +58,28 @@ describe('RuntimeVFS transport', () => {
     await expect(new RuntimeVFS(dispatch).read('/x')).rejects.toThrow(/boom/)
   })
 
-  it('throws TypeError when READ returns non-Uint8Array', async () => {
+  it('throws TypeError when read returns non-Uint8Array', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() =>
       Promise.resolve('not bytes' as unknown as Uint8Array),
     )
     await expect(new RuntimeVFS(dispatch).read('/x')).rejects.toThrow(TypeError)
   })
 
-  it('throws TypeError when LIST returns non-array', async () => {
+  it('throws TypeError when readdir returns non-array', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() =>
       Promise.resolve({ not: 'array' } as unknown as never[]),
     )
     await expect(new RuntimeVFS(dispatch).readdir('/x')).rejects.toThrow(TypeError)
   })
 
-  it('throws TypeError when LIST entry has bad shape', async () => {
+  it('throws TypeError when readdir entry has bad shape', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() =>
       Promise.resolve([{ path: '/x' }] as unknown as never[]),
     )
     await expect(new RuntimeVFS(dispatch).readdir('/x')).rejects.toThrow(TypeError)
   })
 
-  it('throws TypeError when WRITE dispatch returns non-undefined', async () => {
+  it('throws TypeError when write dispatch returns non-undefined', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve('unexpected' as unknown))
     await expect(new RuntimeVFS(dispatch).write('/x', new Uint8Array([1]))).rejects.toThrow(
       TypeError,
@@ -122,7 +122,7 @@ describe('RuntimeVFS routing', () => {
   it('dispatches a rename within one mount', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve(undefined))
     await new RuntimeVFS(dispatch, new PrefixResolver(() => ['/a'])).rename('/a/x', '/a/y')
-    expect(dispatch).toHaveBeenCalledWith('RENAME', '/a/x', undefined, '/a/y')
+    expect(dispatch).toHaveBeenCalledWith('rename', '/a/x', undefined, '/a/y')
   })
 })
 
@@ -133,12 +133,12 @@ describe('RuntimeVFS append', () => {
       '/a/x',
       enc.encode('tail'),
     )
-    expect(dispatch.mock.calls.map((c) => c[0])).toEqual(['APPEND'])
+    expect(dispatch.mock.calls.map((c) => c[0])).toEqual(['append'])
   })
 
   it('writes the whole file the caller supplied when the mount has no append', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op) => {
-      if (op === 'APPEND') return Promise.reject(enotsup('s3', 'append', '/a/x'))
+      if (op === 'append') return Promise.reject(enotsup('s3', 'append', '/a/x'))
       return Promise.resolve(undefined)
     })
     await new RuntimeVFS(dispatch, new PrefixResolver(() => ['/a'])).append(
@@ -146,22 +146,22 @@ describe('RuntimeVFS append', () => {
       enc.encode('tail'),
       enc.encode('headtail'),
     )
-    const write = dispatch.mock.calls.find((c) => c[0] === 'WRITE')
+    const write = dispatch.mock.calls.find((c) => c[0] === 'write')
     if (write?.[2] === undefined) throw new Error('unreachable')
     expect(new TextDecoder().decode(write[2])).toBe('headtail')
   })
 
   it('reads the base itself when no whole file was supplied', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op) => {
-      if (op === 'APPEND') return Promise.reject(enotsup('s3', 'append', '/a/x'))
-      if (op === 'READ') return Promise.resolve(enc.encode('head'))
+      if (op === 'append') return Promise.reject(enotsup('s3', 'append', '/a/x'))
+      if (op === 'read') return Promise.resolve(enc.encode('head'))
       return Promise.resolve(undefined)
     })
     await new RuntimeVFS(dispatch, new PrefixResolver(() => ['/a'])).append(
       '/a/x',
       enc.encode('tail'),
     )
-    const write = dispatch.mock.calls.find((c) => c[0] === 'WRITE')
+    const write = dispatch.mock.calls.find((c) => c[0] === 'write')
     if (write?.[2] === undefined) throw new Error('unreachable')
     expect(new TextDecoder().decode(write[2])).toBe('headtail')
   })
@@ -169,45 +169,45 @@ describe('RuntimeVFS append', () => {
   it('starts from an empty base when the file is simply absent', async () => {
     const missing = Object.assign(new Error('nope'), { code: 'ENOENT' })
     const dispatch = vi.fn<BridgeDispatchFn>((op) => {
-      if (op === 'APPEND') return Promise.reject(enotsup('s3', 'append', '/a/x'))
-      if (op === 'READ') return Promise.reject(missing)
+      if (op === 'append') return Promise.reject(enotsup('s3', 'append', '/a/x'))
+      if (op === 'read') return Promise.reject(missing)
       return Promise.resolve(undefined)
     })
     await new RuntimeVFS(dispatch, new PrefixResolver(() => ['/a'])).append(
       '/a/x',
       enc.encode('tail'),
     )
-    const write = dispatch.mock.calls.find((c) => c[0] === 'WRITE')
+    const write = dispatch.mock.calls.find((c) => c[0] === 'write')
     if (write?.[2] === undefined) throw new Error('unreachable')
     expect(new TextDecoder().decode(write[2])).toBe('tail')
   })
 
   it('propagates a read failure that is not an absence', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op) => {
-      if (op === 'APPEND') return Promise.reject(enotsup('s3', 'append', '/a/x'))
-      if (op === 'READ') return Promise.reject(new Error('transport down'))
+      if (op === 'append') return Promise.reject(enotsup('s3', 'append', '/a/x'))
+      if (op === 'read') return Promise.reject(new Error('transport down'))
       return Promise.resolve(undefined)
     })
     await expect(
       new RuntimeVFS(dispatch, new PrefixResolver(() => ['/a'])).append('/a/x', enc.encode('tail')),
     ).rejects.toThrow(/transport down/)
-    expect(dispatch.mock.calls.some((c) => c[0] === 'WRITE')).toBe(false)
+    expect(dispatch.mock.calls.some((c) => c[0] === 'write')).toBe(false)
   })
 
   it('remembers a mount that declined, so it costs one failed dispatch', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op) => {
-      if (op === 'APPEND') return Promise.reject(enotsup('s3', 'append', '/a/x'))
+      if (op === 'append') return Promise.reject(enotsup('s3', 'append', '/a/x'))
       return Promise.resolve(undefined)
     })
     const vfs = new RuntimeVFS(dispatch, new PrefixResolver(() => ['/a']))
     await vfs.append('/a/x', enc.encode('1'), enc.encode('1'))
     await vfs.append('/a/y', enc.encode('2'), enc.encode('2'))
-    expect(dispatch.mock.calls.filter((c) => c[0] === 'APPEND')).toHaveLength(1)
+    expect(dispatch.mock.calls.filter((c) => c[0] === 'append')).toHaveLength(1)
   })
 
   it('lets a real append failure propagate instead of writing whole', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op) => {
-      if (op === 'APPEND') return Promise.reject(new Error('mount is read-only'))
+      if (op === 'append') return Promise.reject(new Error('mount is read-only'))
       return Promise.resolve(undefined)
     })
     await expect(
@@ -217,7 +217,7 @@ describe('RuntimeVFS append', () => {
         enc.encode('t'),
       ),
     ).rejects.toThrow(/read-only/)
-    expect(dispatch.mock.calls.some((c) => c[0] === 'WRITE')).toBe(false)
+    expect(dispatch.mock.calls.some((c) => c[0] === 'write')).toBe(false)
   })
 })
 
@@ -232,7 +232,7 @@ describe('RuntimeVFS flush', () => {
     )
     const call = dispatch.mock.calls[0]
     if (call?.[2] === undefined) throw new Error('unreachable')
-    expect(call[0]).toBe('APPEND')
+    expect(call[0]).toBe('append')
     expect(new TextDecoder().decode(call[2])).toBe('XYZ')
   })
 
@@ -246,7 +246,7 @@ describe('RuntimeVFS flush', () => {
     )
     const call = dispatch.mock.calls[0]
     if (call?.[2] === undefined) throw new Error('unreachable')
-    expect(call[0]).toBe('WRITE')
+    expect(call[0]).toBe('write')
     expect(new TextDecoder().decode(call[2])).toBe('ZZZdef')
   })
 })

--- a/typescript/packages/core/src/runtime/vfs.ts
+++ b/typescript/packages/core/src/runtime/vfs.ts
@@ -47,9 +47,9 @@ export function concatBytes(head: Uint8Array, tail: Uint8Array): Uint8Array {
 /**
  * The mount-facing op vocabulary a sandboxed runtime encodes into.
  *
- * One instruction set (read/write/append/stat/readdir/unlink/mkdir/
- * rmdir/rename), one routing table, one place that knows an append may
- * have to become a whole-file write. Encoders hold one of these; they
+ * One instruction set (read/write/append/stat/readdir/create/truncate/
+ * unlink/mkdir/rmdir/rename), one routing table, one place that knows
+ * an append may have to become a whole-file write. Encoders hold one of these; they
  * never inherit it, because a monty encoder is the binding's own `os`
  * callback and a quickjs encoder is a table of host functions.
  *
@@ -141,6 +141,24 @@ export class RuntimeVFS {
       }
     }
     return out as VFSEntry[]
+  }
+
+  /**
+   * Establish an empty file at `path` through the mount, so write
+   * modes and a missing parent answer at open time and the ledger
+   * records the op a create is.
+   */
+  async create(path: string): Promise<void> {
+    await this.dispatch('create', path)
+  }
+
+  /**
+   * Discard `path`'s content. Only ever a truncate-to-zero: the guest
+   * surfaces that reach this are fopen-style opens, and a guest
+   * ftruncate to a length operates on its open handle's buffer.
+   */
+  async truncate(path: string): Promise<void> {
+    await this.dispatch('truncate', path)
   }
 
   async unlink(path: string): Promise<void> {

--- a/typescript/packages/core/src/runtime/vfs.ts
+++ b/typescript/packages/core/src/runtime/vfs.ts
@@ -95,22 +95,22 @@ export class RuntimeVFS {
   }
 
   async read(path: string): Promise<Uint8Array> {
-    const out = await this.dispatch('READ', path)
+    const out = await this.dispatch('read', path)
     if (!(out instanceof Uint8Array)) {
-      throw new TypeError(`runtime vfs: READ ${path} expected Uint8Array, got ${typeof out}`)
+      throw new TypeError(`runtime vfs: read ${path} expected Uint8Array, got ${typeof out}`)
     }
     return out
   }
 
   async write(path: string, bytes: Uint8Array): Promise<void> {
-    const out = await this.dispatch('WRITE', path, bytes)
+    const out = await this.dispatch('write', path, bytes)
     if (out !== undefined) {
-      throw new TypeError(`runtime vfs: WRITE ${path} expected void, got ${typeof out}`)
+      throw new TypeError(`runtime vfs: write ${path} expected void, got ${typeof out}`)
     }
   }
 
   async stat(path: string): Promise<VFSStat> {
-    const out = await this.dispatch('STAT', path)
+    const out = await this.dispatch('stat', path)
     const st = out as VFSStat | null
     if (
       st === null ||
@@ -119,15 +119,15 @@ export class RuntimeVFS {
       typeof st.isDir !== 'boolean' ||
       typeof st.mtimeMs !== 'number'
     ) {
-      throw new TypeError(`runtime vfs: STAT ${path} bad shape`)
+      throw new TypeError(`runtime vfs: stat ${path} bad shape`)
     }
     return st
   }
 
   async readdir(path: string): Promise<VFSEntry[]> {
-    const out = await this.dispatch('LIST', path)
+    const out = await this.dispatch('readdir', path)
     if (!Array.isArray(out)) {
-      throw new TypeError(`runtime vfs: LIST ${path} expected array`)
+      throw new TypeError(`runtime vfs: readdir ${path} expected array`)
     }
     for (const e of out) {
       if (
@@ -137,22 +137,22 @@ export class RuntimeVFS {
         typeof (e as VFSEntry).size !== 'number' ||
         typeof (e as VFSEntry).isDir !== 'boolean'
       ) {
-        throw new TypeError(`runtime vfs: LIST ${path} bad entry shape`)
+        throw new TypeError(`runtime vfs: readdir ${path} bad entry shape`)
       }
     }
     return out as VFSEntry[]
   }
 
   async unlink(path: string): Promise<void> {
-    await this.dispatch('UNLINK', path)
+    await this.dispatch('unlink', path)
   }
 
   async mkdir(path: string): Promise<void> {
-    await this.dispatch('MKDIR', path)
+    await this.dispatch('mkdir', path)
   }
 
   async rmdir(path: string): Promise<void> {
-    await this.dispatch('RMDIR', path)
+    await this.dispatch('rmdir', path)
   }
 
   /**
@@ -167,7 +167,7 @@ export class RuntimeVFS {
    */
   async rename(src: string, dst: string): Promise<void> {
     if (this.mountOf(src) !== this.mountOf(dst)) throw new CrossMountError(src, dst)
-    await this.dispatch('RENAME', src, undefined, dst)
+    await this.dispatch('rename', src, undefined, dst)
   }
 
   /**
@@ -211,7 +211,7 @@ export class RuntimeVFS {
     const mount = this.mountOf(path) ?? path
     if (this.noAppend.has(mount)) return false
     try {
-      await this.dispatch('APPEND', path, tail)
+      await this.dispatch('append', path, tail)
     } catch (err) {
       if (!isMissingOp(err, 'append')) throw err
       this.noAppend.add(mount)

--- a/typescript/packages/core/src/utils/mode.test.ts
+++ b/typescript/packages/core/src/utils/mode.test.ts
@@ -13,31 +13,31 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { parseMode } from './mode.ts'
+import { parseChmod } from './mode.ts'
 
-describe('parseMode', () => {
+describe('parseChmod', () => {
   it('parses octal modes', () => {
-    expect(parseMode('644', 0)).toBe(0o644)
-    expect(parseMode('0', 0o777)).toBe(0)
-    expect(parseMode('7777', 0)).toBe(0o7777)
+    expect(parseChmod('644', 0)).toBe(0o644)
+    expect(parseChmod('0', 0o777)).toBe(0)
+    expect(parseChmod('7777', 0)).toBe(0o7777)
   })
 
   it('rejects out-of-range octal', () => {
-    expect(parseMode('77777', 0)).toBeNull()
+    expect(parseChmod('77777', 0)).toBeNull()
   })
 
   it('applies symbolic add/remove/assign', () => {
-    expect(parseMode('u+x', 0o644)).toBe(0o744)
-    expect(parseMode('+x', 0o644)).toBe(0o755)
-    expect(parseMode('go-r', 0o644)).toBe(0o600)
-    expect(parseMode('a=r', 0o777)).toBe(0o444)
-    expect(parseMode('u=rwx,go=', 0o644)).toBe(0o700)
-    expect(parseMode('u+x,g-r', 0o644)).toBe(0o704)
+    expect(parseChmod('u+x', 0o644)).toBe(0o744)
+    expect(parseChmod('+x', 0o644)).toBe(0o755)
+    expect(parseChmod('go-r', 0o644)).toBe(0o600)
+    expect(parseChmod('a=r', 0o777)).toBe(0o444)
+    expect(parseChmod('u=rwx,go=', 0o644)).toBe(0o700)
+    expect(parseChmod('u+x,g-r', 0o644)).toBe(0o704)
   })
 
   it('rejects invalid symbolic text', () => {
-    expect(parseMode('zz', 0o644)).toBeNull()
-    expect(parseMode('u~x', 0o644)).toBeNull()
-    expect(parseMode('u+q', 0o644)).toBeNull()
+    expect(parseChmod('zz', 0o644)).toBeNull()
+    expect(parseChmod('u~x', 0o644)).toBeNull()
+    expect(parseChmod('u+q', 0o644)).toBeNull()
   })
 })

--- a/typescript/packages/core/src/utils/mode.ts
+++ b/typescript/packages/core/src/utils/mode.ts
@@ -22,7 +22,7 @@ export const DEFAULT_FILE_MODE = 0o644
 // common grammar: `[ugoa...][+-=][rwx...]` clauses joined by commas
 // (`u+x`, `go-w`, `a=r`, `+x`). Special bits (s, t, X) are not supported.
 // Returns the new mode, or null when the text does not parse.
-export function parseMode(text: string, current: number): number | null {
+export function parseChmod(text: string, current: number): number | null {
   if (/^[0-7]+$/.test(text)) {
     const value = parseInt(text, 8)
     return value <= 0o7777 ? value : null

--- a/typescript/packages/core/src/workspace/bridge_list.test.ts
+++ b/typescript/packages/core/src/workspace/bridge_list.test.ts
@@ -32,15 +32,15 @@ function mkWorld(): { ws: Workspace; ops: OpsRegistry; resource: RAMResource } {
   return { ws, ops, resource }
 }
 
-// The bridge LIST is the sandboxed runtimes' directory read: what it
+// The bridge readdir is the sandboxed runtimes' directory read: what it
 // swallows, a guest can never see, and what it fails, pyodide's
 // syncMounts treats as the whole tree.
-describe('workspace bridge LIST', () => {
+describe('workspace bridge readdir', () => {
   it('a dangling link degrades to a zero row instead of failing the listing', async () => {
     const { ws } = mkWorld()
     await ws.fs.writeFile('/data/a.txt', 'hi')
     await ws.namespace.symlink('/data/lnk', '/data/gone', 1)
-    const entries = (await bridgeOn(ws)('LIST', '/data')) as VFSEntry[]
+    const entries = (await bridgeOn(ws)('readdir', '/data')) as VFSEntry[]
     const row = entries.find((e) => e.path.endsWith('/lnk'))
     expect(row).toMatchObject({ size: 0, isDir: false, isLink: true })
   })
@@ -61,6 +61,6 @@ describe('workspace bridge LIST', () => {
       },
       write: false,
     })
-    await expect(bridgeOn(ws)('LIST', '/data')).rejects.toThrow('401 Unauthorized')
+    await expect(bridgeOn(ws)('readdir', '/data')).rejects.toThrow('401 Unauthorized')
   })
 })

--- a/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
@@ -17,7 +17,7 @@ import { PolicyDenied } from '../../../policy/index.ts'
 import type { FileStat } from '../../../types.ts'
 import { FileType, PathSpec } from '../../../types.ts'
 import { fsStrerror, isEnoent, isFsError, isMissingOp } from '../../../utils/errors.ts'
-import { DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, parseMode } from '../../../utils/mode.ts'
+import { DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, parseChmod } from '../../../utils/mode.ts'
 import { CycleError, resolvePath } from '../../../utils/path.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 import { mountKey } from '../../../utils/key_prefix.ts'
@@ -354,7 +354,7 @@ export async function handleChmod(
   const first = operands[0]
   if (first === undefined) return errorResult('chmod', 'chmod: missing operand\n', 2)
   const modeText = first instanceof PathSpec ? first.virtual : first
-  if (parseMode(modeText, 0) === null) {
+  if (parseChmod(modeText, 0) === null) {
     return errorResult('chmod', `chmod: invalid mode: '${modeText}'\n`, 1)
   }
 
@@ -395,7 +395,7 @@ export async function handleChmod(
       const current =
         pathStat.mode ??
         (pathStat.type === FileType.DIRECTORY ? DEFAULT_DIR_MODE : DEFAULT_FILE_MODE)
-      const newMode = parseMode(modeText, current)
+      const newMode = parseChmod(modeText, current)
       if (newMode === null) {
         return errorResult('chmod', `chmod: invalid mode: '${modeText}'\n`, 1)
       }

--- a/typescript/packages/core/src/workspace/records_accounting.test.ts
+++ b/typescript/packages/core/src/workspace/records_accounting.test.ts
@@ -49,7 +49,7 @@ describe('Workspace record accounting', () => {
     expect(ws.cacheRecords).toEqual([])
   })
 
-  it('WorkspaceFS ops land in ws.records', async () => {
+  it('Ops facade ops land in ws.records', async () => {
     const ws = new Workspace({ '/data/': new RAMResource() }, { mode: MountMode.WRITE })
     await ws.fs.writeFile('/data/a.txt', 'hello')
     await ws.fs.readFile('/data/a.txt')

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -335,23 +335,23 @@ export class Workspace {
   private buildWorkspaceBridge(): BridgeDispatchFn {
     return async (op, path, bytes, dst) => {
       switch (op) {
-        case 'READ':
+        case 'read':
           return (await this.dispatch('read', path)) as Uint8Array
-        case 'WRITE': {
-          if (bytes === undefined) throw new Error('WRITE op requires bytes')
+        case 'write': {
+          if (bytes === undefined) throw new Error('write op requires bytes')
           const buf =
             bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes as ArrayLike<number>)
           await this.dispatch('write', path, [buf])
           return undefined
         }
-        case 'APPEND': {
-          if (bytes === undefined) throw new Error('APPEND op requires bytes')
+        case 'append': {
+          if (bytes === undefined) throw new Error('append op requires bytes')
           const buf =
             bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes as ArrayLike<number>)
           await this.dispatch('append', path, [buf])
           return undefined
         }
-        case 'STAT': {
+        case 'stat': {
           const st = (await this.dispatch('stat', path)) as FileStat
           // One translator: bare Date.parse read an offset-less stamp
           // as LOCAL time here while the fuse fold read it as UTC.
@@ -363,21 +363,21 @@ export class Workspace {
             mtimeMs: mtimeMs(st) ?? 0,
           }
         }
-        case 'UNLINK':
+        case 'unlink':
           await this.dispatch('unlink', path)
           return undefined
-        case 'MKDIR':
+        case 'mkdir':
           await this.dispatch('mkdir', path)
           return undefined
-        case 'RMDIR':
+        case 'rmdir':
           await this.dispatch('rmdir', path)
           return undefined
-        case 'RENAME': {
-          if (dst === undefined) throw new Error('RENAME op requires dst')
+        case 'rename': {
+          if (dst === undefined) throw new Error('rename op requires dst')
           await this.dispatch('rename', path, [PathSpec.fromStrPath(dst)])
           return undefined
         }
-        case 'LIST': {
+        case 'readdir': {
           const entries = ((await this.dispatch('readdir', path)) as string[] | null) ?? []
           return await Promise.all(
             entries.map(async (entry): Promise<VFSEntry> => {

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -363,6 +363,12 @@ export class Workspace {
             mtimeMs: mtimeMs(st) ?? 0,
           }
         }
+        case 'create':
+          await this.dispatch('create', path)
+          return undefined
+        case 'truncate':
+          await this.dispatch('truncate', path, [0])
+          return undefined
         case 'unlink':
           await this.dispatch('unlink', path)
           return undefined

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -46,7 +46,7 @@ import type { PolicyFn } from '../runtime/policy/index.ts'
 import type { TSNodeLike } from '../shell/types.ts'
 import type { ExecuteFn } from './expand/node.ts'
 import type { ProvisionResult } from '../provision/types.ts'
-import { WorkspaceFS } from './fs.ts'
+import { Ops } from '../ops/ops.ts'
 import type { MountEntry } from './mount/mount.ts'
 import { MountRegistry } from './mount/registry.ts'
 import type { VFSEntry } from '../runtime/vfs.ts'
@@ -102,8 +102,7 @@ export class Workspace {
   readonly namespace: Namespace
   private readonly dispatcher: Dispatcher
   readonly observer: Observer
-  readonly records: OpRecord[] = []
-  readonly fs: WorkspaceFS
+  readonly fs: Ops
   private closed = false
   private readonly closers: (() => Promise<void>)[] = []
   private readonly watchManager: WatchManager
@@ -250,11 +249,10 @@ export class Workspace {
     // The facade delegates every op to the dispatcher, so FUSE and
     // programmatic ws.fs walk the same pipeline as a shell command and
     // the policy gates fire exactly once, at that door. It keeps the
-    // record, which is its own.
-    this.fs = new WorkspaceFS(
+    // ledger, which is its own; the sink is only the observer's copy.
+    this.fs = new Ops(
       this.dispatcher.dispatch,
       async (rec) => {
-        this.records.push(rec)
         await this.observer.logOp(rec, this.agentId ?? '', this.sessionManager.defaultId)
       },
       this.namespace,
@@ -327,7 +325,7 @@ export class Workspace {
   }
 
   // The sandboxed runtimes' sole data path (quickjs, pyodide, monty).
-  // Routes through `dispatch`, not the raw WorkspaceFS, so sandbox I/O
+  // Routes through `dispatch`, not the raw Ops facade, so sandbox I/O
   // takes the same path as shell commands — cache read-through on
   // reads, post-write invalidation, and mount-mode enforcement narrowed
   // by the current session all come from the Dispatcher. Reads are raw
@@ -635,28 +633,32 @@ export class Workspace {
     this.cache.maxDrainBytes = value
   }
 
+  /**
+   * The op ledger. It lives on the `Ops` facade (python parity); these
+   * are thin delegates so the public workspace API keeps reading.
+   */
+  get records(): OpRecord[] {
+    return this.fs.records
+  }
+
   /** Records that hit a remote resource (not cache). */
   get networkRecords(): OpRecord[] {
-    return this.records.filter((r) => !r.isCache)
+    return this.fs.networkRecords
   }
 
   /** Total bytes transferred over the network. */
   get networkBytes(): number {
-    let total = 0
-    for (const r of this.records) if (!r.isCache) total += r.bytes
-    return total
+    return this.fs.networkBytes
   }
 
   /** Records served from in-memory cache. */
   get cacheRecords(): OpRecord[] {
-    return this.records.filter((r) => r.isCache)
+    return this.fs.cacheRecords
   }
 
   /** Total bytes served from cache. */
   get cacheBytes(): number {
-    let total = 0
-    for (const r of this.records) if (r.isCache) total += r.bytes
-    return total
+    return this.fs.cacheBytes
   }
 
   get filePrompt(): string {

--- a/typescript/packages/core/src/workspace/workspace_js_mount.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_js_mount.test.ts
@@ -124,9 +124,7 @@ describe('node/js: std.open dispatches the real establishing op', () => {
   it("'wx' refuses an existing file and leaves it untouched", async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('echo keep > /ram/x.txt')
-    const io = await ws.execute(
-      "js -e \"console.log(std.open('/ram/x.txt', 'wx') === null)\"",
-    )
+    const io = await ws.execute("js -e \"console.log(std.open('/ram/x.txt', 'wx') === null)\"")
     expect(stdoutStr(io)).toBe('true\n')
     const still = await ws.execute('cat /ram/x.txt')
     expect(stdoutStr(still)).toBe('keep\n')
@@ -146,9 +144,7 @@ describe('node/js: std.open dispatches the real establishing op', () => {
 
   it("'r+' does not create a missing file", async () => {
     const { ws } = await makeWorkspace()
-    const io = await ws.execute(
-      "js -e \"console.log(std.open('/ram/absent.txt', 'r+') === null)\"",
-    )
+    const io = await ws.execute("js -e \"console.log(std.open('/ram/absent.txt', 'r+') === null)\"")
     expect(stdoutStr(io)).toBe('true\n')
     const check = await ws.execute('cat /ram/absent.txt')
     expect(check.exitCode).not.toBe(0)

--- a/typescript/packages/core/src/workspace/workspace_js_mount.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_js_mount.test.ts
@@ -93,6 +93,69 @@ describe('node/js: workspace mount access', () => {
   }, 60_000)
 })
 
+// Open's establishing op is the real one — create for a new file,
+// truncate for an existing one — mirroring the python wasi host's
+// path_open, so the op ledger, policy, and a backend with a native
+// truncate all see the same op from both languages' guests.
+describe('node/js: std.open dispatches the real establishing op', () => {
+  it('creating a file records create, not write', async () => {
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute("js -e \"const f = std.open('/ram/new.txt', 'w'); f.close()\"")
+    expect(io.exitCode).toBe(0)
+    const ops = ws.records.filter((r) => r.path.endsWith('/new.txt')).map((r) => r.op)
+    expect(ops).toContain('create')
+    expect(ops).not.toContain('write')
+    await ws.close()
+  }, 60_000)
+
+  it('truncating an existing file records truncate and empties it', async () => {
+    const { ws } = await makeWorkspace()
+    await ws.execute('echo previous > /ram/t.txt')
+    const io = await ws.execute("js -e \"const f = std.open('/ram/t.txt', 'w'); f.close()\"")
+    expect(io.exitCode).toBe(0)
+    const ops = ws.records.filter((r) => r.path.endsWith('/t.txt')).map((r) => r.op)
+    expect(ops).toContain('truncate')
+    expect(ops).not.toContain('create')
+    const wc = await ws.execute('wc -c < /ram/t.txt')
+    expect(stdoutStr(wc).trim()).toBe('0')
+    await ws.close()
+  }, 60_000)
+
+  it("'wx' refuses an existing file and leaves it untouched", async () => {
+    const { ws } = await makeWorkspace()
+    await ws.execute('echo keep > /ram/x.txt')
+    const io = await ws.execute(
+      "js -e \"console.log(std.open('/ram/x.txt', 'wx') === null)\"",
+    )
+    expect(stdoutStr(io)).toBe('true\n')
+    const still = await ws.execute('cat /ram/x.txt')
+    expect(stdoutStr(still)).toBe('keep\n')
+    await ws.close()
+  }, 60_000)
+
+  it("'wx' creates a missing file", async () => {
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute(
+      "js -e \"const f = std.open('/ram/nx.txt', 'wx'); f.puts('made'); f.close()\"",
+    )
+    expect(io.exitCode).toBe(0)
+    const back = await ws.execute('cat /ram/nx.txt')
+    expect(stdoutStr(back)).toBe('made')
+    await ws.close()
+  }, 60_000)
+
+  it("'r+' does not create a missing file", async () => {
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute(
+      "js -e \"console.log(std.open('/ram/absent.txt', 'r+') === null)\"",
+    )
+    expect(stdoutStr(io)).toBe('true\n')
+    const check = await ws.execute('cat /ram/absent.txt')
+    expect(check.exitCode).not.toBe(0)
+    await ws.close()
+  }, 60_000)
+})
+
 // The os.* mutation surface, pinned against the real qjs-wasi engine
 // through the python runtime: 0 / -errno in WASI numbering, os.stat
 // answers [obj, errno], os.remove takes files and empty directories.

--- a/typescript/packages/core/src/workspace/workspace_js_mount.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_js_mount.test.ts
@@ -154,6 +154,20 @@ describe('node/js: std.open dispatches the real establishing op', () => {
     expect(check.exitCode).not.toBe(0)
     await ws.close()
   }, 60_000)
+
+  it('a garbage mode throws the engine refusal, not a silent read-only open', async () => {
+    // qjs-libc validates the mode before touching the filesystem and
+    // throws TypeError("invalid file mode"); the lenient parser used
+    // to read 'zz' as 'r' and hand back a live fd.
+    const { ws } = await makeWorkspace()
+    await ws.execute('echo x > /ram/g.txt')
+    const io = await ws.execute(
+      "js -e \"try { std.open('/ram/g.txt', 'zz') } catch (e) { console.log(e instanceof TypeError, e.message) }\"",
+    )
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('true invalid file mode\n')
+    await ws.close()
+  }, 60_000)
 })
 
 // The os.* mutation surface, pinned against the real qjs-wasi engine

--- a/typescript/packages/node/src/core/disk/truncate.ts
+++ b/typescript/packages/node/src/core/disk/truncate.ts
@@ -14,7 +14,7 @@
 
 import type { DiskAccessor } from '../../accessor/disk.ts'
 import { readFile, writeFile } from 'node:fs/promises'
-import { type PathSpec, invalidateAfterWrite } from '@struktoai/mirage-core'
+import { ResourceName, invalidateAfterWrite, record, type PathSpec } from '@struktoai/mirage-core'
 import { resolveSafe } from './utils.ts'
 
 export async function truncate(
@@ -22,6 +22,7 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
+  const start = performance.now()
   const full = resolveSafe(accessor.root, path.mountPath)
   let data: Buffer
   try {
@@ -36,5 +37,6 @@ export async function truncate(
   const out = new Uint8Array(length)
   out.set(data.subarray(0, Math.min(data.byteLength, length)))
   await writeFile(full, out)
+  record('truncate', path.mountPath, ResourceName.DISK, 0, start)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/node/src/core/gridfs/truncate.ts
+++ b/typescript/packages/node/src/core/gridfs/truncate.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterWrite, type PathSpec } from '@struktoai/mirage-core'
+import { ResourceName, invalidateAfterWrite, record, type PathSpec } from '@struktoai/mirage-core'
 import type { GridFSAccessor } from '../../accessor/gridfs.ts'
 import { gridfsKey, latestFile, rawPathOf } from './_client.ts'
 import { downloadBytes } from './read.ts'
@@ -25,6 +25,7 @@ export async function truncate(
 ): Promise<void> {
   const raw = rawPathOf(path)
   const key = gridfsKey(raw, accessor.config)
+  const startMs = performance.now()
   const doc = await latestFile(accessor, key)
   let data = doc === null ? new Uint8Array(0) : await downloadBytes(accessor, path, doc._id)
   if (data.byteLength > length) {
@@ -35,5 +36,6 @@ export async function truncate(
     data = padded
   }
   await uploadBytes(accessor, key, data)
+  record('truncate', path.virtual, ResourceName.GRIDFS, 0, startMs)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/node/src/core/nextcloud/truncate.ts
+++ b/typescript/packages/node/src/core/nextcloud/truncate.ts
@@ -1,4 +1,4 @@
-import { invalidateAfterWrite, type PathSpec } from '@struktoai/mirage-core'
+import { ResourceName, invalidateAfterWrite, record, type PathSpec } from '@struktoai/mirage-core'
 import type { NextcloudAccessor } from '../../accessor/nextcloud.ts'
 import { isNotFound, nextcloudKey } from './util.ts'
 
@@ -7,6 +7,7 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
+  const start = performance.now()
   const op = await accessor.operator()
   const key = nextcloudKey(path)
   let current: Buffer
@@ -19,5 +20,6 @@ export async function truncate(
   const next = Buffer.alloc(length)
   current.copy(next, 0, 0, Math.min(current.byteLength, length))
   await op.write(key, next)
+  record('truncate', path.virtual, ResourceName.NEXTCLOUD, 0, start)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/node/src/core/redis/create.ts
+++ b/typescript/packages/node/src/core/redis/create.ts
@@ -12,16 +12,18 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterWrite, type PathSpec } from '@struktoai/mirage-core'
+import { ResourceName, invalidateAfterWrite, record, type PathSpec } from '@struktoai/mirage-core'
 import type { RedisAccessor } from '../../accessor/redis.ts'
 import { checkDestParents } from './dest.ts'
 import { norm, nowIso } from './utils.ts'
 
 export async function create(accessor: RedisAccessor, path: PathSpec): Promise<void> {
+  const start = performance.now()
   const p = norm(path.mountPath)
   const store = accessor.store
   await checkDestParents(store, path, p)
   await store.setFile(p, new Uint8Array(0))
   await store.setModified(p, nowIso())
+  record('create', p, ResourceName.REDIS, 0, start)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/node/src/core/redis/truncate.ts
+++ b/typescript/packages/node/src/core/redis/truncate.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { type PathSpec, invalidateAfterWrite } from '@struktoai/mirage-core'
+import { ResourceName, invalidateAfterWrite, record, type PathSpec } from '@struktoai/mirage-core'
 import type { RedisAccessor } from '../../accessor/redis.ts'
 import { norm, nowIso } from './utils.ts'
 
@@ -21,6 +21,7 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
+  const start = performance.now()
   const p = norm(path.mountPath)
   const store = accessor.store
   const existing = await store.getFile(p)
@@ -30,5 +31,6 @@ export async function truncate(
   out.set(data.subarray(0, copyLen), 0)
   await store.setFile(p, out)
   await store.setModified(p, nowIso())
+  record('truncate', p, ResourceName.REDIS, 0, start)
   await invalidateAfterWrite(p)
 }

--- a/typescript/packages/node/src/fuse/core.test.ts
+++ b/typescript/packages/node/src/fuse/core.test.ts
@@ -26,7 +26,7 @@ async function mkCore(): Promise<MountCore> {
   )
   await ws.execute("echo 'hello world' | tee /data/greeting.txt")
   await ws.execute("mkdir -p /data/sub && echo 'nested' > /data/sub/inner.txt")
-  return new MountCore(ws)
+  return new MountCore(ws.fs)
 }
 
 describe('MountCore', () => {
@@ -120,7 +120,7 @@ describe('MountCore', () => {
 
   it('honors the root prefix when resolving', () => {
     const ws = new Workspace({ '/data/': new RAMResource() }, { mode: MountMode.WRITE })
-    const core = new MountCore(ws, { rootPrefix: '/data/' })
+    const core = new MountCore(ws.fs, { rootPrefix: '/data/' })
     expect(core.resolve('/')).toBe('/data')
     expect(core.resolve('/x.txt')).toBe('/data/x.txt')
   })

--- a/typescript/packages/node/src/fuse/core.ts
+++ b/typescript/packages/node/src/fuse/core.ts
@@ -24,8 +24,8 @@ import {
   mtimeMs,
   type OpRecord,
   rstripSlash,
+  type Ops,
   type Session,
-  type Workspace,
   compareCodePoints,
 } from '@struktoai/mirage-core'
 import { errnoError } from './errors.ts'
@@ -85,7 +85,7 @@ export interface MountCoreOptions {
  * record; reaching a backend directly would skip the door.
  */
 export class MountCore {
-  readonly ws: Workspace
+  readonly ops: Ops
   readonly session: Session | null
   private readonly now: Date
   private readonly root: string
@@ -98,8 +98,8 @@ export class MountCore {
   private readonly uid: number
   private readonly gid: number
 
-  constructor(ws: Workspace, options: MountCoreOptions = {}) {
-    this.ws = ws
+  constructor(ops: Ops, options: MountCoreOptions = {}) {
+    this.ops = ops
     this.now = new Date()
     this.root = options.rootPrefix !== undefined ? rstripSlash(options.rootPrefix) : ''
     this.uid = typeof process.getuid === 'function' ? process.getuid() : 0
@@ -175,7 +175,7 @@ export class MountCore {
    * resolve them against the host root and escape the mountpoint.
    */
   linkTarget(path: string): string | null {
-    const links = this.ws.fs.links
+    const links = this.ops.links
     if (links === null) return null
     const target = links.readlink(this.resolve(path))
     if (target === null) return null
@@ -236,7 +236,7 @@ export class MountCore {
     if (inflight !== undefined) return inflight
     const promise = (async (): Promise<Uint8Array | null> => {
       try {
-        const data = await this.ws.fs.readFile(this.resolve(path))
+        const data = await this.ops.readFile(this.resolve(path))
         this.prefetchCache.set(path, { data, expires: Date.now() + PREFETCH_TTL_MS })
         return data
       } catch {
@@ -251,13 +251,13 @@ export class MountCore {
 
   /** Drain and return accumulated op records (mirrors Python's drainOps). */
   drainOps(): OpRecord[] {
-    const records = [...this.ws.records]
-    this.ws.records.length = 0
+    const records = [...this.ops.records]
+    this.ops.records.length = 0
     return records
   }
 
   private async writeFile(path: string, data: Uint8Array): Promise<void> {
-    await this.ws.fs.writeFile(this.resolve(path), data)
+    await this.ops.writeFile(this.resolve(path), data)
   }
 
   /**
@@ -268,7 +268,7 @@ export class MountCore {
   private async applyWrites(path: string, writes: [number, Uint8Array][]): Promise<void> {
     let existing: Uint8Array = new Uint8Array(0)
     try {
-      existing = await this.ws.fs.readFile(this.resolve(path), { raw: true })
+      existing = await this.ops.readFile(this.resolve(path), { raw: true })
     } catch {
       // missing file: start from empty; the write creates it
     }
@@ -289,7 +289,7 @@ export class MountCore {
     // namespace links, so stat on a link path reports the target.
     const target = this.linkTarget(path)
     if (target !== null) return this.linkStat(target)
-    const s = await this.ws.fs.stat(this.resolve(path))
+    const s = await this.ops.stat(this.resolve(path))
     if (s.type === FileType.DIRECTORY) {
       return this.applyStatAttrs(this.dirStat(), s)
     }
@@ -319,7 +319,7 @@ export class MountCore {
     // itself, so the core only normalizes entry shapes and drops macOS
     // metadata names.
     const names = new Set<string>()
-    const entries = await this.ws.fs.readdir(this.resolve(path))
+    const entries = await this.ops.readdir(this.resolve(path))
     for (const e of entries) {
       const part = rstripSlash(e).split('/').pop() ?? ''
       if (part !== '' && !isMacosMetadata(part)) names.add(part)
@@ -335,10 +335,10 @@ export class MountCore {
     // Matches Python's `self._ops.read(path)`, which also dispatches.
     if (ctx !== undefined && ctx.data === undefined) {
       const cached = this.cachedData(path)
-      ctx.data = cached ?? (await this.ws.fs.readFile(this.resolve(path)))
+      ctx.data = cached ?? (await this.ops.readFile(this.resolve(path)))
     }
     const data =
-      ctx?.data ?? this.cachedData(path) ?? (await this.ws.fs.readFile(this.resolve(path)))
+      ctx?.data ?? this.cachedData(path) ?? (await this.ops.readFile(this.resolve(path)))
     return data.subarray(pos, pos + len)
   }
 
@@ -358,7 +358,7 @@ export class MountCore {
     // "create empty" from "write bytes" get the right code path. Falls back
     // to writeFile(empty) when the resource doesn't expose `create`.
     try {
-      await this.ws.fs.create(this.resolve(path))
+      await this.ops.create(this.resolve(path))
     } catch (dispatchErr) {
       if (!isMissingOp(dispatchErr, 'create')) throw dispatchErr
       await this.writeFile(path, new Uint8Array(0))
@@ -367,7 +367,7 @@ export class MountCore {
   }
 
   async mkdir(path: string): Promise<void> {
-    await this.ws.fs.mkdir(this.resolve(path))
+    await this.ops.mkdir(this.resolve(path))
   }
 
   readlink(path: string): string {
@@ -384,21 +384,21 @@ export class MountCore {
    * will later follow.
    */
   async symlink(src: string, dest: string): Promise<void> {
-    const links = this.ws.fs.links
+    const links = this.ops.links
     if (links === null) throw errnoError('EROFS', 'workspace has no namespace links')
     const stored = src.startsWith('/') ? this.resolve(src) : src
     await links.symlink(this.resolve(dest), stored, Date.now() / 1000)
   }
 
   async unlink(path: string): Promise<void> {
-    const links = this.ws.fs.links
+    const links = this.ops.links
     if (links?.isLink(this.resolve(path)) === true) {
       await links.unlink(this.resolve(path))
       this.xattrs.delete(path)
       this.prefetchCache.delete(path)
       return
     }
-    await this.ws.fs.unlink(this.resolve(path))
+    await this.ops.unlink(this.resolve(path))
     this.xattrs.delete(path)
   }
 
@@ -407,7 +407,7 @@ export class MountCore {
     // which is what makes `mv` between two backends fall back to
     // copy+unlink instead of addressing the destination against the
     // source's backend.
-    await this.ws.fs.rename(this.resolve(src), this.resolve(dst))
+    await this.ops.rename(this.resolve(src), this.resolve(dst))
     const moved = this.xattrs.get(src)
     if (moved !== undefined) {
       this.xattrs.delete(src)
@@ -420,7 +420,7 @@ export class MountCore {
     // cleanly. Message-string sniffing alone is unreliable across backends;
     // check contents first.
     try {
-      const entries = await this.ws.fs.readdir(this.resolve(path))
+      const entries = await this.ops.readdir(this.resolve(path))
       if (entries.length > 0) {
         throw errnoError('ENOTEMPTY', `directory not empty: ${path}`)
       }
@@ -429,7 +429,7 @@ export class MountCore {
       // readdir failure — fall through to rmdir and let it raise the real
       // error (e.g. ENOENT for missing path).
     }
-    await this.ws.fs.rmdir(this.resolve(path))
+    await this.ops.rmdir(this.resolve(path))
     this.xattrs.delete(path)
   }
 
@@ -438,10 +438,10 @@ export class MountCore {
     // backends). Fall back to read/resize/write for resources that don't
     // expose one.
     try {
-      await this.ws.fs.truncate(this.resolve(path), size)
+      await this.ops.truncate(this.resolve(path), size)
     } catch (dispatchErr) {
       if (!isMissingOp(dispatchErr, 'truncate')) throw dispatchErr
-      const data = await this.ws.fs
+      const data = await this.ops
         .readFile(this.resolve(path), { raw: true })
         .catch(() => new Uint8Array(0))
       const out = new Uint8Array(size)
@@ -487,7 +487,7 @@ export class MountCore {
   }
 
   async open(path: string): Promise<number> {
-    const s = await this.ws.fs.stat(this.resolve(path))
+    const s = await this.ops.stat(this.resolve(path))
     const ctx: Handle = { path }
     if (s.size === null && s.type !== FileType.DIRECTORY) {
       const data = await this.prefetch(path)

--- a/typescript/packages/node/src/fuse/core.ts
+++ b/typescript/packages/node/src/fuse/core.ts
@@ -337,8 +337,7 @@ export class MountCore {
       const cached = this.cachedData(path)
       ctx.data = cached ?? (await this.ops.readFile(this.resolve(path)))
     }
-    const data =
-      ctx?.data ?? this.cachedData(path) ?? (await this.ops.readFile(this.resolve(path)))
+    const data = ctx?.data ?? this.cachedData(path) ?? (await this.ops.readFile(this.resolve(path)))
     return data.subarray(pos, pos + len)
   }
 

--- a/typescript/packages/node/src/fuse/fs.test.ts
+++ b/typescript/packages/node/src/fuse/fs.test.ts
@@ -59,7 +59,7 @@ async function mkWs(): Promise<Workspace> {
 describe('MirageFS — getattr', () => {
   it('reports root as a directory', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, attr] = await callOp<[number, FuseAttr]>(mfs, 'getattr', '/')
     expect(code).toBe(0)
     expect(attr.mode & 0o170000).toBe(0o040000)
@@ -67,7 +67,7 @@ describe('MirageFS — getattr', () => {
 
   it('reports a mount-prefix path as a virtual directory', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, attr] = await callOp<[number, FuseAttr]>(mfs, 'getattr', '/data')
     expect(code).toBe(0)
     expect(attr.mode & 0o170000).toBe(0o040000)
@@ -75,7 +75,7 @@ describe('MirageFS — getattr', () => {
 
   it('reports a file under a mount with correct size', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, attr] = await callOp<[number, FuseAttr]>(mfs, 'getattr', '/data/greeting.txt')
     expect(code).toBe(0)
     expect(attr.mode & 0o170000).toBe(0o100000)
@@ -84,14 +84,14 @@ describe('MirageFS — getattr', () => {
 
   it('returns ENOENT for missing files', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code] = await callOp<[number]>(mfs, 'getattr', '/data/missing.txt')
     expect(code).toBe(ENOENT)
   })
 
   it('rejects macOS metadata probes early with ENOENT', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code] = await callOp<[number]>(mfs, 'getattr', '/data/.DS_Store')
     expect(code).toBe(ENOENT)
   })
@@ -100,7 +100,7 @@ describe('MirageFS — getattr', () => {
 describe('MirageFS — readdir', () => {
   it('always prepends "." and ".." at root', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, names] = await callOp<[number, string[]]>(mfs, 'readdir', '/')
     expect(code).toBe(0)
     expect(names.slice(0, 2)).toEqual(['.', '..'])
@@ -110,7 +110,7 @@ describe('MirageFS — readdir', () => {
 
   it('lists contents of a mount directory', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, names] = await callOp<[number, string[]]>(mfs, 'readdir', '/data')
     expect(code).toBe(0)
     expect(names.slice(0, 2)).toEqual(['.', '..'])
@@ -127,7 +127,7 @@ describe('MirageFS — chmod/chown/utimens/access validate path existence', () =
     ['access', [0]],
   ] as const)('%s returns ENOENT for missing path', async (op, extra) => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code] = await callOp<[number]>(mfs, op, '/data/missing.txt', ...extra)
     expect(code).toBe(ENOENT)
   })
@@ -139,7 +139,7 @@ describe('MirageFS — chmod/chown/utimens/access validate path existence', () =
     ['access', [0]],
   ] as const)('%s returns 0 for existing path', async (op, extra) => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code] = await callOp<[number]>(mfs, op, '/data/greeting.txt', ...extra)
     expect(code).toBe(0)
   })
@@ -148,7 +148,7 @@ describe('MirageFS — chmod/chown/utimens/access validate path existence', () =
 describe('MirageFS — rmdir maps non-empty to ENOTEMPTY', () => {
   it('refuses to rmdir a directory with children', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code] = await callOp<[number]>(mfs, 'rmdir', '/data/sub')
     expect(code).toBe(ENOTEMPTY)
   })
@@ -161,7 +161,7 @@ describe('MirageFS — read-only mount write consistency', () => {
     await seedWs.fs.writeFile('/data/existing.txt', 'seed')
 
     const readonlyWs = new Workspace({ '/data/': resource }, { mode: MountMode.READ })
-    const mfs = new MirageFS(readonlyWs)
+    const mfs = new MirageFS(readonlyWs.fs)
 
     const [createCode] = await callOp<[number]>(mfs, 'create', '/data/new.txt', 0o100644)
     expect(createCode).toBe(EACCES)
@@ -193,7 +193,7 @@ describe('MirageFS — read-only mount write consistency', () => {
 describe('MirageFS — drainOps()', () => {
   it('returns and clears the workspace op records buffer', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     // Trigger a few ops
     await callOp(mfs, 'getattr', '/data/greeting.txt')
     await callOp(mfs, 'readdir', '/data')
@@ -207,7 +207,7 @@ describe('MirageFS — drainOps()', () => {
     // records them; a write issued straight at the dispatcher would
     // mutate the mount and leave drainOps reporting nothing.
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const bytes = Buffer.from('written through the mount\n')
     const [, fh] = await callOp<[number, number]>(mfs, 'create', '/data/fresh.txt', 0o100644)
     await callOp(mfs, 'write', '/data/fresh.txt', fh, bytes, bytes.byteLength, 0)
@@ -221,7 +221,7 @@ describe('MirageFS — drainOps()', () => {
 describe('MirageFS — ops() registers access', () => {
   it('includes access in the returned ops map', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     expect(typeof mfs.ops().access).toBe('function')
   })
 })
@@ -245,7 +245,7 @@ describe('MirageFS — size=null resources (API-backed)', () => {
       new FileStat({ name: 'api.json', type: FileType.JSON }),
     )
     const readSpy = vi.spyOn(ws.fs, 'readFile')
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, attr] = await callOp<[number, FuseAttr]>(mfs, 'getattr', '/data/api.json')
     expect(code).toBe(0)
     expect(attr.size).toBe(0)
@@ -260,7 +260,7 @@ describe('MirageFS — size=null resources (API-backed)', () => {
     vi.spyOn(ws.fs, 'stat').mockResolvedValue(
       new FileStat({ name: 'api.json', type: FileType.JSON }),
     )
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     await callOp(mfs, 'getattr', '/data/api.json')
     const [openCode, fh] = await callOp<[number, number]>(mfs, 'open', '/data/api.json', 0)
     expect(openCode).toBe(0)
@@ -277,7 +277,7 @@ describe('MirageFS — size=null resources (API-backed)', () => {
     vi.spyOn(ws.fs, 'stat').mockResolvedValue(
       new FileStat({ name: 'api.json', type: FileType.JSON }),
     )
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [, fh] = await callOp<[number, number]>(mfs, 'open', '/data/api.json', 0)
     const buf = Buffer.alloc(64)
     const [eof] = await callOp<[number]>(
@@ -299,7 +299,7 @@ describe('MirageFS — size=null resources (API-backed)', () => {
     vi.spyOn(ws.fs, 'stat').mockResolvedValue(
       new FileStat({ name: 'api.json', type: FileType.JSON }),
     )
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     await callOp<[number, number]>(mfs, 'open', '/data/api.json', 0)
     const [, attr] = await callOp<[number, FuseAttr]>(mfs, 'getattr', '/data/api.json')
     expect(attr.size).toBe(bytes.byteLength)
@@ -312,7 +312,7 @@ describe('MirageFS — size=null resources (API-backed)', () => {
     vi.spyOn(ws.fs, 'stat').mockResolvedValue(
       new FileStat({ name: 'api.json', type: FileType.JSON }),
     )
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [, fh] = await callOp<[number, number]>(mfs, 'open', '/data/api.json', 0)
     const [code, attr] = await callOp<[number, FuseAttr]>(mfs, 'fgetattr', '/data/api.json', fh)
     expect(code).toBe(0)
@@ -326,7 +326,7 @@ describe('MirageFS — release flushes pending writes', () => {
     // issues WRITE then RELEASE with no FLUSH in between; dropping the
     // buffer at release silently lost data written through an fskit mount.
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [, fh] = await callOp<[number, number]>(mfs, 'open', '/data/greeting.txt', 0)
     const data = Buffer.from('clobber')
     await callOp(mfs, 'write', '/data/greeting.txt', fh, data, data.byteLength, 0)
@@ -338,7 +338,7 @@ describe('MirageFS — release flushes pending writes', () => {
 
   it('flush persists the buffered writes', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [, fh] = await callOp<[number, number]>(mfs, 'open', '/data/greeting.txt', 0)
     const data = Buffer.from('CLOBBER world\n')
     await callOp(mfs, 'write', '/data/greeting.txt', fh, data, data.byteLength, 0)
@@ -352,7 +352,7 @@ describe('MirageFS — release flushes pending writes', () => {
 describe('MirageFS — xattr', () => {
   it('round-trips set and get', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     await callOp(mfs, 'setxattr', '/data/greeting.txt', 'user.test', Buffer.from('value'), 0, 0)
     const [code, value] = await callOp<[number, Buffer?]>(
       mfs,
@@ -367,7 +367,7 @@ describe('MirageFS — xattr', () => {
 
   it('returns no value for a missing attribute', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, value] = await callOp<[number, Buffer?]>(
       mfs,
       'getxattr',
@@ -381,7 +381,7 @@ describe('MirageFS — xattr', () => {
 
   it('lists and removes attributes', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     await callOp(mfs, 'setxattr', '/data/greeting.txt', 'user.one', Buffer.from('1'), 0, 0)
     await callOp(mfs, 'setxattr', '/data/greeting.txt', 'user.two', Buffer.from('2'), 0, 0)
     const [, list] = await callOp<[number, string[]]>(mfs, 'listxattr', '/data/greeting.txt')
@@ -393,7 +393,7 @@ describe('MirageFS — xattr', () => {
 
   it('accepts the container probe attribute', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [setCode] = await callOp<[number]>(
       mfs,
       'setxattr',
@@ -408,7 +408,7 @@ describe('MirageFS — xattr', () => {
 
   it('follows a rename and clears on unlink', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     await callOp(mfs, 'setxattr', '/data/greeting.txt', 'user.keep', Buffer.from('v'), 0, 0)
     await callOp(mfs, 'rename', '/data/greeting.txt', '/data/renamed.txt')
     const [, moved] = await callOp<[number, Buffer?]>(
@@ -431,7 +431,7 @@ describe('MirageFS — namespace links', () => {
   it('getattr reports a link with S_IFLNK and target length', async () => {
     const ws = await mkWs()
     await ws.execute('ln -s /data/greeting.txt /data/lnk')
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, attr] = await callOp<[number, FuseAttr]>(mfs, 'getattr', '/data/lnk')
     expect(code).toBe(0)
     expect(attr.mode & 0o170000).toBe(0o120000)
@@ -441,7 +441,7 @@ describe('MirageFS — namespace links', () => {
   it('readlink rewrites an absolute target relative to the link dir', async () => {
     const ws = await mkWs()
     await ws.execute('ln -s /data/sub/inner.txt /data/lnk')
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, target] = await callOp<[number, string]>(mfs, 'readlink', '/data/lnk')
     expect(code).toBe(0)
     expect(target).toBe('sub/inner.txt')
@@ -449,7 +449,7 @@ describe('MirageFS — namespace links', () => {
 
   it('readlink on a non-link returns EINVAL', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code] = await callOp<[number]>(mfs, 'readlink', '/data/greeting.txt')
     expect(code).toBe(-22)
   })
@@ -457,7 +457,7 @@ describe('MirageFS — namespace links', () => {
   it('readdir lists link entries', async () => {
     const ws = await mkWs()
     await ws.execute('ln -s /data/greeting.txt /data/lnk')
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, entries] = await callOp<[number, string[]]>(mfs, 'readdir', '/data')
     expect(code).toBe(0)
     expect(entries).toContain('lnk')
@@ -466,7 +466,7 @@ describe('MirageFS — namespace links', () => {
   it('read follows the link to the target content', async () => {
     const ws = await mkWs()
     await ws.execute('ln -s /data/greeting.txt /data/lnk')
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const buf = Buffer.alloc(256)
     const [n] = await callOp<[number]>(mfs, 'read', '/data/lnk', 0, buf, 256, 0)
     expect(n).toBe('hello world\n'.length)
@@ -475,7 +475,7 @@ describe('MirageFS — namespace links', () => {
 
   it('symlink creates a namespace link readable through FUSE', async () => {
     const ws = await mkWs()
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code] = await callOp<[number]>(mfs, 'symlink', '/data/greeting.txt', '/data/lnk')
     expect(code).toBe(0)
     const [rlCode, target] = await callOp<[number, string]>(mfs, 'readlink', '/data/lnk')
@@ -486,7 +486,7 @@ describe('MirageFS — namespace links', () => {
   it('unlink removes the link entry but keeps the target', async () => {
     const ws = await mkWs()
     await ws.execute('ln -s /data/greeting.txt /data/lnk')
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code] = await callOp<[number]>(mfs, 'unlink', '/data/lnk')
     expect(code).toBe(0)
     const [lnkCode] = await callOp<[number]>(mfs, 'getattr', '/data/lnk')
@@ -498,7 +498,7 @@ describe('MirageFS — namespace links', () => {
   it('scoped root displays link targets in mount-relative form', async () => {
     const ws = await mkWs()
     await ws.execute('ln -s /data/sub/inner.txt /data/sub/lnk')
-    const mfs = new MirageFS(ws, { rootPrefix: '/data/sub' })
+    const mfs = new MirageFS(ws.fs, { rootPrefix: '/data/sub' })
     const [code, target] = await callOp<[number, string]>(mfs, 'readlink', '/lnk')
     expect(code).toBe(0)
     expect(target).toBe('inner.txt')
@@ -509,7 +509,7 @@ describe('MirageFS — stat attr overlay', () => {
   it('getattr honors chmod overlay bits', async () => {
     const ws = await mkWs()
     await ws.execute('chmod 640 /data/greeting.txt')
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, attr] = await callOp<[number, FuseAttr]>(mfs, 'getattr', '/data/greeting.txt')
     expect(code).toBe(0)
     expect(attr.mode & 0o170000).toBe(0o100000)
@@ -519,7 +519,7 @@ describe('MirageFS — stat attr overlay', () => {
   it('getattr honors touched mtime', async () => {
     const ws = await mkWs()
     await ws.execute('touch -t 202603041200 /data/greeting.txt')
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
     const [code, attr] = await callOp<[number, FuseAttr]>(mfs, 'getattr', '/data/greeting.txt')
     expect(code).toBe(0)
     expect(attr.mtime.getTime()).toBe(Date.UTC(2026, 2, 4, 12, 0, 0))
@@ -532,14 +532,14 @@ describe('MirageFS — session binding', () => {
     await ws.execute("echo 'hidden' > /extra/secret.txt")
     const session = ws.createSession('narrow', { mounts: ['/data'] })
 
-    const bound = new MirageFS(ws, { session })
+    const bound = new MirageFS(ws.fs, { session })
     const [okCode, attr] = await callOp<[number, FuseAttr]>(bound, 'getattr', '/data/greeting.txt')
     expect(okCode).toBe(0)
     expect(attr.mode & 0o170000).toBe(0o100000)
     const [deniedCode] = await callOp<[number]>(bound, 'getattr', '/extra/secret.txt')
     expect(deniedCode).toBeLessThan(0)
 
-    const unbound = new MirageFS(ws)
+    const unbound = new MirageFS(ws.fs)
     const [plainCode] = await callOp<[number, FuseAttr]>(unbound, 'getattr', '/extra/secret.txt')
     expect(plainCode).toBe(0)
   })
@@ -547,7 +547,7 @@ describe('MirageFS — session binding', () => {
   it('a read-narrowed session reads through the bound tree but cannot create', async () => {
     const ws = await mkWs()
     const session = ws.createSession('ro', { mounts: { '/data': 'read' } })
-    const bound = new MirageFS(ws, { session })
+    const bound = new MirageFS(ws.fs, { session })
 
     const [openCode, fd] = await callOp<[number, number]>(bound, 'open', '/data/greeting.txt', 0)
     expect(openCode).toBe(0)
@@ -580,7 +580,7 @@ describe('MirageFS — a policy deny on read surfaces EACCES', () => {
       },
     }
     const ws = new Workspace({ '/data/': resource }, { mode: MountMode.READ, policies: [redact] })
-    const mfs = new MirageFS(ws)
+    const mfs = new MirageFS(ws.fs)
 
     const [openCode, fd] = await callOp<[number, number]>(mfs, 'open', '/data/secret.txt', 0)
     expect(openCode).toBe(0)

--- a/typescript/packages/node/src/fuse/fs.ts
+++ b/typescript/packages/node/src/fuse/fs.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { type OpRecord, runWithSession, type Session, type Workspace } from '@struktoai/mirage-core'
+import { type OpRecord, type Ops, runWithSession, type Session } from '@struktoai/mirage-core'
 import { type FuseAttr, MountCore } from './core.ts'
 import { classifyError } from './errors.ts'
 
@@ -42,8 +42,8 @@ export interface MirageFSOptions {
 export class MirageFS {
   readonly core: MountCore
 
-  constructor(ws: Workspace, options: MirageFSOptions = {}) {
-    this.core = new MountCore(ws, options)
+  constructor(ops: Ops, options: MirageFSOptions = {}) {
+    this.core = new MountCore(ops, options)
   }
 
   /** Drain and return accumulated op records (mirrors Python's drainOps). */

--- a/typescript/packages/node/src/fuse/mount.ts
+++ b/typescript/packages/node/src/fuse/mount.ts
@@ -164,7 +164,7 @@ export async function mount(ws: Workspace, options: MountOptions = {}): Promise<
     mountpoint = mkdtempSync(join(tmpdir(), 'mirage-fuse-'))
     ownsMountpoint = true
   }
-  const mfs = new MirageFS(ws, {
+  const mfs = new MirageFS(ws.fs, {
     ...(options.rootPrefix !== undefined ? { rootPrefix: options.rootPrefix } : {}),
     ...(options.session !== undefined ? { session: options.session } : {}),
   })


### PR DESCRIPTION
R7a + R7b from the runtime-fs design docs.

## Guest op surface parity (R7a)

- One verb casing on the TS bridge: the dispatcher's own lowercase op names (`LIST` -> `readdir`).
- `create` and `truncate` join the TS bridge; quickjs `std.open` mirrors the python wasi host's ladder (stat first, EISDIR, exclusive -> refuse, missing-without-create -> refuse, then create/truncate/read as the real op). The RAM core recorded a create as a zero-byte `write` in TS and recorded nothing for create/truncate in python; both now record their own op.
- One fopen-mode parser in `runtime/handles/mode`: strict CPython rule widened by C fopen's `wx` spelling (valid bases: `r`, `w`, `a`, `x`, `wx`), `OpenMode` gains `readable`/`binary`, and the chmod parser is renamed `parse_chmod`/`parseChmod`. A garbage mode in a js guest now throws the engine's own `TypeError: invalid file mode` instead of opening read-only.
- Python `readdir` answers resolved `VFSEntry` rows like the TS bridge; the trailing-slash re-parse in `wasm/vfs.py` is gone, so a wasm guest's `d_type` is real instead of `FT_UNKNOWN` plus one lazy stat per entry.
- New conformance world: an exclusive open refuses an existing file and creates a missing one, pinned in both languages (wasi + quickjs spellings in python, the quickjs shim in TS). monty has no spelling for mode `x` ("exclusive creation mode is not supported").

## One Ops facade (R7b)

- `WorkspaceFS` moves to `ops/ops.ts` as `Ops`, and the op ledger (`records`, network/cache split) moves onto it, matching python. `Workspace` keeps thin delegating getters.
- `MountCore` and `MirageFS` take an `Ops` in both languages; the node FUSE tier no longer reaches through a `Workspace`.
- Surface union: python `Ops` gains `exists`/`is_dir`/`is_file`/`cat`/`list_files`, TS `Ops` gains `append`.
- `ops/file.py`, `ops/open.py`, `ops/os_patch.py` are declared python-only embedding conveniences in `spec/layout_exceptions.json`; the parity baseline drops 310 -> 305 and is spent here.

Behavior notes: quickjs `'w'` on a mount with no `truncate` op now refuses the open (null) instead of falling back to a whole-file write, matching the python host; FUSE metadata ops keep riding the facade, so they stay on the ledger.

Gates: full pytest, TS core 7705 / node 2305 / browser 182, layout parity 305 == 305, pre-commit idempotent-green.