### PR TITLE
fix(cache): rename evicts dst's own listing (13-backend sweep) + disk Windows separators + databricks copy invalidation + derived-ops docs

### DIFF
--- a/docs/python/resource/new.mdx
+++ b/docs/python/resource/new.mdx
@@ -79,6 +79,7 @@ python/mirage/
   resource/<name>/
     __init__.py
     config.py
+    prompt.py
     <name>.py
   accessor/<name>.py
   core/<name>/
@@ -86,12 +87,10 @@ python/mirage/
     readdir.py
     stat.py
   ops/<name>/
-    __init__.py
-    read.py
-    readdir.py
-    stat.py
+    __init__.py          # OPS derived from the CommandIO table
   commands/builtin/<name>/
     __init__.py
+    io.py                # the CommandIO table
     <resource-specific commands>.py
 ```
 
@@ -143,28 +142,35 @@ Add write, append, create, unlink, rename, or directory operations only when the
 
 ## 3. Ops Layer
 
-Ops are thin typed adapters from the workspace dispatcher to core functions. Declare dispatcher-injected arguments explicitly and keep `**flags: object` opaque.
+Ops are derived, not hand-written. `ops/<name>/__init__.py` builds the whole VFS/FUSE op family from the same `CommandIO` table the commands use:
 
 ```python
-from mirage.accessor.base import Accessor
-from mirage.cache.index import IndexCacheStore
-from mirage.core.my_resource.read import read_bytes
+from mirage.commands.builtin.my_resource.io import IO
+from mirage.ops.generic import make_generic_ops
+
+OPS = make_generic_ops("my_resource", IO)
+```
+
+`make_generic_ops` emits read/readdir/stat plus whatever mutations the table carries — a `CommandIO` slot updates commands and ops together, and ops whose table field is `None` are omitted. Knobs mirror backend semantics, e.g. `make_generic_ops("databricks_volume", IO, mkdir_parents=True)`.
+
+Write a dedicated op module only for an irregular handler with no generic equivalent (a native `grep` push-down, a semantic `search`), and append it to the derived list:
+
+```python
+from mirage.core.my_resource.grep import grep_bytes
 from mirage.ops.registry import op
 from mirage.types import PathSpec
 
 
-@op("read", resource="my_resource")
-async def read(
-    accessor: Accessor,
-    path: PathSpec,
-    *,
-    index: IndexCacheStore | None,
-    **flags: object,
-) -> bytes:
-    return await read_bytes(accessor, path, index)
+@op("grep", resource="my_resource")
+async def grep(accessor, paths: list[PathSpec], pattern: str, *, index,
+               **kwargs) -> bytes:
+    return await grep_bytes(accessor, paths, pattern, index)
+
+
+OPS = [*make_generic_ops("my_resource", IO), grep]
 ```
 
-Mark mutation ops with `write=True`. Export the decorated functions as `OPS` from `ops/<name>/__init__.py`.
+Mark a hand-written mutation op with `write=True` so `MountMode.READ` remains a real boundary (derived ops carry this from the table).
 
 ## 4. Commands
 

--- a/integ/unix/mv/empty_dir.json
+++ b/integ/unix/mv/empty_dir.json
@@ -1,0 +1,186 @@
+{
+  "cases": [
+    {
+      "id": "mv_empty_dir_prep",
+      "seq": 613200,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "databricks",
+        "databricks-prefix",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/mvcache/src /data/mvcache/dst/src",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "mv_empty_dir_seed",
+      "seq": 613201,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "databricks",
+        "databricks-prefix",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "echo payload > /data/mvcache/src/f.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "mv_empty_dir_warm",
+      "seq": 613202,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "databricks",
+        "databricks-prefix",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "ls /data/mvcache/dst/src",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "mv_empty_dir_replace",
+      "seq": 613203,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "databricks",
+        "databricks-prefix",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mv /data/mvcache/src /data/mvcache/dst",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "mv_empty_dir_fresh_listing",
+      "seq": 613204,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "databricks",
+        "databricks-prefix",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "ls /data/mvcache/dst/src",
+      "expect": {
+        "exit": 0,
+        "stdout": "f.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "mv_empty_dir_content",
+      "seq": 613205,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "databricks",
+        "databricks-prefix",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "cat /data/mvcache/dst/src/f.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "payload\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "mv_empty_dir_src_gone",
+      "seq": 613206,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "databricks",
+        "databricks-prefix",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "ls /data/mvcache",
+      "expect": {
+        "exit": 0,
+        "stdout": "dst\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/python/mirage/core/box/rename.py
+++ b/python/mirage/core/box/rename.py
@@ -13,8 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.box import BoxAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.core.box.api import (delete_file, delete_folder, update_file,
                                  update_folder)
 from mirage.core.box.resolve import path_parts, resolve_item, resolve_parent_id
@@ -48,5 +47,5 @@ async def rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec) -> None:
                             parent_id=dst_parent)
     else:
         await update_file(tm, item["id"], name=new_name, parent_id=dst_parent)
-    await invalidate_after_write(dst)
+    await invalidate_after_unlink(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/databricks_volume/copy.py
+++ b/python/mirage/core/databricks_volume/copy.py
@@ -17,6 +17,7 @@ from io import BytesIO
 from typing import Any
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.read import read_bytes
@@ -101,6 +102,12 @@ async def copy(
                              f"into itself, '{dst.virtual}'")
         await asyncio.to_thread(_copy_tree_sync, accessor, remote_src,
                                 remote_dst)
+        # create_directory materializes missing ancestors and the walk can
+        # merge into a pre-existing destination directory (mv onto an empty
+        # dir), so evict the destination's own listing and every ancestor
+        # listing, not just the parent (mirrors mkdir with parents=True).
+        await invalidate_after_unlink(dst)
+        await invalidate_ancestors(dst)
         return
     if same_path:
         # Copying a file onto itself would re-upload it; skip.

--- a/python/mirage/core/databricks_volume/rename.py
+++ b/python/mirage/core/databricks_volume/rename.py
@@ -13,8 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.databricks_volume.copy import copy
 from mirage.core.databricks_volume.path import backend_path
@@ -53,5 +52,5 @@ async def rename(
     else:
         await copy(accessor, src, dst, index)
         await unlink(accessor, src, index)
-    await invalidate_after_write(dst)
+    await invalidate_after_unlink(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/disk/du/walk.py
+++ b/python/mirage/core/disk/du/walk.py
@@ -70,7 +70,8 @@ def entries_sync(root: Path, path: str) -> tuple[list[tuple[str, int]], int]:
                 file_size = os.path.getsize(full)
             except OSError:
                 continue
-            found.append(("/" + os.path.relpath(full, root), file_size))
+            rel = os.path.relpath(full, root).replace(os.sep, "/")
+            found.append(("/" + rel, file_size))
             total += file_size
     found.sort()
     return found, total

--- a/python/mirage/core/disk/find.py
+++ b/python/mirage/core/disk/find.py
@@ -78,8 +78,8 @@ def _find_sync(
 
     for dirpath, dirnames, filenames in os.walk(p):
         dp = Path(dirpath)
-        rel = dp.relative_to(root)
-        current = "/" + str(rel) if str(rel) != "." else "/"
+        rel = dp.relative_to(root).as_posix()
+        current = "/" + rel if rel != "." else "/"
 
         current_depth = current.count("/") - base_depth
 

--- a/python/mirage/core/disk/rename.py
+++ b/python/mirage/core/disk/rename.py
@@ -17,8 +17,7 @@ from pathlib import Path
 import aiofiles.os
 
 from mirage.accessor.disk import DiskAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.types import PathSpec
 
 
@@ -35,5 +34,7 @@ async def rename(accessor: DiskAccessor, src_spec: PathSpec,
     dst = dst_spec.mount_path
     root = accessor.root
     await invalidate_after_unlink(src_spec)
-    await invalidate_after_write(dst_spec)
+    # The unlink flavor on dst: a rename destroys the destination's previous
+    # identity, so a replaced empty directory loses its cached listing too.
+    await invalidate_after_unlink(dst_spec)
     await aiofiles.os.rename(_resolve(root, src), _resolve(root, dst))

--- a/python/mirage/core/dropbox/rename.py
+++ b/python/mirage/core/dropbox/rename.py
@@ -15,8 +15,7 @@
 import time
 
 from mirage.accessor.dropbox import DropboxAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write, invalidate_ancestors)
+from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
 from mirage.core.dropbox._client import DropboxApiError
 from mirage.core.dropbox.api import delete_path, get_metadata, move_path
 from mirage.core.dropbox.paths import dropbox_path_of
@@ -55,5 +54,5 @@ async def rename(accessor: DropboxAccessor, src: PathSpec,
     record("rename", src.virtual, "dropbox", 0, start_ms)
     await invalidate_after_unlink(src)
     await invalidate_ancestors(src)
-    await invalidate_after_write(dst)
+    await invalidate_after_unlink(dst)
     await invalidate_ancestors(dst)

--- a/python/mirage/core/gdrive/rename.py
+++ b/python/mirage/core/gdrive/rename.py
@@ -17,8 +17,7 @@ import os
 import posixpath
 
 from mirage.accessor.gdrive import GDriveAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.core.gdrive.resolve import (drive_target_name, eacces_on_denied,
                                         resolve_key, resolve_parent)
 from mirage.core.google.drive import delete_file, list_files, patch_file
@@ -56,5 +55,5 @@ async def rename(accessor: GDriveAccessor, src: PathSpec,
                      src_node.id, {"name": name},
                      add_parents=add_parents,
                      remove_parents=remove_parents)
-    await invalidate_after_write(dst)
+    await invalidate_after_unlink(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/gridfs/rename.py
+++ b/python/mirage/core/gridfs/rename.py
@@ -13,8 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.gridfs import GridFSAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.core.gridfs._client import (_key, delete_all, files_coll,
                                         latest_file)
 from mirage.types import PathSpec
@@ -37,5 +36,5 @@ async def rename(accessor: GridFSAccessor, src_spec: PathSpec,
                                            {"$set": {
                                                "filename": dst_key
                                            }})
-    await invalidate_after_write(dst_spec)
+    await invalidate_after_unlink(dst_spec)
     await invalidate_after_unlink(src_spec)

--- a/python/mirage/core/nextcloud/rename.py
+++ b/python/mirage/core/nextcloud/rename.py
@@ -1,8 +1,7 @@
 from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -16,5 +15,5 @@ async def rename(accessor: NextcloudAccessor, src: PathSpec,
         await op.rename(src_key, dst_key)
     except NotFound as exc:
         raise enoent(src) from exc
-    await invalidate_after_write(dst)
+    await invalidate_after_unlink(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/onedrive/rename.py
+++ b/python/mirage/core/onedrive/rename.py
@@ -13,8 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.core.msgraph.drive_ops import rename_replace
 from mirage.core.onedrive._client import drive_loc, split_path
 from mirage.types import PathSpec
@@ -27,5 +26,5 @@ async def rename(accessor: OneDriveAccessor, src: PathSpec,
     config = accessor.config
     await rename_replace(config, drive_loc(config, src_s),
                          drive_loc(config, dst_s))
-    await invalidate_after_write(dst)
+    await invalidate_after_unlink(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/ram/rename.py
+++ b/python/mirage/core/ram/rename.py
@@ -13,8 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.ram import RAMAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.core.ram.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
@@ -49,5 +48,5 @@ async def rename(accessor: RAMAccessor, src_spec: PathSpec,
                     store.attrs[new_key] = store.attrs.pop(key)
     else:
         raise FileNotFoundError(s)
-    await invalidate_after_write(dst_spec)
+    await invalidate_after_unlink(dst_spec)
     await invalidate_after_unlink(src_spec)

--- a/python/mirage/core/redis/rename.py
+++ b/python/mirage/core/redis/rename.py
@@ -13,8 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.redis import RedisAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.core.redis.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
@@ -67,5 +66,5 @@ async def rename(
                     await store.set_attrs(new_key, sub_attrs)
     else:
         raise FileNotFoundError(s)
-    await invalidate_after_write(dst_spec)
+    await invalidate_after_unlink(dst_spec)
     await invalidate_after_unlink(src_spec)

--- a/python/mirage/core/s3/rename.py
+++ b/python/mirage/core/s3/rename.py
@@ -13,8 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.s3 import S3Accessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.core.s3._client import _client_kwargs, _key, async_session
 from mirage.core.s3.exists import exists
 from mirage.types import PathSpec
@@ -45,5 +44,5 @@ async def rename(accessor: S3Accessor, src_spec: PathSpec,
             Key=_key(dst, config),
         )
         await client.delete_object(Bucket=config.bucket, Key=_key(src, config))
-    await invalidate_after_write(dst_spec)
+    await invalidate_after_unlink(dst_spec)
     await invalidate_after_unlink(src_spec)

--- a/python/mirage/core/sharepoint/rename.py
+++ b/python/mirage/core/sharepoint/rename.py
@@ -1,6 +1,5 @@
 from mirage.accessor.sharepoint import SharePointAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.core.msgraph.drive_ops import rename_replace
 from mirage.core.sharepoint._resolver import resolve
 from mirage.core.sharepoint.copy import drive_loc
@@ -21,5 +20,5 @@ async def rename(accessor: SharePointAccessor, src: PathSpec,
     await rename_replace(accessor.config,
                          drive_loc(accessor.config, src_resolved, src_virt),
                          drive_loc(accessor.config, dst_resolved, dst_virt))
-    await invalidate_after_write(dst)
+    await invalidate_after_unlink(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/ssh/rename.py
+++ b/python/mirage/core/ssh/rename.py
@@ -15,8 +15,7 @@
 import asyncssh
 
 from mirage.accessor.ssh import SSHAccessor
-from mirage.cache.context import (invalidate_after_unlink,
-                                  invalidate_after_write)
+from mirage.cache.context import invalidate_after_unlink
 from mirage.core.ssh._client import _abs
 from mirage.types import PathSpec
 
@@ -38,5 +37,7 @@ async def rename(accessor: SSHAccessor, src_spec: PathSpec,
             raise FileNotFoundError(src)
     except asyncssh.SFTPNoSuchFile:
         raise FileNotFoundError(src)
-    await invalidate_after_write(dst_spec)
+    # The unlink flavor on dst: a rename destroys the destination's previous
+    # identity, so a replaced empty directory loses its cached listing too.
+    await invalidate_after_unlink(dst_spec)
     await invalidate_after_unlink(src_spec)

--- a/python/tests/core/box/test_write.py
+++ b/python/tests/core/box/test_write.py
@@ -188,8 +188,6 @@ async def test_rename_moves_file(root_accessor):
     with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
          patch("mirage.core.box.rename.update_file",
                new_callable=AsyncMock) as uf, \
-         patch("mirage.core.box.rename.invalidate_after_write",
-               new_callable=AsyncMock), \
          patch("mirage.core.box.rename.invalidate_after_unlink",
                new_callable=AsyncMock):
         await rename(root_accessor, _spec("/data/a.txt"), _spec("/data/b.txt"))

--- a/python/tests/core/databricks_volume/test_copy.py
+++ b/python/tests/core/databricks_volume/test_copy.py
@@ -16,9 +16,23 @@ from types import SimpleNamespace
 
 import pytest
 
+from mirage.cache.context import push_cache_manager
 from mirage.core.databricks_volume.copy import copy
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
+
+
+class _FakeManager:
+
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+        self.unlinks: list[str] = []
+
+    async def invalidate_after_write(self, path: PathSpec) -> None:
+        self.writes.append(path.mount_path)
+
+    async def invalidate_after_unlink(self, path: PathSpec) -> None:
+        self.unlinks.append(path.mount_path)
 
 
 def _path(path: str) -> PathSpec:
@@ -146,3 +160,28 @@ async def test_copy_recursive_into_own_subtree_fails(accessor, files,
     assert files.create_directory_calls == []
     assert files.upload_calls == []
     assert files.downloads[f"{remote_root}/d/a.txt"] == b"aaa"
+
+
+@pytest.mark.asyncio
+async def test_copy_recursive_invalidates_destination_tree(
+        accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/d")
+    _seed_file(files, f"{remote_root}/d/a.txt", b"aaa")
+    _seed_directory(files, f"{remote_root}/deep")
+
+    manager = _FakeManager()
+    prev = push_cache_manager(manager)
+    try:
+        await copy(accessor,
+                   _path("/dbx/d"),
+                   _path("/dbx/deep/dst"),
+                   index,
+                   recursive=True)
+    finally:
+        push_cache_manager(prev)
+
+    # The destination's own listing must go (a merge target can pre-exist)
+    # along with every ancestor listing create_directory materialized.
+    assert manager.unlinks == ["/deep/dst"]
+    assert manager.writes == ["/deep"]

--- a/python/tests/core/disk/du/test_entries.py
+++ b/python/tests/core/disk/du/test_entries.py
@@ -12,11 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import os
+from functools import partial
+
 import pytest
 
 from mirage.accessor.disk import DiskAccessor
 from mirage.core.disk.du import entries
 from mirage.types import PathSpec
+
+
+def _backslashed_relpath(real_relpath, path, start):
+    return real_relpath(path, start).replace("/", "\\")
 
 
 @pytest.mark.asyncio
@@ -31,3 +38,18 @@ async def test_entries_returns_pairs(tmp_path):
     assert "/a.txt" in paths
     assert "/sub/b.txt" in paths
     assert total == 5
+
+
+@pytest.mark.asyncio
+async def test_entries_normalizes_native_separator(tmp_path, monkeypatch):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.txt").write_bytes(b"bb")
+    # Simulate Windows: os.path.relpath joins with the native separator.
+    monkeypatch.setattr(os.path, "relpath",
+                        partial(_backslashed_relpath, os.path.relpath))
+    monkeypatch.setattr(os, "sep", "\\")
+    accessor = DiskAccessor(tmp_path)
+    found, total = await entries(
+        accessor, PathSpec(resource_path="", virtual="/", directory="/"))
+    assert [p for p, _ in found] == ["/sub/b.txt"]
+    assert total == 2

--- a/python/tests/core/disk/test_find.py
+++ b/python/tests/core/disk/test_find.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from pathlib import PureWindowsPath
+
 import pytest
 
 from mirage.accessor.disk import DiskAccessor
@@ -82,3 +84,18 @@ async def test_find_with_maxdepth(tmp_path):
     assert "/sub" in result
     assert "/sub/b.txt" not in result
     assert "/sub/deep/c.txt" not in result
+
+
+@pytest.mark.asyncio
+async def test_find_normalizes_native_separator(tmp_path, monkeypatch):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "deep").mkdir()
+    (tmp_path / "sub" / "deep" / "b.txt").write_text("b")
+    # Simulate Windows: str() of a walked Path joins with backslashes.
+    monkeypatch.setitem(find.__globals__, "Path", PureWindowsPath)
+    accessor = DiskAccessor(tmp_path)
+    result = await find(accessor,
+                        PathSpec(resource_path="", virtual="/", directory="/"))
+    assert "/sub/deep" in result
+    assert "/sub/deep/b.txt" in result
+    assert not any("\\" in r for r in result)

--- a/python/tests/core/disk/test_rename.py
+++ b/python/tests/core/disk/test_rename.py
@@ -1,0 +1,67 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.accessor.disk import DiskAccessor
+from mirage.cache.context import push_cache_manager
+from mirage.core.disk.rename import rename
+from mirage.types import PathSpec
+
+
+class _FakeManager:
+
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+        self.unlinks: list[str] = []
+
+    async def invalidate_after_write(self, path: PathSpec) -> None:
+        self.writes.append(path.mount_path)
+
+    async def invalidate_after_unlink(self, path: PathSpec) -> None:
+        self.unlinks.append(path.mount_path)
+
+
+def _spec(path: str) -> PathSpec:
+    return PathSpec(resource_path=path.lstrip("/"),
+                    virtual=path,
+                    directory="/")
+
+
+@pytest.mark.asyncio
+async def test_rename_moves_file(tmp_path):
+    (tmp_path / "a.txt").write_bytes(b"A")
+    accessor = DiskAccessor(tmp_path)
+    await rename(accessor, _spec("/a.txt"), _spec("/b.txt"))
+    assert not (tmp_path / "a.txt").exists()
+    assert (tmp_path / "b.txt").read_bytes() == b"A"
+
+
+@pytest.mark.asyncio
+async def test_rename_evicts_both_identities(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "f.txt").write_bytes(b"x")
+    (tmp_path / "dst").mkdir()
+    accessor = DiskAccessor(tmp_path)
+    manager = _FakeManager()
+    prev = push_cache_manager(manager)
+    try:
+        await rename(accessor, _spec("/src"), _spec("/dst"))
+    finally:
+        push_cache_manager(prev)
+    # A replaced empty directory loses its own cached listing, not just
+    # its parent's: both sides of a rename take the unlink flavor.
+    assert manager.unlinks == ["/src", "/dst"]
+    assert manager.writes == []
+    assert (tmp_path / "dst" / "f.txt").read_bytes() == b"x"

--- a/typescript/packages/core/src/core/box/write.test.ts
+++ b/typescript/packages/core/src/core/box/write.test.ts
@@ -35,6 +35,7 @@ vi.mock('../../cache/context.ts', () => {
 })
 
 import { BoxAccessor } from '../../accessor/box.ts'
+import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
 import { PathSpec } from '../../types.ts'
 import type { BoxTokenManager } from './_client.ts'
 import * as api from './api.ts'
@@ -119,6 +120,17 @@ describe('box write ops', () => {
       name: 'b.txt',
       parentId: '100',
     })
+  })
+
+  it('rename evicts both identities so a replaced empty dir loses its listing', async () => {
+    vi.mocked(invalidateAfterWrite).mockClear()
+    vi.mocked(invalidateAfterUnlink).mockClear()
+    await rename(makeAccessor(), spec('/data/a.txt'), spec('/data/b.txt'))
+    const evicted = vi
+      .mocked(invalidateAfterUnlink)
+      .mock.calls.map(([path]) => (typeof path === 'string' ? path : path.virtual))
+    expect(evicted).toEqual(['/data/b.txt', '/data/a.txt'])
+    expect(vi.mocked(invalidateAfterWrite)).not.toHaveBeenCalled()
   })
 
   it('copy copies a file into the dst parent', async () => {

--- a/typescript/packages/core/src/core/box/write.ts
+++ b/typescript/packages/core/src/core/box/write.ts
@@ -151,7 +151,9 @@ export async function rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec
   if (item.type === 'folder')
     await updateFolder(tm, item.id, { name: newName, parentId: dstParent })
   else await updateFile(tm, item.id, { name: newName, parentId: dstParent })
-  await invalidateAfterWrite(dst)
+  // The unlink flavor on dst: a rename destroys the destination's previous
+  // identity, so a replaced empty directory loses its cached listing too.
+  await invalidateAfterUnlink(dst)
   await invalidateAfterUnlink(src)
 }
 

--- a/typescript/packages/core/src/core/databricks_volume/copy.ts
+++ b/typescript/packages/core/src/core/databricks_volume/copy.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import { invalidateAfterUnlink, invalidateAncestors } from '../../cache/context.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileType, type PathSpec } from '../../types.ts'
 import { rstripSlash } from '../../utils/slash.ts'
@@ -89,6 +90,12 @@ export async function copy(
       throw new Error(`cannot copy a directory, '${s.virtual}', into itself, '${d.virtual}'`)
     }
     await copyTree(accessor, remoteSrc, remoteDst)
+    // create_directory materializes missing ancestors and the walk can
+    // merge into a pre-existing destination directory (mv onto an empty
+    // dir), so evict the destination's own listing and every ancestor
+    // listing, not just the parent (mirrors mkdir with parents=true).
+    await invalidateAfterUnlink(d)
+    await invalidateAncestors(d)
     return
   }
   if (samePath) {

--- a/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
@@ -14,6 +14,7 @@
 
 import { mountKey } from '../../utils/key_prefix.ts'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runWithCacheManager } from '../../cache/context.ts'
 import { copy } from './copy.ts'
 import { rename } from './rename.ts'
 import { resolveGlobOf } from '../../commands/builtin/generic_bind/index.ts'
@@ -30,6 +31,25 @@ import {
 } from './_test_util.ts'
 
 const resolveGlob = resolveGlobOf(DATABRICKS_VOLUME_IO)
+
+class FakeManager {
+  writes: string[] = []
+  unlinks: string[] = []
+
+  invalidateAfterWrite(path: string | PathSpec): Promise<void> {
+    this.writes.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  invalidateAfterUnlink(path: string | PathSpec): Promise<void> {
+    this.unlinks.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  cachedBytes(_path: PathSpec): Promise<Uint8Array | null> {
+    return Promise.resolve(null)
+  }
+}
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -101,6 +121,27 @@ describe('copy', () => {
       true,
     )
     expect(puts.some((c) => c.url.includes('dir2/a.txt'))).toBe(true)
+  })
+
+  it('invalidates the destination tree after a recursive copy', async () => {
+    const { fetch } = routedFetch((call) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) return notFoundResponse()
+      if (call.method === 'HEAD') return new Response(null, { status: 200 })
+      if (call.method === 'GET' && call.url.includes('/fs/directories/')) {
+        return jsonResponse({ contents: [{ path: `${TEST_ROOT}/dir/a.txt` }] })
+      }
+      if (call.method === 'GET') return new Response('data', { status: 200 })
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const manager = new FakeManager()
+    await runWithCacheManager(manager, async () => {
+      await copy(makeAccessor(), spec('/volume/dir'), spec('/volume/deep/dst'), undefined, true)
+    })
+    // The destination's own listing must go (a merge target can pre-exist)
+    // along with every ancestor listing create_directory materialized.
+    expect(manager.unlinks).toEqual(['/deep/dst'])
+    expect(manager.writes).toEqual(['/deep'])
   })
 
   it('refuses copying a directory into its own subtree before any write', async () => {

--- a/typescript/packages/core/src/core/databricks_volume/rename.ts
+++ b/typescript/packages/core/src/core/databricks_volume/rename.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
+import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileType, type PathSpec } from '../../types.ts'
@@ -55,6 +55,6 @@ export async function rename(
     await copy(accessor, s, d, index)
     await unlink(accessor, s, index)
   }
-  await invalidateAfterWrite(d)
+  await invalidateAfterUnlink(d)
   await invalidateAfterUnlink(s)
 }

--- a/typescript/packages/core/src/core/dropbox/rename.ts
+++ b/typescript/packages/core/src/core/dropbox/rename.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
-import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
+import { invalidateAfterUnlink } from '../../cache/context.ts'
 import { record } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
@@ -48,6 +48,6 @@ export async function rename(
   record('rename', src.virtual, 'dropbox', 0, startMs)
   await invalidateAfterUnlink(src)
   await invalidateAncestors(src)
-  await invalidateAfterWrite(dst)
+  await invalidateAfterUnlink(dst)
   await invalidateAncestors(dst)
 }

--- a/typescript/packages/core/src/core/gdrive/rename.ts
+++ b/typescript/packages/core/src/core/gdrive/rename.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GDriveAccessor } from '../../accessor/gdrive.ts'
-import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
+import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent, enotempty } from '../../utils/errors.ts'
 import { deleteFile, listFiles, patchFile } from '../google/drive.ts'
@@ -48,7 +48,7 @@ async function renameImpl(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec
     body: { name },
     ...(move ? { addParents: dstParentId, removeParents: srcParentId } : {}),
   })
-  await invalidateAfterWrite(dst)
+  await invalidateAfterUnlink(dst)
   await invalidateAfterUnlink(src)
 }
 

--- a/typescript/packages/core/src/core/onedrive/index.ts
+++ b/typescript/packages/core/src/core/onedrive/index.ts
@@ -222,7 +222,7 @@ export async function rename(
     accessor.loc(src.resourcePath),
     accessor.loc(dst.resourcePath),
   )
-  await invalidateAfterWrite(dst)
+  await invalidateAfterUnlink(dst)
   await invalidateAfterUnlink(src)
 }
 

--- a/typescript/packages/core/src/core/ram/rename.ts
+++ b/typescript/packages/core/src/core/ram/rename.ts
@@ -18,7 +18,7 @@ import { norm, nowIso } from './utils.ts'
 import { rstripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 import { checkDestParents } from './dest.ts'
-import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
+import { invalidateAfterUnlink } from '../../cache/context.ts'
 
 function moveAttrs(accessor: RAMAccessor, src: string, dst: string): void {
   const attrs = accessor.store.attrs.get(src)
@@ -41,7 +41,7 @@ export async function rename(accessor: RAMAccessor, src: PathSpec, dst: PathSpec
     accessor.store.modified.delete(s)
     moveAttrs(accessor, s, d)
     await invalidateAfterUnlink(src)
-    await invalidateAfterWrite(dst)
+    await invalidateAfterUnlink(dst)
     return Promise.resolve()
   }
   if (accessor.store.dirs.has(s)) {
@@ -64,7 +64,7 @@ export async function rename(accessor: RAMAccessor, src: PathSpec, dst: PathSpec
       }
     }
     await invalidateAfterUnlink(src)
-    await invalidateAfterWrite(dst)
+    await invalidateAfterUnlink(dst)
     return Promise.resolve()
   }
   throw enoent(src)

--- a/typescript/packages/core/src/core/s3/rename.ts
+++ b/typescript/packages/core/src/core/s3/rename.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
+import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
 import { enoent } from '../../utils/errors.ts'
@@ -42,6 +42,6 @@ export async function rename(accessor: S3Accessor, src: PathSpec, dst: PathSpec)
     )
     await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: srcKey }))
   })
-  await invalidateAfterWrite(dst)
+  await invalidateAfterUnlink(dst)
   await invalidateAfterUnlink(src)
 }

--- a/typescript/packages/core/src/core/sharepoint/index.ts
+++ b/typescript/packages/core/src/core/sharepoint/index.ts
@@ -305,7 +305,7 @@ export async function rename(
     accessor.loc(srcResolved, src.resourcePath),
     accessor.loc(dstResolved, dst.resourcePath),
   )
-  await invalidateAfterWrite(dst)
+  await invalidateAfterUnlink(dst)
   await invalidateAfterUnlink(src)
 }
 

--- a/typescript/packages/node/src/core/disk/rename.test.ts
+++ b/typescript/packages/node/src/core/disk/rename.test.ts
@@ -12,12 +12,32 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { access, readFile, writeFile } from 'node:fs/promises'
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runWithCacheManager, type PathSpec } from '@struktoai/mirage-core'
 import type { DiskAccessor } from '../../accessor/disk.ts'
 import { spec, tmpRoot } from '../../test-utils.ts'
 import { rename } from './rename.ts'
+
+class FakeManager {
+  writes: string[] = []
+  unlinks: string[] = []
+
+  invalidateAfterWrite(path: string | PathSpec): Promise<void> {
+    this.writes.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  invalidateAfterUnlink(path: string | PathSpec): Promise<void> {
+    this.unlinks.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  cachedBytes(_path: PathSpec): Promise<Uint8Array | null> {
+    return Promise.resolve(null)
+  }
+}
 
 let root: string
 let accessor: DiskAccessor
@@ -41,5 +61,17 @@ describe('core/disk/rename', () => {
     await expect(rename(accessor, spec('/missing'), spec('/x'))).rejects.toMatchObject({
       code: 'ENOENT',
     })
+  })
+  it('evicts both identities so a replaced empty dir loses its listing', async () => {
+    await mkdir(join(root, 'src'))
+    await writeFile(join(root, 'src', 'f.txt'), 'x')
+    await mkdir(join(root, 'dst'))
+    const manager = new FakeManager()
+    await runWithCacheManager(manager, async () => {
+      await rename(accessor, spec('/src'), spec('/dst'))
+    })
+    expect(manager.unlinks).toEqual(['/src', '/dst'])
+    expect(manager.writes).toEqual([])
+    expect(await readFile(join(root, 'dst', 'f.txt'), 'utf-8')).toBe('x')
   })
 })

--- a/typescript/packages/node/src/core/disk/rename.ts
+++ b/typescript/packages/node/src/core/disk/rename.ts
@@ -14,12 +14,7 @@
 
 import type { DiskAccessor } from '../../accessor/disk.ts'
 import { rename as fsRename } from 'node:fs/promises'
-import {
-  enoent,
-  invalidateAfterUnlink,
-  invalidateAfterWrite,
-  type PathSpec,
-} from '@struktoai/mirage-core'
+import { enoent, invalidateAfterUnlink, type PathSpec } from '@struktoai/mirage-core'
 import { resolveSafe } from './utils.ts'
 
 export async function rename(accessor: DiskAccessor, src: PathSpec, dst: PathSpec): Promise<void> {
@@ -34,5 +29,7 @@ export async function rename(accessor: DiskAccessor, src: PathSpec, dst: PathSpe
     throw err
   }
   await invalidateAfterUnlink(src)
-  await invalidateAfterWrite(dst)
+  // The unlink flavor on dst: a rename destroys the destination's previous
+  // identity, so a replaced empty directory loses its cached listing too.
+  await invalidateAfterUnlink(dst)
 }

--- a/typescript/packages/node/src/core/gridfs/rename.ts
+++ b/typescript/packages/node/src/core/gridfs/rename.ts
@@ -12,12 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import {
-  enoent,
-  invalidateAfterUnlink,
-  invalidateAfterWrite,
-  type PathSpec,
-} from '@struktoai/mirage-core'
+import { enoent, invalidateAfterUnlink, type PathSpec } from '@struktoai/mirage-core'
 import type { GridFSAccessor } from '../../accessor/gridfs.ts'
 import { deleteAll, filesColl, gridfsKey, latestFile, rawPathOf } from './_client.ts'
 
@@ -36,6 +31,6 @@ export async function rename(
   await deleteAll(accessor, { filename: dstKey })
   const files = await filesColl(accessor)
   await files.updateMany({ filename: srcKey }, { $set: { filename: dstKey } })
-  await invalidateAfterWrite(dst)
+  await invalidateAfterUnlink(dst)
   await invalidateAfterUnlink(src)
 }

--- a/typescript/packages/node/src/core/nextcloud/rename.ts
+++ b/typescript/packages/node/src/core/nextcloud/rename.ts
@@ -1,9 +1,4 @@
-import {
-  enoent,
-  invalidateAfterUnlink,
-  invalidateAfterWrite,
-  type PathSpec,
-} from '@struktoai/mirage-core'
+import { enoent, invalidateAfterUnlink, type PathSpec } from '@struktoai/mirage-core'
 import type { NextcloudAccessor } from '../../accessor/nextcloud.ts'
 import { isNotFound, nextcloudKey } from './util.ts'
 
@@ -19,6 +14,6 @@ export async function rename(
     if (isNotFound(error)) throw enoent(source)
     throw error
   }
-  await invalidateAfterWrite(destination)
+  await invalidateAfterUnlink(destination)
   await invalidateAfterUnlink(source)
 }

--- a/typescript/packages/node/src/core/redis/rename.ts
+++ b/typescript/packages/node/src/core/redis/rename.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { type PathSpec, invalidateAfterUnlink, invalidateAfterWrite } from '@struktoai/mirage-core'
+import { type PathSpec, invalidateAfterUnlink } from '@struktoai/mirage-core'
 import type { RedisAccessor } from '../../accessor/redis.ts'
 import { norm, nowIso } from './utils.ts'
 import { checkDestParents } from './dest.ts'
@@ -36,7 +36,7 @@ export async function rename(accessor: RedisAccessor, src: PathSpec, dst: PathSp
     await store.setModified(d, mod ?? now)
     if (Object.keys(attrs).length > 0) await store.setAttrs(d, attrs)
     await invalidateAfterUnlink(s)
-    await invalidateAfterWrite(d)
+    await invalidateAfterUnlink(d)
     return
   }
   if (await store.hasDir(s)) {
@@ -64,7 +64,7 @@ export async function rename(accessor: RedisAccessor, src: PathSpec, dst: PathSp
       }
     }
     await invalidateAfterUnlink(s)
-    await invalidateAfterWrite(d)
+    await invalidateAfterUnlink(d)
     return
   }
   throw enoent(src)

--- a/typescript/packages/node/src/core/ssh/rename.ts
+++ b/typescript/packages/node/src/core/ssh/rename.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterUnlink, invalidateAfterWrite } from '@struktoai/mirage-core'
+import { invalidateAfterUnlink } from '@struktoai/mirage-core'
 import type { PathSpec } from '@struktoai/mirage-core'
 import { enoent } from '@struktoai/mirage-core'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
@@ -41,6 +41,8 @@ export async function rename(accessor: SSHAccessor, src: PathSpec, dst: PathSpec
       sftp.rename(remoteSrc, remoteDst, done)
     }
   })
-  await invalidateAfterWrite(dst)
+  // The unlink flavor on dst: a rename destroys the destination's previous
+  // identity, so a replaced empty directory loses its cached listing too.
+  await invalidateAfterUnlink(dst)
   await invalidateAfterUnlink(src)
 }


### PR DESCRIPTION
## Summary

Phase 0 PR-0e from the restructure audit: bugs 8 + 9 + doc gap G5 — plus a rename-invalidation bug class the new integ pin caught in four more backends.

**1. disk emits native separators on Windows (bug 8).** `du` built entry paths with `os.path.relpath` (backslash-joined on Windows) where the TS twin already normalizes with `.split(path.sep).join('/')`; fixed with `.replace(os.sep, "/")`. The audit missed a second site in the same backend: `find` used `str(dp.relative_to(root))` — `str()` of a `WindowsPath` backslash-joins too, which additionally breaks the `count("/")` depth math behind `-maxdepth`/`-mindepth`; fixed with `.as_posix()`. Python-only: TS `find` builds paths by `/` concatenation. Unit tests simulate Windows (patched `os.sep`/`os.path.relpath` for du; `PureWindowsPath` swapped into the module for find) since neither CI host runs Windows.

**2. databricks_volume recursive copy invalidated nothing (bug 9).** The `_copy_tree_sync` branch (reached via `mv` of a directory — `cp -r` walks per-file) returned without touching caches. It now evicts the destination's own listing (`invalidate_after_unlink` — a merge target can pre-exist), plus every ancestor listing (`invalidate_ancestors` — the Files API `create_directory` materializes missing parents, mirroring `mkdir(parents=True)`). Both twins.

**3. The rename bug class the new pin caught (grew out of bug 9).** The integ case moves a directory onto an existing *empty* directory — GNU `rename(2)` semantics the generic mv already implements, and its own empty-dir probe (`readdir(target)`) warms the index right before the backend rename runs. Pre-fix, four backends then served the stale empty listing: **disk**, **ssh**, **onedrive**, **sharepoint** (on the msgraph pair even `cat` ENOENTs, because reads resolve through the stale listing). Root cause is uniform: every backend `rename` invalidated dst with the *write* flavor, which evicts only the parent's listing. A rename destroys the destination's previous identity, so dst takes the *unlink* flavor (file cache + own listing + parent) — swept across all 13 python `rename.py` and the TS twins. Two of those twins don't live in a `rename.ts`: the msgraph pair invalidates in `onedrive/index.ts` / `sharepoint/index.ts`, and box's rename sits in `box/write.ts` — the box one was caught by this PR's own CI (`FAIL [box] mv_empty_dir_fresh_listing` on the typescript host) after a file-name-driven sweep missed it, which is the pin doing its job.

**4. `docs/python/resource/new.mdx` described the retired per-file ops layer (G5).** The file-structure sketch and the "Ops Layer" section showed hand-written `ops/<name>/read.py`-style forwards that 32/41 backends no longer have. Rewritten to the real shape: `ops/<name>/__init__.py` derives the family from the backend's `CommandIO` table via `make_generic_ops` (knobs like `mkdir_parents=True`), with a dedicated `@op` module only for irregular handlers (dify `grep`/`search` pattern), appended to the derived list.

**Deliberately not taken (follow-ups filed):** the same pin exposed two pre-existing backend rename-semantics bugs, distinct from the cache class and excluded from the case's targets until fixed:
- **dropbox**: `mv` onto an existing empty directory fails with `to/conflict/folder` 409 where GNU succeeds — its native move lacks the delete-empty-then-retry that msgraph's `renameReplace` implements.
- **s3 + gridfs** (both variants): renaming a *directory* is broken outright — their `rename` is a single-object copy+delete, so `mv <dir> <newname>` dies with `NoSuchKey` (s3) / `No such file or directory` (gridfs). Needs a recursive prefix move; K1-kit territory.

## Tests

- **py unit**: du/find Windows-separator simulations (discriminating: fail pre-fix on macOS), databricks recursive-copy invalidation, new `tests/core/disk/test_rename.py` pinning the unlink flavor on both sides; box rename mock updated to the new name. Full python suite green.
- **ts unit**: databricks `copy_rename.test.ts` invalidation case, disk `rename.test.ts` unlink-flavor case (fails pre-fix, verified by stash). Core 293 + node 244 for the swept areas green; `pnpm -r typecheck` clean.
- **integ**: new `integ/unix/mv/empty_dir.json` (7 cases, seq 613200–613206) — mkdir, seed, warm the destination listing, `mv` onto the empty dir, then pin the fresh listing, content readthrough, and source removal. Byte-oracled against GNU in docker (`debian:stable-slim`). Pre-fix it fails on disk/ssh/onedrive/sharepoint exactly as described; post-fix the full battery is green on every python-host target in the case's list run locally (databricks, databricks-prefix, ram, disk, redis, ssh, onedrive, sharepoint, gdrive, gdrive-folder, box, nextcloud) and on the TS host (databricks, databricks-prefix, disk, ram). opfs rides the TS-browser CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
