### PR TITLE
fix(deps): raise the deepagents floor to the API backend.py actually needs

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -141,7 +141,7 @@ pydantic-ai = [
 
 # --- deepagents ---
 deepagents  = [
-    "deepagents>=0.6.12",
+    "deepagents>=0.7.6",
 ]
 
 # --- openhands ---

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -4343,7 +4343,7 @@ requires-dist = [
     { name = "claude-agent-sdk", marker = "extra == 'claude-agent-sdk'", specifier = ">=0.2.123" },
     { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.72.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.176.0" },
-    { name = "deepagents", marker = "extra == 'deepagents'", specifier = ">=0.6.12" },
+    { name = "deepagents", marker = "extra == 'deepagents'", specifier = ">=0.7.6" },
     { name = "dulwich", specifier = ">=1.2.5" },
     { name = "e2b", marker = "extra == 'e2b'", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.135.1" },


### PR DESCRIPTION
`3bbb79121` rewrote `agents/langchain/backend.py` to follow deepagents' new grep
cap — `GrepResult.truncated` and the keyword-only `max_count` on
`grep`/`agrep` — and bumped `python/uv.lock` and
`typescript/packages/agents/package.json` (to `^1.11.1`) to match. It left
`python/pyproject.toml` at `deepagents>=0.6.12`.

0.6.12 is the last release before that API. Its `GrepResult` is a two-field
dataclass (`error`, `matches`), so the adapter's

```python
return GrepResult(matches=matches[:max_count], truncated=True)
```

raises `TypeError: GrepResult.__init__() got an unexpected keyword argument
'truncated'`, and `BackendProtocol.grep` has no `max_count` for the override to
match. Both arrived in **0.7.0**, not 0.7.6 as `3bbb79121`'s message says —
checked by pulling each 0.6.x/0.7.x wheel and reading `backends/protocol.py`.

Nothing in CI resolves that floor, which is why it has been green throughout:
`uv.lock` pins 0.7.6, and `Test (Install)` only exercises a base install with no
extras. The gap is reachable from a downstream `pip install mirage-ai[deepagents]`,
or any env that resolves the range rather than the lock.

Raised to `>=0.7.6`, matching the lock and the treatment the TypeScript side
already got — the floor is the version we test against, which is
`3bbb79121`'s own stated rationale for the bump.

## Notes

- No behavior change. `backend.py` is untouched and already conforms to the
  0.7.x contract on every clause it specifies: total cap rather than per-file,
  `truncated=True` only when matches were actually dropped, and exactly
  `max_count` with none dropped reported complete. Both boundaries are pinned by
  `test_agrep_max_count_truncates` / `test_agrep_max_count_exactly_is_complete`.
- The `uv.lock` edit is the one `requires-dist` specifier line. The resolved
  version is already 0.7.6, so no resolution changes.

## Test plan

- `pytest tests/agents/` — 104 passed
- `mypy` — clean, 1832 source files (it is what caught the incompatible override
  in `3bbb79121`)
- full `pytest` suite, minus the local-env gaps (no macFUSE, no local Redis)

## Follow-up, not taken here

`3bbb79121` bumped the lock for every agent SDK it upgraded. Only deepagents had
adapter code following a new API, so it is the only floor I verified; the other
extras may carry the same lock-vs-floor drift.
