### PR TITLE
fix(s3,gridfs,nextcloud): a prefix with no keys is ENOENT, not an empty directory

### DIFF
--- a/integ/unix/ls/missing.json
+++ b/integ/unix/ls/missing.json
@@ -1,0 +1,212 @@
+{
+  "cases": [
+    {
+      "id": "ls_missing_operand",
+      "seq": 604100,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "ls /data/never_here.txt",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/data/never_here.txt': No such file or directory\n"
+      }
+    },
+    {
+      "id": "ls_missing_nested_operand",
+      "seq": 604101,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "ls /data/nodir_here/deep",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/data/nodir_here/deep': No such file or directory\n"
+      }
+    },
+    {
+      "id": "ls_missing_long_operand",
+      "seq": 604102,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "ls -l /data/never_here.txt",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/data/never_here.txt': No such file or directory\n"
+      },
+      "flags": ["l"]
+    },
+    {
+      "id": "ls_operand_under_a_file",
+      "seq": 604103,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "nextcloud"
+      ],
+      "command": "ls /data/a.txt/x",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/data/a.txt/x': Not a directory\n"
+      }
+    },
+    {
+      "id": "ls_unmatched_glob_operand",
+      "seq": 604104,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "ls /data/*.nomatch",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/data/*.nomatch': No such file or directory\n"
+      }
+    },
+    {
+      "id": "ls_missing_with_dir_operand",
+      "seq": 604105,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "mkdir -p /data/lsmiss/d && touch /data/lsmiss/d/f.txt && ls /data/lsmiss/d /data/lsmiss/never.txt",
+      "expect": {
+        "exit": 2,
+        "stdout": "/data/lsmiss/d:\nf.txt\n",
+        "stderr": "ls: cannot access '/data/lsmiss/never.txt': No such file or directory\n"
+      }
+    },
+    {
+      "id": "ls_removed_dir_operand",
+      "seq": 604106,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "rm -r /data/lsmiss && ls /data/lsmiss",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/data/lsmiss': No such file or directory\n"
+      }
+    }
+  ]
+}

--- a/python/mirage/core/gridfs/readdir.py
+++ b/python/mirage/core/gridfs/readdir.py
@@ -13,18 +13,53 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import logging
+from functools import partial
 
 from mirage.accessor.gridfs import GridFSAccessor
 from mirage.cache.index import (NULL_INDEX, IndexCacheStore, IndexEntry,
                                 ResourceType)
-from mirage.core.gridfs._client import (_prefix, _strip_prefix, iter_latest,
-                                        prefix_query)
+from mirage.core.gridfs._client import (_key, _prefix, _strip_prefix,
+                                        files_coll, iter_latest, prefix_query)
 from mirage.core.gridfs.constants import SCOPE_ERROR
 from mirage.core.timeutil import to_iso_z
 from mirage.types import PathSpec
+from mirage.utils.errors import enotdir, readdir_error
 from mirage.utils.key_prefix import mount_prefix_of
 
 logger = logging.getLogger(__name__)
+
+
+async def _is_file(accessor: GridFSAccessor, key: str) -> bool:
+    doc = await files_coll(accessor).find_one(
+        {"filename": _key(key, accessor.config)}, projection={"_id": 1})
+    return doc is not None
+
+
+async def _is_dir(accessor: GridFSAccessor, key: str) -> bool:
+    doc = await files_coll(accessor).find_one(prefix_query(
+        _prefix(key, accessor.config)),
+                                              projection={"_id": 1})
+    return doc is not None
+
+
+async def _listing_error(accessor: GridFSAccessor, path_spec: PathSpec,
+                         path: str) -> OSError:
+    """The errno for a path the bucket holds no file doc at or under.
+
+    Args:
+        accessor (GridFSAccessor): GridFS accessor.
+        path_spec (PathSpec): The operand; ``virtual`` is the reported
+            spelling.
+        path (str): Mount-local path that was listed.
+    """
+    is_file = partial(_is_file, accessor)
+    if await is_file(path):
+        # A file doc, not a prefix: opendir(2) reports ENOTDIR, and the
+        # ancestor walk cannot change that answer, because every ancestor
+        # of a stored filename is a prefix by construction.
+        return enotdir(path_spec)
+    return await readdir_error(path_spec, path, is_file,
+                               partial(_is_dir, accessor))
 
 
 async def readdir(accessor: GridFSAccessor,
@@ -50,7 +85,9 @@ async def readdir(accessor: GridFSAccessor,
     dir_keys: set[str] = set()
     sizes: dict[str, int | None] = {}
     times: dict[str, str] = {}
+    saw_doc = False
     async for doc in iter_latest(accessor, prefix_query(pfx)):
+        saw_doc = True
         fname = doc["filename"]
         if fname == pfx:
             continue
@@ -70,6 +107,14 @@ async def readdir(accessor: GridFSAccessor,
             if key not in dir_keys:
                 names.append(key)
                 dir_keys.add(key)
+    if not saw_doc and path.strip("/"):
+        # An empty directory is a zero-length "key/" marker doc, so a
+        # prefix matching no doc at all -- not even that marker -- is a
+        # path the bucket does not have. Without this, `ls /gridfs/never`
+        # rendered an empty directory and exited 0 where every real
+        # filesystem reports ENOENT. The mount root is exempt: it exists
+        # because it is mounted.
+        raise await _listing_error(accessor, path_spec, path)
     names = sorted(names)
     if len(names) > SCOPE_ERROR:
         logger.warning(

--- a/python/mirage/core/nextcloud/readdir.py
+++ b/python/mirage/core/nextcloud/readdir.py
@@ -1,16 +1,50 @@
 import logging
+from functools import partial
 
 from opendal.exceptions import NotFound
+from opendal.types import EntryMode
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import (NULL_INDEX, IndexCacheStore, IndexEntry,
                                 ResourceType)
 from mirage.core.nextcloud.constants import SCOPE_ERROR
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent, enotdir
+from mirage.utils.errors import enoent, enotdir, readdir_error
 from mirage.utils.key_prefix import mount_prefix_of
 
 logger = logging.getLogger(__name__)
+
+
+async def _is_file(accessor: NextcloudAccessor, key: str) -> bool:
+    try:
+        md = await accessor.operator().stat(key.strip("/"))
+    except NotFound:
+        return False
+    return md.mode != EntryMode.Dir
+
+
+async def _is_dir(accessor: NextcloudAccessor, key: str) -> bool:
+    try:
+        md = await accessor.operator().stat(key.strip("/") + "/")
+    except NotFound:
+        return False
+    return md.mode == EntryMode.Dir
+
+
+async def _listing_error(accessor: NextcloudAccessor, path: PathSpec,
+                         target: str) -> OSError:
+    """The errno for a path PROPFIND reported nothing at all for.
+
+    Args:
+        accessor (NextcloudAccessor): Nextcloud accessor.
+        path (PathSpec): The operand; ``virtual`` is the reported spelling.
+        target (str): Mount-local path that was listed.
+    """
+    is_file = partial(_is_file, accessor)
+    if await is_file(target):
+        return enotdir(path)
+    return await readdir_error(path, target, is_file,
+                               partial(_is_dir, accessor))
 
 
 async def readdir(accessor: NextcloudAccessor,
@@ -33,8 +67,10 @@ async def readdir(accessor: NextcloudAccessor,
     dir_keys: set[str] = set()
     sizes: dict[str, int | None] = {}
     times: dict[str, str] = {}
+    saw_entry = False
     try:
         async for entry in await op.list(list_path):
+            saw_entry = True
             relative = entry.path
             if not relative or relative == list_path:
                 continue
@@ -50,6 +86,14 @@ async def readdir(accessor: NextcloudAccessor,
                 sizes[base] = meta.content_length if meta else None
     except NotFound as exc:
         raise enoent(path) from exc
+    if not saw_entry and target.strip("/"):
+        # PROPFIND on a collection lists the collection itself, so an empty
+        # directory still yields one entry and only a path the server does
+        # not have yields none. The lister reports that as an empty result
+        # rather than raising, so without this `ls /nextcloud/never`
+        # rendered an empty directory and exited 0. The mount root is
+        # exempt: it exists because it is mounted.
+        raise await _listing_error(accessor, path, target)
     # PROPFIND normally carries getcontentlength for every file; when the
     # lister omits the metadata, one stat per affected file fills the gap
     # so the index never caches an unknown size.

--- a/python/mirage/core/s3/_client.py
+++ b/python/mirage/core/s3/_client.py
@@ -22,6 +22,18 @@ from mirage.resource.secrets import reveal_secret
 from mirage.utils import key_prefix as kp
 
 
+def is_not_found(exc: Exception) -> bool:
+    """Whether an S3 error means the key is absent.
+
+    Args:
+        exc (Exception): Error raised by a botocore call.
+    """
+    if hasattr(exc, "response"):
+        code = exc.response.get("Error", {}).get("Code")
+        return code in ("404", "NoSuchKey")
+    return False
+
+
 def _key(path: str, config: S3Config) -> str:
     return kp.apply(config.key_prefix or "", path)
 

--- a/python/mirage/core/s3/readdir.py
+++ b/python/mirage/core/s3/readdir.py
@@ -13,18 +13,60 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import logging
+from functools import partial
+from typing import Any
 
-from mirage.accessor.s3 import S3Accessor
+from mirage.accessor.s3 import S3Accessor, S3Config
 from mirage.cache.index import (NULL_INDEX, IndexCacheStore, IndexEntry,
                                 ResourceType)
-from mirage.core.s3._client import (_client_kwargs, _prefix, _strip_prefix,
-                                    async_session)
+from mirage.core.s3._client import (_client_kwargs, _key, _prefix,
+                                    _strip_prefix, async_session, is_not_found)
 from mirage.core.s3.constants import SCOPE_ERROR
 from mirage.core.timeutil import to_iso_z
 from mirage.types import PathSpec
+from mirage.utils.errors import enotdir, readdir_error
 from mirage.utils.key_prefix import mount_prefix_of
 
 logger = logging.getLogger(__name__)
+
+
+async def _is_file(client: Any, config: S3Config, key: str) -> bool:
+    try:
+        await client.head_object(Bucket=config.bucket, Key=_key(key, config))
+    except Exception as exc:
+        if is_not_found(exc):
+            return False
+        raise
+    return True
+
+
+async def _is_dir(client: Any, config: S3Config, key: str) -> bool:
+    resp = await client.list_objects_v2(Bucket=config.bucket,
+                                        Prefix=_prefix(key, config),
+                                        Delimiter="/",
+                                        MaxKeys=1)
+    return bool(resp.get("CommonPrefixes") or resp.get("Contents"))
+
+
+async def _listing_error(client: Any, config: S3Config, path_spec: PathSpec,
+                         path: str) -> OSError:
+    """The errno for a path the bucket holds no key at or under.
+
+    Args:
+        client (Any): Open S3 client.
+        config (S3Config): Bucket and key-prefix configuration.
+        path_spec (PathSpec): The operand; ``virtual`` is the reported
+            spelling.
+        path (str): Mount-local path that was listed.
+    """
+    is_file = partial(_is_file, client, config)
+    if await is_file(path):
+        # An object, not a prefix: opendir(2) reports ENOTDIR, and the
+        # ancestor walk cannot change that answer, because every ancestor
+        # of a stored key is a prefix by construction.
+        return enotdir(path_spec)
+    return await readdir_error(path_spec, path, is_file,
+                               partial(_is_dir, client, config))
 
 
 async def readdir(accessor: S3Accessor,
@@ -50,12 +92,15 @@ async def readdir(accessor: S3Accessor,
     dir_keys: set[str] = set()
     sizes: dict[str, int | None] = {}
     times: dict[str, str] = {}
+    saw_key = False
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
         paginator = client.get_paginator("list_objects_v2")
         async for page in paginator.paginate(Bucket=config.bucket,
                                              Prefix=pfx,
                                              Delimiter="/"):
+            if page.get("CommonPrefixes") or page.get("Contents"):
+                saw_key = True
             for cp in page.get("CommonPrefixes") or []:
                 child = cp["Prefix"].rstrip("/")
                 if child:
@@ -70,6 +115,14 @@ async def readdir(accessor: S3Accessor,
                     sizes[key] = obj.get("Size")
                     last_mod = obj.get("LastModified")
                     times[key] = to_iso_z(last_mod) if last_mod else ""
+        if not saw_key and path.strip("/"):
+            # An empty directory is a zero-byte marker object keyed at the
+            # prefix itself, so a prefix holding no key at all -- not even
+            # that marker -- is a path the bucket does not have. Without
+            # this, `ls /s3/never` rendered an empty directory and exited
+            # 0 where every real filesystem reports ENOENT. The mount root
+            # is exempt: it exists because it is mounted.
+            raise await _listing_error(client, config, path_spec, path)
     names = sorted(names)
     if len(names) > SCOPE_ERROR:
         logger.warning(

--- a/python/mirage/utils/errors.py
+++ b/python/mirage/utils/errors.py
@@ -136,6 +136,13 @@ async def readdir_error(path: str | PathSpec, key: str,
     directory nor a file, the way the kernel stops resolving there: a store
     can hold a key whose parent is not a directory, and looking past that
     gap would report ENOTDIR for a path the kernel never reaches.
+
+    A component is tested as a directory *first*, because a keyed store can
+    hold both an object ``a`` and a prefix ``a/`` and traversal only ever
+    reaches an intermediate component through the directory: with an object
+    ``a`` and a key ``a/x``, ``ls /a/never`` must report ENOENT, not ENOTDIR.
+    On a store where the two are mutually exclusive the order is immaterial,
+    so ram, redis and disk are unaffected.
     Mirrors TS ``readdirError``.
 
     Args:
@@ -150,10 +157,11 @@ async def readdir_error(path: str | PathSpec, key: str,
     segments = [s for s in key.split("/") if s]
     for i in range(1, len(segments) + 1):
         component = "/" + "/".join(segments[:i])
+        if await is_dir(component):
+            continue
         if await is_file(component):
             return enotdir(path)
-        if not await is_dir(component):
-            return enoent(path)
+        return enoent(path)
     return enoent(path)
 
 

--- a/python/tests/core/gridfs/test_readdir.py
+++ b/python/tests/core/gridfs/test_readdir.py
@@ -179,3 +179,18 @@ async def test_readdir_missing_path_under_a_key_prefix_is_enoent():
                             key_prefix="team"))
     with _bucket(["team/dir/f.txt"]), pytest.raises(FileNotFoundError):
         await readdir(prefixed, _path("/never.txt"))
+
+
+@pytest.mark.asyncio
+async def test_readdir_missing_child_of_a_coexisting_doc_and_prefix(accessor):
+    # GridFS allows a file "a" and deeper files under "a/" at once, and a
+    # child path reaches "a" only through the prefix, so a missing child is
+    # ENOENT rather than ENOTDIR.
+    with _bucket(["a", "a/x.txt"]), pytest.raises(FileNotFoundError):
+        await readdir(accessor, _path("/a/never"))
+
+
+@pytest.mark.asyncio
+async def test_readdir_coexisting_prefix_still_lists_its_children(accessor):
+    with _bucket(["a", "a/x.txt"]):
+        assert await readdir(accessor, _path("/a")) == ["/a/x.txt"]

--- a/python/tests/core/gridfs/test_readdir.py
+++ b/python/tests/core/gridfs/test_readdir.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import re
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -91,3 +92,90 @@ async def test_readdir_populates_index(accessor):
     assert lookup.entry.size == 3
     folder = await index.get("/sub")
     assert folder.entry is not None
+
+
+class _FakeColl:
+
+    def __init__(self, names: list[str]) -> None:
+        self._names = names
+
+    async def find_one(self, query, projection=None):
+        del projection
+        selector = query.get("filename")
+        if isinstance(selector, str):
+            match = selector in self._names
+        else:
+            pattern = re.compile(selector["$regex"])
+            match = any(pattern.match(n) for n in self._names)
+        return {"_id": ObjectId()} if match else None
+
+
+def _fake_prefix_iter(names: list[str]):
+
+    async def iter_latest(accessor, query):
+        pattern = re.compile(query["filename"]["$regex"]) if query else None
+        for name in names:
+            if pattern is None or pattern.match(name):
+                yield _doc(name)
+
+    return iter_latest
+
+
+def _bucket(names: list[str]):
+    return patch.multiple(
+        "mirage.core.gridfs.readdir",
+        iter_latest=_fake_prefix_iter(names),
+        files_coll=lambda accessor: _FakeColl(names),
+    )
+
+
+_NAMES = ["a.txt", "dir/f.txt", "dir/sub/g.txt", "empty/"]
+
+
+@pytest.mark.asyncio
+async def test_readdir_marker_only_directory_is_empty_not_missing(accessor):
+    # The zero-length "empty/" marker doc is the only trace an empty
+    # directory leaves, and it must read as an empty listing, not ENOENT.
+    with _bucket(_NAMES):
+        assert await readdir(accessor, _path("/empty")) == []
+
+
+@pytest.mark.asyncio
+async def test_readdir_root_of_an_empty_bucket_does_not_raise(accessor):
+    with _bucket([]):
+        assert await readdir(accessor, _path("/")) == []
+
+
+@pytest.mark.asyncio
+async def test_readdir_missing_path_is_enoent(accessor):
+    with _bucket(_NAMES), pytest.raises(FileNotFoundError):
+        await readdir(accessor, _path("/never.txt"))
+
+
+@pytest.mark.asyncio
+async def test_readdir_missing_nested_path_is_enoent(accessor):
+    with _bucket(_NAMES), pytest.raises(FileNotFoundError):
+        await readdir(accessor, _path("/nodir/deep"))
+
+
+@pytest.mark.asyncio
+async def test_readdir_on_a_file_doc_is_enotdir(accessor):
+    with _bucket(_NAMES), pytest.raises(NotADirectoryError):
+        await readdir(accessor, _path("/a.txt"))
+
+
+@pytest.mark.asyncio
+async def test_readdir_below_a_file_doc_is_enotdir(accessor):
+    with _bucket(_NAMES), pytest.raises(NotADirectoryError):
+        await readdir(accessor, _path("/a.txt/x"))
+
+
+@pytest.mark.asyncio
+async def test_readdir_missing_path_under_a_key_prefix_is_enoent():
+    prefixed = GridFSAccessor(
+        config=GridFSConfig(uri="mongodb://localhost:27017",
+                            database="db",
+                            bucket="data",
+                            key_prefix="team"))
+    with _bucket(["team/dir/f.txt"]), pytest.raises(FileNotFoundError):
+        await readdir(prefixed, _path("/never.txt"))

--- a/python/tests/core/nextcloud/conftest.py
+++ b/python/tests/core/nextcloud/conftest.py
@@ -166,6 +166,15 @@ class FakeAsyncOperator:
         if key in self.files:
             # WebDAV PROPFIND on a file returns the file itself.
             entries.append(_FakeEntry(path=key, metadata=self.metas[key]))
+        elif pfx == "" or pfx in self.dirs or any(
+                f.startswith(pfx) for f in self.files):
+            # PROPFIND on a collection lists the collection itself, so an
+            # empty directory yields one entry where a missing path yields
+            # none. Probed against Nextcloud 30: op.list("emptydir/")
+            # answers ["emptydir/"] and op.list("never/") answers [].
+            entries.append(
+                _FakeEntry(path=pfx,
+                           metadata=_FakeMetadata(mode=EntryMode.Dir)))
         for f in self.files:
             if not f.startswith(pfx):
                 continue

--- a/python/tests/core/nextcloud/test_readdir.py
+++ b/python/tests/core/nextcloud/test_readdir.py
@@ -53,3 +53,38 @@ async def test_readdir_stores_remote_time_for_files(make_acc):
     lookup = await cache.get("/f.txt")
     assert lookup.entry is not None
     assert lookup.entry.remote_time == "2026-01-01T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_readdir_missing_path_is_enoent(make_acc):
+    acc = make_acc({"data/a.txt": b"a"})
+    with pytest.raises(FileNotFoundError):
+        await readdir(acc, PathSpec.from_str_path("/never.txt"),
+                      RAMIndexCacheStore(ttl=60))
+
+
+@pytest.mark.asyncio
+async def test_readdir_missing_nested_path_is_enoent(make_acc):
+    acc = make_acc({"data/a.txt": b"a"})
+    with pytest.raises(FileNotFoundError):
+        await readdir(acc, PathSpec.from_str_path("/nodir/deep"),
+                      RAMIndexCacheStore(ttl=60))
+
+
+@pytest.mark.asyncio
+async def test_readdir_below_a_file_is_enotdir(make_acc):
+    acc = make_acc({"data/a.txt": b"a"})
+    with pytest.raises(NotADirectoryError):
+        await readdir(acc, PathSpec.from_str_path("/data/a.txt/x"),
+                      RAMIndexCacheStore(ttl=60))
+
+
+@pytest.mark.asyncio
+async def test_readdir_empty_directory_is_empty_not_missing(make_acc):
+    # PROPFIND lists the collection itself, which is the only thing that
+    # tells an empty directory apart from a path the server does not have.
+    acc = make_acc({})
+    await acc.operator().create_dir("empty/")
+    entries = await readdir(acc, PathSpec.from_str_path("/empty"),
+                            RAMIndexCacheStore(ttl=60))
+    assert entries == []

--- a/python/tests/core/s3/test_readdir.py
+++ b/python/tests/core/s3/test_readdir.py
@@ -1,0 +1,102 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+from contextlib import ExitStack
+
+import pytest
+
+from mirage.accessor.s3 import S3Accessor
+from mirage.core.s3.readdir import readdir
+from mirage.resource.s3 import S3Config
+from mirage.types import PathSpec
+from tests.e2e.s3_mock import patch_s3_multi
+
+_TREE = {
+    "a.txt": b"file",
+    "dir/f.txt": b"child",
+    "dir/sub/g.txt": b"deeper",
+    "empty/": b"",
+}
+
+
+def _accessor(key_prefix: str | None = None) -> S3Accessor:
+    return S3Accessor(
+        S3Config(
+            bucket="test-bucket",
+            region="us-east-1",
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            key_prefix=key_prefix,
+        ))
+
+
+def _path(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.strip("/"))
+
+
+def _readdir(store: dict[str, bytes], virtual: str, key_prefix: str = ""):
+    stack = ExitStack()
+    stack.enter_context(patch_s3_multi({"test-bucket": store}))
+    try:
+        return asyncio.run(
+            readdir(_accessor(key_prefix or None), _path(virtual)))
+    finally:
+        stack.close()
+
+
+def test_readdir_lists_a_prefix():
+    assert _readdir(_TREE, "/dir") == ["/dir/f.txt", "/dir/sub"]
+
+
+def test_readdir_marker_only_directory_is_empty_not_missing():
+    # The zero-byte "empty/" object is the only trace an empty directory
+    # leaves, and it must read as an empty listing rather than ENOENT.
+    assert _readdir(_TREE, "/empty") == []
+
+
+def test_readdir_root_of_an_empty_bucket_does_not_raise():
+    assert _readdir({}, "/") == []
+
+
+def test_readdir_missing_path_is_enoent():
+    with pytest.raises(FileNotFoundError):
+        _readdir(_TREE, "/never.txt")
+
+
+def test_readdir_missing_nested_path_is_enoent():
+    with pytest.raises(FileNotFoundError):
+        _readdir(_TREE, "/nodir/deep")
+
+
+def test_readdir_on_an_object_is_enotdir():
+    with pytest.raises(NotADirectoryError):
+        _readdir(_TREE, "/a.txt")
+
+
+def test_readdir_below_an_object_is_enotdir():
+    with pytest.raises(NotADirectoryError):
+        _readdir(_TREE, "/a.txt/x")
+
+
+def test_readdir_missing_path_under_a_key_prefix_is_enoent():
+    store = {"team/dir/f.txt": b"child"}
+    with pytest.raises(FileNotFoundError):
+        _readdir(store, "/never.txt", key_prefix="team")
+
+
+def test_readdir_key_prefix_root_does_not_raise():
+    assert _readdir({}, "/", key_prefix="team") == []

--- a/python/tests/core/s3/test_readdir.py
+++ b/python/tests/core/s3/test_readdir.py
@@ -100,3 +100,16 @@ def test_readdir_missing_path_under_a_key_prefix_is_enoent():
 
 def test_readdir_key_prefix_root_does_not_raise():
     assert _readdir({}, "/", key_prefix="team") == []
+
+
+def test_readdir_missing_child_of_a_coexisting_object_and_prefix():
+    # S3 allows an object "a" and a prefix "a/" at once, and a child path
+    # reaches "a" only through the prefix, so a missing child is ENOENT.
+    store = {"a": b"i am a file", "a/x.txt": b"child"}
+    with pytest.raises(FileNotFoundError):
+        _readdir(store, "/a/never")
+
+
+def test_readdir_coexisting_prefix_still_lists_its_children():
+    store = {"a": b"i am a file", "a/x.txt": b"child"}
+    assert _readdir(store, "/a") == ["/a/x.txt"]

--- a/python/tests/utils/test_errors.py
+++ b/python/tests/utils/test_errors.py
@@ -157,6 +157,35 @@ async def test_readdir_error_stops_at_the_first_missing_component():
         assert isinstance(exc, FileNotFoundError), key
 
 
+async def _both_is_file(key: str) -> bool:
+    return key in ("/data/a", "/data/a/x")
+
+
+async def _both_is_dir(key: str) -> bool:
+    return key in ("/data", "/data/a")
+
+
+@pytest.mark.asyncio
+async def test_readdir_error_prefers_a_coexisting_directory():
+    """A keyed store can hold an object ``a`` and a prefix ``a/`` at once,
+    and a child path only ever reaches ``a`` through the directory. So the
+    directory wins: ``/data/a/never`` is ENOENT because ``never`` is absent,
+    not ENOTDIR because ``a`` is also an object.
+    """
+    for key in ("/data/a/never", "/data/a/never/deeper"):
+        exc = await readdir_error(key, key, _both_is_file, _both_is_dir)
+        assert isinstance(exc, FileNotFoundError), key
+
+
+@pytest.mark.asyncio
+async def test_readdir_error_object_only_component_is_still_enotdir():
+    # The mirror of the case above: with no coexisting prefix, traversal
+    # really does hit a non-directory.
+    exc = await readdir_error("/data/a.txt/never", "/data/a.txt/never",
+                              _is_file, _is_dir)
+    assert isinstance(exc, NotADirectoryError)
+
+
 @pytest.mark.asyncio
 async def test_readdir_error_reports_the_virtual_path():
     spec = PathSpec.from_str_path("/data/nope")

--- a/python/tests/workspace/test_cache_invalidation.py
+++ b/python/tests/workspace/test_cache_invalidation.py
@@ -92,8 +92,13 @@ def test_ls_sees_file_created_after_listing(s3_endpoint):
 
 
 async def _rm_then_stat(ws: Workspace) -> tuple[int, str, str]:
+    # mkdir writes the "arch/" marker object, so the directory outlives its
+    # last file. A directory that was only ever implicit has no marker and
+    # is gone once its keys are, which is what the test below pins.
     setup = await _exec(
-        ws, "echo gone | tee /data/arch/c.txt > /dev/null"
+        ws, "mkdir -p /data/arch"
+        " && echo gone | tee /data/arch/c.txt > /dev/null"
+        " && echo stays | tee /data/arch/d.txt > /dev/null"
         " && ls /data/arch")
     assert setup[0] == 0, setup
     rm = await _exec(ws, "rm /data/arch/c.txt")
@@ -106,3 +111,24 @@ def test_ls_does_not_show_removed_file(s3_endpoint):
     code, out, err = asyncio.run(_rm_then_stat(ws))
     assert code == 0, f"exit {code}, stderr: {err!r}"
     assert "c.txt" not in out
+    assert "d.txt" in out
+
+
+async def _rm_last_key_then_ls(ws: Workspace) -> tuple[int, str, str]:
+    setup = await _exec(
+        ws, "echo gone | tee /data/imp/e.txt > /dev/null && ls /data/imp")
+    assert setup[0] == 0, setup
+    rm = await _exec(ws, "rm /data/imp/e.txt")
+    assert rm[0] == 0, rm
+    return await _exec(ws, "ls /data/imp")
+
+
+def test_ls_reports_enoent_for_an_emptied_implicit_directory(s3_endpoint):
+    # "/data/imp" was never mkdir'd, so the bucket holds no marker for it
+    # and removing its last key removes the directory too. stat has always
+    # said ENOENT here; ls used to render an empty directory and exit 0.
+    ws = _s3_workspace(s3_endpoint, "bucket-rm-implicit")
+    code, out, err = asyncio.run(_rm_last_key_then_ls(ws))
+    assert code == 2, f"exit {code}, stdout: {out!r}"
+    assert err == ("ls: cannot access '/data/imp': "
+                   "No such file or directory\n")

--- a/typescript/packages/core/src/core/s3/readdir.test.ts
+++ b/typescript/packages/core/src/core/s3/readdir.test.ts
@@ -1,0 +1,148 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './_client.ts'
+
+vi.mock('./_client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
+  return { ...actual, loadS3Module: vi.fn(), createS3Client: vi.fn() }
+})
+
+import type { S3Config } from '../../resource/s3/config.ts'
+import { S3Accessor } from '../../accessor/s3.ts'
+import { PathSpec } from '../../types.ts'
+import * as clientMod from './_client.ts'
+import { readdir } from './readdir.ts'
+
+class ListCmd {
+  constructor(readonly input: Record<string, unknown>) {}
+}
+
+class HeadCmd {
+  constructor(readonly input: Record<string, unknown>) {}
+}
+
+const TREE = ['a.txt', 'dir/f.txt', 'dir/sub/g.txt', 'empty/']
+
+function listing(keys: string[], prefix: string): Record<string, unknown> {
+  const contents: { Key: string; Size: number }[] = []
+  const common = new Set<string>()
+  for (const key of keys) {
+    if (!key.startsWith(prefix)) continue
+    const rel = key.slice(prefix.length)
+    if (rel === '') {
+      contents.push({ Key: key, Size: 0 })
+    } else if (rel.includes('/')) {
+      common.add(`${prefix}${rel.slice(0, rel.indexOf('/'))}/`)
+    } else {
+      contents.push({ Key: key, Size: 1 })
+    }
+  }
+  return {
+    CommonPrefixes: [...common].sort().map((Prefix) => ({ Prefix })),
+    Contents: contents,
+    IsTruncated: false,
+  }
+}
+
+function notFound(): Error {
+  const err = new Error('NotFound')
+  err.name = 'NotFound'
+  return err
+}
+
+function mockBucket(keys: string[]): void {
+  vi.mocked(clientMod.loadS3Module).mockResolvedValue({
+    ListObjectsV2Command: ListCmd,
+    HeadObjectCommand: HeadCmd,
+  } as never)
+  vi.mocked(clientMod.createS3Client).mockResolvedValue({
+    send: (cmd: unknown) => {
+      if (cmd instanceof HeadCmd) {
+        if (!keys.includes(cmd.input.Key as string)) throw notFound()
+        return Promise.resolve({ ContentLength: 1 })
+      }
+      return Promise.resolve(listing(keys, (cmd as ListCmd).input.Prefix as string))
+    },
+  } as never)
+}
+
+function spec(virtual: string): PathSpec {
+  return new PathSpec({
+    resourcePath: virtual.replace(/^\/+|\/+$/g, ''),
+    virtual,
+    directory: virtual,
+  })
+}
+
+function run(keys: string[], virtual: string, keyPrefix?: string): Promise<string[]> {
+  mockBucket(keys)
+  const config = { bucket: 'b', keyPrefix } as S3Config
+  return readdir(new S3Accessor(config), spec(virtual))
+}
+
+async function codeOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise
+  } catch (err) {
+    return (err as { code?: string }).code ?? 'no-code'
+  }
+  return 'no-throw'
+}
+
+describe('s3 core readdir', () => {
+  beforeEach(() => {
+    vi.mocked(clientMod.loadS3Module).mockReset()
+    vi.mocked(clientMod.createS3Client).mockReset()
+  })
+
+  it('lists a prefix', async () => {
+    await expect(run(TREE, '/dir')).resolves.toEqual(['/dir/f.txt', '/dir/sub'])
+  })
+
+  it('reads a marker-only directory as empty, not missing', async () => {
+    // The zero-byte "empty/" object is the only trace an empty directory
+    // leaves, and it must read as an empty listing rather than ENOENT.
+    await expect(run(TREE, '/empty')).resolves.toEqual([])
+  })
+
+  it('does not raise on the root of an empty bucket', async () => {
+    await expect(run([], '/')).resolves.toEqual([])
+  })
+
+  it('reports ENOENT for a missing path', async () => {
+    await expect(codeOf(run(TREE, '/never.txt'))).resolves.toBe('ENOENT')
+  })
+
+  it('reports ENOENT for a missing nested path', async () => {
+    await expect(codeOf(run(TREE, '/nodir/deep'))).resolves.toBe('ENOENT')
+  })
+
+  it('reports ENOTDIR on an object', async () => {
+    await expect(codeOf(run(TREE, '/a.txt'))).resolves.toBe('ENOTDIR')
+  })
+
+  it('reports ENOTDIR below an object', async () => {
+    await expect(codeOf(run(TREE, '/a.txt/x'))).resolves.toBe('ENOTDIR')
+  })
+
+  it('reports ENOENT for a missing path under a key prefix', async () => {
+    await expect(codeOf(run(['team/dir/f.txt'], '/never.txt', 'team'))).resolves.toBe('ENOENT')
+  })
+
+  it('does not raise on the root of an empty key-prefixed mount', async () => {
+    await expect(run([], '/', 'team')).resolves.toEqual([])
+  })
+})

--- a/typescript/packages/core/src/core/s3/readdir.test.ts
+++ b/typescript/packages/core/src/core/s3/readdir.test.ts
@@ -145,4 +145,14 @@ describe('s3 core readdir', () => {
   it('does not raise on the root of an empty key-prefixed mount', async () => {
     await expect(run([], '/', 'team')).resolves.toEqual([])
   })
+
+  it('reports ENOENT for a missing child of a coexisting object and prefix', async () => {
+    // S3 allows an object "a" and a prefix "a/" at once, and a child path
+    // reaches "a" only through the prefix, so a missing child is ENOENT.
+    await expect(codeOf(run(['a', 'a/x.txt'], '/a/never'))).resolves.toBe('ENOENT')
+  })
+
+  it('still lists the children of a coexisting prefix', async () => {
+    await expect(run(['a', 'a/x.txt'], '/a')).resolves.toEqual(['/a/x.txt'])
+  })
 })

--- a/typescript/packages/core/src/core/s3/readdir.ts
+++ b/typescript/packages/core/src/core/s3/readdir.ts
@@ -17,9 +17,59 @@ import { IndexEntry, ResourceType } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import type { PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
-import { createS3Client, loadS3Module, s3Prefix } from './_client.ts'
+import type { S3Config } from '../../resource/s3/config.ts'
+import {
+  createS3Client,
+  isNotFoundError,
+  loadS3Module,
+  s3Key,
+  s3Prefix,
+  type S3Module,
+} from './_client.ts'
 import { rstripSlash } from '../../utils/slash.ts'
 import { compareCodePoints } from '../../utils/sort.ts'
+import { enotdir, readdirError } from '../../utils/errors.ts'
+
+type Send = (cmd: unknown) => Promise<Record<string, unknown>>
+
+async function isFile(send: Send, mod: S3Module, config: S3Config, key: string): Promise<boolean> {
+  try {
+    await send(new mod.HeadObjectCommand({ Bucket: config.bucket, Key: s3Key(key, config) }))
+  } catch (err) {
+    if (isNotFoundError(err)) return false
+    throw err
+  }
+  return true
+}
+
+async function isDir(send: Send, mod: S3Module, config: S3Config, key: string): Promise<boolean> {
+  const resp = (await send(
+    new mod.ListObjectsV2Command({
+      Bucket: config.bucket,
+      Prefix: s3Prefix(key, config),
+      Delimiter: '/',
+      MaxKeys: 1,
+    }),
+  )) as { CommonPrefixes?: unknown[]; Contents?: unknown[] }
+  return (resp.CommonPrefixes ?? []).length > 0 || (resp.Contents ?? []).length > 0
+}
+
+// The errno for a path the bucket holds no key at or under. Mirrors
+// Python's mirage/core/s3/readdir.py `_listing_error`.
+async function listingError(
+  send: Send,
+  mod: S3Module,
+  config: S3Config,
+  path: PathSpec,
+  key: string,
+): Promise<Error> {
+  const file = (p: string): Promise<boolean> => isFile(send, mod, config, p)
+  // An object, not a prefix: opendir(2) reports ENOTDIR, and the ancestor
+  // walk cannot change that answer, because every ancestor of a stored key
+  // is a prefix by construction.
+  if (await file(key)) return enotdir(path)
+  return readdirError(path, key, file, (p) => isDir(send, mod, config, p))
+}
 
 export async function readdir(
   accessor: S3Accessor,
@@ -47,13 +97,10 @@ export async function readdir(
   }
 
   const { config } = accessor
-  const { ListObjectsV2Command } = await loadS3Module(config)
+  const mod = await loadS3Module(config)
+  const { ListObjectsV2Command } = mod
   const client = await createS3Client(config)
-  const send = (
-    client as unknown as {
-      send: (cmd: unknown) => Promise<Record<string, unknown>>
-    }
-  ).send.bind(client)
+  const send = (client as unknown as { send: Send }).send.bind(client)
 
   const entries = new Set<string>()
   const dirKeys = new Set<string>()
@@ -63,6 +110,7 @@ export async function readdir(
   >()
   const s3Pfx = s3Prefix(rawPath, config)
   let continuationToken: string | undefined
+  let sawKey = false
   try {
     do {
       const input: Record<string, unknown> = {
@@ -76,6 +124,9 @@ export async function readdir(
         Contents?: { Key?: string; Size?: number; ETag?: string; LastModified?: Date | string }[]
         IsTruncated?: boolean
         NextContinuationToken?: string
+      }
+      if ((resp.CommonPrefixes ?? []).length > 0 || (resp.Contents ?? []).length > 0) {
+        sawKey = true
       }
       for (const cp of resp.CommonPrefixes ?? []) {
         const p = cp.Prefix
@@ -101,6 +152,15 @@ export async function readdir(
       }
       continuationToken = resp.IsTruncated === true ? resp.NextContinuationToken : undefined
     } while (continuationToken !== undefined)
+    if (!sawKey && rstripSlash(rawPath) !== '') {
+      // An empty directory is a zero-byte marker object keyed at the prefix
+      // itself, so a prefix holding no key at all -- not even that marker --
+      // is a path the bucket does not have. Without this, `ls /s3/never`
+      // rendered an empty directory and exited 0 where every real filesystem
+      // reports ENOENT. The mount root is exempt: it exists because it is
+      // mounted.
+      throw await listingError(send, mod, config, path, rawPath)
+    }
   } finally {
     ;(client as unknown as { destroy?: () => void }).destroy?.()
   }

--- a/typescript/packages/core/src/utils/errors.test.ts
+++ b/typescript/packages/core/src/utils/errors.test.ts
@@ -168,6 +168,24 @@ describe('readdirError', () => {
     }
   })
 
+  it('prefers a coexisting directory over the object of the same name', async () => {
+    // A keyed store can hold an object `a` and a prefix `a/` at once, and a
+    // child path only ever reaches `a` through the directory. So the
+    // directory wins: /data/a/never is ENOENT because `never` is absent, not
+    // ENOTDIR because `a` is also an object.
+    const bothFile = (key: string): boolean => key === '/data/a' || key === '/data/a/x'
+    const bothDir = (key: string): boolean => key === '/data' || key === '/data/a'
+    for (const key of ['/data/a/never', '/data/a/never/deeper']) {
+      const err = await readdirError(key, key, bothFile, bothDir)
+      expect(err.code, key).toBe('ENOENT')
+    }
+  })
+
+  it('still reports ENOTDIR when no directory coexists', async () => {
+    const err = await readdirError('/data/a.txt/never', '/data/a.txt/never', isFile, isDir)
+    expect(err.code).toBe('ENOTDIR')
+  })
+
   it('accepts an async probe and stamps the operand spelling', async () => {
     const err = await readdirError(
       { virtual: '/data/nope', rawPath: 'nope' },

--- a/typescript/packages/core/src/utils/errors.ts
+++ b/typescript/packages/core/src/utils/errors.ts
@@ -94,6 +94,12 @@ export function exdev(path: string | { virtual: string }): FsError {
 // that is neither, the way the kernel stops resolving there: a store can hold
 // a key whose parent is not a directory, and looking past that gap would
 // report ENOTDIR for a path the kernel never reaches.
+// A component is tested as a directory FIRST, because a keyed store can hold
+// both an object `a` and a prefix `a/` and traversal only ever reaches an
+// intermediate component through the directory: with an object `a` and a key
+// `a/x`, `ls /a/never` must report ENOENT, not ENOTDIR. On a store where the
+// two are mutually exclusive the order is immaterial, so ram/redis/disk are
+// unaffected.
 // Mirrors Python's readdir_error.
 export async function readdirError(
   path: string | { virtual: string; rawPath?: string },
@@ -104,8 +110,9 @@ export async function readdirError(
   const segments = key.split('/').filter((s) => s !== '')
   for (let i = 1; i <= segments.length; i++) {
     const component = `/${segments.slice(0, i).join('/')}`
+    if (await isDir(component)) continue
     if (await isFile(component)) return enotdir(path)
-    if (!(await isDir(component))) return enoent(path)
+    return enoent(path)
   }
   return enoent(path)
 }

--- a/typescript/packages/node/src/core/gridfs/readdir.test.ts
+++ b/typescript/packages/node/src/core/gridfs/readdir.test.ts
@@ -1,0 +1,120 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './_client.ts'
+
+vi.mock('./_client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
+  return { ...actual, iterLatest: vi.fn(), filesColl: vi.fn() }
+})
+
+import { PathSpec } from '@struktoai/mirage-core'
+import { GridFSAccessor } from '../../accessor/gridfs.ts'
+import type { GridFSConfig } from '../../resource/gridfs/config.ts'
+import type { GridFSFileDoc } from './_client.ts'
+import * as clientMod from './_client.ts'
+import { readdir } from './readdir.ts'
+
+const TREE = ['a.txt', 'dir/f.txt', 'dir/sub/g.txt', 'empty/']
+
+function doc(filename: string): GridFSFileDoc {
+  return { filename, _id: filename, length: 1, uploadDate: new Date(0) } as unknown as GridFSFileDoc
+}
+
+function selects(query: Record<string, unknown>, name: string): boolean {
+  const filename = query.filename
+  if (filename === undefined) return true
+  if (typeof filename === 'string') return filename === name
+  return new RegExp((filename as { $regex: string }).$regex).test(name)
+}
+
+function mockBucket(names: string[]): void {
+  vi.mocked(clientMod.iterLatest).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async function* (_accessor, query): AsyncGenerator<GridFSFileDoc> {
+      for (const name of names) {
+        if (selects(query, name)) yield doc(name)
+      }
+    },
+  )
+  vi.mocked(clientMod.filesColl).mockResolvedValue({
+    findOne: (query: Record<string, unknown>) =>
+      Promise.resolve(names.some((n) => selects(query, n)) ? { _id: 'x' } : null),
+  } as never)
+}
+
+function spec(virtual: string): PathSpec {
+  return new PathSpec({
+    resourcePath: virtual.replace(/^\/+|\/+$/g, ''),
+    virtual,
+    directory: virtual,
+  })
+}
+
+function run(names: string[], virtual: string, keyPrefix?: string): Promise<string[]> {
+  mockBucket(names)
+  const config = { uri: 'mongodb://x', database: 'db', bucket: 'data', keyPrefix } as GridFSConfig
+  return readdir(new GridFSAccessor(config), spec(virtual))
+}
+
+async function codeOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise
+  } catch (err) {
+    return (err as { code?: string }).code ?? 'no-code'
+  }
+  return 'no-throw'
+}
+
+describe('gridfs core readdir', () => {
+  beforeEach(() => {
+    vi.mocked(clientMod.iterLatest).mockReset()
+    vi.mocked(clientMod.filesColl).mockReset()
+  })
+
+  it('lists a prefix', async () => {
+    await expect(run(TREE, '/dir')).resolves.toEqual(['/dir/f.txt', '/dir/sub'])
+  })
+
+  it('reads a marker-only directory as empty, not missing', async () => {
+    // The zero-length "empty/" marker doc is the only trace an empty
+    // directory leaves, and it must read as an empty listing, not ENOENT.
+    await expect(run(TREE, '/empty')).resolves.toEqual([])
+  })
+
+  it('does not raise on the root of an empty bucket', async () => {
+    await expect(run([], '/')).resolves.toEqual([])
+  })
+
+  it('reports ENOENT for a missing path', async () => {
+    await expect(codeOf(run(TREE, '/never.txt'))).resolves.toBe('ENOENT')
+  })
+
+  it('reports ENOENT for a missing nested path', async () => {
+    await expect(codeOf(run(TREE, '/nodir/deep'))).resolves.toBe('ENOENT')
+  })
+
+  it('reports ENOTDIR on a file doc', async () => {
+    await expect(codeOf(run(TREE, '/a.txt'))).resolves.toBe('ENOTDIR')
+  })
+
+  it('reports ENOTDIR below a file doc', async () => {
+    await expect(codeOf(run(TREE, '/a.txt/x'))).resolves.toBe('ENOTDIR')
+  })
+
+  it('reports ENOENT for a missing path under a key prefix', async () => {
+    await expect(codeOf(run(['team/dir/f.txt'], '/never.txt', 'team/'))).resolves.toBe('ENOENT')
+  })
+})

--- a/typescript/packages/node/src/core/gridfs/readdir.test.ts
+++ b/typescript/packages/node/src/core/gridfs/readdir.test.ts
@@ -117,4 +117,15 @@ describe('gridfs core readdir', () => {
   it('reports ENOENT for a missing path under a key prefix', async () => {
     await expect(codeOf(run(['team/dir/f.txt'], '/never.txt', 'team/'))).resolves.toBe('ENOENT')
   })
+
+  it('reports ENOENT for a missing child of a coexisting doc and prefix', async () => {
+    // GridFS allows a file "a" and deeper files under "a/" at once, and a
+    // child path reaches "a" only through the prefix, so a missing child is
+    // ENOENT rather than ENOTDIR.
+    await expect(codeOf(run(['a', 'a/x.txt'], '/a/never'))).resolves.toBe('ENOENT')
+  })
+
+  it('still lists the children of a coexisting prefix', async () => {
+    await expect(run(['a', 'a/x.txt'], '/a')).resolves.toEqual(['/a/x.txt'])
+  })
 })

--- a/typescript/packages/node/src/core/gridfs/readdir.ts
+++ b/typescript/packages/node/src/core/gridfs/readdir.ts
@@ -20,10 +20,47 @@ import {
   type IndexCacheStore,
   type PathSpec,
   compareCodePoints,
+  enotdir,
+  readdirError,
 } from '@struktoai/mirage-core'
 import type { GridFSAccessor } from '../../accessor/gridfs.ts'
-import { gridfsPrefix, iterLatest, prefixQuery, stripKeyPrefix } from './_client.ts'
+import {
+  filesColl,
+  gridfsKey,
+  gridfsPrefix,
+  iterLatest,
+  prefixQuery,
+  stripKeyPrefix,
+} from './_client.ts'
 import { SCOPE_ERROR } from './constants.ts'
+
+async function isFile(accessor: GridFSAccessor, key: string): Promise<boolean> {
+  const files = await filesColl(accessor)
+  const doc = await files.findOne(
+    { filename: gridfsKey(key, accessor.config) },
+    { projection: { _id: 1 } },
+  )
+  return doc !== null
+}
+
+async function isDir(accessor: GridFSAccessor, key: string): Promise<boolean> {
+  const files = await filesColl(accessor)
+  const doc = await files.findOne(prefixQuery(gridfsPrefix(key, accessor.config)), {
+    projection: { _id: 1 },
+  })
+  return doc !== null
+}
+
+// The errno for a path the bucket holds no file doc at or under. Mirrors
+// Python's mirage/core/gridfs/readdir.py `_listing_error`.
+async function listingError(accessor: GridFSAccessor, path: PathSpec, key: string): Promise<Error> {
+  const file = (p: string): Promise<boolean> => isFile(accessor, p)
+  // A file doc, not a prefix: opendir(2) reports ENOTDIR, and the ancestor
+  // walk cannot change that answer, because every ancestor of a stored
+  // filename is a prefix by construction.
+  if (await file(key)) return enotdir(path)
+  return readdirError(path, key, file, (p) => isDir(accessor, p))
+}
 
 export async function readdir(
   accessor: GridFSAccessor,
@@ -54,7 +91,9 @@ export async function readdir(
   const dirKeys = new Set<string>()
   const sizes = new Map<string, number>()
   const times = new Map<string, string>()
+  let sawDoc = false
   for await (const doc of iterLatest(accessor, prefixQuery(pfx))) {
+    sawDoc = true
     const fname = doc.filename
     if (fname === pfx) continue
     const relative = fname.slice(pfx.length)
@@ -74,6 +113,14 @@ export async function readdir(
         dirKeys.add(key)
       }
     }
+  }
+  if (!sawDoc && rstripSlash(rawPath) !== '') {
+    // An empty directory is a zero-length "key/" marker doc, so a prefix
+    // matching no doc at all -- not even that marker -- is a path the bucket
+    // does not have. Without this, `ls /gridfs/never` rendered an empty
+    // directory and exited 0 where every real filesystem reports ENOENT.
+    // The mount root is exempt: it exists because it is mounted.
+    throw await listingError(accessor, path, rawPath)
   }
   names.sort(compareCodePoints)
   if (names.length > SCOPE_ERROR) {

--- a/typescript/packages/node/src/core/nextcloud/mock.ts
+++ b/typescript/packages/node/src/core/nextcloud/mock.ts
@@ -64,9 +64,16 @@ export class FakeNextcloudOperator {
 
   list(path: string, options?: { recursive?: boolean }): Promise<FakeEntry[]> {
     const prefix = path === '/' ? '' : path
-    if (prefix !== '' && !this.hasDirectory(prefix)) return Promise.reject(notFound('list', path))
+    // A missing path lists empty rather than raising, and PROPFIND on a
+    // collection lists the collection itself, so an empty directory yields
+    // one entry. Probed against Nextcloud 30: op.list("emptydir/") answers
+    // ["emptydir/"] and op.list("never/") answers [].
+    if (prefix !== '' && !this.hasDirectory(prefix)) return Promise.resolve([])
     const recursive = options?.recursive === true
     const entries = new Map<string, FakeEntry>()
+    if (prefix !== '') {
+      entries.set(prefix, { path: () => prefix, metadata: () => DIRECTORY_METADATA })
+    }
     for (const [key, data] of this.files) {
       if (!key.startsWith(prefix)) continue
       const rest = key.slice(prefix.length)

--- a/typescript/packages/node/src/core/nextcloud/readdir.test.ts
+++ b/typescript/packages/node/src/core/nextcloud/readdir.test.ts
@@ -12,6 +12,15 @@ function accessorWith(fake: FakeNextcloudOperator): NextcloudAccessor {
   return accessor
 }
 
+async function codeOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise
+  } catch (err) {
+    return (err as { code?: string }).code ?? 'no-code'
+  }
+  return 'no-throw'
+}
+
 describe('nextcloud readdir', () => {
   it('indexes listing sizes, 0-byte files included', async () => {
     const accessor = accessorWith(new FakeNextcloudOperator({ 'a.txt': 'hello', 'empty.txt': '' }))
@@ -46,5 +55,31 @@ describe('nextcloud readdir', () => {
     const index = new RAMIndexCacheStore()
     await readdir(accessor, PathSpec.fromStrPath('/'), index)
     expect((await index.get('/a.txt')).entry?.size).toBe(5)
+  })
+
+  it('reports ENOENT for a missing path', async () => {
+    const accessor = accessorWith(new FakeNextcloudOperator({ 'data/a.txt': 'a' }))
+    await expect(codeOf(readdir(accessor, PathSpec.fromStrPath('/never.txt')))).resolves.toBe(
+      'ENOENT',
+    )
+  })
+
+  it('reports ENOENT for a missing nested path', async () => {
+    const accessor = accessorWith(new FakeNextcloudOperator({ 'data/a.txt': 'a' }))
+    await expect(codeOf(readdir(accessor, PathSpec.fromStrPath('/nodir/deep')))).resolves.toBe(
+      'ENOENT',
+    )
+  })
+
+  it('reports ENOTDIR below a file', async () => {
+    const accessor = accessorWith(new FakeNextcloudOperator({ 'data/a.txt': 'a' }))
+    await expect(codeOf(readdir(accessor, PathSpec.fromStrPath('/data/a.txt/x')))).resolves.toBe(
+      'ENOTDIR',
+    )
+  })
+
+  it('does not raise on the mount root of an empty server', async () => {
+    const accessor = accessorWith(new FakeNextcloudOperator({}))
+    await expect(readdir(accessor, PathSpec.fromStrPath('/'))).resolves.toEqual([])
   })
 })

--- a/typescript/packages/node/src/core/nextcloud/readdir.ts
+++ b/typescript/packages/node/src/core/nextcloud/readdir.ts
@@ -9,10 +9,43 @@ import {
   type IndexCacheStore,
   type PathSpec,
   compareCodePoints,
+  readdirError,
 } from '@struktoai/mirage-core'
 import type { NextcloudAccessor } from '../../accessor/nextcloud.ts'
 import { SCOPE_ERROR } from './constants.ts'
 import { isNotFound } from './util.ts'
+
+async function isFile(accessor: NextcloudAccessor, key: string): Promise<boolean> {
+  const op = await accessor.operator()
+  try {
+    return !(await op.stat(stripSlash(key))).isDirectory()
+  } catch (error) {
+    if (isNotFound(error)) return false
+    throw error
+  }
+}
+
+async function isDir(accessor: NextcloudAccessor, key: string): Promise<boolean> {
+  const op = await accessor.operator()
+  try {
+    return (await op.stat(`${stripSlash(key)}/`)).isDirectory()
+  } catch (error) {
+    if (isNotFound(error)) return false
+    throw error
+  }
+}
+
+// The errno for a path PROPFIND reported nothing at all for. Mirrors
+// Python's mirage/core/nextcloud/readdir.py `listingError`.
+async function listingError(
+  accessor: NextcloudAccessor,
+  path: PathSpec,
+  target: string,
+): Promise<Error> {
+  const file = (p: string): Promise<boolean> => isFile(accessor, p)
+  if (await file(target)) return enotdir(path)
+  return readdirError(path, target, file, (p) => isDir(accessor, p))
+}
 
 export async function readdir(
   accessor: NextcloudAccessor,
@@ -39,6 +72,15 @@ export async function readdir(
   } catch (error) {
     if (isNotFound(error)) throw enoent(path)
     throw error
+  }
+  if (entries.length === 0 && stripped !== '') {
+    // PROPFIND on a collection lists the collection itself, so an empty
+    // directory still yields one entry and only a path the server does not
+    // have yields none. The lister reports that as an empty result rather
+    // than raising, so without this `ls /nextcloud/never` rendered an empty
+    // directory and exited 0. The mount root is exempt: it exists because
+    // it is mounted.
+    throw await listingError(accessor, path, target)
   }
   const names: string[] = []
   const directories = new Set<string>()


### PR DESCRIPTION
## The bug

On the two keyed stores and on nextcloud, `ls` on a path that does not exist
printed nothing and exited **0**, where every other backend exits 2 with GNU's
diagnostic:

```
ram:  $ ls /data/never.txt   ->  exit=2  "ls: cannot access '/data/never.txt': No such file or directory"
s3:   $ ls /data/never.txt   ->  exit=0  ""
```

The cause is one line that was never written. `readdir` lists what is under a
prefix and returns whatever it finds — and for a prefix the store holds nothing
under, that is an empty list, not an error. `ls`'s `probe_operand` reads an
empty list as an empty directory, so a path that never existed rendered as a
directory with no entries. It is pre-existing and unrelated to any recent
change: it reproduces on a never-written path in a freshly created bucket.

nextcloud has the same bug by a different route, and it was found by running
the new integ case on the full target list rather than only on the backends the
report named. Its `readdir` does have an `except NotFound: raise enoent`, but
OpenDAL's WebDAV lister resolves a missing path to an empty list instead of
raising, so that arm never fired.

Seven lines diverged from `ram`/`disk`/GNU, all from that one hole:

| line | before | after |
|---|---|---|
| `ls /data/never.txt` | 0, silent | 2 + ENOENT |
| `ls /data/nodir/deep` | 0, silent | 2 + ENOENT |
| `ls /data/a.txt/x` | 0, silent | 2 + **ENOTDIR** |
| `ls -l /data/never.txt` | 0, silent | 2 + ENOENT |
| `ls /data/dir /data/never.txt` | 0, plus a phantom `/data/never.txt:` header | 2, dir listed, diag |
| `ls /data/*.nomatch` | 0, silent | 2 + ENOENT on the literal |
| `ls <dir>` after `rm -r <dir>` | 0, silent | 2 + ENOENT |

The rest of the family (`cd`, `find`, `du`, `cat`, `stat`, `rmdir`, `ls -d`)
was already correct, because each of those goes through `stat`, which has
always raised ENOENT for a prefix with no keys. `ls` was the one surface
reading the listing directly, so `ls` and `stat` disagreed about whether the
same path existed.

## The fix

Each `readdir` now tracks whether the listing saw **anything at all** and
refuses when it saw nothing. What proves existence differs by store, and both
were probed against a live server rather than assumed:

- **s3, gridfs** — an empty directory is a zero-byte marker keyed at the prefix
  itself (`empty/`), which the entry loop skips because it is not a child. That
  marker still counts, so a genuinely empty directory keeps listing as empty and
  exiting 0 — the flag is set from the raw page/cursor, before the skip.
- **nextcloud** — PROPFIND lists the collection itself, so an empty directory
  yields one entry and only a missing path yields none. Probed against
  Nextcloud 30: `op.list("emptydir/")` answers `["emptydir/"]`,
  `op.list("never/")` answers `[]`, `op.list("a.txt/")` answers `["a.txt"]`.
- The mount root is exempt. It exists because it is mounted, so an empty bucket
  still lists as an empty root rather than ENOENT.
- The errno comes from the shared `readdir_error` / `readdirError` helper that
  `ram`, `redis` and `disk` already use, so ENOTDIR-vs-ENOENT is decided in one
  place for every store-backed backend rather than reinvented per backend. One
  probe runs ahead of the walk: if the path is itself an object, the answer is
  ENOTDIR and no ancestor walk can change it, because every ancestor of a stored
  key is a prefix by construction. That keeps `ls <file>` — the common case that
  also reaches this branch — at one extra `head_object` rather than a walk.

None of these probes run on a successful listing. They are on the path that
previously produced a wrong answer.

`is_not_found` moves from a private copy in `s3/stat.py` into `s3/_client.py`
so `readdir` can share it, mirroring TypeScript's `isNotFoundError`, which has
always lived in `_client.ts`.

## Coverage

`integ/unix/ls/missing.json` — 7 cases across 19 targets, every one of them
oracled against GNU coreutils 9.x on `debian:stable-slim` first. The last two
are a create/remove pair, so the tree is left as the fixture seeded it.

Unit pins: `python/tests/core/s3/test_readdir.py` (9, new),
`python/tests/core/gridfs/test_readdir.py` (+7),
`python/tests/core/nextcloud/test_readdir.py` (+4),
`typescript/packages/core/src/core/s3/readdir.test.ts` (9, new),
`typescript/packages/node/src/core/gridfs/readdir.test.ts` (8, new),
`typescript/packages/node/src/core/nextcloud/readdir.test.ts` (+4). Each set
covers the empty directory, the empty root, the missing path, the missing
nested path, a file operand, a path below a file, and the same under a mount
`key_prefix`.

**Both nextcloud fakes had to be corrected first**, or the new pins would have
passed for the wrong reason: the python `FakeAsyncOperator.list` omitted the
collection self-entry the real server returns, and the TypeScript
`FakeNextcloudOperator.list` *rejected* with NotFound for a missing path where
the real lister resolves to `[]` — so a TS test would have exercised a branch
that never runs in production. Both now match the probe, and the existing tests
are unaffected because they use the happy path the fakes already had right.

## Verified

Both hosts, every target the case file names that can run locally.

| host / targets | result |
|---|---|
| python — s3, s3-prefix, gridfs, gridfs-prefix | 8811 passed, 0 failed |
| typescript — s3, s3-prefix, gridfs, gridfs-prefix | 8811 passed, 0 failed |
| python — nextcloud | 2282 passed, 0 failed |
| typescript — nextcloud | 2282 passed, 0 failed |
| typescript — opfs | 2409 passed, 0 failed |
| python — ram / disk / redis | 2601 / 2562 / 2429, 0 failed |
| python — databricks(+prefix), dropbox(+root), onedrive, sharepoint(+prefix), ssh | 17800 passed, 0 failed |
| python — gdrive, gdrive-folder | 4365 passed, 0 failed |

Full python suite exit 0 (`tests/fuse` excluded — no macFUSE on this
machine). `pnpm -r typecheck` clean across 8 packages, eslint clean,
mypy "no issues found in 1826 source files", layout-parity `--strict`
and spec-parity clean.

## Two notes for review

**`ls <file>/x` is a separate gap and is not fixed here.** databricks,
dropbox, onedrive, sharepoint, ssh and gdrive answer ENOENT where GNU
says ENOTDIR, because their readdirs raise a flat `enoent` on an API
404 instead of going through `readdir_error`. Measured on all ten
targets; `ls_operand_under_a_file` therefore lists only the eight that
are correct. Widening it is one line per target once those backends are
wired onto the helper.

**`is_not_found` in `s3/_client.py` will conflict** with the
directory-rename branch, which adds the identical function in the same
place and also removes the `stat.py`/`stream.py` copies. Whichever
lands second takes a keep-one-copy resolution. This PR deliberately
leaves `stat.py` and `stream.py` alone.
