### PR TITLE
feat(dsh): ship the package as a dsh bundle with declarative mounts

### DIFF
--- a/docs/typescript/agents/dsh.mdx
+++ b/docs/typescript/agents/dsh.mdx
@@ -67,6 +67,32 @@ const script = await shell.run(
 
 [`examples/typescript/dsh/dsh.ts`](https://github.com/strukto-ai/mirage/blob/main/examples/typescript/dsh/dsh.ts) is the runnable version of this whole page, with the script in [`example.py`](https://github.com/strukto-ai/mirage/blob/main/examples/typescript/dsh/example.py).
 
+## Install into a dsh profile
+
+The package is also a dsh bundle: its manifest carries a patch layer that swaps dsh's filesystem and bash providers for the mirage ones and disables the host-subprocess surfaces the workspace does not contain (PowerShell, the ripgrep search tool). Stock dsh, including its web app, then runs on mounted data:
+
+```bash
+dsh plugin --profile web add @struktoai/mirage-dsh
+dsh --profile web
+```
+
+The bundle's default world is one RAM scratch mount at `/tmp`. Mount real resources by overriding the `mirage` row in the profile's own `cordis.patch.yml`, in declarative form (the resource registry name, a mode, and the resource's config; `!!js` expressions resolve at mount time):
+
+```yaml
+- id: mirage
+  config:
+    mounts:
+      /tmp: { resource: ram, mode: exec }
+      /slack:
+        resource: slack
+        mode: read
+        config: { token: !!js process.env.SLACK_BOT_TOKEN }
+    runtimes:
+      - { name: monty, captures: [python, python3] }
+```
+
+The same blocks work in code, beside live instances, in `MirageService`'s `mounts`. The shell executor reports `workspace-write` confinement, since a command cannot reach anything but the mounts, which is what lets dsh's permission presets compose over it.
+
 A concrete scenario: serving agents from a TypeScript server (an Express endpoint, say), where every request is assigned its own context and workspace, created on entry and gone with the response. What one 2 vCPU / 8 GB box holds then depends on the harness:
 
 | Harness | Startup | Est. concurrent sessions (2 vCPU / 8 GB) |

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export {
   type NativeMove,
   OnExceed,
   OverflowPolicy,
+  parseMountMode,
   PathSpec,
   type PathSpecInit,
   type PolymorphicReadFn,

--- a/typescript/packages/core/src/runtime/base.ts
+++ b/typescript/packages/core/src/runtime/base.ts
@@ -41,6 +41,15 @@ import type { RuntimeOptions } from './types.ts'
 export abstract class Runtime {
   abstract readonly name: string
   readonly captures: readonly string[]
+  /**
+   * Whether every effect of code this runtime executes lands inside the
+   * workspace. The bridged engines (monty, pyodide, quickjs) and the vfs
+   * routing marker declare true: their I/O rides the VFS bridge or the
+   * workspace executor itself. False by default and for anything that
+   * executes elsewhere — the host `local` python, a RemoteSandbox — so a
+   * custom runtime must declare confinement rather than inherit it.
+   */
+  readonly confined: boolean = false
   /** The runtime's coerced implementation knobs. */
   config: RuntimeConfig
   script?: PolicyScript

--- a/typescript/packages/core/src/runtime/js/quickjs.ts
+++ b/typescript/packages/core/src/runtime/js/quickjs.ts
@@ -161,6 +161,7 @@ globalThis.std = {
 // matching the Python runtime's live file I/O.
 export class QuickJsRuntime extends JsRuntime implements Evaluator {
   readonly name = 'quickjs'
+  override readonly confined = true
   readonly [EVALUATOR] = true as const
   private newAsyncModule: NewAsyncModule | null = null
   private workspaceBridge: BridgeDispatchFn | null = null

--- a/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
@@ -502,6 +502,7 @@ describe('monty unavailable', () => {
       name: 'monty',
       captures: ['python3', 'python'],
       language: 'python' as const,
+      confined: true,
       config: {},
       attach: () => undefined,
       run: () => Promise.reject(new MontyUnavailableError('install @pydantic/monty')),

--- a/typescript/packages/core/src/runtime/python/monty/runtime.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.ts
@@ -95,6 +95,7 @@ function toEvalValue(value: unknown): EvalValue {
  */
 export class MontyRuntime extends PythonRuntime implements Evaluator {
   readonly name = 'monty'
+  override readonly confined = true
   // No import system to resolve a module with, so `-m` has nothing to
   // run; the refusal names this runtime rather than inventing a
   // "No module named" that would imply a search happened.

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -257,6 +257,7 @@ const EVAL_INTERRUPT_SECONDS = 10
 
 export class PyodideRuntime extends PythonRuntime implements Evaluator {
   readonly name = 'pyodide'
+  override readonly confined = true
   readonly [EVALUATOR] = true as const
   private pyodide: PyodideInterface | null = null
   private initPromise: Promise<PyodideInterface> | null = null

--- a/typescript/packages/core/src/runtime/table.ts
+++ b/typescript/packages/core/src/runtime/table.ts
@@ -42,6 +42,7 @@ import type { RuntimeOptions } from './types.ts'
  */
 export class VFSRuntime extends Runtime {
   readonly name = 'vfs'
+  override readonly confined = true
   // Declaring captures (even empty) turns the catch-all off; the
   // dispatcher reads this bit, not the array's length.
   readonly restricted: boolean

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -293,6 +293,11 @@ export class Workspace {
     return this.runtimes.add(runtime)
   }
 
+  /** The ordered runtime world, as a read-only view of the live list. */
+  get runtimeEntries(): readonly Runtime[] {
+    return this.runtimes.entries
+  }
+
   /**
    * Install a CLI under a head word, fully separate from mounts. The
    * name is the dispatch key (two installs of one spec under different

--- a/typescript/packages/dsh/cordis.patch.yml
+++ b/typescript/packages/dsh/cordis.patch.yml
@@ -1,0 +1,54 @@
+# The mirage bundle patch. Applied over dsh-base by `dsh --profile <name>`
+# after `dsh plugin --profile <name> add @struktoai/mirage-dsh`: it swaps
+# the filesystem and shell providers for mirage-backed ones, so dsh's file
+# tools and bash tool operate on a workspace of mounted resources instead
+# of the host disk.
+#
+# Override the `mirage` row's config in the profile's own cordis.patch.yml
+# to mount real resources (the block form is `resource` registry name,
+# `mode`, and the resource's `config`; `!!js` expressions resolve env vars
+# at mount time):
+#
+#   - id: mirage
+#     config:
+#       mounts:
+#         /tmp: { resource: ram, mode: exec }
+#         /slack:
+#           resource: slack
+#           mode: read
+#           config: { token: !!js process.env.SLACK_BOT_TOKEN }
+#       runtimes:
+#         - { name: monty, captures: [python, python3] }
+
+# The host filesystem and bash providers step aside; mirage provides the
+# same ctx.fs and ctx.shell seams over the workspace.
+- id: fs-sandbox
+  disabled: true
+
+- id: bash-sandbox
+  disabled: true
+
+# PowerShell and the ripgrep-based search tool run host subprocesses,
+# which the mirage world does not contain; the bash tool's grep covers
+# search inside the workspace.
+- id: pwsh-sandbox
+  disabled: true
+
+- id: tool-pwsh
+  disabled: true
+
+- id: tool-fs-search
+  disabled: true
+
+- insert:
+    - id: mirage
+      name: '@struktoai/mirage-dsh/service'
+      config:
+        mounts:
+          /tmp: { resource: ram, mode: exec }
+
+    - id: mirage-fs
+      name: '@struktoai/mirage-dsh/fs'
+
+    - id: mirage-shell
+      name: '@struktoai/mirage-dsh/shell'

--- a/typescript/packages/dsh/package.json
+++ b/typescript/packages/dsh/package.json
@@ -23,10 +23,28 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./service": {
+      "types": "./dist/plugin/service.d.ts",
+      "import": "./dist/plugin/service.js"
+    },
+    "./fs": {
+      "types": "./dist/plugin/fs.d.ts",
+      "import": "./dist/plugin/fs.js"
+    },
+    "./shell": {
+      "types": "./dist/plugin/shell.d.ts",
+      "import": "./dist/plugin/shell.js"
+    }
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "cordis.patch.yml"
   ],
   "scripts": {
     "build": "tsup",

--- a/typescript/packages/dsh/src/fs.test.ts
+++ b/typescript/packages/dsh/src/fs.test.ts
@@ -14,10 +14,10 @@
 
 import { afterEach, describe, expect, it } from 'vitest'
 import { Context } from '@deepseek-ai/cordis'
-import { FsError, FsVersion } from '@deepseek-ai/dsh-fs'
+import { FsError, FsTargetKey, FsVersion } from '@deepseek-ai/dsh-fs'
 import type { FsErrorCode } from '@deepseek-ai/dsh-fs'
 import { MountMode, RAMResource } from '@struktoai/mirage-core'
-import { Workspace } from '@struktoai/mirage-node'
+import { registerResourceFactory, Workspace } from '@struktoai/mirage-node'
 import { MirageFileSystem } from './fs.ts'
 import type { MirageFsConfig } from './fs.ts'
 import { MirageService } from './service.ts'
@@ -353,5 +353,38 @@ describe('editText', () => {
     expect(
       await errorCode(fs.editText(missing, { oldString: 'a', newString: 'b', replaceAll: false })),
     ).toBe('FS_STALE_VERSION')
+  })
+})
+
+describe('cancellation across readiness', () => {
+  it('refuses to dispatch a write whose signal fired during the ready wait', async () => {
+    // The executor runs synchronously, so release is assigned by here.
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    registerResourceFactory('gated-ram-write', async () => {
+      await gate
+      return new RAMResource()
+    })
+    const ctx = new Context()
+    const fiber = ctx.plugin(MirageService, {
+      mounts: { '/data': { resource: 'gated-ram-write', mode: 'write' } },
+    })
+    await fiber.await()
+    await ctx.plugin(MirageFileSystem, {}).await()
+    const fs = ctx.fs as MirageFileSystem
+    const controller = new AbortController()
+    const target = { targetKey: FsTargetKey('/data/out.txt'), displayPath: '/data/out.txt' }
+    const pending = fs.writeText(target, 'late', undefined, controller.signal)
+    // One macrotask parks the write on the gated ready, past its entry
+    // assertion; the abort then fires inside the wait window.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    controller.abort()
+    release()
+    expect(await errorCode(pending)).toBe('FS_ABORTED')
+    const ws = await ctx.mirage.ready
+    expect(await ws.fs.exists('/data/out.txt')).toBe(false)
+    await fiber.dispose()
   })
 })

--- a/typescript/packages/dsh/src/fs.ts
+++ b/typescript/packages/dsh/src/fs.ts
@@ -89,7 +89,7 @@ async function* singleChunk(text: string): AsyncGenerator<string, void, void> {
 export class MirageFileSystem extends FileSystem {
   static readonly inject = ['mirage']
 
-  private readonly fsOps: Ops
+  private fsOps: Ops | null = null
   private readonly cwd: string
   private readonly diffBasisMaxBytes: number
   // Per-targetKey tail promise: serializes mutating ops so the
@@ -99,12 +99,22 @@ export class MirageFileSystem extends FileSystem {
 
   constructor(ctx: Context, config: MirageFsConfig = {}) {
     super(ctx)
-    this.fsOps = ctx.mirage.workspace.fs
     this.cwd = config.cwd ?? '/'
     this.diffBasisMaxBytes = config.diffBasisMaxBytes ?? DEFAULT_DIFF_BASIS_MAX_BYTES
   }
 
+  // The workspace may still be building (declarative mounts resolve
+  // asynchronously), so every entry point awaits the service's `ready`
+  // once and caches the op door.
+  private async ops(): Promise<Ops> {
+    this.fsOps ??= (await this.ctx.mirage.ready).fs
+    return this.fsOps
+  }
+
   private get links(): LinksSeam | null {
+    if (this.fsOps === null) {
+      throw new Error('mirage: filesystem used before the workspace is ready')
+    }
     return this.fsOps.links
   }
 
@@ -139,10 +149,11 @@ export class MirageFileSystem extends FileSystem {
     return next
   }
 
-  resolve(path: string, opts?: { cwd?: string; signal?: AbortSignal }): Promise<FsTarget> {
+  async resolve(path: string, opts?: { cwd?: string; signal?: AbortSignal }): Promise<FsTarget> {
     assertNotAborted(opts?.signal, 'resolve')
+    await this.ops()
     const followed = this.follow(this.normalize(path, opts?.cwd))
-    return Promise.resolve({ targetKey: FsTargetKey(followed), displayPath: followed })
+    return { targetKey: FsTargetKey(followed), displayPath: followed }
   }
 
   processPath(target: FsTarget): string {
@@ -167,7 +178,7 @@ export class MirageFileSystem extends FileSystem {
     const key = String(target.targetKey)
     let stat: FileStat
     try {
-      stat = await this.fsOps.stat(key)
+      stat = await (await this.ops()).stat(key)
     } catch (err) {
       if (isMissingPath(err)) return undefined
       throw mapMirageError(err, 'stat', target.displayPath)
@@ -185,6 +196,7 @@ export class MirageFileSystem extends FileSystem {
     signal?: AbortSignal,
   ): Promise<FsPathInfo | undefined> {
     assertNotAborted(signal, 'lstat')
+    await this.ops()
     const normalized = this.normalize(path, opts?.cwd)
     // Follow every component except the last: the probe is about the path
     // entry itself, so a link at the leaf must report as one.
@@ -203,7 +215,7 @@ export class MirageFileSystem extends FileSystem {
     }
     let stat: FileStat
     try {
-      stat = await this.fsOps.stat(parentFollowed)
+      stat = await (await this.ops()).stat(parentFollowed)
     } catch (err) {
       if (isMissingPath(err)) return undefined
       throw mapMirageError(err, 'lstat', normalized)
@@ -220,7 +232,7 @@ export class MirageFileSystem extends FileSystem {
     const key = String(target.targetKey)
     let bytes: Uint8Array
     try {
-      bytes = await this.fsOps.readFile(key)
+      bytes = await (await this.ops()).readFile(key)
     } catch (err) {
       throw mapMirageError(err, 'read', target.displayPath)
     }
@@ -249,7 +261,7 @@ export class MirageFileSystem extends FileSystem {
     }
     let children: string[]
     try {
-      children = await this.fsOps.readdir(key)
+      children = await (await this.ops()).readdir(key)
     } catch (err) {
       throw mapMirageError(err, 'list', target.displayPath)
     }
@@ -292,7 +304,7 @@ export class MirageFileSystem extends FileSystem {
     const target: FsTarget = { targetKey: FsTargetKey(followed), displayPath: childPath }
     let stat: FileStat
     try {
-      stat = await this.fsOps.stat(followed)
+      stat = await (await this.ops()).stat(followed)
     } catch {
       // A child the listing named but stat cannot classify (a broken link,
       // a race with a delete) still lists, as an entry of unknown kind.
@@ -340,7 +352,9 @@ export class MirageFileSystem extends FileSystem {
       const before = existing === undefined ? null : await this.diffBasis(target, content)
       const crlf = before !== null && detectsCrlf(before)
       try {
-        await this.fsOps.writeFile(key, restoreLineEndings(normalizeLineEndings(content), crlf))
+        await (
+          await this.ops()
+        ).writeFile(key, restoreLineEndings(normalizeLineEndings(content), crlf))
       } catch (err) {
         throw mapMirageError(err, 'write', target.displayPath)
       }
@@ -360,7 +374,7 @@ export class MirageFileSystem extends FileSystem {
     if (Buffer.byteLength(content, 'utf8') >= this.diffBasisMaxBytes) return null
     let bytes: Uint8Array
     try {
-      bytes = await this.fsOps.readFile(String(target.targetKey))
+      bytes = await (await this.ops()).readFile(String(target.targetKey))
     } catch {
       return null
     }
@@ -409,7 +423,7 @@ export class MirageFileSystem extends FileSystem {
       }
       let bytes: Uint8Array
       try {
-        bytes = await this.fsOps.readFile(key)
+        bytes = await (await this.ops()).readFile(key)
       } catch (err) {
         throw mapMirageError(err, 'edit', target.displayPath)
       }
@@ -423,7 +437,7 @@ export class MirageFileSystem extends FileSystem {
         target.displayPath,
       )
       try {
-        await this.fsOps.writeFile(key, restoreLineEndings(edited, detectsCrlf(raw)))
+        await (await this.ops()).writeFile(key, restoreLineEndings(edited, detectsCrlf(raw)))
       } catch (err) {
         throw mapMirageError(err, 'edit', target.displayPath)
       }

--- a/typescript/packages/dsh/src/fs.ts
+++ b/typescript/packages/dsh/src/fs.ts
@@ -105,9 +105,12 @@ export class MirageFileSystem extends FileSystem {
 
   // The workspace may still be building (declarative mounts resolve
   // asynchronously), so every entry point awaits the service's `ready`
-  // once and caches the op door.
-  private async ops(): Promise<Ops> {
+  // once and caches the op door. The caller's signal can fire during
+  // that wait, after its entry assertion passed, so it is asserted
+  // again here, before the op it guards dispatches.
+  private async ops(signal?: AbortSignal, operation = 'ready'): Promise<Ops> {
     this.fsOps ??= (await this.ctx.mirage.ready).fs
+    assertNotAborted(signal, operation)
     return this.fsOps
   }
 
@@ -151,7 +154,7 @@ export class MirageFileSystem extends FileSystem {
 
   async resolve(path: string, opts?: { cwd?: string; signal?: AbortSignal }): Promise<FsTarget> {
     assertNotAborted(opts?.signal, 'resolve')
-    await this.ops()
+    await this.ops(opts?.signal, 'resolve')
     const followed = this.follow(this.normalize(path, opts?.cwd))
     return { targetKey: FsTargetKey(followed), displayPath: followed }
   }
@@ -178,7 +181,7 @@ export class MirageFileSystem extends FileSystem {
     const key = String(target.targetKey)
     let stat: FileStat
     try {
-      stat = await (await this.ops()).stat(key)
+      stat = await (await this.ops(signal, 'stat')).stat(key)
     } catch (err) {
       if (isMissingPath(err)) return undefined
       throw mapMirageError(err, 'stat', target.displayPath)
@@ -196,7 +199,7 @@ export class MirageFileSystem extends FileSystem {
     signal?: AbortSignal,
   ): Promise<FsPathInfo | undefined> {
     assertNotAborted(signal, 'lstat')
-    await this.ops()
+    await this.ops(signal, 'lstat')
     const normalized = this.normalize(path, opts?.cwd)
     // Follow every component except the last: the probe is about the path
     // entry itself, so a link at the leaf must report as one.
@@ -215,7 +218,7 @@ export class MirageFileSystem extends FileSystem {
     }
     let stat: FileStat
     try {
-      stat = await (await this.ops()).stat(parentFollowed)
+      stat = await (await this.ops(signal, 'lstat')).stat(parentFollowed)
     } catch (err) {
       if (isMissingPath(err)) return undefined
       throw mapMirageError(err, 'lstat', normalized)
@@ -232,7 +235,7 @@ export class MirageFileSystem extends FileSystem {
     const key = String(target.targetKey)
     let bytes: Uint8Array
     try {
-      bytes = await (await this.ops()).readFile(key)
+      bytes = await (await this.ops(signal, 'read')).readFile(key)
     } catch (err) {
       throw mapMirageError(err, 'read', target.displayPath)
     }
@@ -261,7 +264,7 @@ export class MirageFileSystem extends FileSystem {
     }
     let children: string[]
     try {
-      children = await (await this.ops()).readdir(key)
+      children = await (await this.ops(signal, 'list')).readdir(key)
     } catch (err) {
       throw mapMirageError(err, 'list', target.displayPath)
     }
@@ -353,7 +356,7 @@ export class MirageFileSystem extends FileSystem {
       const crlf = before !== null && detectsCrlf(before)
       try {
         await (
-          await this.ops()
+          await this.ops(signal, 'write')
         ).writeFile(key, restoreLineEndings(normalizeLineEndings(content), crlf))
       } catch (err) {
         throw mapMirageError(err, 'write', target.displayPath)
@@ -423,7 +426,7 @@ export class MirageFileSystem extends FileSystem {
       }
       let bytes: Uint8Array
       try {
-        bytes = await (await this.ops()).readFile(key)
+        bytes = await (await this.ops(signal, 'edit')).readFile(key)
       } catch (err) {
         throw mapMirageError(err, 'edit', target.displayPath)
       }
@@ -437,7 +440,9 @@ export class MirageFileSystem extends FileSystem {
         target.displayPath,
       )
       try {
-        await (await this.ops()).writeFile(key, restoreLineEndings(edited, detectsCrlf(raw)))
+        await (
+          await this.ops(signal, 'edit')
+        ).writeFile(key, restoreLineEndings(edited, detectsCrlf(raw)))
       } catch (err) {
         throw mapMirageError(err, 'edit', target.displayPath)
       }

--- a/typescript/packages/dsh/src/index.ts
+++ b/typescript/packages/dsh/src/index.ts
@@ -12,6 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export { MirageService, type MirageConfig } from './service.ts'
+export {
+  MirageService,
+  type MirageConfig,
+  type MirageMount,
+  type MirageMountBlock,
+  type MirageRuntimeBlock,
+} from './service.ts'
 export { MirageFileSystem, type MirageFsConfig } from './fs.ts'
 export { MirageShellExecutor, type MirageShellConfig } from './shell.ts'

--- a/typescript/packages/dsh/src/plugin/fs.ts
+++ b/typescript/packages/dsh/src/plugin/fs.ts
@@ -12,18 +12,6 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { defineConfig } from 'tsup'
-
-export default defineConfig({
-  entry: ['src/index.ts', 'src/plugin/service.ts', 'src/plugin/fs.ts', 'src/plugin/shell.ts'],
-  format: ['esm'],
-  dts: {
-    compilerOptions: {
-      ignoreDeprecations: '6.0',
-    },
-  },
-  sourcemap: true,
-  clean: true,
-  target: 'es2022',
-  external: ['@deepseek-ai/cordis', '@deepseek-ai/dsh-fs', '@deepseek-ai/dsh-shell'],
-})
+// The dsh loader entry: a plugin module's default export is what a
+// cordis.patch.yml row's name resolves to.
+export { MirageFileSystem as default } from '../fs.ts'

--- a/typescript/packages/dsh/src/plugin/service.ts
+++ b/typescript/packages/dsh/src/plugin/service.ts
@@ -12,18 +12,6 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { defineConfig } from 'tsup'
-
-export default defineConfig({
-  entry: ['src/index.ts', 'src/plugin/service.ts', 'src/plugin/fs.ts', 'src/plugin/shell.ts'],
-  format: ['esm'],
-  dts: {
-    compilerOptions: {
-      ignoreDeprecations: '6.0',
-    },
-  },
-  sourcemap: true,
-  clean: true,
-  target: 'es2022',
-  external: ['@deepseek-ai/cordis', '@deepseek-ai/dsh-fs', '@deepseek-ai/dsh-shell'],
-})
+// The dsh loader entry: a plugin module's default export is what a
+// cordis.patch.yml row's name resolves to.
+export { MirageService as default } from '../service.ts'

--- a/typescript/packages/dsh/src/plugin/shell.ts
+++ b/typescript/packages/dsh/src/plugin/shell.ts
@@ -12,18 +12,6 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { defineConfig } from 'tsup'
-
-export default defineConfig({
-  entry: ['src/index.ts', 'src/plugin/service.ts', 'src/plugin/fs.ts', 'src/plugin/shell.ts'],
-  format: ['esm'],
-  dts: {
-    compilerOptions: {
-      ignoreDeprecations: '6.0',
-    },
-  },
-  sourcemap: true,
-  clean: true,
-  target: 'es2022',
-  external: ['@deepseek-ai/cordis', '@deepseek-ai/dsh-fs', '@deepseek-ai/dsh-shell'],
-})
+// The dsh loader entry: a plugin module's default export is what a
+// cordis.patch.yml row's name resolves to.
+export { MirageShellExecutor as default } from '../shell.ts'

--- a/typescript/packages/dsh/src/service.test.ts
+++ b/typescript/packages/dsh/src/service.test.ts
@@ -43,6 +43,49 @@ describe('MirageService', () => {
     await expect(ws.resolve('/data/a.txt')).rejects.toThrow('closed')
   })
 
+  it('builds declarative mounts through the resource registry', async () => {
+    const ctx = new Context()
+    const fiber = ctx.plugin(MirageService, {
+      mounts: {
+        '/scratch': { resource: 'ram', mode: 'write' },
+        '/live': [new RAMResource(), MountMode.WRITE],
+      },
+      runtimes: [{ name: 'monty', captures: ['python', 'python3'] }],
+    })
+    await fiber.await()
+    expect(() => ctx.mirage.workspace).toThrow('not ready')
+    const ws = await ctx.mirage.ready
+    expect(ctx.mirage.workspace).toBe(ws)
+    await ws.fs.writeFile('/scratch/a.txt', 'declared')
+    expect(await ws.fs.exists('/scratch/a.txt')).toBe(true)
+    await ws.fs.writeFile('/live/b.txt', 'instance')
+    expect(await ws.fs.exists('/live/b.txt')).toBe(true)
+    await fiber.dispose()
+    await expect(ws.resolve('/scratch/a.txt')).rejects.toThrow('closed')
+  })
+
+  it('rejects an unknown declarative resource name', async () => {
+    const ctx = new Context()
+    const fiber = ctx.plugin(MirageService, {
+      mounts: { '/x': { resource: 'no-such-backend' } },
+    })
+    await fiber.await()
+    await expect(ctx.mirage.ready).rejects.toThrow('unknown resource')
+  })
+
+  it('refuses runtimes in both config keys', async () => {
+    const ctx = new Context()
+    await expect(
+      ctx
+        .plugin(MirageService, {
+          mounts: { '/x': new RAMResource() },
+          runtimes: ['monty'],
+          workspaceOptions: { runtimes: ['monty'] },
+        })
+        .await(),
+    ).rejects.toThrow('not both')
+  })
+
   it('refuses both and neither of workspace/mounts', async () => {
     const ws = new Workspace({ '/data': new RAMResource() })
     const ctx = new Context()

--- a/typescript/packages/dsh/src/service.test.ts
+++ b/typescript/packages/dsh/src/service.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from 'vitest'
 import { Context } from '@deepseek-ai/cordis'
 import { MountMode, RAMResource } from '@struktoai/mirage-core'
-import { Workspace } from '@struktoai/mirage-node'
+import { LocalRuntime, registerResourceFactory, Workspace } from '@struktoai/mirage-node'
 import { MirageService } from './service.ts'
 
 describe('MirageService', () => {
@@ -84,6 +84,40 @@ describe('MirageService', () => {
         })
         .await(),
     ).rejects.toThrow('not both')
+  })
+
+  it('reads confinement live off an adopted workspace', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    const ctx = new Context()
+    await ctx.plugin(MirageService, { workspace: ws }).await()
+    expect(ctx.mirage.confined).toBe(true)
+    ws.addRuntime(new LocalRuntime({ captures: ['python'] }))
+    expect(ctx.mirage.confined).toBe(false)
+    await ws.close()
+  })
+
+  it('classifies declared runtimes before the mounts resolve', async () => {
+    // The executor runs synchronously, so release is assigned by here.
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    registerResourceFactory('gated-ram', async () => {
+      await gate
+      return new RAMResource()
+    })
+    const ctx = new Context()
+    const fiber = ctx.plugin(MirageService, {
+      mounts: { '/scratch': { resource: 'gated-ram' } },
+      runtimes: ['local'],
+    })
+    await fiber.await()
+    expect(() => ctx.mirage.workspace).toThrow('not ready')
+    expect(ctx.mirage.confined).toBe(false)
+    release()
+    await ctx.mirage.ready
+    expect(ctx.mirage.confined).toBe(false)
+    await fiber.dispose()
   })
 
   it('refuses both and neither of workspace/mounts', async () => {

--- a/typescript/packages/dsh/src/service.ts
+++ b/typescript/packages/dsh/src/service.ts
@@ -14,14 +14,42 @@
 
 import { Service } from '@deepseek-ai/cordis'
 import type { Context } from '@deepseek-ai/cordis'
-import type { MountSpec } from '@struktoai/mirage-core'
-import { Workspace } from '@struktoai/mirage-node'
+import type { MountSpec, RuntimeEntry } from '@struktoai/mirage-core'
+import { buildRuntime, parseMountMode } from '@struktoai/mirage-core'
+import { buildResource, Workspace } from '@struktoai/mirage-node'
 import type { Mount, NodeWorkspaceOptions } from '@struktoai/mirage-node'
 
 declare module '@deepseek-ai/cordis' {
   interface Context {
     mirage: MirageService
   }
+}
+
+/**
+ * A declarative mount, YAML-friendly: the resource is named by its
+ * registry type and built through `buildResource`, so a dsh bundle
+ * patch can mount anything without holding a live instance. Told apart
+ * from a live `Mount` by the type of `resource`: a string names a
+ * registry entry, an object is the instance itself.
+ */
+export interface MirageMountBlock {
+  /** Resource registry name (`ram`, `s3`, `slack`, `redis`, ...). */
+  resource: string
+  /** Mount mode: `read`, `write`, or `exec`. Omitted = the workspace default. */
+  mode?: string
+  /** Resource constructor config, passed to the registry factory. */
+  config?: Record<string, unknown>
+}
+
+/** One mount entry: a live spec or instance, or a declarative block. */
+export type MirageMount = MountSpec | Mount | MirageMountBlock
+
+/** A runtime entry, YAML-friendly: a name, or a name with captures. */
+export interface MirageRuntimeBlock {
+  /** Runtime registry name (`monty`, `pyodide`, `quickjs`, ...). */
+  name: string
+  /** Command words this runtime captures (e.g. `['python', 'python3']`). */
+  captures?: string[]
 }
 
 /**
@@ -34,9 +62,31 @@ export interface MirageConfig {
   /** A live workspace to adopt; its lifecycle stays with the embedder. */
   workspace?: Workspace
   /** Mounts for a service-owned workspace, keyed by mount prefix. */
-  mounts?: Record<string, MountSpec | Mount>
+  mounts?: Record<string, MirageMount>
+  /**
+   * Runtimes for a service-owned workspace, built via `buildRuntime`.
+   * The YAML-friendly twin of `workspaceOptions.runtimes`; pass one or
+   * the other, not both.
+   */
+  runtimes?: (string | MirageRuntimeBlock)[]
   /** Options forwarded to the service-owned workspace's constructor. */
   workspaceOptions?: NodeWorkspaceOptions
+}
+
+function isMountBlock(entry: MirageMount): entry is MirageMountBlock {
+  if (Array.isArray(entry)) return false
+  return typeof (entry as MirageMountBlock).resource === 'string'
+}
+
+async function resolveMount(entry: MirageMountBlock): Promise<MountSpec> {
+  const resource = await buildResource(entry.resource, entry.config ?? {})
+  if (entry.mode === undefined) return resource
+  return [resource, parseMountMode(entry.mode)]
+}
+
+function toRuntimeEntry(entry: string | MirageRuntimeBlock): RuntimeEntry {
+  if (typeof entry === 'string') return entry
+  return buildRuntime(entry.name, entry.captures === undefined ? {} : { captures: entry.captures })
 }
 
 /**
@@ -45,11 +95,19 @@ export interface MirageConfig {
  * adapters). `MirageFileSystem` and `MirageShellExecutor` both inject it,
  * which is what keeps `ctx.fs` targets and `ctx.shell` commands in one
  * execution world: a `processPath` handed to the shell resolves there.
+ *
+ * Construction with live resources is synchronous; a declarative mount
+ * block defers to `buildResource`, so consumers await `ready` (the
+ * adapters do) and `workspace` throws until it resolves, mirroring how
+ * the E2B service owner exposes its sandbox.
  */
 export class MirageService extends Service {
   static readonly provide = 'mirage'
 
-  readonly workspace: Workspace
+  /** Resolves to the shared workspace once every mount is built. */
+  readonly ready: Promise<Workspace>
+
+  private built: Workspace | null = null
 
   constructor(ctx: Context, config: MirageConfig = {}) {
     super(ctx, 'mirage')
@@ -57,14 +115,55 @@ export class MirageService extends Service {
       throw new Error('mirage: pass either workspace or mounts, not both')
     }
     if (config.workspace !== undefined) {
-      this.workspace = config.workspace
+      this.built = config.workspace
+      this.ready = Promise.resolve(config.workspace)
       return
     }
     if (config.mounts === undefined) {
       throw new Error('mirage: one of workspace or mounts is required')
     }
-    const owned = new Workspace(config.mounts, config.workspaceOptions ?? {})
-    this.workspace = owned
-    ctx.effect(() => () => owned.close(), 'mirage workspace')
+    const options = { ...(config.workspaceOptions ?? {}) }
+    if (config.runtimes !== undefined) {
+      if (options.runtimes !== undefined) {
+        throw new Error('mirage: pass runtimes or workspaceOptions.runtimes, not both')
+      }
+      options.runtimes = config.runtimes.map(toRuntimeEntry)
+    }
+    const blocks = Object.values(config.mounts).some(isMountBlock)
+    if (blocks) {
+      this.ready = this.open(config.mounts, options)
+    } else {
+      const owned = new Workspace(config.mounts as Record<string, MountSpec | Mount>, options)
+      this.built = owned
+      this.ready = Promise.resolve(owned)
+    }
+    ctx.effect(
+      () => async () => {
+        const ws = await this.ready.catch(() => null)
+        if (ws !== null) await ws.close()
+      },
+      'mirage workspace',
+    )
+  }
+
+  /** The live workspace; throws until `ready` resolves. */
+  get workspace(): Workspace {
+    if (this.built === null) {
+      throw new Error('mirage: workspace is not ready yet; await ctx.mirage.ready')
+    }
+    return this.built
+  }
+
+  private async open(
+    mounts: Record<string, MirageMount>,
+    options: NodeWorkspaceOptions,
+  ): Promise<Workspace> {
+    const resolved: Record<string, MountSpec | Mount> = {}
+    for (const [prefix, entry] of Object.entries(mounts)) {
+      resolved[prefix] = isMountBlock(entry) ? await resolveMount(entry) : entry
+    }
+    const ws = new Workspace(resolved, options)
+    this.built = ws
+    return ws
   }
 }

--- a/typescript/packages/dsh/src/service.ts
+++ b/typescript/packages/dsh/src/service.ts
@@ -14,7 +14,7 @@
 
 import { Service } from '@deepseek-ai/cordis'
 import type { Context } from '@deepseek-ai/cordis'
-import type { MountSpec, RuntimeEntry } from '@struktoai/mirage-core'
+import type { MountSpec, Runtime, RuntimeEntry } from '@struktoai/mirage-core'
 import { buildRuntime, parseMountMode } from '@struktoai/mirage-core'
 import { buildResource, Workspace } from '@struktoai/mirage-node'
 import type { Mount, NodeWorkspaceOptions } from '@struktoai/mirage-node'
@@ -89,6 +89,13 @@ function toRuntimeEntry(entry: string | MirageRuntimeBlock): RuntimeEntry {
   return buildRuntime(entry.name, entry.captures === undefined ? {} : { captures: entry.captures })
 }
 
+// A name shorthand builds exactly as the workspace would build it; holding
+// the instance early is what lets `confined` classify the world before the
+// (asynchronous) mounts finish resolving.
+function builtEntry(entry: RuntimeEntry): Runtime {
+  return typeof entry === 'string' ? buildRuntime(entry) : entry
+}
+
 /**
  * The one mirage `Workspace` behind every mirage-backed dsh provider
  * (`ctx.mirage`, mirroring how `ctx.e2b` owns one sandbox for the E2B
@@ -108,6 +115,7 @@ export class MirageService extends Service {
   readonly ready: Promise<Workspace>
 
   private built: Workspace | null = null
+  private readonly plannedRuntimes: readonly Runtime[] | undefined
 
   constructor(ctx: Context, config: MirageConfig = {}) {
     super(ctx, 'mirage')
@@ -129,6 +137,8 @@ export class MirageService extends Service {
       }
       options.runtimes = config.runtimes.map(toRuntimeEntry)
     }
+    this.plannedRuntimes = options.runtimes?.map(builtEntry)
+    if (this.plannedRuntimes !== undefined) options.runtimes = [...this.plannedRuntimes]
     const blocks = Object.values(config.mounts).some(isMountBlock)
     if (blocks) {
       this.ready = this.open(config.mounts, options)
@@ -152,6 +162,20 @@ export class MirageService extends Service {
       throw new Error('mirage: workspace is not ready yet; await ctx.mirage.ready')
     }
     return this.built
+  }
+
+  /**
+   * True while every runtime in the world is confined to the workspace
+   * (`Runtime.confined`): the default world is, and so are the bridged
+   * engines, while the host `local` python or a remote sandbox executes
+   * beyond anything this service can vouch for. Answers before `ready`
+   * from the constructor-resolved entries (mounts resolve
+   * asynchronously, runtimes never do) and from the live workspace
+   * afterwards, so a later `addRuntime` is seen.
+   */
+  get confined(): boolean {
+    const entries = this.built === null ? (this.plannedRuntimes ?? []) : this.built.runtimeEntries
+    return entries.every((entry) => entry.confined)
   }
 
   private async open(

--- a/typescript/packages/dsh/src/shell.test.ts
+++ b/typescript/packages/dsh/src/shell.test.ts
@@ -46,6 +46,11 @@ afterEach(async () => {
 })
 
 describe('resolve', () => {
+  it('declares workspace-write confinement', async () => {
+    const { shell } = await makeShell()
+    expect(shell.sandboxMode).toBe('workspace-write')
+  })
+
   it('applies defaults and caps the timeout', async () => {
     const { shell } = await makeShell({}, { defaultTimeoutMs: 5000, maxTimeoutMs: 8000 })
     const defaulted = shell.resolve({ command: 'true' })

--- a/typescript/packages/dsh/src/shell.test.ts
+++ b/typescript/packages/dsh/src/shell.test.ts
@@ -15,7 +15,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { Context } from '@deepseek-ai/cordis'
 import { MountMode, RAMResource } from '@struktoai/mirage-core'
-import { Workspace } from '@struktoai/mirage-node'
+import { LocalRuntime, Workspace } from '@struktoai/mirage-node'
 import { MirageService } from './service.ts'
 import { MirageShellExecutor } from './shell.ts'
 import type { MirageShellConfig } from './shell.ts'
@@ -49,6 +49,12 @@ describe('resolve', () => {
   it('declares workspace-write confinement', async () => {
     const { shell } = await makeShell()
     expect(shell.sandboxMode).toBe('workspace-write')
+  })
+
+  it('claims no confinement once a runtime executes beyond the workspace', async () => {
+    const { shell, ws } = await makeShell()
+    ws.addRuntime(new LocalRuntime({ captures: ['python'] }))
+    expect(shell.sandboxMode).toBeUndefined()
   })
 
   it('applies defaults and caps the timeout', async () => {

--- a/typescript/packages/dsh/src/shell.ts
+++ b/typescript/packages/dsh/src/shell.ts
@@ -208,14 +208,18 @@ export class MirageShellExecutor extends ShellExecutor {
   }
 
   /**
-   * Every command runs inside the mounted workspace and the host is
-   * unreachable by construction, so this executor confines like a
+   * With every runtime in the world confined to the workspace, a
+   * command cannot reach the host, so this executor confines like a
    * workspace-write sandbox: reads and writes land only where mounts
    * (and their modes) allow. Declaring it lets confinement-aware
-   * plugins (dsh's permission presets) compose over this executor.
+   * plugins (dsh's permission presets) compose over this executor. A
+   * world holding a runtime that executes beyond the workspace (the
+   * host `local` python, a remote sandbox) voids that claim, so this
+   * answers undefined then — the base contract's "does not confine" —
+   * and those plugins refuse to compose instead of trusting a lie.
    */
-  override get sandboxMode(): NonNullable<ShellExecutor['sandboxMode']> {
-    return 'workspace-write'
+  override get sandboxMode(): ShellExecutor['sandboxMode'] {
+    return this.ctx.mirage.confined ? 'workspace-write' : undefined
   }
 
   resolve(request: ShellExecRequest): ShellExecSpec {

--- a/typescript/packages/dsh/src/shell.ts
+++ b/typescript/packages/dsh/src/shell.ts
@@ -183,7 +183,6 @@ class MirageShellProcess implements ShellProcess {
 export class MirageShellExecutor extends ShellExecutor {
   static readonly inject = ['mirage']
 
-  private readonly workspace: Workspace
   private readonly workdir: string
   private readonly defaultTimeoutMs: number
   private readonly maxTimeoutMs: number
@@ -194,13 +193,29 @@ export class MirageShellExecutor extends ShellExecutor {
 
   constructor(ctx: Context, config: MirageShellConfig = {}) {
     super(ctx)
-    this.workspace = ctx.mirage.workspace
     this.workdir = config.workdir ?? '/'
     this.defaultTimeoutMs = config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS
     this.maxTimeoutMs = config.maxTimeoutMs ?? MAX_TIMEOUT_MS
     this.stdoutMaxBytes = config.stdoutMaxBytes ?? DEFAULT_STDOUT_MAX_BYTES
     this.stderrMaxBytes = config.stderrMaxBytes ?? DEFAULT_STDERR_MAX_BYTES
     this.sessionId = config.sessionId
+  }
+
+  // The workspace may still be building (declarative mounts resolve
+  // asynchronously), so every execution awaits the service's `ready`.
+  private workspace(): Promise<Workspace> {
+    return this.ctx.mirage.ready
+  }
+
+  /**
+   * Every command runs inside the mounted workspace and the host is
+   * unreachable by construction, so this executor confines like a
+   * workspace-write sandbox: reads and writes land only where mounts
+   * (and their modes) allow. Declaring it lets confinement-aware
+   * plugins (dsh's permission presets) compose over this executor.
+   */
+  override get sandboxMode(): NonNullable<ShellExecutor['sandboxMode']> {
+    return 'workspace-write'
   }
 
   resolve(request: ShellExecRequest): ShellExecSpec {
@@ -231,9 +246,10 @@ export class MirageShellExecutor extends ShellExecutor {
   }
 
   private async provisionSession(sessionId: string): Promise<void> {
-    await this.workspace.ensureSessionsLoaded()
-    if (this.workspace.listSessions().some((s) => s.sessionId === sessionId)) return
-    const session = this.workspace.createSession(sessionId)
+    const ws = await this.workspace()
+    await ws.ensureSessionsLoaded()
+    if (ws.listSessions().some((s) => s.sessionId === sessionId)) return
+    const session = ws.createSession(sessionId)
     session.cwd = this.workdir
     session.env.PWD = this.workdir
   }
@@ -268,7 +284,8 @@ export class MirageShellExecutor extends ShellExecutor {
     spec.signal?.addEventListener('abort', onAbort, { once: true })
     try {
       await this.ensureSession()
-      const result = await this.workspace.execute(
+      const ws = await this.workspace()
+      const result = await ws.execute(
         spec.command,
         executeOptions(spec, controller.signal, this.sessionId, this.workdir),
       )
@@ -316,8 +333,9 @@ export class MirageShellExecutor extends ShellExecutor {
     }
     spec.signal?.addEventListener('abort', onAbort, { once: true })
     const run = this.ensureSession()
-      .then(() =>
-        this.workspace.execute(
+      .then(() => this.workspace())
+      .then((ws) =>
+        ws.execute(
           spec.command,
           executeOptions(spec, controller.signal, this.sessionId, this.workdir),
         ),


### PR DESCRIPTION
Makes `@struktoai/mirage-dsh` directly installable into stock dsh: the manifest now declares a dsh bundle whose `cordis.patch.yml` swaps the base filesystem and bash providers for the mirage ones (and disables the host-subprocess surfaces the workspace does not contain: PowerShell and the ripgrep search tool). `dsh plugin --profile web add @struktoai/mirage-dsh` then `dsh --profile web` runs dsh, web app included, on mounted data.

To be mountable from YAML, `MirageService` gains declarative mounts (`{ resource, mode, config }` blocks built through `buildResource`, beside live instances) and a `runtimes` twin of `workspaceOptions.runtimes`. Declarative building is asynchronous, so the service exposes `ready` and the fs/shell adapters resolve the workspace lazily, the same shape as dsh's own E2B service owner. The shell executor now declares `workspace-write` confinement, which dsh's permission presets require of a composed executor. `parseMountMode` is newly exported from core; the loader entries live under `./service`, `./fs`, `./shell` subpaths whose default export is the plugin.

Verified end to end against the published `@deepseek-ai/dsh@0.1.0-rc.6` CLI with a local profile: `--dump-config` shows the bundle layer applied (base rows disabled, mirage rows inserted), the web app boots to its URL, and a headless agent run over the openai route executed bash tool calls inside the mirage world (`ls /` answered `dev tmp`, a write to `/tmp/proof.txt` read back).