### PR TITLE
fix(flat-store): implicit dirs, ancestor cache invalidation, exact-only negated -name, ssh revalidation (py+ts)

### DIFF
--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -103,10 +103,54 @@ import { startPythonServer } from './server_process.ts'
 export interface Open {
   ws: ExecWorkspace
   cleanup: () => Promise<void>
+  // A second workspace over the same backing store, which consistency
+  // scenarios mutate through. Adapters that can build their mounts more than
+  // once expose it; the rest leave it undefined and the runner reports their
+  // consistency cases as skipped instead of silently dropping them.
+  shadow?: () => ExecWorkspace
 }
 
 export interface OpenConsistency extends Open {
   mutate: (path: string, content: Uint8Array) => Promise<void>
+}
+
+export interface OpenOptions {
+  consistency?: ConsistencyPolicy
+}
+
+type MountMap = ConstructorParameters<typeof Workspace>[0]
+
+interface OpenedWorkspaces {
+  ws: ExecWorkspace
+  shadow: () => ExecWorkspace
+  closeAll: () => Promise<void>
+}
+
+/**
+ * The workspace an adapter hands back, plus the shadow factory.
+ *
+ * `build` must return fresh resources on every call: two workspaces sharing
+ * resource instances share their caches, and a consistency scenario mutating
+ * through one would invalidate the other's — which is exactly the thing the
+ * scenario is there to observe.
+ */
+function openWorkspaces(build: () => MountMap, options?: OpenOptions): OpenedWorkspaces {
+  const opened: Workspace[] = []
+  const make = (consistency?: ConsistencyPolicy): ExecWorkspace => {
+    const ws = new Workspace(build(), {
+      mode: MountMode.WRITE,
+      ...(consistency !== undefined ? { consistency } : {}),
+    })
+    opened.push(ws)
+    return ws as unknown as ExecWorkspace
+  }
+  return {
+    ws: make(options?.consistency),
+    shadow: () => make(),
+    closeAll: async (): Promise<void> => {
+      for (const ws of opened) await ws.close()
+    },
+  }
 }
 
 const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379/0'
@@ -201,22 +245,25 @@ async function openOpfs(target: Target): Promise<Open> {
   return { ws: ws as unknown as ExecWorkspace, cleanup }
 }
 
-async function openGridfs(target: Target): Promise<Open> {
+async function openGridfs(target: Target, options?: OpenOptions): Promise<Open> {
   const id = runId()
   const uri = MONGODB_URI
   const database = `mirage_integ_${id}`
-  const mounts: Record<string, GridFSResource> = {}
-  for (const m of target.mounts) {
-    mounts[m.path] = new GridFSResource({
-      uri,
-      database,
-      bucket: String(m.bucket),
-      keyPrefix: m.prefix,
-    })
+  const build = (): MountMap => {
+    const mounts: Record<string, GridFSResource> = {}
+    for (const m of target.mounts) {
+      mounts[m.path] = new GridFSResource({
+        uri,
+        database,
+        bucket: String(m.bucket),
+        keyPrefix: m.prefix,
+      })
+    }
+    return mounts
   }
-  const ws = new Workspace(mounts, { mode: MountMode.WRITE })
+  const opened = openWorkspaces(build, options)
   const cleanup = async (): Promise<void> => {
-    await ws.close()
+    await opened.closeAll()
     const { MongoClient } = await import('mongodb')
     const client = new MongoClient(uri)
     try {
@@ -225,7 +272,7 @@ async function openGridfs(target: Target): Promise<Open> {
       await client.close()
     }
   }
-  return { ws: ws as unknown as ExecWorkspace, cleanup }
+  return { ws: opened.ws, shadow: opened.shadow, cleanup }
 }
 
 async function openDatabricksVolume(target: Target): Promise<Open> {
@@ -289,7 +336,7 @@ function objectStorageResource(name: string, bucket: string, keyPrefix: string |
   throw new Error(`unknown object storage resource: ${name}`)
 }
 
-async function openS3(target: Target): Promise<Open> {
+async function openS3(target: Target, options?: OpenOptions): Promise<Open> {
   if (!S3_ENDPOINT) throw new Error('s3 target requires S3_ENDPOINT')
   const id = runId()
   const client = new S3Client({
@@ -307,14 +354,20 @@ async function openS3(target: Target): Promise<Open> {
     }
     return name
   }
-  const mounts: Record<string, S3Resource> = {}
-  for (const m of target.mounts) {
-    const bucket = await bucketFor(m)
-    mounts[m.path] = objectStorageResource(m.resource, bucket, m.prefix)
+  // Bucket names resolve once (creating them on the way); building the mounts
+  // is then pure, so a shadow workspace can be built over the same buckets.
+  const resolved: [string, Mount][] = []
+  for (const m of target.mounts) resolved.push([await bucketFor(m), m])
+  const build = (): MountMap => {
+    const mounts: Record<string, S3Resource> = {}
+    for (const [bucket, m] of resolved) {
+      mounts[m.path] = objectStorageResource(m.resource, bucket, m.prefix)
+    }
+    return mounts
   }
-  const ws = new Workspace(mounts, { mode: MountMode.WRITE })
+  const opened = openWorkspaces(build, options)
   const cleanup = async (): Promise<void> => {
-    await ws.close()
+    await opened.closeAll()
     for (const bucket of buckets) {
       let token: string | undefined
       do {
@@ -330,7 +383,7 @@ async function openS3(target: Target): Promise<Open> {
     }
     client.destroy()
   }
-  return { ws: ws as unknown as ExecWorkspace, cleanup }
+  return { ws: opened.ws, shadow: opened.shadow, cleanup }
 }
 
 function nextcloudMountUrl(root: string | undefined): string {
@@ -447,23 +500,26 @@ async function openEmail(target: Target): Promise<Open> {
   return { ws: ws as unknown as ExecWorkspace, cleanup: () => ws.close() }
 }
 
-async function openHf(target: Target): Promise<Open> {
+async function openHf(target: Target, options?: OpenOptions): Promise<Open> {
   const endpoint = process.env.HF_ENDPOINT
   if (!endpoint) throw new Error('hf target requires HF_ENDPOINT')
   const id = runId()
-  const mounts: Record<string, HfBucketsResource> = {}
-  for (const m of target.mounts) {
-    // Buckets auto-create on first touch in the fake hub, so a per-run
-    // bucket name is enough isolation.
-    mounts[m.path] = new HfBucketsResource({
-      bucket: `integ/${id}-${String(m.bucket)}`,
-      token: 'integ-token',
-      endpoint,
-      keyPrefix: m.prefix,
-    })
+  const build = (): MountMap => {
+    const mounts: Record<string, HfBucketsResource> = {}
+    for (const m of target.mounts) {
+      // Buckets auto-create on first touch in the fake hub, so a per-run
+      // bucket name is enough isolation.
+      mounts[m.path] = new HfBucketsResource({
+        bucket: `integ/${id}-${String(m.bucket)}`,
+        token: 'integ-token',
+        endpoint,
+        keyPrefix: m.prefix,
+      })
+    }
+    return mounts
   }
-  const ws = new Workspace(mounts, { mode: MountMode.WRITE })
-  return { ws: ws as unknown as ExecWorkspace, cleanup: () => ws.close() }
+  const opened = openWorkspaces(build, options)
+  return { ws: opened.ws, shadow: opened.shadow, cleanup: opened.closeAll }
 }
 
 const BOX_AUTH = { Authorization: 'Bearer integ-box-token' }
@@ -566,124 +622,87 @@ async function openBox(target: Target): Promise<Open> {
   return { ws: ws as unknown as ExecWorkspace, cleanup: () => ws.close() }
 }
 
-async function openDropbox(target: Target): Promise<Open> {
+async function openDropbox(target: Target, options?: OpenOptions): Promise<Open> {
   // Mounts sharing a `bucket` share one fake account (the -root target
   // mounts three rootPath subfolders of a single account, mirroring
   // s3-prefix's shared bucket); distinct buckets get isolated accounts.
   const accounts = new Map<string, FakeDropbox>()
-  const mounts: Record<string, DropboxResource> = {}
   for (const m of target.mounts) {
     const account = String(m.bucket ?? m.path)
-    let fake = accounts.get(account)
-    if (fake === undefined) {
-      fake = await startFakeDropbox()
-      accounts.set(account, fake)
-    }
-    mounts[m.path] = new DropboxResource({
-      clientId: 'integ-client',
-      clientSecret: 'integ-secret',
-      refreshToken: 'integ-refresh',
-      // The fake supports full-text search_v2, so exercise grep/rg
-      // narrowing in the battery.
-      contentSearch: true,
-      endpoint: fake.endpoint,
-      ...(m.root !== undefined ? { rootPath: m.root } : {}),
-    })
+    if (!accounts.has(account)) accounts.set(account, await startFakeDropbox())
   }
-  const ws = new Workspace(mounts, { mode: MountMode.WRITE })
+  const build = (): MountMap => {
+    const mounts: Record<string, DropboxResource> = {}
+    for (const m of target.mounts) {
+      const fake = accounts.get(String(m.bucket ?? m.path))
+      if (fake === undefined) throw new Error(`dropbox account missing for ${m.path}`)
+      mounts[m.path] = new DropboxResource({
+        clientId: 'integ-client',
+        clientSecret: 'integ-secret',
+        refreshToken: 'integ-refresh',
+        // The fake supports full-text search_v2, so exercise grep/rg
+        // narrowing in the battery.
+        contentSearch: true,
+        endpoint: fake.endpoint,
+        ...(m.root !== undefined ? { rootPath: m.root } : {}),
+      })
+    }
+    return mounts
+  }
+  const opened = openWorkspaces(build, options)
   const cleanup = async (): Promise<void> => {
-    await ws.close()
+    await opened.closeAll()
     for (const fake of accounts.values()) fake.close()
   }
-  return { ws: ws as unknown as ExecWorkspace, cleanup }
+  return { ws: opened.ws, shadow: opened.shadow, cleanup }
 }
 
-async function openOneDrive(target: Target): Promise<Open> {
+async function openOneDrive(target: Target, options?: OpenOptions): Promise<Open> {
   const server = await startPythonServer('onedrive_server.py', {
     MIRAGE_GRAPH_DRIVES: 'data,xm2,res,shared',
   })
-  const mounts: Record<string, OneDriveResource> = {}
-  for (const mount of target.mounts) {
-    mounts[mount.path] = new OneDriveResource({
-      accessToken: 'integ-token',
-      graphBaseUrl: server.endpoint,
-      ...(mount.prefix !== undefined ? { keyPrefix: mount.prefix } : {}),
-    })
-  }
-  const ws = new Workspace(mounts, { mode: MountMode.WRITE })
-  const cleanup = async (): Promise<void> => {
-    await ws.close()
-    await server.close()
-  }
-  return { ws: ws as unknown as ExecWorkspace, cleanup }
-}
-
-async function openSharePoint(target: Target): Promise<Open> {
-  const server = await startPythonServer('onedrive_server.py', {
-    MIRAGE_GRAPH_DRIVES: 'data,xm2,res,shared',
-  })
-  const mounts: Record<string, SharePointResource> = {}
-  for (const mount of target.mounts) {
-    mounts[mount.path] = new SharePointResource({
-      accessToken: 'integ-token',
-      graphBaseUrl: server.endpoint,
-      site: 'Main',
-      drive: mount.drive,
-      ...(mount.prefix !== undefined ? { keyPrefix: mount.prefix } : {}),
-    })
-  }
-  const ws = new Workspace(mounts, { mode: MountMode.WRITE })
-  const cleanup = async (): Promise<void> => {
-    await ws.close()
-    await server.close()
-  }
-  return { ws: ws as unknown as ExecWorkspace, cleanup }
-}
-
-async function openGraphConsistency(
-  target: Target,
-  consistency: ConsistencyPolicy,
-): Promise<OpenConsistency> {
-  const server = await startPythonServer('onedrive_server.py', {
-    MIRAGE_GRAPH_DRIVES: 'data,xm2,res,shared',
-  })
-  const readMounts: Record<string, OneDriveResource | SharePointResource> = {}
-  const shadowMounts: Record<string, OneDriveResource | SharePointResource> = {}
-  for (const mount of target.mounts) {
-    if (mount.resource === 'onedrive') {
-      const config = {
+  const build = (): MountMap => {
+    const mounts: Record<string, OneDriveResource> = {}
+    for (const mount of target.mounts) {
+      mounts[mount.path] = new OneDriveResource({
         accessToken: 'integ-token',
         graphBaseUrl: server.endpoint,
         ...(mount.prefix !== undefined ? { keyPrefix: mount.prefix } : {}),
-      }
-      readMounts[mount.path] = new OneDriveResource(config)
-      shadowMounts[mount.path] = new OneDriveResource(config)
-    } else {
-      const config = {
+      })
+    }
+    return mounts
+  }
+  const opened = openWorkspaces(build, options)
+  const cleanup = async (): Promise<void> => {
+    await opened.closeAll()
+    await server.close()
+  }
+  return { ws: opened.ws, shadow: opened.shadow, cleanup }
+}
+
+async function openSharePoint(target: Target, options?: OpenOptions): Promise<Open> {
+  const server = await startPythonServer('onedrive_server.py', {
+    MIRAGE_GRAPH_DRIVES: 'data,xm2,res,shared',
+  })
+  const build = (): MountMap => {
+    const mounts: Record<string, SharePointResource> = {}
+    for (const mount of target.mounts) {
+      mounts[mount.path] = new SharePointResource({
         accessToken: 'integ-token',
         graphBaseUrl: server.endpoint,
         site: 'Main',
         drive: mount.drive,
         ...(mount.prefix !== undefined ? { keyPrefix: mount.prefix } : {}),
-      }
-      readMounts[mount.path] = new SharePointResource(config)
-      shadowMounts[mount.path] = new SharePointResource(config)
+      })
     }
+    return mounts
   }
-  const ws = new Workspace(readMounts, { mode: MountMode.WRITE, consistency })
-  const shadow = new Workspace(shadowMounts, { mode: MountMode.WRITE })
-  const mutate = async (path: string, content: Uint8Array): Promise<void> => {
-    const result = await shadow.execute(`tee ${path} > /dev/null`, { stdin: content })
-    if (result.exitCode !== 0) {
-      throw new Error(new TextDecoder().decode(result.stderr))
-    }
-  }
+  const opened = openWorkspaces(build, options)
   const cleanup = async (): Promise<void> => {
-    await ws.close()
-    await shadow.close()
+    await opened.closeAll()
     await server.close()
   }
-  return { ws: ws as unknown as ExecWorkspace, mutate, cleanup }
+  return { ws: opened.ws, shadow: opened.shadow, cleanup }
 }
 
 async function openNotion(target: Target): Promise<Open> {
@@ -1008,7 +1027,7 @@ async function adminExec(ws: Workspace, command: string): Promise<void> {
   }
 }
 
-async function openSsh(target: Target): Promise<Open> {
+async function openSsh(target: Target, options?: OpenOptions): Promise<Open> {
   const host = process.env.SSH_HOST
   if (!host) throw new Error('ssh target requires SSH_HOST')
   const port = Number(process.env.SSH_PORT ?? '22')
@@ -1031,22 +1050,25 @@ async function openSsh(target: Target): Promise<Open> {
       })
     })
   }
-  const mounts: Record<string, SSHResource> = {}
-  for (const m of target.mounts) {
-    mounts[m.path] = new SSHResource({
-      host,
-      port,
-      username: 'integ',
-      root: `/${base}/${String(m.root)}`,
-    })
+  const build = (): MountMap => {
+    const mounts: Record<string, SSHResource> = {}
+    for (const m of target.mounts) {
+      mounts[m.path] = new SSHResource({
+        host,
+        port,
+        username: 'integ',
+        root: `/${base}/${String(m.root)}`,
+      })
+    }
+    return mounts
   }
-  const ws = new Workspace(mounts, { mode: MountMode.WRITE })
+  const opened = openWorkspaces(build, options)
   const cleanup = async (): Promise<void> => {
-    await ws.close()
+    await opened.closeAll()
     await adminExec(admin, `rm -rf /admin/${base}`)
     await admin.close()
   }
-  return { ws: ws as unknown as ExecWorkspace, cleanup }
+  return { ws: opened.ws, shadow: opened.shadow, cleanup }
 }
 
 const GDRIVE_FOLDER_MIME = 'application/vnd.google-apps.folder'
@@ -1638,7 +1660,10 @@ async function openArgError(target: Target): Promise<Open> {
   return { ws: ws as unknown as ExecWorkspace, cleanup: () => ws.close() }
 }
 
-export const ADAPTERS: Record<string, (target: Target) => Promise<Open>> = {
+export const ADAPTERS: Record<
+  string,
+  (target: Target, options?: OpenOptions) => Promise<Open>
+> = {
   ram: openRam,
   disk: openDisk,
   redis: openRedis,
@@ -1680,10 +1705,32 @@ export const ADAPTERS: Record<string, (target: Target) => Promise<Open>> = {
   http_fixture: openHttp,
 }
 
-export const CONSISTENCY_ADAPTERS: Record<
-  string,
-  (target: Target, consistency: ConsistencyPolicy) => Promise<OpenConsistency>
-> = {
-  onedrive: openGraphConsistency,
-  sharepoint: openGraphConsistency,
+/**
+ * Open a target for a consistency scenario: a workspace under the requested
+ * policy plus a shadow workspace the scenario mutates through, out of band
+ * from the first one's caches.
+ *
+ * Returns null when the target's adapter cannot build its mounts twice, which
+ * the runner reports as a skip -- a scenario that quietly never ran is worse
+ * than one that says it did not.
+ */
+export async function openConsistency(
+  target: Target,
+  consistency: ConsistencyPolicy,
+): Promise<OpenConsistency | null> {
+  const adapter = ADAPTERS[target.mounts[0].resource]
+  if (adapter === undefined) return null
+  const opened = await adapter(target, { consistency })
+  if (opened.shadow === undefined) {
+    await opened.cleanup()
+    return null
+  }
+  const shadow = opened.shadow()
+  const mutate = async (path: string, content: Uint8Array): Promise<void> => {
+    const result = await shadow.execute(`tee ${path} > /dev/null`, { stdin: content })
+    if (result.exitCode !== 0) {
+      throw new Error(new TextDecoder().decode(result.stderr))
+    }
+  }
+  return { ws: opened.ws, mutate, cleanup: opened.cleanup }
 }

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -14,7 +14,7 @@
 
 import { writeFileSync } from 'node:fs'
 import { ConsistencyPolicy } from '@struktoai/mirage-node'
-import { ADAPTERS, CONSISTENCY_ADAPTERS } from './adapters.ts'
+import { ADAPTERS, openConsistency } from './adapters.ts'
 import type { Case, Target } from './harness.ts'
 import {
   Report,
@@ -141,15 +141,21 @@ async function runTarget(
   } finally {
     await cleanup()
   }
-  const consistencyAdapter = CONSISTENCY_ADAPTERS[target.mounts[0].resource]
-  if (consistencyAdapter === undefined) return
-  for (const c of cases) {
-    if (!c.targets.includes(target.id) || c.consistency === undefined || c.scenario === undefined) {
-      continue
-    }
+  const scenarios = cases.filter(
+    (c) => c.targets.includes(target.id) && c.consistency !== undefined && c.scenario !== undefined,
+  )
+  for (const c of scenarios) {
     const policy =
       c.consistency === 'always' ? ConsistencyPolicy.ALWAYS : ConsistencyPolicy.LAZY
-    const opened = await consistencyAdapter(target, policy)
+    const opened = await openConsistency(target, policy)
+    if (opened === null) {
+      // Loud on purpose: an adapter that cannot build a shadow workspace used
+      // to drop every scenario case for its target without a word.
+      process.stderr.write(
+        `skip [${target.id}] ${c.id}: ${target.mounts[0].resource} adapter has no shadow workspace\n`,
+      )
+      continue
+    }
     try {
       // Same rule as the ordinary path: a target's declared environment reaches
       // every workspace a case can run against, or a consistency scenario would

--- a/integ/unix/consistency/ancestors.json
+++ b/integ/unix/consistency/ancestors.json
@@ -1,0 +1,21 @@
+{
+  "cases": [
+    {
+      "id": "consistency_deep_write_refreshes_ancestor_listing",
+      "seq": 962100,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "mkdir -p /data2/anc && ls /data2/anc && echo hi > /data2/anc/d1/leaf.txt && ls /data2/anc && ls /data2/anc/d1",
+      "expect": {
+        "exit": 0,
+        "stdout": "d1\nleaf.txt\n",
+        "stderr": ""
+      },
+      "note": "On a flat keyed store one put materializes every missing level of the key, so the write has to refresh the listings above the immediate parent too. The first ls caches an empty /data2/anc; invalidating only the parent would keep serving it until the index TTL expires."
+    }
+  ]
+}

--- a/integ/unix/find/implicit.json
+++ b/integ/unix/find/implicit.json
@@ -1,0 +1,73 @@
+{
+  "cases": [
+    {
+      "id": "find_implicit_dirs",
+      "seq": 962000,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "consistency": "always",
+      "scenario": [
+        {
+          "mutate": {
+            "path": "/data/imp/deep/leaf.txt",
+            "content": "x\n"
+          }
+        },
+        {
+          "command": "find /data/imp -type d"
+        },
+        {
+          "command": "find /data/imp"
+        }
+      ],
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/imp\n/data/imp/deep\n/data/imp\n/data/imp/deep\n/data/imp/deep/leaf.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "type"
+      ],
+      "note": "Keys written out-of-band carry no directory markers; find must synthesize the implicit parent chain so it agrees with readdir on externally-populated buckets."
+    },
+    {
+      "id": "find_implicit_dir_name",
+      "seq": 962001,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "consistency": "always",
+      "scenario": [
+        {
+          "mutate": {
+            "path": "/data/imp2/logs/x.txt",
+            "content": "x\n"
+          }
+        },
+        {
+          "command": "find /data/imp2 -name logs"
+        },
+        {
+          "command": "find /data/imp2 -type f -name '*.txt'"
+        }
+      ],
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/imp2/logs\n/data/imp2/logs/x.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "name",
+        "type"
+      ],
+      "note": "-name without -type f must match an implicit directory (gridfs may not push the glob server-side then); -type f keeps the pushdown."
+    }
+  ]
+}

--- a/integ/unix/find/not.json
+++ b/integ/unix/find/not.json
@@ -213,6 +213,78 @@
         "not",
         "name"
       ]
+    },
+    {
+      "id": "find_bang_name_keeps_glob_literals",
+      "seq": 962200,
+      "targets": [
+        "box",
+        "disk",
+        "dropbox",
+        "dropbox-root",
+        "gdrive",
+        "gdrive-folder",
+        "gridfs",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "nextcloud",
+        "onedrive",
+        "opfs",
+        "ram",
+        "redis",
+        "s3",
+        "s3-prefix",
+        "sharepoint",
+        "ssh"
+      ],
+      "command": "mkdir -p /data2/bangglob && printf 'a\\n' > /data2/bangglob/a_b.txt && printf 'b\\n' > /data2/bangglob/axb.txt && find /data2/bangglob ! -name \"*_b.txt\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data2/bangglob\n/data2/bangglob/axb.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "not",
+        "name"
+      ],
+      "note": "An underscore is literal in a glob and a single-character wildcard in SQL LIKE, so a backend that pushes -name down as LIKE matches a superset. Positive matching survives that (the client-side filter narrows it again), but a negation cannot: NOT(superset) withholds rows the client can never add back, so axb.txt has to stay."
+    },
+    {
+      "id": "find_bang_exact_name_is_case_sensitive",
+      "seq": 962201,
+      "targets": [
+        "box",
+        "disk",
+        "dropbox",
+        "dropbox-root",
+        "gdrive",
+        "gdrive-folder",
+        "gridfs",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "nextcloud",
+        "onedrive",
+        "opfs",
+        "ram",
+        "redis",
+        "s3",
+        "s3-prefix",
+        "sharepoint",
+        "ssh"
+      ],
+      "command": "mkdir -p /data2/bangexact && printf 'a\\n' > /data2/bangexact/alpha.txt && find /data2/bangexact ! -name \"ALPHA.TXT\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data2/bangexact\n/data2/bangexact/alpha.txt\n",
+        "stderr": ""
+      },
+      "flags": [
+        "not",
+        "name"
+      ],
+      "note": "Same rule for the wildcard-free spelling, which backends compile to an equality comparison rather than a LIKE."
     }
   ]
 }

--- a/python/mirage/cache/manager.py
+++ b/python/mirage/cache/manager.py
@@ -98,6 +98,25 @@ class CacheManager:
         await self._index.invalidate_dir(virtual + "/")
         await self._invalidate_parent(virtual)
 
+    async def invalidate_ancestors(self, path: PathSpec) -> None:
+        """Evict the listing of every directory above ``path``'s parent.
+
+        ``invalidate_after_write`` refreshes the immediate parent only. A
+        keyed store materializes every missing level of a key in a single
+        put, so the listings further up gained entries too and would keep
+        serving the pre-write view until the index TTL expires. A backend
+        with real directories cannot gain a level that way, so there this
+        is a handful of spare evictions.
+
+        Args:
+            path (PathSpec): Resource-relative path that was mutated.
+        """
+        parent = self._virtual(path).rsplit("/", 1)[0]
+        while parent and parent != self._prefix:
+            parent = parent.rsplit("/", 1)[0]
+            await self._index.invalidate_dir(parent or "/")
+            await self._index.invalidate_dir(parent + "/")
+
     async def drop_prefix(self) -> None:
         """Drop every cached body under this mount, path unspecified.
 

--- a/python/mirage/core/gridfs/find.py
+++ b/python/mirage/core/gridfs/find.py
@@ -166,9 +166,17 @@ async def find(
     path = path_spec.mount_path
     config = accessor.config
     pfx = _prefix(path, config)
+    stripped = path.strip("/")
+    base = "/" + stripped if stripped else "/"
+    base_depth = 0 if base == "/" else base.count("/")
     results: list[str] = []
+    seen_dirs: set[str] = set()
+    # Narrowing beyond the prefix is only sound when directories cannot
+    # appear in the output (-type f): implicit directories are synthesized
+    # client-side from file paths, so any server-side file exclusion would
+    # also drop the evidence for a matching parent directory.
     pushdown = (tree is None and name_exclude is None and or_names is None
-                and path_pattern is None and not empty)
+                and path_pattern is None and not empty and type == "f")
     tree = tree if tree is not None else build_tree(name=name,
                                                     iname=iname,
                                                     path_pattern=path_pattern,
@@ -188,45 +196,57 @@ async def find(
         saw_descendant = True
         is_dir = key.endswith("/")
         norm_key = key[:-1] if is_dir else key
-        relative = norm_key[len(pfx):]
-        depth = relative.count("/") + 1
-        if maxdepth is not None and depth > maxdepth:
-            continue
-        entry_name = norm_key.rsplit("/", 1)[-1]
         full_path = "/" + _strip_prefix(norm_key, config)
         size = doc["length"]
-        is_empty = (None if not empty else
-                    (size == 0 if not is_dir else False))
-        entry = FindEntry(key=full_path,
-                          name=entry_name,
-                          kind="d" if is_dir else "f",
-                          depth=depth,
-                          is_empty=is_empty)
-        if not keep(entry, tree, mindepth):
-            continue
-        if min_size is not None or max_size is not None:
-            # Directories count as size 0 for -size (deliberate GNU
-            # divergence).
-            effective = 0 if is_dir else size
-            if min_size is not None and effective < min_size:
+        if is_dir:
+            if full_path in seen_dirs:
                 continue
-            if max_size is not None and effective > max_size:
+            seen_dirs.add(full_path)
+        entries: list[tuple[str, str]] = [(full_path, "d" if is_dir else "f")]
+        # Implicit directories exist only as filename prefixes; synthesize
+        # the parent chain so find agrees with readdir on
+        # externally-populated buckets.
+        parent = full_path.rsplit("/", 1)[0] or "/"
+        while parent != base and parent != "/":
+            if parent not in seen_dirs:
+                seen_dirs.add(parent)
+                entries.append((parent, "d"))
+            parent = parent.rsplit("/", 1)[0] or "/"
+        for ep, kind in entries:
+            entry_name = ep.rsplit("/", 1)[-1]
+            depth = ep.count("/") - base_depth
+            if maxdepth is not None and depth > maxdepth:
                 continue
-        results.append(full_path)
+            is_empty = (None if not empty else
+                        (size == 0 if kind == "f" else False))
+            entry = FindEntry(key=ep,
+                              name=entry_name,
+                              kind=kind,
+                              depth=depth,
+                              is_empty=is_empty)
+            if not keep(entry, tree, mindepth):
+                continue
+            if min_size is not None or max_size is not None:
+                # Directories count as size 0 for -size (deliberate GNU
+                # divergence).
+                effective = 0 if kind == "d" else size
+                if min_size is not None and effective < min_size:
+                    continue
+                if max_size is not None and effective > max_size:
+                    continue
+            results.append(ep)
     if narrowed and not (saw_descendant or dir_marker_seen):
         # The narrowed query may have excluded every doc under a prefix
         # that does exist; probe so the start path still emits.
         probe = await files_coll(accessor).find_one(prefix_query(pfx),
                                                     projection={"_id": 1})
         saw_descendant = probe is not None
-    stripped = path.strip("/")
     if saw_descendant or dir_marker_seen:
-        root_key = "/" + stripped if stripped else "/"
         emit_start_path(results,
-                        root_key,
+                        base,
                         start_name,
                         kind="d",
-                        is_empty=False if empty else None,
+                        is_empty=(not saw_descendant) if empty else None,
                         exists=True,
                         tree=tree,
                         maxdepth=maxdepth,

--- a/python/mirage/core/gridfs/find.py
+++ b/python/mirage/core/gridfs/find.py
@@ -253,4 +253,7 @@ async def find(
                         mindepth=mindepth,
                         min_size=min_size,
                         max_size=max_size)
-    return sorted(results)
+    # A file key and a synthesized directory can name the same path (`data/a`
+    # alongside `data/a/b.txt`), which these stores allow and a filesystem
+    # does not; find prints such a path once.
+    return sorted(set(results))

--- a/python/mirage/core/gridfs/write.py
+++ b/python/mirage/core/gridfs/write.py
@@ -15,7 +15,7 @@
 import time
 
 from mirage.accessor.gridfs import GridFSAccessor
-from mirage.cache.context import invalidate_after_write
+from mirage.cache.context import invalidate_after_write, invalidate_ancestors
 from mirage.core.gridfs._client import _key, bucket
 from mirage.observe.context import record
 from mirage.types import PathSpec
@@ -32,3 +32,6 @@ async def write_bytes(accessor: GridFSAccessor, path_spec: PathSpec,
     await bucket(accessor).upload_from_stream(key, data)
     record("write", path, "gridfs", len(data), start_ms)
     await invalidate_after_write(path_spec)
+    # An upload materializes every missing level of the key at once, so the
+    # listings above the immediate parent gained entries too.
+    await invalidate_ancestors(path_spec)

--- a/python/mirage/core/nextcloud/search/query.py
+++ b/python/mirage/core/nextcloud/search/query.py
@@ -65,10 +65,14 @@ def glob_to_like(pattern: str) -> str:
     return "".join(translated)
 
 
-def name_condition(name: Name) -> XmlElement:
+def name_operation(name: Name) -> Comparison:
     has_wildcard = "*" in name.pattern or "?" in name.pattern
-    operation = (Comparison.LIKE
-                 if has_wildcard or name.icase else Comparison.EQUAL)
+    return (Comparison.LIKE
+            if has_wildcard or name.icase else Comparison.EQUAL)
+
+
+def name_condition(name: Name) -> XmlElement:
+    operation = name_operation(name)
     value = (glob_to_like(name.pattern)
              if operation == Comparison.LIKE else name.pattern)
     return comparison(operation, constants.DISPLAY_NAME, value)
@@ -78,9 +82,19 @@ def compile_predicate(node: PredNode) -> CompiledPredicate | None:
     if isinstance(node, TrueNode):
         return CompiledPredicate(None)
     if isinstance(node, Name):
-        if "[" in node.pattern:
+        # A class has no LIKE spelling, and a backslash escapes the next
+        # character out of the glob (`-name 'a\b'` matches `ab`), so the
+        # literal the server would compare is not the name being matched.
+        if "[" in node.pattern or "\\" in node.pattern:
             return None
-        return CompiledPredicate(name_condition(node), negatable=True)
+        # LIKE is a deliberate superset (case-insensitive, and a literal
+        # `%`/`_` in the pattern stays a wildcard) that the client-side
+        # keep() re-filters. Negation has nothing to re-filter with:
+        # NOT(superset) withholds rows the true predicate keeps and no
+        # client pass can add them back, so only the exact comparison is
+        # safe to negate.
+        exact = name_operation(node) == Comparison.EQUAL
+        return CompiledPredicate(name_condition(node), negatable=exact)
     if isinstance(node, Type):
         if node.kind == FindType.DIRECTORY:
             return CompiledPredicate(is_collection(), negatable=True)

--- a/python/mirage/core/s3/find.py
+++ b/python/mirage/core/s3/find.py
@@ -142,4 +142,7 @@ async def find(
                         mindepth=mindepth,
                         min_size=min_size,
                         max_size=max_size)
-    return sorted(results)
+    # A file key and a synthesized directory can name the same path (`data/a`
+    # alongside `data/a/b.txt`), which these stores allow and a filesystem
+    # does not; find prints such a path once.
+    return sorted(set(results))

--- a/python/mirage/core/s3/find.py
+++ b/python/mirage/core/s3/find.py
@@ -64,7 +64,11 @@ async def find(
     path = path_spec.mount_path
     config = accessor.config
     pfx = _prefix(path, config)
+    stripped = path.strip("/")
+    base = "/" + stripped if stripped else "/"
+    base_depth = 0 if base == "/" else base.count("/")
     results: list[str] = []
+    seen_dirs: set[str] = set()
     tree = tree if tree is not None else build_tree(name=name,
                                                     iname=iname,
                                                     path_pattern=path_pattern,
@@ -86,39 +90,52 @@ async def find(
                 saw_descendant = True
                 is_dir = key.endswith("/")
                 norm_key = key[:-1] if is_dir else key
-                relative = norm_key[len(pfx):]
-                depth = relative.count("/") + 1
-                if maxdepth is not None and depth > maxdepth:
-                    continue
-                entry_name = norm_key.rsplit("/", 1)[-1]
                 full_path = "/" + _strip_prefix(norm_key, config)
                 size = obj.get("Size", 0)
-                is_empty = (None if not empty else
-                            (size == 0 if not is_dir else False))
-                entry = FindEntry(key=full_path,
-                                  name=entry_name,
-                                  kind="d" if is_dir else "f",
-                                  depth=depth,
-                                  is_empty=is_empty)
-                if not keep(entry, tree, mindepth):
-                    continue
-                if min_size is not None or max_size is not None:
-                    # Directories count as size 0 for -size (deliberate GNU
-                    # divergence).
-                    effective = 0 if is_dir else size
-                    if min_size is not None and effective < min_size:
+                if is_dir:
+                    if full_path in seen_dirs:
                         continue
-                    if max_size is not None and effective > max_size:
+                    seen_dirs.add(full_path)
+                entries: list[tuple[str, str]] = [(full_path,
+                                                   "d" if is_dir else "f")]
+                # Implicit directories exist only as key prefixes; synthesize
+                # the parent chain so find agrees with readdir on
+                # externally-populated buckets.
+                parent = full_path.rsplit("/", 1)[0] or "/"
+                while parent != base and parent != "/":
+                    if parent not in seen_dirs:
+                        seen_dirs.add(parent)
+                        entries.append((parent, "d"))
+                    parent = parent.rsplit("/", 1)[0] or "/"
+                for ep, kind in entries:
+                    entry_name = ep.rsplit("/", 1)[-1]
+                    depth = ep.count("/") - base_depth
+                    if maxdepth is not None and depth > maxdepth:
                         continue
-                results.append(full_path)
-    stripped = path.strip("/")
+                    is_empty = (None if not empty else
+                                (size == 0 if kind == "f" else False))
+                    entry = FindEntry(key=ep,
+                                      name=entry_name,
+                                      kind=kind,
+                                      depth=depth,
+                                      is_empty=is_empty)
+                    if not keep(entry, tree, mindepth):
+                        continue
+                    if min_size is not None or max_size is not None:
+                        # Directories count as size 0 for -size (deliberate
+                        # GNU divergence).
+                        effective = 0 if kind == "d" else size
+                        if min_size is not None and effective < min_size:
+                            continue
+                        if max_size is not None and effective > max_size:
+                            continue
+                    results.append(ep)
     if saw_descendant or dir_marker_seen:
-        root_key = "/" + stripped if stripped else "/"
         emit_start_path(results,
-                        root_key,
+                        base,
                         start_name,
                         kind="d",
-                        is_empty=False if empty else None,
+                        is_empty=(not saw_descendant) if empty else None,
                         exists=True,
                         tree=tree,
                         maxdepth=maxdepth,

--- a/python/mirage/core/s3/write.py
+++ b/python/mirage/core/s3/write.py
@@ -15,7 +15,7 @@
 import time
 
 from mirage.accessor.s3 import S3Accessor
-from mirage.cache.context import invalidate_after_write
+from mirage.cache.context import invalidate_after_write, invalidate_ancestors
 from mirage.core.s3._client import _client_kwargs, _key, async_session
 from mirage.observe.context import record
 from mirage.types import PathSpec
@@ -32,3 +32,6 @@ async def write_bytes(accessor: S3Accessor, path_spec: PathSpec,
         await client.put_object(Bucket=config.bucket, Key=key, Body=data)
     record("write", path, "s3", len(data), start_ms)
     await invalidate_after_write(path_spec)
+    # A put materializes every missing level of the key at once, so the
+    # listings above the immediate parent gained entries too.
+    await invalidate_ancestors(path_spec)

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -540,3 +540,4 @@ class Dispatcher:
             manager = CacheManager(self._cache, mount.resource.index,
                                    mount.prefix, mount.resource.caches_reads)
         await manager.invalidate_after_write(path)
+        await manager.invalidate_ancestors(path)

--- a/python/tests/cache/test_manager.py
+++ b/python/tests/cache/test_manager.py
@@ -206,3 +206,42 @@ def test_drop_prefix_reaches_every_key_on_a_root_mount():
     assert prefix == ""
     assert a is False
     assert b is False
+
+
+async def _ancestors_case() -> tuple[bool, bool, bool]:
+    cache, index = _stores()
+    for directory in ("/data", "/data/a", "/data/a/b"):
+        await index.set_dir(directory, [])
+    manager = CacheManager(cache, index, "/data/", True)
+    await manager.invalidate_ancestors(PathSpec.from_str_path("/a/b/c.txt"))
+    return (
+        (await index.list_dir("/data")).entries is not None,
+        (await index.list_dir("/data/a")).entries is not None,
+        (await index.list_dir("/data/a/b")).entries is not None,
+    )
+
+
+def test_invalidate_ancestors_walks_up_to_the_mount_root():
+    """One put materializes every missing level of the key, so every
+    listing above the written file gained an entry."""
+    root, a, ab = _run(_ancestors_case())
+    assert root is False
+    assert a is False
+    # The immediate parent is invalidate_after_write's job, not this one.
+    assert ab is True
+
+
+async def _ancestors_root_mount_case() -> tuple[bool, bool]:
+    cache, index = _stores()
+    for directory in ("/", "/a"):
+        await index.set_dir(directory, [])
+    manager = CacheManager(cache, index, "/", True)
+    await manager.invalidate_ancestors(PathSpec.from_str_path("/a/b/c.txt"))
+    return ((await index.list_dir("/")).entries
+            is not None, (await index.list_dir("/a")).entries is not None)
+
+
+def test_invalidate_ancestors_reaches_the_root_listing():
+    root, a = _run(_ancestors_root_mount_case())
+    assert root is False
+    assert a is False

--- a/python/tests/core/gridfs/test_find.py
+++ b/python/tests/core/gridfs/test_find.py
@@ -154,6 +154,15 @@ def test_find_unordered_marker_and_file_no_duplicates(monkeypatch):
     assert out == ["/data", "/data/a"]
 
 
+def test_find_file_shadowed_by_implicit_dir_emits_once(monkeypatch):
+    docs = [("data/a", 1), ("data/a/b.txt", 2)]
+    assert _run_find(monkeypatch,
+                     docs)[0] == ["/data", "/data/a", "/data/a/b.txt"]
+    assert _run_find(monkeypatch, docs, type="d")[0] == ["/data", "/data/a"]
+    assert _run_find(monkeypatch, docs,
+                     type="f")[0] == ["/data/a", "/data/a/b.txt"]
+
+
 def test_find_empty_matches_marker_only_start(monkeypatch):
     out, _ = _run_find(monkeypatch, [("data/", 0)], empty=True)
     assert out == ["/data"]

--- a/python/tests/core/gridfs/test_find.py
+++ b/python/tests/core/gridfs/test_find.py
@@ -12,9 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 import re
 
-from mirage.core.gridfs.find import build_query, glob_regex
+from mirage.accessor.gridfs import GridFSAccessor, GridFSConfig
+from mirage.core.gridfs._client import prefix_query
+from mirage.core.gridfs.find import build_query, find, glob_regex
+from mirage.types import PathSpec
 
 
 def _matches(query_regex: dict, value: str) -> bool:
@@ -90,3 +94,71 @@ def test_build_query_no_pushdown_keeps_prefix_only():
 def test_build_query_unpushable_glob_falls_back_to_prefix():
     query = build_query("data/", "[ab].csv", None, None, None, None, True)
     assert query == {"filename": {"$regex": "^" + re.escape("data/")}}
+
+
+async def _docs_gen(docs):
+    for doc in docs:
+        yield doc
+
+
+class _FakeIterLatest:
+
+    def __init__(self, docs):
+        self.docs = docs
+        self.queries = []
+
+    def __call__(self, accessor, query):
+        self.queries.append(query)
+        return _docs_gen(self.docs)
+
+
+def _run_find(monkeypatch, docs, **kwargs):
+    fake = _FakeIterLatest([{
+        "filename": filename,
+        "length": length
+    } for filename, length in docs])
+    monkeypatch.setitem(find.__globals__, "iter_latest", fake)
+    accessor = GridFSAccessor(
+        GridFSConfig(uri="mongodb://localhost:27017", database="db"))
+    spec = PathSpec(virtual="/mnt/data",
+                    directory="/mnt/",
+                    resource_path="data")
+    out = asyncio.run(find(accessor, spec, **kwargs))
+    return out, fake.queries
+
+
+def test_find_synthesizes_implicit_dirs_without_narrowing(monkeypatch):
+    out, queries = _run_find(monkeypatch, [("data/a/b.txt", 3)], type="d")
+    assert out == ["/data", "/data/a"]
+    assert queries == [prefix_query("data/")]
+
+
+def test_find_name_without_type_scans_prefix_only(monkeypatch):
+    out, queries = _run_find(monkeypatch, [("data/logs/x.txt", 1)],
+                             name="logs")
+    assert out == ["/data/logs"]
+    assert queries == [prefix_query("data/")]
+
+
+def test_find_type_f_keeps_pushdown(monkeypatch):
+    out, queries = _run_find(monkeypatch, [("data/a/b.txt", 3)],
+                             type="f",
+                             name="*.txt")
+    assert out == ["/data/a/b.txt"]
+    assert "$and" in queries[0]
+
+
+def test_find_unordered_marker_and_file_no_duplicates(monkeypatch):
+    out, _ = _run_find(monkeypatch, [("data/a/x.txt", 1), ("data/a/", 0)],
+                       type="d")
+    assert out == ["/data", "/data/a"]
+
+
+def test_find_empty_matches_marker_only_start(monkeypatch):
+    out, _ = _run_find(monkeypatch, [("data/", 0)], empty=True)
+    assert out == ["/data"]
+
+
+def test_find_empty_rejects_populated_start(monkeypatch):
+    out, _ = _run_find(monkeypatch, [("data/x.txt", 3)], empty=True)
+    assert out == []

--- a/python/tests/core/gridfs/test_write.py
+++ b/python/tests/core/gridfs/test_write.py
@@ -1,0 +1,74 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage.accessor.gridfs import GridFSAccessor, GridFSConfig
+from mirage.cache.context import push_cache_manager
+from mirage.core.gridfs.write import write_bytes
+from mirage.types import PathSpec
+
+
+class _FakeManager:
+
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+        self.unlinks: list[str] = []
+
+    async def invalidate_after_write(self, path: PathSpec) -> None:
+        self.writes.append(path.mount_path)
+
+    async def invalidate_after_unlink(self, path: PathSpec) -> None:
+        self.unlinks.append(path.mount_path)
+
+
+class _FakeBucket:
+
+    def __init__(self, uploads: list[tuple[str, bytes]]) -> None:
+        self._uploads = uploads
+
+    async def upload_from_stream(self, key: str, data: bytes) -> None:
+        self._uploads.append((key, data))
+
+
+async def _write(monkeypatch, mount_path: str) -> tuple[_FakeManager, list]:
+    uploads: list[tuple[str, bytes]] = []
+    monkeypatch.setitem(write_bytes.__globals__, "bucket",
+                        lambda accessor: _FakeBucket(uploads))
+    manager = _FakeManager()
+    prev = push_cache_manager(manager)
+    try:
+        await write_bytes(
+            GridFSAccessor(
+                GridFSConfig(uri="mongodb://localhost:27017", database="db")),
+            PathSpec(virtual="/mnt" + mount_path,
+                     directory="/mnt/",
+                     resource_path=mount_path.lstrip("/")),
+            b"hi",
+        )
+    finally:
+        push_cache_manager(prev)
+    return manager, uploads
+
+
+def test_write_invalidates_every_ancestor_listing(monkeypatch):
+    manager, uploads = asyncio.run(_write(monkeypatch, "/a/b/c.txt"))
+    assert uploads == [("a/b/c.txt", b"hi")]
+    # The upload materializes `a` and `a/b` too, so their listings are stale.
+    assert manager.writes == ["/a/b/c.txt", "/a/b", "/a"]
+
+
+def test_write_at_mount_root_invalidates_only_itself(monkeypatch):
+    manager, _ = asyncio.run(_write(monkeypatch, "/c.txt"))
+    assert manager.writes == ["/c.txt"]

--- a/python/tests/core/nextcloud/test_search.py
+++ b/python/tests/core/nextcloud/test_search.py
@@ -120,9 +120,9 @@ def test_query_accepts_fully_representable_boolean_tree():
 @pytest.mark.parametrize(
     "tree",
     [
-        Not(Or([Name("*.txt"), Name("*.csv")])),
-        Not(And([Name("*.txt"), Type("d")])),
-        Not(Not(Name("*.txt"))),
+        Not(Or([Name("notes.txt"), Name("rows.csv")])),
+        Not(And([Name("notes.txt"), Type("d")])),
+        Not(Not(Name("notes.txt"))),
         Not(Type("f")),
     ],
 )
@@ -134,12 +134,31 @@ def test_query_rejects_negated_compound(tree):
     "tree",
     [
         Not(Name("*.txt")),
-        Not(Type("d")),
+        Not(Name("a?.txt")),
+        Not(Name("notes.txt", icase=True)),
         Not(Or([Name("*.txt")])),
+        Not(And([Name("*.txt")])),
+    ],
+)
+def test_query_rejects_negated_inexact_name(tree):
+    assert not supports_query(FilesSearchQuery(tree=tree))
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        Not(Name("notes.txt")),
+        Not(Type("d")),
+        Not(Or([Name("notes.txt")])),
     ],
 )
 def test_query_accepts_negated_comparison(tree):
     assert supports_query(FilesSearchQuery(tree=tree))
+
+
+@pytest.mark.parametrize("pattern", ["[ab].txt", "a\\b"])
+def test_query_rejects_unrepresentable_name_pattern(pattern):
+    assert not supports_query(FilesSearchQuery(tree=Name(pattern)))
 
 
 def test_positive_size_query_excludes_directories():

--- a/python/tests/core/s3/test_find.py
+++ b/python/tests/core/s3/test_find.py
@@ -93,6 +93,15 @@ def test_find_marker_plus_files_no_duplicates(monkeypatch):
     assert out == ["/data", "/data/a"]
 
 
+def test_find_file_shadowed_by_implicit_dir_emits_once(monkeypatch):
+    keys = [("data/a", 1), ("data/a/b.txt", 2)]
+    assert _run_find(monkeypatch,
+                     keys) == ["/data", "/data/a", "/data/a/b.txt"]
+    assert _run_find(monkeypatch, keys, type="d") == ["/data", "/data/a"]
+    assert _run_find(monkeypatch, keys,
+                     type="f") == ["/data/a", "/data/a/b.txt"]
+
+
 def test_find_empty_matches_marker_only_start(monkeypatch):
     out = _run_find(monkeypatch, [("data/", 0)], empty=True)
     assert out == ["/data"]

--- a/python/tests/core/s3/test_find.py
+++ b/python/tests/core/s3/test_find.py
@@ -1,0 +1,123 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+from functools import partial
+
+from mirage.accessor.s3 import S3Accessor, S3Config
+from mirage.core.s3.find import find
+from mirage.types import PathSpec
+
+
+async def _pages_gen(pages):
+    for page in pages:
+        yield page
+
+
+class _FakeClient:
+
+    def __init__(self, pages):
+        self._pages = pages
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def get_paginator(self, name):
+        return self
+
+    def paginate(self, **kwargs):
+        return _pages_gen(self._pages)
+
+
+class _FakeSession:
+
+    def __init__(self, pages):
+        self._pages = pages
+
+    def client(self, **kwargs):
+        return _FakeClient(self._pages)
+
+
+def _session_for(pages, config):
+    return _FakeSession(pages)
+
+
+def _spec(resource_path):
+    if resource_path:
+        return PathSpec(virtual="/mnt/" + resource_path,
+                        directory="/mnt/",
+                        resource_path=resource_path)
+    return PathSpec(virtual="/mnt", directory="/", resource_path="")
+
+
+def _run_find(monkeypatch, keys, resource_path="data", **kwargs):
+    pages = [{"Contents": [{"Key": key, "Size": size} for key, size in keys]}]
+    monkeypatch.setitem(find.__globals__, "async_session",
+                        partial(_session_for, pages))
+    accessor = S3Accessor(S3Config(bucket="b"))
+    return asyncio.run(find(accessor, _spec(resource_path), **kwargs))
+
+
+def test_find_synthesizes_implicit_dirs(monkeypatch):
+    out = _run_find(monkeypatch, [("data/a/b.txt", 3)], type="d")
+    assert out == ["/data", "/data/a"]
+
+
+def test_find_type_f_drops_synthesized_dirs(monkeypatch):
+    out = _run_find(monkeypatch, [("data/a/b.txt", 3)], type="f")
+    assert out == ["/data/a/b.txt"]
+
+
+def test_find_orphan_marker_gets_parents(monkeypatch):
+    out = _run_find(monkeypatch, [("data/a/b/", 0)], type="d")
+    assert out == ["/data", "/data/a", "/data/a/b"]
+
+
+def test_find_marker_plus_files_no_duplicates(monkeypatch):
+    out = _run_find(monkeypatch, [("data/a/", 0), ("data/a/x.txt", 1)],
+                    type="d")
+    assert out == ["/data", "/data/a"]
+
+
+def test_find_empty_matches_marker_only_start(monkeypatch):
+    out = _run_find(monkeypatch, [("data/", 0)], empty=True)
+    assert out == ["/data"]
+
+
+def test_find_empty_rejects_populated_start(monkeypatch):
+    out = _run_find(monkeypatch, [("data/x.txt", 3)], empty=True)
+    assert out == []
+
+
+def test_find_empty_still_matches_empty_files(monkeypatch):
+    out = _run_find(monkeypatch, [("data/x.txt", 0)], empty=True)
+    assert out == ["/data/x.txt"]
+
+
+def test_find_maxdepth_prunes_synthesized_dirs(monkeypatch):
+    out = _run_find(monkeypatch, [("data/a/b/c.txt", 1)], maxdepth=1)
+    assert out == ["/data", "/data/a"]
+
+
+def test_find_name_matches_implicit_dir(monkeypatch):
+    out = _run_find(monkeypatch, [("data/logs/x.txt", 1)], name="logs")
+    assert out == ["/data/logs"]
+
+
+def test_find_root_start_synthesizes_to_root(monkeypatch):
+    out = _run_find(monkeypatch, [("a/b.txt", 2)], resource_path="", type="d")
+    assert out == ["/", "/a"]

--- a/python/tests/core/s3/test_write.py
+++ b/python/tests/core/s3/test_write.py
@@ -1,0 +1,88 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage.accessor.s3 import S3Accessor, S3Config
+from mirage.cache.context import push_cache_manager
+from mirage.core.s3.write import write_bytes
+from mirage.types import PathSpec
+
+
+class _FakeManager:
+
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+        self.unlinks: list[str] = []
+
+    async def invalidate_after_write(self, path: PathSpec) -> None:
+        self.writes.append(path.mount_path)
+
+    async def invalidate_after_unlink(self, path: PathSpec) -> None:
+        self.unlinks.append(path.mount_path)
+
+
+class _FakeClient:
+
+    def __init__(self, puts: list[tuple[str, bytes]]) -> None:
+        self._puts = puts
+
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def put_object(self, Bucket: str, Key: str, Body: bytes) -> None:
+        self._puts.append((Key, Body))
+
+
+class _FakeSession:
+
+    def __init__(self, puts: list[tuple[str, bytes]]) -> None:
+        self._puts = puts
+
+    def client(self, **kwargs: object) -> _FakeClient:
+        return _FakeClient(self._puts)
+
+
+async def _write(monkeypatch, mount_path: str) -> tuple[_FakeManager, list]:
+    puts: list[tuple[str, bytes]] = []
+    monkeypatch.setitem(write_bytes.__globals__, "async_session",
+                        lambda config: _FakeSession(puts))
+    manager = _FakeManager()
+    prev = push_cache_manager(manager)
+    try:
+        await write_bytes(
+            S3Accessor(S3Config(bucket="b")),
+            PathSpec(virtual="/mnt" + mount_path,
+                     directory="/mnt/",
+                     resource_path=mount_path.lstrip("/")),
+            b"hi",
+        )
+    finally:
+        push_cache_manager(prev)
+    return manager, puts
+
+
+def test_write_invalidates_every_ancestor_listing(monkeypatch):
+    manager, puts = asyncio.run(_write(monkeypatch, "/a/b/c.txt"))
+    assert puts == [("a/b/c.txt", b"hi")]
+    # The put materializes `a` and `a/b` too, so their listings are stale.
+    assert manager.writes == ["/a/b/c.txt", "/a/b", "/a"]
+
+
+def test_write_at_mount_root_invalidates_only_itself(monkeypatch):
+    manager, _ = asyncio.run(_write(monkeypatch, "/c.txt"))
+    assert manager.writes == ["/c.txt"]

--- a/typescript/packages/core/src/cache/manager.test.ts
+++ b/typescript/packages/core/src/cache/manager.test.ts
@@ -81,6 +81,28 @@ describe('CacheManager', () => {
     expect(await cache.exists('/data/a.txt')).toBe(false)
   })
 
+  it('invalidateAncestors walks up to the mount root', async () => {
+    // One put materializes every missing level of the key, so every listing
+    // above the written file gained an entry.
+    const index = new RAMIndexCacheStore({ ttl: 600 })
+    for (const dir of ['/data', '/data/a', '/data/a/b']) await index.setDir(dir, [])
+    const manager = new CacheManager(null, index, '/data/', true)
+    await manager.invalidateAncestors(PathSpec.fromStrPath('/a/b/c.txt'))
+    expect((await index.listDir('/data')).entries ?? null).toBeNull()
+    expect((await index.listDir('/data/a')).entries ?? null).toBeNull()
+    // The immediate parent is invalidateAfterWrite's job, not this one.
+    expect((await index.listDir('/data/a/b')).entries ?? null).not.toBeNull()
+  })
+
+  it('invalidateAncestors reaches the root listing', async () => {
+    const index = new RAMIndexCacheStore({ ttl: 600 })
+    for (const dir of ['/', '/a']) await index.setDir(dir, [])
+    const manager = new CacheManager(null, index, '/', true)
+    await manager.invalidateAncestors(PathSpec.fromStrPath('/a/b/c.txt'))
+    expect((await index.listDir('/')).entries ?? null).toBeNull()
+    expect((await index.listDir('/a')).entries ?? null).toBeNull()
+  })
+
   it("drops this mount's bodies without touching a neighbour", async () => {
     const [cache, index] = await seeded()
     await cache.set('/other/keep.txt', new TextEncoder().encode('safe'))

--- a/typescript/packages/core/src/cache/manager.ts
+++ b/typescript/packages/core/src/cache/manager.ts
@@ -95,6 +95,26 @@ export class CacheManager {
   }
 
   /**
+   * Evict the listing of every directory above `path`'s parent.
+   *
+   * `invalidateAfterWrite` refreshes the immediate parent only. A keyed store
+   * materializes every missing level of a key in a single put, so the listings
+   * further up gained entries too and would keep serving the pre-write view
+   * until the index TTL expires. A backend with real directories cannot gain a
+   * level that way, so there this is a handful of spare evictions.
+   */
+  async invalidateAncestors(path: string | PathSpec): Promise<void> {
+    if (this.index === null) return
+    const virtual = this.virtual(path)
+    let parent = virtual.slice(0, Math.max(virtual.lastIndexOf('/'), 0))
+    while (parent !== '' && parent !== this.prefix) {
+      parent = parent.slice(0, Math.max(parent.lastIndexOf('/'), 0))
+      await this.index.invalidateDir(parent === '' ? '/' : parent)
+      await this.index.invalidateDir(parent + '/')
+    }
+  }
+
+  /**
    * Drop every cached body under this mount, path unspecified.
    *
    * For a mutation that names no path: an account CLI writes to its service by

--- a/typescript/packages/core/src/core/s3/find.test.ts
+++ b/typescript/packages/core/src/core/s3/find.test.ts
@@ -105,6 +105,16 @@ describe('s3 core find', () => {
     ).resolves.toEqual(['/data', '/data/a'])
   })
 
+  it('emits a file shadowed by an implicit dir once', async () => {
+    const keys: [string, number][] = [
+      ['data/a', 1],
+      ['data/a/b.txt', 2],
+    ]
+    await expect(runFind(keys)).resolves.toEqual(['/data', '/data/a', '/data/a/b.txt'])
+    await expect(runFind(keys, { type: 'd' })).resolves.toEqual(['/data', '/data/a'])
+    await expect(runFind(keys, { type: 'f' })).resolves.toEqual(['/data/a', '/data/a/b.txt'])
+  })
+
   it('-empty matches a marker-only start dir', async () => {
     await expect(runFind([['data/', 0]], { empty: true })).resolves.toEqual(['/data'])
   })

--- a/typescript/packages/core/src/core/s3/find.test.ts
+++ b/typescript/packages/core/src/core/s3/find.test.ts
@@ -1,0 +1,136 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './_client.ts'
+
+vi.mock('./_client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
+  return { ...actual, loadS3Module: vi.fn(), withClient: vi.fn() }
+})
+
+import type { FindOptions } from '../../resource/base.ts'
+import type { S3Config } from '../../resource/s3/config.ts'
+import { S3Accessor } from '../../accessor/s3.ts'
+import { PathSpec } from '../../types.ts'
+import * as clientMod from './_client.ts'
+import { find } from './find.ts'
+
+class FakeCommand {
+  constructor(readonly input: unknown) {}
+}
+
+function mockListing(keys: [string, number][]): void {
+  vi.mocked(clientMod.loadS3Module).mockResolvedValue({
+    ListObjectsV2Command: FakeCommand,
+  } as never)
+  vi.mocked(clientMod.withClient).mockImplementation(async (_config, fn) => {
+    const client = {
+      send: () =>
+        Promise.resolve({
+          Contents: keys.map(([key, size]) => ({ Key: key, Size: size })),
+          IsTruncated: false,
+        }),
+    }
+    return (await fn(client as never)) as never
+  })
+}
+
+function spec(resourcePath: string): PathSpec {
+  if (resourcePath !== '') {
+    return new PathSpec({
+      resourcePath,
+      virtual: '/mnt/' + resourcePath,
+      directory: '/mnt/',
+    })
+  }
+  return new PathSpec({ resourcePath: '', virtual: '/mnt', directory: '/' })
+}
+
+function runFind(
+  keys: [string, number][],
+  options: FindOptions = {},
+  resourcePath = 'data',
+): Promise<string[]> {
+  mockListing(keys)
+  const accessor = new S3Accessor({ bucket: 'b' } as S3Config)
+  return find(accessor, spec(resourcePath), options)
+}
+
+describe('s3 core find', () => {
+  beforeEach(() => {
+    vi.mocked(clientMod.loadS3Module).mockReset()
+    vi.mocked(clientMod.withClient).mockReset()
+  })
+
+  it('synthesizes implicit dirs from key prefixes', async () => {
+    await expect(runFind([['data/a/b.txt', 3]], { type: 'd' })).resolves.toEqual([
+      '/data',
+      '/data/a',
+    ])
+  })
+
+  it('drops synthesized dirs for -type f', async () => {
+    await expect(runFind([['data/a/b.txt', 3]], { type: 'f' })).resolves.toEqual(['/data/a/b.txt'])
+  })
+
+  it('gives an orphan marker its parent chain', async () => {
+    await expect(runFind([['data/a/b/', 0]], { type: 'd' })).resolves.toEqual([
+      '/data',
+      '/data/a',
+      '/data/a/b',
+    ])
+  })
+
+  it('emits no duplicates when a marker and files coexist', async () => {
+    await expect(
+      runFind(
+        [
+          ['data/a/', 0],
+          ['data/a/x.txt', 1],
+        ],
+        { type: 'd' },
+      ),
+    ).resolves.toEqual(['/data', '/data/a'])
+  })
+
+  it('-empty matches a marker-only start dir', async () => {
+    await expect(runFind([['data/', 0]], { empty: true })).resolves.toEqual(['/data'])
+  })
+
+  it('-empty rejects a populated start dir', async () => {
+    await expect(runFind([['data/x.txt', 3]], { empty: true })).resolves.toEqual([])
+  })
+
+  it('-empty still matches empty files', async () => {
+    await expect(runFind([['data/x.txt', 0]], { empty: true })).resolves.toEqual(['/data/x.txt'])
+  })
+
+  it('maxDepth prunes synthesized dirs by depth', async () => {
+    await expect(runFind([['data/a/b/c.txt', 1]], { maxDepth: 1 })).resolves.toEqual([
+      '/data',
+      '/data/a',
+    ])
+  })
+
+  it('-name matches an implicit dir', async () => {
+    await expect(runFind([['data/logs/x.txt', 1]], { name: 'logs' })).resolves.toEqual([
+      '/data/logs',
+    ])
+  })
+
+  it('synthesizes up to the mount root start', async () => {
+    await expect(runFind([['a/b.txt', 2]], { type: 'd' }, '')).resolves.toEqual(['/', '/a'])
+  })
+})

--- a/typescript/packages/core/src/core/s3/find.ts
+++ b/typescript/packages/core/src/core/s3/find.ts
@@ -29,7 +29,10 @@ export async function find(
   const raw = rawPathOf(path)
   const startName = startBasename(path.virtual)
   const pfx = s3Prefix(raw, accessor.config)
+  const rootKey = rstripSlash('/' + stripKeyPrefix(pfx, accessor.config)) || '/'
+  const baseDepth = rootKey === '/' ? 0 : (rootKey.match(/\//g) ?? []).length
   const results: string[] = []
+  const seenDirs = new Set<string>()
   const seen = { descendant: false, marker: false }
   const empty = options.empty === true
   const tree =
@@ -64,50 +67,59 @@ export async function find(
           continue
         }
         seen.descendant = true
-        const relative = key.slice(pfx.length)
-        const depth = (relative.match(/\//g) ?? []).length + 1
-        if (
-          options.maxDepth !== null &&
-          options.maxDepth !== undefined &&
-          depth > options.maxDepth
-        ) {
-          continue
-        }
         const isDir = key.endsWith('/')
-        const normKey = isDir ? key.slice(0, -1) : key
-        const entryName = normKey.split('/').pop() ?? ''
         const fullPath = rstripSlash('/' + stripKeyPrefix(key, accessor.config)) || '/'
         const size = obj.Size ?? 0
-        const isEmpty = !empty ? null : isDir ? false : size === 0
-        if (
-          !keep(
-            { key: fullPath, name: entryName, kind: isDir ? 'd' : 'f', depth, isEmpty },
-            tree,
-            options.minDepth,
-          )
-        ) {
-          continue
+        if (isDir) {
+          if (seenDirs.has(fullPath)) continue
+          seenDirs.add(fullPath)
         }
-        if (options.minSize != null || options.maxSize != null) {
-          // Directories count as size 0 for -size (deliberate GNU divergence).
-          const effective = isDir ? 0 : size
-          if (options.minSize != null && effective < options.minSize) {
+        const entries: [string, 'f' | 'd'][] = [[fullPath, isDir ? 'd' : 'f']]
+        // Implicit directories exist only as key prefixes; synthesize the
+        // parent chain so find agrees with readdir on externally-populated
+        // buckets.
+        let parent = fullPath.slice(0, fullPath.lastIndexOf('/')) || '/'
+        while (parent !== rootKey && parent !== '/') {
+          if (!seenDirs.has(parent)) {
+            seenDirs.add(parent)
+            entries.push([parent, 'd'])
+          }
+          parent = parent.slice(0, parent.lastIndexOf('/')) || '/'
+        }
+        for (const [ep, kind] of entries) {
+          const entryName = ep.split('/').pop() ?? ''
+          const depth = (ep.match(/\//g) ?? []).length - baseDepth
+          if (
+            options.maxDepth !== null &&
+            options.maxDepth !== undefined &&
+            depth > options.maxDepth
+          ) {
             continue
           }
-          if (options.maxSize != null && effective > options.maxSize) {
+          const isEmpty = !empty ? null : kind === 'd' ? false : size === 0
+          if (!keep({ key: ep, name: entryName, kind, depth, isEmpty }, tree, options.minDepth)) {
             continue
           }
+          if (options.minSize != null || options.maxSize != null) {
+            // Directories count as size 0 for -size (deliberate GNU divergence).
+            const effective = kind === 'd' ? 0 : size
+            if (options.minSize != null && effective < options.minSize) {
+              continue
+            }
+            if (options.maxSize != null && effective > options.maxSize) {
+              continue
+            }
+          }
+          results.push(ep)
         }
-        results.push(fullPath)
       }
       continuationToken = resp.IsTruncated === true ? resp.NextContinuationToken : undefined
     } while (continuationToken !== undefined)
   })
-  const rootKey = rstripSlash('/' + stripKeyPrefix(pfx, accessor.config)) || '/'
   if (seen.descendant || seen.marker) {
     emitStartPath(results, rootKey, startName, {
       kind: 'd',
-      isEmpty: empty ? false : null,
+      isEmpty: empty ? !seen.descendant : null,
       exists: true,
       tree,
       maxDepth: options.maxDepth,

--- a/typescript/packages/core/src/core/s3/find.ts
+++ b/typescript/packages/core/src/core/s3/find.ts
@@ -128,5 +128,8 @@ export async function find(
       maxSize: options.maxSize,
     })
   }
-  return results.sort(compareCodePoints)
+  // A file key and a synthesized directory can name the same path (`data/a`
+  // alongside `data/a/b.txt`), which these stores allow and a filesystem does
+  // not; find prints such a path once.
+  return [...new Set(results)].sort(compareCodePoints)
 }

--- a/typescript/packages/core/src/core/s3/write.test.ts
+++ b/typescript/packages/core/src/core/s3/write.test.ts
@@ -1,0 +1,99 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './_client.ts'
+
+vi.mock('./_client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
+  return { ...actual, loadS3Module: vi.fn(), withClient: vi.fn() }
+})
+
+import { S3Accessor } from '../../accessor/s3.ts'
+import { runWithCacheManager } from '../../cache/context.ts'
+import type { S3Config } from '../../resource/s3/config.ts'
+import { PathSpec } from '../../types.ts'
+import * as clientMod from './_client.ts'
+import { write } from './write.ts'
+
+class FakeManager {
+  writes: string[] = []
+
+  invalidateAfterWrite(path: PathSpec): Promise<void> {
+    this.writes.push(path.mountPath)
+    return Promise.resolve()
+  }
+
+  invalidateAfterUnlink(_path: PathSpec): Promise<void> {
+    return Promise.resolve()
+  }
+
+  cachedBytes(_path: PathSpec): Promise<Uint8Array | null> {
+    return Promise.resolve(null)
+  }
+}
+
+class FakeCommand {
+  constructor(readonly input: { Key?: string }) {}
+}
+
+function mockPut(keys: string[]): void {
+  vi.mocked(clientMod.loadS3Module).mockResolvedValue({
+    PutObjectCommand: FakeCommand,
+  } as never)
+  vi.mocked(clientMod.withClient).mockImplementation(async (_config, fn) => {
+    const client = {
+      send: (command: FakeCommand) => {
+        keys.push(command.input.Key ?? '')
+        return Promise.resolve({})
+      },
+    }
+    return (await fn(client as never)) as never
+  })
+}
+
+async function runWrite(mountPath: string): Promise<{ manager: FakeManager; keys: string[] }> {
+  const keys: string[] = []
+  mockPut(keys)
+  const manager = new FakeManager()
+  const accessor = new S3Accessor({ bucket: 'b' } as S3Config)
+  const spec = new PathSpec({
+    resourcePath: mountPath.replace(/^\//, ''),
+    virtual: `/mnt${mountPath}`,
+    directory: '/mnt/',
+  })
+  await runWithCacheManager(manager, async () => {
+    await write(accessor, spec, new TextEncoder().encode('hi'))
+  })
+  return { manager, keys }
+}
+
+describe('s3 core write', () => {
+  beforeEach(() => {
+    vi.mocked(clientMod.loadS3Module).mockReset()
+    vi.mocked(clientMod.withClient).mockReset()
+  })
+
+  it('invalidates every ancestor listing', async () => {
+    const { manager, keys } = await runWrite('/a/b/c.txt')
+    expect(keys).toEqual(['a/b/c.txt'])
+    // The put materializes `a` and `a/b` too, so their listings are stale.
+    expect(manager.writes).toEqual(['/a/b/c.txt', '/a/b', '/a'])
+  })
+
+  it('invalidates only itself at the mount root', async () => {
+    const { manager } = await runWrite('/c.txt')
+    expect(manager.writes).toEqual(['/c.txt'])
+  })
+})

--- a/typescript/packages/core/src/core/s3/write.ts
+++ b/typescript/packages/core/src/core/s3/write.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterWrite } from '../../cache/context.ts'
+import { invalidateAfterWrite, invalidateAncestors } from '../../cache/context.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
 import { record } from '../../observe/context.ts'
@@ -33,4 +33,7 @@ export async function write(accessor: S3Accessor, path: PathSpec, data: Uint8Arr
   })
   record('write', path.virtual, ResourceName.S3, data.byteLength, start)
   await invalidateAfterWrite(path)
+  // A put materializes every missing level of the key at once, so the
+  // listings above the immediate parent gained entries too.
+  await invalidateAncestors(path)
 }

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -15,6 +15,7 @@
 import { NOOPAccessor } from '../../accessor/base.ts'
 import { applyIo } from '../../cache/file/io.ts'
 import type { FileCache } from '../../cache/file/mixin.ts'
+import { CacheManager } from '../../cache/manager.ts'
 import { applyOpLimit, runWithTimeout } from '../../commands/builtin/utils/limit.ts'
 import { getExtension } from '../../commands/resolve.ts'
 import { IOResult, type OpReport } from '../../io/types.ts'
@@ -534,6 +535,10 @@ export class Dispatcher {
       const parent = slash <= 0 ? '/' : path.slice(0, slash)
       await idx.invalidateDir(parent)
       await idx.invalidateDir(parent + '/')
+      const manager =
+        mount.cacheManager ??
+        new CacheManager(this.cache, idx, mount.prefix, cachesReads(mount.resource))
+      await manager.invalidateAncestors(path)
     }
   }
 

--- a/typescript/packages/node/src/core/gridfs/find.test.ts
+++ b/typescript/packages/node/src/core/gridfs/find.test.ts
@@ -12,8 +12,21 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it } from 'vitest'
-import { buildQuery, globRegex } from './find.ts'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './_client.ts'
+
+vi.mock('./_client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
+  return { ...actual, iterLatest: vi.fn() }
+})
+
+import type { FindOptions } from '@struktoai/mirage-core'
+import { PathSpec } from '@struktoai/mirage-core'
+import { GridFSAccessor } from '../../accessor/gridfs.ts'
+import type { GridFSConfig } from '../../resource/gridfs/config.ts'
+import type { GridFSFileDoc } from './_client.ts'
+import * as clientMod from './_client.ts'
+import { buildQuery, find, globRegex } from './find.ts'
 
 function matches(cond: Record<string, unknown>, value: string): boolean {
   const regex = cond as { $regex: string; $options?: string }
@@ -92,5 +105,77 @@ describe('buildQuery', () => {
     expect(buildQuery('data/', { name: '[ab].csv' }, true)).toEqual({
       filename: { $regex: '^data/' },
     })
+  })
+})
+
+async function* docsGen(docs: GridFSFileDoc[]) {
+  for (const doc of docs) {
+    yield await Promise.resolve(doc)
+  }
+}
+
+function runFind(
+  docs: [string, number][],
+  options: FindOptions = {},
+): { out: Promise<string[]>; queries: Record<string, unknown>[] } {
+  const queries: Record<string, unknown>[] = []
+  vi.mocked(clientMod.iterLatest).mockImplementation((_accessor, query) => {
+    queries.push(query)
+    return docsGen(docs.map(([filename, length]) => ({ filename, length }) as GridFSFileDoc))
+  })
+  const accessor = new GridFSAccessor({
+    uri: 'mongodb://localhost:27017',
+    database: 'db',
+  } as GridFSConfig)
+  const spec = new PathSpec({
+    resourcePath: 'data',
+    virtual: '/mnt/data',
+    directory: '/mnt/',
+  })
+  return { out: find(accessor, spec, options), queries }
+}
+
+describe('gridfs core find', () => {
+  beforeEach(() => {
+    vi.mocked(clientMod.iterLatest).mockReset()
+  })
+
+  it('synthesizes implicit dirs without narrowing the query', async () => {
+    const { out, queries } = runFind([['data/a/b.txt', 3]], { type: 'd' })
+    await expect(out).resolves.toEqual(['/data', '/data/a'])
+    expect(queries).toEqual([{ filename: { $regex: '^data/' } }])
+  })
+
+  it('-name without -type f scans the prefix only', async () => {
+    const { out, queries } = runFind([['data/logs/x.txt', 1]], { name: 'logs' })
+    await expect(out).resolves.toEqual(['/data/logs'])
+    expect(queries).toEqual([{ filename: { $regex: '^data/' } }])
+  })
+
+  it('-type f keeps the pushdown', async () => {
+    const { out, queries } = runFind([['data/a/b.txt', 3]], { type: 'f', name: '*.txt' })
+    await expect(out).resolves.toEqual(['/data/a/b.txt'])
+    expect(queries[0]).toHaveProperty('$and')
+  })
+
+  it('unordered marker and file emit no duplicates', async () => {
+    const { out } = runFind(
+      [
+        ['data/a/x.txt', 1],
+        ['data/a/', 0],
+      ],
+      { type: 'd' },
+    )
+    await expect(out).resolves.toEqual(['/data', '/data/a'])
+  })
+
+  it('-empty matches a marker-only start dir', async () => {
+    const { out } = runFind([['data/', 0]], { empty: true })
+    await expect(out).resolves.toEqual(['/data'])
+  })
+
+  it('-empty rejects a populated start dir', async () => {
+    const { out } = runFind([['data/x.txt', 3]], { empty: true })
+    await expect(out).resolves.toEqual([])
   })
 })

--- a/typescript/packages/node/src/core/gridfs/find.test.ts
+++ b/typescript/packages/node/src/core/gridfs/find.test.ts
@@ -169,6 +169,16 @@ describe('gridfs core find', () => {
     await expect(out).resolves.toEqual(['/data', '/data/a'])
   })
 
+  it('emits a file shadowed by an implicit dir once', async () => {
+    const docs: [string, number][] = [
+      ['data/a', 1],
+      ['data/a/b.txt', 2],
+    ]
+    await expect(runFind(docs).out).resolves.toEqual(['/data', '/data/a', '/data/a/b.txt'])
+    await expect(runFind(docs, { type: 'd' }).out).resolves.toEqual(['/data', '/data/a'])
+    await expect(runFind(docs, { type: 'f' }).out).resolves.toEqual(['/data/a', '/data/a/b.txt'])
+  })
+
   it('-empty matches a marker-only start dir', async () => {
     const { out } = runFind([['data/', 0]], { empty: true })
     await expect(out).resolves.toEqual(['/data'])

--- a/typescript/packages/node/src/core/gridfs/find.ts
+++ b/typescript/packages/node/src/core/gridfs/find.ts
@@ -106,15 +106,23 @@ export async function find(
   const raw = rawPathOf(path)
   const startName = startBasename(path.virtual)
   const pfx = gridfsPrefix(raw, accessor.config)
+  const rootKey = rstripSlash('/' + stripKeyPrefix(pfx, accessor.config)) || '/'
+  const baseDepth = rootKey === '/' ? 0 : (rootKey.match(/\//g) ?? []).length
   const results: string[] = []
+  const seenDirs = new Set<string>()
   const seen = { descendant: false, marker: false }
   const empty = options.empty === true
+  // Narrowing beyond the prefix is only sound when directories cannot
+  // appear in the output (-type f): implicit directories are synthesized
+  // client-side from file paths, so any server-side file exclusion would
+  // also drop the evidence for a matching parent directory.
   const pushdown =
     options.tree === undefined &&
     options.nameExclude === undefined &&
     options.orNames === undefined &&
     options.pathPattern === undefined &&
-    !empty
+    !empty &&
+    options.type === 'f'
   const tree =
     options.tree ??
     buildTree({
@@ -135,33 +143,43 @@ export async function find(
       continue
     }
     seen.descendant = true
-    const relative = key.slice(pfx.length)
-    const depth = (relative.match(/\//g) ?? []).length + 1
-    if (options.maxDepth !== null && options.maxDepth !== undefined && depth > options.maxDepth) {
-      continue
-    }
     const isDir = key.endsWith('/')
-    const normKey = isDir ? key.slice(0, -1) : key
-    const entryName = normKey.split('/').pop() ?? ''
     const fullPath = rstripSlash('/' + stripKeyPrefix(key, accessor.config)) || '/'
     const size = doc.length
-    const isEmpty = !empty ? null : isDir ? false : size === 0
-    if (
-      !keep(
-        { key: fullPath, name: entryName, kind: isDir ? 'd' : 'f', depth, isEmpty },
-        tree,
-        options.minDepth,
-      )
-    ) {
-      continue
+    if (isDir) {
+      if (seenDirs.has(fullPath)) continue
+      seenDirs.add(fullPath)
     }
-    if (options.minSize != null || options.maxSize != null) {
-      // Directories count as size 0 for -size (deliberate GNU divergence).
-      const effective = isDir ? 0 : size
-      if (options.minSize != null && effective < options.minSize) continue
-      if (options.maxSize != null && effective > options.maxSize) continue
+    const entries: [string, 'f' | 'd'][] = [[fullPath, isDir ? 'd' : 'f']]
+    // Implicit directories exist only as filename prefixes; synthesize the
+    // parent chain so find agrees with readdir on externally-populated
+    // buckets.
+    let parent = fullPath.slice(0, fullPath.lastIndexOf('/')) || '/'
+    while (parent !== rootKey && parent !== '/') {
+      if (!seenDirs.has(parent)) {
+        seenDirs.add(parent)
+        entries.push([parent, 'd'])
+      }
+      parent = parent.slice(0, parent.lastIndexOf('/')) || '/'
     }
-    results.push(fullPath)
+    for (const [ep, kind] of entries) {
+      const entryName = ep.split('/').pop() ?? ''
+      const depth = (ep.match(/\//g) ?? []).length - baseDepth
+      if (options.maxDepth !== null && options.maxDepth !== undefined && depth > options.maxDepth) {
+        continue
+      }
+      const isEmpty = !empty ? null : kind === 'd' ? false : size === 0
+      if (!keep({ key: ep, name: entryName, kind, depth, isEmpty }, tree, options.minDepth)) {
+        continue
+      }
+      if (options.minSize != null || options.maxSize != null) {
+        // Directories count as size 0 for -size (deliberate GNU divergence).
+        const effective = kind === 'd' ? 0 : size
+        if (options.minSize != null && effective < options.minSize) continue
+        if (options.maxSize != null && effective > options.maxSize) continue
+      }
+      results.push(ep)
+    }
   }
   if (narrowed && !seen.descendant && !seen.marker) {
     // The narrowed query may have excluded every doc under a prefix that
@@ -173,11 +191,10 @@ export async function find(
     )
     seen.descendant = probe !== null
   }
-  const rootKey = rstripSlash('/' + stripKeyPrefix(pfx, accessor.config)) || '/'
   if (seen.descendant || seen.marker) {
     emitStartPath(results, rootKey, startName, {
       kind: 'd',
-      isEmpty: empty ? false : null,
+      isEmpty: empty ? !seen.descendant : null,
       exists: true,
       tree,
       maxDepth: options.maxDepth,

--- a/typescript/packages/node/src/core/gridfs/find.ts
+++ b/typescript/packages/node/src/core/gridfs/find.ts
@@ -203,5 +203,8 @@ export async function find(
       maxSize: options.maxSize,
     })
   }
-  return results.sort(compareCodePoints)
+  // A file key and a synthesized directory can name the same path (`data/a`
+  // alongside `data/a/b.txt`), which these stores allow and a filesystem does
+  // not; find prints such a path once.
+  return [...new Set(results)].sort(compareCodePoints)
 }

--- a/typescript/packages/node/src/core/gridfs/write.test.ts
+++ b/typescript/packages/node/src/core/gridfs/write.test.ts
@@ -1,0 +1,94 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './_client.ts'
+
+vi.mock('./_client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
+  return { ...actual, bucket: vi.fn() }
+})
+
+import { PathSpec, runWithCacheManager } from '@struktoai/mirage-core'
+import { GridFSAccessor } from '../../accessor/gridfs.ts'
+import type { GridFSConfig } from '../../resource/gridfs/config.ts'
+import * as clientMod from './_client.ts'
+import { write } from './write.ts'
+
+class FakeManager {
+  writes: string[] = []
+
+  invalidateAfterWrite(path: PathSpec): Promise<void> {
+    this.writes.push(path.mountPath)
+    return Promise.resolve()
+  }
+
+  invalidateAfterUnlink(_path: PathSpec): Promise<void> {
+    return Promise.resolve()
+  }
+
+  cachedBytes(_path: PathSpec): Promise<Uint8Array | null> {
+    return Promise.resolve(null)
+  }
+}
+
+function fakeBucket(keys: string[]): unknown {
+  return {
+    openUploadStream: (key: string) => {
+      keys.push(key)
+      const handlers: Record<string, () => void> = {}
+      return {
+        on: (event: string, handler: () => void) => {
+          handlers[event] = handler
+        },
+        end: () => {
+          handlers.finish?.()
+        },
+      }
+    },
+  }
+}
+
+async function runWrite(mountPath: string): Promise<{ manager: FakeManager; keys: string[] }> {
+  const keys: string[] = []
+  vi.mocked(clientMod.bucket).mockResolvedValue(fakeBucket(keys) as never)
+  const manager = new FakeManager()
+  const accessor = new GridFSAccessor({
+    uri: 'mongodb://localhost:27017',
+    database: 'db',
+  } as GridFSConfig)
+  const spec = new PathSpec({
+    resourcePath: mountPath.replace(/^\//, ''),
+    virtual: `/mnt${mountPath}`,
+    directory: '/mnt/',
+  })
+  await runWithCacheManager(manager, async () => {
+    await write(accessor, spec, new TextEncoder().encode('hi'))
+  })
+  return { manager, keys }
+}
+
+describe('gridfs core write', () => {
+  it('invalidates every ancestor listing', async () => {
+    const { manager, keys } = await runWrite('/a/b/c.txt')
+    expect(keys).toEqual(['a/b/c.txt'])
+    // The upload materializes `a` and `a/b` too, so their listings are stale.
+    expect(manager.writes).toEqual(['/a/b/c.txt', '/a/b', '/a'])
+  })
+
+  it('invalidates only itself at the mount root', async () => {
+    const { manager } = await runWrite('/c.txt')
+    expect(manager.writes).toEqual(['/c.txt'])
+  })
+})

--- a/typescript/packages/node/src/core/gridfs/write.ts
+++ b/typescript/packages/node/src/core/gridfs/write.ts
@@ -12,7 +12,13 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { ResourceName, invalidateAfterWrite, record, type PathSpec } from '@struktoai/mirage-core'
+import {
+  ResourceName,
+  invalidateAfterWrite,
+  invalidateAncestors,
+  record,
+  type PathSpec,
+} from '@struktoai/mirage-core'
 import type { GridFSAccessor } from '../../accessor/gridfs.ts'
 import { bucket, gridfsKey, rawPathOf } from './_client.ts'
 
@@ -45,4 +51,7 @@ export async function write(
   await uploadBytes(accessor, key, data)
   record('write', path.virtual, ResourceName.GRIDFS, data.byteLength, startMs)
   await invalidateAfterWrite(path)
+  // An upload materializes every missing level of the key at once, so the
+  // listings above the immediate parent gained entries too.
+  await invalidateAncestors(path)
 }

--- a/typescript/packages/node/src/core/nextcloud/search.test.ts
+++ b/typescript/packages/node/src/core/nextcloud/search.test.ts
@@ -7,7 +7,8 @@ import { globToLike, requestBody } from './search/query.ts'
 import { relativePath, searchTarget } from './search/target.ts'
 
 const NAME_TXT: PredNode = { op: 'name', pattern: '*.txt', icase: false }
-const NAME_CSV: PredNode = { op: 'name', pattern: '*.csv', icase: false }
+const NAME_NOTES: PredNode = { op: 'name', pattern: 'notes.txt', icase: false }
+const NAME_ROWS: PredNode = { op: 'name', pattern: 'rows.csv', icase: false }
 const DIRECTORY: PredNode = { op: 'type', kind: 'd' }
 
 function multistatus(paths: { href: string; directory?: boolean }[]): string {
@@ -93,20 +94,36 @@ describe('Nextcloud Files Search query', () => {
   })
 
   it.each<[string, PredNode]>([
-    ['not of an or', { op: 'not', kid: { op: 'or', kids: [NAME_TXT, NAME_CSV] } }],
-    ['not of an and', { op: 'not', kid: { op: 'and', kids: [NAME_TXT, DIRECTORY] } }],
-    ['not of a not', { op: 'not', kid: { op: 'not', kid: NAME_TXT } }],
+    ['not of an or', { op: 'not', kid: { op: 'or', kids: [NAME_NOTES, NAME_ROWS] } }],
+    ['not of an and', { op: 'not', kid: { op: 'and', kids: [NAME_NOTES, DIRECTORY] } }],
+    ['not of a not', { op: 'not', kid: { op: 'not', kid: NAME_NOTES } }],
     ['not of -type f', { op: 'not', kid: { op: 'type', kind: 'f' } }],
   ])('refuses to push down a negated compound: %s', (_label, tree) => {
     expect(supportsQuery({ tree })).toBe(false)
   })
 
   it.each<[string, PredNode]>([
-    ['not of a name', { op: 'not', kid: NAME_TXT }],
-    ['not of -type d', { op: 'not', kid: DIRECTORY }],
+    ['not of a star glob', { op: 'not', kid: NAME_TXT }],
+    ['not of a question glob', { op: 'not', kid: { op: 'name', pattern: 'a?.txt', icase: false } }],
+    ['not of an -iname', { op: 'not', kid: { op: 'name', pattern: 'notes.txt', icase: true } }],
     ['not of a one-armed group', { op: 'not', kid: { op: 'or', kids: [NAME_TXT] } }],
+  ])('refuses to push down a negated inexact name: %s', (_label, tree) => {
+    expect(supportsQuery({ tree })).toBe(false)
+  })
+
+  it.each<[string, PredNode]>([
+    ['not of an exact name', { op: 'not', kid: NAME_NOTES }],
+    ['not of -type d', { op: 'not', kid: DIRECTORY }],
+    ['not of a one-armed group', { op: 'not', kid: { op: 'or', kids: [NAME_NOTES] } }],
   ])('pushes down a negated comparison: %s', (_label, tree) => {
     expect(supportsQuery({ tree })).toBe(true)
+  })
+
+  it.each<[string, string]>([
+    ['a character class', '[ab].txt'],
+    ['a backslash escape', 'a\\b'],
+  ])('refuses to push down %s', (_label, pattern) => {
+    expect(supportsQuery({ tree: { op: 'name', pattern, icase: false } })).toBe(false)
   })
 
   it('broadens SQL wildcard and backslash literals safely', () => {

--- a/typescript/packages/node/src/core/nextcloud/search/query.ts
+++ b/typescript/packages/node/src/core/nextcloud/search/query.ts
@@ -71,9 +71,13 @@ export function globToLike(pattern: string): string {
   return translated
 }
 
-function nameCondition(node: Extract<PredNode, { op: 'name' }>): string {
+function nameOperation(node: Extract<PredNode, { op: 'name' }>): ComparisonOperator {
   const wildcard = node.pattern.includes('*') || node.pattern.includes('?')
-  const operation = wildcard || node.icase ? Comparison.LIKE : Comparison.EQUAL
+  return wildcard || node.icase ? Comparison.LIKE : Comparison.EQUAL
+}
+
+function nameCondition(node: Extract<PredNode, { op: 'name' }>): string {
+  const operation = nameOperation(node)
   const value = operation === Comparison.LIKE ? globToLike(node.pattern) : node.pattern
   return comparison(operation, DISPLAY_NAME, value)
 }
@@ -82,8 +86,21 @@ function compilePredicate(node: PredNode): CompiledPredicate | null {
   switch (node.op) {
     case 'true':
       return { condition: null, negatable: false }
-    case 'name':
-      return node.pattern.includes('[') ? null : { condition: nameCondition(node), negatable: true }
+    case 'name': {
+      // A class has no LIKE spelling, and a backslash escapes the next
+      // character out of the glob (`-name 'a\b'` matches `ab`), so the literal
+      // the server would compare is not the name being matched.
+      if (node.pattern.includes('[') || node.pattern.includes('\\')) return null
+      // LIKE is a deliberate superset (case-insensitive, and a literal `%`/`_`
+      // in the pattern stays a wildcard) that the client-side keep()
+      // re-filters. Negation has nothing to re-filter with: NOT(superset)
+      // withholds rows the true predicate keeps and no client pass can add
+      // them back, so only the exact comparison is safe to negate.
+      return {
+        condition: nameCondition(node),
+        negatable: nameOperation(node) === Comparison.EQUAL,
+      }
+    }
     case 'type':
       if (node.kind === 'd') return { condition: isCollection(), negatable: true }
       if (node.kind === 'f') return { condition: negate(isCollection()), negatable: false }

--- a/typescript/packages/node/src/core/ssh/entry.test.ts
+++ b/typescript/packages/node/src/core/ssh/entry.test.ts
@@ -50,6 +50,24 @@ describe('attrsToFileStat', () => {
     expect(stat.modified).toBeNull()
   })
 
+  it('fingerprints a file by its mtime so ALWAYS can revalidate', () => {
+    const stat = attrsToFileStat('foo.txt', { mode: 0o100644, mtime: 0 })
+    expect(stat.fingerprint).toBe(stat.modified)
+    expect(attrsToFileStat('foo.txt', { mode: 0o100644, mtime: 1 }).fingerprint).not.toBe(
+      stat.fingerprint,
+    )
+  })
+
+  it('fingerprints a directory by its mtime too', () => {
+    const stat = attrsToFileStat('mydir', { mode: 0o040755, mtime: 0 })
+    expect(stat.fingerprint).toBe(stat.modified)
+  })
+
+  it('returns null fingerprint when mtime is omitted', () => {
+    expect(attrsToFileStat('foo.txt', { mode: 0o100644 }).fingerprint).toBeNull()
+    expect(attrsToFileStat('mydir', { mode: 0o040755 }).fingerprint).toBeNull()
+  })
+
   it('carries the name through unchanged', () => {
     const stat = attrsToFileStat('weird-name.parquet', { mode: 0o100644, size: 100 })
     expect(stat.name).toBe('weird-name.parquet')

--- a/typescript/packages/node/src/core/ssh/entry.ts
+++ b/typescript/packages/node/src/core/ssh/entry.ts
@@ -37,11 +37,16 @@ export function attrsToFileStat(name: string, attrs: SshAttrs): FileStat {
   // server-side uid/gid stay in extra only.
   const mode = attrs.mode !== undefined ? attrs.mode & 0o7777 : null
   const atime = attrs.atime !== undefined ? new Date(attrs.atime * 1000).toISOString() : null
+  // The remote mtime is the only cheap change token SFTP offers, so it is
+  // also the fingerprint: without one, the ALWAYS consistency policy has
+  // nothing to compare and keeps serving a cached copy that the server has
+  // already replaced. Mirrors the python stat.
   if (isDirectoryAttrs(attrs)) {
     return new FileStat({
       name,
       size: null,
       modified,
+      fingerprint: modified,
       type: FileType.DIRECTORY,
       mode,
       atime,
@@ -52,7 +57,7 @@ export function attrsToFileStat(name: string, attrs: SshAttrs): FileStat {
     name,
     size: attrs.size ?? null,
     modified,
-    fingerprint: null,
+    fingerprint: modified,
     type: guessType(name),
     mode,
     atime,


### PR DESCRIPTION
## Summary

Four flat-store / push-down correctness fixes found in the Phase 0 audit, plus the integ plumbing needed to prove the TypeScript half of them. Python and TypeScript twins change identically throughout.

**1. `find` never emitted implicit directories on s3/gridfs.** Prefix-only listing with no parent synthesis: `find -type d` disagreed with `ls`/readdir on externally-populated buckets, whole subtrees were invisible, and `-name <dir>` could not match a marker-less directory. Ports hf_buckets' `seen_dirs` parent-chain synthesis, extended to orphan dir markers (a marker `a/b/` with no `a/` now yields `a` too). Two follow-ons:
- `-empty` on the start dir was hard-coded false; now `not saw_descendant`.
- gridfs server-side narrowing (`-name`/`-iname`/`-type`/`-size`) now engages only with `-type f`. With implicit dirs synthesized client-side from file paths, any server-side file exclusion also drops the evidence for a matching parent directory; `-type f` is the one shape where directories cannot appear in the output.
- Codex review catch: a file key and a synthesized directory can name the same path (`data/a` beside `data/a/b.txt`), which these stores allow and a filesystem does not. All four implementations now dedup before sorting, as hf_buckets already did.

**2. A deep write left every ancestor listing stale.** One put materializes every missing level of a key, but only the immediate parent's listing was invalidated, so `ls` kept serving the pre-write view for up to the 600s index TTL. `ls /data2/anc` returned nothing while `find` (which does not read the index) already listed the new subtree.

Fixing this needed **both** invalidation surfaces, which is the interesting part:
- `cache.context.invalidate_ancestors` (the existing hf/dropbox helper) only fires when a cache manager is pushed, i.e. on the *command* path (`tee`, `cp`, `touch`). Added to the s3 and gridfs `write` twins for that path.
- A shell redirect, FUSE, and the ops facade go through the dispatcher instead, which does its own post-write bookkeeping and invalidated only the immediate parent. New `CacheManager.invalidate_ancestors` (py + TS), called from both dispatchers.

The dispatcher walk is unconditional rather than gated on a "flat store" capability flag, which does not exist yet: over-invalidation costs a refetch of a few ancestor listings, and only backends with real directories pay it. `databricks_volume` was evaluated and deliberately left alone — its write requires the parent to exist (`ensureParentDirectory`), so it cannot materialize a level.

**3. Nextcloud negated `-name` under-matched.** `glob_to_like` compiles a glob to `LIKE`, a deliberate superset (a literal `_`/`%` in the pattern stays a SQL wildcard, and LIKE is case-insensitive on some backing databases). A superset is safe for positive matching because the client-side `keep()` re-filters it, but `NOT(superset)` is a strict subset of the true negation and no client pass can add the withheld rows back: `find ! -name '*_b.txt'` dropped `axb.txt`, which GNU keeps. `Name` is now negatable only when it compiles to an exact comparison (no wildcard, no `-iname`), and a pattern containing a backslash is not pushed down at all in either direction (`-name 'a\b'` matches `ab`, so the literal the server would compare is not the name being matched). Refusing falls the whole find back to the scan walk, which has no such limit.

**4. The TS integ runner silently dropped every consistency case for most targets.** `CONSISTENCY_ADAPTERS` covered only onedrive/sharepoint, so scenario cases for s3/gridfs/dropbox/ssh/hf ran on the Python host and vanished on the TypeScript one with no output. Replaced with the generic shape the Python runner already has: adapters expose an optional `shadow()` (a second workspace over the same store, with independent caches — sharing resource instances would share their caches and the scenario would measure nothing), and `openConsistency` builds the read workspace under the requested policy plus the shadow to mutate through. `openGraphConsistency` folded into the ordinary onedrive/sharepoint adapters. A target whose adapter cannot build a shadow now logs a skip line per case instead of saying nothing.

**5. …and the first thing that generic adapter caught: TS ssh never revalidated.** Python's ssh stat carries `fingerprint=mod_str or None` (the remote mtime); the TypeScript twin hard-coded `fingerprint: null`. Under `ConsistencyPolicy.ALWAYS`, `reconcile.probe` reads that fingerprint, so TypeScript returned `Verdict.UNKNOWN`, `mayServeCached` said yes, and the cached copy kept being served after the server had replaced it — `v1\nv1\n` where python gives `v1\nv2\n`. With only onedrive/sharepoint registered, `consistency_always_revalidates` had never run against ssh on the TypeScript host, so nothing caught it. Fixed by fingerprinting on mtime, the only cheap change token SFTP offers and the one python already uses; directories get it too, matching python's single FileStat. Audited the class: the other hard-coded `fingerprint: null` sites (`core/dify/stat.ts`, `node/nextcloud/watch.ts`) both match python's `fingerprint=None`.

Left as a separate finding: the same function formats `modified`/`atime` with `new Date().toISOString()` (`.000Z`) where python emits second-precision `Z` via `epoch_to_iso`. Aligning them means exporting `epochToIso` from core's public index, a wider surface change than this fix needs, and the difference is invisible at the command level (the parity job is green).

## Tests

- py unit: `tests/core/s3/test_find.py` (new, 11), `tests/core/s3/test_write.py` (new), `tests/core/gridfs/test_write.py` (new), `tests/core/gridfs/test_find.py` (+7), `tests/cache/test_manager.py` (+2), `tests/core/nextcloud/test_search.py` (negation matrix reworked)
- ts unit: `core/s3/find.test.ts` (new, 11), `core/s3/write.test.ts` (new), `node/gridfs/write.test.ts` (new), `node/gridfs/find.test.ts` (+7), `cache/manager.test.ts` (+2), `node/nextcloud/search.test.ts` (negation matrix reworked)
- integ: `unix/find/implicit.json` (2 scenario cases seeding marker-less keys through the consistency runner's out-of-band mutate), `unix/consistency/ancestors.json`, and two `unix/find/not.json` cases pinning that a glob's `_` stays literal under negation and that the wildcard-free spelling keeps its push-down.
- Every new case was checked to actually fail before the fix: the nextcloud one returns only the start directory pre-fix, the implicit-dir ones fail 8/8 across the four targets, the ancestors one prints an empty listing.
- GNU pinned with docker `debian:stable-slim` (findutils 4.10.0) for `-name` case sensitivity, `! -name '*_b.txt'`, and `-name 'a\b'`.
- ts unit (fix 5): `node/ssh/entry.test.ts` (+3) pinning file and directory fingerprints and the mtime-absent null.
- Full unit suites green on both languages (py ~14.2k, ts core 8136 / node 2175 / browser 182); `pnpm -r typecheck` clean.
- TypeScript battery over s3, s3-prefix, gridfs, gridfs-prefix against live minio + mongo: 8679 passed, 0 failed. The new consistency adapter makes `find_implicit_dirs`, `find_implicit_dir_name`, `consistency_lazy_serves_stale`, and `consistency_always_revalidates` run on the TypeScript host for the first time.
- TypeScript battery over the other newly-covered adapters (dropbox, dropbox-root, onedrive, sharepoint, sharepoint-prefix, hf, hf-prefix, ssh): 17136 passed, 1 failed — that one failure was fix 5, reproduced locally before the CI log was even available. `consistency_always_revalidates` on ssh is its regression test: it fails on the old code and passes on the new. Re-ran the ssh target 3x post-fix (2250 passed, 0 failed each) since the fingerprint is a 1-second-resolution mtime and the granularity risk was worth ruling out.
- Python host: ~33.6k cases over 24 targets (ram/ram-*, disk, redis, s3, s3-prefix, gridfs, gridfs-prefix, dropbox, dropbox-root, ssh, onedrive, sharepoint, sharepoint-prefix, box, hf, hf-prefix, mongodb, databricks, databricks-prefix, object-storage-prefix, statvfs, git-disk, git-ram) plus gdrive/gdrive-folder/gdrive-shared/gapps (4323) — 0 failures. nextcloud runs locally only (CI `--allow-skip`s it): 2242 passed, 0 failed, including the two new negation pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
