### PR TITLE
feat(dsh): session binding for the shell executor

### DIFF
--- a/docs/typescript/agents/dsh.mdx
+++ b/docs/typescript/agents/dsh.mdx
@@ -45,6 +45,14 @@ const sweep = await shell.run(shell.resolve({ command: 'grep -rln session /redis
 
 `MirageService` also accepts `mounts` instead of a live `workspace`; it then constructs the workspace itself and closes it when the plugin unloads.
 
+Each command is a clean slate: `cd`, `export`, and function definitions inside one bash call do not survive into the next, which is the one-shot contract of dsh's bash tool. For a persistent shell instead, bind the executor to a named workspace session:
+
+```ts
+await ctx.plugin(MirageShellExecutor, { sessionId: 'agent-1' }).await()
+```
+
+A bound session keeps its cwd, exports, and functions across calls. It is created on first use (an existing session is adopted as is), and two executors bound to different sessions stay fully apart on one workspace.
+
 ## Run Python with monty
 
 The `runtimes` entry above sets [monty](https://github.com/pydantic/monty), a sandboxed Python interpreter with no host access, up to capture `python` and `python3`; the catch-all `vfs` runtime serving the shell commands is always present and needs no entry. A captured invocation (a script file, inline `-c` code, or code piped on stdin) runs inside the workspace, never on the machine. A script can live on any mount: upload `example.py` to a Slack channel and run it straight off the mount, with the shell's redirection filing its stdout back into Redis:

--- a/typescript/packages/dsh/src/shell.test.ts
+++ b/typescript/packages/dsh/src/shell.test.ts
@@ -22,6 +22,13 @@ import type { MirageShellConfig } from './shell.ts'
 
 const workspaces: Workspace[] = []
 
+async function attachShell(ws: Workspace, config: MirageShellConfig): Promise<MirageShellExecutor> {
+  const ctx = new Context()
+  await ctx.plugin(MirageService, { workspace: ws }).await()
+  await ctx.plugin(MirageShellExecutor, config).await()
+  return ctx.shell as MirageShellExecutor
+}
+
 async function makeShell(
   seed: Record<string, string> = {},
   config: MirageShellConfig = {},
@@ -31,10 +38,7 @@ async function makeShell(
   for (const [path, content] of Object.entries(seed)) {
     await ws.fs.writeFile(`/data/${path}`, content)
   }
-  const ctx = new Context()
-  await ctx.plugin(MirageService, { workspace: ws }).await()
-  await ctx.plugin(MirageShellExecutor, config).await()
-  return { shell: ctx.shell as MirageShellExecutor, ws }
+  return { shell: await attachShell(ws, config), ws }
 }
 
 afterEach(async () => {
@@ -127,6 +131,105 @@ describe('run', () => {
     expect(result.timedOut).toBe(false)
     expect(result.exitCode).toBeNull()
     expect(await ws.fs.exists('/data/out.txt')).toBe(false)
+  })
+})
+
+describe('session isolation', () => {
+  it('gives each run a clean slate by default', async () => {
+    const { shell } = await makeShell()
+    await shell.run(shell.resolve({ command: 'export FOO=leak; greet() { echo hi; }; cd /data' }))
+    const probe = await shell.run(shell.resolve({ command: 'echo "[$FOO]"; pwd; type -t greet' }))
+    expect(probe.stdout.text).toBe('[]\n/\n')
+    expect(probe.exitCode).not.toBe(0)
+  })
+
+  it('stays isolated when a spec carries an empty workdir', async () => {
+    const { shell } = await makeShell()
+    await shell.run({ ...shell.resolve({ command: 'export FOO=leak; cd /data' }), workdir: '' })
+    const probe = await shell.run({
+      ...shell.resolve({ command: 'echo "[$FOO]"; pwd' }),
+      workdir: '',
+    })
+    expect(probe.stdout.text).toBe('[]\n/\n')
+  })
+
+  it('keeps start() isolated on an empty workdir too', async () => {
+    const { shell } = await makeShell()
+    const proc = shell.start({ ...shell.resolve({ command: 'export BG=leak' }), workdir: '' })
+    await proc.done
+    const probe = await shell.run({ ...shell.resolve({ command: 'echo "[$BG]"' }), workdir: '' })
+    expect(probe.stdout.text.trim()).toBe('[]')
+  })
+})
+
+describe('session binding', () => {
+  it('persists exports, cwd, and functions across runs', async () => {
+    const { shell } = await makeShell({}, { sessionId: 's1' })
+    const setup = await shell.run(
+      shell.resolve({
+        command: 'export GREETING=salut; greet() { echo "$GREETING from $PWD"; }; cd /data',
+      }),
+    )
+    expect(setup.exitCode).toBe(0)
+    const out = await shell.run(shell.resolve({ command: 'greet' }))
+    expect(out.stdout.text.trim()).toBe('salut from /data')
+  })
+
+  it('keeps differently bound executors apart on one workspace', async () => {
+    const ws = new Workspace({ '/data': [new RAMResource(), MountMode.WRITE] })
+    workspaces.push(ws)
+    const alpha = await attachShell(ws, { sessionId: 'alpha' })
+    const beta = await attachShell(ws, { sessionId: 'beta' })
+    await alpha.run(alpha.resolve({ command: 'export WHO=alpha' }))
+    const cross = await beta.run(beta.resolve({ command: 'echo "[$WHO]"' }))
+    expect(cross.stdout.text.trim()).toBe('[]')
+    const back = await alpha.run(alpha.resolve({ command: 'echo "[$WHO]"' }))
+    expect(back.stdout.text.trim()).toBe('[alpha]')
+    const direct = await ws.execute('echo "[$WHO]"')
+    expect(direct.stdoutText.trim()).toBe('[]')
+  })
+
+  it('adopts an existing session instead of recreating it', async () => {
+    const ws = new Workspace({ '/data': [new RAMResource(), MountMode.WRITE] })
+    workspaces.push(ws)
+    ws.createSession('pre')
+    await ws.execute('export SEED=planted', { sessionId: 'pre' })
+    const shell = await attachShell(ws, { sessionId: 'pre' })
+    const out = await shell.run(shell.resolve({ command: 'echo "$SEED"' }))
+    expect(out.stdout.text.trim()).toBe('planted')
+  })
+
+  it('seeds a created session at the configured workdir', async () => {
+    const { shell } = await makeShell({}, { sessionId: 'seeded', workdir: '/data' })
+    const out = await shell.run(shell.resolve({ command: 'pwd; echo "$PWD"' }))
+    expect(out.stdout.text).toBe('/data\n/data\n')
+  })
+
+  it('treats an explicit workdir as a one-call subshell', async () => {
+    const { shell } = await makeShell({}, { sessionId: 's2' })
+    await shell.run(shell.resolve({ command: 'cd /data' }))
+    const sub = await shell.run(shell.resolve({ command: 'pwd', workdir: '/' }))
+    expect(sub.stdout.text.trim()).toBe('/')
+    const back = await shell.run(shell.resolve({ command: 'pwd' }))
+    expect(back.stdout.text.trim()).toBe('/data')
+  })
+
+  it('keeps a per-call env override out of the session', async () => {
+    const { shell } = await makeShell({}, { sessionId: 's3' })
+    const once = await shell.run(
+      shell.resolve({ command: 'echo "[$TOKEN]"', env: { TOKEN: 'once' } }),
+    )
+    expect(once.stdout.text.trim()).toBe('[once]')
+    const later = await shell.run(shell.resolve({ command: 'echo "[$TOKEN]"' }))
+    expect(later.stdout.text.trim()).toBe('[]')
+  })
+
+  it('binds start() to the session too', async () => {
+    const { shell } = await makeShell({}, { sessionId: 's4' })
+    const proc = shell.start(shell.resolve({ command: 'export BG=yes' }))
+    await proc.done
+    const out = await shell.run(shell.resolve({ command: 'echo "$BG"' }))
+    expect(out.stdout.text.trim()).toBe('yes')
   })
 })
 

--- a/typescript/packages/dsh/src/shell.ts
+++ b/typescript/packages/dsh/src/shell.ts
@@ -36,7 +36,11 @@ const STDERR_MARKER = '\n--- stderr ---\n'
 
 /** Configuration for the mirage shell executor. */
 export interface MirageShellConfig {
-  /** Default working directory for commands. Defaults to `/`. */
+  /**
+   * Default working directory for commands. Defaults to `/`. With
+   * `sessionId` it instead seeds the bound session's initial cwd, and the
+   * session's own cwd is the default from then on.
+   */
   workdir?: string
   /** Default foreground timeout in milliseconds. Defaults to 120000. */
   defaultTimeoutMs?: number
@@ -46,6 +50,18 @@ export interface MirageShellConfig {
   stdoutMaxBytes?: number
   /** stderr capture budget in bytes. Defaults to 64000. */
   stderrMaxBytes?: number
+  /**
+   * Bind every command to this named workspace session. By default each
+   * command runs in an ephemeral fork of the workspace's default session,
+   * so nothing persists between calls, which is the one-shot contract of
+   * dsh's bash tool. With a session bound, `cd`, `export`, and function
+   * definitions persist across calls, the persistent-shell contract. The
+   * session is created on first use if the workspace does not have it; an
+   * existing session is adopted as is. A spec carrying an explicit
+   * `workdir` or `env` still runs as a one-call subshell of the bound
+   * session, per mirage's `ExecuteOptions` semantics.
+   */
+  sessionId?: string
 }
 
 function collect(text: string, maxBytes: number): CollectedOutput {
@@ -56,14 +72,23 @@ function collect(text: string, maxBytes: number): CollectedOutput {
 function executeOptions(
   spec: ShellExecSpec,
   signal: AbortSignal,
+  sessionId: string | undefined,
+  fallbackWorkdir: string,
 ): ExecuteOptions & { provision?: false } {
   const env = {
     ...(spec.env ?? {}),
     ...((spec.dshEnv as Record<string, string> | undefined) ?? {}),
   }
+  // Unbound, `cwd` is always present so every command runs in an ephemeral
+  // fork of the default session: isolation must not hinge on a spec
+  // happening to carry a workdir. Bound, an absent workdir runs in the
+  // session itself, which is what lets its state persist.
+  const cwd =
+    spec.workdir !== '' ? spec.workdir : sessionId === undefined ? fallbackWorkdir : undefined
   return {
     signal,
-    ...(spec.workdir !== '' ? { cwd: spec.workdir } : {}),
+    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(cwd !== undefined ? { cwd } : {}),
     ...(Object.keys(env).length > 0 ? { env } : {}),
     ...(spec.stdin !== undefined ? { stdin: new TextEncoder().encode(spec.stdin) } : {}),
   }
@@ -148,6 +173,12 @@ class MirageShellProcess implements ShellProcess {
  * path from `ctx.fs` means the same file here. There is no OS process
  * behind a command: `signal` in results is a compatibility value for kills,
  * and abort/timeout act cooperatively at the executor's own boundaries.
+ *
+ * Every command runs in an ephemeral fork of the workspace's default
+ * session, so no shell state survives from one call to the next, matching
+ * the one-shot contract of dsh's bash tool. Configuring a `sessionId`
+ * binds all commands to one named session instead, whose cwd, exports,
+ * and functions persist across calls.
  */
 export class MirageShellExecutor extends ShellExecutor {
   static readonly inject = ['mirage']
@@ -158,6 +189,8 @@ export class MirageShellExecutor extends ShellExecutor {
   private readonly maxTimeoutMs: number
   private readonly stdoutMaxBytes: number
   private readonly stderrMaxBytes: number
+  private readonly sessionId: string | undefined
+  private sessionReady: Promise<void> | null = null
 
   constructor(ctx: Context, config: MirageShellConfig = {}) {
     super(ctx)
@@ -167,12 +200,17 @@ export class MirageShellExecutor extends ShellExecutor {
     this.maxTimeoutMs = config.maxTimeoutMs ?? MAX_TIMEOUT_MS
     this.stdoutMaxBytes = config.stdoutMaxBytes ?? DEFAULT_STDOUT_MAX_BYTES
     this.stderrMaxBytes = config.stderrMaxBytes ?? DEFAULT_STDERR_MAX_BYTES
+    this.sessionId = config.sessionId
   }
 
   resolve(request: ShellExecRequest): ShellExecSpec {
+    // Bound to a session, an unspecified workdir stays empty so the
+    // session's own cwd governs; filling the default here would turn
+    // every call into a subshell and nothing would ever persist.
+    const workdir = request.workdir ?? (this.sessionId === undefined ? this.workdir : '')
     return {
       command: request.command,
-      workdir: request.workdir ?? this.workdir,
+      workdir,
       timeoutMs: Math.min(request.timeoutMs ?? this.defaultTimeoutMs, this.maxTimeoutMs),
       stdoutMaxBytes: request.stdoutMaxBytes ?? this.stdoutMaxBytes,
       signal: request.signal,
@@ -181,6 +219,23 @@ export class MirageShellExecutor extends ShellExecutor {
       dshEnv: request.dshEnv,
       sandboxPolicy: request.sandboxPolicy,
     }
+  }
+
+  private ensureSession(): Promise<void> {
+    if (this.sessionId === undefined) return Promise.resolve()
+    this.sessionReady ??= this.provisionSession(this.sessionId).catch((err: unknown) => {
+      this.sessionReady = null
+      throw err
+    })
+    return this.sessionReady
+  }
+
+  private async provisionSession(sessionId: string): Promise<void> {
+    await this.workspace.ensureSessionsLoaded()
+    if (this.workspace.listSessions().some((s) => s.sessionId === sessionId)) return
+    const session = this.workspace.createSession(sessionId)
+    session.cwd = this.workdir
+    session.env.PWD = this.workdir
   }
 
   async run(spec: ShellExecSpec): Promise<ShellRunResult> {
@@ -212,9 +267,10 @@ export class MirageShellExecutor extends ShellExecutor {
     }
     spec.signal?.addEventListener('abort', onAbort, { once: true })
     try {
+      await this.ensureSession()
       const result = await this.workspace.execute(
         spec.command,
-        executeOptions(spec, controller.signal),
+        executeOptions(spec, controller.signal, this.sessionId, this.workdir),
       )
       return {
         exitCode: result.exitCode,
@@ -259,8 +315,13 @@ export class MirageShellExecutor extends ShellExecutor {
       controller.abort()
     }
     spec.signal?.addEventListener('abort', onAbort, { once: true })
-    const run = this.workspace
-      .execute(spec.command, executeOptions(spec, controller.signal))
+    const run = this.ensureSession()
+      .then(() =>
+        this.workspace.execute(
+          spec.command,
+          executeOptions(spec, controller.signal, this.sessionId, this.workdir),
+        ),
+      )
       .finally(() => spec.signal?.removeEventListener('abort', onAbort))
     return new MirageShellProcess(run, controller, spec.stdoutMaxBytes, this.stderrMaxBytes)
   }


### PR DESCRIPTION
By default every `run()`/`start()` executes in an ephemeral fork of the workspace's default session, matching the one-shot contract of dsh's bash tool. That isolation used to hinge on the spec carrying a non-empty workdir; a spec with `workdir: ''` silently landed in the shared default session. The fork is now unconditional.

New `MirageShellConfig.sessionId` binds all commands to one named workspace session instead: `cd`, `export`, and function definitions persist across calls, the persistent-shell contract. The session is created lazily on first use (adopting an existing one as is), `workdir` seeds a created session's initial cwd, and a spec carrying an explicit `workdir` or `env` runs as a one-call subshell of the bound session, per `ExecuteOptions` semantics.

Known limitation, left for a separate fix: nested evals ($(), backticks, `eval`) re-enter execute without the caller's session and resolve against the default session, in both languages. The binding tests here avoid nested evals for that reason.