### PR TITLE
fix(discord): dirname-parsed scope, tombstoned attachments, date-less grep paths, smart head revival (py+ts)

### DIFF
--- a/integ/fixtures/discord/v1.json
+++ b/integ/fixtures/discord/v1.json
@@ -86,6 +86,11 @@
                 "filename": "budget.csv",
                 "content_type": "text/csv",
                 "body": "quarter,amount\nQ1,100\nQ2,250\n"
+              },
+              {
+                "id": "500000000000000002",
+                "filename": "ghost.png",
+                "tombstoned": true
               }
             ]
           },
@@ -102,6 +107,12 @@
             "author": "900000000000000001",
             "content": "v1.2.0 released",
             "timestamp": "2026-06-01T12:00:00.000000+00:00"
+          },
+          {
+            "id": "1511285744391782400",
+            "author": "900000000000000001",
+            "content": "v1.2.1 hotfix released",
+            "timestamp": "2026-06-02T09:00:00.000000+00:00"
           }
         ]
       }

--- a/integ/resources/discord/scope.json
+++ b/integ/resources/discord/scope.json
@@ -1,0 +1,56 @@
+{
+  "cases": [
+    {
+      "id": "dc_grep_w_channel_native",
+      "seq": 690200,
+      "targets": [
+        "discord"
+      ],
+      "command": "grep -w green '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/2026-06-01/chat.jsonl:[alice] deploy is green\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_grep_w_day_file_native",
+      "seq": 690201,
+      "targets": [
+        "discord"
+      ],
+      "command": "grep -w standup '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/2026-06-02/chat.jsonl'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/2026-06-02/chat.jsonl:[bob] second day standup\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_head_day_boundary",
+      "seq": 690202,
+      "targets": [
+        "discord"
+      ],
+      "command": "head -n 5 '/discord/Mirage HQ__100000000000000001/channels/releases__200000000000000002/2026-06-01/chat.jsonl' | jq -r .content",
+      "expect": {
+        "exit": 0,
+        "stdout": "v1.2.0 released\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_head_second_day_file",
+      "seq": 690203,
+      "targets": [
+        "discord"
+      ],
+      "command": "head -n 1 '/discord/Mirage HQ__100000000000000001/channels/releases__200000000000000002/2026-06-02/chat.jsonl' | jq -r .content",
+      "expect": {
+        "exit": 0,
+        "stdout": "v1.2.1 hotfix released\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/resources/discord/scope.json
+++ b/integ/resources/discord/scope.json
@@ -51,6 +51,45 @@
         "stdout": "v1.2.1 hotfix released\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "dc_grep_w_attachment_scans_bytes",
+      "seq": 690204,
+      "targets": [
+        "discord"
+      ],
+      "command": "grep -w quarter '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/2026-06-01/files/budget__500000000000000001.csv'",
+      "expect": {
+        "exit": 0,
+        "stdout": "quarter,amount\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_head_v_prints_header",
+      "seq": 690205,
+      "targets": [
+        "discord"
+      ],
+      "command": "head -v -n 1 '/discord/Mirage HQ__100000000000000001/channels/releases__200000000000000002/2026-06-01/chat.jsonl' | head -n 1",
+      "expect": {
+        "exit": 0,
+        "stdout": "==> /discord/Mirage HQ__100000000000000001/channels/releases__200000000000000002/2026-06-01/chat.jsonl <==\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_head_empty_day",
+      "seq": 690206,
+      "targets": [
+        "discord"
+      ],
+      "command": "head -n 3 '/discord/Mirage HQ__100000000000000001/channels/releases__200000000000000002/2026-05-20/chat.jsonl'",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/server/discord_server.py
+++ b/integ/server/discord_server.py
@@ -115,6 +115,15 @@ class FakeDiscord:
         author = self._user(author_id)
         attachments = []
         for att in raw.get("attachments", []):
+            if att.get("tombstoned"):
+                # Deleted / access-restricted attachments come back with an
+                # id but no download URL and no size; clients must not list
+                # them as files.
+                attachments.append({
+                    "id": att["id"],
+                    "filename": att["filename"],
+                })
+                continue
             body = att.get("body", "").encode()
             self.attachments[att["id"]] = body
             attachments.append({

--- a/python/mirage/commands/builtin/discord/grep.py
+++ b/python/mirage/commands/builtin/discord/grep.py
@@ -64,7 +64,7 @@ async def grep(accessor: DiscordAccessor, paths: list[PathSpec],
     pushdown_warnings: list[str] = []
     if paths and pattern is not None and "\n" not in pattern:
         scope = detect_scope(paths[0])
-        if not scope.use_native:
+        if scope.level == "messages":
             scope = coalesce_scopes(paths) or scope
 
         # Provider search matches whole words while grep matches

--- a/python/mirage/commands/builtin/discord/grep.py
+++ b/python/mirage/commands/builtin/discord/grep.py
@@ -63,25 +63,17 @@ async def grep(accessor: DiscordAccessor, paths: list[PathSpec],
 
     pushdown_warnings: list[str] = []
     if paths and pattern is not None and "\n" not in pattern:
-        scope = await detect_scope(paths[0], opts.index)
-        if scope.level in ("messages", "file_blob", "date"):
-            coalesced = await coalesce_scopes(paths, opts.index)
-            if coalesced is not None:
-                scope = coalesced
-
-        if scope.level == "root":
-            return b"", IOResult(exit_code=1,
-                                 stderr=b"grep: root-level search "
-                                 b"not yet supported\n")
+        scope = detect_scope(paths[0])
+        if not scope.use_native:
+            scope = coalesce_scopes(paths) or scope
 
         # Provider search matches whole words while grep matches
         # substrings, and the native path returns search results verbatim
         # as the output, so a bare literal would under-report. Only -w
         # makes the two agree; otherwise fall through to the scan.
-        if scope.level in ("channel", "guild") and fl.as_bool("w"):
+        if (scope.use_native and scope.guild_id is not None
+                and fl.as_bool("w")):
             try:
-                if scope.guild_id is None:
-                    raise RuntimeError("cannot resolve guild ID")
                 msgs = await search_guild(
                     accessor.config,
                     scope.guild_id,

--- a/python/mirage/commands/builtin/discord/head.py
+++ b/python/mirage/commands/builtin/discord/head.py
@@ -56,13 +56,14 @@ async def head(accessor: DiscordAccessor, paths: list[PathSpec],
         return None, IOResult(exit_code=1, stderr=str(exc).encode())
     lines = parsed.lines if parsed.lines is not None else 10
     if paths:
-        scope = await detect_scope(paths[0], opts.index)
+        scope = detect_scope(paths[0])
 
         # Smart head: fetch only first N messages for a single date.
-        if (len(paths) == 1 and scope.level == "file" and scope.channel_id
+        if (len(paths) == 1 and scope.level == "messages" and scope.channel_id
                 and scope.date_str and parsed.bytes_ is None
                 and not parsed.zero_terminated):
             after = date_to_snowflake(scope.date_str)
+            before_int = int(date_to_snowflake(scope.date_str, end=True))
             msgs = await discord_get(
                 accessor.config,
                 f"/channels/{scope.channel_id}/messages",
@@ -72,6 +73,11 @@ async def head(accessor: DiscordAccessor, paths: list[PathSpec],
                 },
             )
             assert isinstance(msgs, list)
+            # With `after`, a short day spills into the next one: the API
+            # keeps returning messages past midnight until `limit` is met,
+            # so bound to the same end-of-day snowflake the readdir walk
+            # uses or head would print lines chat.jsonl does not contain.
+            msgs = [m for m in msgs if int(m["id"]) <= before_int]
             msgs.sort(key=lambda m: int(m["id"]))
             jsonl = "\n".join(
                 json.dumps(m, ensure_ascii=False, separators=(",", ":"))

--- a/python/mirage/commands/builtin/discord/head.py
+++ b/python/mirage/commands/builtin/discord/head.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
 from dataclasses import replace
 
 from mirage.accessor.discord import DiscordAccessor
@@ -29,6 +28,7 @@ from mirage.commands.spec import SPECS
 from mirage.core.discord._client import discord_get
 from mirage.core.discord.history import date_to_snowflake
 from mirage.core.discord.read import read as discord_read
+from mirage.core.discord.render import history_jsonl_bytes
 from mirage.core.discord.scope import detect_scope
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
@@ -58,10 +58,14 @@ async def head(accessor: DiscordAccessor, paths: list[PathSpec],
     if paths:
         scope = detect_scope(paths[0])
 
-        # Smart head: fetch only first N messages for a single date.
+        # Smart head: fetch only first N messages for a single date. Only
+        # counts one API page can honor (Discord caps limit at 100) take
+        # the shortcut; zero, negative (all-but-last-N) and larger counts,
+        # -v headers, byte counts and -z all keep the generic path.
         if (len(paths) == 1 and scope.level == "messages" and scope.channel_id
                 and scope.date_str and parsed.bytes_ is None
-                and not parsed.zero_terminated):
+                and not parsed.zero_terminated and not parsed.verbose
+                and 0 < lines <= 100):
             after = date_to_snowflake(scope.date_str)
             before_int = int(date_to_snowflake(scope.date_str, end=True))
             msgs = await discord_get(
@@ -79,10 +83,7 @@ async def head(accessor: DiscordAccessor, paths: list[PathSpec],
             # uses or head would print lines chat.jsonl does not contain.
             msgs = [m for m in msgs if int(m["id"]) <= before_int]
             msgs.sort(key=lambda m: int(m["id"]))
-            jsonl = "\n".join(
-                json.dumps(m, ensure_ascii=False, separators=(",", ":"))
-                for m in msgs) + "\n"
-            return generic_head(jsonl.encode(), n=lines), IOResult()
+            return generic_head(history_jsonl_bytes(msgs), n=lines), IOResult()
     resolved = await resolve_or_empty(IO, accessor, paths, opts.index)
     return await head_generic(resolved, list(texts), opts,
                               bound_op(IO.stat, accessor, opts.index),

--- a/python/mirage/commands/builtin/discord/rg.py
+++ b/python/mirage/commands/builtin/discord/rg.py
@@ -52,25 +52,17 @@ async def rg(accessor: DiscordAccessor, paths: list[PathSpec],
 
     pushdown_warnings: list[str] = []
     if paths and "\n" not in pattern_str:
-        scope = await detect_scope(paths[0], opts.index)
-        if scope.level in ("messages", "file_blob", "date"):
-            coalesced = await coalesce_scopes(paths, opts.index)
-            if coalesced is not None:
-                scope = coalesced
-
-        if scope.level == "root":
-            return b"", IOResult(exit_code=1,
-                                 stderr=b"rg: root-level search "
-                                 b"not yet supported\n")
+        scope = detect_scope(paths[0])
+        if not scope.use_native:
+            scope = coalesce_scopes(paths) or scope
 
         # Provider search matches whole words while grep matches
         # substrings, and the native path returns search results verbatim
         # as the output, so a bare literal would under-report. Only -w
         # makes the two agree; otherwise fall through to the scan.
-        if scope.level in ("channel", "guild") and fl.as_bool("w"):
+        if (scope.use_native and scope.guild_id is not None
+                and fl.as_bool("w")):
             try:
-                if scope.guild_id is None:
-                    raise RuntimeError("cannot resolve guild ID")
                 msgs = await search_guild(
                     accessor.config,
                     scope.guild_id,

--- a/python/mirage/commands/builtin/discord/rg.py
+++ b/python/mirage/commands/builtin/discord/rg.py
@@ -53,7 +53,7 @@ async def rg(accessor: DiscordAccessor, paths: list[PathSpec],
     pushdown_warnings: list[str] = []
     if paths and "\n" not in pattern_str:
         scope = detect_scope(paths[0])
-        if not scope.use_native:
+        if scope.level == "messages":
             scope = coalesce_scopes(paths) or scope
 
         # Provider search matches whole words while grep matches

--- a/python/mirage/core/discord/formatters.py
+++ b/python/mirage/core/discord/formatters.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from mirage.core.discord.entry import snowflake_to_iso
+
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,11 +37,18 @@ def format_grep_results(
     names = channel_names or {}
     lines: list[str] = []
     for msg in messages:
-        ts = msg.get("timestamp", "")[:10]
+        ts = (msg.get("timestamp") or "")[:10]
+        if not ts:
+            # A hit without a timestamp still has a snowflake id, which
+            # encodes the creation day readdir buckets it under.
+            iso = snowflake_to_iso(str(msg.get("id") or ""))
+            ts = iso[:10] if iso else ""
         ch_id = msg.get("channel_id", "")
         ch_name = names.get(ch_id, ch_id)
         author = msg.get("author", {}).get("username", "?")
         content = msg.get("content", "").replace("\n", " ")
-        lines.append(f"{prefix}/{guild_dirname}/channels/{ch_name}/"
-                     f"{ts}/chat.jsonl:[{author}] {content}")
+        path = (f"{prefix}/{guild_dirname}/channels/{ch_name}/"
+                f"{ts}/chat.jsonl"
+                if ts else f"{prefix}/{guild_dirname}/channels/{ch_name}")
+        lines.append(f"{path}:[{author}] {content}")
     return lines

--- a/python/mirage/core/discord/readdir.py
+++ b/python/mirage/core/discord/readdir.py
@@ -247,7 +247,12 @@ async def _fetch_day(
     file_entries: list[tuple[str, IndexEntry]] = []
     for msg in messages:
         for att in msg.get("attachments") or []:
-            if not att.get("id"):
+            # Tombstoned (deleted) and access-restricted attachment payloads
+            # carry an id but no download URL and no byte size; read()
+            # ENOENTs on them, so listing them would surface phantom files
+            # with unknown sizes. Mirrors the slack guard.
+            if (not att.get("id") or not att.get("url")
+                    or att.get("size") is None):
                 continue
             blob_name = file_blob_name(att)
             file_entries.append((blob_name,

--- a/python/mirage/core/discord/scope.py
+++ b/python/mirage/core/discord/scope.py
@@ -15,7 +15,6 @@
 import re
 from dataclasses import dataclass
 
-from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
 
@@ -29,36 +28,45 @@ class DiscordScope:
     Attributes:
         level (str): one of ``root``, ``guild``, ``channel``, ``date``,
             ``messages``, ``files``, ``file_blob``, ``member``.
-        guild_id (str | None): guild snowflake.
-        channel_id (str | None): channel snowflake.
+        use_native (bool): whether native guild search may serve this scope.
+        guild_name (str | None): display half of the guild dirname.
+        guild_id (str | None): guild snowflake parsed from the dirname.
+        channel_name (str | None): display half of the channel dirname.
+        channel_id (str | None): channel snowflake parsed from the dirname.
+        member_name (str | None): display half of the member filename.
+        member_id (str | None): user snowflake parsed from the filename.
+        container (str | None): ``channels`` or ``members``.
         date_str (str | None): ``YYYY-MM-DD`` for date-level and below.
         resource_path (str): resource-relative key (prefix stripped).
     """
 
     level: str
+    use_native: bool
+    guild_name: str | None = None
     guild_id: str | None = None
+    channel_name: str | None = None
     channel_id: str | None = None
+    member_name: str | None = None
+    member_id: str | None = None
+    container: str | None = None
     date_str: str | None = None
     resource_path: str = "/"
 
 
-def _strip_prefix(raw: str, prefix: str) -> str:
-    stripped = raw.strip("/")
-    if not prefix:
-        return stripped
-    pfx = prefix.strip("/")
-    if stripped == pfx:
-        return ""
-    if stripped.startswith(pfx + "/"):
-        return stripped[len(pfx) + 1:]
-    return stripped
+def _split_dirname(dirname: str) -> tuple[str, str | None]:
+    if "__" in dirname:
+        name, _, cid = dirname.rpartition("__")
+        return name, cid or None
+    return dirname, None
 
 
-async def detect_scope(
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> DiscordScope:
+def detect_scope(path: PathSpec) -> DiscordScope:
     """Determine scope from a path.
+
+    IDs come straight out of the ``name__id`` dirnames the tree mints, so
+    detection is pure and needs no index or network round-trip; a bare
+    name without ``__id`` yields ``None`` ids and the caller falls back
+    to the scan. Mirrors the TypeScript ``detectScope``.
 
     Examples::
 
@@ -77,39 +85,115 @@ async def detect_scope(
     prefix = mount_prefix_of(path.virtual, path.resource_path) or ""
 
     if path.pattern and path.pattern.endswith(".jsonl"):
-        dir_key = _strip_prefix(path.directory, prefix)
-        parts = dir_key.split("/") if dir_key else []
-        if len(parts) >= 3 and parts[1] == "channels":
-            guild_id, channel_id = await _resolve_ids(parts[0],
-                                                      "/".join(parts[:3]),
-                                                      index, prefix)
-            date_str = (parts[3] if len(parts) == 4
-                        and _DATE_RE.match(parts[3]) else None)
+        dir_key = path.directory.strip("/")
+        if prefix:
+            dir_key = dir_key.removeprefix(prefix.strip("/") + "/")
+        dp = dir_key.split("/") if dir_key else []
+        if len(dp) == 3 and dp[1] == "channels" and dp[0] and dp[2]:
+            guild_name, guild_id = _split_dirname(dp[0])
+            channel_name, channel_id = _split_dirname(dp[2])
             return DiscordScope(
-                level="messages" if date_str else "channel",
+                level="channel",
+                use_native=True,
+                guild_name=guild_name,
                 guild_id=guild_id,
+                channel_name=channel_name,
                 channel_id=channel_id,
-                date_str=date_str,
+                container="channels",
+                resource_path=dir_key,
+            )
+        if (len(dp) == 4 and dp[1] == "channels" and dp[0] and dp[2]
+                and _DATE_RE.match(dp[3])):
+            guild_name, guild_id = _split_dirname(dp[0])
+            channel_name, channel_id = _split_dirname(dp[2])
+            return DiscordScope(
+                level="messages",
+                use_native=True,
+                guild_name=guild_name,
+                guild_id=guild_id,
+                channel_name=channel_name,
+                channel_id=channel_id,
+                container="channels",
+                date_str=dp[3],
                 resource_path=dir_key,
             )
 
-    key = _strip_prefix(path.virtual, prefix)
-
+    key = path.resource_path
     if not key:
-        return DiscordScope(level="root", resource_path="/")
+        return DiscordScope(level="root", use_native=True, resource_path="/")
 
     parts = key.split("/")
 
-    # /<guild>/channels/<ch>/<date>/files/<blob>
-    if (len(parts) == 6 and parts[1] == "channels" and _DATE_RE.match(parts[3])
-            and parts[4] == "files"):
-        guild_id, channel_id = await _resolve_ids(parts[0],
-                                                  "/".join(parts[:3]), index,
-                                                  prefix)
+    if len(parts) == 1:
+        guild_name, guild_id = _split_dirname(parts[0])
         return DiscordScope(
-            level="file_blob",
+            level="guild",
+            use_native=True,
+            guild_name=guild_name,
             guild_id=guild_id,
+            resource_path=key,
+        )
+
+    if len(parts) == 2:
+        guild_name, guild_id = _split_dirname(parts[0])
+        if parts[1] in ("channels", "members"):
+            return DiscordScope(
+                level="guild",
+                use_native=parts[1] == "channels",
+                guild_name=guild_name,
+                guild_id=guild_id,
+                container=parts[1],
+                resource_path=key,
+            )
+        return DiscordScope(
+            level="guild",
+            use_native=False,
+            guild_name=guild_name,
+            guild_id=guild_id,
+            resource_path=key,
+        )
+
+    if len(parts) == 3:
+        guild_name, guild_id = _split_dirname(parts[0])
+        if parts[1] == "channels":
+            channel_name, channel_id = _split_dirname(parts[2])
+            return DiscordScope(
+                level="channel",
+                use_native=True,
+                guild_name=guild_name,
+                guild_id=guild_id,
+                channel_name=channel_name,
+                channel_id=channel_id,
+                container="channels",
+                resource_path=key,
+            )
+        if parts[1] == "members":
+            member_name, member_id = _split_dirname(
+                parts[2].removesuffix(".json"))
+            return DiscordScope(
+                level="member",
+                use_native=False,
+                guild_name=guild_name,
+                guild_id=guild_id,
+                member_name=member_name,
+                member_id=member_id,
+                container="members",
+                resource_path=key,
+            )
+
+    # /<guild>/channels/<ch>/<date>
+    if (len(parts) == 4 and parts[1] == "channels"
+            and _DATE_RE.match(parts[3])):
+        guild_name, guild_id = _split_dirname(parts[0])
+        channel_name, channel_id = _split_dirname(parts[2])
+        return DiscordScope(
+            level="date",
+            use_native=True,
+            guild_name=guild_name,
+            guild_id=guild_id,
+            channel_name=channel_name,
             channel_id=channel_id,
+            container="channels",
             date_str=parts[3],
             resource_path=key,
         )
@@ -117,78 +201,57 @@ async def detect_scope(
     # /<guild>/channels/<ch>/<date>/chat.jsonl or .../files
     if (len(parts) == 5 and parts[1] == "channels"
             and _DATE_RE.match(parts[3])):
-        guild_id, channel_id = await _resolve_ids(parts[0],
-                                                  "/".join(parts[:3]), index,
-                                                  prefix)
+        guild_name, guild_id = _split_dirname(parts[0])
+        channel_name, channel_id = _split_dirname(parts[2])
         if parts[4] == "chat.jsonl":
             return DiscordScope(
                 level="messages",
+                use_native=False,
+                guild_name=guild_name,
                 guild_id=guild_id,
+                channel_name=channel_name,
                 channel_id=channel_id,
+                container="channels",
                 date_str=parts[3],
                 resource_path=key,
             )
         if parts[4] == "files":
             return DiscordScope(
                 level="files",
+                use_native=True,
+                guild_name=guild_name,
                 guild_id=guild_id,
+                channel_name=channel_name,
                 channel_id=channel_id,
+                container="channels",
                 date_str=parts[3],
                 resource_path=key,
             )
 
-    # /<guild>/channels/<ch>/<date>
-    if (len(parts) == 4 and parts[1] == "channels"
-            and _DATE_RE.match(parts[3])):
-        guild_id, channel_id = await _resolve_ids(parts[0],
-                                                  "/".join(parts[:3]), index,
-                                                  prefix)
+    # /<guild>/channels/<ch>/<date>/files/<blob>
+    if (len(parts) == 6 and parts[1] == "channels" and _DATE_RE.match(parts[3])
+            and parts[4] == "files"):
+        guild_name, guild_id = _split_dirname(parts[0])
+        channel_name, channel_id = _split_dirname(parts[2])
         return DiscordScope(
-            level="date",
+            level="file_blob",
+            use_native=False,
+            guild_name=guild_name,
             guild_id=guild_id,
+            channel_name=channel_name,
             channel_id=channel_id,
+            container="channels",
             date_str=parts[3],
             resource_path=key,
         )
 
-    # /<guild>/channels/<ch>
-    if len(parts) == 3 and parts[1] == "channels":
-        guild_id, channel_id = await _resolve_ids(parts[0], key, index, prefix)
-        return DiscordScope(
-            level="channel",
-            guild_id=guild_id,
-            channel_id=channel_id,
-            resource_path=key,
-        )
-
-    # /<guild>/members/<user>.json
-    if len(parts) == 3 and parts[1] == "members":
-        guild_id = await _resolve_guild_id(parts[0], index, prefix)
-        return DiscordScope(
-            level="member",
-            guild_id=guild_id,
-            resource_path=key,
-        )
-
-    # /<guild>, /<guild>/channels, /<guild>/members
-    if len(parts) <= 2:
-        guild_id = await _resolve_guild_id(parts[0], index, prefix)
-        return DiscordScope(
-            level="guild",
-            guild_id=guild_id,
-            resource_path=key,
-        )
-
-    return DiscordScope(level="file_blob", resource_path=key)
+    return DiscordScope(level="guild", use_native=False, resource_path=key)
 
 
-async def coalesce_scopes(
-    paths: list[PathSpec],
-    index: IndexCacheStore = NULL_INDEX,
-) -> DiscordScope | None:
+def coalesce_scopes(paths: list[PathSpec]) -> DiscordScope | None:
     if not paths:
         return None
-    scopes = [await detect_scope(p, index) for p in paths]
+    scopes = [detect_scope(p) for p in paths]
     first = scopes[0]
     if first.guild_id is None or first.channel_id is None:
         return None
@@ -197,36 +260,12 @@ async def coalesce_scopes(
             return None
     return DiscordScope(
         level="channel",
+        use_native=True,
+        guild_name=first.guild_name,
         guild_id=first.guild_id,
+        channel_name=first.channel_name,
         channel_id=first.channel_id,
+        container="channels",
         resource_path=first.resource_path.rsplit("/", 1)[0]
         if first.level == "messages" else first.resource_path,
     )
-
-
-async def _resolve_guild_id(
-    guild_name: str,
-    index: IndexCacheStore,
-    prefix: str,
-) -> str | None:
-    virtual_key = prefix + "/" + guild_name if prefix else "/" + guild_name
-    lookup = await index.get(virtual_key)
-    if lookup.entry is not None:
-        return lookup.entry.id
-    return None
-
-
-async def _resolve_ids(
-    guild_name: str,
-    channel_path: str,
-    index: IndexCacheStore,
-    prefix: str,
-) -> tuple[str | None, str | None]:
-    guild_id = await _resolve_guild_id(guild_name, index, prefix)
-    channel_id = None
-    virtual_key = (prefix + "/" + channel_path if prefix else "/" +
-                   channel_path)
-    lookup = await index.get(virtual_key)
-    if lookup.entry is not None:
-        channel_id = lookup.entry.id
-    return guild_id, channel_id

--- a/python/mirage/core/discord/scope.py
+++ b/python/mirage/core/discord/scope.py
@@ -249,14 +249,23 @@ def detect_scope(path: PathSpec) -> DiscordScope:
 
 
 def coalesce_scopes(paths: list[PathSpec]) -> DiscordScope | None:
+    """Fold same-channel chat.jsonl operands into one channel scope.
+
+    Only message files coalesce: guild search answers questions about
+    message content, so widening any other leaf (an attachment blob, a
+    member JSON) to a channel-wide message search would return hits that
+    say nothing about the requested bytes.
+    """
     if not paths:
         return None
     scopes = [detect_scope(p) for p in paths]
     first = scopes[0]
-    if first.guild_id is None or first.channel_id is None:
+    if (first.level != "messages" or first.guild_id is None
+            or first.channel_id is None):
         return None
     for s in scopes[1:]:
-        if (s.guild_id != first.guild_id or s.channel_id != first.channel_id):
+        if (s.level != "messages" or s.guild_id != first.guild_id
+                or s.channel_id != first.channel_id):
             return None
     return DiscordScope(
         level="channel",
@@ -266,6 +275,5 @@ def coalesce_scopes(paths: list[PathSpec]) -> DiscordScope | None:
         channel_name=first.channel_name,
         channel_id=first.channel_id,
         container="channels",
-        resource_path=first.resource_path.rsplit("/", 1)[0]
-        if first.level == "messages" else first.resource_path,
+        resource_path=first.resource_path.rsplit("/", 1)[0],
     )

--- a/python/tests/commands/builtin/discord/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/discord/test_grep_pushdown.py
@@ -20,6 +20,7 @@ from mirage.commands.builtin.discord.grep import grep
 from mirage.commands.builtin.discord.rg import rg
 from mirage.commands.config import CommandOpts
 from mirage.commands.errors import UsageError
+from mirage.io.types import materialize
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -308,3 +309,38 @@ async def test_discord_grep_without_word_flag_skips_native_search():
         with pytest.raises(UsageError):
             await grep(accessor, _concrete_paths(7), ['hello'], CommandOpts())
     fake_search.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_grep_file_blob_skips_native_search():
+    """An attachment operand must scan its bytes; widening it to a
+    channel-wide message search would return hits that say nothing about
+    the requested file."""
+    accessor = AsyncMock()
+    accessor.config = AsyncMock()
+    path = ("/discord/myguild__g_123/channels/general__ch_456/2026-01-01/"
+            "files/img__A1.png")
+    paths = [
+        PathSpec(resource_path=mount_key(path, "/discord"),
+                 virtual=path,
+                 directory=path)
+    ]
+    with patch(
+            "mirage.commands.builtin.discord.grep.search_guild",
+            new=AsyncMock(return_value=[]),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.discord.grep.resolve_glob",
+            new=AsyncMock(return_value=paths),
+    ), patch(
+            "mirage.commands.builtin.discord.grep.discord_read",
+            new=AsyncMock(return_value=b"quarter,amount\n"),
+    ), patch(
+            "mirage.commands.builtin.discord.grep._stat",
+            new=AsyncMock(
+                return_value=FileStat(name="img__A1.png", type=FileType.TEXT)),
+    ):
+        out, io = await grep(accessor, paths, ['quarter'],
+                             CommandOpts(flags={'w': True}))
+    fake_search.assert_not_awaited()
+    assert io.exit_code == 0
+    assert b"quarter,amount" in await materialize(out)

--- a/python/tests/commands/builtin/discord/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/discord/test_grep_pushdown.py
@@ -27,8 +27,8 @@ from mirage.utils.key_prefix import mount_key
 def _concrete_paths(n: int = 7):
     paths = []
     for d in range(1, n + 1):
-        original = (
-            f"/discord/myguild/channels/general/2026-01-{d:02d}/chat.jsonl")
+        original = (f"/discord/myguild__g_123/channels/general__ch_456/"
+                    f"2026-01-{d:02d}/chat.jsonl")
         paths.append(
             PathSpec(
                 resource_path=mount_key(original, "/discord"),
@@ -36,23 +36,6 @@ def _concrete_paths(n: int = 7):
                 directory=original,
             ))
     return paths
-
-
-def _fake_index(channel_id: str = "ch_456", guild_id: str = "g_123"):
-    idx = AsyncMock()
-
-    async def _get(virtual_key):
-        result = AsyncMock()
-        if virtual_key.endswith("/myguild/channels/general"):
-            result.entry = type("E", (), {"id": channel_id})
-        elif virtual_key.endswith("/myguild"):
-            result.entry = type("E", (), {"id": guild_id})
-        else:
-            result.entry = None
-        return result
-
-    idx.get.side_effect = _get
-    return idx
 
 
 @pytest.mark.asyncio
@@ -76,15 +59,66 @@ async def test_discord_grep_with_many_concrete_paths_uses_native_search():
             "mirage.commands.builtin.discord.grep.list_channels",
             new=AsyncMock(return_value=fake_channels),
     ):
-        out, io = await grep(
-            accessor, _concrete_paths(7), ['hello'],
-            CommandOpts(index=_fake_index(), flags={'w': True}))
+        out, io = await grep(accessor, _concrete_paths(7), ['hello'],
+                             CommandOpts(flags={'w': True}))
     assert fake_search.await_count == 1
     assert io.exit_code == 0
     assert b"hello" in out
     assert out.endswith(b"\n")
-    assert (b"/discord/myguild/channels/general__ch_456/"
+    assert (b"/discord/myguild__g_123/channels/general__ch_456/"
             b"2026-01-15/chat.jsonl:") in out
+
+
+@pytest.mark.asyncio
+async def test_discord_grep_resolves_ids_without_index():
+    """The ids ride in the ``name__id`` dirnames, so a cold cache must not
+    degrade the push-down or emit a spurious fallback warning."""
+    accessor = AsyncMock()
+    accessor.config = AsyncMock()
+    path = "/discord/myguild__g_123/channels/general__ch_456"
+    paths = [
+        PathSpec(resource_path=mount_key(path, "/discord"),
+                 virtual=path,
+                 directory=path)
+    ]
+    with patch(
+            "mirage.commands.builtin.discord.grep.search_guild",
+            new=AsyncMock(return_value=[]),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.discord.grep.list_channels",
+            new=AsyncMock(return_value=[]),
+    ):
+        out, io = await grep(accessor, paths, ['hello'],
+                             CommandOpts(flags={'w': True}))
+    assert fake_search.await_count == 1
+    assert fake_search.await_args.args[1] == "g_123"
+    assert fake_search.await_args.kwargs["channel_id"] == "ch_456"
+    assert io.stderr in (None, b"")
+
+
+@pytest.mark.asyncio
+async def test_discord_grep_bare_names_skip_native_search():
+    """Without ``__id`` in the dirnames there is nothing to search with —
+    fall through to the scan instead of guessing."""
+    accessor = AsyncMock()
+    accessor.config = AsyncMock()
+    path = "/discord/myguild/channels/general"
+    paths = [
+        PathSpec(resource_path=mount_key(path, "/discord"),
+                 virtual=path,
+                 directory=path)
+    ]
+    with patch(
+            "mirage.commands.builtin.discord.grep.search_guild",
+            new=AsyncMock(return_value=[]),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.discord.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ):
+        with pytest.raises(UsageError):
+            await grep(accessor, paths, ['hello'],
+                       CommandOpts(flags={'w': True}))
+    fake_search.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -93,9 +127,11 @@ async def test_discord_grep_falls_back_when_native_raises():
     accessor.config = AsyncMock()
     paths = [
         PathSpec(resource_path=mount_key(
-            "/discord/myguild/channels/general/*.jsonl", "/discord"),
-                 virtual="/discord/myguild/channels/general/*.jsonl",
-                 directory="/discord/myguild/channels/general/",
+            "/discord/myguild__g_123/channels/general__ch_456/*.jsonl",
+            "/discord"),
+                 virtual="/discord/myguild__g_123/channels/general__ch_456"
+                 "/*.jsonl",
+                 directory="/discord/myguild__g_123/channels/general__ch_456/",
                  pattern="*.jsonl"),
     ]
     with patch(
@@ -112,9 +148,8 @@ async def test_discord_grep_falls_back_when_native_raises():
             new=AsyncMock(return_value=FileStat(name="2026-04-10.jsonl",
                                                 type=FileType.TEXT)),
     ):
-        out, io = await grep(
-            accessor, paths, ['hello'],
-            CommandOpts(index=_fake_index(), flags={'w': True}))
+        out, io = await grep(accessor, paths, ['hello'],
+                             CommandOpts(flags={'w': True}))
     assert fake_resolve.await_count == 1
     assert io.exit_code in (0, 1)
 
@@ -134,9 +169,8 @@ async def test_discord_grep_native_empty_does_not_trigger_fallback():
             "mirage.commands.builtin.discord.grep.discord_read",
             new=AsyncMock(return_value=b""),
     ) as fake_read:
-        out, io = await grep(
-            accessor, _concrete_paths(7), ['missing'],
-            CommandOpts(index=_fake_index(), flags={'w': True}))
+        out, io = await grep(accessor, _concrete_paths(7), ['missing'],
+                             CommandOpts(flags={'w': True}))
     assert fake_search.await_count == 1
     assert fake_read.await_count == 0
     assert io.exit_code == 1
@@ -155,9 +189,11 @@ async def test_discord_grep_multi_pattern_skips_native_search():
     accessor.config = AsyncMock()
     paths = [
         PathSpec(resource_path=mount_key(
-            "/discord/myguild/channels/general/*.jsonl", "/discord"),
-                 virtual="/discord/myguild/channels/general/*.jsonl",
-                 directory="/discord/myguild/channels/general/",
+            "/discord/myguild__g_123/channels/general__ch_456/*.jsonl",
+            "/discord"),
+                 virtual="/discord/myguild__g_123/channels/general__ch_456"
+                 "/*.jsonl",
+                 directory="/discord/myguild__g_123/channels/general__ch_456/",
                  pattern="*.jsonl"),
     ]
     with patch(
@@ -174,13 +210,11 @@ async def test_discord_grep_multi_pattern_skips_native_search():
             new=AsyncMock(return_value=FileStat(name="2026-04-10.jsonl",
                                                 type=FileType.TEXT)),
     ):
-        _, io = await grep(
-            accessor, paths, [],
-            CommandOpts(index=_fake_index(),
-                        flags={
-                            'e': ['ada', 'ben'],
-                            'w': True
-                        }))
+        _, io = await grep(accessor, paths, [],
+                           CommandOpts(flags={
+                               'e': ['ada', 'ben'],
+                               'w': True
+                           }))
     assert fake_search.await_count == 0
     assert fake_resolve.await_count == 1
 
@@ -207,12 +241,12 @@ async def test_discord_rg_with_many_concrete_paths_uses_native_search():
             new=AsyncMock(return_value=fake_channels),
     ):
         out, io = await rg(accessor, _concrete_paths(7), ['hello'],
-                           CommandOpts(index=_fake_index(), flags={'w': True}))
+                           CommandOpts(flags={'w': True}))
     assert fake_search.await_count == 1
     assert io.exit_code == 0
     assert b"hello" in out
     assert out.endswith(b"\n")
-    assert (b"/discord/myguild/channels/general__ch_456/"
+    assert (b"/discord/myguild__g_123/channels/general__ch_456/"
             b"2026-01-15/chat.jsonl:") in out
 
 
@@ -228,9 +262,11 @@ async def test_discord_rg_multi_pattern_skips_native_search():
     accessor.config = AsyncMock()
     paths = [
         PathSpec(resource_path=mount_key(
-            "/discord/myguild/channels/general/*.jsonl", "/discord"),
-                 virtual="/discord/myguild/channels/general/*.jsonl",
-                 directory="/discord/myguild/channels/general/",
+            "/discord/myguild__g_123/channels/general__ch_456/*.jsonl",
+            "/discord"),
+                 virtual="/discord/myguild__g_123/channels/general__ch_456"
+                 "/*.jsonl",
+                 directory="/discord/myguild__g_123/channels/general__ch_456/",
                  pattern="*.jsonl"),
     ]
     with patch(
@@ -247,13 +283,11 @@ async def test_discord_rg_multi_pattern_skips_native_search():
             new=AsyncMock(return_value=FileStat(name="2026-04-10.jsonl",
                                                 type=FileType.TEXT)),
     ):
-        _, io = await rg(
-            accessor, paths, [],
-            CommandOpts(index=_fake_index(),
-                        flags={
-                            'e': ['ada', 'ben'],
-                            'w': True
-                        }))
+        _, io = await rg(accessor, paths, [],
+                         CommandOpts(flags={
+                             'e': ['ada', 'ben'],
+                             'w': True
+                         }))
     assert fake_search.await_count == 0
     assert fake_resolve.await_count == 1
 
@@ -272,6 +306,5 @@ async def test_discord_grep_without_word_flag_skips_native_search():
             new=AsyncMock(return_value=[]),
     ):
         with pytest.raises(UsageError):
-            await grep(accessor, _concrete_paths(7), ['hello'],
-                       CommandOpts(index=_fake_index()))
+            await grep(accessor, _concrete_paths(7), ['hello'], CommandOpts())
     fake_search.assert_not_awaited()

--- a/python/tests/commands/builtin/discord/test_head.py
+++ b/python/tests/commands/builtin/discord/test_head.py
@@ -111,3 +111,59 @@ async def test_head_non_messages_path_uses_generic_path():
         await head(AsyncMock(), [_path(member)], [], CommandOpts())
     fake_get.assert_not_awaited()
     assert fake_generic.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_head_verbose_uses_generic_path():
+    # -v prints the ==> path <== header, which only the generic path
+    # renders.
+    fake_get = AsyncMock()
+    with patch("mirage.commands.builtin.discord.head.discord_get",
+               new=fake_get), patch(
+                   "mirage.commands.builtin.discord.head.resolve_or_empty",
+                   new=AsyncMock(return_value=[]),
+               ), patch(
+                   "mirage.commands.builtin.discord.head.head_generic",
+                   new=AsyncMock(return_value=(b"", None)),
+               ) as fake_generic:
+        await head(AsyncMock(), [_path(CHAT)], [],
+                   CommandOpts(flags={
+                       "lines": "2",
+                       "verbose": True
+                   }))
+    fake_get.assert_not_awaited()
+    assert fake_generic.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_head_count_beyond_one_page_uses_generic_path():
+    # Discord caps a message page at 100; larger counts (and zero or
+    # negative all-but-last-N forms) keep the generic path.
+    fake_get = AsyncMock()
+    with patch("mirage.commands.builtin.discord.head.discord_get",
+               new=fake_get), patch(
+                   "mirage.commands.builtin.discord.head.resolve_or_empty",
+                   new=AsyncMock(return_value=[]),
+               ), patch(
+                   "mirage.commands.builtin.discord.head.head_generic",
+                   new=AsyncMock(return_value=(b"", None)),
+               ) as fake_generic:
+        await head(AsyncMock(), [_path(CHAT)], [],
+                   CommandOpts(flags={"lines": "150"}))
+        await head(AsyncMock(), [_path(CHAT)], [],
+                   CommandOpts(flags={"lines": "-5"}))
+    fake_get.assert_not_awaited()
+    assert fake_generic.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_smart_head_empty_day_outputs_nothing():
+    # A day whose fetch is entirely next-day spill must render b"" like
+    # the day renderer does, not a lone blank line.
+    fake_get = AsyncMock(return_value=[_msg(_next_day(), "spill")])
+    with patch("mirage.commands.builtin.discord.head.discord_get",
+               new=fake_get):
+        out, io = await head(AsyncMock(), [_path(CHAT)], [],
+                             CommandOpts(flags={"lines": "3"}))
+    assert io.exit_code == 0
+    assert (await materialize(out)) == b""

--- a/python/tests/commands/builtin/discord/test_head.py
+++ b/python/tests/commands/builtin/discord/test_head.py
@@ -1,0 +1,113 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.commands.builtin.discord.head import head
+from mirage.commands.config import CommandOpts
+from mirage.core.discord.history import date_to_snowflake
+from mirage.io.types import materialize
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import mount_key
+
+DAY = "2026-06-01"
+CHAT = (f"/discord/myguild__G1/channels/general__C1/{DAY}/chat.jsonl")
+
+
+def _path(path: str) -> PathSpec:
+    return PathSpec(resource_path=mount_key(path, "/discord"),
+                    virtual=path,
+                    directory=path)
+
+
+def _msg(mid: str, content: str) -> dict:
+    return {"id": mid, "content": content}
+
+
+def _in_day(offset: int) -> str:
+    return str(int(date_to_snowflake(DAY)) + offset)
+
+
+def _next_day() -> str:
+    return str(int(date_to_snowflake(DAY, end=True)) + 1)
+
+
+@pytest.mark.asyncio
+async def test_smart_head_fetches_only_first_n_messages():
+    fake_get = AsyncMock(
+        return_value=[_msg(_in_day(2), "b"),
+                      _msg(_in_day(1), "a")])
+    with patch("mirage.commands.builtin.discord.head.discord_get",
+               new=fake_get):
+        out, io = await head(AsyncMock(), [_path(CHAT)], [],
+                             CommandOpts(flags={"lines": "2"}))
+    assert io.exit_code == 0
+    assert fake_get.await_count == 1
+    assert fake_get.await_args.args[1] == "/channels/C1/messages"
+    assert fake_get.await_args.kwargs["params"]["limit"] == 2
+    lines = (await materialize(out)).decode().splitlines()
+    assert [json.loads(ln)["content"] for ln in lines] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_smart_head_drops_messages_past_end_of_day():
+    # With `after`, a short day spills into the next one; head must not
+    # print lines the day's chat.jsonl does not contain.
+    fake_get = AsyncMock(
+        return_value=[_msg(_in_day(1), "in-day"),
+                      _msg(_next_day(), "spill")])
+    with patch("mirage.commands.builtin.discord.head.discord_get",
+               new=fake_get):
+        out, io = await head(AsyncMock(), [_path(CHAT)], [],
+                             CommandOpts(flags={"lines": "5"}))
+    assert io.exit_code == 0
+    lines = (await materialize(out)).decode().splitlines()
+    assert [json.loads(ln)["content"] for ln in lines] == ["in-day"]
+
+
+@pytest.mark.asyncio
+async def test_head_bytes_flag_uses_generic_path():
+    fake_get = AsyncMock()
+    with patch("mirage.commands.builtin.discord.head.discord_get",
+               new=fake_get), patch(
+                   "mirage.commands.builtin.discord.head.resolve_or_empty",
+                   new=AsyncMock(return_value=[]),
+               ), patch(
+                   "mirage.commands.builtin.discord.head.head_generic",
+                   new=AsyncMock(return_value=(b"", None)),
+               ) as fake_generic:
+        await head(AsyncMock(), [_path(CHAT)], [],
+                   CommandOpts(flags={"bytes": "10"}))
+    fake_get.assert_not_awaited()
+    assert fake_generic.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_head_non_messages_path_uses_generic_path():
+    fake_get = AsyncMock()
+    member = "/discord/myguild__G1/members/alice__U1.json"
+    with patch("mirage.commands.builtin.discord.head.discord_get",
+               new=fake_get), patch(
+                   "mirage.commands.builtin.discord.head.resolve_or_empty",
+                   new=AsyncMock(return_value=[]),
+               ), patch(
+                   "mirage.commands.builtin.discord.head.head_generic",
+                   new=AsyncMock(return_value=(b"", None)),
+               ) as fake_generic:
+        await head(AsyncMock(), [_path(member)], [], CommandOpts())
+    fake_get.assert_not_awaited()
+    assert fake_generic.await_count == 1

--- a/python/tests/commands/builtin/discord/test_search_pushdown_fallback.py
+++ b/python/tests/commands/builtin/discord/test_search_pushdown_fallback.py
@@ -30,28 +30,14 @@ def _path(path: str) -> PathSpec:
                     directory=path)
 
 
-def _fake_index():
-    idx = AsyncMock()
-
-    async def _get(virtual_key):
-        result = AsyncMock()
-        if virtual_key.endswith("/myguild/channels/general"):
-            result.entry = type("E", (), {"id": "C1", "remote_time": ""})
-        elif virtual_key.endswith("/myguild"):
-            result.entry = type("E", (), {"id": "G1"})
-        else:
-            result.entry = None
-        return result
-
-    idx.get.side_effect = _get
-    return idx
-
-
 @pytest.mark.asyncio
 async def test_grep_emits_token_hint_on_forbidden():
     accessor = AsyncMock()
     accessor.config = AsyncMock()
-    paths = [_path("/discord/myguild/channels/general/2026-01-01/chat.jsonl")]
+    paths = [
+        _path("/discord/myguild__G1/channels/general__C1/"
+              "2026-01-01/chat.jsonl")
+    ]
     with patch(
             "mirage.commands.builtin.discord.grep.search_guild",
             new=AsyncMock(side_effect=RuntimeError("403 Forbidden")),
@@ -62,12 +48,11 @@ async def test_grep_emits_token_hint_on_forbidden():
             "mirage.commands.builtin.discord.grep.discord_read",
             new=AsyncMock(return_value=b""),
     ):
-        _out, io = await grep(
-            accessor, paths, ['hi'],
-            CommandOpts(index=_fake_index(), flags={
-                'w': True,
-                'args_l': True
-            }))
+        _out, io = await grep(accessor, paths, ['hi'],
+                              CommandOpts(flags={
+                                  'w': True,
+                                  'args_l': True
+                              }))
     stderr = (io.stderr or b"").decode()
     assert "push-down failed" in stderr
     assert "READ_MESSAGE_HISTORY" in stderr
@@ -77,7 +62,10 @@ async def test_grep_emits_token_hint_on_forbidden():
 async def test_rg_emits_warning_on_rate_limit():
     accessor = AsyncMock()
     accessor.config = AsyncMock()
-    paths = [_path("/discord/myguild/channels/general/2026-01-01/chat.jsonl")]
+    paths = [
+        _path("/discord/myguild__G1/channels/general__C1/"
+              "2026-01-01/chat.jsonl")
+    ]
     with patch(
             "mirage.commands.builtin.discord.rg.search_guild",
             new=AsyncMock(side_effect=RuntimeError("rate limited 429")),
@@ -88,9 +76,8 @@ async def test_rg_emits_warning_on_rate_limit():
             "mirage.commands.builtin.discord.rg.generic_rg",
             new=AsyncMock(return_value=(b"", IOResult(exit_code=1))),
     ):
-        _out, io = await rg(
-            accessor, paths, ['hi'],
-            CommandOpts(index=_fake_index(), flags={'w': True}))
+        _out, io = await rg(accessor, paths, ['hi'],
+                            CommandOpts(flags={'w': True}))
     stderr = (io.stderr or b"").decode()
     assert "push-down failed" in stderr
     # 429 doesn't trigger the perm hint; should still warn

--- a/python/tests/core/discord/test_formatters.py
+++ b/python/tests/core/discord/test_formatters.py
@@ -84,3 +84,35 @@ def test_format_grep_results_replaces_newlines():
     assert lines == [
         "/discord/G__G1/channels/C/2024-01-02/chat.jsonl:[u] line1 line2"
     ]
+
+
+def test_format_grep_results_derives_date_from_snowflake():
+    # A hit without a timestamp still has a snowflake id, which encodes the
+    # creation day readdir buckets it under. 1510934682009600000 is
+    # 2026-06-01 09:15 UTC.
+    msgs = [{
+        "id": "1510934682009600000",
+        "channel_id": "C1",
+        "author": {
+            "username": "alice"
+        },
+        "content": "hello",
+    }]
+    lines = format_grep_results(msgs, "/discord", "G__G1", channel_names={})
+    assert lines == [
+        "/discord/G__G1/channels/C1/2026-06-01/chat.jsonl:[alice] hello"
+    ]
+
+
+def test_format_grep_results_dateless_hit_points_at_channel_dir():
+    # No timestamp and no parseable snowflake: point at the channel dir
+    # instead of minting a `//chat.jsonl` path that cannot exist.
+    msgs = [{
+        "channel_id": "C1",
+        "author": {
+            "username": "alice"
+        },
+        "content": "hello",
+    }]
+    lines = format_grep_results(msgs, "/discord", "G__G1", channel_names={})
+    assert lines == ["/discord/G__G1/channels/C1:[alice] hello"]

--- a/python/tests/core/discord/test_readdir.py
+++ b/python/tests/core/discord/test_readdir.py
@@ -300,3 +300,74 @@ async def test_readdir_leaf_raises_enotdir(accessor, index):
             accessor,
             PathSpec(resource_path=key, virtual="/" + key,
                      directory="/" + key), index)
+
+
+@pytest.mark.asyncio
+async def test_readdir_files_skips_tombstoned_attachments(accessor, index):
+    # Tombstoned and access-restricted attachments carry an id but no
+    # download URL and no byte size; listing them would surface phantom
+    # files that ENOENT on read.
+    await index.put(
+        "/My Server",
+        IndexEntry(
+            id="G001",
+            name="My Server",
+            resource_type="discord/guild",
+            vfs_name="My Server",
+        ),
+    )
+    await index.put(
+        "/My Server/channels/general",
+        IndexEntry(
+            id="C001",
+            name="general",
+            resource_type="discord/channel",
+            vfs_name="general",
+        ),
+    )
+    messages = [{
+        "id":
+        "1",
+        "content":
+        "files",
+        "author": {
+            "username": "alice"
+        },
+        "attachments": [
+            {
+                "id": "A1",
+                "filename": "kept.txt",
+                "url": "https://cdn.example/kept.txt",
+                "size": 5,
+            },
+            {
+                "id": "A2",
+                "filename": "tombstoned.txt",
+            },
+            {
+                "id": "A3",
+                "filename": "sizeless.txt",
+                "url": "https://cdn.example/sizeless.txt",
+            },
+            {
+                "id": "A4",
+                "filename": "urlless.txt",
+                "size": 9,
+            },
+        ],
+    }]
+    with patch(
+            "mirage.core.discord.readdir.list_messages_for_day",
+            new_callable=AsyncMock,
+            return_value=messages,
+    ):
+        names = await readdir(
+            accessor,
+            PathSpec(
+                resource_path="My Server/channels/general/2024-01-15/files",
+                virtual="/My Server/channels/general/2024-01-15/files",
+                directory="/My Server/channels/general/2024-01-15/files"),
+            index)
+    assert names == [
+        "/My Server/channels/general/2024-01-15/files/kept__A1.txt"
+    ]

--- a/python/tests/core/discord/test_scope.py
+++ b/python/tests/core/discord/test_scope.py
@@ -242,3 +242,23 @@ def test_coalesce_returns_none_without_ids():
 
 def test_coalesce_empty_list_returns_none():
     assert coalesce_scopes([]) is None
+
+
+def test_coalesce_returns_none_for_file_blobs():
+    # Guild search answers questions about message content; an attachment
+    # operand must scan its bytes, not widen to a channel message search.
+    paths = [
+        _spec("/discord/myserver__G1/channels/general__C1/2026-01-01/files/"
+              "img__A1.png"),
+    ]
+    assert coalesce_scopes(paths) is None
+
+
+def test_coalesce_returns_none_for_mixed_levels():
+    paths = [
+        _spec("/discord/myserver__G1/channels/general__C1/"
+              "2026-01-01/chat.jsonl"),
+        _spec("/discord/myserver__G1/channels/general__C1/2026-01-01/files/"
+              "img__A1.png"),
+    ]
+    assert coalesce_scopes(paths) is None

--- a/python/tests/core/discord/test_scope.py
+++ b/python/tests/core/discord/test_scope.py
@@ -12,198 +12,196 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import asyncio
-from unittest.mock import AsyncMock
-
-import pytest
-
-from mirage.cache.index import IndexEntry
-from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.core.discord.scope import coalesce_scopes, detect_scope
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
 
-def _run(coro):
-    return asyncio.run(coro)
-
-
-def _gs(path: str,
-        prefix: str = "",
-        pattern: str | None = None,
-        resolved: bool = True) -> PathSpec:
+def _gs(path: str, prefix: str = "", pattern: str | None = None) -> PathSpec:
     return PathSpec(
         resource_path=mount_key(path, prefix),
         virtual=path,
-        directory=path.rsplit("/", 1)[0] + "/" if "/" in path else "/",
+        directory=path.rsplit("/", 1)[0] + "/" if pattern else path,
         pattern=pattern,
-        resolved=resolved,
+        resolved=pattern is None,
     )
-
-
-@pytest.fixture
-def index():
-    idx = RAMIndexCacheStore(ttl=600)
-    _run(
-        idx.put(
-            "/discord/TestGuild",
-            IndexEntry(id="G1",
-                       name="TestGuild",
-                       resource_type="discord/guild")))
-    _run(
-        idx.put(
-            "/discord/TestGuild/channels/general",
-            IndexEntry(id="C1",
-                       name="general",
-                       resource_type="discord/channel")))
-    return idx
 
 
 # ── root ──────────────────────────────────────
 
 
 def test_root_empty():
-    scope = _run(
-        detect_scope(PathSpec.from_str_path("/"), RAMIndexCacheStore()))
+    scope = detect_scope(PathSpec.from_str_path("/"))
     assert scope.level == "root"
+    assert scope.use_native is True
+    assert scope.resource_path == "/"
 
 
 def test_root_prefix():
-    scope = _run(
-        detect_scope(_gs("/discord/", prefix="/discord"),
-                     RAMIndexCacheStore()))
+    scope = detect_scope(_gs("/discord/", prefix="/discord"))
     assert scope.level == "root"
 
 
 # ── guild ─────────────────────────────────────
 
 
-def test_guild(index):
-    scope = _run(
-        detect_scope(_gs("/discord/TestGuild", prefix="/discord"), index))
+def test_guild():
+    scope = detect_scope(_gs("/discord/myserver__G1", prefix="/discord"))
     assert scope.level == "guild"
+    assert scope.use_native is True
+    assert scope.guild_name == "myserver"
     assert scope.guild_id == "G1"
 
 
-def test_guild_channels(index):
-    scope = _run(
-        detect_scope(_gs("/discord/TestGuild/channels", prefix="/discord"),
-                     index))
+def test_guild_channels():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/channels", prefix="/discord"))
     assert scope.level == "guild"
+    assert scope.use_native is True
+    assert scope.container == "channels"
     assert scope.guild_id == "G1"
 
 
-def test_guild_members(index):
-    scope = _run(
-        detect_scope(_gs("/discord/TestGuild/members", prefix="/discord"),
-                     index))
+def test_guild_members_not_native():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/members", prefix="/discord"))
     assert scope.level == "guild"
+    assert scope.use_native is False
+    assert scope.container == "members"
     assert scope.guild_id == "G1"
+
+
+def test_guild_bare_name_has_no_id():
+    scope = detect_scope(_gs("/discord/myserver", prefix="/discord"))
+    assert scope.level == "guild"
+    assert scope.guild_name == "myserver"
+    assert scope.guild_id is None
 
 
 # ── channel ───────────────────────────────────
 
 
-def test_channel(index):
-    scope = _run(
-        detect_scope(
-            _gs("/discord/TestGuild/channels/general", prefix="/discord"),
-            index))
+def test_channel():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/channels/general__C1", prefix="/discord"))
     assert scope.level == "channel"
+    assert scope.use_native is True
+    assert scope.guild_name == "myserver"
     assert scope.guild_id == "G1"
+    assert scope.channel_name == "general"
     assert scope.channel_id == "C1"
+    assert scope.container == "channels"
+
+
+def test_channel_bare_name_has_no_id():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/channels/general", prefix="/discord"))
+    assert scope.level == "channel"
+    assert scope.channel_name == "general"
+    assert scope.channel_id is None
+
+
+# ── member ────────────────────────────────────
+
+
+def test_member_json():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/members/alice__U1.json", prefix="/discord"))
+    assert scope.level == "member"
+    assert scope.use_native is False
+    assert scope.container == "members"
+    assert scope.guild_id == "G1"
+    assert scope.member_name == "alice"
+    assert scope.member_id == "U1"
+    assert scope.channel_id is None
 
 
 # ── date / messages / files ────────────────────
 
 
-def test_date_dir(index):
-    scope = _run(
-        detect_scope(
-            _gs("/discord/TestGuild/channels/general/2024-04-10",
-                prefix="/discord"), index))
+def test_date_dir():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/channels/general__C1/2026-04-10",
+            prefix="/discord"))
     assert scope.level == "date"
+    assert scope.use_native is True
     assert scope.guild_id == "G1"
     assert scope.channel_id == "C1"
-    assert scope.date_str == "2024-04-10"
+    assert scope.date_str == "2026-04-10"
 
 
-def test_messages_file(index):
-    scope = _run(
-        detect_scope(
-            _gs("/discord/TestGuild/channels/general/2024-04-10/chat.jsonl",
-                prefix="/discord"), index))
+def test_messages_file():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/channels/general__C1/2026-04-10/chat.jsonl",
+            prefix="/discord"))
     assert scope.level == "messages"
+    assert scope.use_native is False
     assert scope.guild_id == "G1"
     assert scope.channel_id == "C1"
-    assert scope.date_str == "2024-04-10"
+    assert scope.date_str == "2026-04-10"
 
 
-def test_files_dir(index):
-    scope = _run(
-        detect_scope(
-            _gs("/discord/TestGuild/channels/general/2024-04-10/files",
-                prefix="/discord"), index))
+def test_files_dir():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/channels/general__C1/2026-04-10/files",
+            prefix="/discord"))
     assert scope.level == "files"
-    assert scope.guild_id == "G1"
-    assert scope.channel_id == "C1"
-    assert scope.date_str == "2024-04-10"
+    assert scope.use_native is True
+    assert scope.date_str == "2026-04-10"
 
 
-def test_file_blob(index):
-    scope = _run(
-        detect_scope(
-            _gs(
-                "/discord/TestGuild/channels/general/2024-04-10/files/"
-                "img__A1.png",
-                prefix="/discord"), index))
+def test_file_blob():
+    scope = detect_scope(
+        _gs(
+            "/discord/myserver__G1/channels/general__C1/2026-04-10/files/"
+            "img__A1.png",
+            prefix="/discord"))
     assert scope.level == "file_blob"
+    assert scope.use_native is False
     assert scope.channel_id == "C1"
-    assert scope.date_str == "2024-04-10"
+    assert scope.date_str == "2026-04-10"
 
 
-# ── PathSpec ─────────────────────────────────
+def test_deep_unknown_path_falls_back():
+    scope = detect_scope(_gs("/discord/a/b/c/d/e/f/g", prefix="/discord"))
+    assert scope.level == "guild"
+    assert scope.use_native is False
 
 
-def test_glob_jsonl_in_channel(index):
-    gs = PathSpec(
-        resource_path=mount_key("/discord/TestGuild/channels/general/*.jsonl",
-                                "/discord"),
-        virtual="/discord/TestGuild/channels/general/*.jsonl",
-        directory="/discord/TestGuild/channels/general/",
-        pattern="*.jsonl",
-        resolved=False,
-    )
-    scope = _run(detect_scope(gs, index))
+# ── glob patterns ─────────────────────────────
+
+
+def test_glob_jsonl_in_channel():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/channels/general__C1/*.jsonl",
+            prefix="/discord",
+            pattern="*.jsonl"))
     assert scope.level == "channel"
+    assert scope.use_native is True
     assert scope.guild_id == "G1"
     assert scope.channel_id == "C1"
 
 
-def test_glob_specific_date(index):
-    gs = PathSpec(
-        resource_path=mount_key(
-            "/discord/TestGuild/channels/general/2024-04-*.jsonl", "/discord"),
-        virtual="/discord/TestGuild/channels/general/2024-04-*.jsonl",
-        directory="/discord/TestGuild/channels/general/",
-        pattern="2024-04-*.jsonl",
-        resolved=False,
-    )
-    scope = _run(detect_scope(gs, index))
-    assert scope.level == "channel"
+def test_glob_jsonl_in_date_dir():
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/channels/general__C1/2026-04-10/*.jsonl",
+            prefix="/discord",
+            pattern="*.jsonl"))
+    assert scope.level == "messages"
+    assert scope.use_native is True
+    assert scope.date_str == "2026-04-10"
     assert scope.channel_id == "C1"
 
 
 def test_glob_non_jsonl():
-    gs = PathSpec(
-        resource_path="discord/TestGuild/members/*.json",
-        virtual="/discord/TestGuild/members/*.json",
-        directory="/discord/TestGuild/members/",
-        pattern="*.json",
-        resolved=False,
-    )
-    scope = _run(detect_scope(gs, RAMIndexCacheStore()))
+    scope = detect_scope(
+        _gs("/discord/myserver__G1/members/*.json",
+            prefix="/discord",
+            pattern="*.json"))
     assert scope.level != "channel"
+
+
+# ── coalesce ──────────────────────────────────
 
 
 def _spec(path: str, prefix: str = "/discord") -> PathSpec:
@@ -212,46 +210,35 @@ def _spec(path: str, prefix: str = "/discord") -> PathSpec:
                     directory=path)
 
 
-@pytest.fixture
-def fake_index():
-    idx = AsyncMock()
-
-    async def _get(virtual_key):
-        result = AsyncMock()
-        if virtual_key.endswith("/myguild/channels/general"):
-            result.entry = type("E", (), {"id": "ch_456"})
-        elif virtual_key.endswith("/myguild"):
-            result.entry = type("E", (), {"id": "g_123"})
-        else:
-            result.entry = None
-        return result
-
-    idx.get.side_effect = _get
-    return idx
-
-
-@pytest.mark.asyncio
-async def test_coalesce_concrete_jsonl_paths_same_channel(fake_index):
+def test_coalesce_concrete_jsonl_paths_same_channel():
     paths = [
-        _spec(f"/discord/myguild/channels/general/2026-01-{d:02d}/chat.jsonl")
-        for d in range(1, 8)
+        _spec(f"/discord/myserver__G1/channels/general__C1/"
+              f"2026-01-{d:02d}/chat.jsonl") for d in range(1, 8)
     ]
-    scope = await coalesce_scopes(paths, fake_index)
+    scope = coalesce_scopes(paths)
     assert scope is not None
     assert scope.level == "channel"
-    assert scope.guild_id == "g_123"
-    assert scope.channel_id == "ch_456"
+    assert scope.use_native is True
+    assert scope.guild_id == "G1"
+    assert scope.channel_id == "C1"
 
 
-@pytest.mark.asyncio
-async def test_coalesce_returns_none_for_mixed_channels(fake_index):
+def test_coalesce_returns_none_for_mixed_channels():
     paths = [
-        _spec("/discord/myguild/channels/general/2026-01-01/chat.jsonl"),
-        _spec("/discord/myguild/channels/random/2026-01-01/chat.jsonl"),
+        _spec("/discord/myserver__G1/channels/general__C1/"
+              "2026-01-01/chat.jsonl"),
+        _spec("/discord/myserver__G1/channels/random__C2/"
+              "2026-01-01/chat.jsonl"),
     ]
-    assert await coalesce_scopes(paths, fake_index) is None
+    assert coalesce_scopes(paths) is None
 
 
-@pytest.mark.asyncio
-async def test_coalesce_empty_list_returns_none(fake_index):
-    assert await coalesce_scopes([], fake_index) is None
+def test_coalesce_returns_none_without_ids():
+    paths = [
+        _spec("/discord/myserver/channels/general/2026-01-01/chat.jsonl"),
+    ]
+    assert coalesce_scopes(paths) is None
+
+
+def test_coalesce_empty_list_returns_none():
+    assert coalesce_scopes([]) is None

--- a/typescript/packages/core/src/commands/builtin/discord/grep.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.test.ts
@@ -176,4 +176,34 @@ describe('discord grep', () => {
       '/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/chat.jsonl:',
     )
   })
+
+  it('scans attachment blobs instead of widening to a message search', async () => {
+    // The blob does not exist, so the scan fails per-operand — the pin is
+    // that the search endpoint is never consulted for a file_blob path.
+    const idx = new RAMIndexCacheStore()
+    await seedGuild(idx, '/mnt/discord', 'My Server__G1', 'G1')
+    await seedChannel(idx, '/mnt/discord', 'My Server__G1', 'general__C1', 'C1', {
+      dates: ['2016-04-30'],
+    })
+    const transport = new FakeDiscordTransport((_method, endpoint) =>
+      endpoint === '/channels/C1/messages' ? [] : null,
+    )
+    const blob = '/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/files/data__A1.csv'
+    const out = await runGrep(
+      [
+        new PathSpec({
+          virtual: blob,
+          directory: blob,
+          resolved: false,
+          resourcePath: mountKey(blob, '/mnt/discord'),
+        }),
+      ],
+      ['quarter'],
+      { w: true },
+      { index: idx, transport },
+    )
+    const searches = transport.calls.filter((c) => c.endpoint.includes('/messages/search'))
+    expect(searches).toHaveLength(0)
+    expect(out.exitCode).not.toBe(0)
+  })
 })

--- a/typescript/packages/core/src/commands/builtin/discord/grep.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.test.ts
@@ -122,7 +122,7 @@ describe('discord grep', () => {
         }),
       ],
       ['hello'],
-      { w: true },
+      {},
       { index: idx, transport },
     )
     const lines = out.stdout.split('\n').filter((l) => l !== '')
@@ -130,5 +130,50 @@ describe('discord grep', () => {
     for (const l of lines) {
       expect(l).toContain('hello')
     }
+  })
+
+  it('coalesces concrete chat.jsonl paths into one channel-wide native search', async () => {
+    const transport = new FakeDiscordTransport((_method, endpoint) => {
+      if (endpoint === '/guilds/G1/messages/search') {
+        return {
+          total_results: 1,
+          messages: [
+            [
+              {
+                id: '175928847299117056',
+                content: 'hello world',
+                channel_id: 'C1',
+                timestamp: '2016-04-30T12:00:00.000+00:00',
+                author: { username: 'alice' },
+              },
+            ],
+          ],
+        }
+      }
+      return null
+    })
+    const mk = (date: string): PathSpec =>
+      new PathSpec({
+        virtual: `/mnt/discord/My Server__G1/channels/general__C1/${date}/chat.jsonl`,
+        directory: `/mnt/discord/My Server__G1/channels/general__C1/${date}/chat.jsonl`,
+        resolved: true,
+        resourcePath: mountKey(
+          `/mnt/discord/My Server__G1/channels/general__C1/${date}/chat.jsonl`,
+          '/mnt/discord',
+        ),
+      })
+    const out = await runGrep(
+      [mk('2016-04-29'), mk('2016-04-30')],
+      ['hello'],
+      { w: true },
+      { transport },
+    )
+    expect(transport.calls[0]?.endpoint).toBe('/guilds/G1/messages/search')
+    expect(transport.calls[0]?.params?.channel_id).toBe('C1')
+    const lines = out.stdout.split('\n').filter((l) => l !== '')
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain(
+      '/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/chat.jsonl:',
+    )
   })
 })

--- a/typescript/packages/core/src/commands/builtin/discord/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.ts
@@ -21,7 +21,7 @@ import { resolveGlobOf } from '../generic_bind/index.ts'
 import { DISCORD_IO } from './io.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
-import { detectScope } from '../../../core/discord/scope.ts'
+import { coalesceScopes, detectScope } from '../../../core/discord/scope.ts'
 import { formatGrepResults, searchGuild } from '../../../core/discord/search.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
 import { IOResult } from '../../../io/types.ts'
@@ -59,7 +59,8 @@ async function grepCommand(
   const pushdownWarnings: string[] = []
   const firstPath = paths[0]
   if (firstPath !== undefined && pattern !== null && !pattern.includes('\n')) {
-    const scope = detectScope(firstPath)
+    let scope = detectScope(firstPath)
+    if (!scope.useNative) scope = coalesceScopes(paths) ?? scope
     // Discord search matches whole words while grep matches substrings,
     // and the native path returns search results verbatim as the output, so
     // a bare literal would under-report. Only -w makes the two agree.

--- a/typescript/packages/core/src/commands/builtin/discord/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.ts
@@ -60,7 +60,7 @@ async function grepCommand(
   const firstPath = paths[0]
   if (firstPath !== undefined && pattern !== null && !pattern.includes('\n')) {
     let scope = detectScope(firstPath)
-    if (!scope.useNative) scope = coalesceScopes(paths) ?? scope
+    if (scope.level === 'messages') scope = coalesceScopes(paths) ?? scope
     // Discord search matches whole words while grep matches substrings,
     // and the native path returns search results verbatim as the output, so
     // a bare literal would under-report. Only -w makes the two agree.

--- a/typescript/packages/core/src/commands/builtin/discord/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/rg.ts
@@ -21,7 +21,7 @@ import { DISCORD_IO } from './io.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
-import { detectScope } from '../../../core/discord/scope.ts'
+import { coalesceScopes, detectScope } from '../../../core/discord/scope.ts'
 import { listChannels } from '../../../core/discord/channels.ts'
 import { formatGrepResults, searchGuild } from '../../../core/discord/search.ts'
 import { IOResult } from '../../../io/types.ts'
@@ -64,7 +64,8 @@ async function rgCommand(
   if (paths.length > 0 && !pattern.includes('\n')) {
     const firstPath = paths[0]
     if (firstPath !== undefined) {
-      const scope = detectScope(firstPath)
+      let scope = detectScope(firstPath)
+      if (!scope.useNative) scope = coalesceScopes(paths) ?? scope
       // Discord search matches whole words while grep matches substrings,
       // and the native path returns search results verbatim as the output, so
       // a bare literal would under-report. Only -w makes the two agree.

--- a/typescript/packages/core/src/commands/builtin/discord/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/rg.ts
@@ -65,7 +65,7 @@ async function rgCommand(
     const firstPath = paths[0]
     if (firstPath !== undefined) {
       let scope = detectScope(firstPath)
-      if (!scope.useNative) scope = coalesceScopes(paths) ?? scope
+      if (scope.level === 'messages') scope = coalesceScopes(paths) ?? scope
       // Discord search matches whole words while grep matches substrings,
       // and the native path returns search results verbatim as the output, so
       // a bare literal would under-report. Only -w makes the two agree.

--- a/typescript/packages/core/src/core/discord/readdir.test.ts
+++ b/typescript/packages/core/src/core/discord/readdir.test.ts
@@ -339,6 +339,48 @@ describe('readdir /<guild>/channels/<ch>/<date>', () => {
     )
     expect(lookup.entry?.size).toBe(historyJsonlBytes(messages).byteLength)
   })
+
+  it('skips tombstoned attachments in the files listing', async () => {
+    // Tombstoned and access-restricted attachments carry an id but no
+    // download URL and no byte size; listing them would surface phantom
+    // files that ENOENT on read.
+    const idx = new RAMIndexCacheStore()
+    await idx.setDir('/mnt/discord/My Server__G1/channels', [
+      [
+        'general__C1',
+        new IndexEntry({
+          id: 'C1',
+          name: 'general',
+          resourceType: 'discord/channel',
+          vfsName: 'general__C1',
+          remoteTime: '175928847299117056',
+        }),
+      ],
+    ])
+    const messages = [
+      {
+        id: '1',
+        content: 'files',
+        attachments: [
+          { id: 'A1', filename: 'kept.txt', url: 'https://cdn.example/kept.txt', size: 5 },
+          { id: 'A2', filename: 'tombstoned.txt' },
+          { id: 'A3', filename: 'sizeless.txt', url: 'https://cdn.example/sizeless.txt' },
+          { id: 'A4', filename: 'urlless.txt', size: 9 },
+        ],
+      },
+    ]
+    const t = new FakeDiscordTransport((_m, endpoint) =>
+      endpoint === '/channels/C1/messages' ? messages : null,
+    )
+    const out = await readdir(
+      new DiscordAccessor(t),
+      spec('/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/files', '/mnt/discord'),
+      idx,
+    )
+    expect(out).toEqual([
+      '/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/files/kept__A1.txt',
+    ])
+  })
 })
 
 describe('readdir /<guild>/channels/<ch>', () => {

--- a/typescript/packages/core/src/core/discord/readdir.ts
+++ b/typescript/packages/core/src/core/discord/readdir.ts
@@ -290,16 +290,20 @@ async function fetchDay(
       size?: number
     }[]
     for (const att of atts) {
-      if (!att.id) continue
+      // Tombstoned (deleted) and access-restricted attachment payloads
+      // carry an id but no download URL and no byte size; read() ENOENTs
+      // on them, so listing them would surface phantom files with unknown
+      // sizes. Mirrors the slack guard.
+      if (!att.id || !att.url || att.size === undefined) continue
       const blobName = fileBlobName(att)
       const entry = new IndexEntry({
         id: att.id,
         name: att.filename ?? '',
         resourceType: DiscordResourceType.FILE,
         vfsName: blobName,
-        ...(att.size !== undefined ? { size: att.size } : {}),
+        size: att.size,
         extra: {
-          url: att.url ?? '',
+          url: att.url,
           proxy_url: att.proxy_url ?? '',
           content_type: att.content_type ?? '',
           message_id: msg.id,

--- a/typescript/packages/core/src/core/discord/scope.test.ts
+++ b/typescript/packages/core/src/core/discord/scope.test.ts
@@ -252,6 +252,19 @@ describe('coalesceScopes', () => {
     expect(coalesceScopes(paths)).toBeNull()
   })
 
+  it('returns null for attachment blobs — message search cannot answer them', () => {
+    const paths = [spec('/discord/myserver__G1/channels/general__C1/2026-01-01/files/img__A1.png')]
+    expect(coalesceScopes(paths)).toBeNull()
+  })
+
+  it('returns null when message files are mixed with blobs', () => {
+    const paths = [
+      spec('/discord/myserver__G1/channels/general__C1/2026-01-01/chat.jsonl'),
+      spec('/discord/myserver__G1/channels/general__C1/2026-01-01/files/img__A1.png'),
+    ]
+    expect(coalesceScopes(paths)).toBeNull()
+  })
+
   it('returns null for an empty list', () => {
     expect(coalesceScopes([])).toBeNull()
   })

--- a/typescript/packages/core/src/core/discord/scope.test.ts
+++ b/typescript/packages/core/src/core/discord/scope.test.ts
@@ -15,7 +15,7 @@
 import { stripSlash } from '../../utils/slash.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
-import { detectScope } from './scope.ts'
+import { coalesceScopes, detectScope } from './scope.ts'
 import { PathSpec } from '../../types.ts'
 
 describe('detectScope', () => {
@@ -216,5 +216,43 @@ describe('detectScope', () => {
     expect(s.level).toBe('guild')
     expect(s.guildName).toBe('myserver')
     expect(s.guildId).toBeUndefined()
+  })
+})
+
+describe('coalesceScopes', () => {
+  const spec = (path: string): PathSpec =>
+    new PathSpec({
+      resourcePath: mountKey(path, '/discord'),
+      virtual: path,
+      directory: path,
+    })
+
+  it('coalesces concrete chat.jsonl paths of one channel into a channel scope', () => {
+    const paths = ['2026-01-01', '2026-01-02', '2026-01-03'].map((d) =>
+      spec(`/discord/myserver__G1/channels/general__C1/${d}/chat.jsonl`),
+    )
+    const s = coalesceScopes(paths)
+    expect(s).not.toBeNull()
+    expect(s?.level).toBe('channel')
+    expect(s?.useNative).toBe(true)
+    expect(s?.guildId).toBe('G1')
+    expect(s?.channelId).toBe('C1')
+  })
+
+  it('returns null for paths spanning channels', () => {
+    const paths = [
+      spec('/discord/myserver__G1/channels/general__C1/2026-01-01/chat.jsonl'),
+      spec('/discord/myserver__G1/channels/random__C2/2026-01-01/chat.jsonl'),
+    ]
+    expect(coalesceScopes(paths)).toBeNull()
+  })
+
+  it('returns null when the dirnames carry no ids', () => {
+    const paths = [spec('/discord/myserver/channels/general/2026-01-01/chat.jsonl')]
+    expect(coalesceScopes(paths)).toBeNull()
+  })
+
+  it('returns null for an empty list', () => {
+    expect(coalesceScopes([])).toBeNull()
   })
 })

--- a/typescript/packages/core/src/core/discord/scope.ts
+++ b/typescript/packages/core/src/core/discord/scope.ts
@@ -264,15 +264,25 @@ export function detectScope(path: PathSpec): DiscordScope {
   return { level: 'guild', useNative: false, resourcePath: key }
 }
 
+/**
+ * Fold same-channel chat.jsonl operands into one channel scope.
+ *
+ * Only message files coalesce: guild search answers questions about message
+ * content, so widening any other leaf (an attachment blob, a member JSON) to
+ * a channel-wide message search would return hits that say nothing about the
+ * requested bytes.
+ */
 export function coalesceScopes(paths: readonly PathSpec[]): DiscordScope | null {
   if (paths.length === 0) return null
   const scopes = paths.map((p) => detectScope(p))
   const first = scopes[0]
-  if (first?.guildId === undefined || first.channelId === undefined) {
+  if (first?.guildId === undefined || first.channelId === undefined || first.level !== 'messages') {
     return null
   }
   for (const s of scopes.slice(1)) {
-    if (s.guildId !== first.guildId || s.channelId !== first.channelId) return null
+    if (s.level !== 'messages' || s.guildId !== first.guildId || s.channelId !== first.channelId) {
+      return null
+    }
   }
   const cut = first.resourcePath.lastIndexOf('/')
   return {
@@ -283,9 +293,6 @@ export function coalesceScopes(paths: readonly PathSpec[]): DiscordScope | null 
     ...(first.channelName !== undefined ? { channelName: first.channelName } : {}),
     channelId: first.channelId,
     container: 'channels',
-    resourcePath:
-      first.level === 'messages' && cut !== -1
-        ? first.resourcePath.slice(0, cut)
-        : first.resourcePath,
+    resourcePath: cut !== -1 ? first.resourcePath.slice(0, cut) : first.resourcePath,
   }
 }

--- a/typescript/packages/core/src/core/discord/scope.ts
+++ b/typescript/packages/core/src/core/discord/scope.ts
@@ -25,7 +25,6 @@ type DiscordLevel =
   | 'files'
   | 'file_blob'
   | 'member'
-  | 'file'
 
 export interface DiscordScope {
   level: DiscordLevel
@@ -263,4 +262,30 @@ export function detectScope(path: PathSpec): DiscordScope {
   }
 
   return { level: 'guild', useNative: false, resourcePath: key }
+}
+
+export function coalesceScopes(paths: readonly PathSpec[]): DiscordScope | null {
+  if (paths.length === 0) return null
+  const scopes = paths.map((p) => detectScope(p))
+  const first = scopes[0]
+  if (first?.guildId === undefined || first.channelId === undefined) {
+    return null
+  }
+  for (const s of scopes.slice(1)) {
+    if (s.guildId !== first.guildId || s.channelId !== first.channelId) return null
+  }
+  const cut = first.resourcePath.lastIndexOf('/')
+  return {
+    level: 'channel',
+    useNative: true,
+    ...(first.guildName !== undefined ? { guildName: first.guildName } : {}),
+    guildId: first.guildId,
+    ...(first.channelName !== undefined ? { channelName: first.channelName } : {}),
+    channelId: first.channelId,
+    container: 'channels',
+    resourcePath:
+      first.level === 'messages' && cut !== -1
+        ? first.resourcePath.slice(0, cut)
+        : first.resourcePath,
+  }
 }

--- a/typescript/packages/core/src/core/discord/search.test.ts
+++ b/typescript/packages/core/src/core/discord/search.test.ts
@@ -179,4 +179,42 @@ describe('formatGrepResults', () => {
       '/discord/My Server__G1/channels/eng__C3/2026-04-25/chat.jsonl:[carol] msg',
     ])
   })
+
+  it('derives the date from the snowflake when the timestamp is missing', () => {
+    // A hit without a timestamp still has a snowflake id, which encodes the
+    // creation day readdir buckets it under. 175928847299117056 is
+    // 2016-04-30 UTC.
+    const lines = formatGrepResults(
+      [
+        {
+          id: '175928847299117056',
+          channel_id: 'C1',
+          author: { username: 'alice' },
+          content: 'hello',
+        },
+      ],
+      scope,
+      '/discord',
+      new Map([['C1', 'general']]),
+    )
+    expect(lines).toEqual([
+      '/discord/My Server__G1/channels/general__C1/2016-04-30/chat.jsonl:[alice] hello',
+    ])
+  })
+
+  it('points a fully dateless hit at the channel dir instead of //chat.jsonl', () => {
+    const lines = formatGrepResults(
+      [
+        {
+          channel_id: 'C1',
+          author: { username: 'alice' },
+          content: 'hello',
+        },
+      ],
+      scope,
+      '/discord',
+      new Map([['C1', 'general']]),
+    )
+    expect(lines).toEqual(['/discord/My Server__G1/channels/general__C1:[alice] hello'])
+  })
 })

--- a/typescript/packages/core/src/core/discord/search.ts
+++ b/typescript/packages/core/src/core/discord/search.ts
@@ -15,6 +15,7 @@
 import type { DiscordAccessor } from '../../accessor/discord.ts'
 import { channelDirname, guildDirname } from './entry.ts'
 import { offsetPages } from './paginate.ts'
+import { snowflakeToIso } from './readdir.ts'
 import type { DiscordScope } from './scope.ts'
 
 const PAGE_SIZE = 25
@@ -91,13 +92,23 @@ export function formatGrepResults(
   })
   const lines: string[] = []
   for (const msg of messages) {
-    const ts = asString(msg.timestamp).slice(0, 10)
+    let ts = asString(msg.timestamp).slice(0, 10)
+    if (ts === '') {
+      // A hit without a timestamp still has a snowflake id, which encodes
+      // the creation day readdir buckets it under.
+      const iso = snowflakeToIso(asString(msg.id))
+      ts = iso !== null ? iso.slice(0, 10) : ''
+    }
     const chId = asString(msg.channel_id)
     const chName = channelNames.get(chId) ?? scope.channelName ?? ''
     const chVfs = channelDirname({ id: chId, ...(chName !== '' ? { name: chName } : {}) })
     const author = (msg.author as { username?: string } | undefined)?.username ?? '?'
     const content = asString(msg.content).replace(/\n/g, ' ')
-    lines.push(`${prefix}/${guildVfs}/channels/${chVfs}/${ts}/chat.jsonl:[${author}] ${content}`)
+    const path =
+      ts !== ''
+        ? `${prefix}/${guildVfs}/channels/${chVfs}/${ts}/chat.jsonl`
+        : `${prefix}/${guildVfs}/channels/${chVfs}`
+    lines.push(`${path}:[${author}] ${content}`)
   }
   return lines
 }


### PR DESCRIPTION
## Summary

Phase 0 PR-0d from the restructure audit: the discord parity batch (bugs 5+6+7), plus one dead-code bug the investigation surfaced. Python and TypeScript twins change together throughout.

**1. Scope detection now parses ids from the dirnames instead of asking the index (bug 6).** Python's `detect_scope` was async and resolved guild/channel ids through the index cache; the TypeScript twin parses them out of the `name__id` dirnames the tree itself mints. The index store is an exact-key lookup, so the async machinery could never resolve anything the dirname doesn't already carry — but it *could* miss: on a cold cache, `grep -w`/`rg -w` raised "cannot resolve guild ID" internally and fell back to a per-file scan with a spurious stderr warning, on operands whose ids were right there in the path. Python is rewritten to the slack-py/discord-ts shape (sync, dirname-parsed, same field set). Deliberate consequences:
- members-container paths no longer push down to guild *message* search (matches TS; message search can't answer a grep over member JSONs),
- the `grep: root-level search not yet supported` special case is gone — a root operand falls through to the generic scan and errors GNU-shaped, like TS,
- bare names (no `__id`) skip the push-down silently instead of depending on cache temperature.

**2. `coalesce_scopes` ported to TypeScript.** Python (like slack) coalesces concrete same-channel `chat.jsonl` operands into one channel-wide native search under `-w`; TS discord never had it, so the same command produced formatted search lines on python and raw JSONL scan lines on TS. TS gains `coalesceScopes` with python's exact semantics — the discord pair is now self-consistent (slack-ts still lacks it; that's the K2 chat-toolkit's business).

**3. Tombstoned attachments filtered (bug 5).** Discord listed any attachment carrying an id; slack's guard requires id + download URL + size, because tombstoned/access-restricted payloads carry an id but nothing to read — discord surfaced them as phantom files that ENOENT on read, with unknown sizes. Both twins now carry slack's three-part guard; the integ fake gained a `tombstoned` seed knob so the battery proves it end to end.

**4. Date-less grep result paths (bug 7).** A search hit without a timestamp rendered `.../channel//chat.jsonl` in both languages. Both now derive the day from the message snowflake — the same day readdir buckets the message under — and a hit with neither timestamp nor parseable id points at the channel dir, slack-style.

**5. Smart head was dead code (found during the bug-6 investigation).** `head.py` gated its native first-N-messages fetch on `scope.level == "file"`, a level no `detect_scope` in either language has ever produced, so every head fetched and rendered the whole day. Revived on level `"messages"` — plus the end-of-day bound the branch always needed: with `after`, a short day spills into the next one until `limit` is met, so an unbounded revival would print lines the file does not contain. Output is byte-identical to the generic path by construction (single renderer, same sort); TS keeps its scan and produces the same bytes.

Also removed the vestigial `'file'` member from the TS `DiscordLevel` union.

**Deliberately not taken here (family-wide, slack included, pre-dating this change):** the native push-down ignores `-r` on directory operands, and a coalesced/date-level push-down can return hits outside the operand date set. Both need one decision across the chat family — recorded for the K2 phase.

## Review round (`74706c207`)

All four codex findings taken:
- **P1** — coalescing keyed on `not use_native` swallowed `file_blob` operands into a channel-wide *message* search (pre-existing python behavior the port had copied into TS). `coalesce_scopes`/`coalesceScopes` now require every operand to be a chat.jsonl messages scope, enforced inside the function and at the call sites.
- **P2** — smart head forwarded any count as one Discord page (capped at 100); counts outside `1..100` — including zero and negative all-but-last-N — keep the generic path.
- **P2** — an empty day rendered `"\n"`; the branch now renders through `history_jsonl_bytes`, the same function `read()` uses, so its bytes match the generic path by construction.
- **P2** — `head -v` bypassed the `==> path <==` header; verbose keeps the generic path.

New pins: py unit +5, ts unit +3, integ +3 (`dc_grep_w_attachment_scans_bytes`, `dc_head_v_prints_header`, `dc_head_empty_day`). Pre-fix the attachment pin fails on both hosts and the two head pins fail on python (the empty-day run produced exactly the predicted lone `"\n"`); post-fix discord + cli-discord = **65/65 on both hosts**.

## Tests

- **py unit**: `test_scope.py` rewritten against the sync API, mirroring `scope.test.ts` case-for-case; `test_grep_pushdown.py` reworked to `name__id` paths with new cold-cache and bare-name pins; `test_head.py` new (smart gate, day-boundary spill, `-c`/non-messages generic fallbacks); readdir tombstone + formatter fallback cases. Full python suite green.
- **ts unit**: `scope.test.ts` +4 (coalesce), `readdir.test.ts` +1 (tombstone), `search.test.ts` +2 (snowflake fallback, date-less channel path), `grep.test.ts` single-file test repointed at the scan path + a new coalesce-native case. Core suite 8205 passed; `pnpm -r typecheck` clean.
- **integ**: fixture gains a tombstoned attachment on the existing budget message and a second releases-channel day; new `unix`-style `resources/discord/scope.json` cases pin channel-native `grep -w` with **empty stderr**, coalesced single-file `grep -w`, and head day boundaries. Post-fix: `discord` + `cli-discord` = **62 passed / 0 failed on both hosts**. Pre-fix (sources stashed, pins kept): TS fails 3 (ghost attachment listed by `ls`/`find`, raw-line grep output), python fails 2 (ghost in `ls`/`find`). Python's grep pins pass pre-fix only because the battery's shared workspace pre-warms the index — the cold-cache symptom is exactly what the new unit pins cover.
- pre-commit clean (mypy: no issues in 1819 source files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
