### PR TITLE
fix(shell): don't unescape an already-expanded word in classification

### DIFF
--- a/integ/unix/sym/verbatim.json
+++ b/integ/unix/sym/verbatim.json
@@ -27,7 +27,7 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "mkdir -p /data/symv",
+      "command": "mkdir -p /data/symv && echo alpha > /data/symv/t.txt",
       "expect": {
         "exit": 0,
         "stdout": "",

--- a/integ/unix/sym/verbatim.json
+++ b/integ/unix/sym/verbatim.json
@@ -1,0 +1,208 @@
+{
+  "cases": [
+    {
+      "id": "symv_setup",
+      "seq": 820,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/symv",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symv_ln_control_char_target",
+      "seq": 821,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "ln -s \"$(printf '/data/symv/x\\ty')\" /data/symv/tab && readlink /data/symv/tab",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/symv/x\ty\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symv_ln_literal_backslash_target",
+      "seq": 822,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "ln -s '/data/symv/a\\b' /data/symv/bs && readlink /data/symv/bs",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/symv/a\\b\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symv_ln_escaped_space_target",
+      "seq": 823,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "ln -s /data/symv/two\\ words /data/symv/sp && readlink /data/symv/sp",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/symv/two words\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symv_printf_path_shaped_format",
+      "seq": 824,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf '/data/symv/x\\ty\\n'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/symv/x\ty\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "symv_cleanup",
+      "seq": 825,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "rm /data/symv/tab /data/symv/bs /data/symv/sp && rm -r /data/symv",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/python/mirage/core/hf_buckets/mkdir.py
+++ b/python/mirage/core/hf_buckets/mkdir.py
@@ -21,5 +21,11 @@ async def mkdir(accessor: HfBucketsAccessor,
                 path: PathSpec,
                 parents: bool = False,
                 index: IndexCacheStore = NULL_INDEX) -> None:
-    # Object stores don't have real directories; mkdir is a no-op.
+    # Not "object stores have no directories": s3 and gridfs are object
+    # stores too and both put a zero-byte `key/` marker, which is what
+    # keeps an empty directory visible there. OpenDAL's hf service cannot
+    # store one and refuses client-side, before any request is sent:
+    # create_dir is unsupported, and a write to a slash-terminated path
+    # is IsADirectory. So an hf directory exists only while it holds a
+    # key, and `mkdir x` then `rmdir x` is ENOENT here but fine on s3.
     return None

--- a/python/mirage/workspace/expand/classify/heuristic.py
+++ b/python/mirage/workspace/expand/classify/heuristic.py
@@ -14,7 +14,6 @@
 
 import posixpath
 import re
-import shlex
 
 from mirage.types import PathSpec
 from mirage.utils.glob_walk import has_glob
@@ -28,28 +27,15 @@ _RELATIVE_PATH = re.compile(
     r"(?:\.?[a-zA-Z0-9_\-]*/)*[a-zA-Z0-9_\-]+\.[a-zA-Z0-9]+")
 
 
-def _unescape_path(word: str) -> str:
-    """Strip shell backslash escapes from a path string.
-
-    Uses shlex.split which handles all POSIX shell escaping rules:
-        Zecheng\\'s\\ Server  ->  Zecheng's Server
-        hello\\ world         ->  hello world
-
-    Args:
-        word (str): raw path string possibly containing backslash escapes.
-    """
-    if "\\" not in word:
-        return word
-    try:
-        parts = shlex.split(word)
-        return parts[0] if parts else word
-    except ValueError:
-        return word
-
-
 def classify_word(word: str, registry: MountRegistry,
                   cwd: str) -> str | PathSpec:
     """Classify an expanded word as text or PathSpec.
+
+    Every caller hands this an already-expanded word, so quote removal
+    has happened and a surviving backslash is a literal character of the
+    name (GNU reads a file named ``a\\b`` as ``cat '/data/a\\b'``).
+    Unescaping again here corrupted both that name and any control
+    character an escape had produced.
 
     Rules:
     - Absolute + glob chars -> PathSpec with pattern
@@ -61,11 +47,6 @@ def classify_word(word: str, registry: MountRegistry,
     word_has_glob = has_glob(word)
 
     if word.startswith("/"):
-        # Unescape backslash-escaped paths (e.g. /data/Zecheng\'s\ Server).
-        # Only for absolute paths — non-path text like sed programs
-        # (N;s/\n/ /) also contains \ and / but must not be unescaped.
-        if "\\" in word:
-            word = _unescape_path(word)
         try:
             mount = registry.mount_for(word)
         except ValueError:
@@ -120,8 +101,6 @@ def classify_word(word: str, registry: MountRegistry,
     #   for f in file.txt  (loop value — should stay text)
     # Users must use "./file.txt" or absolute paths for bare filenames.
     if not word_has_glob and "/" in word and _RELATIVE_PATH.fullmatch(word):
-        if "\\" in word:
-            word = _unescape_path(word)
         return relative_spec(word, registry, cwd)
 
     return word

--- a/python/tests/commands/native/test_ln.py
+++ b/python/tests/commands/native/test_ln.py
@@ -33,3 +33,15 @@ def test_ln_n(env):
     result = env.mirage(
         "ln -s -n /data/a.txt /data/link.txt && readlink /data/link.txt")
     assert "/data/a.txt" in result
+
+
+def test_ln_s_keeps_control_char_in_target(env):
+    # A symlink target is stored verbatim as typed. GNU: readlink of a
+    # link made from `printf '/data/x\ty'` prints the tab back.
+    env.mirage(r"""ln -s "$(printf '/data/x\ty')" /data/tabby""")
+    assert env.mirage("readlink /data/tabby") == "/data/x\ty\n"
+
+
+def test_ln_s_keeps_literal_backslash_in_target(env):
+    env.mirage(r"""ln -s '/data/a\b' /data/bs""")
+    assert env.mirage("readlink /data/bs") == "/data/a\\b\n"

--- a/python/tests/shell/test_quoting_coverage.py
+++ b/python/tests/shell/test_quoting_coverage.py
@@ -614,3 +614,36 @@ def test_empty_element_splat_is_still_a_word(line, expected):
     ws = _ws_with_paths()
     io = _exec(ws, line)
     assert _stdout(io) == expected
+
+
+# ── literal backslashes survive classification ─────────────
+# Quote removal happens once, in the expansion layer. A backslash that
+# survives it is a literal character of the name, so classifying a word
+# as a path must not run a second pass over it. Pinned against GNU
+# coreutils 9.7 / bash 5.2 on debian:stable-slim.
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        # printf's own format is path-shaped; a second unescape pass ate
+        # the backslash, so the escape never reached printf.
+        (r"""printf '/data/x\ty'""", b"/data/x\ty"),
+        (r"""printf '/data/x\ny'""", b"/data/x\ny"),
+        # A single-quoted backslash is literal to the shell either way.
+        (r"""echo '/data/a\b'""", b"/data/a\\b\n"),
+        (r"""echo "/data/a\\b" """, b"/data/a\\b\n"),
+        # ...while an unquoted escape is removed exactly once.
+        (r"""echo /data/hello\ world""", b"/data/hello world\n"),
+        (r"""echo /data/Zecheng\'s\ Server""", b"/data/Zecheng's Server\n"),
+    ])
+def test_backslash_in_path_shaped_word(line, expected):
+    ws = _ws_with_paths()
+    io = _exec(ws, line)
+    assert _stdout(io) == expected
+
+
+def test_control_char_survives_command_substitution():
+    ws = _ws_with_paths()
+    io = _exec(ws, r"""echo "$(printf '/data/x\ty')" """)
+    assert _stdout(io) == b"/data/x\ty\n"

--- a/python/tests/workspace/expand/classify/test_heuristic.py
+++ b/python/tests/workspace/expand/classify/test_heuristic.py
@@ -14,29 +14,36 @@
 
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode, PathSpec
-from mirage.workspace.expand.classify.heuristic import (_unescape_path,
-                                                        classify_word)
+from mirage.workspace.expand.classify.heuristic import classify_word
 from mirage.workspace.mount import MountRegistry
 
 
-def test_unescape_backslash_apostrophe():
-    assert _unescape_path(r"Zecheng\'s\ Server") == "Zecheng's Server"
-
-
-def test_unescape_no_backslash():
-    assert _unescape_path("normal") == "normal"
-
-
-def test_unescape_only_space():
-    assert _unescape_path(r"hello\ world") == "hello world"
-
-
-def test_classify_backslash_escaped_absolute():
+def _ram_registry() -> MountRegistry:
     registry = MountRegistry()
     resource = RAMResource()
     resource._store.dirs.add("/")
     registry.mount("/ram/", resource, MountMode.WRITE)
-    result = classify_word(r"/ram/Zecheng\'s\ Server/", registry, "/")
+    return registry
+
+
+# Quote removal is the expansion layer's job and it happens once, so a
+# backslash reaching classification is a literal character of the name.
+# GNU keeps it: a file named `a\b` is read by `cat '/data/a\b'`.
+def test_classify_keeps_literal_backslash():
+    result = classify_word(r"/ram/a\b", _ram_registry(), "/")
+    assert isinstance(result, PathSpec)
+    assert result.virtual == r"/ram/a\b"
+    assert result.raw_path == r"/ram/a\b"
+
+
+def test_classify_keeps_control_char():
+    result = classify_word("/ram/x\ty", _ram_registry(), "/")
+    assert isinstance(result, PathSpec)
+    assert result.virtual == "/ram/x\ty"
+
+
+def test_classify_already_unescaped_absolute():
+    result = classify_word("/ram/Zecheng's Server/", _ram_registry(), "/")
     assert isinstance(result, PathSpec)
     assert result.virtual == "/ram/Zecheng's Server"
 

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -742,7 +742,6 @@ export {
   type ExecuteFn,
   lookupVar,
   type TSNodeLike,
-  unescapePath,
 } from './workspace/expand/index.ts'
 export { resolveGlobs, type ResourceWithGlob } from './workspace/expand/globs.ts'
 export {

--- a/typescript/packages/core/src/workspace/expand/classify/heuristic.test.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/heuristic.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest'
 import type { Resource } from '../../../resource/base.ts'
 import { MountMode, PathSpec } from '../../../types.ts'
 import { MountRegistry } from '../../mount/registry.ts'
-import { classifyWord, unescapePath } from './heuristic.ts'
+import { classifyWord } from './heuristic.ts'
 
 class StubResource implements Resource {
   readonly kind = 'stub'
@@ -32,13 +32,27 @@ function setup(): MountRegistry {
   return new MountRegistry({ '/ram': new StubResource() }, MountMode.WRITE)
 }
 
-describe('unescapePath', () => {
-  it('strips backslash escapes from paths', () => {
-    expect(unescapePath("Zecheng\\'s\\ Server")).toBe("Zecheng's Server")
+// Quote removal is the expansion layer's job and it happens once, so a
+// backslash reaching classification is a literal character of the name.
+// GNU keeps it: a file named `a\b` is read by `cat '/data/a\b'`.
+describe('classifyWord — backslashes are literal', () => {
+  it('keeps a literal backslash in an absolute path', () => {
+    const r = classifyWord('/ram/a\\b', setup(), '/')
+    if (!(r instanceof PathSpec)) throw new Error('expected PathSpec')
+    expect(r.virtual).toBe('/ram/a\\b')
+    expect(r.rawPath).toBe('/ram/a\\b')
   })
 
-  it('leaves unescaped strings untouched', () => {
-    expect(unescapePath('/a/b/c')).toBe('/a/b/c')
+  it('keeps a control character in an absolute path', () => {
+    const r = classifyWord('/ram/x\ty', setup(), '/')
+    if (!(r instanceof PathSpec)) throw new Error('expected PathSpec')
+    expect(r.virtual).toBe('/ram/x\ty')
+  })
+
+  it('classifies an already-unescaped name', () => {
+    const r = classifyWord("/ram/Zecheng's Server/", setup(), '/')
+    if (!(r instanceof PathSpec)) throw new Error('expected PathSpec')
+    expect(r.virtual).toBe("/ram/Zecheng's Server")
   })
 })
 

--- a/typescript/packages/core/src/workspace/expand/classify/heuristic.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/heuristic.ts
@@ -15,7 +15,6 @@
 import { PathSpec } from '../../../types.ts'
 import type { MountRegistry } from '../../mount/registry.ts'
 import { posixNormpath } from '../../../utils/path.ts'
-import { shlexSplit } from '../../../utils/shlex.ts'
 import { stripSlash } from '../../../utils/slash.ts'
 import { hasGlob } from '../../../utils/glob_walk.ts'
 import { relativeSpec } from './relative.ts'
@@ -24,12 +23,11 @@ const FILENAME_CHAR = /[a-zA-Z0-9_./]/
 const NON_PATH_CHAR = /[(){}=;|&<> ]/
 const RELATIVE_PATH = /^(?:\.?[a-zA-Z0-9_-]*\/)*[a-zA-Z0-9_-]+\.[a-zA-Z0-9]+$/
 
-export function unescapePath(word: string): string {
-  if (!word.includes('\\')) return word
-  const parts = shlexSplit(word)
-  return parts[0] ?? word
-}
-
+// Every caller hands this an already-expanded word, so quote removal has
+// happened and a surviving backslash is a literal character of the name
+// (GNU reads a file named `a\b` as `cat '/data/a\b'`). Unescaping again
+// here corrupted both that name and any control character an escape had
+// produced.
 export function classifyWord(
   word: string,
   registry: MountRegistry,
@@ -38,12 +36,10 @@ export function classifyWord(
   const wordHasGlob = hasGlob(word)
 
   if (word.startsWith('/')) {
-    let w = word
-    if (w.includes('\\')) w = unescapePath(w)
-    const mount = registry.mountFor(w)
+    const mount = registry.mountFor(word)
     if (mount === null) return word
-    let isDir = w.endsWith('/')
-    const path = posixNormpath(w)
+    let isDir = word.endsWith('/')
+    const path = posixNormpath(word)
     if (!isDir && `${path}/` === mount.prefix) {
       isDir = true
     }
@@ -57,7 +53,7 @@ export function classifyWord(
         virtual: path,
         directory: path.slice(0, lastSlash + 1),
         pattern: path.slice(lastSlash + 1),
-        rawPath: w,
+        rawPath: word,
         resolved: false,
       })
     }
@@ -66,7 +62,7 @@ export function classifyWord(
         resourcePath: stripSlash(path),
         virtual: path,
         directory: `${path}/`,
-        rawPath: w,
+        rawPath: word,
         resolved: false,
       })
     }
@@ -75,7 +71,7 @@ export function classifyWord(
       resourcePath: stripSlash(path),
       virtual: path,
       directory: path.slice(0, lastSlash + 1),
-      rawPath: w,
+      rawPath: word,
       resolved: true,
     })
   }
@@ -88,9 +84,7 @@ export function classifyWord(
   }
 
   if (!wordHasGlob && word.includes('/') && RELATIVE_PATH.test(word)) {
-    let w = word
-    if (w.includes('\\')) w = unescapePath(w)
-    return relativeSpec(w, registry, cwd)
+    return relativeSpec(word, registry, cwd)
   }
 
   return word

--- a/typescript/packages/core/src/workspace/expand/classify/index.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/index.ts
@@ -12,6 +12,6 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export { classifyWord, unescapePath } from './heuristic.ts'
+export { classifyWord } from './heuristic.ts'
 export { classifyParts } from './parts.ts'
 export { classifyBarePath } from './path.ts'

--- a/typescript/packages/core/src/workspace/expand/index.ts
+++ b/typescript/packages/core/src/workspace/expand/index.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 export { ARITH_DELIMITERS, ARITH_OPERATORS } from './constants.ts'
-export { classifyBarePath, classifyParts, classifyWord, unescapePath } from './classify/index.ts'
+export { classifyBarePath, classifyParts, classifyWord } from './classify/index.ts'
 export { type ExecuteFn, expandNode } from './node.ts'
 export { expandAndClassify, expandParts } from './parts.ts'
 export { expandBraces, lookupVar } from './variable.ts'

--- a/typescript/packages/node/src/commands/native_ln.test.ts
+++ b/typescript/packages/node/src/commands/native_ln.test.ts
@@ -55,4 +55,26 @@ describe.each(NATIVE_BACKENDS)('native ln (%s backend)', (kind) => {
       await env.cleanup()
     }
   })
+
+  // A symlink target is stored verbatim as typed. GNU: readlink of a link
+  // made from `printf '/data/x\ty'` prints the tab back.
+  it('ln -s keeps a control character in the target', async () => {
+    const env = makeEnv(kind)
+    try {
+      await env.mirage(`ln -s "$(printf '/data/x\\ty')" /data/tabby`)
+      expect(await env.mirage('readlink /data/tabby')).toBe('/data/x\ty\n')
+    } finally {
+      await env.cleanup()
+    }
+  })
+
+  it('ln -s keeps a literal backslash in the target', async () => {
+    const env = makeEnv(kind)
+    try {
+      await env.mirage(`ln -s '/data/a\\b' /data/bs`)
+      expect(await env.mirage('readlink /data/bs')).toBe('/data/a\\b\n')
+    } finally {
+      await env.cleanup()
+    }
+  })
 })

--- a/typescript/packages/node/src/core/hf/mkdir.ts
+++ b/typescript/packages/node/src/core/hf/mkdir.ts
@@ -20,5 +20,11 @@ export async function mkdir(
   _path: PathSpec,
   _index?: IndexCacheStore,
 ): Promise<void> {
-  // Object stores don't have real directories; mkdir is a no-op.
+  // Not "object stores have no directories": s3 and gridfs are object
+  // stores too and both put a zero-byte `key/` marker, which is what keeps
+  // an empty directory visible there. OpenDAL's hf service cannot store one
+  // and refuses client-side, before any request is sent: create_dir is
+  // unsupported, and a write to a slash-terminated path is IsADirectory. So
+  // an hf directory exists only while it holds a key, and `mkdir x` then
+  // `rmdir x` is ENOENT here but fine on s3.
 }


### PR DESCRIPTION
## Summary

`ln -s "$(printf '/data/x\ty')" /data/tabby` stored a target with no tab.

`classify_word` / `classifyWord` ran a second POSIX quote-removal pass (`shlex.split`) over words the expansion layer had already unquoted. A backslash surviving expansion is a literal name character, so the pass corrupted it. `printf`'s format arg is path-shaped, so the tab was destroyed before printf ran.

`ln` and the namespace symlink write are innocent; both store verbatim.

- delete `_unescape_path` / `unescapePath` and both call sites, py + ts
- the relative-branch call site was unreachable (`_RELATIVE_PATH` admits no backslash)
- side effect: a file named `a\b` is addressable for the first time, matching GNU

## Test plan

- pinned against GNU coreutils 9.7 in docker `debian:stable-slim`
- unit: `test_heuristic.py` / `heuristic.test.ts` (the old tests pinned the bug), `test_quoting_coverage.py`, `test_ln.py`, `native_ln.test.ts`
- integ: new `integ/unix/sym/verbatim.json`, seq 820-825
- full py suite, all 8 ts packages, integ both hosts, pre-commit: green
- reverted just the two source files to confirm 3 of 5 new integ cases fail identically on both hosts