### PR TITLE
refactor(runtime): name the default python engine (#609 item 19 / T1-N)

### DIFF
--- a/integ/runtime/defaults.json
+++ b/integ/runtime/defaults.json
@@ -1,0 +1,51 @@
+{
+  "suite": "defaults",
+  "cases": [
+    {
+      "id": "default_python_is_monty",
+      "hosts": [
+        "python"
+      ],
+      "world": {},
+      "steps": [
+        {
+          "command": "python3 -m nosuchmodule",
+          "expect": {
+            "exit": 1,
+            "stderr": "python3: -m is not supported by the 'monty' runtime\n"
+          }
+        },
+        {
+          "command": "python3 -c \"print(6 * 7)\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "42\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "default_python_is_pyodide",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {},
+      "steps": [
+        {
+          "command": "python3 -m nosuchmodule",
+          "expect": {
+            "exit": 1,
+            "stderr_contains": "No module named"
+          }
+        },
+        {
+          "command": "python3 -c \"print(6 * 7)\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "42\n"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integ/runtime/monty.json
+++ b/integ/runtime/monty.json
@@ -34,6 +34,31 @@
       ]
     },
     {
+      "id": "module_flag_refused_by_name",
+      "world": {
+        "runtimes": [
+          "monty",
+          "vfs"
+        ]
+      },
+      "steps": [
+        {
+          "command": "python3 -m nosuchmodule",
+          "expect": {
+            "exit": 1,
+            "stderr": "python3: -m is not supported by the 'monty' runtime\n"
+          }
+        },
+        {
+          "command": "python -m json.tool",
+          "expect": {
+            "exit": 1,
+            "stderr": "python3: -m is not supported by the 'monty' runtime\n"
+          }
+        }
+      ]
+    },
+    {
       "id": "argv_global",
       "world": {
         "runtimes": [

--- a/python/mirage/runtime/table.py
+++ b/python/mirage/runtime/table.py
@@ -81,12 +81,24 @@ SANDBOX_MODULES: dict[str, str] = {
     "e2b": "mirage.runtime.sandbox.e2b:E2BRuntime",
 }
 
-# The default world when no runtimes list is given: today's behavior
-# exactly. Defaults build gracefully (a missing extra leaves the
-# command reporting its install hint per invocation); an explicitly
-# listed name still fails loud. `local` is deliberately absent: a
-# sandboxed default must never silently escalate to host execution.
-DEFAULT_ENTRIES: tuple[str, ...] = ("monty", "quickjs", VFSRuntime.name)
+# The python engine a default world registers, named rather than left
+# to a slot in DEFAULT_ENTRIES because it is the one entry the two
+# implementations disagree on: Python registers monty, TypeScript
+# registers pyodide (`DEFAULT_PYTHON` in runtime/table.ts), because
+# `@pydantic/monty` cannot answer builtin `open()` calls yet while
+# `pydantic-monty` can. Both are sandboxed; neither reaches the host.
+# Pinned by integ/runtime/defaults.json, which reads the split back
+# out of a default world on each host.
+DEFAULT_PYTHON: str = MontyRuntime.name
+
+# The default world when no runtimes list is given: one python engine,
+# one js engine, and the builtin command engine. Defaults build
+# gracefully (a missing extra leaves the command reporting its install
+# hint per invocation); an explicitly listed name still fails loud.
+# `local` is deliberately absent: a sandboxed default must never
+# silently escalate to host execution.
+DEFAULT_ENTRIES: tuple[str, ...] = (DEFAULT_PYTHON, QuickJsRuntime.name,
+                                    VFSRuntime.name)
 
 # TypeScript-only runtime names a cross-language config may carry.
 TS_ONLY_HINTS: dict[str, str] = {

--- a/python/mirage/workspace/workspace/runtimes.py
+++ b/python/mirage/workspace/workspace/runtimes.py
@@ -63,10 +63,11 @@ class Runtimes:
         the workspace dispatch attached. The vfs runtime is required:
         when the list omits it, an unconditional one is appended, so
         there is always an executor for unclaimed commands. An explicit
-        list fails loud per entry. The default set (monty, quickjs,
-        vfs) builds gracefully: a missing extra skips the entry so its
-        commands report the install hint per invocation, never a silent
-        escalation to another runtime.
+        list fails loud per entry. The default set (DEFAULT_ENTRIES,
+        whose python engine is DEFAULT_PYTHON) builds gracefully: a
+        missing extra skips the entry so its commands report the
+        install hint per invocation, never a silent escalation to
+        another runtime.
 
         Args:
             runtimes (list[Runtime | str] | None): user entries, or

--- a/python/tests/runtime/test_table.py
+++ b/python/tests/runtime/test_table.py
@@ -17,9 +17,11 @@ import pytest
 from mirage.runtime.base import Runtime
 from mirage.runtime.mixin import LineExecutorMixin
 from mirage.runtime.python import LocalRuntime
-from mirage.runtime.table import (DEFAULT_ENTRIES, RUNTIMES, VFSRuntime,
-                                  bind_commands, build_runtime,
-                                  runtime_bindings_for, whole_line_runtime)
+from mirage.runtime.python.base import PythonRuntime
+from mirage.runtime.table import (DEFAULT_ENTRIES, DEFAULT_PYTHON, NAMED,
+                                  RUNTIMES, VFSRuntime, bind_commands,
+                                  build_runtime, runtime_bindings_for,
+                                  whole_line_runtime)
 from mirage.runtime.types import RunArgs, RunResult
 
 
@@ -34,6 +36,17 @@ class FakeRuntime(Runtime):
 def test_default_entries_never_include_local():
     assert "local" not in DEFAULT_ENTRIES
     assert DEFAULT_ENTRIES[-1] == "vfs"
+
+
+def test_default_python_is_monty_and_leads_the_default_world():
+    # The one entry TypeScript disagrees on, so it is named rather than
+    # left to a slot: TypeScript registers pyodide.
+    assert DEFAULT_PYTHON == "monty"
+    assert DEFAULT_ENTRIES[0] == DEFAULT_PYTHON
+
+
+def test_default_python_is_a_registered_python_engine():
+    assert issubclass(NAMED[DEFAULT_PYTHON], PythonRuntime)
 
 
 def test_build_runtime_unknown_name_fails_loud():

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -532,7 +532,13 @@ export { Runtime, type RuntimeEntry } from './runtime/base.ts'
 export { LanguageRuntime } from './runtime/language.ts'
 export { PythonRuntime } from './runtime/python/base.ts'
 export { JsRuntime } from './runtime/js/base.ts'
-export { bindCommands, DEFAULT_ENTRIES, runtimeBindingsFor, VFSRuntime } from './runtime/table.ts'
+export {
+  bindCommands,
+  DEFAULT_ENTRIES,
+  DEFAULT_PYTHON,
+  runtimeBindingsFor,
+  VFSRuntime,
+} from './runtime/table.ts'
 export {
   coerceRuntimeConfig,
   HOME_CONFIG_KEYS,

--- a/typescript/packages/core/src/runtime/table.test.ts
+++ b/typescript/packages/core/src/runtime/table.test.ts
@@ -19,10 +19,12 @@ import {
   buildRuntime,
   candidates,
   DEFAULT_ENTRIES,
+  DEFAULT_PYTHON,
   runtimeBindingsFor,
   VFSRuntime,
 } from './table.ts'
 import { MontyRuntime } from './python/monty/index.ts'
+import { PythonRuntime } from './python/base.ts'
 import { PyodideRuntime } from './python/pyodide.ts'
 import { QuickJsRuntime } from './js/quickjs.ts'
 
@@ -52,6 +54,14 @@ describe('runtime table', () => {
 
   it('default entries end with the vfs runtime', () => {
     expect(DEFAULT_ENTRIES[DEFAULT_ENTRIES.length - 1]).toBe('vfs')
+  })
+
+  it('the default python engine is pyodide and leads the default world', () => {
+    // The one entry Python disagrees on, so it is named rather than
+    // left to a slot: Python registers monty.
+    expect(DEFAULT_PYTHON).toBe('pyodide')
+    expect(DEFAULT_ENTRIES[0]).toBe(DEFAULT_PYTHON)
+    expect(buildRuntime(DEFAULT_PYTHON)).toBeInstanceOf(PythonRuntime)
   })
 
   it('buildRuntime fails loud on unknown names', () => {

--- a/typescript/packages/core/src/runtime/table.ts
+++ b/typescript/packages/core/src/runtime/table.ts
@@ -70,12 +70,26 @@ const NAMED: Record<string, new (options?: RuntimeOptions<never>) => Runtime> = 
 )
 
 /**
- * The default world when no runtimes list is given: today's behavior
- * exactly. Pyodide stays the TypeScript python default until
- * `@pydantic/monty` can answer builtin `open()` calls; `local`/`wasi`
- * are Python-only.
+ * The python engine a default world registers, named rather than left
+ * to a slot in DEFAULT_ENTRIES because it is the one entry the two
+ * implementations disagree on: TypeScript registers pyodide, Python
+ * registers monty (`DEFAULT_PYTHON` in `mirage/runtime/table.py`),
+ * because `@pydantic/monty` cannot answer builtin `open()` calls yet
+ * while `pydantic-monty` can. Both are sandboxed; neither reaches the
+ * host. Pinned by integ/runtime/defaults.json, which reads the split
+ * back out of a default world on each host.
+ *
+ * A name, not a class: `name` is an instance field, so `PyodideRuntime.name`
+ * is the JS function name, not the registry key.
  */
-export const DEFAULT_ENTRIES: readonly string[] = ['pyodide', 'quickjs', 'vfs']
+export const DEFAULT_PYTHON = 'pyodide'
+
+/**
+ * The default world when no runtimes list is given: one python engine,
+ * one js engine, and the builtin command engine. `local`/`wasi` are
+ * Python-only.
+ */
+export const DEFAULT_ENTRIES: readonly string[] = [DEFAULT_PYTHON, 'quickjs', 'vfs']
 
 /** Python-only runtime names a cross-language config may carry. */
 const PYTHON_ONLY_HINTS: Record<string, string> = {

--- a/typescript/packages/core/src/workspace/workspace/runtimes.ts
+++ b/typescript/packages/core/src/workspace/workspace/runtimes.ts
@@ -20,6 +20,7 @@ import {
   bindCommands,
   buildRuntime,
   DEFAULT_ENTRIES,
+  DEFAULT_PYTHON,
   VFSRuntime,
   wholeLineRuntime,
 } from '../../runtime/table.ts'
@@ -32,7 +33,7 @@ export interface RuntimesInit {
   registry: MountRegistry
   /** The `runtimes` option: instances and name shorthands, or undefined for the default world. */
   entries: RuntimeEntry[] | undefined
-  /** `options.python`, forwarded into the default pyodide build. */
+  /** `options.python`, forwarded into the default python engine's build. */
   pythonConfig: Record<string, unknown>
   bridge: () => BridgeDispatchFn
   resolver: MountResolver
@@ -64,7 +65,7 @@ export class Runtimes {
     if (init.entries === undefined) {
       for (const name of DEFAULT_ENTRIES) {
         this.entries.push(
-          buildRuntime(name, name === 'pyodide' ? { config: { ...init.pythonConfig } } : {}),
+          buildRuntime(name, name === DEFAULT_PYTHON ? { config: { ...init.pythonConfig } } : {}),
         )
       }
     } else {


### PR DESCRIPTION
## What

The default runtime world was an opaque positional triple on both sides:

```python
DEFAULT_ENTRIES = ("monty", "quickjs", VFSRuntime.name)      # python
```
```ts
export const DEFAULT_ENTRIES = ['pyodide', 'quickjs', 'vfs']  // typescript
```

The one fact the two implementations disagree on — which python engine a default world registers — was readable only by diffing two literals in two languages, and nothing said it was deliberate.

This lifts it to a named registration on each side and derives the triple from it:

```python
DEFAULT_PYTHON: str = MontyRuntime.name
DEFAULT_ENTRIES: tuple[str, ...] = (DEFAULT_PYTHON, QuickJsRuntime.name, VFSRuntime.name)
```
```ts
export const DEFAULT_PYTHON = 'pyodide'
export const DEFAULT_ENTRIES: readonly string[] = [DEFAULT_PYTHON, 'quickjs', 'vfs']
```

**No behavior change.** Python stays on monty, TypeScript stays on pyodide. The divergence is now one greppable constant per tree, carrying twin comments that name the reason (`@pydantic/monty` cannot answer builtin `open()` calls yet, while `pydantic-monty` can) and point at each other.

Also drops the second hardcoded copy of the same fact: the TS `Runtimes` constructor forwarded `options.python` on a literal `name === 'pyodide'` test, now `name === DEFAULT_PYTHON`.

The TS constant is a name rather than a class because `name` is an instance field there — `PyodideRuntime.name` would be the JS function name, not the registry key. Noted in the docstring so nobody "fixes" it.

## Recorded as a pin, not prose

`integ/runtime/defaults.json` reads the split back out of a live default world on each host, so the asymmetry is asserted rather than commented:

| host | `python3 -m nosuchmodule` |
| --- | --- |
| python | exit 1, `python3: -m is not supported by the 'monty' runtime` |
| typescript | exit 1, stderr contains `No module named` (real CPython under pyodide) |

The refusal names the runtime, so the python case is a direct read of which engine got registered. Both also run `python3 -c "print(6 * 7)"` so a case that skipped rather than bound would not pass silently. Suites are glob-discovered, so no registration was needed.

A `default_js_is_quickjs` case was written and dropped: `requires` is suite-level in this runner, and quickjs needs `MIRAGE_QUICKJS_HOME`, so it cannot be gated per case. The js slot is not the divergent one anyway.

## Verification

- `integ/runtime` — python host **74 passed, 0 failed**; typescript host **95 passed, 0 failed** (`defaults/default_python_is_monty` and `defaults/default_python_is_pyodide` both ok)
- `pnpm -r typecheck` — clean across all 7 packages
- `pnpm --filter @struktoai/mirage-core test` — **621 files, 7748 passed**
- `pytest python/tests/runtime/` — green
- `pre-commit run --all-files` — clean (mypy: no issues in 1795 source files)

The full `pytest` run was cut short locally by a 10-minute cap after the runtime tests passed; CI covers it.

Closes the last open item in Block C of the cleanup plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)