### PR TITLE
fix(shell): ambient session for nested evals, whole-body cmdsub

### DIFF
--- a/integ/bash/cmdsub/body.json
+++ b/integ/bash/cmdsub/body.json
@@ -1,8 +1,8 @@
 {
   "cases": [
     {
-      "id": "job_bg_then_wait",
-      "seq": 502400,
+      "id": "cmdsub_body_runs_all_statements",
+      "seq": 930320,
       "targets": [
         "ram",
         "disk",
@@ -27,16 +27,16 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "(sleep 0.2 & wait) 2>/dev/null; echo done",
+      "command": "echo $(echo a; echo b)",
       "expect": {
         "exit": 0,
-        "stdout": "done\n",
+        "stdout": "a b\n",
         "stderr": ""
       }
     },
     {
-      "id": "job_bg_write_visible_after_wait",
-      "seq": 502402,
+      "id": "cmdsub_body_control_flow",
+      "seq": 930322,
       "targets": [
         "ram",
         "disk",
@@ -48,6 +48,8 @@
         "s3-prefix",
         "databricks-prefix",
         "gridfs-prefix",
+        "hf",
+        "hf-prefix",
         "dropbox",
         "dropbox-root",
         "onedrive",
@@ -59,16 +61,16 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "(echo bgdata > /data/zjb.txt & wait) 2>/dev/null; cat /data/zjb.txt",
+      "command": "echo $(if true; then echo yes; fi)",
       "expect": {
         "exit": 0,
-        "stdout": "bgdata\n",
+        "stdout": "yes\n",
         "stderr": ""
       }
     },
     {
-      "id": "job_bg_cmdsub_reads_fork_cwd",
-      "seq": 502404,
+      "id": "cmdsub_body_assignment",
+      "seq": 930324,
       "targets": [
         "ram",
         "disk",
@@ -80,6 +82,8 @@
         "s3-prefix",
         "databricks-prefix",
         "gridfs-prefix",
+        "hf",
+        "hf-prefix",
         "dropbox",
         "dropbox-root",
         "onedrive",
@@ -91,16 +95,16 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "(cd /data && echo $(pwd) > /data/zbgc.txt & wait) 2>/dev/null; cat /data/zbgc.txt",
+      "command": "echo $(X=5; echo $X)",
       "expect": {
         "exit": 0,
-        "stdout": "/data\n",
+        "stdout": "5\n",
         "stderr": ""
       }
     },
     {
-      "id": "job_bg_cmdsub_cd_no_leak",
-      "seq": 502406,
+      "id": "cmdsub_body_declaration",
+      "seq": 930326,
       "targets": [
         "ram",
         "disk",
@@ -112,6 +116,8 @@
         "s3-prefix",
         "databricks-prefix",
         "gridfs-prefix",
+        "hf",
+        "hf-prefix",
         "dropbox",
         "dropbox-root",
         "onedrive",
@@ -123,10 +129,10 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "(echo $(cd /data) > /data/zbgn.txt & wait) 2>/dev/null; pwd",
+      "command": "echo $(export Y=7; echo $Y)",
       "expect": {
         "exit": 0,
-        "stdout": "/\n",
+        "stdout": "7\n",
         "stderr": ""
       }
     }

--- a/python/mirage/context/__init__.py
+++ b/python/mirage/context/__init__.py
@@ -14,13 +14,14 @@
 
 from mirage.context.session_context import (  # isort: skip
     assert_mount_allowed, effective_mount_mode, get_current_session,
-    hidden_paths_active, mount_allowed, path_allowed, reset_current_session,
-    set_current_session)
+    get_current_session_for, hidden_paths_active, mount_allowed, path_allowed,
+    reset_current_session, set_current_session)
 
 __all__ = [
     "assert_mount_allowed",
     "effective_mount_mode",
     "get_current_session",
+    "get_current_session_for",
     "hidden_paths_active",
     "mount_allowed",
     "path_allowed",

--- a/python/mirage/context/session_context.py
+++ b/python/mirage/context/session_context.py
@@ -13,23 +13,52 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from contextvars import ContextVar, Token
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from mirage.types import MountMode, weaker_mode
 from mirage.utils.hidden import path_hidden
 
 if TYPE_CHECKING:
+    from mirage.workspace.session.manager import SessionManager
     from mirage.workspace.session.session import Session
 
-_current_session: ContextVar["Session | None"] = ContextVar(
+
+@dataclass(frozen=True, slots=True)
+class SessionBinding:
+    """The session bound to one async context, and whose it is.
+
+    Args:
+        session (Session | None): the live session.
+        owner (SessionManager | None): the session manager the session
+            belongs to, which is one per workspace. None when the
+            binder did not name one.
+    """
+    session: "Session | None"
+    owner: "SessionManager | None"
+
+
+_current_session: ContextVar[SessionBinding | None] = ContextVar(
     "mirage_current_session",
     default=None,
 )
 
 
-def set_current_session(session: "Session | None") -> Token[Any]:
-    """Bind ``session`` to the current async context."""
-    return _current_session.set(session)
+def set_current_session(session: "Session | None",
+                        owner: "SessionManager | None" = None) -> Token[Any]:
+    """Bind ``session`` to the current async context.
+
+    Args:
+        session (Session | None): the session to bind.
+        owner (SessionManager | None): the manager the session belongs
+            to. None keeps the owner already bound, so a nested bind
+            inside a line (a background job's fork) stays attributed to
+            the workspace running it.
+    """
+    if owner is None:
+        current = _current_session.get()
+        owner = current.owner if current is not None else None
+    return _current_session.set(SessionBinding(session=session, owner=owner))
 
 
 def reset_current_session(token: Token[Any]) -> None:
@@ -39,7 +68,24 @@ def reset_current_session(token: Token[Any]) -> None:
 
 def get_current_session() -> "Session | None":
     """Return the session bound to the current async context, if any."""
-    return _current_session.get()
+    binding = _current_session.get()
+    return binding.session if binding is not None else None
+
+
+def get_current_session_for(owner: "SessionManager") -> "Session | None":
+    """Return the bound session only when ``owner`` published it.
+
+    A session carries one workspace's cwd, env and mount grants, so a
+    second workspace re-entered mid-line must resolve its own session
+    rather than adopt this one.
+
+    Args:
+        owner (SessionManager): the asking workspace's session manager.
+    """
+    binding = _current_session.get()
+    if binding is None or binding.owner is not owner:
+        return None
+    return binding.session
 
 
 def _norm_prefix(mount_prefix: str) -> str:
@@ -57,7 +103,7 @@ def _session_mode(mount_prefix: str) -> "MountMode | None":
     Args:
         mount_prefix (str): the mount's prefix, e.g. ``/s3``.
     """
-    sess = _current_session.get()
+    sess = get_current_session()
     if sess is None or sess.mount_modes is None:
         return MountMode.EXEC
     return sess.mount_modes.get(_norm_prefix(mount_prefix))
@@ -72,7 +118,7 @@ def hidden_paths_active() -> bool:
     Args:
         None
     """
-    sess = _current_session.get()
+    sess = get_current_session()
     return sess is not None and sess.hidden_paths is not None
 
 
@@ -89,7 +135,7 @@ def path_allowed(virtual: str) -> bool:
     Args:
         virtual (str): absolute virtual path.
     """
-    sess = _current_session.get()
+    sess = get_current_session()
     if sess is None or sess.hidden_paths is None:
         return True
     return not path_hidden(sess.hidden_paths, virtual)
@@ -128,7 +174,7 @@ def assert_mount_allowed(mount_prefix: str) -> None:
     """
     if _session_mode(mount_prefix) is not None:
         return
-    sess = _current_session.get()
+    sess = get_current_session()
     sid = sess.session_id if sess is not None else "<none>"
     raise PermissionError(f"session {sid!r} not allowed to "
                           f"access mount {_norm_prefix(mount_prefix)!r}")

--- a/python/mirage/workspace/executor/jobs.py
+++ b/python/mirage/workspace/executor/jobs.py
@@ -22,7 +22,8 @@ from mirage.io.types import ByteSource, materialize
 from mirage.shell.errors import ExitSignal
 from mirage.shell.helpers import get_text
 from mirage.shell.job_table import JobTable
-from mirage.workspace.session import Session
+from mirage.workspace.session import (Session, reset_current_session,
+                                      set_current_session)
 from mirage.workspace.types import ExecutionNode
 
 
@@ -44,30 +45,42 @@ async def handle_background(
         # behavior where bg processes get /dev/null. This prevents
         # race conditions when stdin is an async iterator.
         cmd_str_inner = get_text(left) if hasattr(left, "text") else str(left)
+        # The task's context snapshot still points at the OUTER session
+        # (create_task copies the context before the fork can be bound),
+        # and the fork keeps its parent's id, so without this rebind a
+        # nested eval inside the job resolves the ambient outer session
+        # and escapes the fork.
+        token = set_current_session(bg_session)
         try:
-            stdout, io, exec_node = await execute_node(left, bg_session, None,
-                                                       call_stack)
-        except CommandTimeoutError as exc:
-            msg = (str(exc) + "\n").encode()
-            io = IOResult(exit_code=124, stderr=msg)
-            exec_node = ExecutionNode(command=cmd_str_inner,
-                                      stderr=msg,
-                                      exit_code=124)
-            return b"", io, exec_node
-        except ExitSignal as sig:
-            # A background job is its own shell: exit ends the job only.
-            io = IOResult(exit_code=sig.contained_code,
-                          stderr=sig.stderr or None)
-            exec_node = ExecutionNode(command=cmd_str_inner,
-                                      stderr=sig.stderr,
-                                      exit_code=sig.contained_code)
-            return sig.stdout or b"", io, exec_node
-        stdout = await materialize(stdout)
-        # Eagerly materialize stderr too so JobTable._refresh can read
-        # the task result synchronously without an async hop.
-        await io.materialize_stderr()
-        io.sync_exit_code()
-        return stdout, io, exec_node
+            try:
+                stdout, io, exec_node = await execute_node(
+                    left, bg_session, None, call_stack)
+            except CommandTimeoutError as exc:
+                msg = (str(exc) + "\n").encode()
+                io = IOResult(exit_code=124, stderr=msg)
+                exec_node = ExecutionNode(command=cmd_str_inner,
+                                          stderr=msg,
+                                          exit_code=124)
+                return b"", io, exec_node
+            except ExitSignal as sig:
+                # A background job is its own shell: exit ends the job
+                # only.
+                io = IOResult(exit_code=sig.contained_code,
+                              stderr=sig.stderr or None)
+                exec_node = ExecutionNode(command=cmd_str_inner,
+                                          stderr=sig.stderr,
+                                          exit_code=sig.contained_code)
+                return sig.stdout or b"", io, exec_node
+            # Materialize inside the rebind: draining the pipeline can
+            # still run ops that read the ambient session.
+            stdout = await materialize(stdout)
+            # Eagerly materialize stderr too so JobTable._refresh can
+            # read the task result synchronously without an async hop.
+            await io.materialize_stderr()
+            io.sync_exit_code()
+            return stdout, io, exec_node
+        finally:
+            reset_current_session(token)
 
     task = asyncio.create_task(_run_bg())
     cmd_str = get_text(left) if hasattr(left, 'text') else str(left)

--- a/python/mirage/workspace/expand/node.py
+++ b/python/mirage/workspace/expand/node.py
@@ -246,14 +246,13 @@ async def expand_node(
                 if arith is not None:
                     return prefix + await expand_node(arith, session,
                                                       execute_fn, call_stack)
-        inner_cmds = [
-            c for c in ts_node.named_children
-            if c.type in (NT.COMMAND, NT.PIPELINE, NT.LIST,
-                          NT.REDIRECTED_STATEMENT, NT.SUBSHELL)
-        ]
-        if not inner_cmds:
+        # The whole body goes to the evaluator: bash substitutes the
+        # full statement list, and picking child nodes dropped every
+        # statement after a `;` and every non-command statement
+        # (declarations, assignments, control flow).
+        inner = raw[2:-1]
+        if not inner.strip():
             return prefix
-        inner = get_text(inner_cmds[0])
         io = await execute_fn(inner, session_id=session.session_id)
         text = (await io.stdout_str()).rstrip("\n")
         # Record the substitution's status: an assignment-only

--- a/python/mirage/workspace/session/__init__.py
+++ b/python/mirage/workspace/session/__init__.py
@@ -13,7 +13,8 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.context import (assert_mount_allowed, get_current_session,
-                            reset_current_session, set_current_session)
+                            get_current_session_for, reset_current_session,
+                            set_current_session)
 from mirage.workspace.session.errors import ReadonlyVariableError
 from mirage.workspace.session.manager import SessionManager
 from mirage.workspace.session.profile import SessionProfile
@@ -41,6 +42,7 @@ __all__ = [
     "SessionStore",
     "assert_mount_allowed",
     "get_current_session",
+    "get_current_session_for",
     "reset_current_session",
     "set_current_session",
 ]

--- a/python/mirage/workspace/workspace/execute.py
+++ b/python/mirage/workspace/workspace/execute.py
@@ -29,7 +29,9 @@ from mirage.shell.parse import (find_syntax_error, find_unterminated_backtick,
                                 parse)
 from mirage.workspace.abort import MirageAbortError
 from mirage.workspace.node import provision_node, run_command_tree
-from mirage.workspace.session import reset_current_session, set_current_session
+from mirage.workspace.session import (get_current_session,
+                                      reset_current_session,
+                                      set_current_session)
 from mirage.workspace.snapshot import ContentDriftError
 from mirage.workspace.workspace.failure import failure_result
 from mirage.workspace.workspace.line import run_whole_line
@@ -136,9 +138,20 @@ async def execute_line(
     if ws._drift.pending:
         await ws._drift.drain(ws._registry.mount_for)
 
-    if session_id is None:
-        session_id = ws._session_mgr.default_id
-    session = ws._session_mgr.get(session_id)
+    # A re-entrant execute (the evaluator's $(), eval, source, xargs, or
+    # an embedder callback fired mid-line) continues in the live ambient
+    # session unless it names a different one. An id cannot say that: it
+    # names a registered session, never the ephemeral per-call fork the
+    # outer line actually runs in, and re-resolving through the manager
+    # is how a nested line used to escape the fork and its confinement.
+    ambient = get_current_session()
+    if ambient is not None and session_id in (None, ambient.session_id):
+        session = ambient
+        session_id = ambient.session_id
+    else:
+        if session_id is None:
+            session_id = ws._session_mgr.default_id
+        session = ws._session_mgr.get(session_id)
     effective_session = fork_for_call(session, cwd, env)
     ws._current_agent_id = (agent_id
                             if agent_id is not None else ws._default_agent_id)

--- a/python/mirage/workspace/workspace/execute.py
+++ b/python/mirage/workspace/workspace/execute.py
@@ -29,7 +29,7 @@ from mirage.shell.parse import (find_syntax_error, find_unterminated_backtick,
                                 parse)
 from mirage.workspace.abort import MirageAbortError
 from mirage.workspace.node import provision_node, run_command_tree
-from mirage.workspace.session import (get_current_session,
+from mirage.workspace.session import (get_current_session_for,
                                       reset_current_session,
                                       set_current_session)
 from mirage.workspace.snapshot import ContentDriftError
@@ -144,7 +144,10 @@ async def execute_line(
     # names a registered session, never the ephemeral per-call fork the
     # outer line actually runs in, and re-resolving through the manager
     # is how a nested line used to escape the fork and its confinement.
-    ambient = get_current_session()
+    # Only this workspace's own binding counts: a session carries one
+    # workspace's cwd, env and mount grants, so a callback reaching a
+    # second workspace must resolve that workspace's session instead.
+    ambient = get_current_session_for(ws._session_mgr)
     if ambient is not None and session_id in (None, ambient.session_id):
         session = ambient
         session_id = ambient.session_id
@@ -166,7 +169,8 @@ async def execute_line(
         effective_session._stdin_buffer = None
     scope = RecordingScope(active=is_line)
 
-    session_token = set_current_session(effective_session)
+    session_token = set_current_session(effective_session,
+                                        owner=ws._session_mgr)
     try:
         ast = parse(command)
         # Syntax gates before policy, mirroring the TS order and

--- a/python/tests/context/test_session_context.py
+++ b/python/tests/context/test_session_context.py
@@ -15,10 +15,11 @@
 import pytest
 
 from mirage.context import (assert_mount_allowed, effective_mount_mode,
-                            get_current_session, mount_allowed,
-                            reset_current_session, set_current_session)
+                            get_current_session, get_current_session_for,
+                            mount_allowed, reset_current_session,
+                            set_current_session)
 from mirage.types import MountMode, weaker_mode
-from mirage.workspace.session import Session
+from mirage.workspace.session import Session, SessionManager
 
 
 @pytest.fixture
@@ -95,3 +96,40 @@ def test_mount_allowed_is_the_non_raising_twin(bound_session):
 
 def test_mount_allowed_without_session_permits_everything():
     assert mount_allowed("/anything") is True
+
+
+def test_ownership_gates_the_binding():
+    """A binding answers only the manager that published it."""
+    mine = SessionManager("default")
+    theirs = SessionManager("default")
+    sess = Session(session_id="default")
+    token = set_current_session(sess, owner=mine)
+    try:
+        assert get_current_session_for(mine) is sess
+        assert get_current_session_for(theirs) is None
+        assert get_current_session() is sess
+    finally:
+        reset_current_session(token)
+
+
+def test_a_nested_binding_keeps_the_owner():
+    """A background job's fork is still the workspace's own session."""
+    mine = SessionManager("default")
+    outer = Session(session_id="default")
+    inner = Session(session_id="default")
+    outer_token = set_current_session(outer, owner=mine)
+    inner_token = set_current_session(inner)
+    try:
+        assert get_current_session_for(mine) is inner
+    finally:
+        reset_current_session(inner_token)
+        reset_current_session(outer_token)
+
+
+def test_an_unowned_binding_answers_nobody():
+    """The op-dispatch binders name no owner, so no line adopts one."""
+    token = set_current_session(Session(session_id="default"))
+    try:
+        assert get_current_session_for(SessionManager("default")) is None
+    finally:
+        reset_current_session(token)

--- a/python/tests/test_tests_mirror_sources.py
+++ b/python/tests/test_tests_mirror_sources.py
@@ -61,7 +61,7 @@ UNMIRRORED_DIRS = {
 # would count 816 today. What the ratchet buys is narrower than it looks:
 # a module whose name appears nowhere in the suite cannot be added
 # silently.
-MIRROR_BASELINE = 206
+MIRROR_BASELINE = 203
 
 
 def _test_dirs() -> list[pathlib.Path]:

--- a/python/tests/workspace/test_expand.py
+++ b/python/tests/workspace/test_expand.py
@@ -176,6 +176,28 @@ def test_expand_command_sub():
     execute_fn.assert_called_once()
 
 
+def test_expand_command_sub_runs_the_whole_body():
+    # bash substitutes the full statement list, so the whole body goes
+    # to the evaluator: filtering to the first command node dropped
+    # everything after a `;` and every non-command statement.
+    node = _first_arg("echo $(echo a; echo b)")
+    execute_fn = AsyncMock()
+    io = IOResult()
+    io.stdout = b"a\nb\n"
+    execute_fn.return_value = io
+    result = _run(expand_node(node, _session(), execute_fn))
+    assert result == "a\nb"
+    assert execute_fn.call_args.args[0] == "echo a; echo b"
+
+
+def test_expand_command_sub_runs_a_declaration():
+    node = _first_arg("echo $(export X=1)")
+    execute_fn = AsyncMock()
+    execute_fn.return_value = IOResult()
+    _run(expand_node(node, _session(), execute_fn))
+    assert execute_fn.call_args.args[0] == "export X=1"
+
+
 # ── arithmetic expansion $((expr)) ──────────────
 
 

--- a/python/tests/workspace/workspace/test_execute.py
+++ b/python/tests/workspace/workspace/test_execute.py
@@ -1,0 +1,154 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from mirage.resource.ram import RAMResource
+
+
+def _make_ws() -> Workspace:
+    resource = RAMResource()
+    store = resource._store
+    store.dirs.add("/")
+    store.dirs.add("/subdir")
+    store.dirs.add("/other")
+    return Workspace({"/ram/": resource}, mode=MountMode.WRITE)
+
+
+def _two_mounts() -> Workspace:
+    a = RAMResource()
+    a._store.dirs.add("/")
+    b = RAMResource()
+    b._store.dirs.add("/")
+    b._store.files["/y.txt"] = b"secret\n"
+    return Workspace(
+        {
+            "/a": (a, MountMode.WRITE),
+            "/b": (b, MountMode.WRITE)
+        },
+        mode=MountMode.WRITE,
+    )
+
+
+# A nested eval ($(), eval, source, xargs) re-enters execute and must
+# continue in the LIVE session the outer line runs in. An id cannot say
+# that: it names a registered session, never the ephemeral per-call
+# fork, so these pin the fork cases that only the ambient session
+# context can answer.
+
+
+@pytest.mark.asyncio
+async def test_cmdsub_reads_the_per_call_forks_cwd():
+    ws = _make_ws()
+    r = await ws.execute("echo $(pwd)", cwd="/ram/subdir")
+    assert (await r.stdout_str()).strip() == "/ram/subdir"
+
+
+@pytest.mark.asyncio
+async def test_eval_moves_the_fork_not_the_default_session():
+    ws = _make_ws()
+    before = ws.get_session(ws.default_session_id).cwd
+    r = await ws.execute("eval 'cd /ram/other'; pwd", cwd="/ram/subdir")
+    assert (await r.stdout_str()).strip() == "/ram/other"
+    assert ws.get_session(ws.default_session_id).cwd == before
+
+
+@pytest.mark.asyncio
+async def test_cmdsub_cd_stays_in_the_fork():
+    ws = _make_ws()
+    before = ws.get_session(ws.default_session_id).cwd
+    await ws.execute("echo $(cd /ram/other)", env={"FOO": "bar"})
+    assert ws.get_session(ws.default_session_id).cwd == before
+
+
+@pytest.mark.asyncio
+async def test_cmdsub_reads_the_named_sessions_cwd():
+    ws = _make_ws()
+    ws.create_session("agent")
+    await ws.execute("cd /ram/subdir", session_id="agent")
+    r = await ws.execute("echo $(pwd)", session_id="agent")
+    assert (await r.stdout_str()).strip() == "/ram/subdir"
+
+
+@pytest.mark.asyncio
+async def test_cmdsub_keeps_the_named_sessions_confinement():
+    ws = _two_mounts()
+    ws.create_session("agent", mounts={"/a": "write"})
+    r = await ws.execute("echo $(cat /b/y.txt)", session_id="agent")
+    assert "secret" not in (await r.stdout_str())
+
+
+@pytest.mark.asyncio
+async def test_cmdsub_cd_on_the_live_session_persists():
+    # Documented divergence: bash runs $() in a subshell, mirage runs it
+    # in the live session, so a cd inside one persists when no per-call
+    # fork is in play. Pinned so the fork-containment fix is never
+    # "improved" into forking every substitution.
+    ws = _make_ws()
+    await ws.execute("echo $(cd /ram/subdir)")
+    assert ws.get_session(ws.default_session_id).cwd == "/ram/subdir"
+
+
+# A background job forks the session, so it is the one mid-line point
+# where the ambient session must be rebound: without that, a nested
+# eval inside `... &` resolves the OUTER live session (the fork keeps
+# its parent's id) and escapes the job's isolation.
+
+
+@pytest.mark.asyncio
+async def test_bg_job_cmdsub_reads_the_jobs_fork():
+    ws = _make_ws()
+    r = await ws.execute("cd /ram/other && echo $(pwd) & wait %1")
+    assert (await r.stdout_str()).strip() == "/ram/other"
+
+
+@pytest.mark.asyncio
+async def test_bg_job_cmdsub_cd_stays_in_the_jobs_fork():
+    ws = _make_ws()
+    before = ws.get_session(ws.default_session_id).cwd
+    await ws.execute("echo $(cd /ram/other) & wait %1")
+    assert ws.get_session(ws.default_session_id).cwd == before
+
+
+# $() must run its whole body: bash substitutes the output of the full
+# statement list, not of the first simple command it contains.
+
+
+@pytest.mark.asyncio
+async def test_cmdsub_runs_every_statement():
+    ws = _make_ws()
+    r = await ws.execute("echo $(echo a; echo b)")
+    assert (await r.stdout_str()).strip() == "a b"
+
+
+@pytest.mark.asyncio
+async def test_cmdsub_runs_control_flow():
+    ws = _make_ws()
+    r = await ws.execute("echo $(if true; then echo yes; fi)")
+    assert (await r.stdout_str()).strip() == "yes"
+
+
+@pytest.mark.asyncio
+async def test_cmdsub_runs_assignments():
+    ws = _make_ws()
+    r = await ws.execute("echo $(X=5; echo $X)")
+    assert (await r.stdout_str()).strip() == "5"
+
+
+@pytest.mark.asyncio
+async def test_cmdsub_runs_declarations():
+    ws = _make_ws()
+    r = await ws.execute("echo $(export Y=7; echo $Y)")
+    assert (await r.stdout_str()).strip() == "7"

--- a/python/tests/workspace/workspace/test_execute.py
+++ b/python/tests/workspace/workspace/test_execute.py
@@ -15,7 +15,16 @@
 import pytest
 
 from mirage import MountMode, Workspace
+from mirage.commands.registry import command
+from mirage.commands.spec import CommandSpec
+from mirage.io.types import IOResult
 from mirage.resource.ram import RAMResource
+
+
+def _register(ws: Workspace, prefix: str, fn) -> None:
+    mount = ws._registry.mount_for(prefix)
+    for registered in fn._registered_commands:
+        mount.register(registered)
 
 
 def _make_ws() -> Workspace:
@@ -152,3 +161,53 @@ async def test_cmdsub_runs_declarations():
     ws = _make_ws()
     r = await ws.execute("echo $(export Y=7; echo $Y)")
     assert (await r.stdout_str()).strip() == "7"
+
+
+# The ambient session belongs to the workspace that published it. A
+# callback fired mid-line reaching a SECOND workspace must not adopt
+# it: that workspace's own session owns its cwd, env and mount grants,
+# and an unrestricted session must never stand in for a restricted one.
+
+
+@pytest.mark.asyncio
+async def test_another_workspace_resolves_its_own_session():
+    ws_a = _make_ws()
+    ws_b = _two_mounts()
+    seen: list[str] = []
+
+    @command("crossprobe", resource="ram", spec=CommandSpec())
+    async def crossprobe(accessor, paths, texts, opts):
+        result = await ws_b.execute("pwd")
+        seen.append((await result.stdout_str()).strip())
+        return b"", IOResult()
+
+    _register(ws_a, "/ram/", crossprobe)
+    await ws_a.execute("crossprobe", cwd="/ram/subdir")
+    assert seen == ["/"]
+
+
+@pytest.mark.asyncio
+async def test_policy_reads_the_ambient_sessions_cwd():
+    # The policy decides about the line the session actually runs, so
+    # it reads the resolved session's cwd, not the registered
+    # session's: a re-entrant line runs in the live ambient fork.
+    seen: list[str] = []
+
+    def policy(ctx):
+        seen.append(ctx.cwd)
+        return None
+
+    resource = RAMResource()
+    store = resource._store
+    store.dirs.add("/")
+    store.dirs.add("/subdir")
+    ws = Workspace({"/ram/": resource}, mode=MountMode.WRITE, policy=policy)
+
+    @command("policyprobe", resource="ram", spec=CommandSpec())
+    async def policyprobe(accessor, paths, texts, opts):
+        await ws.execute("pwd")
+        return b"", IOResult()
+
+    _register(ws, "/ram/", policyprobe)
+    await ws.execute("policyprobe", cwd="/ram/subdir")
+    assert seen == ["/ram/subdir", "/ram/subdir"]

--- a/typescript/packages/core/src/context/session_context.test.ts
+++ b/typescript/packages/core/src/context/session_context.test.ts
@@ -16,10 +16,14 @@ import { describe, expect, it } from 'vitest'
 import {
   assertMountAllowed,
   effectiveMountMode,
+  getCurrentSession,
+  getCurrentSessionFor,
   MountNotAllowedError,
   runWithSession,
 } from './session_context.ts'
+import { asyncContextIsolatesTasks } from '../utils/async_context.ts'
 import { MountMode, weakerMode } from '../types.ts'
+import { SessionManager } from '../workspace/session/manager.ts'
 import { Session } from '../workspace/session/session.ts'
 
 function grantedSession(): Session {
@@ -112,5 +116,54 @@ describe('session grants', () => {
       expect(effectiveMountMode('/other', MountMode.EXEC)).toBe(MountMode.READ)
       return Promise.resolve()
     })
+  })
+})
+
+describe('a binding belongs to the workspace that published it', () => {
+  it('answers only its own manager', async () => {
+    const mine = new SessionManager('default')
+    const theirs = new SessionManager('default')
+    const session = new Session({ sessionId: 'default' })
+    await runWithSession(
+      session,
+      () => {
+        expect(getCurrentSessionFor(mine)).toBe(session)
+        expect(getCurrentSessionFor(theirs)).toBeNull()
+        expect(getCurrentSession()).toBe(session)
+        return Promise.resolve()
+      },
+      mine,
+    )
+  })
+
+  it('a nested bind keeps the owner', async () => {
+    // A background job's fork is still the workspace's own session.
+    const mine = new SessionManager('default')
+    const outer = new Session({ sessionId: 'default' })
+    const inner = new Session({ sessionId: 'default' })
+    await runWithSession(
+      outer,
+      () =>
+        runWithSession(inner, () => {
+          expect(getCurrentSessionFor(mine)).toBe(inner)
+          return Promise.resolve()
+        }),
+      mine,
+    )
+  })
+
+  it('an unowned bind answers nobody', async () => {
+    // The op-dispatch binders name no owner, so no line adopts one.
+    await runWithSession(new Session({ sessionId: 'default' }), () => {
+      expect(getCurrentSessionFor(new SessionManager('default'))).toBeNull()
+      return Promise.resolve()
+    })
+  })
+
+  it('node isolates concurrent tasks', () => {
+    // What lets a background job bind its fork without the foreground
+    // seeing it; the browser fallback storage cannot, and jobs.ts
+    // reads this to decide.
+    expect(asyncContextIsolatesTasks).toBe(true)
   })
 })

--- a/typescript/packages/core/src/context/session_context.ts
+++ b/typescript/packages/core/src/context/session_context.ts
@@ -13,19 +13,57 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { createAsyncContext } from '../utils/async_context.ts'
+import type { SessionManager } from '../workspace/session/manager.ts'
 import type { Session } from '../workspace/session/session.ts'
 import { stripSlash } from '../utils/slash.ts'
 import { pathHidden } from '../utils/hidden.ts'
 import { MountMode, weakerMode } from '../types.ts'
 
-const sessionStorage = createAsyncContext<Session>()
+/**
+ * The session bound to one async context, and whose it is: `owner` is
+ * the session manager it belongs to, which is one per workspace.
+ */
+interface SessionBinding {
+  session: Session
+  owner: SessionManager | null
+}
 
-export function runWithSession<T>(session: Session, fn: () => Promise<T>): Promise<T> {
-  return Promise.resolve(sessionStorage.run(session, fn))
+const sessionStorage = createAsyncContext<SessionBinding>()
+
+/**
+ * Bind `session` for the duration of `fn`.
+ *
+ * `owner` names the manager the session belongs to; omitting it keeps
+ * the owner already bound, so a nested bind inside a line (a
+ * background job's fork) stays attributed to the workspace running it.
+ */
+export function runWithSession<T>(
+  session: Session,
+  fn: () => Promise<T>,
+  owner?: SessionManager,
+): Promise<T> {
+  const binding: SessionBinding = {
+    session,
+    owner: owner ?? sessionStorage.getStore()?.owner ?? null,
+  }
+  return Promise.resolve(sessionStorage.run(binding, fn))
 }
 
 export function getCurrentSession(): Session | null {
-  return sessionStorage.getStore() ?? null
+  return sessionStorage.getStore()?.session ?? null
+}
+
+/**
+ * The bound session, but only when `owner` published it.
+ *
+ * A session carries one workspace's cwd, env and mount grants, so a
+ * second workspace re-entered mid-line must resolve its own session
+ * rather than adopt this one.
+ */
+export function getCurrentSessionFor(owner: SessionManager): Session | null {
+  const binding = sessionStorage.getStore()
+  if (binding?.owner !== owner) return null
+  return binding.session
 }
 
 /**

--- a/typescript/packages/core/src/context/session_context.ts
+++ b/typescript/packages/core/src/context/session_context.ts
@@ -24,7 +24,7 @@ export function runWithSession<T>(session: Session, fn: () => Promise<T>): Promi
   return Promise.resolve(sessionStorage.run(session, fn))
 }
 
-function getCurrentSession(): Session | null {
+export function getCurrentSession(): Session | null {
   return sessionStorage.getStore() ?? null
 }
 

--- a/typescript/packages/core/src/utils/async_context.ts
+++ b/typescript/packages/core/src/utils/async_context.ts
@@ -65,6 +65,18 @@ async function resolveCtor(): Promise<ALSCtor> {
 
 const AsyncStorageCtor: ALSCtor = await resolveCtor()
 
+/**
+ * Whether the resolved storage isolates concurrent tasks.
+ *
+ * `AsyncLocalStorage` gives every task its own store. The fallback is
+ * one global slot restored when `run`'s promise settles, so work
+ * started beside a still-running scope observes that scope's store;
+ * a caller that binds a store for concurrent work has to know which
+ * it got.
+ */
+export const asyncContextIsolatesTasks: boolean =
+  (AsyncStorageCtor as unknown) !== (FallbackStorage as unknown)
+
 export function createAsyncContext<T>(): AsyncStorage<T> {
   return new AsyncStorageCtor<T>()
 }

--- a/typescript/packages/core/src/workspace/executor/jobs.ts
+++ b/typescript/packages/core/src/workspace/executor/jobs.ts
@@ -19,6 +19,7 @@ import type { CallStack } from '../../shell/call_stack.ts'
 import { ExitSignal } from '../../shell/errors.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import { runWithSession } from '../../context/session_context.ts'
+import { asyncContextIsolatesTasks } from '../../utils/async_context.ts'
 import { mergeSignals } from '../abort.ts'
 import type { Session } from '../session/session.ts'
 import type { TSNodeLike } from '../../shell/types.ts'
@@ -55,42 +56,51 @@ export async function handleBackground(
   // context, and the fork keeps its parent's id, so without this
   // rebind a nested eval inside the job resolves the ambient outer
   // session and escapes the fork.
-  const task: Promise<[ByteSource | null, IOResult, ExecutionNode]> = runWithSession(
-    bgSession,
-    async (): Promise<[ByteSource | null, IOResult, ExecutionNode]> => {
-      let stdout: ByteSource | null
-      let io: IOResult
-      let execNode: ExecutionNode
-      try {
-        ;[stdout, io, execNode] = await executeNode(left, bgSession, null, callStack)
-      } catch (err) {
-        if (err instanceof CommandTimeoutError) {
-          const msg = new TextEncoder().encode(`${err.message}\n`)
-          return [
-            new Uint8Array(),
-            new IOResult({ exitCode: 124, stderr: msg }),
-            new ExecutionNode({ command: cmdStrInner, stderr: msg, exitCode: 124 }),
-          ]
-        }
-        if (err instanceof ExitSignal) {
-          // A background job is its own shell: exit ends the job only.
-          return [
-            err.stdout ?? new Uint8Array(),
-            new IOResult({ exitCode: err.containedCode, stderr: err.stderr }),
-            new ExecutionNode({
-              command: cmdStrInner,
-              stderr: err.stderr,
-              exitCode: err.containedCode,
-            }),
-          ]
-        }
-        throw err
+  //
+  // A job runs concurrently with the rest of the line, so the bind is
+  // only safe where the async context isolates tasks. On the fallback
+  // storage (a browser with no AsyncLocalStorage) it is one global
+  // slot that would stay set while the foreground continues, showing
+  // the job's fork to the rest of the line. There the job's inner
+  // evals resolve by id instead, which is what they did before
+  // ambient sessions existed: a job that leaks into its own nested
+  // eval is narrower than a job that leaks into the whole line.
+  const body = async (): Promise<[ByteSource | null, IOResult, ExecutionNode]> => {
+    let stdout: ByteSource | null
+    let io: IOResult
+    let execNode: ExecutionNode
+    try {
+      ;[stdout, io, execNode] = await executeNode(left, bgSession, null, callStack)
+    } catch (err) {
+      if (err instanceof CommandTimeoutError) {
+        const msg = new TextEncoder().encode(`${err.message}\n`)
+        return [
+          new Uint8Array(),
+          new IOResult({ exitCode: 124, stderr: msg }),
+          new ExecutionNode({ command: cmdStrInner, stderr: msg, exitCode: 124 }),
+        ]
       }
-      const materialized = await materialize(stdout)
-      io.syncExitCode()
-      return [materialized, io, execNode]
-    },
-  )
+      if (err instanceof ExitSignal) {
+        // A background job is its own shell: exit ends the job only.
+        return [
+          err.stdout ?? new Uint8Array(),
+          new IOResult({ exitCode: err.containedCode, stderr: err.stderr }),
+          new ExecutionNode({
+            command: cmdStrInner,
+            stderr: err.stderr,
+            exitCode: err.containedCode,
+          }),
+        ]
+      }
+      throw err
+    }
+    const materialized = await materialize(stdout)
+    io.syncExitCode()
+    return [materialized, io, execNode]
+  }
+  const task: Promise<[ByteSource | null, IOResult, ExecutionNode]> = asyncContextIsolatesTasks
+    ? runWithSession(bgSession, body)
+    : body()
   task.catch(() => {
     // unhandled rejections silenced here; callers use jobTable.wait()
   })

--- a/typescript/packages/core/src/workspace/executor/jobs.ts
+++ b/typescript/packages/core/src/workspace/executor/jobs.ts
@@ -18,6 +18,7 @@ import { CommandTimeoutError } from '../../commands/builtin/utils/limit.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
 import { ExitSignal } from '../../shell/errors.ts'
 import type { JobTable } from '../../shell/job_table.ts'
+import { runWithSession } from '../../context/session_context.ts'
 import { mergeSignals } from '../abort.ts'
 import type { Session } from '../session/session.ts'
 import type { TSNodeLike } from '../../shell/types.ts'
@@ -50,39 +51,46 @@ export async function handleBackground(
   // observes the kill, merged with any enclosing job's channel.
   bgSession.abortSignal = mergeSignals(session.abortSignal, abort.signal) ?? abort.signal
   const cmdStrInner = left.text
-  const task: Promise<[ByteSource | null, IOResult, ExecutionNode]> = (async () => {
-    let stdout: ByteSource | null
-    let io: IOResult
-    let execNode: ExecutionNode
-    try {
-      ;[stdout, io, execNode] = await executeNode(left, bgSession, null, callStack)
-    } catch (err) {
-      if (err instanceof CommandTimeoutError) {
-        const msg = new TextEncoder().encode(`${err.message}\n`)
-        return [
-          new Uint8Array(),
-          new IOResult({ exitCode: 124, stderr: msg }),
-          new ExecutionNode({ command: cmdStrInner, stderr: msg, exitCode: 124 }),
-        ]
+  // The task inherits the OUTER ambient session from its creation
+  // context, and the fork keeps its parent's id, so without this
+  // rebind a nested eval inside the job resolves the ambient outer
+  // session and escapes the fork.
+  const task: Promise<[ByteSource | null, IOResult, ExecutionNode]> = runWithSession(
+    bgSession,
+    async (): Promise<[ByteSource | null, IOResult, ExecutionNode]> => {
+      let stdout: ByteSource | null
+      let io: IOResult
+      let execNode: ExecutionNode
+      try {
+        ;[stdout, io, execNode] = await executeNode(left, bgSession, null, callStack)
+      } catch (err) {
+        if (err instanceof CommandTimeoutError) {
+          const msg = new TextEncoder().encode(`${err.message}\n`)
+          return [
+            new Uint8Array(),
+            new IOResult({ exitCode: 124, stderr: msg }),
+            new ExecutionNode({ command: cmdStrInner, stderr: msg, exitCode: 124 }),
+          ]
+        }
+        if (err instanceof ExitSignal) {
+          // A background job is its own shell: exit ends the job only.
+          return [
+            err.stdout ?? new Uint8Array(),
+            new IOResult({ exitCode: err.containedCode, stderr: err.stderr }),
+            new ExecutionNode({
+              command: cmdStrInner,
+              stderr: err.stderr,
+              exitCode: err.containedCode,
+            }),
+          ]
+        }
+        throw err
       }
-      if (err instanceof ExitSignal) {
-        // A background job is its own shell: exit ends the job only.
-        return [
-          err.stdout ?? new Uint8Array(),
-          new IOResult({ exitCode: err.containedCode, stderr: err.stderr }),
-          new ExecutionNode({
-            command: cmdStrInner,
-            stderr: err.stderr,
-            exitCode: err.containedCode,
-          }),
-        ]
-      }
-      throw err
-    }
-    const materialized = await materialize(stdout)
-    io.syncExitCode()
-    return [materialized, io, execNode]
-  })()
+      const materialized = await materialize(stdout)
+      io.syncExitCode()
+      return [materialized, io, execNode]
+    },
+  )
   task.catch(() => {
     // unhandled rejections silenced here; callers use jobTable.wait()
   })

--- a/typescript/packages/core/src/workspace/expand/node.ts
+++ b/typescript/packages/core/src/workspace/expand/node.ts
@@ -275,16 +275,12 @@ export async function expandNode(
         return prefix + arith.value.toString()
       }
     }
-    const innerCmds = tsNode.namedChildren.filter(
-      (c) =>
-        c.type === NT.COMMAND ||
-        c.type === NT.PIPELINE ||
-        c.type === NT.LIST ||
-        c.type === NT.REDIRECTED_STATEMENT ||
-        c.type === NT.SUBSHELL,
-    )
-    if (innerCmds.length === 0) return prefix
-    const inner = innerCmds[0]?.text ?? ''
+    // The whole body goes to the evaluator: bash substitutes the full
+    // statement list, and picking child nodes dropped every statement
+    // after a `;` and every non-command statement (declarations,
+    // assignments, control flow).
+    const inner = rawSub.slice(2, -1)
+    if (inner.trim() === '') return prefix
     const io = await executeFn(inner, { sessionId: session.sessionId })
     const text = (await io.stdoutStr()).replace(/\n+$/, '')
     // Record the substitution's status: an assignment-only statement

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -181,7 +181,6 @@ export class Workspace {
       this.registry,
       this.runtimes,
       this.policy,
-      this.sessionManager,
       this.agentId,
       sandboxResolver,
     )

--- a/typescript/packages/core/src/workspace/workspace/execute.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/execute.test.ts
@@ -13,12 +13,17 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { afterEach, describe, expect, it } from 'vitest'
+import { RegisteredCommand } from '../../commands/config.ts'
+import { CommandSpec } from '../../commands/spec/types.ts'
+import { IOResult } from '../../io/types.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
-import { MountMode } from '../../types.ts'
+import { MountMode, ResourceName } from '../../types.ts'
 import { getTestParser, stdoutStr } from '../fixtures/workspace_fixture.ts'
 import { Workspace } from '../workspace.ts'
 
 const ENC = new TextEncoder()
+
+const PROBE_SPEC = new CommandSpec({})
 
 const open: Workspace[] = []
 
@@ -146,5 +151,65 @@ describe('command substitution runs its whole body', () => {
     const ws = await makeWs()
     const io = await ws.execute('echo $(export Y=7; echo $Y)')
     expect(stdoutStr(io).trim()).toBe('7')
+  })
+})
+
+// The ambient session belongs to the workspace that published it. A
+// callback fired mid-line reaching a SECOND workspace must not adopt
+// it: that workspace's own session owns its cwd, env and mount grants,
+// and an unrestricted session must never stand in for a restricted one.
+describe('the ambient session is scoped to its workspace', () => {
+  it('another workspace resolves its own session', async () => {
+    const wsA = await makeWs()
+    const wsB = await makeTwoMounts()
+    const seen: string[] = []
+    const rc = new RegisteredCommand({
+      name: 'crossprobe',
+      spec: PROBE_SPEC,
+      resource: ResourceName.RAM,
+      fn: async () => {
+        const io = await wsB.execute('pwd')
+        seen.push(stdoutStr(io).trim())
+        return [new Uint8Array(), new IOResult()]
+      },
+    })
+    wsA.registry.mountForPrefix('/ram/')?.register(rc)
+    await wsA.execute('crossprobe', { cwd: '/ram/subdir' })
+    expect(seen).toEqual(['/'])
+  })
+
+  it('the policy reads the ambient session cwd', async () => {
+    // The policy decides about the line the session actually runs, so
+    // it reads the resolved session's cwd, not the registered
+    // session's: a re-entrant line runs in the live ambient fork.
+    const seen: string[] = []
+    const parser = await getTestParser()
+    const r = new RAMResource()
+    r.store.dirs.add('/')
+    r.store.dirs.add('/subdir')
+    const ws = new Workspace(
+      { '/ram/': r },
+      {
+        mode: MountMode.WRITE,
+        shellParser: parser,
+        policy: (ctx) => {
+          seen.push(ctx.cwd)
+          return null
+        },
+      },
+    )
+    open.push(ws)
+    const rc = new RegisteredCommand({
+      name: 'policyprobe',
+      spec: PROBE_SPEC,
+      resource: ResourceName.RAM,
+      fn: async () => {
+        await ws.execute('pwd')
+        return [new Uint8Array(), new IOResult()]
+      },
+    })
+    ws.registry.mountForPrefix('/ram/')?.register(rc)
+    await ws.execute('policyprobe', { cwd: '/ram/subdir' })
+    expect(seen).toEqual(['/ram/subdir', '/ram/subdir'])
   })
 })

--- a/typescript/packages/core/src/workspace/workspace/execute.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/execute.test.ts
@@ -1,0 +1,150 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { RAMResource } from '../../resource/ram/ram.ts'
+import { MountMode } from '../../types.ts'
+import { getTestParser, stdoutStr } from '../fixtures/workspace_fixture.ts'
+import { Workspace } from '../workspace.ts'
+
+const ENC = new TextEncoder()
+
+const open: Workspace[] = []
+
+async function makeWs(): Promise<Workspace> {
+  const parser = await getTestParser()
+  const r = new RAMResource()
+  r.store.dirs.add('/')
+  r.store.dirs.add('/subdir')
+  r.store.dirs.add('/other')
+  const ws = new Workspace({ '/ram/': r }, { mode: MountMode.WRITE, shellParser: parser })
+  open.push(ws)
+  return ws
+}
+
+async function makeTwoMounts(): Promise<Workspace> {
+  const parser = await getTestParser()
+  const a = new RAMResource()
+  a.store.dirs.add('/')
+  const b = new RAMResource()
+  b.store.dirs.add('/')
+  b.store.files.set('/y.txt', ENC.encode('secret\n'))
+  const ws = new Workspace({ '/a': a, '/b': b }, { mode: MountMode.WRITE, shellParser: parser })
+  open.push(ws)
+  return ws
+}
+
+afterEach(async () => {
+  for (const ws of open.splice(0)) await ws.close()
+})
+
+// A nested eval ($(), eval, source, xargs) re-enters execute and must
+// continue in the LIVE session the outer line runs in. An id cannot say
+// that: it names a registered session, never the ephemeral per-call
+// fork, so these pin the cases only the ambient session context can
+// answer.
+describe('nested evals run in the live ambient session', () => {
+  it('cmdsub reads the per-call fork cwd', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('echo $(pwd)', { cwd: '/ram/subdir' })
+    expect(stdoutStr(io).trim()).toBe('/ram/subdir')
+  })
+
+  it('eval moves the fork, not the default session', async () => {
+    const ws = await makeWs()
+    const before = ws.getSession(ws.defaultSessionId).cwd
+    const io = await ws.execute("eval 'cd /ram/other'; pwd", { cwd: '/ram/subdir' })
+    expect(stdoutStr(io).trim()).toBe('/ram/other')
+    expect(ws.getSession(ws.defaultSessionId).cwd).toBe(before)
+  })
+
+  it('cmdsub cd stays in the fork', async () => {
+    const ws = await makeWs()
+    const before = ws.getSession(ws.defaultSessionId).cwd
+    await ws.execute('echo $(cd /ram/other)', { env: { FOO: 'bar' } })
+    expect(ws.getSession(ws.defaultSessionId).cwd).toBe(before)
+  })
+
+  it('cmdsub reads the named session cwd', async () => {
+    const ws = await makeWs()
+    ws.createSession('agent')
+    await ws.execute('cd /ram/subdir', { sessionId: 'agent' })
+    const io = await ws.execute('echo $(pwd)', { sessionId: 'agent' })
+    expect(stdoutStr(io).trim()).toBe('/ram/subdir')
+  })
+
+  it('cmdsub keeps the named session confinement', async () => {
+    const ws = await makeTwoMounts()
+    ws.createSession('agent', { mounts: { '/a': MountMode.WRITE } })
+    const io = await ws.execute('echo $(cat /b/y.txt)', { sessionId: 'agent' })
+    expect(stdoutStr(io)).not.toContain('secret')
+  })
+
+  it('cmdsub cd on the live session persists', async () => {
+    // Documented divergence: bash runs $() in a subshell, mirage runs
+    // it in the live session, so a cd inside one persists when no
+    // per-call fork is in play. Pinned so the fork-containment fix is
+    // never "improved" into forking every substitution.
+    const ws = await makeWs()
+    await ws.execute('echo $(cd /ram/subdir)')
+    expect(ws.getSession(ws.defaultSessionId).cwd).toBe('/ram/subdir')
+  })
+})
+
+// A background job forks the session, so it is the one mid-line point
+// where the ambient session must be rebound: without that, a nested
+// eval inside `... &` resolves the OUTER live session (the fork keeps
+// its parent's id) and escapes the job's isolation.
+describe('nested evals inside background jobs run in the job fork', () => {
+  it('bg job cmdsub reads the job fork', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('cd /ram/other && echo $(pwd) & wait %1')
+    expect(stdoutStr(io).trim()).toBe('/ram/other')
+  })
+
+  it('bg job cmdsub cd stays in the job fork', async () => {
+    const ws = await makeWs()
+    const before = ws.getSession(ws.defaultSessionId).cwd
+    await ws.execute('echo $(cd /ram/other) & wait %1')
+    expect(ws.getSession(ws.defaultSessionId).cwd).toBe(before)
+  })
+})
+
+// $() must run its whole body: bash substitutes the output of the full
+// statement list, not of the first simple command it contains.
+describe('command substitution runs its whole body', () => {
+  it('runs every statement', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('echo $(echo a; echo b)')
+    expect(stdoutStr(io).trim()).toBe('a b')
+  })
+
+  it('runs control flow', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('echo $(if true; then echo yes; fi)')
+    expect(stdoutStr(io).trim()).toBe('yes')
+  })
+
+  it('runs assignments', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('echo $(X=5; echo $X)')
+    expect(stdoutStr(io).trim()).toBe('5')
+  })
+
+  it('runs declarations', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('echo $(export Y=7; echo $Y)')
+    expect(stdoutStr(io).trim()).toBe('7')
+  })
+})

--- a/typescript/packages/core/src/workspace/workspace/execute.ts
+++ b/typescript/packages/core/src/workspace/workspace/execute.ts
@@ -18,7 +18,7 @@ import { runWithRecording } from '../../observe/context.ts'
 import type { Observer } from '../../observe/observer.ts'
 import type { OpRecord } from '../../observe/record.ts'
 import type { Resource } from '../../resource/base.ts'
-import { runWithSession } from '../../context/session_context.ts'
+import { getCurrentSession, runWithSession } from '../../context/session_context.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import { findSyntaxError, findUnterminatedBacktick, type ShellParser } from '../../shell/parse.ts'
 import type { ProvisionResult } from '../../provision/types.ts'
@@ -94,12 +94,11 @@ async function deniedResult(
   env: ExecuteEnv,
   command: string,
   options: ExecuteOptions,
+  session: Session,
   reason: string,
 ): Promise<ExecuteResult> {
   const cmdName = commandName(command) || command
   const msg = new TextEncoder().encode(`${cmdName}: policy denied: ${reason}\n`)
-  const sessionId = options.sessionId ?? env.sessions.defaultId
-  const session = env.sessions.get(sessionId)
   session.lastExitCode = 126
   if (options.record !== false) {
     await env.observer.logExecution(
@@ -107,7 +106,7 @@ async function deniedResult(
       new IOResult({ exitCode: 126, stderr: msg }),
       [],
       options.agentId ?? env.agentId ?? '',
-      sessionId,
+      session.sessionId,
       options.cwd ?? session.cwd,
     )
   }
@@ -151,12 +150,23 @@ export async function executeLine(
   }
   if (options.provision === true) return env.provision(command)
   const rootNode = root as unknown as TSNodeLike
+  // A re-entrant execute (the evaluator's $(), eval, source, xargs, or
+  // an embedder callback fired mid-line) continues in the live ambient
+  // session unless it names a different one. An id cannot say that: it
+  // names a registered session, never the ephemeral per-call fork the
+  // outer line actually runs in, and re-resolving through the manager
+  // is how a nested line used to escape the fork and its confinement.
+  const ambient = getCurrentSession()
+  const targetSession =
+    ambient !== null && (options.sessionId === undefined || options.sessionId === ambient.sessionId)
+      ? ambient
+      : env.sessions.get(options.sessionId ?? env.sessions.defaultId)
   let routingDecision: PolicyDecision | null
   try {
     routingDecision = await env.policyRouter.decide(rootNode, command, options)
   } catch (caught) {
     if (caught instanceof PolicyDeny) {
-      return deniedResult(env, command, options, caught.reason)
+      return deniedResult(env, command, options, targetSession, caught.reason)
     }
     throw caught
   }
@@ -168,7 +178,10 @@ export async function executeLine(
     // never a typed line: they must not record a history entry or open
     // their own recording context, so their ops flow into this line's
     // recorder (GNU: history is appended by the line reader).
-    const innerOpts: ExecuteOptions & { provision?: false } = { record: false }
+    const innerOpts: ExecuteOptions & { provision?: false } = {
+      record: false,
+      sessionId: opts.sessionId,
+    }
     if (options.signal !== undefined) innerOpts.signal = options.signal
     // Nested lines never re-route: the evaluator's inner lines keep
     // the typed line's decision (runtime argument, policy, or scripts).
@@ -201,8 +214,6 @@ export async function executeLine(
     ...(routingDecision !== null ? { routingDecision } : {}),
     ...(options.signal !== undefined ? { signal: options.signal } : {}),
   }
-  const targetSessionId = options.sessionId ?? env.sessions.defaultId
-  const targetSession = env.sessions.get(targetSessionId)
   try {
     return await runParsedLine(env, command, options, rootNode, deps, targetSession, stdin)
   } finally {

--- a/typescript/packages/core/src/workspace/workspace/execute.ts
+++ b/typescript/packages/core/src/workspace/workspace/execute.ts
@@ -18,7 +18,7 @@ import { runWithRecording } from '../../observe/context.ts'
 import type { Observer } from '../../observe/observer.ts'
 import type { OpRecord } from '../../observe/record.ts'
 import type { Resource } from '../../resource/base.ts'
-import { getCurrentSession, runWithSession } from '../../context/session_context.ts'
+import { getCurrentSessionFor, runWithSession } from '../../context/session_context.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import { findSyntaxError, findUnterminatedBacktick, type ShellParser } from '../../shell/parse.ts'
 import type { ProvisionResult } from '../../provision/types.ts'
@@ -156,14 +156,17 @@ export async function executeLine(
   // names a registered session, never the ephemeral per-call fork the
   // outer line actually runs in, and re-resolving through the manager
   // is how a nested line used to escape the fork and its confinement.
-  const ambient = getCurrentSession()
+  // Only this workspace's own binding counts: a session carries one
+  // workspace's cwd, env and mount grants, so a callback reaching a
+  // second workspace must resolve that workspace's session instead.
+  const ambient = getCurrentSessionFor(env.sessions)
   const targetSession =
     ambient !== null && (options.sessionId === undefined || options.sessionId === ambient.sessionId)
       ? ambient
       : env.sessions.get(options.sessionId ?? env.sessions.defaultId)
   let routingDecision: PolicyDecision | null
   try {
-    routingDecision = await env.policyRouter.decide(rootNode, command, options)
+    routingDecision = await env.policyRouter.decide(rootNode, command, options, targetSession)
   } catch (caught) {
     if (caught instanceof PolicyDeny) {
       return deniedResult(env, command, options, targetSession, caught.reason)
@@ -274,7 +277,11 @@ async function runParsedLine(
     return new ExecuteResult(result.stdout, result.stderr ?? new Uint8Array(), result.exitCode)
   }
   const runBody = (): Promise<[ByteSource | null, IOResult, ExecutionNode]> =>
-    runWithSession(effectiveSession, () => runCommandTree(deps, rootNode, effectiveSession, stdin))
+    runWithSession(
+      effectiveSession,
+      () => runCommandTree(deps, rootNode, effectiveSession, stdin),
+      env.sessions,
+    )
   let execResult: [[ByteSource | null, IOResult, ExecutionNode], OpRecord[]]
   try {
     execResult = isLine ? await runWithRecording(runBody) : [await runBody(), []]

--- a/typescript/packages/core/src/workspace/workspace/policy.ts
+++ b/typescript/packages/core/src/workspace/workspace/policy.ts
@@ -25,7 +25,7 @@ import type { MountResolver } from '../../runtime/resolver.ts'
 import { catchAll, runtimeBindingsFor } from '../../runtime/table.ts'
 import type { TSNodeLike } from '../../shell/types.ts'
 import type { MountRegistry } from '../mount/registry.ts'
-import type { SessionManager } from '../session/manager.ts'
+import type { Session } from '../session/session.ts'
 import { envSnapshot } from '../session/state.ts'
 import type { ExecuteOptions } from './types.ts'
 import type { Runtimes } from './runtimes.ts'
@@ -42,7 +42,6 @@ export class PolicyRouter {
   private readonly registry: MountRegistry
   private readonly runtimes: Runtimes
   private readonly policy: PolicyFn | null
-  private readonly sessions: SessionManager
   private readonly agentId: string | null
   private readonly resolver: MountResolver
 
@@ -50,14 +49,12 @@ export class PolicyRouter {
     registry: MountRegistry,
     runtimes: Runtimes,
     policy: PolicyFn | null,
-    sessions: SessionManager,
     agentId: string | null,
     resolver: MountResolver,
   ) {
     this.registry = registry
     this.runtimes = runtimes
     this.policy = policy
-    this.sessions = sessions
     this.agentId = agentId
     this.resolver = resolver
   }
@@ -66,6 +63,7 @@ export class PolicyRouter {
     root: TSNodeLike,
     command: string,
     options: ExecuteOptions,
+    session: Session,
   ): Promise<PolicyDecision | null> {
     if (options.routingDecision !== undefined) return options.routingDecision
     if (options.runtime !== undefined) {
@@ -89,8 +87,6 @@ export class PolicyRouter {
     const hasScripts = this.runtimes.entries.some((entry) => entry.script !== undefined)
     if (this.policy === null && !hasScripts) return null
     const commands = parsedCommands(root, this.registry.clis.names())
-    const sessionId = options.sessionId ?? this.sessions.defaultId
-    const session = this.sessions.get(sessionId)
     const ctx: PolicyContext = {
       line: command,
       commands,
@@ -98,7 +94,7 @@ export class PolicyRouter {
       builtin: commands[0]?.builtin ?? false,
       cwd: options.cwd ?? session.cwd,
       env: { ...envSnapshot(session), ...(options.env ?? {}) },
-      sessionId,
+      sessionId: session.sessionId,
       agentId: options.agentId ?? this.agentId ?? '',
       mounts: this.resolver.prefixes(),
     }


### PR DESCRIPTION
## What

Three related shell-core fixes, mirrored in Python and TypeScript.

**Nested evals run in the live ambient session.** A re-entrant execute (`$()`, backticks, `eval`, `source`, `xargs`, `timeout`, `command`, `env`, process substitution, or an embedder callback fired mid-line) used to re-resolve its session by id through the session manager. An id cannot name the ephemeral per-call cwd/env fork the outer line actually runs in, and TypeScript dropped the id entirely, so on a named session `$(pwd)` answered the default session's cwd and a restricted session could read forbidden mounts through a command substitution. `execute_line`/`executeLine` now continue in the ambient live session when the call names no session or the same id; every eval site inherits this from the one resolution point.

**Background jobs rebind the ambient session.** `&` forks the session but the fork keeps its parent's id, so a nested eval inside a background job resolved the outer session: `$(pwd)` read the parent's cwd, and `$(cd ...)` moved the parent. The job task now runs inside its fork's ambient scope in both languages.

**Command substitution executes its whole body.** The expansion filtered the parse tree to command-like nodes and ran only the first one, so `$(echo a; echo b)` ran only `echo a`, and declarations, assignments and control flow (`$(export X=1)`, `$(X=5; ...)`, `$(if ...)`, `$(for ...)`) ran nothing at all. The whole text between `$(` and `)` now goes to the evaluator.

One documented divergence is pinned in the tests: bash runs `$()` in a subshell, mirage runs it in the live session, so a `cd` inside a substitution on the unforked session persists.

## Tests

- Red-first unit coverage: `python/tests/workspace/workspace/test_execute.py` and `typescript/.../workspace/workspace/execute.test.ts` (12 cases each side: named-session, per-call fork, confinement, bg-job fidelity, whole-body cmdsub, divergence pin), plus two `test_expand.py` cases pinning the exact text handed to the evaluator.
- Six shared integ cases, byte-pinned against real bash: `integ/bash/jobs/bg.json` (+2) and new `integ/bash/cmdsub/body.json` (+4).

## Verification

- Python battery, facet core: green across all local targets (the two bg cases and four cmdsub cases pass on every target).
- TypeScript battery, facet core: 24479 ok, 0 failures.
- Parity (`parity.py ram disk redis ram-history`, the CI diff): 7264 case/target pairs, 0 mismatches.
- Full Python suite, TS core/node/browser/dsh suites, `pnpm -r typecheck`, pre-commit twice with a stable tree, layout parity at baseline.