### PR TITLE
Release 0.0.5

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirage-ai"
-version = "0.0.4"
+version = "0.0.5a1"
 description = "A unified virtual filesystem for AI agents. Mount S3, Google Drive, Slack, Gmail, GitHub, Linear, Notion, Postgres, MongoDB, SSH, and more behind one filesystem so agents read, write, and pipe across services with familiar shell commands."
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirage-ai"
-version = "0.0.5a1"
+version = "0.0.5"
 description = "A unified virtual filesystem for AI agents. Mount S3, Google Drive, Slack, Gmail, GitHub, Linear, Notion, Postgres, MongoDB, SSH, and more behind one filesystem so agents read, write, and pipe across services with familiar shell commands."
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -4070,7 +4070,7 @@ wheels = [
 
 [[package]]
 name = "mirage-ai"
-version = "0.0.5a1"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -4070,7 +4070,7 @@ wheels = [
 
 [[package]]
 name = "mirage-ai"
-version = "0.0.4"
+version = "0.0.5a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/typescript/packages/agents/package.json
+++ b/typescript/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-agents",
-  "version": "0.0.5-alpha.1",
+  "version": "0.0.5",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/agents/package.json
+++ b/typescript/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-agents",
-  "version": "0.0.4",
+  "version": "0.0.5-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/browser/package.json
+++ b/typescript/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-browser",
-  "version": "0.0.4",
+  "version": "0.0.5-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/browser/package.json
+++ b/typescript/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-browser",
-  "version": "0.0.5-alpha.1",
+  "version": "0.0.5",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/cli/package.json
+++ b/typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-cli",
-  "version": "0.0.5-alpha.1",
+  "version": "0.0.5",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/cli/package.json
+++ b/typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-cli",
-  "version": "0.0.4",
+  "version": "0.0.5-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-core",
-  "version": "0.0.4",
+  "version": "0.0.5-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-core",
-  "version": "0.0.5-alpha.1",
+  "version": "0.0.5",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/core/src/commands/multi_provider.test.ts
+++ b/typescript/packages/core/src/commands/multi_provider.test.ts
@@ -142,14 +142,14 @@ describe('command() registers multiple resources', () => {
     const stdout = result?.[0]
     expect(stdout).toBeDefined()
     const text = new TextDecoder().decode(stdout as Uint8Array)
-    expect(text).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+\n$/)
+    expect(text).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+(?:-[\w.]+)?\n$/)
   })
 })
 
 describe('versionRequest', () => {
   it('matches the injected option', () => {
     const out = versionRequest('tsort', specFor('tsort'), ['--version'])
-    expect(decode(out)).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+\n$/)
+    expect(decode(out)).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+(?:-[\w.]+)?\n$/)
   })
 
   it('is null without the flag', () => {

--- a/typescript/packages/core/src/workspace/help_man_integration.test.ts
+++ b/typescript/packages/core/src/workspace/help_man_integration.test.ts
@@ -92,7 +92,7 @@ describe('--help and man through the executor', () => {
     const io = await ws.execute('tsort --version')
     const out = stdoutStr(io)
     expect(io.exitCode).toBe(0)
-    expect(out).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+\n$/)
+    expect(out).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+(?:-[\w.]+)?\n$/)
   })
 
   it('--version is listed in --help for registered commands', async () => {
@@ -105,7 +105,7 @@ describe('--help and man through the executor', () => {
     const ws = await makeMultiWs()
     const io = await ws.execute('rm --version /ro/c.txt')
     expect(io.exitCode).toBe(0)
-    expect(stdoutStr(io)).toMatch(/^rm \(Mirage\) \d+\.\d+\.\d+\n$/)
+    expect(stdoutStr(io)).toMatch(/^rm \(Mirage\) \d+\.\d+\.\d+(?:-[\w.]+)?\n$/)
   })
 
   it('--help beats the read-only mount refusal', async () => {
@@ -119,7 +119,7 @@ describe('--help and man through the executor', () => {
     const ws = await makeMultiWs()
     const io = await ws.execute('cat --version /ram/a.txt /other/b.txt')
     expect(io.exitCode).toBe(0)
-    expect(stdoutStr(io)).toMatch(/^cat \(Mirage\) \d+\.\d+\.\d+\n$/)
+    expect(stdoutStr(io)).toMatch(/^cat \(Mirage\) \d+\.\d+\.\d+(?:-[\w.]+)?\n$/)
   })
 
   it('--version does not run a write command', async () => {

--- a/typescript/packages/dsh/package.json
+++ b/typescript/packages/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-dsh",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.1",
   "description": "DeepSeek Harness (dsh) providers backed by a mirage workspace: ctx.fs and ctx.shell over mounted resources",
   "homepage": "https://github.com/strukto-ai/mirage#readme",
   "bugs": {

--- a/typescript/packages/dsh/package.json
+++ b/typescript/packages/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-dsh",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1",
   "description": "DeepSeek Harness (dsh) providers backed by a mirage workspace: ctx.fs and ctx.shell over mounted resources",
   "homepage": "https://github.com/strukto-ai/mirage#readme",
   "bugs": {

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-node",
-  "version": "0.0.5-alpha.1",
+  "version": "0.0.5",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-node",
-  "version": "0.0.4",
+  "version": "0.0.5-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/server/package.json
+++ b/typescript/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-server",
-  "version": "0.0.5-alpha.1",
+  "version": "0.0.5",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/server/package.json
+++ b/typescript/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-server",
-  "version": "0.0.4",
+  "version": "0.0.5-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",


### PR DESCRIPTION
Release 0.0.5, cut from main at 5cfb4598b (170 PRs since v0.0.4).

- `python/pyproject.toml` + `python/uv.lock` to `0.0.5`
- the six published TypeScript packages (agents, browser, cli, core, node, server) to `0.0.5`
- `@struktoai/mirage-dsh` to `0.0.1`, its own line, first release
- `opencode` stays at 0.0.0

Cross-package deps are `workspace:*`, so pnpm rewrites them at publish time and no dependency edits are needed; `pnpm-lock.yaml` is unchanged for the same reason. Both `mirage.__version__` and the TS side read their version from package metadata, so there is no second place to bump.

### Validated as 0.0.5-alpha.1 first

The alpha was published to both registries and exercised end to end before this PR moved to the final version.

**PyPI** (`mirage-ai 0.0.5a1`, wheel + sdist, `twine check` clean): in a clean venv installing only from PyPI, `mirage.__version__` reported `0.0.5a1`, the `mirage` console script ran, the shell smoke test passed (redirect + `cat`, `sort | tr`, `find | wc`, `du -a`, `history`), and plain `pip install mirage-ai` still resolved to 0.0.4.

**npm** (all seven packages, `--tag alpha`): `latest` stayed on 0.0.4 for the six, `workspace:*` deps were rewritten to real versions in the published manifests, and a clean project installing only from the registry ran the workspace commands, the dsh shell seam (reporting `sandbox: workspace-write`), incremental background streaming, and spill-with-recovery from #796.

### One test fix

Five TypeScript `--version` assertions pinned the output to `\d+\.\d+\.\d+`, which cannot express a prerelease, so all five failed under `0.0.5-alpha.1`. Python asserts the same output with `startswith` and was unaffected. The shape is still asserted, now with an optional prerelease suffix, so a future alpha does not break CI again.

After merge: tag `v0.0.5`, publish the release page, then upload 0.0.5 to PyPI and npm.