### PR TITLE
fix(prompt): mount trees that match readdir, and ntn's real grammar

### DIFF
--- a/python/mirage/resource/notion/prompt.py
+++ b/python/mirage/resource/notion/prompt.py
@@ -22,22 +22,31 @@ PROMPT = """\
   databases/
     <database-title>__<database-id>/
       database.json
-      <row-page-title>__<page-id>/
-        page.json
+      <data-source-title>__<data-source-id>/
+        data_source.json
+        <row-page-title>__<page-id>/
+          page.json
   Hierarchical page tree plus shared databases. cat page.json shows
   metadata, the page body rendered as markdown, and raw blocks (nested
-  blocks under "children"). cat database.json shows the database metadata
-  and its typed property schema (not the rows); ls the database dir to
-  list row pages.
+  blocks under "children"). A database is a container plus one or more
+  data sources: database.json holds the container's identity and its
+  data_sources stubs, while data_source.json holds the typed property
+  schema (not the rows). ls a data source dir to list its row pages.
 
   Titles are sanitized; don't construct paths, ls the parent dir.
-  Use the <page-id>/<database-id> from a path segment as the --page,
-  --block, or --datasource value in ntn CLI commands (ntn --help)."""
+  ntn takes ids as positional operands, not flags: ntn pages get
+  <page-id>, ntn datasources query <data-source-id>, ntn datasources
+  resolve <database-id>."""
 
 WRITE_PROMPT = """\
   Writes go through the ntn CLI if installed:
-    ntn pages create --json \
-'{"parent":{"page_id":"..."},\
-"properties":{"title":[{"text":{"content":"Title"}}]}}'
-    ntn blocks append --block <block-id> --json '{"children":[...]}'
-  See ntn --help for every verb (pages, blocks, comments, search)."""
+    ntn pages create --parent data-source:<data-source-id> \
+--content '# Title'
+    ntn pages edit <page-id> --content '## Notes'
+    ntn pages trash <page-id> --yes
+  --parent takes page:<id>, database:<id> or data-source:<id>, and
+  --content also reads stdin. Blocks, comments and search have no typed
+  verb; reach them through ntn api:
+    ntn api v1/blocks/<block-id>/children -X PATCH \
+-d '{"children":[...]}'
+  See ntn --help: api, auth, datasources, pages, whoami."""

--- a/python/mirage/resource/trello/prompt.py
+++ b/python/mirage/resource/trello/prompt.py
@@ -20,6 +20,10 @@ PROMPT = """\
       boards/
         <board-name>__<board-id>/
           board.json
+          members/
+            <full-name>__<member-id>.json
+          labels/
+            <label-name>__<label-id>.json
           lists/
             <list-name>__<list-id>/
               list.json

--- a/typescript/packages/core/src/resource/notion/prompt.ts
+++ b/typescript/packages/core/src/resource/notion/prompt.ts
@@ -21,17 +21,28 @@ export const NOTION_PROMPT = `{prefix}
   databases/
     <database-title>__<database-id>/
       database.json
-      <row-page-title>__<page-id>/
-        page.json
+      <data-source-title>__<data-source-id>/
+        data_source.json
+        <row-page-title>__<page-id>/
+          page.json
   Hierarchical page tree plus shared databases. cat page.json shows
   metadata, the page body rendered as markdown, and raw blocks (nested
-  blocks under "children"). cat database.json shows the database metadata
-  and its typed property schema (not the rows); ls the database dir to
-  list row pages.
+  blocks under "children"). A database is a container plus one or more
+  data sources: database.json holds the container's identity and its
+  data_sources stubs, while data_source.json holds the typed property
+  schema (not the rows). ls a data source dir to list its row pages.
 
-  Titles are sanitized; don't construct paths, ls the parent dir.`
+  Titles are sanitized; don't construct paths, ls the parent dir.
+  ntn takes ids as positional operands, not flags: ntn pages get
+  <page-id>, ntn datasources query <data-source-id>, ntn datasources
+  resolve <database-id>.`
 
 export const NOTION_WRITE_PROMPT = `  Writes go through the ntn CLI if installed:
-    ntn pages create --json '{"parent":{"page_id":"..."},"properties":{"title":[{"text":{"content":"Title"}}]}}'
-    ntn blocks append --block <block-id> --json '{"children":[...]}'
-  See ntn --help for every verb (pages, blocks, comments, search).`
+    ntn pages create --parent data-source:<data-source-id> --content '# Title'
+    ntn pages edit <page-id> --content '## Notes'
+    ntn pages trash <page-id> --yes
+  --parent takes page:<id>, database:<id> or data-source:<id>, and
+  --content also reads stdin. Blocks, comments and search have no typed
+  verb; reach them through ntn api:
+    ntn api v1/blocks/<block-id>/children -X PATCH -d '{"children":[...]}'
+  See ntn --help: api, auth, datasources, pages, whoami.`

--- a/typescript/packages/core/src/resource/trello/prompt.ts
+++ b/typescript/packages/core/src/resource/trello/prompt.ts
@@ -19,6 +19,10 @@ export const TRELLO_PROMPT = `{prefix}
       boards/
         <board-name>__<board-id>/
           board.json
+          members/
+            <full-name>__<member-id>.json
+          labels/
+            <label-name>__<label-id>.json
           lists/
             <list-name>__<list-id>/
               list.json


### PR DESCRIPTION
The LLM-facing Notion and Trello mount prompts described virtual filesystem
trees that no backend serves. Both languages had drifted the same way, so the
py/ts parity gate could not catch it: a prompt is a string, and nothing
compares it to `readdir`.

## Notion: the data source level was missing

Since `Notion-Version: 2025-09-03` a database is a container plus one or more
*data sources*, and both `readdir`s have served three levels under `databases/`
accordingly — `database.json` plus one dir per data source at depth 2,
`data_source.json` plus row pages at depth 3, row page dirs from depth 4
(`core/notion/readdir.py`, `core/notion/readdir.ts`, pinned by
`readdir.test.ts`'s `/databases/Tasks__${DB_ID}/Tasks__${DS_ID}`). The prompt
still showed row pages hanging directly off the database.

```diff
   databases/
     <database-title>__<database-id>/
       database.json
-      <row-page-title>__<page-id>/
-        page.json
+      <data-source-title>__<data-source-id>/
+        data_source.json
+        <row-page-title>__<page-id>/
+          page.json
```

The prose was wrong in the same way, and would have sent an agent looking for a
key that is not there: it claimed `database.json` shows "its typed property
schema". It does not. `normalize_database` emits no `properties` at all — the
schema lives on `normalize_data_source` — and `ls` on a database dir lists data
sources, not rows.

## Trello: two directories that have always existed

`readdir` seeds every board dir with four children and serves
`members/<full-name>__<member-id>.json` and `labels/<label-name>__<label-id>.json`.
The prompt showed only `board.json` and `lists/`.

## ntn guidance that the CLI, and the docs, already contradicted

The Notion prompts also advertised a CLI that does not exist:
`ntn blocks append` (there is no `blocks` verb), ids passed as
`--page`/`--block`/`--datasource` (none are options — ids are positional), and
`--json` used as a request body when it is a boolean *output* flag.

This one is not a judgement call: `ntn` is gated against real npm `ntn@0.21.9`
by `integ/ntn_conformance.ts`, and `docs/python/cli/ntn.mdx` already states
**"Ids are positional, not flags. There is no `--page`, `--block` or
`--datasource`"** and "There is no `ntn blocks`, `ntn comments` or `ntn
search`." Only the prompts were stale. They now teach the five real verbs
(`api`, `auth`, `datasources`, `pages`, `whoami`), positional ids,
`pages create --parent/--content`, and blocks/comments/search through `ntn api`
(with `-X PATCH`, since any body source otherwise infers POST).

The Notion prompts now render **byte-identical** across the two languages —
verified by rendering both and diffing. The ids sentence was previously
Python-only.

## Scope notes

- **Docs needed no change.** All eight Notion/Trello doc files and both
  `cli/ntn.mdx` were already correct on every count; the prompts were the only
  stale surface. Nothing in `docs/` or `examples/` carried either error.
- **No prompt snapshot tests exist** for these two backends — the only
  assertions are `typeof === 'string'` and a length check, so nothing needed
  updating.
- **Trello's command list was already accurate.** Every read and write command
  it advertises (`trello card label`, `unlabel`, `comment`, `comment-update`, …)
  matches its registration; only the tree was wrong.

## Verification

- Full Python suite green (`--ignore=tests/fuse`; no libfuse on this host).
- TS core suite green, 635/635 files, 8088 passed.
- `pnpm -r typecheck` clean across all packages.
- All pre-commit hooks pass, including mypy, ESLint and Knip.
- Rebased onto current `main` (#791) and re-verified: that commit touches
  `ntn/datasources/query` but not the spec, and `ntn --help` still renders the
  same five verbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
