### PR TITLE
feat(integ): a restricted-token GitHub fake, gh api --jq, and notion retrieve-block

### DIFF
--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -1330,6 +1330,7 @@ jobs:
         run: |
           nohup ./python/.venv/bin/python integ/server/github_server.py \
             --port 5098 --repo integ/repo-cli=github/repo-v1 \
+            --no-create-repos \
             > /tmp/github.log 2>&1 &
           for i in $(seq 1 30); do grep -q "GITHUB_ENDPOINT=" /tmp/github.log && break; sleep 1; done
           cat /tmp/github.log

--- a/integ/cli/gh.json
+++ b/integ/cli/gh.json
@@ -178,7 +178,7 @@
       "command": "gh repo fork integ/repo-cli --fork-name forked",
       "expect": {
         "exit": 0,
-        "stdout": "\u2713 Created fork integ-user/forked\n",
+        "stdout": "✓ Created fork integ-user/forked\n",
         "stderr": ""
       }
     },
@@ -191,7 +191,7 @@
       "command": "gh repo rename renamed -R integ-user/forked",
       "expect": {
         "exit": 0,
-        "stdout": "\u2713 Renamed repository integ-user/renamed\n",
+        "stdout": "✓ Renamed repository integ-user/renamed\n",
         "stderr": ""
       }
     },
@@ -323,6 +323,19 @@
         "exit": 0,
         "stdout": "{\n  \"type\": \"file\",\n",
         "stderr": ""
+      }
+    },
+    {
+      "id": "gh_api_create_repo_is_refused_by_the_token",
+      "seq": 569026,
+      "targets": [
+        "cli-gh"
+      ],
+      "command": "gh api user/repos -f name=fresh-repo",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "gh api: Resource not accessible by personal access token\n"
       }
     }
   ]

--- a/integ/cli/gh.json
+++ b/integ/cli/gh.json
@@ -337,6 +337,45 @@
         "stdout": "",
         "stderr": "gh api: Resource not accessible by personal access token\n"
       }
+    },
+    {
+      "id": "gh_api_jq_prints_a_string_raw",
+      "seq": 569027,
+      "targets": [
+        "cli-gh"
+      ],
+      "command": "gh api repos/integ/repo-cli --jq .full_name",
+      "expect": {
+        "exit": 0,
+        "stdout": "integ/repo-cli\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gh_api_jq_compacts_non_strings_one_per_line",
+      "seq": 569028,
+      "targets": [
+        "cli-gh"
+      ],
+      "command": "gh api repos/integ/repo-cli --jq '{repo: .name}, .default_branch'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"repo\":\"repo-cli\"}\nmain\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gh_api_jq_prints_null_as_an_empty_line",
+      "seq": 569029,
+      "targets": [
+        "cli-gh"
+      ],
+      "command": "gh api repos/integ/repo-cli -q .description",
+      "expect": {
+        "exit": 0,
+        "stdout": "\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/gh.json
+++ b/integ/cli/gh.json
@@ -376,6 +376,19 @@
         "stdout": "\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "gh_api_jq_failure_still_expires_the_mount",
+      "seq": 569030,
+      "targets": [
+        "cli-gh"
+      ],
+      "command": "gh api repos/integ/repo-cli/contents/JQFAIL.md -X PUT -f message=x -f content=anEgZmFpbAo= --jq '.content |' 2>/dev/null; cat /repo/JQFAIL.md",
+      "expect": {
+        "exit": 0,
+        "stdout": "jq fail\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/ntn.json
+++ b/integ/cli/ntn.json
@@ -896,6 +896,58 @@
         "stdout": "",
         "stderr": "error: Public API request failed (404 Not Found object_not_found): Could not find data source with ID: 11111111-1111-1111-1111-111111111111. Make sure the relevant pages and databases are shared with your integration.\n  hint: Could not find a data source or database with ID `11111111-1111-1111-1111-111111111111`. Check that the ID or URL points to a data source or database shared with your integration.\n"
       }
+    },
+    {
+      "id": "ntn_api_block_retrieve",
+      "seq": 566069,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/blocks/dddd2222-3333-4444-5555-666677778888 | jq -r '.type, .has_children, .in_trash'",
+      "expect": {
+        "exit": 0,
+        "stdout": "bulleted_list_item\ntrue\nfalse\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_block_of_a_database",
+      "seq": 566070,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/blocks/eeee1111-2222-3333-4444-555566667777 | jq -r '.type, .child_database.title'",
+      "expect": {
+        "exit": 0,
+        "stdout": "child_database\nTasks\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_block_of_a_page",
+      "seq": 566071,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/blocks/aaaa1111-2222-3333-4444-555566667777 | jq -r '.type, .has_children, .child_page.title'",
+      "expect": {
+        "exit": 0,
+        "stdout": "child_page\ntrue\nProject Roadmap\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ntn_api_trashed_block_answers_with_the_flag",
+      "seq": 566072,
+      "targets": [
+        "cli-ntn"
+      ],
+      "command": "ntn api v1/blocks/ffff1111-2222-3333-4444-555566667777 | jq -r '.object, .type, .in_trash'",
+      "expect": {
+        "exit": 0,
+        "stdout": "block\nchild_page\ntrue\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/server/github_server.py
+++ b/integ/server/github_server.py
@@ -540,6 +540,13 @@ class FakeGitHub:
         self.login = DEFAULT_LOGIN
         # The command line's seed, kept so `POST /reset` can rebuild it.
         self.seed: tuple[list[str], list[str], list[str]] = ([], [], [])
+        # Whether this token may create a repository from nothing. A real
+        # fine-grained PAT without Administration:write may not, and a
+        # harness that restricts its agent to named repositories issues
+        # exactly that kind of token, so the fake has to be able to model
+        # one. Forking and renaming stay open: the restriction is on
+        # creating from nothing, not on a repository coming into existence.
+        self.create_repos = True
 
     def repo(self,
              owner: str,
@@ -681,10 +688,14 @@ class GitHubServer:
             request (web.Request): the incoming request.
 
         Returns:
-            web.Response: the created repository, or 422 if it exists.
+            web.Response: the created repository, 422 if it exists, or 403
+                if the token was issued without the scope.
         """
         if not self._authed(request):
             return _error(401, "Requires authentication")
+        if not self.state.create_repos:
+            return _error(403,
+                          "Resource not accessible by personal access token")
         body = await _json_body(request)
         name = str(body.get("name") or "").strip()
         if not name:
@@ -1857,8 +1868,9 @@ def seed_state(state: FakeGitHub, repos: list[str], metadata: list[str],
 
 
 async def _serve(port: int, repos: list[str], metadata: list[str],
-                 commits: list[str]) -> None:
+                 commits: list[str], create_repos: bool) -> None:
     state = FakeGitHub()
+    state.create_repos = create_repos
     state.seed = (repos, metadata, commits)
     seed_state(state, repos, metadata, commits)
     server = GitHubServer(state)
@@ -1893,8 +1905,16 @@ def main() -> None:
         default=[],
         help="owner/name=<JSON file of commits keyed by branch, each array "
         "oldest first>; repeatable")
+    parser.add_argument(
+        "--no-create-repos",
+        action="store_true",
+        help="refuse POST /user/repos with 403, the way a fine-grained "
+        "token without Administration:write does; fork and rename stay "
+        "available")
     args = parser.parse_args()
-    asyncio.run(_serve(args.port, args.repo, args.metadata, args.commits))
+    asyncio.run(
+        _serve(args.port, args.repo, args.metadata, args.commits,
+               not args.no_create_repos))
 
 
 if __name__ == "__main__":

--- a/integ/server/notion_server.ts
+++ b/integ/server/notion_server.ts
@@ -1468,6 +1468,63 @@ async function handle(
     return { status: 200, json: pageOf(rows.map(blockJson), q.get('start_cursor'), size) }
   }
 
+  // Retrieve one block. The children route was here and this one was not,
+  // which is a gap only a client that walks *to* a block notices:
+  // @notionhq/notion-mcp-server reads an inline database by asking for the
+  // block whose id it is, and got a 404 saying the object did not exist. A
+  // database and a page both answer, because in Notion the child_database /
+  // child_page block and the thing it points at share an id; a trashed row
+  // still answers with the flag set, the way retrieve serves a trashed page
+  // and DELETE reports the block it just trashed.
+  if (method === 'GET' && parts.length === 3 && parts[1] === 'blocks') {
+    const id = parts[2] ?? ''
+    const block = (await db.notionBlock.findFirst({
+      where: { workspaceId: ws, id },
+    })) as BlockRow | null
+    if (block !== null) {
+      return {
+        status: 200,
+        json: { ...blockJson(block), archived: block.inTrash, in_trash: block.inTrash },
+      }
+    }
+    const database = (await db.notionDatabase.findFirst({
+      where: { workspaceId: ws, id },
+    })) as DatabaseRow | null
+    if (database !== null) {
+      return {
+        status: 200,
+        json: {
+          object: 'block',
+          id: database.id,
+          type: 'child_database',
+          has_children: false,
+          child_database: { title: database.titleText },
+          archived: database.inTrash,
+          in_trash: database.inTrash,
+        },
+      }
+    }
+    const page = (await db.notionPage.findFirst({
+      where: { workspaceId: ws, id },
+    })) as PageRow | null
+    if (page !== null) {
+      const kids = await childrenOf(db, ws, id)
+      return {
+        status: 200,
+        json: {
+          object: 'block',
+          id: page.id,
+          type: 'child_page',
+          has_children: kids.length > 0,
+          child_page: { title: page.titleText },
+          archived: page.inTrash,
+          in_trash: page.inTrash,
+        },
+      }
+    }
+    return notFound('block', id)
+  }
+
   if (method === 'POST' && parts.length === 2 && parts[1] === 'search') {
     const results = await searchResults(db, ws, body, apiVersion(req))
     const size = intOr(body.page_size, MAX_PAGE_SIZE)

--- a/python/mirage/commands/cli/builtin/gh/__init__.py
+++ b/python/mirage/commands/cli/builtin/gh/__init__.py
@@ -105,6 +105,13 @@ GH = CLISpec(
                     multiple=True,
                     description="Add a typed parameter in key=value format",
                 ),
+                Option(
+                    short="-q",
+                    long="--jq",
+                    type="str",
+                    description="Query to select values from the response "
+                    "using jq syntax",
+                ),
             ),
         ),
     ),

--- a/python/mirage/commands/cli/builtin/gh/accessor.py
+++ b/python/mirage/commands/cli/builtin/gh/accessor.py
@@ -52,5 +52,7 @@ def json_out(
     return yield_bytes(text.encode()), IOResult(mutated=mutated)
 
 
-def text_out(text: str) -> tuple[ByteSource | None, IOResult]:
-    return yield_bytes(text.encode()), IOResult()
+def text_out(
+        text: str,
+        mutated: bool | None = None) -> tuple[ByteSource | None, IOResult]:
+    return yield_bytes(text.encode()), IOResult(mutated=mutated)

--- a/python/mirage/commands/cli/builtin/gh/api.py
+++ b/python/mirage/commands/cli/builtin/gh/api.py
@@ -12,14 +12,16 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import json
 import re
 
-from mirage.commands.cli.builtin.gh.accessor import json_out
+from mirage.commands.cli.builtin.gh.accessor import json_out, text_out
 from mirage.commands.cli.types import CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.core.github._client import github_request
 from mirage.core.github.config import GhConfig
 from mirage.core.github.placeholder import expand
+from mirage.core.jq import jq_eval
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import JsonValue
 
@@ -49,6 +51,26 @@ def typed(value: str) -> JsonValue:
     if INT_RE.match(value):
         return int(value)
     return value
+
+
+def jq_line(value: JsonValue) -> str:
+    """One `--jq` output the way gh renders it, probed against 2.85.
+
+    A string prints raw, null prints as an empty line (where jq's own
+    `-r` would print the word), and every other value prints as compact
+    JSON. Each output ends its own line.
+
+    Args:
+        value (JsonValue): one value the jq program emitted.
+
+    Returns:
+        str: the line's body, without its newline.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
 
 
 def split(pair: str) -> tuple[str, str]:
@@ -110,6 +132,14 @@ async def api(
                                       path,
                                       fields or None,
                                       base_url=inv.config.base_url)
+    # `--jq` filters the response client-side, exactly as real gh does; a
+    # failing request never reaches it. Deliberate divergence: a bad or
+    # failing program is reported in mirage's jq engine's words, not
+    # gojq's, with the same exit code.
+    program = fl.as_str("jq")
+    if program:
+        lines = "".join(f"{jq_line(v)}\n" for v in jq_eval(result, program))
+        return text_out(lines, mutated)
     return json_out(result, mutated)
 
 

--- a/python/mirage/workspace/executor/command/cli.py
+++ b/python/mirage/workspace/executor/command/cli.py
@@ -349,6 +349,13 @@ async def handle_cli(
         # Any other thrown leaf error (an API RuntimeError, a ValueError)
         # becomes this command's IOResult, prefixed like GNU
         # (prog: message), so the rest of the line keeps running.
+        # The write may already have landed when a leaf throws after its
+        # request (a PUT whose --jq program fails filters a response the
+        # service already applied), and with no IOResult to consult the
+        # spec's static answer is the only one left; without the drop a
+        # github mount keeps serving its pre-write bytes.
+        if leaf.write and drop_caches is not None:
+            await drop_caches()
         err_stderr = f"{prog}: {exc}\n".encode()
         err_io = IOResult(exit_code=1, stderr=err_stderr)
         return None, err_io, ExecutionNode(command=cmd_str,

--- a/python/tests/commands/cli/builtin/gh/test_gh.py
+++ b/python/tests/commands/cli/builtin/gh/test_gh.py
@@ -254,6 +254,49 @@ async def test_api_stringifies_a_typed_field_bound_for_the_query():
     assert "body" not in CALLS[0]
 
 
+# `--jq` renders the way gh 2.85 does, probed live: a string raw, null as
+# an empty line, everything else as compact JSON, one output per line.
+@pytest.mark.asyncio
+async def test_api_jq_prints_a_string_raw():
+    _reset({"full_name": "o/r"})
+    out, _io = await api(_inv(["repos/o/r"], {"jq": ".full_name"}))
+    assert await materialize(out) == b"o/r\n"
+
+
+@pytest.mark.asyncio
+async def test_api_jq_prints_non_strings_as_compact_json():
+    _reset({"name": "r", "count": 2, "ok": True})
+    out, _io = await api(
+        _inv(["repos/o/r"], {"jq": "{name: .name, count: .count}, .ok"}))
+    assert await materialize(out) == b'{"name":"r","count":2}\ntrue\n'
+
+
+@pytest.mark.asyncio
+async def test_api_jq_prints_null_as_an_empty_line():
+    _reset({"name": "r"})
+    out, _io = await api(_inv(["repos/o/r"], {"jq": ".nope"}))
+    assert await materialize(out) == b"\n"
+
+
+@pytest.mark.asyncio
+async def test_api_jq_emits_one_line_per_output():
+    _reset({"a": "x", "b": "y"})
+    out, _io = await api(_inv(["repos/o/r"], {"jq": ".a, .b"}))
+    assert await materialize(out) == b"x\ny\n"
+
+
+@pytest.mark.asyncio
+async def test_api_jq_keeps_the_write_flag_of_the_method():
+    _reset({"ok": True})
+    _out, io = await api(
+        _inv(["repos/o/r/contents/f"], {
+            "method": "PUT",
+            "raw_field": ["content=YQ=="],
+            "jq": ".ok"
+        }))
+    assert io.mutated is True
+
+
 # gh prints two tab-separated header lines and then the README verbatim;
 # with no README there is no `--` separator at all. Probed against 2.85.
 def test_summary_is_gh_s_two_headers_then_the_readme():

--- a/typescript/packages/core/src/commands/cli/builtin/gh/accessor.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gh/accessor.ts
@@ -46,7 +46,7 @@ export function jsonOut(value: unknown, mutated?: boolean): CommandFnResult {
   return [out, new IOResult(mutated === undefined ? {} : { mutated })]
 }
 
-export function textOut(text: string): CommandFnResult {
+export function textOut(text: string, mutated?: boolean): CommandFnResult {
   const out: ByteSource = ENC.encode(text)
-  return [out, new IOResult()]
+  return [out, new IOResult(mutated === undefined ? {} : { mutated })]
 }

--- a/typescript/packages/core/src/commands/cli/builtin/gh/api.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gh/api.ts
@@ -17,7 +17,8 @@ import type { CommandFnResult } from '../../../config.ts'
 import type { CLIInvocation } from '../../types.ts'
 import { expand } from '../../../../core/github/placeholder.ts'
 import type { GhConfig } from '../../../../core/github/config.ts'
-import { ghTransport, jsonOut } from './accessor.ts'
+import { jqEval } from '../../../../core/jq/index.ts'
+import { ghTransport, jsonOut, textOut } from './accessor.ts'
 
 /**
  * `-f key=value` is always a string; `-F key=value` reads `true`, `false`,
@@ -38,6 +39,18 @@ function split(pair: string): [string, string] {
   const at = pair.indexOf('=')
   if (at < 0) throw new Error(`expected "key=value", got "${pair}"`)
   return [pair.slice(0, at), pair.slice(at + 1)]
+}
+
+/**
+ * One `--jq` output the way gh renders it, probed against 2.85: a string
+ * prints raw, null prints as an empty line (where jq's own `-r` would
+ * print the word), and every other value prints as compact JSON. Each
+ * output ends its own line.
+ */
+function jqLine(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
 }
 
 export async function api(inv: CLIInvocation): Promise<CommandFnResult> {
@@ -69,13 +82,22 @@ export async function api(inv: CLIInvocation): Promise<CommandFnResult> {
   const empty = Object.keys(fields).length === 0
   // A GET carries its fields in the query string, everything else in a JSON
   // body; a call with no fields sends neither, so a bare DELETE has no body.
+  let reply: unknown
   if (upper === 'GET') {
     const params: Record<string, string> = {}
     for (const [key, value] of Object.entries(fields)) params[key] = String(value)
-    return jsonOut(await ghTransport(inv.config).request(upper, path, undefined, params), mutated)
+    reply = await ghTransport(inv.config).request(upper, path, undefined, params)
+  } else {
+    reply = await ghTransport(inv.config).request(upper, path, empty ? undefined : fields)
   }
-  return jsonOut(
-    await ghTransport(inv.config).request(upper, path, empty ? undefined : fields),
-    mutated,
-  )
+  // `--jq` filters the response client-side, exactly as real gh does; a
+  // failing request never reaches it. Deliberate divergence: a bad or
+  // failing program is reported in mirage's jq engine's words, not
+  // gojq's, with the same exit code.
+  const program = fl.asStr('jq')
+  if (program !== undefined && program !== '') {
+    const values = await jqEval(reply, program)
+    return textOut(values.map((v) => `${jqLine(v)}\n`).join(''), mutated)
+  }
+  return jsonOut(reply, mutated)
 }

--- a/typescript/packages/core/src/commands/cli/builtin/gh/gh.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gh/gh.test.ts
@@ -221,6 +221,34 @@ describe('gh api', () => {
   })
 })
 
+// `--jq` renders the way gh 2.85 does, probed live: a string raw, null as
+// an empty line, everything else as compact JSON, one output per line.
+describe('gh api --jq', () => {
+  it('prints a string raw', async () => {
+    reset({ full_name: 'o/r' })
+    const out = await api(inv(['repos/o/r'], { jq: '.full_name' }))
+    expect(out === null ? '' : text(out)).toBe('o/r\n')
+  })
+
+  it('prints non-strings as compact JSON', async () => {
+    reset({ name: 'r', count: 2, ok: true })
+    const out = await api(inv(['repos/o/r'], { jq: '{name: .name, count: .count}, .ok' }))
+    expect(out === null ? '' : text(out)).toBe('{"name":"r","count":2}\ntrue\n')
+  })
+
+  it('prints null as an empty line', async () => {
+    reset({ name: 'r' })
+    const out = await api(inv(['repos/o/r'], { jq: '.nope' }))
+    expect(out === null ? '' : text(out)).toBe('\n')
+  })
+
+  it('emits one line per output', async () => {
+    reset({ a: 'x', b: 'y' })
+    const out = await api(inv(['repos/o/r'], { jq: '.a, .b' }))
+    expect(out === null ? '' : text(out)).toBe('x\ny\n')
+  })
+})
+
 // gh prints two tab-separated header lines and then the README verbatim;
 // with no README there is no `--` separator at all. Probed against 2.85.
 describe('gh repo view rendering', () => {

--- a/typescript/packages/core/src/commands/cli/builtin/gh/index.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gh/index.ts
@@ -103,6 +103,12 @@ export const GH = new CLISpec({
           multiple: true,
           description: 'Add a typed parameter in key=value format',
         }),
+        new Option({
+          short: '-q',
+          long: '--jq',
+          type: 'str',
+          description: 'Query to select values from the response using jq syntax',
+        }),
       ],
     }),
   ],

--- a/typescript/packages/core/src/workspace/executor/command/cli.test.ts
+++ b/typescript/packages/core/src/workspace/executor/command/cli.test.ts
@@ -553,3 +553,60 @@ describe('handleCli script arm', () => {
     ).rejects.toThrow(/pager: timed out/)
   })
 })
+
+// A write may have landed before the leaf threw: `gh api -X PUT --jq`
+// filters a response the service already applied, so the failure arm
+// falls back to the spec's static `write` the same way the success arm
+// does when a handler's result says nothing.
+describe('cache drop on a thrown leaf', () => {
+  function throwingInstall(write: boolean): CLIInstall {
+    const spec = new CLISpec({
+      name: 'prog',
+      configModel: (input) => input,
+      subcommands: [
+        new CLISpec({
+          name: 'push',
+          write,
+          fn: () => {
+            throw new Error('filter failed after the request')
+          },
+        }),
+      ],
+    })
+    return { name: 'prog', spec, config: { token: 'tok' } }
+  }
+
+  it('a write leaf that throws still drops caches', async () => {
+    const dropped: boolean[] = []
+    const [, io] = await handleCli(
+      throwingInstall(true),
+      ['prog', 'push'],
+      new Session({ sessionId: 't' }),
+      null,
+      {},
+      () => {
+        dropped.push(true)
+        return Promise.resolve()
+      },
+    )
+    expect(io.exitCode).toBe(1)
+    expect(dropped).toEqual([true])
+  })
+
+  it('a read leaf that throws drops nothing', async () => {
+    const dropped: boolean[] = []
+    const [, io] = await handleCli(
+      throwingInstall(false),
+      ['prog', 'push'],
+      new Session({ sessionId: 't' }),
+      null,
+      {},
+      () => {
+        dropped.push(true)
+        return Promise.resolve()
+      },
+    )
+    expect(io.exitCode).toBe(1)
+    expect(dropped).toEqual([])
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/command/cli.ts
+++ b/typescript/packages/core/src/workspace/executor/command/cli.ts
@@ -343,6 +343,12 @@ export async function handleCli(
     // Any other thrown leaf error (an API error, a TypeError) becomes
     // this command's IOResult, prefixed like GNU (prog: message), so
     // the rest of the line keeps running.
+    // The write may already have landed when a leaf throws after its
+    // request (a PUT whose --jq program fails filters a response the
+    // service already applied), and with no IOResult to consult the
+    // spec's static answer is the only one left; without the drop a
+    // github mount keeps serving its pre-write bytes.
+    if (leaf.write && dropCaches !== null) await dropCaches()
     const message = err instanceof Error ? err.message : String(err)
     const stderr = new TextEncoder().encode(`${prog}: ${message}\n`)
     return [


### PR DESCRIPTION
#768 merged an earlier snapshot of this branch, so the overlap is dropped and the branch is rebuilt on main with the three pieces main does not have.

**A fake token that cannot create repositories.** `--no-create-repos` makes the integ GitHub fake answer `POST /user/repos` with 403 "Resource not accessible by personal access token", the way a fine-grained PAT without Administration:write does, while fork and rename stay open. The cli facet in CI now runs the fake this way, and a battery case pins the refusal.

**`gh api --jq`.** The real binary has `--jq`/`-q` and the CLI did not, which is exactly the kind of gap a conformance gate would have caught. Filtered through mirage's jq engine and rendered the way gh 2.85 renders it (probed live): strings raw, null as an empty line, everything else compact JSON, one output per line. Unit tests in both languages plus three battery cases. Deliberate divergence: a bad program is reported in the engine's wording, not gojq's, with the same exit code.

**Notion retrieve-block.** The fake served block children but not `GET /v1/blocks/{id}`, which @notionhq/notion-mcp-server walks to for an inline database and read as "object does not exist". A database and a page both answer as their child_database / child_page block (they share an id), and a trashed row answers with `in_trash` set, matching the fake's own retrieve and delete conventions. Four ntn battery cases, all checked against the real ntn 0.21.9 binary by the conformance runner.

Dropped from the original branch: the himalaya sent-copy commit (superseded by deliver.py / deliver.ts on main; merging both would have filed every sent message twice) and the Actions routes (the github_ci backend they served was removed from main).

Verified: gh unit tests both languages, `pnpm -r typecheck`, battery cli-gh 29/29 and cli-ntn 73/73 on both hosts, ntn conformance 71 checked all matching, pre-commit clean.
