### PR TITLE
docs(cli): quote every CLI page description

### DIFF
--- a/docs/python/cli/discord.mdx
+++ b/docs/python/cli/discord.mdx
@@ -1,6 +1,6 @@
 ---
 title: discord
-description: Discord REST API client speaking the OpenClaw Discord action vocabulary.
+description: "Discord REST API client speaking the OpenClaw Discord action vocabulary."
 icon: discord
 ---
 

--- a/docs/python/cli/gh.mdx
+++ b/docs/python/cli/gh.mdx
@@ -1,6 +1,6 @@
 ---
 title: gh
-description: Act on GitHub in the official CLI's vocabulary, alongside a github mount that reads the repository as files.
+description: "Act on GitHub in the official CLI's vocabulary, alongside a github mount that reads the repository as files."
 icon: github
 ---
 

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -1,6 +1,6 @@
 ---
 title: git
-description: Read and change a git repository that lives on any mount, in git's own vocabulary.
+description: "Read and change a git repository that lives on any mount, in git's own vocabulary."
 icon: git-alt
 ---
 

--- a/docs/python/cli/himalaya.mdx
+++ b/docs/python/cli/himalaya.mdx
@@ -1,6 +1,6 @@
 ---
 title: Himalaya
-description: IMAP/SMTP mail client following the pimalaya/himalaya vocabulary.
+description: "IMAP/SMTP mail client following the pimalaya/himalaya vocabulary."
 icon: envelope
 ---
 

--- a/docs/python/cli/index.mdx
+++ b/docs/python/cli/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLIs
-description: Install typed command-line programs beside your mounts and let agents act on services by name.
+description: "Install typed command-line programs beside your mounts and let agents act on services by name."
 icon: terminal
 ---
 

--- a/docs/python/cli/linear.mdx
+++ b/docs/python/cli/linear.mdx
@@ -1,6 +1,6 @@
 ---
 title: linear
-description: Linear GraphQL API client with the noun/verb grammar of the mount commands.
+description: "Linear GraphQL API client with the noun/verb grammar of the mount commands."
 icon: chart-gantt
 ---
 

--- a/docs/python/cli/ntn.mdx
+++ b/docs/python/cli/ntn.mdx
@@ -1,6 +1,6 @@
 ---
 title: ntn
-description: Notion API client following the official Notion CLI grammar.
+description: "Notion API client following the official Notion CLI grammar."
 icon: book
 ---
 

--- a/docs/python/cli/slack.mdx
+++ b/docs/python/cli/slack.mdx
@@ -1,6 +1,6 @@
 ---
 title: slack
-description: Slack Web API client speaking the OpenClaw Slack action vocabulary.
+description: "Slack Web API client speaking the OpenClaw Slack action vocabulary."
 icon: slack
 ---
 

--- a/docs/typescript/cli/discord.mdx
+++ b/docs/typescript/cli/discord.mdx
@@ -1,6 +1,6 @@
 ---
 title: discord
-description: Discord REST API client speaking the OpenClaw Discord action vocabulary.
+description: "Discord REST API client speaking the OpenClaw Discord action vocabulary."
 icon: discord
 ---
 

--- a/docs/typescript/cli/gh.mdx
+++ b/docs/typescript/cli/gh.mdx
@@ -1,6 +1,6 @@
 ---
 title: gh
-description: Act on GitHub in the official CLI's vocabulary, alongside a github mount that reads the repository as files.
+description: "Act on GitHub in the official CLI's vocabulary, alongside a github mount that reads the repository as files."
 icon: github
 ---
 

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -1,6 +1,6 @@
 ---
 title: git
-description: Read and change a git repository that lives on any mount, in git's own vocabulary.
+description: "Read and change a git repository that lives on any mount, in git's own vocabulary."
 icon: git-alt
 ---
 

--- a/docs/typescript/cli/himalaya.mdx
+++ b/docs/typescript/cli/himalaya.mdx
@@ -1,6 +1,6 @@
 ---
 title: Himalaya
-description: IMAP/SMTP mail client following the pimalaya/himalaya vocabulary.
+description: "IMAP/SMTP mail client following the pimalaya/himalaya vocabulary."
 icon: envelope
 ---
 

--- a/docs/typescript/cli/index.mdx
+++ b/docs/typescript/cli/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLIs
-description: Install typed command-line programs beside your mounts and let agents act on services by name from Node.
+description: "Install typed command-line programs beside your mounts and let agents act on services by name from Node."
 icon: terminal
 ---
 

--- a/docs/typescript/cli/linear.mdx
+++ b/docs/typescript/cli/linear.mdx
@@ -1,6 +1,6 @@
 ---
 title: linear
-description: Linear GraphQL API client with the noun/verb grammar of the mount commands.
+description: "Linear GraphQL API client with the noun/verb grammar of the mount commands."
 icon: chart-gantt
 ---
 

--- a/docs/typescript/cli/ntn.mdx
+++ b/docs/typescript/cli/ntn.mdx
@@ -1,6 +1,6 @@
 ---
 title: ntn
-description: Notion API client following the official Notion CLI grammar.
+description: "Notion API client following the official Notion CLI grammar."
 icon: book
 ---
 

--- a/docs/typescript/cli/slack.mdx
+++ b/docs/typescript/cli/slack.mdx
@@ -1,6 +1,6 @@
 ---
 title: slack
-description: Slack Web API client speaking the OpenClaw Slack action vocabulary.
+description: "Slack Web API client speaking the OpenClaw Slack action vocabulary."
 icon: slack
 ---
 


### PR DESCRIPTION
Follow-up to #803. The CLI sidebar icons from #801 are still not live, and this re-targets the pages so they publish.

## Why the icons never appeared

The icon names were never the problem. Mintlify deploys incrementally, over the `Updating targeted paths:` set, which is just the files a push changed. When #801's deploy hit the gws frontmatter error and reported `Deployment not updated`, it dropped **all sixteen** files in that commit, including the fourteen icon changes that had nothing wrong with them.

#803 then fixed gws, but it only changed the two gws files, so the green build republished those two alone. That is why GWS is the single page showing its new icon and its new capitalized title while the other eight still render `terminal`.

Confirmed against the live embedded nav on both trees:

| page | live | in main |
| --- | --- | --- |
| gws | `GWS` / `google` | matches |
| himalaya | `himalaya` / `terminal` | `Himalaya` / `envelope` |
| slack, discord, ntn, linear, gh, git | `terminal` | slack, discord, book, chart-gantt, github, git-alt |

`himalaya` is the clean discriminator: the site still serves the lowercase title #801 renamed.

## The change

Every CLI page description is now quoted. gws had been left as the only quoted one, which is exactly the shape that invites the next unquoted colon, so this is the same hardening applied uniformly rather than a whitespace nudge.

Scope is the fourteen stale pages plus the two `index.mdx` pages, so the rule holds for the whole directory. The index pages were already current; re-publishing them is a no-op.

## Verification

Parsed every page's frontmatter before and after and diffed the values: **0 semantic changes**, quoting only. No description contains a quote or backslash, so the double-quoted form is exact.

`check_docs_frontmatter.py` (added in #803) passes at 241 pages. pre-commit passes on all sixteen files with no formatter rewrites.

After merge the deploy should carry all nine distinct icons. Worth a look at the sidebar once it lands, and if anything is still stale a full redeploy from the Mintlify dashboard is the fallback.