### PR TITLE
fix(glob): let glob expansion see nested mount roots and symlinks

### DIFF
--- a/integ/crossmount/nested/basic.json
+++ b/integ/crossmount/nested/basic.json
@@ -207,6 +207,97 @@
         "stdout": "/ghost\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "nest_glob_enumerates_child_mount_root",
+      "seq": 950017,
+      "targets": [
+        "ram-nested"
+      ],
+      "command": "echo /data/*",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/inner /data/top.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "nest_glob_matching_one_name_is_installed",
+      "seq": 950018,
+      "targets": [
+        "ram-nested"
+      ],
+      "command": "ls -d /data/i*",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/inner\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "nest_du_glob_reaches_child_mount",
+      "seq": 950019,
+      "targets": [
+        "ram-nested"
+      ],
+      "command": "du /data/i*",
+      "expect": {
+        "exit": 0,
+        "stdout": "5\t/data/inner\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "nest_midpath_glob_descends_child_mount",
+      "seq": 950020,
+      "targets": [
+        "ram-nested"
+      ],
+      "command": "echo /data/*/leaf.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/inner/leaf.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "nest_glob_does_not_descend_into_a_file",
+      "seq": 950021,
+      "targets": [
+        "ram-nested"
+      ],
+      "command": "echo /data/t*/top.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/t*/top.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "nest_glob_produced_mount_root_is_refused",
+      "seq": 950022,
+      "targets": [
+        "ram-nested"
+      ],
+      "command": "tar -c -f /data/gmount.tar /data/i*",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "tar: /data/inner: Cannot open: Device or resource busy\ntar: Error is not recoverable: exiting now\n"
+      }
+    },
+    {
+      "id": "nest_glob_follows_a_linked_directory",
+      "seq": 950023,
+      "targets": [
+        "ram-nested"
+      ],
+      "command": "ln -s /data/inner /data/dlink && echo /data/d*/leaf.txt && echo /data/dlink/* && rm /data/dlink",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/dlink/leaf.txt\n/data/dlink/leaf.txt\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/unix/ln/relative.json
+++ b/integ/unix/ln/relative.json
@@ -145,6 +145,20 @@
       "flags": [
         "r"
       ]
+    },
+    {
+      "id": "ln_glob_descends_symlinked_dir",
+      "seq": 611026,
+      "targets": [
+        "ram",
+        "disk"
+      ],
+      "command": "echo /data/lns/alias/* && echo /data/lns/a*/a/f.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/lns/alias/a\n/data/lns/alias/a/f.txt\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -23,7 +23,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.du import (DEFAULT_MAX_DU_ENTRIES,
                                                 DuEntries)
 from mirage.commands.config import CommandFnResult, CommandOpts, ProvisionFn
-from mirage.ops.types import StatOverlay
+from mirage.ops.types import ChildMounts, StatOverlay
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import MISS_ERRORS, eisdir
 from mirage.utils.glob_walk import DEFAULT_MAX_GLOB_MATCHES, make_resolve_glob
@@ -338,10 +338,16 @@ class CommandIO:
     append: WriteOp | None = None
     # Kwargs vary per backend (mode/times/owner); loose like TS's any.
     set_attrs: OperationFn | None = None
+    # Child names the namespace owes a directory (nested mount roots and
+    # symlinks). Stamped per invocation from opts.child_mounts by the
+    # factory, because it is session-scoped state and the adapter itself
+    # is built once per backend.
+    glob_children: ChildMounts | None = None
 
     @property
     def resolve_glob(self) -> ResolveGlobOp:
-        return make_resolve_glob(self.readdir, self.max_glob_matches)
+        return make_resolve_glob(self.readdir, self.max_glob_matches,
+                                 self.glob_children)
 
     def operation(self, op: Operation) -> OperationFn | None:
         operations = {

--- a/python/mirage/commands/builtin/generic_bind/factory.py
+++ b/python/mirage/commands/builtin/generic_bind/factory.py
@@ -24,7 +24,7 @@ from mirage.cache.read_through import (cache_aware_read_bytes,
 from mirage.commands.builtin.generic_bind.adapter import CommandIO
 from mirage.commands.builtin.generic_bind.builders import _BUILDERS
 from mirage.commands.builtin.generic_bind.provision import default_provision
-from mirage.commands.config import command
+from mirage.commands.config import CommandOpts, command
 from mirage.commands.spec import SPECS
 from mirage.types import PathSpec
 
@@ -89,6 +89,36 @@ def with_stat_cache(ops: CommandIO) -> CommandIO:
     return replace(ops, stat=functools.partial(_cached_stat, ops.stat))
 
 
+async def _run_with_namespace_globs(ops: CommandIO, fn: Callable[..., Any],
+                                    accessor: Accessor, paths: list[PathSpec],
+                                    texts: list[str],
+                                    opts: CommandOpts) -> Any:
+    """Run a builder with an adapter whose globs see the namespace.
+
+    A nested mount's keys live in another resource and no resource stores
+    a symlink, so a glob resolved by one backend's readdir misses both,
+    while the same names are already merged into a listing. The adapter
+    is built once per backend and the names are session-scoped, so the
+    fact is stamped on here, per invocation, from ``opts.child_mounts``:
+    every builder then keeps calling ``ops.resolve_glob`` unchanged.
+
+    ``ops`` stays the first bound argument, because that partial slot is
+    how the adapter is reached for a registered command.
+
+    Args:
+        ops (CommandIO): the backend's IO adapter.
+        fn (Callable): the builder's command function.
+        accessor (Accessor): backend handle.
+        paths (list[PathSpec]): the command's path operands.
+        texts (list[str]): the command's text arguments.
+        opts (CommandOpts): the per-invocation option bag.
+    """
+    if opts.child_mounts is None:
+        return await fn(ops, accessor, paths, texts, opts)
+    return await fn(replace(ops, glob_children=opts.child_mounts), accessor,
+                    paths, texts, opts)
+
+
 def make_generic_commands(
     resource: str,
     ops: CommandIO,
@@ -130,7 +160,7 @@ def make_generic_commands(
             cmd_ops = with_stat_cache(base_ops)
         else:
             cmd_ops = base_ops
-        bound = functools.partial(b.fn, cmd_ops)
+        bound = functools.partial(_run_with_namespace_globs, cmd_ops, b.fn)
         provision: Callable[..., Any] | None
         if b.name in prov_over:
             provision = prov_over[b.name]

--- a/python/mirage/utils/glob_walk.py
+++ b/python/mirage/utils/glob_walk.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from mirage.accessor.base import Accessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.ops.types import ChildMounts
 from mirage.types import PathSpec
 from mirage.utils.fnmatch import fnmatch
 from mirage.utils.key_prefix import rekey
@@ -91,6 +92,7 @@ async def expand_pattern(
     accessor: Accessor,
     path: PathSpec,
     index: IndexCacheStore,
+    children: ChildMounts | None = None,
 ) -> list[PathSpec]:
     """Expand a glob PathSpec segment-by-segment via readdir.
 
@@ -109,6 +111,10 @@ async def expand_pattern(
         path (PathSpec): unresolved spec whose ``resource_path`` still
             contains the pattern.
         index (IndexCacheStore): the per-call cache index.
+        children (ChildMounts | None): child names the namespace owes a
+            directory (nested mount roots and symlinks). No backend can
+            see either, so a walk that stops at readdir misses both; this
+            is the union ``merge_readdir`` applies to a listing.
     """
     prefix = path.virtual[:len(path.virtual.rstrip("/")) -
                           len(path.resource_path)]
@@ -130,11 +136,20 @@ async def expand_pattern(
             try:
                 entries = await readdir(accessor, spec, index)
             except (FileNotFoundError, NotADirectoryError):
-                continue
+                entries = []
             next_level.extend(
                 e for e in entries
                 if fnmatch(e.rstrip("/").rsplit("/", 1)[-1], seg))
-        level = next_level
+            if children is not None:
+                # A nested mount root or a link is a real child of this
+                # parent whether or not the backend could list it.
+                base_dir = parent.rstrip("/")
+                next_level.extend(f"{base_dir}/{name}"
+                                  for name in children(f"{base_dir}/")
+                                  if fnmatch(name, seg))
+        # bash sorts a pathname expansion, and the two sources are
+        # enumerated separately, so the union is ordered here.
+        level = sorted(set(next_level))
         if not level:
             return []
     matches = [
@@ -157,6 +172,7 @@ async def expand_pattern(
 def make_resolve_glob(
     readdir: Callable[..., Any],
     max_glob_matches: int | None = DEFAULT_MAX_GLOB_MATCHES,
+    children: ChildMounts | None = None,
 ) -> Callable[..., Any]:
     """Build a resolve_glob generic over a backend's readdir.
 
@@ -164,6 +180,8 @@ def make_resolve_glob(
         readdir (Callable): backend readdir ``(accessor, path, index)``.
         max_glob_matches (int | None): cap on matches per pattern before
             truncation.
+        children (ChildMounts | None): child names the namespace owes a
+            directory, so an expansion sees nested mount roots and links.
     """
 
     async def resolve_glob(
@@ -172,7 +190,7 @@ def make_resolve_glob(
         index: IndexCacheStore = NULL_INDEX,
     ) -> list[PathSpec]:
         return await resolve_glob_with(readdir, accessor, paths, index,
-                                       max_glob_matches)
+                                       max_glob_matches, children)
 
     return resolve_glob
 
@@ -183,6 +201,7 @@ async def resolve_glob_with(
     paths: list[PathSpec],
     index: IndexCacheStore,
     cap: int | None = None,
+    children: ChildMounts | None = None,
 ) -> list[PathSpec]:
     """Shared resolve_glob loop over a backend's readdir.
 
@@ -199,13 +218,16 @@ async def resolve_glob_with(
         paths (list[PathSpec]): specs to resolve.
         index (IndexCacheStore): the per-call cache index.
         cap (int | None): cap on matches per pattern before truncation.
+        children (ChildMounts | None): child names the namespace owes a
+            directory, so an expansion sees nested mount roots and links.
     """
     result: list[PathSpec] = []
     for p in paths:
         if p.resolved:
             result.append(p)
         elif p.pattern:
-            matched = await expand_pattern(readdir, accessor, p, index)
+            matched = await expand_pattern(readdir, accessor, p, index,
+                                           children)
             if not matched and is_word_shaped(p):
                 # bash with nullglob off: an unmatched glob word stays
                 # the literal; the command then errors on it like GNU

--- a/python/mirage/workspace/executor/command/command.py
+++ b/python/mirage/workspace/executor/command/command.py
@@ -213,7 +213,9 @@ async def handle_command(
             # expands the operand's glob. RELAY bypasses the mount command
             # wrappers entirely, so its glob operands must expand here; an
             # unmatched glob stays the literal word, like bash.
-            expanded = await resolve_globs(list(path_scopes), registry)
+            expanded = await resolve_globs(list(path_scopes),
+                                           registry,
+                                           links=namespace)
             cross_scopes = [p for p in expanded if isinstance(p, PathSpec)]
         run_single = functools.partial(run_on_mount,
                                        registry,

--- a/python/mirage/workspace/expand/argv.py
+++ b/python/mirage/workspace/expand/argv.py
@@ -29,6 +29,7 @@ from mirage.workspace.expand.spec_hints import (spec_for_command,
                                                 spec_word_bases,
                                                 spec_word_kinds)
 from mirage.workspace.mount import MountRegistry
+from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.route import (WordPolicy, end_options_after_program,
                                     route, word_policy)
 from mirage.workspace.session import Session
@@ -82,6 +83,7 @@ async def expand_argv(
     execute_fn: Callable[..., Any],
     call_stack: CallStack | None,
     registry: MountRegistry,
+    namespace: Namespace | None = None,
 ) -> Argv:
     """Expand, classify, and glob-resolve a command's word nodes.
 
@@ -96,6 +98,9 @@ async def expand_argv(
         execute_fn (Callable): evaluator for command substitutions.
         call_stack (CallStack | None): shell call stack.
         registry (MountRegistry): mount registry for classification.
+        namespace (Namespace | None): addressing authority holding the
+            links, so a glob word sees links and nested mount roots the
+            way a listing does.
     """
     expanded = await expand_parts(parts, session, execute_fn, call_stack)
     if not expanded:
@@ -153,7 +158,7 @@ async def expand_argv(
     # patterns for backend pushdown; unknown names fail without
     # touching backends.
     if policy is WordPolicy.SHELL:
-        words = await resolve_globs(classified, registry)
+        words = await resolve_globs(classified, registry, links=namespace)
     else:
         words = classified
     # The text view renders words as typed (raw_path): bash hands

--- a/python/mirage/workspace/expand/globs.py
+++ b/python/mirage/workspace/expand/globs.py
@@ -14,15 +14,146 @@
 
 import dataclasses
 
+from mirage.ops.config import NamespaceLinks
+from mirage.ops.namespace_view import child_mount_names, namespace_names
 from mirage.types import PathSpec
+from mirage.utils.fnmatch import fnmatch
 from mirage.utils.glob_walk import has_glob, spell_match
 from mirage.utils.key_prefix import mount_key
 from mirage.workspace.mount import MountRegistry
 from mirage.workspace.mount.mount import MountEntry
 
 
-async def _walk_segments(item: PathSpec, mount: MountEntry,
-                         prefix: str) -> list[PathSpec]:
+def _namespace_children(registry: MountRegistry, links: NamespaceLinks | None,
+                        directory: str, pattern: str) -> list[str]:
+    """Virtual paths a directory owes the namespace, matching a segment.
+
+    Child mounts and symlinks are namespace state no backend can see, so
+    a glob that stops at one backend misses both: a nested mount's keys
+    live in another resource, and no resource stores a link. This is the
+    union ``merge_readdir`` already applies to a listing, filtered by the
+    glob segment with the same matcher backends use, and session-filtered
+    by ``namespace_names`` so a scoped session never learns an ungranted
+    mount's name from an expansion.
+
+    Args:
+        registry (MountRegistry): registry holding the mount table.
+        links (NamespaceLinks | None): the namespace symlink table.
+        directory (str): the directory being globbed.
+        pattern (str): the glob segment matched against child names.
+    """
+    base = directory.rstrip("/")
+    return [
+        f"{base}/{name}" for name in namespace_names(
+            [m.prefix for m in registry.mounts()], links, directory)
+        if fnmatch(name, pattern)
+    ]
+
+
+def _as_spec(match: str | PathSpec, prefix: str) -> PathSpec:
+    """Normalize one backend match to a PathSpec.
+
+    Args:
+        match (str | PathSpec): one match as the backend reported it.
+        prefix (str): the mount prefix with no trailing slash.
+    """
+    if isinstance(match, PathSpec):
+        return match
+    full = match if match.startswith(prefix) else prefix + match
+    return PathSpec.from_str_path(full, mount_key(full, prefix))
+
+
+def _merge_namespace(item: PathSpec, matches: list[str | PathSpec],
+                     extra: list[str], prefix: str, registry: MountRegistry,
+                     mount: MountEntry) -> list[PathSpec]:
+    """Union a backend's matches with the namespace-owed ones.
+
+    Sorted, because bash sorts a pathname expansion and the two sources
+    are enumerated separately. A backend that matched nothing answers
+    with the literal word (nullglob off); that is "no match", not an
+    entry to merge against, so it is dropped here and the literal is
+    reinstated by the caller only if the union is empty too.
+
+    Args:
+        item (PathSpec): the glob word being resolved.
+        matches (list[str | PathSpec]): the backend's own matches.
+        extra (list[str]): namespace-owed virtual paths.
+        prefix (str): the mount prefix with no trailing slash.
+        registry (MountRegistry): registry holding the mount table.
+        mount (MountEntry): the mount owning the glob word.
+    """
+    specs = [
+        s for s in (_as_spec(m, prefix) for m in matches)
+        if s.virtual != item.virtual
+    ]
+    seen = {s.virtual for s in specs}
+    for virtual in extra:
+        if virtual in seen:
+            continue
+        seen.add(virtual)
+        # A nested mount root belongs to the mount it opens, not to the
+        # one being listed, so it is keyed against its own backend.
+        owner = _mount_of(registry, virtual, mount).prefix.rstrip("/")
+        specs.append(PathSpec.from_str_path(virtual, mount_key(virtual,
+                                                               owner)))
+    return sorted(specs, key=lambda s: s.virtual)
+
+
+def _mount_of(registry: MountRegistry, virtual: str,
+              fallback: MountEntry) -> MountEntry:
+    """The mount owning a path, falling back to the word's own.
+
+    Args:
+        registry (MountRegistry): registry holding the mount table.
+        virtual (str): the virtual path to place.
+        fallback (MountEntry): mount to use for a path outside the table.
+    """
+    try:
+        return registry.mount_for(virtual)
+    except ValueError:
+        return fallback
+
+
+async def _level_matches(registry: MountRegistry, mount: MountEntry,
+                         links: NamespaceLinks | None, dir_virtual: str,
+                         seg: str) -> list[str]:
+    """One descent step: the owning backend's matches plus the namespace's.
+
+    The walk can cross into a nested mount, because a mid-path segment
+    may match a mount root, so the backend asked is the one owning that
+    parent rather than the one owning the typed word.
+
+    Args:
+        registry (MountRegistry): registry holding the mount table.
+        mount (MountEntry): the mount owning the typed word.
+        links (NamespaceLinks | None): the namespace symlink table.
+        dir_virtual (str): the parent directory, slash-terminated.
+        seg (str): the glob segment being matched.
+    """
+    owner = _mount_of(registry, dir_virtual, mount)
+    prefix = owner.prefix.rstrip("/")
+    spec = PathSpec(virtual=dir_virtual,
+                    directory=dir_virtual,
+                    resource_path=mount_key(dir_virtual, prefix),
+                    pattern=seg,
+                    resolved=False)
+    try:
+        matches = await owner.resource.resolve_glob([spec], prefix=prefix)
+    except OSError:
+        # This parent is not a listable directory; bash skips it during
+        # descent. A nested mount root or a link under it is still real.
+        matches = []
+    out = [
+        m.virtual if isinstance(m, PathSpec) else
+        (m if m.startswith(prefix) else prefix + m) for m in matches
+    ]
+    out.extend(_namespace_children(registry, links, dir_virtual, seg))
+    return out
+
+
+async def _walk_segments(item: PathSpec, mount: MountEntry, prefix: str,
+                         registry: MountRegistry,
+                         links: NamespaceLinks | None) -> list[PathSpec]:
     """Expand a mid-path pattern level by level via resolve_glob.
 
     A glob in a non-final segment (``s*/x.txt``) cannot resolve in one
@@ -45,30 +176,20 @@ async def _walk_segments(item: PathSpec, mount: MountEntry,
     for seg in segments[first:]:
         gathered: list[str] = []
         for parent in level:
-            dir_virtual = parent.rstrip("/") + "/"
-            spec = PathSpec(virtual=dir_virtual,
-                            directory=dir_virtual,
-                            resource_path=mount_key(dir_virtual, prefix),
-                            pattern=seg,
-                            resolved=False)
-            try:
-                matches = await mount.resource.resolve_glob([spec],
-                                                            prefix=prefix)
-            except OSError:
-                # This parent is not a listable directory; bash skips it
-                # during descent.
-                continue
-            for m in matches:
-                virtual = m.virtual if isinstance(
-                    m, PathSpec) else (m if m.startswith(prefix) else prefix +
-                                       m)
-                gathered.append(virtual)
-        level = gathered
+            gathered.extend(await _level_matches(registry, mount, links,
+                                                 parent.rstrip("/") + "/",
+                                                 seg))
+        # bash sorts a pathname expansion, and the backend and the
+        # namespace are enumerated separately, so the union is ordered
+        # here.
+        level = sorted(set(gathered))
         if not level:
             return []
     item_raw = item.raw_path
     return [
-        dataclasses.replace(PathSpec.from_str_path(v, mount_key(v, prefix)),
+        dataclasses.replace(PathSpec.from_str_path(
+            v, mount_key(v,
+                         _mount_of(registry, v, mount).prefix.rstrip("/"))),
                             raw_path=spell_match(item_raw, v, walked))
         for v in level
     ]
@@ -102,6 +223,7 @@ async def resolve_globs(
     classified: list[str | PathSpec],
     registry: MountRegistry,
     noglob: bool = False,
+    links: NamespaceLinks | None = None,
 ) -> list[str | PathSpec]:
     """Resolve glob patterns in PathSpec args, preserving PathSpec type.
 
@@ -116,12 +238,16 @@ async def resolve_globs(
         registry (MountRegistry): mount registry.
         noglob (bool): ``set -f`` — skip resolution entirely, so every
             glob word keeps its literal spelling like a zero-match glob.
+        links (NamespaceLinks | None): the namespace symlink table, so a
+            glob sees links and nested mount roots the way a listing
+            does. None outside a workspace.
     """
     if noglob:
         return list(classified)
     result: list[str | PathSpec] = []
     for item in classified:
         if isinstance(item, PathSpec) and item.pattern:
+            pattern = item.pattern
             try:
                 mount = registry.mount_for(item.virtual)
                 prefix = mount.prefix.rstrip("/")
@@ -131,26 +257,22 @@ async def resolve_globs(
                                            resource_path=mount_key(
                                                item.virtual, prefix))
                 if has_glob(item.directory):
-                    resolved = await _walk_segments(item, mount, prefix)
+                    resolved = await _walk_segments(item, mount, prefix,
+                                                    registry, links)
                 else:
-                    resolved = await mount.resource.resolve_glob([item],
-                                                                 prefix=prefix)
+                    resolved = _merge_namespace(
+                        item,
+                        list(await mount.resource.resolve_glob([item],
+                                                               prefix=prefix)),
+                        _namespace_children(registry, links, item.directory,
+                                            pattern), prefix, registry, mount)
                 # bash with nullglob off: a zero-match glob stays the
                 # literal word instead of vanishing.
                 if not resolved:
                     result.append(item)
                     continue
                 for p in resolved:
-                    if isinstance(p, PathSpec):
-                        result.append(_match_raw(item, p))
-                    else:
-                        full = prefix + p if not p.startswith(prefix) else p
-                        result.append(
-                            _match_raw(
-                                item,
-                                PathSpec.from_str_path(full,
-                                                       mount_key(full,
-                                                                 prefix))))
+                    result.append(_match_raw(item, _as_spec(p, prefix)))
             except (ValueError, AttributeError, TypeError):
                 result.append(item)
         elif isinstance(item, PathSpec):
@@ -158,3 +280,54 @@ async def resolve_globs(
         else:
             result.append(item)
     return result
+
+
+def _glob_head(spec: PathSpec) -> str:
+    """The fixed directory above a word's first glob segment.
+
+    Args:
+        spec (PathSpec): the glob word.
+    """
+    fixed: list[str] = []
+    for seg in spec.virtual.split("/"):
+        if has_glob(seg):
+            break
+        fixed.append(seg)
+    return "/".join(fixed) + "/"
+
+
+async def expand_boundary_globs(
+    parts: list[str | PathSpec],
+    registry: MountRegistry,
+    links: NamespaceLinks | None,
+) -> list[str | PathSpec]:
+    """Expand glob words that could match across a mount boundary.
+
+    A glob operand is normally left for the owning backend to resolve,
+    which is how a prefix store pushes the listing down. That only holds
+    while every match belongs to that backend: a nested mount's root is a
+    child of the directory but its keys live in another resource, so the
+    backend answers "no such file" for a name its own listing shows. When
+    the glob's fixed head holds a child mount, the word is expanded here
+    instead, before routing, so the matches route per mount exactly as
+    the same paths typed by hand already do. Every other glob is left
+    untouched, so pushdown is unaffected.
+
+    Args:
+        parts (list[str | PathSpec]): the command's words after the name.
+        registry (MountRegistry): registry holding the mount table.
+        links (NamespaceLinks | None): the namespace symlink table.
+    """
+    prefixes = [m.prefix for m in registry.mounts()]
+    if not any(
+            isinstance(p, PathSpec) and p.pattern
+            and child_mount_names(prefixes, _glob_head(p)) for p in parts):
+        return parts
+    out: list[str | PathSpec] = []
+    for item in parts:
+        if (isinstance(item, PathSpec) and item.pattern
+                and child_mount_names(prefixes, _glob_head(item))):
+            out.extend(await resolve_globs([item], registry, links=links))
+        else:
+            out.append(item)
+    return out

--- a/python/mirage/workspace/expand/globs.py
+++ b/python/mirage/workspace/expand/globs.py
@@ -20,6 +20,7 @@ from mirage.types import PathSpec
 from mirage.utils.fnmatch import fnmatch
 from mirage.utils.glob_walk import has_glob, spell_match
 from mirage.utils.key_prefix import mount_key
+from mirage.utils.path import CycleError
 from mirage.workspace.mount import MountRegistry
 from mirage.workspace.mount.mount import MountEntry
 
@@ -114,6 +115,43 @@ def _mount_of(registry: MountRegistry, virtual: str,
         return fallback
 
 
+def _listing_dir(links: NamespaceLinks | None, directory: str) -> str:
+    """The directory a backend must list to answer a glob's parent.
+
+    bash descends through a symlinked directory during pathname
+    expansion (``base/dlink/*`` and ``base/*/f2`` both reach the target's
+    entries), but a link is namespace state no backend can see, so the
+    parent has to be resolved here or the listing comes back empty and
+    the word stays literal. The match keeps the typed spelling, exactly
+    as bash reports ``base/dlink/f2`` rather than the target's path.
+
+    Args:
+        links (NamespaceLinks | None): the namespace symlink table.
+        directory (str): the directory being globbed, slash-terminated.
+    """
+    if links is None:
+        return directory
+    base = directory.rstrip("/") or "/"
+    try:
+        real = links.follow(base)
+    except CycleError:
+        # A loop resolves to nothing, which is bash's own answer: the
+        # word matches no file and stays literal.
+        return directory
+    return directory if real == base else real.rstrip("/") + "/"
+
+
+def _respell(virtuals: list[str], directory: str) -> list[str]:
+    """Move matches found under a resolved directory back to the typed one.
+
+    Args:
+        virtuals (list[str]): matches as the target directory names them.
+        directory (str): the directory as typed, slash-terminated.
+    """
+    base = directory.rstrip("/")
+    return [f"{base}/{v.rsplit('/', 1)[-1]}" for v in virtuals]
+
+
 async def _level_matches(registry: MountRegistry, mount: MountEntry,
                          links: NamespaceLinks | None, dir_virtual: str,
                          seg: str) -> list[str]:
@@ -121,7 +159,10 @@ async def _level_matches(registry: MountRegistry, mount: MountEntry,
 
     The walk can cross into a nested mount, because a mid-path segment
     may match a mount root, so the backend asked is the one owning that
-    parent rather than the one owning the typed word.
+    parent rather than the one owning the typed word. It can equally
+    descend through a symlinked directory, so the parent is resolved
+    through the namespace first and the matches are spelled back under
+    the name that was typed.
 
     Args:
         registry (MountRegistry): registry holding the mount table.
@@ -130,11 +171,12 @@ async def _level_matches(registry: MountRegistry, mount: MountEntry,
         dir_virtual (str): the parent directory, slash-terminated.
         seg (str): the glob segment being matched.
     """
-    owner = _mount_of(registry, dir_virtual, mount)
+    real = _listing_dir(links, dir_virtual)
+    owner = _mount_of(registry, real, mount)
     prefix = owner.prefix.rstrip("/")
-    spec = PathSpec(virtual=dir_virtual,
-                    directory=dir_virtual,
-                    resource_path=mount_key(dir_virtual, prefix),
+    spec = PathSpec(virtual=real,
+                    directory=real,
+                    resource_path=mount_key(real, prefix),
                     pattern=seg,
                     resolved=False)
     try:
@@ -143,12 +185,19 @@ async def _level_matches(registry: MountRegistry, mount: MountEntry,
         # This parent is not a listable directory; bash skips it during
         # descent. A nested mount root or a link under it is still real.
         matches = []
+    base = real.rstrip("/")
+    # A descent step yields children, so a match that is the parent
+    # itself is not one. A backend asked to list a path that is really a
+    # file answers with that file, which walked back out as a doubled
+    # segment (`/base/f*/f1` -> `/base/base/f1`); bash keeps the literal
+    # because a file is not a directory to descend into.
     out = [
-        m.virtual if isinstance(m, PathSpec) else
-        (m if m.startswith(prefix) else prefix + m) for m in matches
+        v for v in (m.virtual if isinstance(m, PathSpec) else (
+            m if m.startswith(prefix) else prefix + m)
+                    for m in matches) if v.startswith(f"{base}/")
     ]
-    out.extend(_namespace_children(registry, links, dir_virtual, seg))
-    return out
+    out.extend(_namespace_children(registry, links, real, seg))
+    return out if real == dir_virtual else _respell(out, dir_virtual)
 
 
 async def _walk_segments(item: PathSpec, mount: MountEntry, prefix: str,
@@ -185,13 +234,27 @@ async def _walk_segments(item: PathSpec, mount: MountEntry, prefix: str,
         level = sorted(set(gathered))
         if not level:
             return []
-    item_raw = item.raw_path
+    return _to_specs(level, item, registry, mount, walked)
+
+
+def _to_specs(virtuals: list[str], item: PathSpec, registry: MountRegistry,
+              mount: MountEntry, walked: int) -> list[PathSpec]:
+    """Key matched virtual paths to their mounts and spell them as typed.
+
+    Args:
+        virtuals (list[str]): the matched absolute virtual paths.
+        item (PathSpec): the glob word they answer.
+        registry (MountRegistry): registry holding the mount table.
+        mount (MountEntry): the mount owning the word.
+        walked (int): segment count from the word's first glob segment.
+    """
+    raw = item.raw_path
     return [
         dataclasses.replace(PathSpec.from_str_path(
             v, mount_key(v,
                          _mount_of(registry, v, mount).prefix.rstrip("/"))),
-                            raw_path=spell_match(item_raw, v, walked))
-        for v in level
+                            raw_path=spell_match(raw, v, walked))
+        for v in virtuals
     ]
 
 
@@ -259,6 +322,16 @@ async def resolve_globs(
                 if has_glob(item.directory):
                     resolved = await _walk_segments(item, mount, prefix,
                                                     registry, links)
+                elif _listing_dir(links, item.directory) != item.directory:
+                    # The parent is a symlink, so the backend holding the
+                    # typed path has nothing to list; _level_matches
+                    # follows it and spells the matches back.
+                    resolved = _to_specs(
+                        sorted(
+                            set(await
+                                _level_matches(registry, mount, links,
+                                               item.directory, pattern))),
+                        item, registry, mount, 1)
                 else:
                     resolved = _merge_namespace(
                         item,

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import dataclasses
 from typing import Any
 
 from mirage.commands.builtin.utils.limit import run_with_timeout
@@ -33,6 +34,7 @@ from mirage.workspace.executor.control import BreakSignal, ContinueSignal
 from mirage.workspace.expand import expand_node
 from mirage.workspace.expand.argv import Argv, expand_argv
 from mirage.workspace.expand.classify import classify_bare_path
+from mirage.workspace.expand.globs import expand_boundary_globs
 from mirage.workspace.route import (NO_FOLLOW_COMMANDS, UNSUPPORTED_BUILTINS,
                                     dereferences, reports_link)
 from mirage.workspace.session.shell_dirs import home_dir, logical_cwd
@@ -232,7 +234,8 @@ async def _dispatch_command_body(
         stdin = b"".join(proc_sub_parts)
     parts = clean_parts
 
-    argv = await expand_argv(parts, session, execute_fn, call_stack, registry)
+    argv = await expand_argv(parts, session, execute_fn, call_stack, registry,
+                             namespace)
 
     # Limits resolve against the expanded name, so `$CMD`-style
     # invocations get their real command's policy.
@@ -551,6 +554,20 @@ async def _run_argv(
                                                                  exit_code=1,
                                                                  stderr=err)
         return await handle_df(registry, session, dispatch, operands)
+
+    # A glob whose directory holds a child mount cannot be pushed down to
+    # one backend: the mount root is a child of that directory but its
+    # keys live in another resource, so the backend reports "no such
+    # file" for a name its own listing shows. Expanding such a word here
+    # (before the follow policy below, so a matched link is followed
+    # exactly as a typed one is) lets the matches route per mount.
+    boundary = await expand_boundary_globs(list(argv.operands), registry,
+                                           namespace)
+    if len(boundary) != len(argv.operands):
+        argv = dataclasses.replace(argv,
+                                   operands=tuple(boundary),
+                                   args=tuple(word_text(w) for w in boundary))
+        operands = list(argv.operands)
 
     # ── symlink-aware dispatch: reads follow links (open(2)); rm/mv act
     #    on the link entry itself (lstat semantics) ──

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -280,6 +280,30 @@ async def _run_argv(
 ) -> tuple[Any, IOResult, ExecutionNode]:
     """Route one expanded command to its builtin or mount handler."""
     name = argv.name
+
+    # ── boundary globs ──────────────────────────
+    # A glob whose directory holds a child mount cannot be pushed down
+    # to one backend: the mount root is a child of that directory but
+    # its keys live in another resource, so the backend reports "no such
+    # file" for a name its own listing shows. Expanding such a word here
+    # lets the matches route per mount. It has to happen before the
+    # admission policies below, not just before the follow policy: a
+    # word left unexpanded reaches `pre_command` as the literal pattern,
+    # and `MountRootPolicy` cannot recognize a mount root inside one, so
+    # `tar -cf out.tar /base/*` would archive a whole backend the same
+    # operand typed by hand is refused for.
+    boundary = await expand_boundary_globs(list(argv.operands), registry,
+                                           namespace)
+    expanded = [word_text(w) for w in boundary]
+    # Compared as words, not as a count: a glob that matches exactly one
+    # name (`du /base/i*` where only the mount root matches) is still an
+    # expansion, and dropping it routes the pattern to a backend that
+    # cannot serve the child mount's keys.
+    if expanded != [word_text(w) for w in argv.operands]:
+        argv = dataclasses.replace(argv,
+                                   operands=tuple(boundary),
+                                   args=tuple(expanded))
+
     args = list(argv.args)
     operands = list(argv.operands)
 
@@ -562,20 +586,6 @@ async def _run_argv(
                                                                  exit_code=1,
                                                                  stderr=err)
         return await handle_df(registry, session, dispatch, operands)
-
-    # A glob whose directory holds a child mount cannot be pushed down to
-    # one backend: the mount root is a child of that directory but its
-    # keys live in another resource, so the backend reports "no such
-    # file" for a name its own listing shows. Expanding such a word here
-    # (before the follow policy below, so a matched link is followed
-    # exactly as a typed one is) lets the matches route per mount.
-    boundary = await expand_boundary_globs(list(argv.operands), registry,
-                                           namespace)
-    if len(boundary) != len(argv.operands):
-        argv = dataclasses.replace(argv,
-                                   operands=tuple(boundary),
-                                   args=tuple(word_text(w) for w in boundary))
-        operands = list(argv.operands)
 
     # ── symlink-aware dispatch: reads follow links (open(2)); rm/mv act
     #    on the link entry itself (lstat semantics) ──

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -113,6 +113,7 @@ async def _expand_array_items(
     session: Session,
     execute_fn: Callable[..., Any],
     registry: MountRegistry,
+    namespace: Namespace,
     cs: CallStack | None,
 ) -> list[str]:
     """Expand an array literal into its element words.
@@ -126,6 +127,7 @@ async def _expand_array_items(
         session (Session): shell session.
         execute_fn (Callable): workspace execute for substitutions.
         registry (MountRegistry): mount registry for glob resolution.
+        namespace (Namespace): addressing authority holding the links.
         cs (CallStack | None): function-call scope, if any.
     """
     values = list(array_node.named_children)
@@ -134,7 +136,8 @@ async def _expand_array_items(
     resolved = await resolve_globs(classified,
                                    registry,
                                    noglob=bool(
-                                       session.shell_options.get("noglob")))
+                                       session.shell_options.get("noglob")),
+                                   links=namespace)
     return [word_text(w) for w in resolved]
 
 
@@ -449,7 +452,8 @@ async def execute_node(
         classified = await resolve_globs(
             classified,
             registry,
-            noglob=bool(session.shell_options.get("noglob")))
+            noglob=bool(session.shell_options.get("noglob")),
+            links=namespace)
         if kind == NodeKind.SELECT:
             return await handle_select(recurse, var, classified, body, session,
                                        stdin, cs)
@@ -507,7 +511,8 @@ async def execute_node(
                 if val_nodes and val_nodes[0].type == NT.ARRAY:
                     key = get_text(child).partition("=")[0]
                     items = await _expand_array_items(val_nodes[0], session,
-                                                      execute_fn, registry, cs)
+                                                      execute_fn, registry,
+                                                      namespace, cs)
                     staged.append(
                         (key.removesuffix("+"), key.endswith("+"), items))
                     continue
@@ -648,7 +653,8 @@ async def execute_node(
         ]
         if val_nodes and val_nodes[0].type == NT.ARRAY:
             items = await _expand_array_items(val_nodes[0], session,
-                                              execute_fn, registry, cs)
+                                              execute_fn, registry, namespace,
+                                              cs)
             if append:
                 base = session.arrays.get(key)
                 if base is None:

--- a/python/tests/workspace/expand/test_globs.py
+++ b/python/tests/workspace/expand/test_globs.py
@@ -390,3 +390,79 @@ def test_midpath_glob_descends_into_nested_mount():
     ws = _ws()
     _run(_seed(ws))
     assert _out(ws, "echo /base/*/g1").split() == ["/base/inner/g1"]
+
+
+def test_single_match_boundary_glob_is_installed():
+    """One match is still an expansion.
+
+    Comparing operand counts read it as unchanged, so the pattern stayed
+    routed to the parent mount, which cannot serve the child mount's
+    keys.
+    """
+    ws = _ws()
+    _run(_seed(ws))
+    assert _out(ws, "du /base/i*").splitlines() == ["7\t/base/inner"]
+    assert _out(ws, "ls -d /base/i*").split() == ["/base/inner"]
+
+
+def test_glob_produced_mount_root_is_refused():
+    """The mount-root refusal reads operands, so it must see expanded ones.
+
+    Expanding after the admission policies handed ``tar`` a mount root
+    nobody had checked, letting a glob archive a whole backend the same
+    operand typed by hand is refused for.
+    """
+    ws = _ws()
+    _run(_seed(ws))
+    typed = _run(ws.execute("tar -cf /out.tar /base/inner", session_id="s"))
+    globbed = _run(ws.execute("tar -cf /out2.tar /base/i*", session_id="s"))
+    assert globbed.stderr == typed.stderr
+    assert globbed.exit_code == typed.exit_code
+    assert b"Device or resource busy" in globbed.stderr
+
+
+def _seed_links(ws):
+    _run(_seed(ws))
+    _run(ws.execute("ln -s /base/sub /base/dlink", session_id="s"))
+    _run(ws.execute("ln -s /base/inner /base/mlink", session_id="s"))
+
+
+def test_glob_descends_a_symlinked_directory():
+    """bash follows a link while expanding and keeps the typed spelling.
+
+    GNU bash 5.2 (debian:stable-slim, ``base/dlink -> base/sub``):
+    ``echo base/d*/f2`` -> ``base/dlink/f2``.
+    """
+    ws = _ws()
+    _seed_links(ws)
+    assert _out(ws, "echo /base/d*/f2").split() == ["/base/dlink/f2"]
+    assert _out(ws, "echo /base/dlink/*").split() == ["/base/dlink/f2"]
+
+
+def test_glob_reports_a_link_and_its_target():
+    """``echo base/*/f2`` -> ``base/dlink/f2 base/sub/f2`` on GNU bash."""
+    ws = _ws()
+    _seed_links(ws)
+    assert _out(
+        ws, "echo /base/*/f2").split() == ["/base/dlink/f2", "/base/sub/f2"]
+
+
+def test_glob_follows_a_link_into_a_nested_mount():
+    """The followed directory is re-owned, so it can be another mount."""
+    ws = _ws()
+    _seed_links(ws)
+    assert _out(ws, "echo /base/mlink/*").split() == ["/base/mlink/g1"]
+    assert _out(ws, "echo /base/m*/g1").split() == ["/base/mlink/g1"]
+
+
+def test_midpath_glob_does_not_descend_into_a_file():
+    """A descent step yields children, so a file parent matches nothing.
+
+    A backend asked to list a path that is really a file answers with
+    that file, which walked back out as a doubled segment
+    (``/base/f*/f1`` -> ``/base/base/f1``). GNU bash keeps the literal.
+    """
+    ws = _ws()
+    _run(_seed(ws))
+    assert _out(ws, "echo /base/f*/f1").split() == ["/base/f*/f1"]
+    assert _out(ws, "echo /base/f1/*").split() == ["/base/f1/*"]

--- a/python/tests/workspace/expand/test_globs.py
+++ b/python/tests/workspace/expand/test_globs.py
@@ -18,9 +18,10 @@ from unittest.mock import MagicMock
 from mirage.cache.index import RAMIndexCacheStore
 from mirage.core.ram.readdir import readdir as ram_readdir
 from mirage.resource.ram import RAMResource
-from mirage.types import PathSpec
+from mirage.types import MountMode, PathSpec
 from mirage.utils.glob_walk import make_resolve_glob
 from mirage.utils.key_prefix import mount_key
+from mirage.workspace import Workspace
 from mirage.workspace.cli.registry import CLIRegistry
 from mirage.workspace.expand.globs import resolve_globs
 
@@ -40,6 +41,7 @@ def _mock_registry(resolve_result=None):
     reg = MagicMock()
     reg.clis = CLIRegistry()
     reg.mount_for = MagicMock(return_value=mount)
+    reg.mounts = MagicMock(return_value=[mount])
     return reg
 
 
@@ -295,3 +297,96 @@ def test_bare_relative_glob_raw_has_no_dir_prefix():
     result = _run(resolve_globs(["ls", glob_ps], reg))
     assert isinstance(result[1], PathSpec)
     assert result[1].raw_path == "a.txt"
+
+
+def _ws():
+    """Workspace with a nested mount and a symlink under /base."""
+    ws = Workspace({
+        "/": RAMResource(),
+        "/base/inner": RAMResource()
+    },
+                   mode=MountMode.WRITE)
+    ws.create_session("s")
+    return ws
+
+
+async def _seed(ws):
+    await ws.execute("mkdir -p /base/sub", session_id="s")
+    await ws.execute("printf 111 > /base/f1", session_id="s")
+    await ws.execute("printf 2222222 > /base/sub/f2", session_id="s")
+    await ws.execute("printf 3333333 > /base/inner/g1", session_id="s")
+    await ws.execute("ln -s /base/sub/f2 /base/link", session_id="s")
+
+
+def _out(ws, line):
+    r = _run(ws.execute(line, session_id="s"))
+    return r.stdout.decode()
+
+
+def test_glob_enumerates_nested_mount_root_and_symlink():
+    """A glob lists what its directory holds, mounts and links included.
+
+    GNU coreutils 9.7 (debian:stable-slim, tmpfs at base/inner):
+    ``echo base/*`` -> ``base/f1 base/inner base/link base/sub``.
+    """
+    ws = _ws()
+    _run(_seed(ws))
+    assert _out(ws, "echo /base/*").split() == [
+        "/base/f1", "/base/inner", "/base/link", "/base/sub"
+    ]
+
+
+def test_du_glob_rows_match_gnu():
+    """Pinned against ``du -b base/*`` on GNU coreutils 9.7."""
+    ws = _ws()
+    _run(_seed(ws))
+    assert _out(ws, "du /base/*").splitlines() == [
+        "3\t/base/f1",
+        "7\t/base/inner",
+        "12\t/base/link",
+        "7\t/base/sub",
+    ]
+
+
+def test_glob_operand_commands_see_mount_and_link():
+    """The omission was the expander's, so every glob consumer had it."""
+    ws = _ws()
+    _run(_seed(ws))
+    assert _out(ws, "ls -d /base/*").split() == [
+        "/base/f1", "/base/inner", "/base/link", "/base/sub"
+    ]
+    assert _out(ws, "find /base/* -maxdepth 0").split() == [
+        "/base/f1", "/base/inner", "/base/link", "/base/sub"
+    ]
+    # stat renders a mount root's name as "/" (a separate, pre-existing
+    # divergence reproducible with the operand typed by hand), so this
+    # pins the row count rather than the naming.
+    assert len(_out(ws, "stat /base/*").splitlines()) == 4
+    # wc follows the link and reports the target's bytes under the link's
+    # name, and names each directory operand on stderr, like GNU.
+    assert _out(ws, "wc -c /base/*").split() == [
+        "3", "/base/f1", "7", "/base/link", "10", "total"
+    ]
+
+
+def test_glob_matches_only_the_pattern():
+    """Merged namespace names are filtered by the pattern like any entry."""
+    ws = _ws()
+    _run(_seed(ws))
+    assert _out(ws, "echo /base/i*").split() == ["/base/inner"]
+    assert _out(ws, "echo /base/l*").split() == ["/base/link"]
+    assert _out(ws, "echo /base/f*").split() == ["/base/f1"]
+
+
+def test_unmatched_glob_still_stays_literal():
+    """bash with nullglob off: a zero-match word keeps its spelling."""
+    ws = _ws()
+    _run(_seed(ws))
+    assert _out(ws, "echo /base/zzz*").split() == ["/base/zzz*"]
+
+
+def test_midpath_glob_descends_into_nested_mount():
+    """A mount root is a directory a mid-path segment can match."""
+    ws = _ws()
+    _run(_seed(ws))
+    assert _out(ws, "echo /base/*/g1").split() == ["/base/inner/g1"]

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -29,6 +29,7 @@ import {
   type StatFn,
 } from '../../../types.ts'
 import { eisdir } from '../../../utils/errors.ts'
+import type { ChildMounts } from '../../../ops/types.ts'
 import { DEFAULT_MAX_GLOB_MATCHES, resolveGlobWith } from '../../../utils/glob_walk.ts'
 import { norm, parent } from '../../../utils/path.ts'
 import { stripSlash } from '../../../utils/slash.ts'
@@ -96,9 +97,10 @@ export type ResolveGlobOp<A extends Accessor = Accessor> = (
 export function makeResolveGlob<A extends Accessor = Accessor>(
   readdir: ReaddirOp<A>,
   maxGlobMatches: number = DEFAULT_MAX_GLOB_MATCHES,
+  children?: ChildMounts,
 ): ResolveGlobOp<A> {
   return async (accessor, paths, index) =>
-    resolveGlobWith(readdir, accessor, paths, index, maxGlobMatches)
+    resolveGlobWith(readdir, accessor, paths, index, maxGlobMatches, children)
 }
 
 // A backend's native du, both halves at once. The generic derives its
@@ -149,10 +151,15 @@ export interface CommandIO<A extends Accessor = Accessor> {
   append?: (accessor: A, path: PathSpec, data: Uint8Array) => Promise<void>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setAttrs?: (...args: any[]) => unknown
+  // Child names the namespace owes a directory (nested mount roots and
+  // symlinks). Stamped per invocation from opts.childMounts by the
+  // factory, because it is session-scoped state while the adapter itself
+  // is built once per backend.
+  globChildren?: ChildMounts
 }
 
 export function resolveGlobOf<A extends Accessor = Accessor>(ops: CommandIO<A>): ResolveGlobOp<A> {
-  return makeResolveGlob(ops.readdir, ops.maxGlobMatches)
+  return makeResolveGlob(ops.readdir, ops.maxGlobMatches, ops.globChildren)
 }
 
 /**

--- a/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
@@ -74,8 +74,19 @@ export function makeGenericCommands<A extends Accessor = Accessor>(
     if (!supports(baseOps, b.requirements ?? [])) continue
     const cmdOps =
       b.read === true ? withReadCache(baseOps) : b.write === true ? baseOps : withStatCache(baseOps)
+    // A glob resolved by one backend cannot see a nested mount root or a
+    // symlink: the mount keys live in another resource and no resource
+    // stores a link. The adapter is built once per backend and the names
+    // are session-scoped, so the fact is stamped on per invocation and
+    // every builder keeps calling resolveGlobOf(ops) unchanged.
     const fn: CommandFn = (accessor, paths, texts, opts) =>
-      b.fn(cmdOps, accessor, paths, texts, opts)
+      b.fn(
+        opts.childMounts === undefined ? cmdOps : { ...cmdOps, globChildren: opts.childMounts },
+        accessor,
+        paths,
+        texts,
+        opts,
+      )
     const provision =
       b.name in provOver
         ? ((provOver[b.name] ?? null) as ProvisionFn | null)

--- a/typescript/packages/core/src/core/mongodb/glob.test.ts
+++ b/typescript/packages/core/src/core/mongodb/glob.test.ts
@@ -63,7 +63,10 @@ describe('resolveGlob', () => {
       resourcePath: mountKey('/mongo/app/u*.jsonl', '/mongo'),
     })
     const out = await resolveGlob(makeAccessor(), [p])
-    expect(out.map((x) => x.virtual)).toEqual(['/mongo/app/users.jsonl', '/mongo/app/usage.jsonl'])
+    // bash sorts a pathname expansion rather than echoing readdir order
+    // (pinned on GNU coreutils 9.7), so the mocked order above does not
+    // survive: usage sorts before users.
+    expect(out.map((x) => x.virtual)).toEqual(['/mongo/app/usage.jsonl', '/mongo/app/users.jsonl'])
     expect(
       out[0] === undefined ? undefined : mountPrefixOf(out[0].virtual, out[0].resourcePath),
     ).toBe('/mongo')

--- a/typescript/packages/core/src/ops/namespace_view.ts
+++ b/typescript/packages/core/src/ops/namespace_view.ts
@@ -27,7 +27,7 @@ import { compareCodePoints } from '../utils/sort.ts'
  * names (leading dot) are included; presentation filtering is the
  * consumer's job, exactly as for backend entries.
  */
-function childMountNames(prefixes: readonly string[], parent: string): string[] {
+export function childMountNames(prefixes: readonly string[], parent: string): string[] {
   const norm = normDir(parent)
   const out = new Set<string>()
   for (const prefix of prefixes) {

--- a/typescript/packages/core/src/utils/glob_walk.ts
+++ b/typescript/packages/core/src/utils/glob_walk.ts
@@ -12,10 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { ChildMounts } from '../ops/types.ts'
 import { PathSpec } from '../types.ts'
 import { fnmatch } from './fnmatch.ts'
 import { rekey } from './key_prefix.ts'
 import { rstripSlash } from './slash.ts'
+import { compareCodePoints } from './sort.ts'
 
 export const GLOB_CHARS = ['*', '?', '[']
 
@@ -77,6 +79,7 @@ export async function resolveGlobWith<A, I>(
   paths: readonly PathSpec[],
   index: I | undefined,
   cap?: number,
+  children?: ChildMounts,
 ): Promise<PathSpec[]> {
   const result: PathSpec[] = []
   for (const p of paths) {
@@ -85,7 +88,7 @@ export async function resolveGlobWith<A, I>(
       continue
     }
     if (p.pattern !== null && p.pattern !== '') {
-      const matched = await expandPattern(readdir, accessor, p, index)
+      const matched = await expandPattern(readdir, accessor, p, index, children)
       if (matched.length === 0 && isWordShaped(p)) {
         result.push(
           new PathSpec({
@@ -122,6 +125,7 @@ export async function expandPattern<A, I>(
   accessor: A,
   path: PathSpec,
   index?: I,
+  children?: ChildMounts,
 ): Promise<PathSpec[]> {
   const prefix = path.virtual.slice(0, rstripSlash(path.virtual).length - path.resourcePath.length)
   const segments = path.resourcePath === '' ? [] : path.resourcePath.split('/')
@@ -143,15 +147,25 @@ export async function expandPattern<A, I>(
       try {
         entries = await readdir(accessor, spec, index)
       } catch (err) {
-        if (isMissingDir(err)) continue
-        throw err
+        if (!isMissingDir(err)) throw err
+        entries = []
       }
       for (const e of entries) {
         const name = rstripSlash(e).split('/').pop() ?? ''
         if (fnmatch(name, seg)) nextLevel.push(e)
       }
+      if (children !== undefined) {
+        // A nested mount root or a link is a real child of this parent
+        // whether or not the backend could list it.
+        const baseDir = rstripSlash(parent)
+        for (const name of children(`${baseDir}/`)) {
+          if (fnmatch(name, seg)) nextLevel.push(`${baseDir}/${name}`)
+        }
+      }
     }
-    level = nextLevel
+    // bash sorts a pathname expansion, and the two sources are enumerated
+    // separately, so the union is ordered here.
+    level = [...new Set(nextLevel)].sort(compareCodePoints)
     if (level.length === 0) return []
   }
   const matches = level.map((e) =>

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -240,7 +240,7 @@ export async function handleCommand(
       // expands the operand's glob. RELAY bypasses the mount command
       // wrappers entirely, so its glob operands must expand here; an
       // unmatched glob stays the literal word, like bash.
-      const expanded = await resolveGlobs(pathScopes, registry)
+      const expanded = await resolveGlobs(pathScopes, registry, false, namespace ?? null)
       csScopes = expanded.filter((p): p is PathSpec => typeof p !== 'string')
     }
     const runCtx: RunOnMountCtx = {

--- a/typescript/packages/core/src/workspace/expand/argv.ts
+++ b/typescript/packages/core/src/workspace/expand/argv.ts
@@ -18,6 +18,7 @@ import type { MountRegistry } from '../mount/registry.ts'
 import { WordPolicy, endOptionsAfterProgram, route, wordPolicy } from '../route/index.ts'
 import type { Session } from '../session/session.ts'
 import { classifyParts } from './classify/index.ts'
+import type { NamespaceLinks } from '../../ops/config.ts'
 import { resolveGlobs } from './globs.ts'
 import { type ExecuteFn } from './node.ts'
 import { expandParts } from './parts.ts'
@@ -78,6 +79,7 @@ export async function expandArgv(
   executeFn: ExecuteFn,
   callStack: CallStack | null,
   registry: MountRegistry,
+  namespace: NamespaceLinks | null = null,
 ): Promise<Argv> {
   const expanded = await expandParts(parts, session, executeFn, callStack)
   if (expanded.length === 0) return new Argv('', [], [])
@@ -136,7 +138,10 @@ export async function expandArgv(
   // WordPolicy.SHELL words get matches here; mount commands keep
   // patterns for backend pushdown; unknown names fail without
   // touching backends.
-  const words = policy === WordPolicy.SHELL ? await resolveGlobs(classified, registry) : classified
+  const words =
+    policy === WordPolicy.SHELL
+      ? await resolveGlobs(classified, registry, false, namespace)
+      : classified
   // The text view renders words as typed (rawPath): bash hands
   // programs their words unchanged, so `echo sub/file.txt` prints the
   // relative form, not the resolved absolute path.

--- a/typescript/packages/core/src/workspace/expand/glob_namespace.test.ts
+++ b/typescript/packages/core/src/workspace/expand/glob_namespace.test.ts
@@ -102,4 +102,63 @@ describe('glob expansion sees namespace state', () => {
     const ws = await makeWs()
     expect((await out(ws, 'echo /base/*/g1')).trim()).toBe('/base/inner/g1')
   })
+
+  // A glob matching exactly one name is still an expansion. Comparing
+  // counts read it as unchanged, so the pattern stayed routed to the
+  // parent mount, which cannot serve the child mount's keys.
+  it('installs a boundary glob that matches one name', async () => {
+    const ws = await makeWs()
+    expect((await out(ws, 'du /base/i*')).trimEnd()).toBe('7\t/base/inner')
+    expect((await out(ws, 'ls -d /base/i*')).trim()).toBe('/base/inner')
+  })
+
+  // The mount-root refusal reads the operands, so an expansion that
+  // happens after the admission policies hands tar a mount root nobody
+  // checked. Both spellings must answer identically.
+  it('refuses a mount root a glob produced', async () => {
+    const ws = await makeWs()
+    const typed = await ws.execute('tar -cf /out.tar /base/inner', { sessionId: 's' })
+    const globbed = await ws.execute('tar -cf /out2.tar /base/i*', { sessionId: 's' })
+    expect(new TextDecoder().decode(globbed.stderr)).toBe(new TextDecoder().decode(typed.stderr))
+    expect(globbed.exitCode).toBe(typed.exitCode)
+    expect(new TextDecoder().decode(globbed.stderr)).toContain('Device or resource busy')
+  })
+})
+
+// bash descends through a symlinked directory during pathname expansion
+// and reports the match under the typed name. Pinned against GNU bash
+// 5.2 on debian:stable-slim with base/dlink -> base/sub:
+//   echo base/d*/f2 -> base/dlink/f2
+//   echo base/*/f2  -> base/dlink/f2 base/sub/f2
+describe('glob expansion follows a symlinked directory', () => {
+  async function makeLinked(): Promise<Workspace> {
+    const ws = await makeWs()
+    await ws.execute('ln -s /base/sub /base/dlink', { sessionId: 's' })
+    await ws.execute('ln -s /base/inner /base/mlink', { sessionId: 's' })
+    return ws
+  }
+
+  it('descends a link in a mid-path segment', async () => {
+    const ws = await makeLinked()
+    expect((await out(ws, 'echo /base/d*/f2')).trim()).toBe('/base/dlink/f2')
+  })
+
+  it('lists a link named as the final parent', async () => {
+    const ws = await makeLinked()
+    expect((await out(ws, 'echo /base/dlink/*')).trim()).toBe('/base/dlink/f2')
+  })
+
+  it('reports both the link and its target', async () => {
+    const ws = await makeLinked()
+    expect((await out(ws, 'echo /base/*/f2')).split(/\s+/).filter(Boolean)).toEqual([
+      '/base/dlink/f2',
+      '/base/sub/f2',
+    ])
+  })
+
+  it('follows a link that points into a nested mount', async () => {
+    const ws = await makeLinked()
+    expect((await out(ws, 'echo /base/mlink/*')).trim()).toBe('/base/mlink/g1')
+    expect((await out(ws, 'echo /base/m*/g1')).trim()).toBe('/base/mlink/g1')
+  })
 })

--- a/typescript/packages/core/src/workspace/expand/glob_namespace.test.ts
+++ b/typescript/packages/core/src/workspace/expand/glob_namespace.test.ts
@@ -1,0 +1,105 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { OpsRegistry } from '../../ops/registry.ts'
+import { RAMResource } from '../../resource/ram/ram.ts'
+import { MountMode } from '../../types.ts'
+import { getTestParser, stdoutStr } from '../fixtures/workspace_fixture.ts'
+import { Workspace } from '../workspace.ts'
+
+// A glob lists what its directory holds, nested mount roots and symlinks
+// included. Pinned against GNU coreutils 9.7 on debian:stable-slim with a
+// tmpfs at base/inner and the same symlink:
+//   echo base/*   -> base/f1 base/inner base/link base/sub
+//   du -b base/*  -> 3 base/f1 / 7 base/inner / <target len> base/link / 7 base/sub
+
+async function makeWs(): Promise<Workspace> {
+  const parser = await getTestParser()
+  const root = new RAMResource()
+  const inner = new RAMResource()
+  const registry = new OpsRegistry()
+  registry.registerResource(root)
+  registry.registerResource(inner)
+  const ws = new Workspace(
+    { '/': root, '/base/inner': inner },
+    { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+  )
+  ws.createSession('s')
+  await ws.execute('mkdir -p /base/sub', { sessionId: 's' })
+  await ws.execute('printf 111 > /base/f1', { sessionId: 's' })
+  await ws.execute('printf 2222222 > /base/sub/f2', { sessionId: 's' })
+  await ws.execute('printf 3333333 > /base/inner/g1', { sessionId: 's' })
+  await ws.execute('ln -s /base/sub/f2 /base/link', { sessionId: 's' })
+  return ws
+}
+
+async function out(ws: Workspace, line: string): Promise<string> {
+  return stdoutStr(await ws.execute(line, { sessionId: 's' }))
+}
+
+describe('glob expansion sees namespace state', () => {
+  it('enumerates a nested mount root and a symlink', async () => {
+    const ws = await makeWs()
+    expect((await out(ws, 'echo /base/*')).split(/\s+/).filter(Boolean)).toEqual([
+      '/base/f1',
+      '/base/inner',
+      '/base/link',
+      '/base/sub',
+    ])
+  })
+
+  it('du rows match GNU', async () => {
+    const ws = await makeWs()
+    expect((await out(ws, 'du /base/*')).trimEnd().split('\n')).toEqual([
+      '3\t/base/f1',
+      '7\t/base/inner',
+      '12\t/base/link',
+      '7\t/base/sub',
+    ])
+  })
+
+  it('every glob-operand command sees them', async () => {
+    const ws = await makeWs()
+    expect((await out(ws, 'ls -d /base/*')).split(/\s+/).filter(Boolean)).toEqual([
+      '/base/f1',
+      '/base/inner',
+      '/base/link',
+      '/base/sub',
+    ])
+    expect((await out(ws, 'find /base/* -maxdepth 0')).split(/\s+/).filter(Boolean)).toEqual([
+      '/base/f1',
+      '/base/inner',
+      '/base/link',
+      '/base/sub',
+    ])
+  })
+
+  it('matches only the pattern', async () => {
+    const ws = await makeWs()
+    expect((await out(ws, 'echo /base/i*')).trim()).toBe('/base/inner')
+    expect((await out(ws, 'echo /base/l*')).trim()).toBe('/base/link')
+    expect((await out(ws, 'echo /base/f*')).trim()).toBe('/base/f1')
+  })
+
+  it('keeps an unmatched glob literal', async () => {
+    const ws = await makeWs()
+    expect((await out(ws, 'echo /base/zzz*')).trim()).toBe('/base/zzz*')
+  })
+
+  it('descends into a nested mount mid-path', async () => {
+    const ws = await makeWs()
+    expect((await out(ws, 'echo /base/*/g1')).trim()).toBe('/base/inner/g1')
+  })
+})

--- a/typescript/packages/core/src/workspace/expand/globs.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.ts
@@ -21,6 +21,7 @@ import { PathSpec } from '../../types.ts'
 import type { MountEntry } from '../mount/mount.ts'
 import type { MountRegistry } from '../mount/registry.ts'
 import { hasGlob as hasGlobChars, spellMatch } from '../../utils/glob_walk.ts'
+import { CycleError } from '../../utils/path.ts'
 import { rstripSlash, stripSlash } from '../../utils/slash.ts'
 import { compareCodePoints } from '../../utils/sort.ts'
 
@@ -57,6 +58,54 @@ function mountOf(registry: MountRegistry, virtual: string, fallback: MountEntry)
   return registry.mountFor(virtual) ?? fallback
 }
 
+// The directory a backend must list to answer a glob's parent. bash
+// descends through a symlinked directory during pathname expansion
+// (`base/dlink/*` and `base/*/f2` both reach the target's entries), but a
+// link is namespace state no backend can see, so the parent has to be
+// resolved here or the listing comes back empty and the word stays
+// literal. The match keeps the typed spelling, exactly as bash reports
+// `base/dlink/f2` rather than the target's path.
+function listingDir(links: NamespaceLinks | null, directory: string): string {
+  if (links === null) return directory
+  const base = rstripSlash(directory) || '/'
+  let real: string
+  try {
+    real = links.follow(base)
+  } catch (err) {
+    // A loop resolves to nothing, which is bash's own answer: the word
+    // matches no file and stays literal.
+    if (err instanceof CycleError) return directory
+    throw err
+  }
+  return real === base ? directory : `${rstripSlash(real)}/`
+}
+
+// Move matches found under a resolved directory back to the typed one.
+function respell(virtuals: readonly string[], directory: string): string[] {
+  const base = rstripSlash(directory)
+  return virtuals.map((v) => `${base}/${v.slice(v.lastIndexOf('/') + 1)}`)
+}
+
+// Key matched virtual paths to their mounts and spell them as typed.
+function toSpecs(
+  virtuals: readonly string[],
+  item: PathSpec,
+  registry: MountRegistry,
+  mount: MountEntry,
+  walked: number,
+): PathSpec[] {
+  return virtuals.map((v) => {
+    const prefix = rstripSlash(mountOf(registry, v, mount).prefix)
+    const base = PathSpec.fromStrPath(v, mountKey(v, prefix))
+    return new PathSpec({
+      virtual: base.virtual,
+      directory: base.directory,
+      resourcePath: base.resourcePath,
+      rawPath: spellMatch(item.rawPath, v, walked),
+    })
+  })
+}
+
 // Union a backend's matches with the namespace-owed ones. Sorted, because
 // bash sorts a pathname expansion and the two sources are enumerated
 // separately. A backend that matched nothing answers with the literal word
@@ -86,7 +135,10 @@ function mergeNamespace(
 // One descent step: the owning backend's matches plus the namespace's.
 // The walk can cross into a nested mount, because a mid-path segment may
 // match a mount root, so the backend asked is the one owning that parent
-// rather than the one owning the typed word.
+// rather than the one owning the typed word. It can equally descend
+// through a symlinked directory, so the parent is resolved through the
+// namespace first and the matches are spelled back under the name that
+// was typed.
 async function levelMatches(
   registry: MountRegistry,
   mount: MountEntry,
@@ -94,20 +146,29 @@ async function levelMatches(
   dirVirtual: string,
   seg: string,
 ): Promise<string[]> {
-  const owner = mountOf(registry, dirVirtual, mount)
+  const real = listingDir(links, dirVirtual)
+  const owner = mountOf(registry, real, mount)
   const prefix = rstripSlash(owner.prefix)
   const out: string[] = []
   if (hasGlob(owner.resource)) {
     const spec = new PathSpec({
-      virtual: dirVirtual,
-      directory: dirVirtual,
-      resourcePath: mountKey(dirVirtual, prefix),
+      virtual: real,
+      directory: real,
+      resourcePath: mountKey(real, prefix),
       pattern: seg,
       resolved: false,
     })
     try {
       const matches = await owner.resource.glob([spec], prefix)
-      for (const m of matches) out.push(m.virtual)
+      // A descent step yields children, so a match that is the parent
+      // itself is not one. A backend asked to list a path that is really
+      // a file answers with that file, which walked back out as a
+      // doubled segment (`/base/f*/f1` -> `/base/base/f1`); bash keeps
+      // the literal because a file is not a directory to descend into.
+      const base = `${rstripSlash(real)}/`
+      for (const m of matches) {
+        if (m.virtual.startsWith(base)) out.push(m.virtual)
+      }
     } catch (err) {
       // fs-coded failures mean this parent is not a listable directory
       // (bash skips it); anything else is a real bug and propagates. A
@@ -115,8 +176,8 @@ async function levelMatches(
       if ((err as { code?: string }).code === undefined) throw err
     }
   }
-  out.push(...namespaceChildren(registry, links, dirVirtual, seg))
-  return out
+  out.push(...namespaceChildren(registry, links, real, seg))
+  return real === dirVirtual ? out : respell(out, dirVirtual)
 }
 
 // Expand a mid-path pattern level by level via the resource's glob. A glob
@@ -146,16 +207,7 @@ async function walkSegments(
     level = [...new Set(gathered)].sort(compareCodePoints)
     if (level.length === 0) return []
   }
-  return level.map((v) => {
-    const prefix = rstripSlash(mountOf(registry, v, mount).prefix)
-    const base = PathSpec.fromStrPath(v, mountKey(v, prefix))
-    return new PathSpec({
-      virtual: base.virtual,
-      directory: base.directory,
-      resourcePath: base.resourcePath,
-      rawPath: spellMatch(item.rawPath, v, walked),
-    })
-  })
+  return toSpecs(level, item, registry, mount, walked)
 }
 
 // Stamp a glob match with the spelling the user's word implies.
@@ -202,8 +254,12 @@ export async function resolveGlobs(
       // root or a link under the globbed directory; with nothing for the
       // namespace to add it keeps the untouched pass-through it had.
       const midPath = hasGlobChars(item.directory)
-      const extra = midPath ? [] : namespaceChildren(registry, links, item.directory, item.pattern)
-      if (!hasGlob(mount.resource) && extra.length === 0) {
+      // The parent is a symlink, so the backend holding the typed path
+      // has nothing to list and levelMatches has to follow it first.
+      const linked = !midPath && listingDir(links, item.directory) !== item.directory
+      const extra =
+        midPath || linked ? [] : namespaceChildren(registry, links, item.directory, item.pattern)
+      if (!linked && !hasGlob(mount.resource) && extra.length === 0) {
         result.push(item)
         continue
       }
@@ -216,10 +272,23 @@ export async function resolveGlobs(
         rawPath: item.rawPath,
       })
       try {
-        const own = hasGlob(mount.resource) ? await mount.resource.glob([withPrefix], prefix) : []
-        const resolved = midPath
-          ? await walkSegments(withPrefix, mount, registry, links)
-          : mergeNamespace(withPrefix, own, extra, registry, mount)
+        const own =
+          !linked && hasGlob(mount.resource) ? await mount.resource.glob([withPrefix], prefix) : []
+        let resolved: PathSpec[]
+        if (midPath) {
+          resolved = await walkSegments(withPrefix, mount, registry, links)
+        } else if (linked) {
+          const found = await levelMatches(registry, mount, links, item.directory, item.pattern)
+          resolved = toSpecs(
+            [...new Set(found)].sort(compareCodePoints),
+            withPrefix,
+            registry,
+            mount,
+            1,
+          )
+        } else {
+          resolved = mergeNamespace(withPrefix, own, extra, registry, mount)
+        }
         // bash with nullglob off: a zero-match glob stays the literal
         // word instead of vanishing.
         if (resolved.length === 0) {

--- a/typescript/packages/core/src/workspace/expand/globs.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.ts
@@ -12,12 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { childMountNames, namespaceNames } from '../../ops/namespace_view.ts'
+import type { NamespaceLinks } from '../../ops/config.ts'
+import { fnmatch } from '../../utils/fnmatch.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import type { Resource } from '../../resource/base.ts'
 import { PathSpec } from '../../types.ts'
+import type { MountEntry } from '../mount/mount.ts'
 import type { MountRegistry } from '../mount/registry.ts'
 import { hasGlob as hasGlobChars, spellMatch } from '../../utils/glob_walk.ts'
 import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { compareCodePoints } from '../../utils/sort.ts'
 
 export interface ResourceWithGlob extends Resource {
   glob(paths: readonly PathSpec[], prefix?: string): Promise<PathSpec[]>
@@ -25,6 +30,93 @@ export interface ResourceWithGlob extends Resource {
 
 function hasGlob(r: Resource): r is ResourceWithGlob {
   return 'glob' in r && typeof (r as { glob?: unknown }).glob === 'function'
+}
+
+// Virtual paths a directory owes the namespace, matching a segment.
+// Child mounts and symlinks are namespace state no backend can see, so a
+// glob that stops at one backend misses both: a nested mount's keys live
+// in another resource, and no resource stores a link. This is the union
+// mergeReaddir already applies to a listing, filtered by the glob segment
+// with the same matcher backends use, and session-filtered by
+// namespaceNames so a scoped session never learns an ungranted mount's
+// name from an expansion.
+function namespaceChildren(
+  registry: MountRegistry,
+  links: NamespaceLinks | null,
+  directory: string,
+  pattern: string,
+): string[] {
+  const base = rstripSlash(directory)
+  return namespaceNames(registry.mountPrefixes(), links, directory)
+    .filter((name) => fnmatch(name, pattern))
+    .map((name) => `${base}/${name}`)
+}
+
+// The mount owning a path, falling back to the word's own.
+function mountOf(registry: MountRegistry, virtual: string, fallback: MountEntry): MountEntry {
+  return registry.mountFor(virtual) ?? fallback
+}
+
+// Union a backend's matches with the namespace-owed ones. Sorted, because
+// bash sorts a pathname expansion and the two sources are enumerated
+// separately. A backend that matched nothing answers with the literal word
+// (nullglob off); that is "no match", not an entry to merge against, so it
+// is dropped here and the literal is reinstated by the caller only if the
+// union is empty too.
+function mergeNamespace(
+  item: PathSpec,
+  matches: readonly PathSpec[],
+  extra: readonly string[],
+  registry: MountRegistry,
+  mount: MountEntry,
+): PathSpec[] {
+  const specs = matches.filter((m) => m.virtual !== item.virtual)
+  const seen = new Set(specs.map((m) => m.virtual))
+  for (const virtual of extra) {
+    if (seen.has(virtual)) continue
+    seen.add(virtual)
+    // A nested mount root belongs to the mount it opens, not to the one
+    // being listed, so it is keyed against its own backend.
+    const owner = rstripSlash(mountOf(registry, virtual, mount).prefix)
+    specs.push(PathSpec.fromStrPath(virtual, mountKey(virtual, owner)))
+  }
+  return specs.sort((a, b) => compareCodePoints(a.virtual, b.virtual))
+}
+
+// One descent step: the owning backend's matches plus the namespace's.
+// The walk can cross into a nested mount, because a mid-path segment may
+// match a mount root, so the backend asked is the one owning that parent
+// rather than the one owning the typed word.
+async function levelMatches(
+  registry: MountRegistry,
+  mount: MountEntry,
+  links: NamespaceLinks | null,
+  dirVirtual: string,
+  seg: string,
+): Promise<string[]> {
+  const owner = mountOf(registry, dirVirtual, mount)
+  const prefix = rstripSlash(owner.prefix)
+  const out: string[] = []
+  if (hasGlob(owner.resource)) {
+    const spec = new PathSpec({
+      virtual: dirVirtual,
+      directory: dirVirtual,
+      resourcePath: mountKey(dirVirtual, prefix),
+      pattern: seg,
+      resolved: false,
+    })
+    try {
+      const matches = await owner.resource.glob([spec], prefix)
+      for (const m of matches) out.push(m.virtual)
+    } catch (err) {
+      // fs-coded failures mean this parent is not a listable directory
+      // (bash skips it); anything else is a real bug and propagates. A
+      // nested mount root or a link under it is still real.
+      if ((err as { code?: string }).code === undefined) throw err
+    }
+  }
+  out.push(...namespaceChildren(registry, links, dirVirtual, seg))
+  return out
 }
 
 // Expand a mid-path pattern level by level via the resource's glob. A glob
@@ -36,8 +128,9 @@ function hasGlob(r: Resource): r is ResourceWithGlob {
 // is skipped, matching bash's directories-only descent.
 async function walkSegments(
   item: PathSpec,
-  resource: ResourceWithGlob,
-  prefix: string,
+  mount: MountEntry,
+  registry: MountRegistry,
+  links: NamespaceLinks | null,
 ): Promise<PathSpec[]> {
   const segments = stripSlash(item.virtual).split('/')
   const first = segments.findIndex((seg) => hasGlobChars(seg))
@@ -46,29 +139,15 @@ async function walkSegments(
   for (const seg of segments.slice(first)) {
     const gathered: string[] = []
     for (const parent of level) {
-      const dirVirtual = `${rstripSlash(parent)}/`
-      const spec = new PathSpec({
-        virtual: dirVirtual,
-        directory: dirVirtual,
-        resourcePath: mountKey(dirVirtual, prefix),
-        pattern: seg,
-        resolved: false,
-      })
-      let matches: PathSpec[]
-      try {
-        matches = await resource.glob([spec], prefix)
-      } catch (err) {
-        // fs-coded failures mean this parent is not a listable directory
-        // (bash skips it); anything else is a real bug and propagates.
-        if ((err as { code?: string }).code === undefined) throw err
-        continue
-      }
-      for (const m of matches) gathered.push(m.virtual)
+      gathered.push(...(await levelMatches(registry, mount, links, `${rstripSlash(parent)}/`, seg)))
     }
-    level = gathered
+    // bash sorts a pathname expansion, and the backend and the namespace
+    // are enumerated separately, so the union is ordered here.
+    level = [...new Set(gathered)].sort(compareCodePoints)
     if (level.length === 0) return []
   }
   return level.map((v) => {
+    const prefix = rstripSlash(mountOf(registry, v, mount).prefix)
     const base = PathSpec.fromStrPath(v, mountKey(v, prefix))
     return new PathSpec({
       virtual: base.virtual,
@@ -105,6 +184,7 @@ export async function resolveGlobs(
   classified: readonly (string | PathSpec)[],
   registry: MountRegistry,
   noglob = false,
+  links: NamespaceLinks | null = null,
 ): Promise<(string | PathSpec)[]> {
   // set -f: skip resolution entirely, so every glob word keeps its
   // literal spelling like a zero-match glob.
@@ -113,11 +193,20 @@ export async function resolveGlobs(
   for (const item of classified) {
     if (item instanceof PathSpec && item.pattern !== null) {
       const mount = registry.mountFor(item.virtual)
-      if (mount === null || !hasGlob(mount.resource)) {
+      if (mount === null) {
         result.push(item)
         continue
       }
       const prefix = rstripSlash(mount.prefix)
+      // A resource with no glob of its own can still hold a nested mount
+      // root or a link under the globbed directory; with nothing for the
+      // namespace to add it keeps the untouched pass-through it had.
+      const midPath = hasGlobChars(item.directory)
+      const extra = midPath ? [] : namespaceChildren(registry, links, item.directory, item.pattern)
+      if (!hasGlob(mount.resource) && extra.length === 0) {
+        result.push(item)
+        continue
+      }
       const withPrefix = new PathSpec({
         virtual: item.virtual,
         directory: item.directory,
@@ -127,9 +216,10 @@ export async function resolveGlobs(
         rawPath: item.rawPath,
       })
       try {
-        const resolved = hasGlobChars(withPrefix.directory)
-          ? await walkSegments(withPrefix, mount.resource, prefix)
-          : await mount.resource.glob([withPrefix], prefix)
+        const own = hasGlob(mount.resource) ? await mount.resource.glob([withPrefix], prefix) : []
+        const resolved = midPath
+          ? await walkSegments(withPrefix, mount, registry, links)
+          : mergeNamespace(withPrefix, own, extra, registry, mount)
         // bash with nullglob off: a zero-match glob stays the literal
         // word instead of vanishing.
         if (resolved.length === 0) {
@@ -145,4 +235,47 @@ export async function resolveGlobs(
     }
   }
   return result
+}
+
+// The fixed directory above a word's first glob segment.
+function globHead(spec: PathSpec): string {
+  const fixed: string[] = []
+  for (const seg of spec.virtual.split('/')) {
+    if (hasGlobChars(seg)) break
+    fixed.push(seg)
+  }
+  return fixed.join('/') + '/'
+}
+
+/**
+ * Expand glob words that could match across a mount boundary.
+ *
+ * A glob operand is normally left for the owning backend to resolve,
+ * which is how a prefix store pushes the listing down. That only holds
+ * while every match belongs to that backend: a nested mount's root is a
+ * child of the directory but its keys live in another resource, so the
+ * backend answers "no such file" for a name its own listing shows. When
+ * the glob's fixed head holds a child mount, the word is expanded here
+ * instead, before routing, so the matches route per mount exactly as the
+ * same paths typed by hand already do. Every other glob is left
+ * untouched, so pushdown is unaffected.
+ */
+export async function expandBoundaryGlobs(
+  parts: readonly (string | PathSpec)[],
+  registry: MountRegistry,
+  links: NamespaceLinks | null,
+): Promise<(string | PathSpec)[]> {
+  const prefixes = registry.mountPrefixes()
+  const spans = (p: string | PathSpec): boolean =>
+    p instanceof PathSpec && p.pattern !== null && childMountNames(prefixes, globHead(p)).length > 0
+  if (!parts.some(spans)) return [...parts]
+  const out: (string | PathSpec)[] = []
+  for (const item of parts) {
+    if (spans(item)) {
+      out.push(...(await resolveGlobs([item], registry, false, links)))
+    } else {
+      out.push(item)
+    }
+  }
+  return out
 }

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -411,6 +411,31 @@ async function runArgv(
   signal?: AbortSignal,
 ): Promise<Result> {
   const name = argv.name
+
+  // A glob whose directory holds a child mount cannot be pushed down to
+  // one backend: the mount root is a child of that directory but its keys
+  // live in another resource, so the backend reports "no such file" for a
+  // name its own listing shows. Expanding such a word here lets the
+  // matches route per mount. It has to happen before the admission
+  // policies below, not just before the follow policy: a word left
+  // unexpanded reaches preCommand as the literal pattern, and
+  // MountRootPolicy cannot recognize a mount root inside one, so
+  // `tar -cf out.tar /base/*` would archive a whole backend the same
+  // operand typed by hand is refused for.
+  const boundary = await expandBoundaryGlobs(argv.operands, registry, namespace)
+  const expandedWords = boundary.map(wordText)
+  // Compared as words, not as a count: a glob that matches exactly one
+  // name (`du /base/i*` where only the mount root matches) is still an
+  // expansion, and dropping it routes the pattern to a backend that
+  // cannot serve the child mount's keys.
+  const typedWords = argv.operands.map(wordText)
+  if (
+    expandedWords.length !== typedWords.length ||
+    expandedWords.some((w, i) => w !== typedWords[i])
+  ) {
+    argv = new Argv(argv.name, expandedWords, boundary)
+  }
+
   const args = [...argv.args]
   let operands = [...argv.operands]
 
@@ -725,18 +750,6 @@ async function runArgv(
       }
     }
     return handleDf(registry, session, dispatch, operands)
-  }
-
-  // A glob whose directory holds a child mount cannot be pushed down to
-  // one backend: the mount root is a child of that directory but its keys
-  // live in another resource, so the backend reports "no such file" for a
-  // name its own listing shows. Expanding such a word here (before the
-  // follow policy below, so a matched link is followed exactly as a typed
-  // one is) lets the matches route per mount.
-  const boundary = await expandBoundaryGlobs(argv.operands, registry, namespace)
-  if (boundary.length !== argv.operands.length) {
-    argv = new Argv(argv.name, boundary.map(wordText), boundary)
-    operands = [...argv.operands]
   }
 
   // Symlink-aware dispatch: reads follow links (open(2)); rm/mv act on

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -32,8 +32,8 @@ import type { JobTable } from '../../shell/job_table.ts'
 import { NodeType as NT, ShellBuiltin as SB } from '../../shell/types.ts'
 import { PathSpec, wordText } from '../../types.ts'
 import { classifyBarePath } from '../expand/classify/index.ts'
-import type { Argv } from '../expand/argv.ts'
-import { expandArgv } from '../expand/argv.ts'
+import { Argv, expandArgv } from '../expand/argv.ts'
+import { expandBoundaryGlobs } from '../expand/globs.ts'
 import { type ExecuteFn, expandNode } from '../expand/node.ts'
 import type { TSNodeLike } from '../../shell/types.ts'
 import { handleCommand } from '../executor/command.ts'
@@ -329,7 +329,7 @@ async function runCommandBody(
     stdin = merged
   }
 
-  const argv = await expandArgv(cleanParts, session, executeFn, callStack, registry)
+  const argv = await expandArgv(cleanParts, session, executeFn, callStack, registry, namespace)
 
   // Limits resolve against the expanded name, so `$CMD`-style
   // invocations get their real command's policy.
@@ -721,6 +721,18 @@ async function runArgv(
       }
     }
     return handleDf(registry, session, dispatch, operands)
+  }
+
+  // A glob whose directory holds a child mount cannot be pushed down to
+  // one backend: the mount root is a child of that directory but its keys
+  // live in another resource, so the backend reports "no such file" for a
+  // name its own listing shows. Expanding such a word here (before the
+  // follow policy below, so a matched link is followed exactly as a typed
+  // one is) lets the matches route per mount.
+  const boundary = await expandBoundaryGlobs(argv.operands, registry, namespace)
+  if (boundary.length !== argv.operands.length) {
+    argv = new Argv(argv.name, boundary.map(wordText), boundary)
+    operands = [...argv.operands]
   }
 
   // Symlink-aware dispatch: reads follow links (open(2)); rm/mv act on

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -137,6 +137,7 @@ async function expandArrayItems(
   session: Session,
   executeFn: ExecuteFn,
   registry: MountRegistry,
+  namespace: Namespace,
   callStack: CallStack | null,
 ): Promise<string[]> {
   const classified = await expandAndClassify(
@@ -147,7 +148,12 @@ async function expandArrayItems(
     session.cwd,
     callStack,
   )
-  const resolved = await resolveGlobs(classified, registry, session.shellOptions.noglob === true)
+  const resolved = await resolveGlobs(
+    classified,
+    registry,
+    session.shellOptions.noglob === true,
+    namespace,
+  )
   return resolved.map((w) => wordText(w))
 }
 
@@ -498,7 +504,12 @@ export async function executeNode(
     )
     // The loop word list is consumed by the shell (WordPolicy.SHELL):
     // globs resolve to matches before iteration starts.
-    const resolved = await resolveGlobs(classified, registry, session.shellOptions.noglob === true)
+    const resolved = await resolveGlobs(
+      classified,
+      registry,
+      session.shellOptions.noglob === true,
+      deps.namespace,
+    )
     if (kind === NodeKind.SELECT) {
       return handleSelect(recurse, variable, resolved, body, session, stdin, callStack)
     }
@@ -558,7 +569,14 @@ export async function executeNode(
           staged.push({
             name: append ? key.slice(0, -1) : key,
             append,
-            items: await expandArrayItems(firstVal, session, executeFn, registry, callStack),
+            items: await expandArrayItems(
+              firstVal,
+              session,
+              executeFn,
+              registry,
+              deps.namespace,
+              callStack,
+            ),
           })
           continue
         }
@@ -713,7 +731,14 @@ export async function executeNode(
     )
     const firstVal = valNodes[0]
     if (firstVal?.type === NT.ARRAY) {
-      const items = await expandArrayItems(firstVal, session, executeFn, registry, callStack)
+      const items = await expandArrayItems(
+        firstVal,
+        session,
+        executeFn,
+        registry,
+        deps.namespace,
+        callStack,
+      )
       if (append) {
         let base = session.arrays[key]
         if (base === undefined) {


### PR DESCRIPTION
## The bug

`du /base/*` printed only two of the four entries `ls /base` shows:

```
3	/base/f1
7	/base/sub
```

GNU coreutils 9.7 expands `base/*` to all four and prints a row for each.

## Root cause

Not `du`, and not the backend listing. `echo /base/*` printed the same
two words, so it was the expander itself.

Glob expansion enumerates candidates from one backend's readdir. A
nested mount's keys live in a different resource and no resource stores
a symlink, so neither was ever offered as a candidate. They were never
filtered out, they were never enumerated. `merge_readdir` already states
the rule for listings: "Child mounts and symlinks are namespace state no
backend can see, so a listing that stops at one backend misses both." A
glob is such a listing.

Boundary evidence:

```
BACKEND   resolve_glob('/base/*')  -> ['/base/f1', '/base/sub']
NAMESPACE namespace_names('/base/') -> ['inner', 'link']
```

Two disjoint halves of one answer.

## The fix

Both glob tiers now merge the same `namespace_names` union a listing
uses, so there is no second source of truth and no second filtering
rule. It stays session-filtered, so a scoped session still cannot learn
an ungranted mount's name from an expansion.

- Shell tier (`workspace/expand/globs.py`, `globs.ts`): merges the union,
  and the mid-path walk resolves each level against the mount that owns
  that parent, so a segment can match a mount root and keep descending.
- Command tier (`utils/glob_walk`): `opts.child_mounts` is stamped onto
  the adapter per invocation in the factory, so all ~30 builders keep
  calling `resolve_glob` unchanged.
- Matches sort, because bash sorts a pathname expansion and the two
  sources are enumerated separately.
- A glob whose directory holds a child mount is expanded before routing,
  since the mount root cannot be served by the backend being listed. That
  happens before the follow policy, so a matched symlink is followed
  exactly as a typed one is.

## Scope

The task named `du`, but the expander is shared, so `ls`, `stat`, `find`,
`wc`, `echo` and every other glob consumer had the same omission and are
all fixed.

## GNU pins

`debian:stable-slim`, coreutils 9.7, tmpfs at `base/inner`, same symlink:

```
echo base/*   -> base/f1 base/inner base/link base/sub
du -b base/*  -> 3 base/f1 / 7 base/inner / 12 base/link / 7 base/sub
wc -c base/*  -> follows the link, names each directory on stderr, exit 1
```

`du -b` is the byte mode mirage implements, and a symlink reports its
target string's length there, which is where `12` comes from.

## Left alone (pre-existing, reproducible with operands typed by hand)

- `stat` renders a mount root's name as `/`.
- `wc` omits GNU's `0 <dir>` row for a directory operand.

## Testing

Python suite, TS core (7820), node and browser suites, pre-commit and the
layout parity gate all pass. New tests in both languages; verified they
fail without the fix.
