### PR TITLE
refactor(ts): derive config types from their zod schemas

### DIFF
--- a/typescript/packages/browser/src/resource/aliyun/config.ts
+++ b/typescript/packages/browser/src/resource/aliyun/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface AliyunConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface AliyunConfigRedacted extends Omit<AliyunConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const AliyunConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const AliyunConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type AliyunConfig = ConfigOf<typeof AliyunConfigSchema>
+
+export type AliyunConfigRedacted = RedactedConfig<AliyunConfig, 'presignedUrlProvider'>
 
 export function resolvedAliyunEndpoint(config: AliyunConfig): string | undefined {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/browser/src/resource/backblaze/config.ts
+++ b/typescript/packages/browser/src/resource/backblaze/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface BackblazeConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface BackblazeConfigRedacted extends Omit<BackblazeConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const BackblazeConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const BackblazeConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type BackblazeConfig = ConfigOf<typeof BackblazeConfigSchema>
+
+export type BackblazeConfigRedacted = RedactedConfig<BackblazeConfig, 'presignedUrlProvider'>
 
 export function resolvedBackblazeEndpoint(config: BackblazeConfig): string | undefined {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/browser/src/resource/box/config.ts
+++ b/typescript/packages/browser/src/resource/box/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 export interface BoxConfig {
   // API origin override (e.g. an integ fake). Defaults to api.box.com.
@@ -36,15 +43,6 @@ export interface BoxConfig {
   onRefreshTokenRotated?: (newRefreshToken: string) => void | Promise<void>
 }
 
-export interface BoxConfigRedacted {
-  endpoint?: string
-  rootFolderId?: string
-  clientId?: string
-  clientSecret?: '<REDACTED>'
-  refreshToken?: '<REDACTED>'
-  accessToken?: '<REDACTED>'
-}
-
 const BoxConfigSchema = z.object({
   endpoint: z.string().optional(),
   rootFolderId: z.string().optional(),
@@ -54,6 +52,13 @@ const BoxConfigSchema = z.object({
   refreshToken: secretStr().optional(),
   accessToken: secretStr().optional(),
 })
+
+// Only the redacted twin derives: the schema deliberately omits the
+// callbacks, which no snapshot can carry.
+export type BoxConfigRedacted = RedactedConfig<
+  ConfigOf<typeof BoxConfigSchema>,
+  'clientSecret' | 'refreshToken' | 'accessToken'
+>
 
 export function redactBoxConfig(config: BoxConfig): BoxConfigRedacted {
   return redactConfigWithSchema(BoxConfigSchema, config) as unknown as BoxConfigRedacted

--- a/typescript/packages/browser/src/resource/ceph/config.ts
+++ b/typescript/packages/browser/src/resource/ceph/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface CephConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  endpoint?: string
-  region?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface CephConfigRedacted extends Omit<CephConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const CephConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const CephConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type CephConfig = ConfigOf<typeof CephConfigSchema>
+
+export type CephConfigRedacted = RedactedConfig<CephConfig, 'presignedUrlProvider'>
 
 export function cephToS3Config(config: CephConfig): S3Config {
   return {

--- a/typescript/packages/browser/src/resource/digitalocean/config.ts
+++ b/typescript/packages/browser/src/resource/digitalocean/config.ts
@@ -12,24 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface DigitalOceanConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface DigitalOceanConfigRedacted extends Omit<
-  DigitalOceanConfig,
-  'presignedUrlProvider'
-> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const DigitalOceanConfigSchema = z.object({
   bucket: z.string(),
@@ -41,6 +31,10 @@ const DigitalOceanConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type DigitalOceanConfig = ConfigOf<typeof DigitalOceanConfigSchema>
+
+export type DigitalOceanConfigRedacted = RedactedConfig<DigitalOceanConfig, 'presignedUrlProvider'>
 
 export function resolvedDigitalOceanEndpoint(config: DigitalOceanConfig): string | undefined {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/browser/src/resource/discord/config.ts
+++ b/typescript/packages/browser/src/resource/discord/config.ts
@@ -12,24 +12,26 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 
-export interface DiscordConfig {
-  proxyUrl: string
-  getHeaders?: () => Promise<Record<string, string>> | Record<string, string>
-}
-
-export interface DiscordConfigRedacted {
-  proxyUrl: string
-  getHeaders?: '<REDACTED>'
-}
+type HeaderProvider = () => Promise<Record<string, string>> | Record<string, string>
 
 const DiscordConfigSchema = z.object({
   proxyUrl: z.string(),
   getHeaders: secretSchema(
-    z.custom<DiscordConfig['getHeaders']>((value) => typeof value === 'function'),
+    z.custom<HeaderProvider>((value) => typeof value === 'function'),
   ).optional(),
 })
+
+export type DiscordConfig = ConfigOf<typeof DiscordConfigSchema>
+
+export type DiscordConfigRedacted = RedactedConfig<DiscordConfig, 'getHeaders'>
 
 export function redactDiscordConfig(config: DiscordConfig): DiscordConfigRedacted {
   return redactConfigWithSchema(DiscordConfigSchema, config) as unknown as DiscordConfigRedacted

--- a/typescript/packages/browser/src/resource/dropbox/config.ts
+++ b/typescript/packages/browser/src/resource/dropbox/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 export interface DropboxConfig {
   clientId: string
@@ -24,15 +31,6 @@ export interface DropboxConfig {
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
 }
 
-export interface DropboxConfigRedacted {
-  clientId: string
-  clientSecret?: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-  rootPath?: string
-  contentSearch?: boolean
-  endpoint?: string
-}
-
 const DropboxConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr().optional(),
@@ -41,6 +39,13 @@ const DropboxConfigSchema = z.object({
   contentSearch: z.boolean().optional(),
   endpoint: z.string().optional(),
 })
+
+// Only the redacted twin derives: the schema deliberately omits
+// `refreshFn`, which no snapshot can carry.
+export type DropboxConfigRedacted = RedactedConfig<
+  ConfigOf<typeof DropboxConfigSchema>,
+  'clientSecret' | 'refreshToken'
+>
 
 export function redactDropboxConfig(config: DropboxConfig): DropboxConfigRedacted {
   return redactConfigWithSchema(DropboxConfigSchema, config) as unknown as DropboxConfigRedacted

--- a/typescript/packages/browser/src/resource/gcs/config.ts
+++ b/typescript/packages/browser/src/resource/gcs/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface GCSConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface GCSConfigRedacted extends Omit<GCSConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const GCSConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const GCSConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type GCSConfig = ConfigOf<typeof GCSConfigSchema>
+
+export type GCSConfigRedacted = RedactedConfig<GCSConfig, 'presignedUrlProvider'>
 
 export function gcsToS3Config(config: GCSConfig): S3Config {
   return {

--- a/typescript/packages/browser/src/resource/github/config.ts
+++ b/typescript/packages/browser/src/resource/github/config.ts
@@ -12,23 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GitHubConfig {
-  token: string
-  owner: string
-  repo: string
-  ref?: string
-  baseUrl?: string
-}
-
-export interface GitHubConfigRedacted {
-  token: '<REDACTED>'
-  owner: string
-  repo: string
-  ref?: string
-  baseUrl?: string
-}
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const GitHubConfigSchema = z.object({
   token: secretStr(),
@@ -37,6 +28,10 @@ const GitHubConfigSchema = z.object({
   ref: z.string().optional(),
   baseUrl: z.string().optional(),
 })
+
+export type GitHubConfig = ConfigOf<typeof GitHubConfigSchema>
+
+export type GitHubConfigRedacted = RedactedConfig<GitHubConfig, 'token'>
 
 export function redactGitHubConfig(config: GitHubConfig): GitHubConfigRedacted {
   return redactConfigWithSchema(GitHubConfigSchema, config) as unknown as GitHubConfigRedacted

--- a/typescript/packages/browser/src/resource/github_ci/config.ts
+++ b/typescript/packages/browser/src/resource/github_ci/config.ts
@@ -12,23 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GitHubCIConfig {
-  token: string
-  owner: string
-  repo: string
-  days?: number
-  baseUrl?: string
-}
-
-export interface GitHubCIConfigRedacted {
-  token: '<REDACTED>'
-  owner: string
-  repo: string
-  days?: number
-  baseUrl?: string
-}
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const GitHubCIConfigSchema = z.object({
   token: secretStr(),
@@ -37,6 +28,10 @@ const GitHubCIConfigSchema = z.object({
   days: z.number().optional(),
   baseUrl: z.string().optional(),
 })
+
+export type GitHubCIConfig = ConfigOf<typeof GitHubCIConfigSchema>
+
+export type GitHubCIConfigRedacted = RedactedConfig<GitHubCIConfig, 'token'>
 
 export function redactGitHubCIConfig(config: GitHubCIConfig): GitHubCIConfigRedacted {
   return redactConfigWithSchema(GitHubCIConfigSchema, config) as unknown as GitHubCIConfigRedacted

--- a/typescript/packages/browser/src/resource/langfuse/config.ts
+++ b/typescript/packages/browser/src/resource/langfuse/config.ts
@@ -12,25 +12,13 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface LangfuseConfig {
-  publicKey: string
-  secretKey: string
-  host?: string
-  defaultTraceLimit?: number
-  defaultSearchLimit?: number
-  defaultFromTimestamp?: string
-}
-
-export interface LangfuseConfigRedacted {
-  publicKey: string
-  secretKey: '<REDACTED>'
-  host?: string
-  defaultTraceLimit?: number
-  defaultSearchLimit?: number
-  defaultFromTimestamp?: string
-}
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const LangfuseConfigSchema = z.object({
   publicKey: z.string(),
@@ -40,6 +28,10 @@ const LangfuseConfigSchema = z.object({
   defaultSearchLimit: z.number().optional(),
   defaultFromTimestamp: z.string().optional(),
 })
+
+export type LangfuseConfig = ConfigOf<typeof LangfuseConfigSchema>
+
+export type LangfuseConfigRedacted = RedactedConfig<LangfuseConfig, 'secretKey'>
 
 export function redactLangfuseConfig(config: LangfuseConfig): LangfuseConfigRedacted {
   return redactConfigWithSchema(LangfuseConfigSchema, config) as unknown as LangfuseConfigRedacted

--- a/typescript/packages/browser/src/resource/linear/config.ts
+++ b/typescript/packages/browser/src/resource/linear/config.ts
@@ -12,28 +12,24 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface LinearConfig {
-  apiKey: string
-  workspace?: string
-  teamIds?: readonly string[]
-  baseUrl?: string
-}
-
-export interface LinearConfigRedacted {
-  apiKey: '<REDACTED>'
-  workspace?: string
-  teamIds?: readonly string[]
-  baseUrl?: string
-}
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const LinearConfigSchema = z.object({
   apiKey: secretStr(),
   workspace: z.string().optional(),
-  teamIds: z.array(z.string()).optional(),
+  teamIds: z.array(z.string()).readonly().optional(),
   baseUrl: z.string().optional(),
 })
+
+export type LinearConfig = ConfigOf<typeof LinearConfigSchema>
+
+export type LinearConfigRedacted = RedactedConfig<LinearConfig, 'apiKey'>
 
 export function redactLinearConfig(config: LinearConfig): LinearConfigRedacted {
   return redactConfigWithSchema(LinearConfigSchema, config) as unknown as LinearConfigRedacted

--- a/typescript/packages/browser/src/resource/minio/config.ts
+++ b/typescript/packages/browser/src/resource/minio/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface MinIOConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  endpoint?: string
-  region?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface MinIOConfigRedacted extends Omit<MinIOConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const MinIOConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const MinIOConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type MinIOConfig = ConfigOf<typeof MinIOConfigSchema>
+
+export type MinIOConfigRedacted = RedactedConfig<MinIOConfig, 'presignedUrlProvider'>
 
 export function minioToS3Config(config: MinIOConfig): S3Config {
   return {

--- a/typescript/packages/browser/src/resource/notion/config.ts
+++ b/typescript/packages/browser/src/resource/notion/config.ts
@@ -13,17 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
-
-export interface NotionConfig {
-  authProvider: OAuthClientProvider
-  serverUrl?: string
-}
-
-export interface NotionConfigRedacted {
-  authProvider: '<REDACTED>'
-  serverUrl?: string
-}
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 
 const NotionConfigSchema = z.object({
   authProvider: secretSchema(
@@ -31,6 +27,10 @@ const NotionConfigSchema = z.object({
   ),
   serverUrl: z.string().optional(),
 })
+
+export type NotionConfig = ConfigOf<typeof NotionConfigSchema>
+
+export type NotionConfigRedacted = RedactedConfig<NotionConfig, 'authProvider'>
 
 export function redactNotionConfig(config: NotionConfig): NotionConfigRedacted {
   return redactConfigWithSchema(NotionConfigSchema, config) as unknown as NotionConfigRedacted

--- a/typescript/packages/browser/src/resource/oci/config.ts
+++ b/typescript/packages/browser/src/resource/oci/config.ts
@@ -12,22 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface OCIConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  namespace?: string
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface OCIConfigRedacted extends Omit<OCIConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const OCIConfigSchema = z.object({
   bucket: z.string(),
@@ -40,6 +32,10 @@ const OCIConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type OCIConfig = ConfigOf<typeof OCIConfigSchema>
+
+export type OCIConfigRedacted = RedactedConfig<OCIConfig, 'presignedUrlProvider'>
 
 export function resolvedOciEndpoint(config: OCIConfig): string | undefined {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/browser/src/resource/qingstor/config.ts
+++ b/typescript/packages/browser/src/resource/qingstor/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface QingStorConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface QingStorConfigRedacted extends Omit<QingStorConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const QingStorConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const QingStorConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type QingStorConfig = ConfigOf<typeof QingStorConfigSchema>
+
+export type QingStorConfigRedacted = RedactedConfig<QingStorConfig, 'presignedUrlProvider'>
 
 export function resolvedQingStorEndpoint(config: QingStorConfig): string | undefined {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/browser/src/resource/r2/config.ts
+++ b/typescript/packages/browser/src/resource/r2/config.ts
@@ -12,22 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface R2Config {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  accountId?: string
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface R2ConfigRedacted extends Omit<R2Config, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const R2ConfigSchema = z.object({
   bucket: z.string(),
@@ -40,6 +32,10 @@ const R2ConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type R2Config = ConfigOf<typeof R2ConfigSchema>
+
+export type R2ConfigRedacted = RedactedConfig<R2Config, 'presignedUrlProvider'>
 
 export function resolvedR2Endpoint(config: R2Config): string | undefined {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/browser/src/resource/scaleway/config.ts
+++ b/typescript/packages/browser/src/resource/scaleway/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface ScalewayConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface ScalewayConfigRedacted extends Omit<ScalewayConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const ScalewayConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const ScalewayConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type ScalewayConfig = ConfigOf<typeof ScalewayConfigSchema>
+
+export type ScalewayConfigRedacted = RedactedConfig<ScalewayConfig, 'presignedUrlProvider'>
 
 export function resolvedScalewayEndpoint(config: ScalewayConfig): string | undefined {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/browser/src/resource/seaweedfs/config.ts
+++ b/typescript/packages/browser/src/resource/seaweedfs/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface SeaweedFSConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  endpoint?: string
-  region?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface SeaweedFSConfigRedacted extends Omit<SeaweedFSConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const SeaweedFSConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const SeaweedFSConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type SeaweedFSConfig = ConfigOf<typeof SeaweedFSConfigSchema>
+
+export type SeaweedFSConfigRedacted = RedactedConfig<SeaweedFSConfig, 'presignedUrlProvider'>
 
 export function seaweedfsToS3Config(config: SeaweedFSConfig): S3Config {
   return {

--- a/typescript/packages/browser/src/resource/slack/config.ts
+++ b/typescript/packages/browser/src/resource/slack/config.ts
@@ -12,24 +12,26 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 
-export interface SlackConfig {
-  proxyUrl: string
-  getHeaders?: () => Promise<Record<string, string>> | Record<string, string>
-}
-
-export interface SlackConfigRedacted {
-  proxyUrl: string
-  getHeaders?: '<REDACTED>'
-}
+type HeaderProvider = () => Promise<Record<string, string>> | Record<string, string>
 
 const SlackConfigSchema = z.object({
   proxyUrl: z.string(),
   getHeaders: secretSchema(
-    z.custom<SlackConfig['getHeaders']>((value) => typeof value === 'function'),
+    z.custom<HeaderProvider>((value) => typeof value === 'function'),
   ).optional(),
 })
+
+export type SlackConfig = ConfigOf<typeof SlackConfigSchema>
+
+export type SlackConfigRedacted = RedactedConfig<SlackConfig, 'getHeaders'>
 
 export function redactSlackConfig(config: SlackConfig): SlackConfigRedacted {
   return redactConfigWithSchema(SlackConfigSchema, config) as unknown as SlackConfigRedacted

--- a/typescript/packages/browser/src/resource/supabase/config.ts
+++ b/typescript/packages/browser/src/resource/supabase/config.ts
@@ -12,22 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface SupabaseConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  projectRef?: string
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface SupabaseConfigRedacted extends Omit<SupabaseConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const SupabaseConfigSchema = z.object({
   bucket: z.string(),
@@ -40,6 +32,10 @@ const SupabaseConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type SupabaseConfig = ConfigOf<typeof SupabaseConfigSchema>
+
+export type SupabaseConfigRedacted = RedactedConfig<SupabaseConfig, 'presignedUrlProvider'>
 
 export function resolvedSupabaseEndpoint(config: SupabaseConfig): string | undefined {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/browser/src/resource/tencent/config.ts
+++ b/typescript/packages/browser/src/resource/tencent/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface TencentConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface TencentConfigRedacted extends Omit<TencentConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const TencentConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const TencentConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type TencentConfig = ConfigOf<typeof TencentConfigSchema>
+
+export type TencentConfigRedacted = RedactedConfig<TencentConfig, 'presignedUrlProvider'>
 
 export function resolvedTencentEndpoint(config: TencentConfig): string | undefined {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/browser/src/resource/trello/config.ts
+++ b/typescript/packages/browser/src/resource/trello/config.ts
@@ -12,31 +12,25 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface TrelloConfig {
-  apiKey: string
-  apiToken: string
-  workspaceId?: string
-  boardIds?: readonly string[]
-  baseUrl?: string
-}
-
-export interface TrelloConfigRedacted {
-  apiKey: '<REDACTED>'
-  apiToken: '<REDACTED>'
-  workspaceId?: string
-  boardIds?: readonly string[]
-  baseUrl?: string
-}
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const TrelloConfigSchema = z.object({
   apiKey: secretStr(),
   apiToken: secretStr(),
   workspaceId: z.string().optional(),
-  boardIds: z.array(z.string()).optional(),
+  boardIds: z.array(z.string()).readonly().optional(),
   baseUrl: z.string().optional(),
 })
+
+export type TrelloConfig = ConfigOf<typeof TrelloConfigSchema>
+
+export type TrelloConfigRedacted = RedactedConfig<TrelloConfig, 'apiKey' | 'apiToken'>
 
 export function redactTrelloConfig(config: TrelloConfig): TrelloConfigRedacted {
   return redactConfigWithSchema(TrelloConfigSchema, config) as unknown as TrelloConfigRedacted

--- a/typescript/packages/browser/src/resource/wasabi/config.ts
+++ b/typescript/packages/browser/src/resource/wasabi/config.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretSchema,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3BrowserPresignedUrlProvider, S3Config } from '../s3/config.ts'
-
-export interface WasabiConfig {
-  bucket: string
-  presignedUrlProvider: S3BrowserPresignedUrlProvider
-  region?: string
-  endpoint?: string
-  defaultContentType?: string
-  keyPrefix?: string
-}
-
-export interface WasabiConfigRedacted extends Omit<WasabiConfig, 'presignedUrlProvider'> {
-  presignedUrlProvider: '<REDACTED>'
-}
 
 const WasabiConfigSchema = z.object({
   bucket: z.string(),
@@ -38,6 +31,10 @@ const WasabiConfigSchema = z.object({
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type WasabiConfig = ConfigOf<typeof WasabiConfigSchema>
+
+export type WasabiConfigRedacted = RedactedConfig<WasabiConfig, 'presignedUrlProvider'>
 
 export function resolvedWasabiEndpoint(config: WasabiConfig): string {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/core/src/accessor/onedrive.ts
+++ b/typescript/packages/core/src/accessor/onedrive.ts
@@ -22,7 +22,7 @@ import {
   type MsGraphConfigResolved,
 } from '../core/msgraph/config.ts'
 import { DriveLoc } from '../core/msgraph/drive.ts'
-import { redactConfigWithSchema } from '../resource/secrets.ts'
+import { type ConfigOf, redactConfigWithSchema, type RedactedConfig } from '../resource/secrets.ts'
 import { normalizeFields } from '../utils/normalize.ts'
 import { stripSlash } from '../utils/slash.ts'
 
@@ -32,19 +32,6 @@ export interface OneDriveConfig extends MsGraphConfig {
   // A Teams/Microsoft 365 group's document library, and another user's
   // drive under app-only auth. Both are reachable without first resolving
   // a drive id out of band.
-  groupId?: string
-  userId?: string
-  keyPrefix?: string
-}
-
-export interface OneDriveConfigRedacted {
-  accessToken: '<REDACTED>'
-  tenantHost?: string
-  graphBaseUrl?: string
-  timeout?: number
-  maxRetries?: number
-  driveId?: string
-  siteId?: string
   groupId?: string
   userId?: string
   keyPrefix?: string
@@ -74,6 +61,11 @@ export const OneDriveConfigSchema = z
   .refine((c) => DRIVE_TARGETS.filter((f) => c[f] !== undefined).length <= 1, {
     message: driveTargetError(DRIVE_TARGETS),
   })
+
+export type OneDriveConfigRedacted = RedactedConfig<
+  ConfigOf<typeof OneDriveConfigSchema>,
+  'accessToken'
+>
 
 export function redactOneDriveConfig(config: OneDriveConfig): OneDriveConfigRedacted {
   return redactConfigWithSchema(OneDriveConfigSchema, config) as unknown as OneDriveConfigRedacted

--- a/typescript/packages/core/src/accessor/sharepoint.ts
+++ b/typescript/packages/core/src/accessor/sharepoint.ts
@@ -23,24 +23,12 @@ import {
   type MsGraphConfigResolved,
 } from '../core/msgraph/config.ts'
 import { DriveLoc } from '../core/msgraph/drive.ts'
-import { redactConfigWithSchema } from '../resource/secrets.ts'
+import { type ConfigOf, redactConfigWithSchema, type RedactedConfig } from '../resource/secrets.ts'
 import { normalizeFields } from '../utils/normalize.ts'
 import { stripSlash } from '../utils/slash.ts'
 import { compareCodePoints } from '../utils/sort.ts'
 
 export interface SharePointConfig extends MsGraphConfig {
-  siteFilter?: string
-  site?: string
-  drive?: string
-  keyPrefix?: string
-}
-
-export interface SharePointConfigRedacted {
-  accessToken: '<REDACTED>'
-  tenantHost?: string
-  graphBaseUrl?: string
-  timeout?: number
-  maxRetries?: number
   siteFilter?: string
   site?: string
   drive?: string
@@ -54,6 +42,11 @@ export const SharePointConfigSchema = z.object({
   drive: z.string().optional(),
   keyPrefix: z.string().optional(),
 })
+
+export type SharePointConfigRedacted = RedactedConfig<
+  ConfigOf<typeof SharePointConfigSchema>,
+  'accessToken'
+>
 
 export function redactSharePointConfig(config: SharePointConfig): SharePointConfigRedacted {
   return redactConfigWithSchema(

--- a/typescript/packages/core/src/core/discord/config.ts
+++ b/typescript/packages/core/src/core/discord/config.ts
@@ -13,23 +13,22 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { z } from 'zod'
-import { redactConfigWithSchema, secretStr } from '../../resource/secrets.ts'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+} from '../../resource/secrets.ts'
 import { normalizeFields } from '../../utils/normalize.ts'
-
-export interface DiscordConfig {
-  token: string
-  baseUrl?: string
-}
-
-export interface DiscordConfigRedacted {
-  token: '<REDACTED>'
-  baseUrl?: string
-}
 
 export const DiscordConfigSchema = z.object({
   token: secretStr(),
   baseUrl: z.string().optional(),
 })
+
+export type DiscordConfig = ConfigOf<typeof DiscordConfigSchema>
+
+export type DiscordConfigRedacted = RedactedConfig<DiscordConfig, 'token'>
 
 export function redactDiscordConfig(config: DiscordConfig): DiscordConfigRedacted {
   return redactConfigWithSchema(DiscordConfigSchema, config) as unknown as DiscordConfigRedacted

--- a/typescript/packages/core/src/core/github/config.ts
+++ b/typescript/packages/core/src/core/github/config.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { z } from 'zod'
-import type { REDACTED_SECRET } from '../../resource/secrets.ts'
+import type { ConfigOf, RedactedConfig } from '../../resource/secrets.ts'
 import { redactConfigWithSchema, secretStr } from '../../resource/secrets.ts'
 import { normalizeFields } from '../../utils/normalize.ts'
 
@@ -28,11 +28,9 @@ export const GhConfigSchema = z.object({
 // it validates an install's config and carries the `secretStr` marker
 // redaction reads -- so a hand-written twin only adds a shape that can
 // drift from it, which is how `branch` reached the schema and not the type.
-export type GhConfig = z.infer<typeof GhConfigSchema>
+export type GhConfig = ConfigOf<typeof GhConfigSchema>
 
-export type GhConfigRedacted = Omit<GhConfig, 'token'> & {
-  token: typeof REDACTED_SECRET
-}
+export type GhConfigRedacted = RedactedConfig<GhConfig, 'token'>
 
 export function redactGhConfig(config: GhConfig): GhConfigRedacted {
   return redactConfigWithSchema(GhConfigSchema, config) as unknown as GhConfigRedacted

--- a/typescript/packages/core/src/core/google/config.ts
+++ b/typescript/packages/core/src/core/google/config.ts
@@ -13,7 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { z } from 'zod'
-import { redactConfigWithSchema, secretStr } from '../../resource/secrets.ts'
+import {
+  type ConfigOf,
+  redactConfigWithSchema,
+  type RedactedConfig,
+  secretStr,
+} from '../../resource/secrets.ts'
 import { normalizeFields } from '../../utils/normalize.ts'
 
 export interface GoogleConfig {
@@ -47,17 +52,6 @@ export interface GoogleConfig {
   today?: string
 }
 
-export interface GoogleConfigRedacted {
-  clientId: string
-  clientSecret?: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-  apiBase?: string
-  folderId?: string
-  timeZone?: string
-  minAccessRole?: string
-  today?: string
-}
-
 export const GoogleConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr().optional(),
@@ -68,6 +62,13 @@ export const GoogleConfigSchema = z.object({
   minAccessRole: z.string().optional(),
   today: z.string().optional(),
 })
+
+// Only the redacted twin derives: the schema deliberately omits `refreshFn`,
+// which no snapshot can carry.
+export type GoogleConfigRedacted = RedactedConfig<
+  ConfigOf<typeof GoogleConfigSchema>,
+  'clientSecret' | 'refreshToken'
+>
 
 export function redactGoogleConfig(config: GoogleConfig): GoogleConfigRedacted {
   return redactConfigWithSchema(GoogleConfigSchema, config) as unknown as GoogleConfigRedacted

--- a/typescript/packages/core/src/core/linear/config.ts
+++ b/typescript/packages/core/src/core/linear/config.ts
@@ -24,7 +24,7 @@ import { normalizeFields } from '../../utils/normalize.ts'
 export const LinearConfigSchema = z.object({
   apiKey: secretStr(),
   workspace: z.string().optional(),
-  teamIds: z.array(z.string()).optional(),
+  teamIds: z.array(z.string()).readonly().optional(),
   baseUrl: z.string().optional(),
 })
 

--- a/typescript/packages/core/src/core/linear/config.ts
+++ b/typescript/packages/core/src/core/linear/config.ts
@@ -13,22 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { z } from 'zod'
-import { redactConfigWithSchema, secretStr } from '../../resource/secrets.ts'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+} from '../../resource/secrets.ts'
 import { normalizeFields } from '../../utils/normalize.ts'
-
-export interface LinearConfig {
-  apiKey: string
-  workspace?: string
-  teamIds?: readonly string[]
-  baseUrl?: string
-}
-
-export interface LinearConfigRedacted {
-  apiKey: '<REDACTED>'
-  workspace?: string
-  teamIds?: readonly string[]
-  baseUrl?: string
-}
 
 export const LinearConfigSchema = z.object({
   apiKey: secretStr(),
@@ -36,6 +27,10 @@ export const LinearConfigSchema = z.object({
   teamIds: z.array(z.string()).optional(),
   baseUrl: z.string().optional(),
 })
+
+export type LinearConfig = ConfigOf<typeof LinearConfigSchema>
+
+export type LinearConfigRedacted = RedactedConfig<LinearConfig, 'apiKey'>
 
 export function redactLinearConfig(config: LinearConfig): LinearConfigRedacted {
   return redactConfigWithSchema(LinearConfigSchema, config) as unknown as LinearConfigRedacted

--- a/typescript/packages/core/src/core/notion/config.ts
+++ b/typescript/packages/core/src/core/notion/config.ts
@@ -13,23 +13,22 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { z } from 'zod'
-import { redactConfigWithSchema, secretStr } from '../../resource/secrets.ts'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+} from '../../resource/secrets.ts'
 import { normalizeFields } from '../../utils/normalize.ts'
-
-export interface NotionConfig {
-  apiKey: string
-  baseUrl?: string
-}
-
-export interface NotionConfigRedacted {
-  apiKey: '<REDACTED>'
-  baseUrl?: string
-}
 
 export const NotionConfigSchema = z.object({
   apiKey: secretStr(),
   baseUrl: z.string().optional(),
 })
+
+export type NotionConfig = ConfigOf<typeof NotionConfigSchema>
+
+export type NotionConfigRedacted = RedactedConfig<NotionConfig, 'apiKey'>
 
 export function redactNotionConfig(config: NotionConfig): NotionConfigRedacted {
   return redactConfigWithSchema(NotionConfigSchema, config) as unknown as NotionConfigRedacted

--- a/typescript/packages/core/src/core/slack/config.ts
+++ b/typescript/packages/core/src/core/slack/config.ts
@@ -13,26 +13,23 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { z } from 'zod'
-import { redactConfigWithSchema, secretStr } from '../../resource/secrets.ts'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+} from '../../resource/secrets.ts'
 import { normalizeFields } from '../../utils/normalize.ts'
-
-export interface SlackConfig {
-  token: string
-  searchToken?: string
-  baseUrl?: string
-}
-
-export interface SlackConfigRedacted {
-  token: '<REDACTED>'
-  searchToken?: '<REDACTED>'
-  baseUrl?: string
-}
 
 export const SlackConfigSchema = z.object({
   token: secretStr(),
   searchToken: secretStr().optional(),
   baseUrl: z.string().optional(),
 })
+
+export type SlackConfig = ConfigOf<typeof SlackConfigSchema>
+
+export type SlackConfigRedacted = RedactedConfig<SlackConfig, 'token' | 'searchToken'>
 
 export function redactSlackConfig(config: SlackConfig): SlackConfigRedacted {
   return redactConfigWithSchema(SlackConfigSchema, config) as unknown as SlackConfigRedacted

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -100,9 +100,11 @@ export {
   throwUnsupported,
 } from './resource/base.ts'
 export {
+  type ConfigOf,
   hasRedactedSecret,
   REDACTED_SECRET,
   redactConfigWithSchema,
+  type RedactedConfig,
   resourceStateRequiresOverride,
   secretSchema,
   secretStr,

--- a/typescript/packages/core/src/resource/databricks_volume/config.ts
+++ b/typescript/packages/core/src/resource/databricks_volume/config.ts
@@ -13,30 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { z } from 'zod'
-import { redactConfigWithSchema, secretStr } from '../secrets.ts'
+import {
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+} from '../secrets.ts'
 import { normalizeFields } from '../../utils/normalize.ts'
-
-export interface DatabricksVolumeConfig {
-  catalog: string
-  schema: string
-  volume: string
-  rootPath: string
-  host?: string
-  token?: string
-  profile?: string
-  timeout: number
-}
-
-export interface DatabricksVolumeConfigRedacted {
-  catalog: string
-  schema: string
-  volume: string
-  rootPath: string
-  host?: string
-  token?: '<REDACTED>'
-  profile?: string
-  timeout: number
-}
 
 function validVolumePart(value: string): boolean {
   return value !== '' && !value.includes('/')
@@ -61,6 +44,10 @@ export const DatabricksVolumeConfigSchema = z.object({
   profile: z.string().optional(),
   timeout: z.number().default(30),
 })
+
+export type DatabricksVolumeConfig = ConfigOf<typeof DatabricksVolumeConfigSchema>
+
+export type DatabricksVolumeConfigRedacted = RedactedConfig<DatabricksVolumeConfig, 'token'>
 
 export function redactDatabricksVolumeConfig(
   config: DatabricksVolumeConfig,

--- a/typescript/packages/core/src/resource/mem0/config.ts
+++ b/typescript/packages/core/src/resource/mem0/config.ts
@@ -1,19 +1,14 @@
 import { z } from 'zod'
 import { normalizeFields } from '../../utils/normalize.ts'
 import { rstripSlash } from '../../utils/slash.ts'
-import { redactConfigWithSchema, secretStr } from '../secrets.ts'
+import {
+  type ConfigOf,
+  redactConfigWithSchema,
+  type RedactedConfig,
+  secretStr,
+} from '../secrets.ts'
 
 export type Mem0ScopeKind = 'user' | 'agent' | 'run'
-
-export interface Mem0Config {
-  apiKey: string
-  host?: string
-  userId?: string
-  agentId?: string
-  runId?: string
-  defaultPageSize?: number
-  defaultSearchLimit?: number
-}
 
 export interface Mem0ConfigResolved {
   apiKey: string
@@ -27,16 +22,6 @@ export interface Mem0ConfigResolved {
   scopeFilter: Record<string, string>
 }
 
-export interface Mem0ConfigRedacted {
-  apiKey: '<REDACTED>'
-  host?: string
-  userId?: string
-  agentId?: string
-  runId?: string
-  defaultPageSize?: number
-  defaultSearchLimit?: number
-}
-
 export const Mem0ConfigSchema = z.object({
   apiKey: secretStr(),
   host: z.string().optional(),
@@ -46,6 +31,10 @@ export const Mem0ConfigSchema = z.object({
   defaultPageSize: z.number().optional(),
   defaultSearchLimit: z.number().optional(),
 })
+
+export type Mem0Config = ConfigOf<typeof Mem0ConfigSchema>
+
+export type Mem0ConfigRedacted = RedactedConfig<Mem0Config, 'apiKey'>
 
 export function redactMem0Config(config: Mem0Config): Mem0ConfigRedacted {
   return redactConfigWithSchema(Mem0ConfigSchema, config) as unknown as Mem0ConfigRedacted

--- a/typescript/packages/core/src/resource/s3/config.ts
+++ b/typescript/packages/core/src/resource/s3/config.ts
@@ -13,7 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { z } from 'zod'
-import { redactConfigWithSchema, secretSchema, secretStr } from '../secrets.ts'
+import {
+  type ConfigOf,
+  redactConfigWithSchema,
+  type RedactedConfig,
+  secretSchema,
+  secretStr,
+} from '../secrets.ts'
 import * as kp from '../../utils/key_prefix.ts'
 
 export type S3BrowserOperation = 'GET' | 'PUT' | 'HEAD' | 'DELETE' | 'LIST' | 'COPY'
@@ -86,16 +92,12 @@ export function normalizeKeyPrefix(v: string | undefined): string | undefined {
   return out === '' ? undefined : out
 }
 
-export interface S3ConfigRedacted extends Omit<
-  S3Config,
+// Only the redacted twin derives: `S3Config` carries a `profile` the schema
+// does not, so the schema is not this config's own shape.
+export type S3ConfigRedacted = RedactedConfig<
+  ConfigOf<typeof S3ConfigSchema>,
   'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'presignedUrlProvider' | 'httpAgentProvider'
-> {
-  accessKeyId?: string
-  secretAccessKey?: string
-  sessionToken?: string
-  presignedUrlProvider?: '<REDACTED>'
-  httpAgentProvider?: '<REDACTED>'
-}
+>
 
 export function redactConfig(config: S3Config): S3ConfigRedacted {
   return redactConfigWithSchema(S3ConfigSchema, config) as unknown as S3ConfigRedacted

--- a/typescript/packages/core/src/resource/secrets.ts
+++ b/typescript/packages/core/src/resource/secrets.ts
@@ -26,6 +26,29 @@ interface SchemaDef {
 
 export type SecretStr = string & { readonly __mirageSecret: unique symbol }
 
+// A config's shape, read off the schema that already validates it rather
+// than declared a second time by hand. `z.infer` alone is not a drop-in:
+// it renders an optional field as `k?: T | undefined`, which under
+// `exactOptionalPropertyTypes` is wider than the `k?: T` these configs
+// were written with and stops a subclass's state from matching its base's.
+// The mapping is homomorphic, so `?` survives and only the explicit
+// `undefined` goes.
+export type ConfigOf<S extends z.ZodType> = {
+  [K in keyof z.infer<S>]: Exclude<z.infer<S>[K], undefined>
+}
+
+// The redacted twin of a config, naming only the secret fields. The
+// `secretStr`/`secretSchema` marker is runtime metadata on a plain
+// `z.ZodString`, so no type can read it back off the schema and the secret
+// list has to be written down once; what this removes is the other half of
+// the twin, which used to re-list every ordinary field by hand and drifted
+// the moment one was added. The mapping goes through `Pick` so it is
+// homomorphic and an optional secret stays optional: a bare `[P in K]` is
+// not, and made every optional secret required.
+export type RedactedConfig<T, K extends keyof T> = Omit<T, K> & {
+  [P in keyof Pick<T, K>]: typeof REDACTED_SECRET
+}
+
 export function secretStr(): z.ZodString {
   return secretSchema(z.string())
 }

--- a/typescript/packages/node/src/core/email/config.ts
+++ b/typescript/packages/node/src/core/email/config.ts
@@ -12,32 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  type ConfigOf,
+  normalizeFields,
+  redactConfigWithSchema,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 function asString(v: unknown): string {
   return typeof v === 'string' ? v : ''
-}
-
-export interface EmailConfig {
-  imapHost: string
-  imapPort: number
-  smtpHost: string
-  smtpPort: number
-  username: string
-  password: string
-  useSsl: boolean
-  maxMessages: number
-  /**
-   * Upstream himalaya's message.send.save-copy, whose default is true
-   * since pimalaya/himalaya#536.
-   */
-  saveCopy: boolean
-  /** Its folder.alias.sent: null means ask the server for its \Sent mailbox. */
-  sentFolder: string | null
-}
-
-export interface EmailConfigRedacted extends Omit<EmailConfig, 'password'> {
-  password: '<REDACTED>'
 }
 
 // Doubles as the himalaya CLI's configModel: parse applies the same
@@ -52,26 +37,25 @@ export const EmailConfigSchema = z.object({
   password: secretStr(),
   useSsl: z.boolean().default(true),
   maxMessages: z.number().default(200),
+  /**
+   * Upstream himalaya's message.send.save-copy, whose default is true
+   * since pimalaya/himalaya#536.
+   */
   saveCopy: z.boolean().default(true),
+  /** Its folder.alias.sent: null means ask the server for its \Sent mailbox. */
   sentFolder: z.string().nullable().default(null),
 })
+
+export type EmailConfig = ConfigOf<typeof EmailConfigSchema>
+
+export type EmailConfigRedacted = RedactedConfig<EmailConfig, 'password'>
 
 export function redactEmailConfig(config: EmailConfig): EmailConfigRedacted {
   return redactConfigWithSchema(EmailConfigSchema, config) as unknown as EmailConfigRedacted
 }
 
-export interface EmailConfigInput {
-  imapHost: string
-  imapPort?: number
-  smtpHost: string
-  smtpPort?: number
-  username: string
-  password: string
-  useSsl?: boolean
-  maxMessages?: number
-  saveCopy?: boolean
-  sentFolder?: string | null
-}
+// What a caller writes, which is the schema before its defaults land.
+export type EmailConfigInput = z.input<typeof EmailConfigSchema>
 
 export function buildEmailConfig(input: EmailConfigInput): EmailConfig {
   return {

--- a/typescript/packages/node/src/resource/box/config.ts
+++ b/typescript/packages/node/src/resource/box/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 export interface BoxConfig {
   // API origin override (e.g. an integ fake). Defaults to api.box.com.
@@ -43,16 +50,6 @@ export interface BoxConfig {
   onRefreshTokenRotated?: (newRefreshToken: string) => void | Promise<void>
 }
 
-export interface BoxConfigRedacted {
-  endpoint?: string
-  rootFolderId?: string
-  clientId?: string
-  clientSecret?: '<REDACTED>'
-  refreshToken?: '<REDACTED>'
-  enterpriseId?: string
-  accessToken?: '<REDACTED>'
-}
-
 const BoxConfigSchema = z.object({
   endpoint: z.string().optional(),
   rootFolderId: z.string().optional(),
@@ -63,6 +60,13 @@ const BoxConfigSchema = z.object({
   enterpriseId: z.string().optional(),
   accessToken: secretStr().optional(),
 })
+
+// Only the redacted twin derives: the schema deliberately omits the
+// callbacks, which no snapshot can carry.
+export type BoxConfigRedacted = RedactedConfig<
+  ConfigOf<typeof BoxConfigSchema>,
+  'clientSecret' | 'refreshToken' | 'accessToken'
+>
 
 export function redactBoxConfig(config: BoxConfig): BoxConfigRedacted {
   return redactConfigWithSchema(BoxConfigSchema, config) as unknown as BoxConfigRedacted

--- a/typescript/packages/node/src/resource/dropbox/config.ts
+++ b/typescript/packages/node/src/resource/dropbox/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 export interface DropboxConfig {
   clientId: string
@@ -24,15 +31,6 @@ export interface DropboxConfig {
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
 }
 
-export interface DropboxConfigRedacted {
-  clientId: string
-  clientSecret: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-  rootPath?: string
-  contentSearch?: boolean
-  endpoint?: string
-}
-
 const DropboxConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr(),
@@ -41,6 +39,13 @@ const DropboxConfigSchema = z.object({
   contentSearch: z.boolean().optional(),
   endpoint: z.string().optional(),
 })
+
+// Only the redacted twin derives: the schema deliberately omits
+// `refreshFn`, which no snapshot can carry.
+export type DropboxConfigRedacted = RedactedConfig<
+  ConfigOf<typeof DropboxConfigSchema>,
+  'clientSecret' | 'refreshToken'
+>
 
 export function redactDropboxConfig(config: DropboxConfig): DropboxConfigRedacted {
   return redactConfigWithSchema(DropboxConfigSchema, config) as unknown as DropboxConfigRedacted

--- a/typescript/packages/node/src/resource/gcs/config.ts
+++ b/typescript/packages/node/src/resource/gcs/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3Config } from '../s3/config.ts'
 
 export const GCS_ENDPOINT = 'https://storage.googleapis.com'
@@ -25,20 +32,6 @@ export interface GCSConfig {
   profile?: string
   endpoint?: string
   region?: string
-  timeoutMs?: number
-  forcePathStyle?: boolean
-  keyPrefix?: string
-  proxy?: string
-}
-
-export interface GCSConfigRedacted {
-  bucket: string
-  accessKeyId?: string
-  secretAccessKey?: string
-  sessionToken?: string
-  profile?: string
-  endpoint: string
-  region: string
   timeoutMs?: number
   forcePathStyle?: boolean
   keyPrefix?: string
@@ -58,6 +51,13 @@ const GCSConfigSchema = z.object({
   keyPrefix: z.string().optional(),
   proxy: secretStr().optional(),
 })
+
+// Only the redacted twin derives: the schema is the resolved shape, with
+// the region and endpoint the redactor fills in.
+export type GCSConfigRedacted = RedactedConfig<
+  ConfigOf<typeof GCSConfigSchema>,
+  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'proxy'
+>
 
 export function gcsToS3Config(config: GCSConfig): S3Config {
   return {

--- a/typescript/packages/node/src/resource/github/config.ts
+++ b/typescript/packages/node/src/resource/github/config.ts
@@ -12,23 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GitHubConfig {
-  token: string
-  owner: string
-  repo: string
-  ref?: string
-  baseUrl?: string
-}
-
-export interface GitHubConfigRedacted {
-  token: '<REDACTED>'
-  owner: string
-  repo: string
-  ref?: string
-  baseUrl?: string
-}
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const GitHubConfigSchema = z.object({
   token: secretStr(),
@@ -37,6 +28,10 @@ const GitHubConfigSchema = z.object({
   ref: z.string().optional(),
   baseUrl: z.string().optional(),
 })
+
+export type GitHubConfig = ConfigOf<typeof GitHubConfigSchema>
+
+export type GitHubConfigRedacted = RedactedConfig<GitHubConfig, 'token'>
 
 export function redactGitHubConfig(config: GitHubConfig): GitHubConfigRedacted {
   return redactConfigWithSchema(GitHubConfigSchema, config) as unknown as GitHubConfigRedacted

--- a/typescript/packages/node/src/resource/github_ci/config.ts
+++ b/typescript/packages/node/src/resource/github_ci/config.ts
@@ -12,25 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GitHubCIConfig {
-  token: string
-  owner: string
-  repo: string
-  days?: number
-  maxRuns?: number
-  baseUrl?: string
-}
-
-export interface GitHubCIConfigRedacted {
-  token: '<REDACTED>'
-  owner: string
-  repo: string
-  days?: number
-  maxRuns?: number
-  baseUrl?: string
-}
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const GitHubCIConfigSchema = z.object({
   token: secretStr(),
@@ -40,6 +29,10 @@ const GitHubCIConfigSchema = z.object({
   maxRuns: z.number().optional(),
   baseUrl: z.string().optional(),
 })
+
+export type GitHubCIConfig = ConfigOf<typeof GitHubCIConfigSchema>
+
+export type GitHubCIConfigRedacted = RedactedConfig<GitHubCIConfig, 'token'>
 
 export function redactGitHubCIConfig(config: GitHubCIConfig): GitHubCIConfigRedacted {
   return redactConfigWithSchema(GitHubCIConfigSchema, config) as unknown as GitHubCIConfigRedacted

--- a/typescript/packages/node/src/resource/gridfs/config.ts
+++ b/typescript/packages/node/src/resource/gridfs/config.ts
@@ -16,17 +16,11 @@ import {
   normalizeFields,
   normalizeKeyPrefix,
   redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
   secretStr,
   z,
 } from '@struktoai/mirage-core'
-
-export interface GridFSConfig {
-  uri: string
-  database: string
-  bucket?: string
-  keyPrefix?: string
-  chunkSizeBytes?: number
-}
 
 const GridFSConfigSchema = z.object({
   uri: secretStr(),
@@ -36,9 +30,9 @@ const GridFSConfigSchema = z.object({
   chunkSizeBytes: z.number().optional(),
 })
 
-export interface GridFSConfigRedacted extends Omit<GridFSConfig, 'uri'> {
-  uri?: string
-}
+export type GridFSConfig = ConfigOf<typeof GridFSConfigSchema>
+
+export type GridFSConfigRedacted = RedactedConfig<GridFSConfig, 'uri'>
 
 export function redactConfig(config: GridFSConfig): GridFSConfigRedacted {
   return redactConfigWithSchema(GridFSConfigSchema, config) as unknown as GridFSConfigRedacted

--- a/typescript/packages/node/src/resource/hf_buckets/config.ts
+++ b/typescript/packages/node/src/resource/hf_buckets/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  type ConfigOf,
+  normalizeFields,
+  redactConfigWithSchema,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 export const HF_ENDPOINT = 'https://huggingface.co'
 
@@ -32,14 +39,6 @@ export interface HfBucketsConfig {
   keyPrefix?: string
 }
 
-export interface HfBucketsConfigRedacted {
-  bucket: string
-  token?: string
-  endpoint: string
-  timeoutMs?: number
-  keyPrefix?: string
-}
-
 const HfBucketsConfigSchema = z.object({
   bucket: z.string(),
   token: secretStr().optional(),
@@ -47,6 +46,13 @@ const HfBucketsConfigSchema = z.object({
   timeoutMs: z.number().optional(),
   keyPrefix: z.string().optional(),
 })
+
+// Only the redacted twin derives: the schema is the resolved shape, with
+// the endpoint the redactor fills in.
+export type HfBucketsConfigRedacted = RedactedConfig<
+  ConfigOf<typeof HfBucketsConfigSchema>,
+  'token'
+>
 
 export function redactHfBucketsConfig(config: HfBucketsConfig): HfBucketsConfigRedacted {
   return redactConfigWithSchema(HfBucketsConfigSchema, {
@@ -78,15 +84,6 @@ export interface HfRepoConfig {
   revision?: string
 }
 
-export interface HfRepoConfigRedacted {
-  repoId: string
-  token?: string
-  endpoint: string
-  timeoutMs?: number
-  keyPrefix?: string
-  revision?: string
-}
-
 const HfRepoConfigSchema = z.object({
   repoId: z.string(),
   token: secretStr().optional(),
@@ -95,6 +92,10 @@ const HfRepoConfigSchema = z.object({
   keyPrefix: z.string().optional(),
   revision: z.string().optional(),
 })
+
+// Only the redacted twin derives: the schema is the resolved shape, with
+// the endpoint the redactor fills in.
+export type HfRepoConfigRedacted = RedactedConfig<ConfigOf<typeof HfRepoConfigSchema>, 'token'>
 
 export function redactHfRepoConfig(config: HfRepoConfig): HfRepoConfigRedacted {
   return redactConfigWithSchema(HfRepoConfigSchema, {

--- a/typescript/packages/node/src/resource/jaeger/config.ts
+++ b/typescript/packages/node/src/resource/jaeger/config.ts
@@ -12,17 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, z } from '@struktoai/mirage-core'
-
-export interface JaegerConfig {
-  host?: string
-  defaultTraceLimit?: number
-  defaultFromTimestamp?: string
-  defaultToTimestamp?: string
-  requestTimeout?: number
-}
-
-export type JaegerConfigRedacted = JaegerConfig
+import { type ConfigOf, normalizeFields, redactConfigWithSchema, z } from '@struktoai/mirage-core'
 
 const JaegerConfigSchema = z.object({
   host: z.string().optional(),
@@ -31,6 +21,11 @@ const JaegerConfigSchema = z.object({
   defaultToTimestamp: z.string().optional(),
   requestTimeout: z.number().optional(),
 })
+
+export type JaegerConfig = ConfigOf<typeof JaegerConfigSchema>
+
+// Nothing on a Jaeger config is a secret, so the twin is the config.
+export type JaegerConfigRedacted = JaegerConfig
 
 export function redactJaegerConfig(config: JaegerConfig): JaegerConfigRedacted {
   return redactConfigWithSchema(JaegerConfigSchema, config) as unknown as JaegerConfigRedacted

--- a/typescript/packages/node/src/resource/langfuse/config.ts
+++ b/typescript/packages/node/src/resource/langfuse/config.ts
@@ -12,25 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface LangfuseConfig {
-  publicKey: string
-  secretKey: string
-  host?: string
-  defaultTraceLimit?: number
-  defaultSearchLimit?: number
-  defaultFromTimestamp?: string
-}
-
-export interface LangfuseConfigRedacted {
-  publicKey: string
-  secretKey: '<REDACTED>'
-  host?: string
-  defaultTraceLimit?: number
-  defaultSearchLimit?: number
-  defaultFromTimestamp?: string
-}
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const LangfuseConfigSchema = z.object({
   publicKey: z.string(),
@@ -40,6 +29,10 @@ const LangfuseConfigSchema = z.object({
   defaultSearchLimit: z.number().optional(),
   defaultFromTimestamp: z.string().optional(),
 })
+
+export type LangfuseConfig = ConfigOf<typeof LangfuseConfigSchema>
+
+export type LangfuseConfigRedacted = RedactedConfig<LangfuseConfig, 'secretKey'>
 
 export function redactLangfuseConfig(config: LangfuseConfig): LangfuseConfigRedacted {
   return redactConfigWithSchema(LangfuseConfigSchema, config) as unknown as LangfuseConfigRedacted

--- a/typescript/packages/node/src/resource/nextcloud/config.ts
+++ b/typescript/packages/node/src/resource/nextcloud/config.ts
@@ -1,3 +1,5 @@
+import type { RedactedConfig } from '@struktoai/mirage-core'
+
 export interface NextcloudConfig {
   url: string
   username?: string
@@ -6,9 +8,7 @@ export interface NextcloudConfig {
   timeout?: number
 }
 
-export interface NextcloudConfigRedacted extends Omit<NextcloudConfig, 'password'> {
-  password?: '<REDACTED>'
-}
+export type NextcloudConfigRedacted = RedactedConfig<NextcloudConfig, 'password'>
 
 export function normalizeNextcloudConfig(config: Record<string, unknown>): NextcloudConfig {
   const url = config.url

--- a/typescript/packages/node/src/resource/oci/config.ts
+++ b/typescript/packages/node/src/resource/oci/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3Config } from '../s3/config.ts'
 
 export interface OCIConfig {
@@ -24,20 +31,6 @@ export interface OCIConfig {
   sessionToken?: string
   profile?: string
   endpoint?: string
-  keyPrefix?: string
-  timeoutMs?: number
-  proxy?: string
-}
-
-export interface OCIConfigRedacted {
-  bucket: string
-  namespace: string
-  region: string
-  accessKeyId?: string
-  secretAccessKey?: string
-  sessionToken?: string
-  profile?: string
-  endpoint: string
   keyPrefix?: string
   timeoutMs?: number
   proxy?: string
@@ -56,6 +49,13 @@ const OCIConfigSchema = z.object({
   timeoutMs: z.number().optional(),
   proxy: secretStr().optional(),
 })
+
+// Only the redacted twin derives: the schema is the resolved shape, with
+// the region and endpoint the redactor fills in.
+export type OCIConfigRedacted = RedactedConfig<
+  ConfigOf<typeof OCIConfigSchema>,
+  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'proxy'
+>
 
 function resolvedOciEndpoint(config: OCIConfig): string {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/node/src/resource/r2/config.ts
+++ b/typescript/packages/node/src/resource/r2/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3Config } from '../s3/config.ts'
 
 export interface R2Config {
@@ -23,21 +30,6 @@ export interface R2Config {
   accountId?: string
   endpoint?: string
   region?: string
-  profile?: string
-  forcePathStyle?: boolean
-  keyPrefix?: string
-  timeoutMs?: number
-  proxy?: string
-}
-
-export interface R2ConfigRedacted {
-  bucket: string
-  accessKeyId?: string
-  secretAccessKey?: string
-  sessionToken?: string
-  accountId?: string
-  endpoint: string
-  region: string
   profile?: string
   forcePathStyle?: boolean
   keyPrefix?: string
@@ -59,6 +51,13 @@ const R2ConfigSchema = z.object({
   timeoutMs: z.number().optional(),
   proxy: secretStr().optional(),
 })
+
+// Only the redacted twin derives: the schema is the resolved shape, with
+// the region and endpoint the redactor fills in.
+export type R2ConfigRedacted = RedactedConfig<
+  ConfigOf<typeof R2ConfigSchema>,
+  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'proxy'
+>
 
 function resolvedR2Endpoint(config: R2Config): string {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/node/src/resource/s3/config.ts
+++ b/typescript/packages/node/src/resource/s3/config.ts
@@ -13,11 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
+  type ConfigOf,
   normalizeFields,
   redactConfigWithSchema,
   S3ConfigSchema as S3CoreConfigSchema,
   type S3Config as S3CoreConfig,
-  type S3ConfigRedacted as S3CoreConfigRedacted,
+  type RedactedConfig,
   secretStr,
   z,
 } from '@struktoai/mirage-core'
@@ -27,15 +28,20 @@ export interface S3Config extends S3CoreConfig {
   proxy?: string
 }
 
-export interface S3ConfigRedacted extends S3CoreConfigRedacted {
-  profile?: string
-  proxy?: string
-}
-
 const S3ConfigSchema = S3CoreConfigSchema.extend({
   profile: z.string().optional(),
   proxy: secretStr().optional(),
 })
+
+export type S3ConfigRedacted = RedactedConfig<
+  ConfigOf<typeof S3ConfigSchema>,
+  | 'accessKeyId'
+  | 'secretAccessKey'
+  | 'sessionToken'
+  | 'presignedUrlProvider'
+  | 'httpAgentProvider'
+  | 'proxy'
+>
 
 export function redactConfig(config: S3Config): S3ConfigRedacted {
   return redactConfigWithSchema(S3ConfigSchema, config) as unknown as S3ConfigRedacted

--- a/typescript/packages/node/src/resource/s3_alias.ts
+++ b/typescript/packages/node/src/resource/s3_alias.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  type ConfigOf,
+  normalizeFields,
+  redactConfigWithSchema,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3Config } from './s3/config.ts'
 
 /**
@@ -40,20 +47,6 @@ export interface S3AliasConfig {
   profile?: string
   region?: string
   endpoint?: string
-  forcePathStyle?: boolean
-  keyPrefix?: string
-  timeoutMs?: number
-  proxy?: string
-}
-
-export interface S3AliasConfigRedacted {
-  bucket: string
-  accessKeyId?: string
-  secretAccessKey?: string
-  sessionToken?: string
-  profile?: string
-  region: string
-  endpoint: string
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
@@ -90,6 +83,13 @@ const ALIAS_SCHEMA = z.object({
   timeoutMs: z.number().optional(),
   proxy: secretStr().optional(),
 })
+
+// Only the redacted twin derives: the schema is the resolved shape, with
+// the region and endpoint each provider's rule fills in.
+export type S3AliasConfigRedacted = RedactedConfig<
+  ConfigOf<typeof ALIAS_SCHEMA>,
+  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'proxy'
+>
 
 export interface Alias<C extends S3AliasConfig, R> {
   toS3Config: (config: C) => S3Config

--- a/typescript/packages/node/src/resource/ssh/config.ts
+++ b/typescript/packages/node/src/resource/ssh/config.ts
@@ -12,33 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface SSHConfig {
-  host: string
-  hostname?: string
-  port?: number
-  username?: string
-  password?: string
-  identityFile?: string
-  passphrase?: string
-  root?: string
-  timeout?: number
-  knownHosts?: string
-}
-
-export interface SSHConfigRedacted {
-  host: string
-  hostname?: string
-  port?: number
-  username?: string
-  password?: '<REDACTED>'
-  identityFile?: string
-  passphrase?: '<REDACTED>'
-  root?: string
-  timeout?: number
-  knownHosts?: string
-}
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const SSHConfigSchema = z.object({
   host: z.string(),
@@ -52,6 +33,10 @@ const SSHConfigSchema = z.object({
   timeout: z.number().optional(),
   knownHosts: z.string().optional(),
 })
+
+export type SSHConfig = ConfigOf<typeof SSHConfigSchema>
+
+export type SSHConfigRedacted = RedactedConfig<SSHConfig, 'password' | 'passphrase'>
 
 export function redactSshConfig(config: SSHConfig): SSHConfigRedacted {
   return redactConfigWithSchema(SSHConfigSchema, config) as unknown as SSHConfigRedacted

--- a/typescript/packages/node/src/resource/supabase/config.ts
+++ b/typescript/packages/node/src/resource/supabase/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3Config } from '../s3/config.ts'
 
 export interface SupabaseConfig {
@@ -22,20 +29,6 @@ export interface SupabaseConfig {
   secretAccessKey?: string
   projectRef?: string
   endpoint?: string
-  sessionToken?: string
-  profile?: string
-  keyPrefix?: string
-  timeoutMs?: number
-  proxy?: string
-}
-
-export interface SupabaseConfigRedacted {
-  bucket: string
-  region: string
-  projectRef?: string
-  endpoint: string
-  accessKeyId?: string
-  secretAccessKey?: string
   sessionToken?: string
   profile?: string
   keyPrefix?: string
@@ -56,6 +49,13 @@ const SupabaseConfigSchema = z.object({
   timeoutMs: z.number().optional(),
   proxy: secretStr().optional(),
 })
+
+// Only the redacted twin derives: the schema is the resolved shape, with
+// the region and endpoint the redactor fills in.
+export type SupabaseConfigRedacted = RedactedConfig<
+  ConfigOf<typeof SupabaseConfigSchema>,
+  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'proxy'
+>
 
 export function resolvedSupabaseEndpoint(config: SupabaseConfig): string {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint

--- a/typescript/packages/node/src/resource/trello/config.ts
+++ b/typescript/packages/node/src/resource/trello/config.ts
@@ -12,23 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface TrelloConfig {
-  apiKey: string
-  apiToken: string
-  workspaceId?: string
-  boardIds?: readonly string[]
-  baseUrl?: string
-}
-
-export interface TrelloConfigRedacted {
-  apiKey: '<REDACTED>'
-  apiToken: '<REDACTED>'
-  workspaceId?: string
-  boardIds?: readonly string[]
-  baseUrl?: string
-}
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 
 const TrelloConfigSchema = z.object({
   apiKey: secretStr(),
@@ -37,6 +28,10 @@ const TrelloConfigSchema = z.object({
   boardIds: z.array(z.string()).optional(),
   baseUrl: z.string().optional(),
 })
+
+export type TrelloConfig = ConfigOf<typeof TrelloConfigSchema>
+
+export type TrelloConfigRedacted = RedactedConfig<TrelloConfig, 'apiKey' | 'apiToken'>
 
 export function redactTrelloConfig(config: TrelloConfig): TrelloConfigRedacted {
   return redactConfigWithSchema(TrelloConfigSchema, config) as unknown as TrelloConfigRedacted

--- a/typescript/packages/node/src/resource/trello/config.ts
+++ b/typescript/packages/node/src/resource/trello/config.ts
@@ -25,7 +25,7 @@ const TrelloConfigSchema = z.object({
   apiKey: secretStr(),
   apiToken: secretStr(),
   workspaceId: z.string().optional(),
-  boardIds: z.array(z.string()).optional(),
+  boardIds: z.array(z.string()).readonly().optional(),
   baseUrl: z.string().optional(),
 })
 

--- a/typescript/packages/node/src/resource/wasabi/config.ts
+++ b/typescript/packages/node/src/resource/wasabi/config.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
+import {
+  normalizeFields,
+  redactConfigWithSchema,
+  type ConfigOf,
+  type RedactedConfig,
+  secretStr,
+  z,
+} from '@struktoai/mirage-core'
 import type { S3Config } from '../s3/config.ts'
 
 export interface WasabiConfig {
@@ -23,20 +30,6 @@ export interface WasabiConfig {
   profile?: string
   region?: string
   endpoint?: string
-  forcePathStyle?: boolean
-  keyPrefix?: string
-  timeoutMs?: number
-  proxy?: string
-}
-
-export interface WasabiConfigRedacted {
-  bucket: string
-  accessKeyId?: string
-  secretAccessKey?: string
-  sessionToken?: string
-  profile?: string
-  region: string
-  endpoint: string
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
@@ -56,6 +49,13 @@ const WasabiConfigSchema = z.object({
   timeoutMs: z.number().optional(),
   proxy: secretStr().optional(),
 })
+
+// Only the redacted twin derives: the schema is the resolved shape, with
+// the region and endpoint the redactor fills in.
+export type WasabiConfigRedacted = RedactedConfig<
+  ConfigOf<typeof WasabiConfigSchema>,
+  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'proxy'
+>
 
 export function resolvedWasabiEndpoint(config: WasabiConfig): string {
   if (config.endpoint !== undefined && config.endpoint !== '') return config.endpoint


### PR DESCRIPTION
Follow-up to #768, which collapsed `GhConfig` into its schema. The same duplication was in every other TypeScript config.

Each one declared its shape twice, as an interface and as the zod schema that actually validates it, plus a `*Redacted` twin that re-listed every field by hand. Two type helpers in `resource/secrets.ts` replace both:

- `ConfigOf<Schema>` reads a config's shape off the schema.
- `RedactedConfig<T, K>` builds the redacted twin from the config plus the names of its secret fields. The secret marker is runtime metadata on a plain `z.ZodString`, so the names still have to be written once; what goes is the half that re-listed every ordinary field (SSH repeated ten).

Neither is a bare `z.infer`. That renders an optional field as `k?: T | undefined`, which under `exactOptionalPropertyTypes` is wider than the `k?: T` these configs were written with, and it broke every S3-alias subclass against its base.

## Drift this uncovered

The twin is reached through an `as unknown as` cast, so TypeScript never checked it:

- `gcs`, `oci`, `r2`, `supabase`, `wasabi`, `hf_buckets` and node's own `s3` typed redacted credentials as plain `string`, when redaction replaces them with `'<REDACTED>'`.
- `gridfs` typed its `uri` as `uri?: string`, which after redaction is neither optional nor a string.
- `box` dropped `contentSearch` from its redacted type although the schema carries it.

## Where the config type stays hand-written

Ten files, each saying why in place: `s3` carries a `profile` its schema lacks; `google`, `box` and `dropbox` omit callbacks no snapshot can carry; the S3-alias family and `hf_buckets` describe the *resolved* config, with region and endpoint the redactor fills in. Those derive only the twin.

## Runtime

One change: browser `trello` and `linear` declared `readonly string[]` their schemas did not, so the schemas say `.readonly()` now.

## Verification

`pnpm -r typecheck` clean across all 7 packages, `pre-commit --all-files` clean and stable, and every suite green: core 7808, node 2149, browser 182, server 249, agents 175, cli 92, opencode 2. No Python files change.