### PR TITLE
fix(glob): a match named like the glob word is not the nullglob literal

### DIFF
--- a/integ/bash/glob/matched.json
+++ b/integ/bash/glob/matched.json
@@ -33,6 +33,29 @@
         "stdout": "/data/sorted_a.txt /data/sorted_b.txt /data/sorted_c.txt\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "glob_matched_name_is_the_word",
+      "seq": 960095,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "ssh"
+      ],
+      "command": "touch '/data/zg*zg.txt' /data/zgXzg.txt && echo /data/zg*zg.txt && rm /data/zg*zg.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/zg*zg.txt /data/zgXzg.txt\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/python/mirage/utils/glob_walk.py
+++ b/python/mirage/utils/glob_walk.py
@@ -347,6 +347,15 @@ async def resolve_glob_with(
     command then errors on it like GNU), and matches cap at ``cap`` when
     given. Per-backend glob modules bind their own readdir.
 
+    The spec shape is how a caller chooses between the two answers, and
+    the choice matters because the literal is not distinguishable from a
+    match by looking at it: a file may be named exactly like the word
+    that globbed for it. A word-shaped spec asks for bash's own answer,
+    literal included. A directory-shaped spec (``PathSpec.dir``) asks for
+    matches alone, so an empty list means nothing matched -- what a
+    caller merging these matches with another source needs, since only it
+    can tell whether the union is empty.
+
     Args:
         readdir (Callable): backend readdir ``(accessor, path, index)``
             returning absolute virtual paths.
@@ -379,7 +388,8 @@ async def resolve_glob_with(
                 # (cat '*.nope' -> No such file or directory, exit 1).
                 # The literal is the word after quote removal, so the
                 # marks come off here. Dir-shaped specs (PathSpec.dir)
-                # are internal expansions and keep the empty result.
+                # keep the empty result, which is what a caller that has
+                # to merge these matches with another source asks for.
                 result.append(
                     _unmark_spec(
                         dataclasses.replace(p, pattern=None, resolved=True)))

--- a/python/mirage/workspace/expand/globs.py
+++ b/python/mirage/workspace/expand/globs.py
@@ -66,29 +66,25 @@ def _as_spec(match: str | PathSpec, prefix: str) -> PathSpec:
     return PathSpec.from_str_path(full, mount_key(full, prefix))
 
 
-def _merge_namespace(item: PathSpec, matches: list[str | PathSpec],
-                     extra: list[str], prefix: str, registry: MountRegistry,
+def _merge_namespace(matches: list[str | PathSpec], extra: list[str],
+                     prefix: str, registry: MountRegistry,
                      mount: MountEntry) -> list[PathSpec]:
     """Union a backend's matches with the namespace-owed ones.
 
     Sorted, because bash sorts a pathname expansion and the two sources
-    are enumerated separately. A backend that matched nothing answers
-    with the literal word (nullglob off); that is "no match", not an
-    entry to merge against, so it is dropped here and the literal is
-    reinstated by the caller only if the union is empty too.
+    are enumerated separately. Every spec here is a real match: the
+    backend is asked with a directory-shaped spec, which answers with
+    matches alone, so "nothing matched" arrives as an empty list and the
+    caller reinstates the literal only when the union is empty too.
 
     Args:
-        item (PathSpec): the glob word being resolved.
         matches (list[str | PathSpec]): the backend's own matches.
         extra (list[str]): namespace-owed virtual paths.
         prefix (str): the mount prefix with no trailing slash.
         registry (MountRegistry): registry holding the mount table.
         mount (MountEntry): the mount owning the glob word.
     """
-    specs = [
-        s for s in (_as_spec(m, prefix) for m in matches)
-        if s.virtual != item.virtual
-    ]
+    specs = [_as_spec(m, prefix) for m in matches]
     seen = {s.virtual for s in specs}
     for virtual in extra:
         if virtual in seen:
@@ -345,9 +341,15 @@ async def resolve_globs(
                                                      directory, pattern))),
                         item, registry, mount, 1)
                 else:
+                    # Asked with the word, a backend that matched nothing
+                    # answers with the word (nullglob off), which is
+                    # byte-identical to a real match on a file named like
+                    # the pattern -- `*a.txt` next to `xa.txt` lost its
+                    # first match to that ambiguity. The directory-shaped
+                    # spec has no literal to reinstate, so an empty list
+                    # means no match and every spec returned is one.
                     resolved = _merge_namespace(
-                        item,
-                        list(await mount.resource.resolve_glob([item],
+                        list(await mount.resource.resolve_glob([item.dir],
                                                                prefix=prefix)),
                         _namespace_children(registry, links, directory,
                                             pattern), prefix, registry, mount)

--- a/python/mirage/workspace/expand/globs.py
+++ b/python/mirage/workspace/expand/globs.py
@@ -67,24 +67,39 @@ def _as_spec(match: str | PathSpec, prefix: str) -> PathSpec:
 
 
 def _merge_namespace(matches: list[str | PathSpec], extra: list[str],
-                     prefix: str, registry: MountRegistry,
+                     directory: str, prefix: str, registry: MountRegistry,
                      mount: MountEntry) -> list[PathSpec]:
     """Union a backend's matches with the namespace-owed ones.
 
     Sorted, because bash sorts a pathname expansion and the two sources
-    are enumerated separately. Every spec here is a real match: the
-    backend is asked with a directory-shaped spec, which answers with
-    matches alone, so "nothing matched" arrives as an empty list and the
-    caller reinstates the literal only when the union is empty too.
+    are enumerated separately. The backend is asked with a
+    directory-shaped spec, which answers with matches alone, so "nothing
+    matched" arrives as an empty list and the caller reinstates the
+    literal only when the union is empty too.
+
+    A match is a child of the directory it was globbed in, so a spec that
+    is the directory itself is not one. The shared resolver never answers
+    a dir-shaped ask that way, but ``resolve_glob`` is a public hook and a
+    resource reinstating the literal on its own would hand back the spec
+    it was given. Unlike the word comparison this replaces, the test
+    cannot discard a real match: a match is strictly longer than the
+    directory holding it, while a word can be spelled exactly like one.
 
     Args:
         matches (list[str | PathSpec]): the backend's own matches.
         extra (list[str]): namespace-owed virtual paths.
+        directory (str): the globbed directory, slash-terminated, with
+            its marks off: a match is a real path a backend listed, so a
+            glob character quoted in the directory's name is a character
+            of it and the marked spelling would match no match at all.
         prefix (str): the mount prefix with no trailing slash.
         registry (MountRegistry): registry holding the mount table.
         mount (MountEntry): the mount owning the glob word.
     """
-    specs = [_as_spec(m, prefix) for m in matches]
+    specs = [
+        s for s in (_as_spec(m, prefix) for m in matches)
+        if s.virtual.startswith(directory) and s.virtual != directory
+    ]
     seen = {s.virtual for s in specs}
     for virtual in extra:
         if virtual in seen:
@@ -352,7 +367,8 @@ async def resolve_globs(
                         list(await mount.resource.resolve_glob([item.dir],
                                                                prefix=prefix)),
                         _namespace_children(registry, links, directory,
-                                            pattern), prefix, registry, mount)
+                                            pattern), directory, prefix,
+                        registry, mount)
                 # bash with nullglob off: a zero-match glob stays the
                 # literal word instead of vanishing.
                 if not resolved:

--- a/python/tests/workspace/expand/test_globs.py
+++ b/python/tests/workspace/expand/test_globs.py
@@ -31,6 +31,8 @@ def _mock_registry(resolve_result=None):
     mount.prefix = "/data/"
 
     async def _resolve_glob(scopes, prefix=""):
+        if callable(resolve_result):
+            return resolve_result(scopes)
         if resolve_result is not None:
             return resolve_result
         # A backend holding nothing the patterns match. Echoing the specs
@@ -187,6 +189,28 @@ def test_match_named_like_the_glob_word_survives():
     result = _run(resolve_globs(["echo", glob_ps], reg))
     assert [r.virtual for r in result[1:]] == ["/data/*a.txt", "/data/xa.txt"]
     assert all(not r.pattern for r in result[1:])
+
+
+def test_resource_reinstating_the_literal_itself_yields_no_match():
+    """``resolve_glob`` is a public hook, so the shape is not a contract.
+
+    A resource that implements nullglob-off on its own answers a
+    no-match ask with the spec it was handed, which is now the directory.
+    That is not a child of the directory, so it is no match, and the word
+    stays literal rather than expanding to ``/data/``.
+    """
+    reg = _mock_registry(resolve_result=list)
+    glob_ps = PathSpec(
+        resource_path="*.nope",
+        virtual="/data/*.nope",
+        directory="/data/",
+        pattern="*.nope",
+        resolved=False,
+    )
+    result = _run(resolve_globs(["cat", glob_ps], reg))
+    assert len(result) == 2
+    assert result[1].virtual == "/data/*.nope"
+    assert result[1].pattern
 
 
 def test_mixed_text_and_pathspec():
@@ -423,6 +447,29 @@ def test_glob_keeps_a_match_spelled_like_the_word():
     _run(ws.execute("touch /base/xa.txt", session_id="s"))
     assert _out(
         ws, "echo /base/*a.txt").split() == ["/base/*a.txt", "/base/xa.txt"]
+
+
+def test_glob_lists_a_directory_whose_name_holds_a_quoted_glob_char():
+    """A quoted glob character in the parent is part of a real name.
+
+    The backend is asked with the directory-shaped spec, and a match is a
+    real path it listed, so the two are compared in unmarked space. The
+    marked spelling names no directory, so it would answer every word
+    under ``'/base/*d'/`` with the literal. GNU bash 5.2
+    (debian:stable-slim): ``echo '/data/*d'/*.txt`` ->
+    ``/data/*d/one.txt /data/*d/two.txt``.
+    """
+    ws = _ws()
+    _run(_seed(ws))
+    _run(ws.execute("mkdir '/base/*d'", session_id="s"))
+    _run(ws.execute("touch '/base/*d/one.txt'", session_id="s"))
+    _run(ws.execute("touch '/base/*d/two.txt'", session_id="s"))
+    assert _out(ws, "echo '/base/*d'/*.txt").split() == [
+        "/base/*d/one.txt", "/base/*d/two.txt"
+    ]
+    assert _out(ws, "echo '/base/*d'/o*.txt").split() == ["/base/*d/one.txt"]
+    # Nothing under it still falls back to the literal word.
+    assert _out(ws, "echo '/base/*d'/*.none").split() == ["/base/*d/*.none"]
 
 
 def test_unmatched_glob_still_stays_literal():

--- a/python/tests/workspace/expand/test_globs.py
+++ b/python/tests/workspace/expand/test_globs.py
@@ -33,7 +33,10 @@ def _mock_registry(resolve_result=None):
     async def _resolve_glob(scopes, prefix=""):
         if resolve_result is not None:
             return resolve_result
-        return scopes
+        # A backend holding nothing the patterns match. Echoing the specs
+        # back would stand in for no backend: a real one never answers a
+        # dir-shaped ask with the directory itself.
+        return [s for s in scopes if not s.pattern]
 
     mount.resource = MagicMock()
     mount.resource.resolve_glob = _resolve_glob
@@ -153,6 +156,37 @@ def test_glob_no_match_keeps_literal_word():
     assert isinstance(result[1], PathSpec)
     assert result[1].virtual == "/data/*.xyz"
     assert result[1].pattern
+
+
+def test_match_named_like_the_glob_word_survives():
+    """A file may be named exactly like the word that globbed for it.
+
+    The merge layer used to read "the backend handed me back the word I
+    gave it" as "nothing matched", which is what a zero-match backend
+    answers with nullglob off. The two are byte-identical, so the real
+    match was thrown away.
+    """
+    matches = [
+        PathSpec(resource_path="*a.txt",
+                 virtual="/data/*a.txt",
+                 directory="/data/",
+                 resolved=True),
+        PathSpec(resource_path="xa.txt",
+                 virtual="/data/xa.txt",
+                 directory="/data/",
+                 resolved=True),
+    ]
+    reg = _mock_registry(resolve_result=matches)
+    glob_ps = PathSpec(
+        resource_path="*a.txt",
+        virtual="/data/*a.txt",
+        directory="/data/",
+        pattern="*a.txt",
+        resolved=False,
+    )
+    result = _run(resolve_globs(["echo", glob_ps], reg))
+    assert [r.virtual for r in result[1:]] == ["/data/*a.txt", "/data/xa.txt"]
+    assert all(not r.pattern for r in result[1:])
 
 
 def test_mixed_text_and_pathspec():
@@ -376,6 +410,19 @@ def test_glob_matches_only_the_pattern():
     assert _out(ws, "echo /base/i*").split() == ["/base/inner"]
     assert _out(ws, "echo /base/l*").split() == ["/base/link"]
     assert _out(ws, "echo /base/f*").split() == ["/base/f1"]
+
+
+def test_glob_keeps_a_match_spelled_like_the_word():
+    """GNU bash 5.2 (debian:stable-slim), ``*a.txt`` beside ``xa.txt``:
+    ``echo /data/*a.txt`` -> ``/data/*a.txt /data/xa.txt``. The live ``*``
+    matches the literal ``*`` in the first name.
+    """
+    ws = _ws()
+    _run(_seed(ws))
+    _run(ws.execute("touch '/base/*a.txt'", session_id="s"))
+    _run(ws.execute("touch /base/xa.txt", session_id="s"))
+    assert _out(
+        ws, "echo /base/*a.txt").split() == ["/base/*a.txt", "/base/xa.txt"]
 
 
 def test_unmatched_glob_still_stays_literal():

--- a/python/tests/workspace/node/test_execute_node.py
+++ b/python/tests/workspace/node/test_execute_node.py
@@ -43,15 +43,11 @@ def _mock_dispatch():
     return d
 
 
-async def _echo_resolve_glob(scopes, prefix=""):
-    # Return resource-relative paths, matching real resolve_glob behavior
-    results = []
-    for s in scopes:
-        path = s.virtual
-        if prefix and path.startswith(prefix):
-            path = path[len(prefix):] or "/"
-        results.append(path)
-    return results
+async def _no_match_resolve_glob(scopes, prefix=""):
+    # A backend holding nothing the patterns match: a resolved spec passes
+    # through, a pattern spec resolves to no matches and the expander
+    # reinstates the literal word (bash with nullglob off).
+    return [s for s in scopes if not s.pattern]
 
 
 def _mock_registry():
@@ -60,7 +56,7 @@ def _mock_registry():
     mount.mode = MountMode.EXEC
     mount.execute_cmd = AsyncMock(return_value=(b"ok\n", IOResult()))
     mount.resource = MagicMock()
-    mount.resource.resolve_glob = _echo_resolve_glob
+    mount.resource.resolve_glob = _no_match_resolve_glob
     mount.spec_for = MagicMock(return_value=None)
 
     reg = MagicMock()

--- a/typescript/packages/core/src/utils/glob_walk.ts
+++ b/typescript/packages/core/src/utils/glob_walk.ts
@@ -188,6 +188,14 @@ function isMissingDir(err: unknown): boolean {
 // unmatched glob word stays the literal (bash nullglob off: the command
 // then errors on it like GNU), and matches cap at `cap` when given.
 // Per-backend glob modules bind their own readdir.
+//
+// The spec shape is how a caller chooses between the two answers, and the
+// choice matters because the literal is not distinguishable from a match by
+// looking at it: a file may be named exactly like the word that globbed for
+// it. A word-shaped spec asks for bash's own answer, literal included. A
+// directory-shaped spec (`PathSpec.dir`) asks for matches alone, so an empty
+// list means nothing matched -- what a caller merging these matches with
+// another source needs, since only it can tell whether the union is empty.
 export async function resolveGlobWith<A, I>(
   readdir: (accessor: A, path: PathSpec, index?: I) => Promise<string[]>,
   accessor: A,
@@ -212,6 +220,8 @@ export async function resolveGlobWith<A, I>(
       const matched = (await expandPattern(readdir, accessor, p, index, children)).filter((m) =>
         pathAllowed(m.virtual),
       )
+      // Dir-shaped specs keep the empty result, which is what a caller
+      // that has to merge these matches with another source asks for.
       if (matched.length === 0 && isWordShaped(p)) {
         // The literal is the word after quote removal, so the marks come
         // off here.

--- a/typescript/packages/core/src/workspace/expand/glob_namespace.test.ts
+++ b/typescript/packages/core/src/workspace/expand/glob_namespace.test.ts
@@ -106,6 +106,26 @@ describe('glob expansion sees namespace state', () => {
     ])
   })
 
+  // A quoted glob character in the parent is part of a real name. The
+  // backend is asked with the directory-shaped spec, and a match is a real
+  // path it listed, so the two are compared in unmarked space; the marked
+  // spelling names no directory and would answer every word under
+  // `'/base/*d'/` with the literal. GNU bash 5.2 (debian:stable-slim):
+  //   echo '/data/*d'/*.txt -> /data/*d/one.txt /data/*d/two.txt
+  it('lists a directory whose name holds a quoted glob character', async () => {
+    const ws = await makeWs()
+    await ws.execute("mkdir '/base/*d'", { sessionId: 's' })
+    await ws.execute("touch '/base/*d/one.txt'", { sessionId: 's' })
+    await ws.execute("touch '/base/*d/two.txt'", { sessionId: 's' })
+    expect((await out(ws, "echo '/base/*d'/*.txt")).split(/\s+/).filter(Boolean)).toEqual([
+      '/base/*d/one.txt',
+      '/base/*d/two.txt',
+    ])
+    expect((await out(ws, "echo '/base/*d'/o*.txt")).trim()).toBe('/base/*d/one.txt')
+    // Nothing under it still falls back to the literal word.
+    expect((await out(ws, "echo '/base/*d'/*.none")).trim()).toBe('/base/*d/*.none')
+  })
+
   it('keeps an unmatched glob literal', async () => {
     const ws = await makeWs()
     expect((await out(ws, 'echo /base/zzz*')).trim()).toBe('/base/zzz*')

--- a/typescript/packages/core/src/workspace/expand/glob_namespace.test.ts
+++ b/typescript/packages/core/src/workspace/expand/glob_namespace.test.ts
@@ -93,6 +93,19 @@ describe('glob expansion sees namespace state', () => {
     expect((await out(ws, 'echo /base/f*')).trim()).toBe('/base/f1')
   })
 
+  // GNU bash 5.2 (debian:stable-slim), `*a.txt` beside `xa.txt`:
+  //   echo /data/*a.txt -> /data/*a.txt /data/xa.txt
+  // The live `*` matches the literal `*` in the first name.
+  it('keeps a match spelled like the glob word', async () => {
+    const ws = await makeWs()
+    await ws.execute("touch '/base/*a.txt'", { sessionId: 's' })
+    await ws.execute('touch /base/xa.txt', { sessionId: 's' })
+    expect((await out(ws, 'echo /base/*a.txt')).split(/\s+/).filter(Boolean)).toEqual([
+      '/base/*a.txt',
+      '/base/xa.txt',
+    ])
+  })
+
   it('keeps an unmatched glob literal', async () => {
     const ws = await makeWs()
     expect((await out(ws, 'echo /base/zzz*')).trim()).toBe('/base/zzz*')

--- a/typescript/packages/core/src/workspace/expand/globs.test.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.test.ts
@@ -28,6 +28,22 @@ class PlainResource implements Resource {
   }
 }
 
+// A resource that implements nullglob-off on its own: a no-match ask comes
+// back as the spec it was handed. `glob` is a public hook, so the shape
+// resolveGlobs sends is not a contract it can rely on.
+class EchoGlobResource implements ResourceWithGlob {
+  readonly kind = 'echo'
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+  glob(paths: readonly PathSpec[]): Promise<PathSpec[]> {
+    return Promise.resolve([...paths])
+  }
+}
+
 class GlobResource implements ResourceWithGlob {
   readonly kind = 'glob'
   constructor(private readonly results: PathSpec[]) {}
@@ -111,6 +127,24 @@ describe('resolveGlobs', () => {
     const out = await resolveGlobs([p], reg)
     expect(out.map((x) => (x as PathSpec).virtual)).toEqual(['/ram/*a.txt', '/ram/xa.txt'])
     expect(out.every((x) => (x as PathSpec).pattern === null)).toBe(true)
+  })
+
+  // The echoed spec is the directory, which is not a child of itself, so
+  // it is no match and the word stays literal rather than expanding to
+  // `/ram/`.
+  it('takes no match from a resource that reinstates the literal itself', async () => {
+    const reg = new MountRegistry({ '/ram': new EchoGlobResource() }, MountMode.WRITE)
+    const p = new PathSpec({
+      resourcePath: 'ram/*.nope',
+      virtual: '/ram/*.nope',
+      directory: '/ram/',
+      pattern: '*.nope',
+      resolved: false,
+    })
+    const out = await resolveGlobs([p], reg)
+    expect(out).toHaveLength(1)
+    expect((out[0] as PathSpec).virtual).toBe('/ram/*.nope')
+    expect((out[0] as PathSpec).pattern).toBe('*.nope')
   })
 
   it('keeps the literal word on zero matches (bash nullglob off)', async () => {

--- a/typescript/packages/core/src/workspace/expand/globs.test.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.test.ts
@@ -90,6 +90,29 @@ describe('resolveGlobs', () => {
     ])
   })
 
+  // A file may be named exactly like the word that globbed for it. The
+  // merge layer used to read "the backend handed me back the word I gave
+  // it" as "nothing matched", which is what a zero-match backend answers
+  // with nullglob off. The two are byte-identical, so the real match was
+  // thrown away.
+  it('keeps a match named exactly like the glob word', async () => {
+    const res = new GlobResource([
+      PathSpec.fromStrPath('/ram/*a.txt'),
+      PathSpec.fromStrPath('/ram/xa.txt'),
+    ])
+    const reg = new MountRegistry({ '/ram': res }, MountMode.WRITE)
+    const p = new PathSpec({
+      resourcePath: 'ram/*a.txt',
+      virtual: '/ram/*a.txt',
+      directory: '/ram/',
+      pattern: '*a.txt',
+      resolved: false,
+    })
+    const out = await resolveGlobs([p], reg)
+    expect(out.map((x) => (x as PathSpec).virtual)).toEqual(['/ram/*a.txt', '/ram/xa.txt'])
+    expect(out.every((x) => (x as PathSpec).pattern === null)).toBe(true)
+  })
+
   it('keeps the literal word on zero matches (bash nullglob off)', async () => {
     const res = new GlobResource([])
     const reg = new MountRegistry({ '/ram': res }, MountMode.WRITE)

--- a/typescript/packages/core/src/workspace/expand/globs.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.ts
@@ -111,17 +111,28 @@ function toSpecs(
 
 // Union a backend's matches with the namespace-owed ones. Sorted, because
 // bash sorts a pathname expansion and the two sources are enumerated
-// separately. Every spec here is a real match: the backend is asked with a
-// directory-shaped spec, which answers with matches alone, so "nothing
-// matched" arrives as an empty list and the caller reinstates the literal
-// only when the union is empty too.
+// separately. The backend is asked with a directory-shaped spec, which
+// answers with matches alone, so "nothing matched" arrives as an empty list
+// and the caller reinstates the literal only when the union is empty too.
+//
+// A match is a child of the directory it was globbed in, so a spec that is
+// the directory itself is not one. The shared resolver never answers a
+// dir-shaped ask that way, but `glob` is a public hook and a resource
+// reinstating the literal on its own would hand back the spec it was given.
+// Unlike the word comparison this replaces, the test cannot discard a real
+// match: a match is strictly longer than the directory holding it, while a
+// word can be spelled exactly like one. `directory` arrives with its marks
+// off, because a match is a real path a backend listed: a glob character
+// quoted in the directory's name is a character of it, and the marked
+// spelling would match no match at all.
 function mergeNamespace(
   matches: readonly PathSpec[],
   extra: readonly string[],
+  directory: string,
   registry: MountRegistry,
   mount: MountEntry,
 ): PathSpec[] {
-  const specs = [...matches]
+  const specs = matches.filter((m) => m.virtual.startsWith(directory) && m.virtual !== directory)
   const seen = new Set(specs.map((m) => m.virtual))
   for (const virtual of extra) {
     if (seen.has(virtual)) continue
@@ -307,7 +318,7 @@ export async function resolveGlobs(
             mount.resource.glob !== undefined
               ? await mount.resource.glob([withPrefix.dir], prefix)
               : []
-          resolved = mergeNamespace(own, extra, registry, mount)
+          resolved = mergeNamespace(own, extra, directory, registry, mount)
         }
         // bash with nullglob off: a zero-match glob stays the literal
         // word instead of vanishing.

--- a/typescript/packages/core/src/workspace/expand/globs.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.ts
@@ -111,18 +111,17 @@ function toSpecs(
 
 // Union a backend's matches with the namespace-owed ones. Sorted, because
 // bash sorts a pathname expansion and the two sources are enumerated
-// separately. A backend that matched nothing answers with the literal word
-// (nullglob off); that is "no match", not an entry to merge against, so it
-// is dropped here and the literal is reinstated by the caller only if the
-// union is empty too.
+// separately. Every spec here is a real match: the backend is asked with a
+// directory-shaped spec, which answers with matches alone, so "nothing
+// matched" arrives as an empty list and the caller reinstates the literal
+// only when the union is empty too.
 function mergeNamespace(
-  item: PathSpec,
   matches: readonly PathSpec[],
   extra: readonly string[],
   registry: MountRegistry,
   mount: MountEntry,
 ): PathSpec[] {
-  const specs = matches.filter((m) => m.virtual !== item.virtual)
+  const specs = [...matches]
   const seen = new Set(specs.map((m) => m.virtual))
   for (const virtual of extra) {
     if (seen.has(virtual)) continue
@@ -285,10 +284,6 @@ export async function resolveGlobs(
         rawPath: item.rawPath,
       })
       try {
-        const own =
-          !linked && mount.resource.glob !== undefined
-            ? await mount.resource.glob([withPrefix], prefix)
-            : []
         let resolved: PathSpec[]
         if (midPath) {
           resolved = await walkSegments(withPrefix, mount, registry, links)
@@ -302,7 +297,17 @@ export async function resolveGlobs(
             1,
           )
         } else {
-          resolved = mergeNamespace(withPrefix, own, extra, registry, mount)
+          // Asked with the word, a backend that matched nothing answers
+          // with the word (nullglob off), which is byte-identical to a
+          // real match on a file named like the pattern -- `*a.txt` next
+          // to `xa.txt` lost its first match to that ambiguity. The
+          // directory-shaped spec has no literal to reinstate, so an
+          // empty list means no match and every spec returned is one.
+          const own =
+            mount.resource.glob !== undefined
+              ? await mount.resource.glob([withPrefix.dir], prefix)
+              : []
+          resolved = mergeNamespace(own, extra, registry, mount)
         }
         // bash with nullglob off: a zero-match glob stays the literal
         // word instead of vanishing.


### PR DESCRIPTION
## The bug

Pathname expansion silently dropped a real match whose name equalled the glob word itself.

```bash
# a directory holding two files: "*a.txt" and "xa.txt"
echo /data/*a.txt
```

GNU bash 5.2.37 (`debian:stable-slim`) prints `/data/*a.txt /data/xa.txt` — the live `*` matches the literal `*` in the first name. mirage printed only `/data/xa.txt`, in both languages.

Reproduced on `main` at 8369f0453, so this is not caused by #783.

## Root cause

`_merge_namespace` / `mergeNamespace` unions a backend's matches with the namespace-owed ones (nested mount roots and symlinks, which no backend can see). It has to discard the backend's nullglob-off fallback — a zero-match backend answers with the literal word, and that is "no match", not an entry to merge against — and it identified that fallback by comparing the returned path to the word:

```python
specs = [
    s for s in (_as_spec(m, prefix) for m in matches)
    if s.virtual != item.virtual
]
```

The inference is unsound, and GNU's own behavior is why: after quote removal, a zero-match glob and a file genuinely named `*a.txt` are the same string. The returned value carries no evidence of which happened, so a real match was thrown away. A `?` pattern was unaffected only because its word never equals the name it matches.

The backend was innocent throughout — `ram.resolve_glob` returned **both** paths.

## The fix

Rather than marking the reinstated literal, this removes the guess by asking a question whose empty answer is unambiguous.

`resolve_glob_with` already answers two different questions depending on the spec shape it is handed: a **word-shaped** spec gets bash's own answer with the literal reinstated, a **directory-shaped** one (`PathSpec.dir`) gets matches alone. The expander now asks the dir-shaped question, so an empty list *means* nothing matched, the comparison is deleted, and `resolve_globs` remains the single place that reinstates the literal — which it has to be, since only it can see whether the backend and the namespace between them matched anything.

That shape contract was previously an incidental comment; it is now stated in `resolve_glob_with` / `resolveGlobWith` in both languages, because the fix rests on it.

No backend changes: every resource's `resolve_glob` / `glob` funnels through `expand_pattern` / `expandPattern`, which already handles both spec shapes — the mid-path walk and the symlinked-parent branch have been sending dir-shaped specs all along.

### Rider

TypeScript computed its backend `glob` call *before* branching, so a mid-path word paid for a request whose result was then discarded. Python's `if/elif/else` never did. The call now lives in the branch that uses it.

## GNU pins

`debian:stable-slim`, bash 5.2.37:

```
echo /data/*a.txt      ->  /data/*a.txt /data/xa.txt
echo /data/*d/f        ->  /data/*d/f /data/xd/f
cd /data; echo *a.txt  ->  *a.txt xa.txt
ls -d /data/*a.txt     ->  /data/*a.txt
                           /data/xa.txt
```

## Coverage

Each new test was confirmed red without the fix and green with it:

- **py** `test_globs.py` — a resolver-level test that a match equal to the word survives, plus an end-to-end `echo /base/*a.txt`
- **ts** `globs.test.ts` + `glob_namespace.test.ts` — the same two
- **integ** `glob_matched_name_is_the_word`, restricted to the backends that allow `*` in a name (the target list from `glob_quoted_touch_creates_literal`)

Beyond the committed tests, mid-path (`/data/*d/f`), relative spellings, root-mounted globs, a nested mount root, and the nullglob-off literal were all checked against GNU on both hosts.

### A stale test mock, fixed

`_echo_resolve_glob` in `test_execute_node.py` echoed back whatever spec it was handed, commented as "matching real resolve_glob behavior." That was only ever true on the word-shaped zero-match branch, so three tests asserting the zero-match literal were passing *through* the unsound filter this PR deletes. It now answers as a backend holding nothing the pattern matches, and those tests assert the literal for the honest reason. The same latent echo in `test_globs.py`'s default mock is fixed too — no test exercises it today, but it would mislead the next one.

## Verification

- Both integ hosts agree: **4999 passed, 0 failed** on `ram`+`disk`; the new case goes red without the fix
- Python suite: **14,276 passed, 890 skipped, 0 failed** (`tests/fuse` excluded — no libfuse locally)
- `pnpm -r typecheck` clean; mypy clean over 1807 files
- Spec drift, spec parity, width table, and `check_layout_parity.py --strict` (302/302) all pass
- pre-commit clean **except two pre-existing `ts-eslint` errors in `packages/core/src/workspace/workspace/execute.test.ts`** (`Unnecessary optional chain on a non-nullish value`, lines 176 and 211). Those reproduce on pristine `main` with this branch's changes stashed — #788 added `?.` on a call that #781 made non-nullish. Untouched here since they are outside this change's scope.

## Note for the reviewer

`glob_quoted_touch_creates_literal` on the in-flight quoted-glob branch does **not** catch this bug: with a single file, the dropped match and the reinstated literal print the same string. Two files are required to see it, which is why the new case creates both.

The integ target list is inherited from that case rather than proven independently — only `ram`/`disk` are runnable locally. If `ssh` or an object-store target rejects `*` in a name, that case will need narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
