### PR TITLE
fix(du): a namespace-only directory is not absent

### DIFF
--- a/python/mirage/commands/builtin/generic/du.py
+++ b/python/mirage/commands/builtin/generic/du.py
@@ -11,7 +11,7 @@ from mirage.commands.errors import UsageError
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagView
 from mirage.io.types import IOResult
-from mirage.ops.types import LinkView, MountView
+from mirage.ops.types import LinkView, MountView, StatPath
 from mirage.types import FileStat, PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
 from mirage.utils.path import respell_raw
@@ -168,6 +168,7 @@ async def du_operands(
     stat: Callable[[PathSpec], Awaitable[FileStat]],
     has_content: Callable[[PathSpec], Awaitable[bool]] | None = None,
     links: LinkView | None = None,
+    stat_path: StatPath | None = None,
 ) -> tuple[list[PathSpec], list[str]]:
     """Split the operands into the ones du can read and the ones it cannot.
 
@@ -175,11 +176,19 @@ async def du_operands(
     and exits 1. With no operand at all it measures the working
     directory.
 
-    A failed stat is not proof of absence. Several backends never
-    materialise a directory entry for the mount root (redis is one), so
-    ``stat`` raises there even though the subtree is full. ``has_content``
-    is the second opinion: only an operand that neither stats nor holds
-    anything is reported missing.
+    A failed stat is not proof of absence, and du runs bound to one
+    backend, so its own stat cannot see two things that make a path a
+    real directory: a mount nested below it and a symlink below it are
+    both namespace state, held in another resource or in no resource at
+    all. ``stat_path`` is the channel that knows, because it resolves
+    through the dispatcher rather than one accessor, and it is the same
+    probe ``find`` classifies its start point with. Session filtering
+    rides along with it: a mount the session may not see contributes no
+    directory here, so absence stays the answer for it.
+
+    ``has_content`` is the last resort behind that, for a backend that
+    never materialises a directory entry for its own mount root (redis is
+    one) while the subtree below it is full.
 
     Args:
         paths (list[PathSpec]): the operands as parsed, possibly empty.
@@ -191,6 +200,8 @@ async def du_operands(
         links (LinkView | None): the namespace's symlink facts. A link
             has no backend inode, so it fails stat while still being a
             perfectly readable operand.
+        stat_path (StatPath | None): dispatcher-backed stat, None when du
+            runs outside a workspace and there is no namespace to ask.
 
     Returns:
         tuple[list[PathSpec], list[str]]: readable operands, then the
@@ -211,7 +222,11 @@ async def du_operands(
         try:
             await stat(path)
         except (FileNotFoundError, ValueError):
-            if has_content is None or not await has_content(path):
+            probed: FileStat | None = None
+            if stat_path is not None:
+                probed = await stat_path(path.virtual)
+            if probed is None and (has_content is None
+                                   or not await has_content(path)):
                 missing.append(path.raw_path)
                 continue
         present.append(path)
@@ -530,6 +545,7 @@ async def run_du(
     truncated: Callable[[], bool] | None = None,
     links: LinkView | None = None,
     mounts: MountView | None = None,
+    stat_path: StatPath | None = None,
 ) -> DuOutput:
     """Run one whole ``du`` invocation, from raw flags to rendered bytes.
 
@@ -556,6 +572,8 @@ async def run_du(
         mounts (MountView | None): where the mount boundaries are, so
             keys shadowed by a nested mount are excluded from every row
             and total.
+        stat_path (StatPath | None): dispatcher-backed stat, which is what
+            answers for a directory the bound backend cannot see.
 
     Raises:
         UsageError: on a bad depth or a conflicting flag combination.
@@ -572,7 +590,8 @@ async def run_du(
                                          stat,
                                          partial(du_has_content,
                                                  compute_entries),
-                                         links=links)
+                                         links=links,
+                                         stat_path=stat_path)
     return await du(present,
                     compute_size=compute_size,
                     compute_entries=compute_entries,
@@ -686,5 +705,6 @@ async def du_generic(
         links=(None if fl.as_bool("L") else
                opts.ns.links if opts.ns is not None else None),
         mounts=opts.ns.mounts if opts.ns is not None else None,
+        stat_path=opts.stat_path,
     )
     return out.stdout, IOResult(stderr=out.stderr, exit_code=out.exit_code)

--- a/python/tests/commands/builtin/generic/test_du.py
+++ b/python/tests/commands/builtin/generic/test_du.py
@@ -9,6 +9,7 @@ from mirage.commands.builtin.generic_bind import CommandIO, DuOps
 from mirage.commands.errors import UsageError
 from mirage.ops.types import LinkView, MountView
 from mirage.resource.disk import DiskResource
+from mirage.resource.ram import RAMResource
 from mirage.types import FileStat, FileType, PathSpec
 
 
@@ -415,6 +416,59 @@ async def test_backend_error_on_the_content_probe_reads_as_missing():
 
 
 @pytest.mark.asyncio
+async def test_namespace_only_directory_is_present_not_missing():
+    """A directory that exists only above a nested mount is readable.
+
+    The parent backend holds nothing at the operand and cannot: the
+    content lives in the descendant's own resource. Both backend channels
+    therefore come back empty, and only the dispatcher-backed probe knows
+    the path is a directory.
+    """
+    compute_size, compute_entries = _make_backend({})
+
+    async def stat(path):
+        raise FileNotFoundError(path.virtual)
+
+    async def stat_path(virtual: str) -> FileStat | None:
+        return FileStat(name="empty", type=FileType.DIRECTORY)
+
+    out = await run_du([_spec("/empty", "empty")],
+                       "/",
+                       lambda targets: _ok(list(targets)),
+                       stat,
+                       compute_size,
+                       compute_entries,
+                       stat_path=stat_path)
+    assert out.stdout == b"0\t/empty\n"
+    assert out.stderr == b""
+    assert out.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_stat_path_answering_none_still_reports_missing():
+    """The probe is evidence of presence, never of absence on its own."""
+    compute_size, compute_entries = _make_backend({})
+
+    async def stat(path):
+        raise FileNotFoundError(path.virtual)
+
+    async def stat_path(virtual: str) -> FileStat | None:
+        return None
+
+    out = await run_du([_spec("/nope", "nope")],
+                       "/",
+                       lambda targets: _ok(list(targets)),
+                       stat,
+                       compute_size,
+                       compute_entries,
+                       stat_path=stat_path)
+    assert out.stdout == b""
+    assert out.stderr == (b"du: cannot access '/nope': "
+                          b"No such file or directory\n")
+    assert out.exit_code == 1
+
+
+@pytest.mark.asyncio
 async def test_truncated_walk_reports_partial_output_and_exits_one():
     """GNU du prints what it accounted for, warns, and exits 1."""
     compute_size, compute_entries = _make_backend({"/dir/a.txt": 2})
@@ -723,4 +777,80 @@ async def test_du_partial_operands_keeps_present_output(tmp_path):
     assert result.exit_code == 1
     assert "/d/sub" in await result.stdout_str()
     assert "__nf_missing__" in await result.stderr_str()
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_du_on_the_implied_parent_of_a_nested_mount():
+    # GNU coreutils 9.7 on debian:stable-slim, tmpfs mounted at /empty/hole:
+    # `du --apparent-size -B1 /empty` prints both rows and exits 0. The
+    # absence line is reserved for a path that is really not there.
+    ws = Workspace({
+        "/": RAMResource(),
+        "/empty/hole": RAMResource()
+    },
+                   mode=MountMode.WRITE)
+    ws.create_session("s")
+    result = await ws.execute("du /empty", session_id="s")
+    assert await result.stdout_str() == "0\t/empty/hole\n0\t/empty\n"
+    assert await result.stderr_str() == ""
+    assert result.exit_code == 0
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_du_on_the_implied_parent_of_a_nested_mount_under_s():
+    ws = Workspace({
+        "/": RAMResource(),
+        "/empty/hole": RAMResource()
+    },
+                   mode=MountMode.WRITE)
+    ws.create_session("s")
+    result = await ws.execute("du -s /empty", session_id="s")
+    assert await result.stdout_str() == "0\t/empty\n"
+    assert await result.stderr_str() == ""
+    assert result.exit_code == 0
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_du_on_a_directory_implied_only_by_a_link_below_it():
+    """The same false absence, with no descendant mount in sight.
+
+    ``namespace_names`` synthesizes a directory for a link's ancestors
+    too, so the mount table alone is not enough evidence; the probe that
+    answers here is the one that asks the namespace as a whole.
+    """
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+    ws.create_session("s")
+    await ws.execute("mkdir -p /real", session_id="s")
+    await ws.execute("echo hi > /real/f.txt", session_id="s")
+    await ws.execute("ln -s /real/f.txt /ghost/deep/lnk", session_id="s")
+    result = await ws.execute("du /ghost", session_id="s")
+    assert await result.stderr_str() == ""
+    assert result.exit_code == 0
+    assert "/ghost" in await result.stdout_str()
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_du_still_reports_absence_when_the_descendant_is_ungranted():
+    """A session that may not see the mount must not learn it is there.
+
+    ``registry.descendant_mounts`` is not session-filtered, so proving
+    presence from the mount table alone would answer ``0 /empty`` here and
+    confirm a walled-off mount's parent. The dispatcher-backed probe is
+    filtered, so absence stays the answer.
+    """
+    ws = Workspace({
+        "/": RAMResource(),
+        "/empty/hole": RAMResource()
+    },
+                   mode=MountMode.WRITE)
+    ws.create_session("scoped", {"/": "rw"})
+    result = await ws.execute("du /empty", session_id="scoped")
+    assert await result.stdout_str() == ""
+    assert (await result.stderr_str()) == (
+        "du: cannot access '/empty': No such file or directory\n")
+    assert result.exit_code == 1
     await ws.close()

--- a/typescript/packages/core/src/commands/builtin/generic/du.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/du.test.ts
@@ -29,7 +29,7 @@ import { FileStat, FileType, PathSpec } from '../../../types.ts'
 import { enoent } from '../../../utils/errors.ts'
 import type { CommandOpts } from '../../config.ts'
 import type { UsageError } from '../../errors.ts'
-import type { LinkView, MountView } from '../../../ops/types.ts'
+import type { LinkView, MountView, StatPath } from '../../../ops/types.ts'
 
 const DEC = new TextDecoder()
 
@@ -42,13 +42,14 @@ function spec(virtual: string, resourcePath: string, rawPath?: string): PathSpec
   })
 }
 
-function opts(flags: Record<string, string | boolean> = {}): CommandOpts {
+function opts(flags: Record<string, string | boolean> = {}, statPath?: StatPath): CommandOpts {
   return {
     stdin: null,
     flags,
     filetypeFns: null,
     cwd: '/',
     resource: {} as never,
+    statPath,
   } as unknown as CommandOpts
 }
 
@@ -318,6 +319,39 @@ describe('duGeneric', () => {
     expect(DEC.decode(out.stderr)).toBe(
       "du: cannot access '/data/nosuch': No such file or directory\n",
     )
+    expect(out.exitCode).toBe(1)
+  })
+
+  it('treats a namespace-only directory as present, not missing', async () => {
+    // The parent backend holds nothing at the operand and cannot: the
+    // content lives in the descendant mount's own resource. Only the
+    // dispatcher-backed probe knows the path is a directory.
+    const [size, entries] = backend({})
+    const out = await runDu(
+      [spec('/empty', 'empty')],
+      opts({}, () => Promise.resolve(new FileStat({ name: 'empty', type: FileType.DIRECTORY }))),
+      (targets) => Promise.resolve(targets),
+      (p) => Promise.reject(enoent(p.virtual)),
+      size,
+      entries,
+    )
+    expect(DEC.decode(out.stdout)).toBe('0\t/empty\n')
+    expect(DEC.decode(out.stderr)).toBe('')
+    expect(out.exitCode).toBe(0)
+  })
+
+  it('still reports missing when the probe answers null', async () => {
+    const [size, entries] = backend({})
+    const out = await runDu(
+      [spec('/nope', 'nope')],
+      opts({}, () => Promise.resolve(null)),
+      (targets) => Promise.resolve(targets),
+      (p) => Promise.reject(enoent(p.virtual)),
+      size,
+      entries,
+    )
+    expect(DEC.decode(out.stdout)).toBe('')
+    expect(DEC.decode(out.stderr)).toBe("du: cannot access '/nope': No such file or directory\n")
     expect(out.exitCode).toBe(1)
   })
 

--- a/typescript/packages/core/src/commands/builtin/generic/du.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/du.ts
@@ -23,7 +23,7 @@ import { respellRaw } from '../../../utils/path.ts'
 import { lstripSlash, rstripSlash, stripSlash } from '../../../utils/slash.ts'
 import { formatRecords } from '../utils/output.ts'
 import { humanSize } from '../utils/formatting.ts'
-import type { LinkView, MountView } from '../../../ops/types.ts'
+import type { LinkView, MountView, StatPath } from '../../../ops/types.ts'
 import { compareCodePoints } from '../../../utils/sort.ts'
 
 export type DuEntries = [entries: [string, number][], total: number]
@@ -168,10 +168,18 @@ async function duHasContent(computeEntries: ComputeEntries, path: PathSpec): Pro
  * GNU names every operand it fails to stat, keeps going with the rest, and
  * exits 1. With no operand at all it measures the working directory.
  *
- * A failed stat is not proof of absence. Several backends never materialise a
- * directory entry for the mount root (redis is one), so `stat` throws there
- * even though the subtree is full. `hasContent` is the second opinion: only an
- * operand that neither stats nor holds anything is reported missing.
+ * A failed stat is not proof of absence, and du runs bound to one backend, so
+ * its own stat cannot see two things that make a path a real directory: a
+ * mount nested below it and a symlink below it are both namespace state, held
+ * in another resource or in no resource at all. `statPath` is the channel that
+ * knows, because it resolves through the dispatcher rather than one accessor,
+ * and it is the same probe `find` classifies its start point with. Session
+ * filtering rides along with it: a mount the session may not see contributes
+ * no directory here, so absence stays the answer for it.
+ *
+ * `hasContent` is the last resort behind that, for a backend that never
+ * materialises a directory entry for its own mount root (redis is one) while
+ * the subtree below it is full.
  */
 async function duOperands(
   paths: PathSpec[],
@@ -181,6 +189,7 @@ async function duOperands(
   hasContent?: (p: PathSpec) => Promise<boolean>,
   mountPrefix?: string,
   links: LinkView | null = null,
+  statPath: StatPath | null = null,
 ): Promise<{ present: PathSpec[]; missing: string[] }> {
   const targets = paths.length > 0 ? paths : [cwdSpec(cwd, mountPrefix)]
   const resolved = await resolveGlob(targets)
@@ -205,6 +214,10 @@ async function duOperands(
     } catch (err) {
       if (!isMissingPath(err)) throw err
       stattable = false
+    }
+    if (!stattable && statPath !== null && (await statPath(path.virtual)) !== null) {
+      present.push(path)
+      continue
     }
     if (!stattable && !(hasContent !== undefined && (await hasContent(path)))) {
       missing.push(path.rawPath)
@@ -496,6 +509,7 @@ export async function runDu(
     (p) => duHasContent(computeEntries, p),
     opts.mountPrefix,
     links,
+    opts.statPath ?? null,
   )
   return duGeneric(
     present,

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -348,6 +348,56 @@ describe('ls injects child mounts as virtual subdirectories', () => {
     expect(result.stdoutText.split('\n')).not.toContain('data')
     await ws.close()
   })
+
+  // GNU coreutils 9.7 on debian:stable-slim, tmpfs mounted at /empty/hole:
+  // `du --apparent-size -B1 /empty` prints both rows and exits 0. The absence
+  // line is reserved for a path that is really not there. No backend holds an
+  // entry for /empty, so only the dispatcher-backed probe knows it is there.
+  it('du on the implied parent of a nested mount does not report absence', async () => {
+    const ws = await makeWs({ '/': new RAMResource(), '/empty/hole': new RAMResource() })
+    const result = await ws.execute('du /empty')
+    expect(result.stdoutText).toBe('0\t/empty/hole\n0\t/empty\n')
+    expect(result.stderrText).toBe('')
+    expect(result.exitCode).toBe(0)
+    await ws.close()
+  })
+
+  it('du -s on the implied parent of a nested mount does not report absence', async () => {
+    const ws = await makeWs({ '/': new RAMResource(), '/empty/hole': new RAMResource() })
+    const result = await ws.execute('du -s /empty')
+    expect(result.stdoutText).toBe('0\t/empty\n')
+    expect(result.stderrText).toBe('')
+    expect(result.exitCode).toBe(0)
+    await ws.close()
+  })
+
+  // The mount table alone is not enough evidence: namespaceNames synthesizes a
+  // directory for a link's ancestors too, and there is no descendant mount
+  // here at all.
+  it('du on a directory implied only by a link below it does not report absence', async () => {
+    const ws = await makeWs({ '/': new RAMResource() })
+    await ws.execute('mkdir -p /real')
+    await ws.execute('echo hi > /real/f.txt')
+    await ws.execute('ln -s /real/f.txt /ghost/deep/lnk')
+    const result = await ws.execute('du /ghost')
+    expect(result.stderrText).toBe('')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdoutText).toContain('/ghost')
+    await ws.close()
+  })
+
+  // registry.descendantMounts is not session-filtered, so proving presence
+  // from the mount table alone would answer `0 /empty` here and confirm a
+  // walled-off mount's parent. The dispatcher-backed probe is filtered.
+  it('du still reports absence when the descendant mount is ungranted', async () => {
+    const ws = await makeWs({ '/': new RAMResource(), '/empty/hole': new RAMResource() })
+    ws.createSession('scoped', { mounts: { '/': 'rw' } })
+    const result = await ws.execute('du /empty', { sessionId: 'scoped' })
+    expect(result.stdoutText).toBe('')
+    expect(result.stderrText).toBe("du: cannot access '/empty': No such file or directory\n")
+    expect(result.exitCode).toBe(1)
+    await ws.close()
+  })
 })
 
 describe('rm/rmdir on a mount prefix is refused (Unix-like)', () => {


### PR DESCRIPTION
## The bug

```
ws = Workspace({"/": RAMResource(), "/empty/hole": RAMResource()}, mode=MountMode.WRITE)
await ws.execute("du /empty")
```

```
stdout: 0	/empty/hole
        0	/empty
stderr: du: cannot access '/empty': No such file or directory
exit=1
```

The rows were right. The diagnostic and the exit code were not. `/empty` is a real directory (`ls /` shows it, `test -d` agrees), but no backend holds an entry for it: the content lives in the descendant mount's own resource.

## Root cause

Not du-specific. A command runs bound to one mount and decides existence from that mount's backend stat, so it cannot see either fact that makes such a path a directory. Both are namespace state:

- a mount nested below it (`/empty`)
- a symlink at or below it (`/ghost` after `ln -s x /ghost/deep/lnk`, since `namespace_names` synthesizes a link's ancestors)

The dispatcher already answers both correctly, and always did: it catches the backend's miss and falls back to `namespace_stat`. Probed live, `dispatch("stat", "/empty")` returns a DIRECTORY stat. That answer is offered to every handler as `stat_path`, and `find` was its only consumer, which is why `find /empty` was the one sibling that got this right.

## The fix

`du_operands` / `duOperands` now ask that probe when the backend stat fails, ahead of the `has_content` walk: one dispatch is cheaper than a full readdir walk and it is the authoritative channel. `has_content` stays behind it for a backend with no directory entry for its own mount root (redis).

## Why `stat_path` and not `registry.descendant_mounts`

1. The registry lookup is **not session-filtered**. `mount_allowed` is applied in `ops/namespace_view.py` and `fanout._allowed_descendants`, but not in the registry, and `MountView.descendants` reads it raw. Proving presence from the mount table would answer `0 /empty` for a session scoped to `/` alone and confirm a walled-off mount's parent. `namespace_stat` is filtered, so absence stays the answer there.
2. It misses half the bug class: the link-implied directory has no descendant mount at all.

Both are pinned by tests.

## GNU pin

coreutils 9.7 on `debian:stable-slim`, tmpfs mounted at `/empty/hole`:

| line | stdout | exit |
| --- | --- | --- |
| `du --apparent-size -B1 /empty` | `0 /empty/hole`, `0 /empty` | 0 |
| same, 6 bytes inside | `6 /empty/hole`, `6 /empty` | 0 |
| `-s` | `6 /empty` | 0 |
| `-a` | adds `6 /empty/hole/f.txt` | 0 |
| control `du /nope` | `cannot access` | 1 |

mirage now matches every row. GNU reserves that diagnostic for real absence. Behavior is identical with and without `-S`, so this is orthogonal to #722 (rebased on top of it).

## Not fixed here

The same false absence remains in `stat`, `wc`, `file`, `cat` and `tree` for such a path. Each needs its own GNU wording rather than the same channel read (`wc` prints `0 /empty` on stdout plus `Is a directory` on stderr; `file` prints `directory`; `cat` prints `Is a directory`), so they are a separate change. `ls`, `find` and `test -d` were already correct.

## Verification

Python full suite exit 0 - TS core 630 files / 7878 tests - `pnpm typecheck` exit 0 - `pre-commit --all-files` exit 0 with a stable tree - mypy clean - layout parity at baseline. The three new presence tests fail with the wiring reverted in both languages; the ungranted-session test passes either way, as a guard should.