### PR TITLE
fix(stat): render the symlink arrow for %N

### DIFF
--- a/integ/unix/sym/surface.json
+++ b/integ/unix/sym/surface.json
@@ -443,8 +443,212 @@
       }
     },
     {
-      "id": "symx_readlink_plain",
+      "id": "symx_stat_percent_n_link",
       "seq": 810,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "stat -c '%N' /data/symx/flink",
+      "expect": {
+        "exit": 0,
+        "stdout": "'/data/symx/flink' -> '/data/symx/real.txt'\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symx_stat_percent_n_dirlink",
+      "seq": 811,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "stat -c '%N' /data/symx/dlink",
+      "expect": {
+        "exit": 0,
+        "stdout": "'/data/symx/dlink' -> '/data/symx/sub'\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symx_stat_percent_n_dangling",
+      "seq": 812,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "stat -c '%N' /data/symx/dangle",
+      "expect": {
+        "exit": 0,
+        "stdout": "'/data/symx/dangle' -> '/data/symx/none'\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symx_stat_percent_n_plain",
+      "seq": 813,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "stat -c '%N' /data/symx/real.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "'/data/symx/real.txt'\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symx_stat_percent_n_deref",
+      "seq": 814,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "stat -c '%N' /data/symx/flink -L",
+      "expect": {
+        "exit": 0,
+        "stdout": "'/data/symx/flink'\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symx_stat_percent_n_width",
+      "seq": 815,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "stat -c '[%25N]' /data/symx/flink",
+      "expect": {
+        "exit": 0,
+        "stdout": "[         /data/symx/flink ->       /data/symx/real.txt]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symx_readlink_plain",
+      "seq": 816,
       "targets": [
         "ram",
         "disk",
@@ -478,7 +682,7 @@
     },
     {
       "id": "symx_readlink_e_dangling",
-      "seq": 811,
+      "seq": 817,
       "targets": [
         "ram",
         "disk",
@@ -512,7 +716,7 @@
     },
     {
       "id": "symx_readlink_f_dangling",
-      "seq": 812,
+      "seq": 818,
       "targets": [
         "ram",
         "disk",
@@ -546,7 +750,7 @@
     },
     {
       "id": "symx_readlink_e_live",
-      "seq": 813,
+      "seq": 819,
       "targets": [
         "ram",
         "disk",
@@ -580,7 +784,7 @@
     },
     {
       "id": "symx_file_link",
-      "seq": 814,
+      "seq": 820,
       "targets": [
         "ram",
         "disk",
@@ -614,7 +818,7 @@
     },
     {
       "id": "symx_file_broken",
-      "seq": 815,
+      "seq": 821,
       "targets": [
         "ram",
         "disk",
@@ -648,7 +852,7 @@
     },
     {
       "id": "symx_file_deref",
-      "seq": 816,
+      "seq": 822,
       "targets": [
         "ram",
         "disk",
@@ -682,7 +886,7 @@
     },
     {
       "id": "symx_du_link_operand",
-      "seq": 817,
+      "seq": 823,
       "targets": [
         "ram",
         "disk",
@@ -716,7 +920,7 @@
     },
     {
       "id": "symx_du_a_lists_links",
-      "seq": 818,
+      "seq": 824,
       "targets": [
         "ram",
         "disk",
@@ -750,7 +954,7 @@
     },
     {
       "id": "symx_cleanup",
-      "seq": 819,
+      "seq": 825,
       "targets": [
         "ram",
         "disk",

--- a/integ/unix/sym/surface.json
+++ b/integ/unix/sym/surface.json
@@ -953,7 +953,7 @@
       }
     },
     {
-      "id": "symx_cleanup",
+      "id": "symx_link_metachar_target",
       "seq": 825,
       "targets": [
         "ram",
@@ -979,7 +979,75 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "rm /data/symx/flink /data/symx/dlink /data/symx/dangle && rm -r /data/symx",
+      "command": "ln -s \"/data/symx/a'b\\$c\" /data/symx/qlink",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symx_stat_percent_n_metachar_target",
+      "seq": 826,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "stat -c '%N' /data/symx/qlink",
+      "expect": {
+        "exit": 0,
+        "stdout": "'/data/symx/qlink' -> '/data/symx/a'\\''b$c'\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symx_cleanup",
+      "seq": 827,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "rm /data/symx/flink /data/symx/dlink /data/symx/dangle /data/symx/qlink && rm -r /data/symx",
       "expect": {
         "exit": 0,
         "stdout": "",

--- a/python/mirage/commands/builtin/generic/stat.py
+++ b/python/mirage/commands/builtin/generic/stat.py
@@ -1,5 +1,6 @@
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
+from itertools import groupby
 
 from mirage.commands.builtin.utils.formatting import _ls_mode_string
 from mirage.commands.builtin.utils.output import format_records
@@ -28,6 +29,20 @@ _TYPE_LABELS = {
 }
 
 _DEFAULT_OWNER = "user"
+
+_SHELL_SPECIAL = frozenset("!\"#$&()*;<=>?[\\^`{|}~")
+
+_START_SAFE = frozenset("#~")
+
+_ESCAPE_NAMES = {
+    "\a": "\\a",
+    "\b": "\\b",
+    "\t": "\\t",
+    "\n": "\\n",
+    "\v": "\\v",
+    "\f": "\\f",
+    "\r": "\\r",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,21 +101,77 @@ def _epoch(iso: str | None) -> str:
         return "0"
 
 
+def _needs_escape(char: str) -> bool:
+    """Whether GNU spells a character as a ``$'..'`` escape.
+
+    Args:
+        char (str): the character to test.
+    """
+    return char < " " or char == "\x7f"
+
+
+def _escape_char(char: str) -> str:
+    """Spell one character the way bash's ``$'..'`` does.
+
+    Args:
+        char (str): the character to escape.
+    """
+    named = _ESCAPE_NAMES.get(char)
+    return named if named is not None else f"\\{ord(char):03o}"
+
+
+def _double_quotable(name: str) -> bool:
+    """Whether a name holding an apostrophe still fits in double quotes.
+
+    GNU only reaches for them when nothing else in the name would stay
+    live inside them, so ``a'b`` renders as ``"a'b"`` but ``a'b$c`` does
+    not. ``#`` and ``~`` count as special only away from the front.
+
+    Args:
+        name (str): the name to test.
+    """
+    for index, char in enumerate(name):
+        if _needs_escape(char):
+            return False
+        if char in _SHELL_SPECIAL and not (index == 0 and char in _START_SAFE):
+            return False
+    return True
+
+
+def _single_quoted(name: str) -> str:
+    """Render single-quoted runs spliced with ``$'..'`` escape segments.
+
+    Args:
+        name (str): the name to quote.
+    """
+    parts: list[str] = []
+    for index, (escaped, chars) in enumerate(groupby(name, _needs_escape)):
+        run = "".join(chars)
+        if not escaped:
+            parts.append("'" + run.replace("'", "'\\''") + "'")
+            continue
+        # A leading escape keeps the empty quotes GNU emits; a trailing
+        # one does not.
+        if index == 0:
+            parts.append("''")
+        parts.append("$'" + "".join(_escape_char(c) for c in run) + "'")
+    return "".join(parts) if parts else "''"
+
+
 def _quote_name(name: str) -> str:
     """Shell-safe quoting for %N, mirroring GNU's default.
 
-    A name with no apostrophe is single-quoted; one containing an
-    apostrophe (but no double quote) switches to double quotes; one with
-    both is single-quoted with each apostrophe escaped as ``'\\''``.
+    Single quotes are the rule, with each apostrophe escaped as
+    ``'\\''`` and every unprintable character lifted into a ``$'..'``
+    segment. A name whose only awkward character is an apostrophe reads
+    better in double quotes, and GNU renders that one case that way.
 
     Args:
         name (str): the file name to quote.
     """
-    if "'" not in name:
-        return f"'{name}'"
-    if '"' not in name:
+    if "'" in name and _double_quotable(name):
         return f'"{name}"'
-    return "'" + name.replace("'", "'\\''") + "'"
+    return _single_quoted(name)
 
 
 def _apply_flags(value: str, flags: str, width: str, precision: str | None,

--- a/python/mirage/commands/builtin/generic/stat.py
+++ b/python/mirage/commands/builtin/generic/stat.py
@@ -9,7 +9,7 @@ from mirage.commands.spec.types import FlagValue, FlagView
 from mirage.core.timeutil import iso_to_epoch
 from mirage.io.types import ByteSource, IOResult
 from mirage.ops.types import LinkView
-from mirage.types import FileStat, FileType, PathSpec
+from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
 from mirage.utils.errors import FS_ERRORS, fs_error_line
 
 _STR_DIRECTIVES = frozenset("nNF")
@@ -134,8 +134,6 @@ def _directive_value(spec: str, s: FileStat, name: str) -> str:
         return "%"
     if spec == "n":
         return name
-    if spec == "N":
-        return _quote_name(name)
     if spec == "s":
         return str(s.size if s.size is not None else 0)
     if spec == "F":
@@ -171,6 +169,42 @@ def _directive_value(spec: str, s: FileStat, name: str) -> str:
         # major/minor, which a VFS has no truthful value for.
         return "0" if spec[1] in "rR" else "?"
     return "?"
+
+
+def _name_parts(s: FileStat, name: str, quoted: bool) -> list[str]:
+    """The fields ``%N`` renders: the name, plus a symlink's target.
+
+    Args:
+        s (FileStat): the stat being rendered.
+        name (str): the operand as it was typed.
+        quoted (bool): shell-quote each field. GNU only does so for a bare
+            ``%N``; any flag, width or precision drops the quotes.
+    """
+    parts = [name]
+    if s.type == FileType.SYMLINK:
+        target = s.extra.get(LINK_TARGET_KEY)
+        if target:
+            parts.append(str(target))
+    return [_quote_name(p) for p in parts] if quoted else parts
+
+
+def _render_directive(d: _FormatDirective, s: FileStat, name: str) -> str:
+    """Render one directive with its flags, width and precision applied.
+
+    Args:
+        d (_FormatDirective): the parsed directive.
+        s (FileStat): the stat being rendered.
+        name (str): the operand as it was typed.
+    """
+    if d.spec == "N":
+        # GNU formats the name and a symlink's target as two separate
+        # fields, so a width pads each one rather than the joined line.
+        bare = not d.flags and not d.width and d.precision is None
+        return " -> ".join(
+            _apply_flags(part, d.flags, d.width, d.precision, d.spec)
+            for part in _name_parts(s, name, bare))
+    return _apply_flags(_directive_value(d.spec, s, name), d.flags, d.width,
+                        d.precision, d.spec)
 
 
 def _is_conversion(char: str) -> bool:
@@ -236,10 +270,7 @@ def _format_stat(fmt: str, s: FileStat, name: str) -> str:
             parts.append("%")
             cursor = start + 1
             continue
-        parts.append(
-            _apply_flags(_directive_value(directive.spec, s,
-                                          name), directive.flags,
-                         directive.width, directive.precision, directive.spec))
+        parts.append(_render_directive(directive, s, name))
         cursor = directive.end
     return "".join(parts)
 

--- a/python/tests/commands/builtin/generic/test_stat.py
+++ b/python/tests/commands/builtin/generic/test_stat.py
@@ -44,6 +44,20 @@ async def _render(fmt: str, fs: FileStat) -> str:
     return (await materialize(out)).decode().rstrip("\n")
 
 
+async def _render_named(fmt: str, name: str) -> str:
+    """Render one directive for an operand typed as ``name``.
+
+    Args:
+        fmt (str): the format string.
+        name (str): the operand, kept verbatim for %n and %N.
+    """
+    out, io = await stat([PathSpec.from_str_path(name)],
+                         stat_fn=partial(_const_stat, _fs()),
+                         c=fmt)
+    assert io.exit_code == 0
+    return (await materialize(out)).decode().rstrip("\n")
+
+
 async def _run(ws: Workspace, cmd: str) -> tuple[int, str, str]:
     r = await ws.execute(cmd)
     return r.exit_code, await r.stdout_str(), await r.stderr_str()
@@ -106,19 +120,59 @@ async def test_printf_flags_width_precision():
     assert await _render("%.3F", _fs()) == "reg"
 
 
+# Pinned against GNU coreutils 9.7 on debian:stable-slim. Single quotes
+# are the rule; a name whose only awkward character is an apostrophe reads
+# better in double quotes and GNU renders that one case that way, but any
+# other shell character (or an unprintable one) sends it back to single
+# quotes. mirage paths are text rather than bytes, so a non-ASCII name
+# stays literal the way GNU renders it in a UTF-8 locale instead of the
+# octal bytes it emits under LC_ALL=C.
+_GNU_QUOTED = [
+    ("/data/f.txt", "'/data/f.txt'"),
+    ("a$b", "'a$b'"),
+    ('a"b', "'a\"b'"),
+    ("a'b", "\"a'b\""),
+    ("a'b c", "\"a'b c\""),
+    ("a'b$c", "'a'\\''b$c'"),
+    ("a'b`c", "'a'\\''b`c'"),
+    ("a'b\\c", "'a'\\''b\\c'"),
+    ("a'b\"c", "'a'\\''b\"c'"),
+    ("a'b!c", "'a'\\''b!c'"),
+    # # and ~ count as special only away from the front.
+    ("#a'b", "\"#a'b\""),
+    ("~a'b", "\"~a'b\""),
+    ("a#'b", "'a#'\\''b'"),
+    ("$a'b", "'$a'\\''b'"),
+    ("a\tb", "'a'$'\\t''b'"),
+    ("a\nb", "'a'$'\\n''b'"),
+    ("a\x07b", "'a'$'\\a''b'"),
+    ("a\x01b", "'a'$'\\001''b'"),
+    ("a\x1bb", "'a'$'\\033''b'"),
+    ("a\x7fb", "'a'$'\\177''b'"),
+    # A leading escape keeps the empty quotes; a trailing one does not.
+    ("\ta", "''$'\\t''a'"),
+    ("a\t", "'a'$'\\t'"),
+    ("a\t\nb", "'a'$'\\t\\n''b'"),
+    ("a'b\tc", "'a'\\''b'$'\\t''c'"),
+    ("café", "'café'"),
+    ("a'béc", "\"a'béc\""),
+]
+
+
 @pytest.mark.asyncio
-async def test_quoted_name_is_shell_safe():
-    assert await _render("%N", _fs()) == "'/data/f.txt'"
-    # An apostrophe in the path switches to double quotes.
-    ap, _io = await stat([PathSpec.from_str_path("/data/a'b.txt")],
-                         stat_fn=partial(_const_stat, _fs()),
-                         c="%N")
-    assert (await materialize(ap)).decode() == "\"/data/a'b.txt\"\n"
-    # Both quote kinds -> single-quote with escaped apostrophes.
-    both, _io2 = await stat([PathSpec.from_str_path("/data/a'b\"c")],
-                            stat_fn=partial(_const_stat, _fs()),
-                            c="%N")
-    assert (await materialize(both)).decode() == "'/data/a'\\''b\"c'\n"
+@pytest.mark.parametrize("name,quoted", _GNU_QUOTED)
+async def test_quoted_name_is_shell_safe(name: str, quoted: str):
+    assert await _render_named("%N", name) == quoted
+
+
+@pytest.mark.asyncio
+async def test_a_link_target_is_quoted_by_the_same_rule():
+    """The target is a second field, so it gets its own quoting."""
+    assert await _render("%N",
+                         _link_fs("a'b$c")) == "'/data/f.txt' -> 'a'\\''b$c'"
+    assert await _render("%N", _link_fs("a'b")) == "'/data/f.txt' -> \"a'b\""
+    assert await _render("%N",
+                         _link_fs("a\tb")) == "'/data/f.txt' -> 'a'$'\\t''b'"
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/test_symlinks.py
+++ b/python/tests/workspace/test_symlinks.py
@@ -614,6 +614,16 @@ async def test_stat_percent_n_quotes_each_side_on_its_own():
 
 
 @pytest.mark.asyncio
+async def test_stat_percent_n_target_holding_shell_metacharacters():
+    """A target with an apostrophe next to a live character goes back to
+    single quotes, so replaying the line cannot expand ``$c``."""
+    ws = _ws()
+    await ws.execute("""ln -s "/data/a'b\\$c" /data/meta""")
+    r = await ws.execute("stat -c '%N' /data/meta")
+    assert r.stdout.decode() == "'/data/meta' -> '/data/a'\\''b$c'\n"
+
+
+@pytest.mark.asyncio
 async def test_stat_percent_n_modifiers_drop_quotes_and_pad_each_side():
     """GNU quotes %N only when the directive carries no modifier, and a
     width or precision applies to the name and the target separately."""

--- a/python/tests/workspace/test_symlinks.py
+++ b/python/tests/workspace/test_symlinks.py
@@ -581,6 +581,55 @@ async def test_stat_format_directives_on_a_link():
     assert r.stdout.decode().strip() == "symbolic link lrwxrwxrwx"
 
 
+@pytest.mark.asyncio
+async def test_stat_percent_n_renders_the_link_arrow():
+    """GNU: ``'name' -> 'target'`` for a link, bare quoted name otherwise."""
+    ws = await _seeded()
+    r = await ws.execute("stat -c '%N' /data/link.txt")
+    assert r.stdout.decode() == "'/data/link.txt' -> '/data/dir/real.txt'\n"
+    r = await ws.execute("stat -c '%N' /data/dir/real.txt")
+    assert r.stdout.decode() == "'/data/dir/real.txt'\n"
+    # %n is the bare name even for a link.
+    r = await ws.execute("stat -c '%n' /data/link.txt")
+    assert r.stdout.decode() == "/data/link.txt\n"
+    # -L reports the target, which is not a link, so no arrow.
+    r = await ws.execute("stat -L -c '%N' /data/link.txt")
+    assert r.stdout.decode() == "'/data/link.txt'\n"
+
+
+@pytest.mark.asyncio
+async def test_stat_percent_n_arrow_on_a_dangling_link():
+    ws = await _dangling()
+    r = await ws.execute("stat -c '%N' /data/dangle")
+    assert r.stdout.decode() == "'/data/dangle' -> '/data/nope'\n"
+
+
+@pytest.mark.asyncio
+async def test_stat_percent_n_quotes_each_side_on_its_own():
+    ws = _ws()
+    await ws.execute("echo hi > \"/data/it's\"")
+    await ws.execute("ln -s \"/data/it's\" /data/plain")
+    r = await ws.execute("stat -c '%N' /data/plain")
+    assert r.stdout.decode() == "'/data/plain' -> \"/data/it's\"\n"
+
+
+@pytest.mark.asyncio
+async def test_stat_percent_n_modifiers_drop_quotes_and_pad_each_side():
+    """GNU quotes %N only when the directive carries no modifier, and a
+    width or precision applies to the name and the target separately."""
+    ws = await _seeded()
+    r = await ws.execute("stat -c '[%20N]' /data/link.txt")
+    assert r.stdout.decode() == (
+        "[      /data/link.txt ->   /data/dir/real.txt]\n")
+    r = await ws.execute("stat -c '[%-20N]' /data/link.txt")
+    assert r.stdout.decode() == (
+        "[/data/link.txt       -> /data/dir/real.txt  ]\n")
+    r = await ws.execute("stat -c '[%.6N]' /data/link.txt")
+    assert r.stdout.decode() == "[/data/ -> /data/]\n"
+    r = await ws.execute("stat -c '[%20N]' /data/dir/real.txt")
+    assert r.stdout.decode() == "[  /data/dir/real.txt]\n"
+
+
 async def _dangling():
     """The seeded tree plus a link whose target does not exist."""
     ws = await _seeded()

--- a/typescript/packages/core/src/commands/builtin/generic/stat.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/stat.test.ts
@@ -17,7 +17,14 @@ import { materialize } from '../../../io/types.ts'
 import { OpsRegistry, type RegisteredOp } from '../../../ops/registry.ts'
 import { RAMResource } from '../../../resource/ram/ram.ts'
 import { type CommandOpts } from '../../config.ts'
-import { FileStat, type FileStatInit, FileType, MountMode, PathSpec } from '../../../types.ts'
+import {
+  FileStat,
+  type FileStatInit,
+  FileType,
+  LINK_TARGET_KEY,
+  MountMode,
+  PathSpec,
+} from '../../../types.ts'
 import { getTestParser } from '../../../workspace/fixtures/workspace_fixture.ts'
 import { Workspace } from '../../../workspace/workspace.ts'
 import { statGeneric } from './stat.ts'
@@ -65,6 +72,48 @@ async function renderNamed(fmt: string, name: string): Promise<string> {
   if (result === null) throw new Error('statGeneric returned null')
   return DEC.decode(await materialize(result[0]))
 }
+
+function linkFs(target: string): FileStat {
+  return fs({ type: FileType.SYMLINK, extra: { [LINK_TARGET_KEY]: target } })
+}
+
+// Pinned against GNU coreutils 9.7 on debian:stable-slim. Single quotes are
+// the rule; a name whose only awkward character is an apostrophe reads better
+// in double quotes and GNU renders that one case that way, but any other shell
+// character (or an unprintable one) sends it back to single quotes. mirage
+// paths are text rather than bytes, so a non-ASCII name stays literal the way
+// GNU renders it in a UTF-8 locale instead of the octal bytes it emits under
+// LC_ALL=C.
+const GNU_QUOTED: [string, string][] = [
+  ['/data/f.txt', "'/data/f.txt'"],
+  ['a$b', "'a$b'"],
+  ['a"b', "'a\"b'"],
+  ["a'b", '"a\'b"'],
+  ["a'b c", '"a\'b c"'],
+  ["a'b$c", "'a'\\''b$c'"],
+  ["a'b`c", "'a'\\''b`c'"],
+  ["a'b\\c", "'a'\\''b\\c'"],
+  ['a\'b"c', "'a'\\''b\"c'"],
+  ["a'b!c", "'a'\\''b!c'"],
+  // # and ~ count as special only away from the front.
+  ["#a'b", '"#a\'b"'],
+  ["~a'b", '"~a\'b"'],
+  ["a#'b", "'a#'\\''b'"],
+  ["$a'b", "'$a'\\''b'"],
+  ['a\tb', "'a'$'\\t''b'"],
+  ['a\nb', "'a'$'\\n''b'"],
+  ['a\x07b', "'a'$'\\a''b'"],
+  ['a\x01b', "'a'$'\\001''b'"],
+  ['a\x1bb', "'a'$'\\033''b'"],
+  ['a\x7fb', "'a'$'\\177''b'"],
+  // A leading escape keeps the empty quotes; a trailing one does not.
+  ['\ta', "''$'\\t''a'"],
+  ['a\t', "'a'$'\\t'"],
+  ['a\t\nb', "'a'$'\\t\\n''b'"],
+  ["a'b\tc", "'a'\\''b'$'\\t''c'"],
+  ['café', "'café'"],
+  ["a'béc", '"a\'béc"'],
+]
 
 class NoSetattrRegistry extends OpsRegistry {
   override register(ro: RegisteredOp): void {
@@ -125,10 +174,14 @@ describe('stat -c directive formatting', () => {
     expect(await render('%.3F', fs())).toBe('reg')
   })
 
-  it('shell-quotes %N safely', async () => {
-    expect(await render('%N', fs())).toBe("'/data/f.txt'")
-    expect(await renderNamed('%N', "/data/a'b.txt")).toBe('"/data/a\'b.txt"\n')
-    expect(await renderNamed('%N', '/data/a\'b"c')).toBe("'/data/a'\\''b\"c'\n")
+  it.each(GNU_QUOTED)('shell-quotes %N safely: %j', async (name, quoted) => {
+    expect(await renderNamed('%N', name)).toBe(quoted + '\n')
+  })
+
+  it('quotes a link target by the same rule', async () => {
+    expect(await render('%N', linkFs("a'b$c"))).toBe("'/data/f.txt' -> 'a'\\''b$c'")
+    expect(await render('%N', linkFs("a'b"))).toBe("'/data/f.txt' -> \"a'b\"")
+    expect(await render('%N', linkFs('a\tb'))).toBe("'/data/f.txt' -> 'a'$'\\t''b'")
   })
 
   it('renders owner directives, falling back to "user"', async () => {

--- a/typescript/packages/core/src/commands/builtin/generic/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/stat.ts
@@ -74,14 +74,72 @@ interface FormatDirective {
   spec: string
 }
 
-// Shell-safe quoting for %N, mirroring GNU's default: a name with no
-// apostrophe is single-quoted; one containing an apostrophe (but no double
-// quote) switches to double quotes; one with both is single-quoted with each
-// apostrophe escaped as '\''.
+const SHELL_SPECIAL = new Set('!"#$&()*;<=>?[\\^`{|}~')
+
+const START_SAFE = new Set('#~')
+
+const ESCAPE_NAMES: Record<string, string> = {
+  '\x07': '\\a',
+  '\b': '\\b',
+  '\t': '\\t',
+  '\n': '\\n',
+  '\v': '\\v',
+  '\f': '\\f',
+  '\r': '\\r',
+}
+
+// Whether GNU spells a character as a $'..' escape.
+function needsEscape(char: string): boolean {
+  return char < ' ' || char === '\x7f'
+}
+
+function escapeChar(char: string): string {
+  return ESCAPE_NAMES[char] ?? '\\' + char.charCodeAt(0).toString(8).padStart(3, '0')
+}
+
+// Whether a name holding an apostrophe still fits in double quotes. GNU only
+// reaches for them when nothing else in the name would stay live inside them,
+// so a'b renders as "a'b" but a'b$c does not. # and ~ count as special only
+// away from the front.
+function doubleQuotable(name: string): boolean {
+  for (let index = 0; index < name.length; index += 1) {
+    const char = name.charAt(index)
+    if (needsEscape(char)) return false
+    if (SHELL_SPECIAL.has(char) && !(index === 0 && START_SAFE.has(char))) return false
+  }
+  return true
+}
+
+// Single-quoted runs spliced with $'..' escape segments.
+function singleQuoted(name: string): string {
+  const parts: string[] = []
+  let index = 0
+  while (index < name.length) {
+    const escaped = needsEscape(name.charAt(index))
+    let end = index
+    while (end < name.length && needsEscape(name.charAt(end)) === escaped) end += 1
+    if (escaped) {
+      // A leading escape keeps the empty quotes GNU emits; a trailing one does not.
+      if (index === 0) parts.push("''")
+      let text = ''
+      for (let at = index; at < end; at += 1) text += escapeChar(name.charAt(at))
+      parts.push("$'" + text + "'")
+    } else {
+      parts.push("'" + name.slice(index, end).replaceAll("'", "'\\''") + "'")
+    }
+    index = end
+  }
+  return parts.length > 0 ? parts.join('') : "''"
+}
+
+// Shell-safe quoting for %N, mirroring GNU's default: single quotes are the
+// rule, with each apostrophe escaped as '\'' and every unprintable character
+// lifted into a $'..' segment. A name whose only awkward character is an
+// apostrophe reads better in double quotes, and GNU renders that one case
+// that way.
 function quoteName(name: string): string {
-  if (!name.includes("'")) return `'${name}'`
-  if (!name.includes('"')) return `"${name}"`
-  return "'" + name.replaceAll("'", "'\\''") + "'"
+  if (name.includes("'") && doubleQuotable(name)) return `"${name}"`
+  return singleQuoted(name)
 }
 
 function applyFlags(

--- a/typescript/packages/core/src/commands/builtin/generic/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/stat.ts
@@ -15,7 +15,7 @@
 import { specOf } from '../../spec/builtins.ts'
 import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, type FileStat, type PathSpec } from '../../../types.ts'
+import { FileType, LINK_TARGET_KEY, type FileStat, type PathSpec } from '../../../types.ts'
 import { isoToEpoch } from '../../../utils/dates.ts'
 import { fsErrorLine, isFsError } from '../../../utils/errors.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -107,7 +107,6 @@ function applyFlags(
 function directiveValue(spec: string, s: FileStat, name: string): string {
   if (spec === '%') return '%'
   if (spec === 'n') return name
-  if (spec === 'N') return quoteName(name)
   if (spec === 's') return String(s.size ?? 0)
   if (spec === 'F') return typeLabel(s)
   if (spec === 'a') return effectiveMode(s).toString(8)
@@ -129,6 +128,29 @@ function directiveValue(spec: string, s: FileStat, name: string): string {
     return spec[1] === 'r' || spec[1] === 'R' ? '0' : '?'
   }
   return '?'
+}
+
+// The fields %N renders: the name, plus a symlink's target. GNU shell-quotes
+// each one only for a bare %N; any flag, width or precision drops the quotes.
+function nameParts(s: FileStat, name: string, quoted: boolean): string[] {
+  const parts = [name]
+  if (s.type === FileType.SYMLINK) {
+    const target = s.extra[LINK_TARGET_KEY]
+    if (typeof target === 'string' && target !== '') parts.push(target)
+  }
+  return quoted ? parts.map(quoteName) : parts
+}
+
+function renderDirective(d: FormatDirective, s: FileStat, name: string): string {
+  if (d.spec === 'N') {
+    // GNU formats the name and a symlink's target as two separate fields,
+    // so a width pads each one rather than the joined line.
+    const bare = d.flags === '' && d.width === '' && d.precision === undefined
+    return nameParts(s, name, bare)
+      .map((part) => applyFlags(part, d.flags, d.width, d.precision, d.spec))
+      .join(' -> ')
+  }
+  return applyFlags(directiveValue(d.spec, s, name), d.flags, d.width, d.precision, d.spec)
 }
 
 function isAsciiDigit(char: string | undefined): boolean {
@@ -193,15 +215,7 @@ function formatStat(fmt: string, s: FileStat, name: string): string {
       cursor = start + 1
       continue
     }
-    parts.push(
-      applyFlags(
-        directiveValue(directive.spec, s, name),
-        directive.flags,
-        directive.width,
-        directive.precision,
-        directive.spec,
-      ),
-    )
+    parts.push(renderDirective(directive, s, name))
     cursor = directive.end
   }
   return parts.join('')

--- a/typescript/packages/core/src/workspace/symlinks.test.ts
+++ b/typescript/packages/core/src/workspace/symlinks.test.ts
@@ -617,6 +617,17 @@ describe('symlinks (namespace-backed)', () => {
     await ws.close()
   })
 
+  // A target with an apostrophe next to a live character goes back to single
+  // quotes, so replaying the line cannot expand $c.
+  it('stat %N single-quotes a target holding shell metacharacters', async () => {
+    const ws = buildWorkspace()
+    await ws.execute('ln -s "/data/a\'b\\$c" /data/meta')
+    expect(dec((await ws.execute("stat -c '%N' /data/meta")).stdout)).toBe(
+      "'/data/meta' -> '/data/a'\\''b$c'\n",
+    )
+    await ws.close()
+  })
+
   // GNU quotes %N only when the directive carries no modifier, and a width
   // or precision applies to the name and the target separately.
   it('stat %N modifiers drop the quotes and pad each side', async () => {

--- a/typescript/packages/core/src/workspace/symlinks.test.ts
+++ b/typescript/packages/core/src/workspace/symlinks.test.ts
@@ -579,6 +579,62 @@ describe('symlinks (namespace-backed)', () => {
     expect(dec((await ws.execute('stat -L /data/link.txt')).stdout)).toContain('type=text')
     await ws.close()
   })
+
+  // GNU renders %N as `'name' -> 'target'` for a link, and as the bare
+  // quoted name otherwise.
+  it('stat %N renders the link arrow', async () => {
+    const ws = await seeded()
+    expect(dec((await ws.execute("stat -c '%N' /data/link.txt")).stdout)).toBe(
+      "'/data/link.txt' -> '/data/dir/real.txt'\n",
+    )
+    expect(dec((await ws.execute("stat -c '%N' /data/dir/real.txt")).stdout)).toBe(
+      "'/data/dir/real.txt'\n",
+    )
+    // %n is the bare name even for a link.
+    expect(dec((await ws.execute("stat -c '%n' /data/link.txt")).stdout)).toBe('/data/link.txt\n')
+    // -L reports the target, which is not a link, so no arrow.
+    expect(dec((await ws.execute("stat -L -c '%N' /data/link.txt")).stdout)).toBe(
+      "'/data/link.txt'\n",
+    )
+    await ws.close()
+  })
+
+  it('stat %N renders the arrow for a dangling link', async () => {
+    const ws = await dangling()
+    expect(dec((await ws.execute("stat -c '%N' /data/dangle")).stdout)).toBe(
+      "'/data/dangle' -> '/data/nope'\n",
+    )
+    await ws.close()
+  })
+
+  it('stat %N quotes each side on its own', async () => {
+    const ws = buildWorkspace()
+    await ws.execute('echo hi > "/data/it\'s"')
+    await ws.execute('ln -s "/data/it\'s" /data/plain')
+    expect(dec((await ws.execute("stat -c '%N' /data/plain")).stdout)).toBe(
+      "'/data/plain' -> \"/data/it's\"\n",
+    )
+    await ws.close()
+  })
+
+  // GNU quotes %N only when the directive carries no modifier, and a width
+  // or precision applies to the name and the target separately.
+  it('stat %N modifiers drop the quotes and pad each side', async () => {
+    const ws = await seeded()
+    expect(dec((await ws.execute("stat -c '[%20N]' /data/link.txt")).stdout)).toBe(
+      '[      /data/link.txt ->   /data/dir/real.txt]\n',
+    )
+    expect(dec((await ws.execute("stat -c '[%-20N]' /data/link.txt")).stdout)).toBe(
+      '[/data/link.txt       -> /data/dir/real.txt  ]\n',
+    )
+    expect(dec((await ws.execute("stat -c '[%.6N]' /data/link.txt")).stdout)).toBe(
+      '[/data/ -> /data/]\n',
+    )
+    expect(dec((await ws.execute("stat -c '[%20N]' /data/dir/real.txt")).stdout)).toBe(
+      '[  /data/dir/real.txt]\n',
+    )
+    await ws.close()
+  })
   it('find -L classifies a link by its target', async () => {
     const ws = buildWorkspace()
     for (const c of [


### PR DESCRIPTION
`stat -c '%N'` on a symlink printed only the quoted name:

```
stat -c '%N' /data/l2   ->  '/data/l2'
```

GNU prints `'/data/l2' -> '/data/f2'`. The target was already on `FileStat.extra` under `LINK_TARGET_KEY`, which is what `ls -l`'s name column and `file`'s "symbolic link to" line read, so `%N` now reads the same fact instead of doing a second lookup.

Pinned against coreutils 9.7 on `debian:stable-slim` before changing anything. Every expectation below is copied byte-for-byte from docker output.

## %N is two fields

`'name'` and `'target'` joined by ` -> `, and that turned up two rules beyond the arrow:

- **Any format modifier drops the quoting.** A flag alone (`%-N`), a width alone (`%1N`, even one shorter than the name), or a precision alone all print unquoted. Only a bare `%N` quotes.
- **Width and precision apply to each side separately.** `stat -c '[%20N]'` on a link pads the name to 20 *and* the target to 20, not the joined line.

The second rule had to be settled either way to render `%20N` on a link, and implementing GNU's rule is the same amount of code as a special case. It also fixes a pre-existing divergence on plain files: `[%30N]` used to keep the quotes where GNU drops them.

## The quoting itself was unsafe

Codex caught this on review, and sweeping ASCII 32-126 plus the C0 range showed the helper was wrong in two ways. Of a 27-case probe table, 15 diverged.

**Quote-style choice.** The old rule was "single, unless there is an apostrophe, then double", so `a'b$c` rendered as `"a'b$c"` and replaying the advertised shell-safe output expanded `$c`. GNU's rule is the reverse: single quotes are the default with `'\''` escaping, and double quotes are an optimization for exactly one shape, a name whose only awkward character is an apostrophe. The characters that cancel it are ``! " # $ & ( ) * ; < = > ? [ \ ^ ` { | } ~`` , with `#` and `~` counting only away from index 0 (backwards from shell semantics, but verified both ways: `#a'b` -> `"#a'b"`, `a#'b` -> `'a#'\''b'`).

**Control characters.** GNU lifts them into `$'..'` segments spliced between single-quoted runs: `a<TAB>b` -> `'a'$'\t''b'`. Named escapes for `\a \b \t \n \v \f \r`, 3-digit octal otherwise (ESC is `$'\033'`, not `$'\e'`). Adjacent escapes merge; a leading escape keeps an empty `''`, a trailing one does not. mirage passed the raw byte through.

Both now implement gnulib's actual rule, and it applies to the target as well since each field is quoted on its own. One documented divergence: non-ASCII is locale-dependent upstream (octal bytes under `LC_ALL=C`, literal under `C.UTF-8`), and mirage paths are text rather than bytes, so it implements the UTF-8 column.

## Tests

- `test_stat.py` / `stat.test.ts`: the same 26-row GNU quoting table in both languages, plus target-side quoting. 46/46 match.
- `test_symlinks.py` / `symlinks.test.ts`: arrow, dangling link, `%n` staying bare, `-L` suppressing the arrow, per-side quoting, the modifier cases, and a target holding `a'b$c` end to end through `ln -s`.
- `integ/unix/sym/surface.json`: eight cases across all 22 targets. The two metacharacter cases sit after the enumerating cases so the `ls -R` / `du -a` / `find` goldens are untouched.

## Verification

| Gate | Result |
|---|---|
| Python suite | 14031 passed, 456 skipped, 0 failed |
| TS suite (8 packages) | 10807 passed, 0 failed |
| Integ `--target ram`, Python | 2449 passed, 0 failed |
| Integ `--target ram`, TypeScript | 2449 passed, 0 failed |
| `pre-commit run --all-files` | exit 0 |
