### PR TITLE
docs: fix the gws frontmatter parse error and gate it

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -79,3 +79,9 @@ jobs:
       # so new drift is blocked and a closed divergence has to be locked in.
       - name: Layout parity
         run: ./python/.venv/bin/python scripts/check_layout_parity.py --strict
+
+      # The docs build parses frontmatter as YAML and stops on the first page
+      # it cannot read, so an unquoted description holding ": " fails the
+      # deploy with no local signal at all.
+      - name: Docs frontmatter
+        run: ./python/.venv/bin/python scripts/check_docs_frontmatter.py

--- a/docs/python/cli/gws.mdx
+++ b/docs/python/cli/gws.mdx
@@ -1,6 +1,6 @@
 ---
 title: GWS
-description: Google Workspace API client: Discovery passthroughs plus ergonomic helpers.
+description: "Google Workspace API client: Discovery passthroughs plus ergonomic helpers."
 icon: google
 ---
 

--- a/docs/typescript/cli/gws.mdx
+++ b/docs/typescript/cli/gws.mdx
@@ -1,6 +1,6 @@
 ---
 title: GWS
-description: Google Workspace API client: Discovery passthroughs plus ergonomic helpers.
+description: "Google Workspace API client: Discovery passthroughs plus ergonomic helpers."
 icon: google
 ---
 

--- a/scripts/check_docs_frontmatter.py
+++ b/scripts/check_docs_frontmatter.py
@@ -1,0 +1,86 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs"
+FENCE = "---"
+
+
+def frontmatter(text: str) -> str | None:
+    """The raw YAML between the opening and closing ``---`` fences.
+
+    Args:
+        text (str): Full contents of an ``.mdx`` page.
+
+    Returns:
+        str | None: The fence body, or None when the page opens with no
+        fence or never closes the one it opened.
+    """
+    if not text.startswith(f"{FENCE}\n"):
+        return None
+    end = text.find(f"\n{FENCE}", len(FENCE))
+    if end == -1:
+        return None
+    return text[len(FENCE) + 1:end]
+
+
+def check(path: Path) -> str | None:
+    """Parse one page's frontmatter the way the docs builder does.
+
+    Args:
+        path (Path): Absolute path to an ``.mdx`` page.
+
+    Returns:
+        str | None: A one-line reason the page would fail the build, or
+        None when it parses as a mapping.
+    """
+    body = frontmatter(path.read_text())
+    if body is None:
+        return "no frontmatter block"
+    try:
+        parsed = yaml.safe_load(body)
+    except yaml.YAMLError as exc:
+        # An unquoted value holding ": " is the one that keeps recurring:
+        # YAML reads it as a nested mapping key and the build stops.
+        return str(exc).split("\n")[0].strip()
+    if not isinstance(parsed, dict):
+        return f"frontmatter is {type(parsed).__name__}, expected a mapping"
+    return None
+
+
+def main() -> int:
+    pages = sorted(DOCS.rglob("*.mdx"))
+    if not pages:
+        print(f"docs frontmatter check FAILED\n\nno .mdx pages under {DOCS}")
+        return 1
+
+    failures = [(p, reason) for p in pages if (reason := check(p)) is not None]
+    if failures:
+        print("docs frontmatter check FAILED\n")
+        for path, reason in failures:
+            print(f"{path.relative_to(ROOT)}: {reason}")
+        print(f"\n{len(failures)} page(s) the docs build cannot parse")
+        return 1
+
+    print(f"docs frontmatter OK: {len(pages)} pages parse")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`gws.mdx` set an unquoted `description` holding `": "`:

```yaml
description: Google Workspace API client: Discovery passthroughs plus ergonomic helpers.
```

YAML reads the colon-space as a nested mapping key, so the value parsed as a dict instead of a string and Mintlify stopped the whole deploy:

```
Failed to parse frontMatter content at path typescript/cli/gws.mdx:
incomplete explicit mapping pair; a key node is missed
Encountered syntax error(s). Deployment not updated
```

Quoting it fixes both pages.

## Scope

Rather than patch the two files the log named, I parsed the frontmatter of all 241 `.mdx` pages. Only those two are broken. I also checked the quieter variant, frontmatter that parses but yields the wrong type, and the only hits were the `keywords` flow sequences in `install.mdx`/`quickstart.mdx`, which are intentional lists.

## Why it reached the deploy

Nothing checked docs frontmatter in pre-commit or CI, so a one-character YAML mistake got through review and only surfaced as a failed deploy.

`scripts/check_docs_frontmatter.py` parses every page the way the docs build does and fails on any that would stop it. It runs as a workflow step beside `check_spec_parity.py` and `check_layout_parity.py`, matching how the other repo-root checks are wired.

## Verification

Checked both directions rather than only watching it pass. Flipping the fix back reproduces Mintlify's own wording:

```
docs frontmatter check FAILED

docs/python/cli/gws.mdx: mapping values are not allowed here

1 page(s) the docs build cannot parse
```

With the fix in place: `docs frontmatter OK: 241 pages parse`.

pre-commit passes on every changed file with no formatter rewrites left in the tree. `pyyaml` is already a declared dependency, so the CI venv has it. mypy is scoped to `packages = ["mirage"]`, so `scripts/` sits outside it, same as the existing check scripts. I did not run the full pytest suite or `pre-commit --all-files`: this touches no Python package source and no TypeScript.