### PR TITLE
fix(cache): make Redis file cache add atomic

### DIFF
--- a/python/mirage/cache/file/add.lua
+++ b/python/mirage/cache/file/add.lua
@@ -1,0 +1,16 @@
+-- Insert one cache entry only when the data key is absent: the bytes go
+-- under KEYS[1], their fingerprint under KEYS[2], and ARGV[3] carries the
+-- TTL in seconds ('' for none). Keeping the check, both writes and both
+-- expirations in one execution is what makes add() insert-only across
+-- processes: a background drain finishing late cannot land between the
+-- check and the write and overwrite a newer fill.
+if redis.call('EXISTS', KEYS[1]) ~= 0 then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('SET', KEYS[2], ARGV[2])
+if ARGV[3] ~= '' then
+  redis.call('EXPIRE', KEYS[1], ARGV[3])
+  redis.call('EXPIRE', KEYS[2], ARGV[3])
+end
+return 1

--- a/python/mirage/cache/file/redis.py
+++ b/python/mirage/cache/file/redis.py
@@ -13,13 +13,26 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-from collections.abc import Iterable
-from typing import Any
+from collections.abc import Awaitable, Iterable
+from typing import Any, cast
 
 from mirage.cache.file.mixin import FileCacheMixin, validate_max_drain_bytes
 from mirage.cache.file.utils import (default_fingerprint, glob_escape,
                                      parse_limit)
 from mirage.resource.redis.redis import RedisResource
+
+ADD_SCRIPT = """
+if redis.call('EXISTS', KEYS[1]) ~= 0 then
+    return 0
+end
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('SET', KEYS[2], ARGV[2])
+if ARGV[3] ~= '' then
+    redis.call('EXPIRE', KEYS[1], ARGV[3])
+    redis.call('EXPIRE', KEYS[2], ARGV[3])
+end
+return 1
+"""
 
 
 class RedisFileCacheStore(RedisResource, FileCacheMixin):
@@ -75,11 +88,26 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         ttl: int | None = None,
     ) -> bool:
         dk = f"{self._data_prefix}{key}"
-        exists = await self._cache_client.exists(dk)
-        if exists:
-            return False
-        await self.set(key, data, fingerprint=fingerprint, ttl=ttl)
-        return True
+        mk = f"{self._meta_prefix}{key}"
+        if fingerprint is None:
+            fingerprint = default_fingerprint(data)
+        # The background drain deliberately uses insert-only semantics: an
+        # older drain finishing late must not overwrite a newer cache fill.
+        # Keep the existence check, bytes, fingerprint and TTL in one Redis
+        # execution so shared-cache writers cannot interleave between them.
+        inserted = await cast(
+            Awaitable[int],
+            self._cache_client.eval(
+                ADD_SCRIPT,
+                2,
+                dk,
+                mk,
+                data,
+                fingerprint,
+                "" if ttl is None else str(ttl),
+            ),
+        )
+        return inserted == 1
 
     async def remove(self, key: str) -> None:
         task = self._drain_tasks.pop(key, None)

--- a/python/mirage/cache/file/redis.py
+++ b/python/mirage/cache/file/redis.py
@@ -13,26 +13,17 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-from collections.abc import Awaitable, Iterable
-from typing import Any, cast
+from collections.abc import Iterable
+from importlib.resources import files
+from typing import Any
 
 from mirage.cache.file.mixin import FileCacheMixin, validate_max_drain_bytes
 from mirage.cache.file.utils import (default_fingerprint, glob_escape,
                                      parse_limit)
 from mirage.resource.redis.redis import RedisResource
 
-ADD_SCRIPT = """
-if redis.call('EXISTS', KEYS[1]) ~= 0 then
-    return 0
-end
-redis.call('SET', KEYS[1], ARGV[1])
-redis.call('SET', KEYS[2], ARGV[2])
-if ARGV[3] ~= '' then
-    redis.call('EXPIRE', KEYS[1], ARGV[3])
-    redis.call('EXPIRE', KEYS[2], ARGV[3])
-end
-return 1
-"""
+# Shipped next to this module; byte-identical to the TypeScript add.lua.
+ADD_LUA = (files("mirage.cache.file") / "add.lua").read_text(encoding="utf-8")
 
 
 class RedisFileCacheStore(RedisResource, FileCacheMixin):
@@ -57,9 +48,16 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         self._meta_prefix = f"{key_prefix}meta:"
         self.max_drain_bytes: int | None = max_drain_bytes
         self._drain_tasks: dict[str, asyncio.Task[Any]] = {}
+        self._add = self._cache_client.register_script(ADD_LUA)
+
+    def _data_key(self, key: str) -> str:
+        return f"{self._data_prefix}{key}"
+
+    def _meta_key(self, key: str) -> str:
+        return f"{self._meta_prefix}{key}"
 
     async def get(self, key: str) -> bytes | None:
-        return await self._cache_client.get(f"{self._data_prefix}{key}")
+        return await self._cache_client.get(self._data_key(key))
 
     async def set(
         self,
@@ -71,8 +69,8 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         if fingerprint is None:
             fingerprint = default_fingerprint(data)
         pipe = self._cache_client.pipeline()
-        dk = f"{self._data_prefix}{key}"
-        mk = f"{self._meta_prefix}{key}"
+        dk = self._data_key(key)
+        mk = self._meta_key(key)
         pipe.set(dk, data)
         pipe.set(mk, fingerprint)
         if ttl is not None:
@@ -87,43 +85,33 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         fingerprint: str | None = None,
         ttl: int | None = None,
     ) -> bool:
-        dk = f"{self._data_prefix}{key}"
-        mk = f"{self._meta_prefix}{key}"
         if fingerprint is None:
             fingerprint = default_fingerprint(data)
         # The background drain deliberately uses insert-only semantics: an
         # older drain finishing late must not overwrite a newer cache fill.
-        # Keep the existence check, bytes, fingerprint and TTL in one Redis
-        # execution so shared-cache writers cannot interleave between them.
-        inserted = await cast(
-            Awaitable[int],
-            self._cache_client.eval(
-                ADD_SCRIPT,
-                2,
-                dk,
-                mk,
-                data,
-                fingerprint,
-                "" if ttl is None else str(ttl),
-            ),
+        # add.lua keeps the existence check, bytes, fingerprint and TTL in
+        # one Redis execution so shared-cache writers cannot interleave.
+        inserted = await self._add(
+            keys=[self._data_key(key),
+                  self._meta_key(key)],
+            args=[data, fingerprint, "" if ttl is None else str(ttl)],
         )
-        return inserted == 1
+        return bool(inserted)
 
     async def remove(self, key: str) -> None:
         task = self._drain_tasks.pop(key, None)
         if task:
             task.cancel()
         pipe = self._cache_client.pipeline()
-        pipe.delete(f"{self._data_prefix}{key}")
-        pipe.delete(f"{self._meta_prefix}{key}")
+        pipe.delete(self._data_key(key))
+        pipe.delete(self._meta_key(key))
         await pipe.execute()
 
     async def exists(self, key: str) -> bool:
-        return bool(await
-                    self._cache_client.exists(f"{self._data_prefix}{key}"))
+        return bool(await self._cache_client.exists(self._data_key(key)))
 
     async def is_fresh(self, key: str, remote_fingerprint: str) -> bool:
-        fp = await self._cache_client.get(f"{self._meta_prefix}{key}")
+        fp = await self._cache_client.get(self._meta_key(key))
         if fp is None:
             return False
         if isinstance(fp, bytes):

--- a/python/tests/cache/file/test_redis_cache.py
+++ b/python/tests/cache/file/test_redis_cache.py
@@ -104,6 +104,33 @@ async def test_add_existing(cache):
 
 
 @pytest.mark.asyncio
+async def test_concurrent_add_has_one_winner(cache):
+    contenders = [(f"value-{i}".encode(), f"fingerprint-{i}")
+                  for i in range(32)]
+    inserted = await asyncio.gather(
+        *(cache.add("/shared.txt", data, fingerprint=fingerprint)
+          for data, fingerprint in contenders))
+
+    assert sum(inserted) == 1
+    winner = inserted.index(True)
+    data, fingerprint = contenders[winner]
+    assert await cache.get("/shared.txt") == data
+    assert await cache.is_fresh("/shared.txt", fingerprint) is True
+
+
+@pytest.mark.asyncio
+async def test_add_preserves_binary_data_and_ttl(cache):
+    data = b"\x00\xff\x80binary"
+    assert await cache.add("/binary.bin", data, fingerprint="binary-fp", ttl=1)
+    assert await cache.get("/binary.bin") == data
+    assert await cache.is_fresh("/binary.bin", "binary-fp") is True
+
+    await asyncio.sleep(1.1)
+    assert await cache.get("/binary.bin") is None
+    assert await cache.is_fresh("/binary.bin", "binary-fp") is False
+
+
+@pytest.mark.asyncio
 async def test_set_with_fingerprint(cache):
     await cache.set("/file.txt", b"data", fingerprint="fp1")
     assert await cache.is_fresh("/file.txt", "fp1") is True

--- a/python/tests/shell/console/redis/test_constants.py
+++ b/python/tests/shell/console/redis/test_constants.py
@@ -12,12 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from pathlib import Path
-
 from mirage.shell.console.redis.constants import APPEND_LUA, BLOCK_MS
-
-TS_LUA = (Path(__file__).parents[4].parent / "typescript" / "packages" /
-          "node" / "src" / "shell" / "console" / "redis" / "append.lua")
 
 
 def test_append_script_loads_from_the_lua_file():
@@ -33,8 +28,3 @@ def test_append_script_loads_from_the_lua_file():
 def test_block_interval_is_short():
     """Close is only noticed between rounds, so a round must be short."""
     assert 0 < BLOCK_MS <= 1000
-
-
-def test_lua_is_byte_identical_to_the_typescript_copy():
-    """One wire schema, two copies: the two files must never drift."""
-    assert APPEND_LUA == TS_LUA.read_text(encoding="utf-8")

--- a/python/tests/test_lua_parity.py
+++ b/python/tests/test_lua_parity.py
@@ -1,0 +1,57 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+PY_LUA = sorted((REPO / "python" / "mirage").rglob("*.lua"))
+TS_LUA = sorted(
+    (REPO / "typescript" / "packages" / "node" / "src").rglob("*.lua"))
+
+
+def _by_name(paths: list[pathlib.Path]) -> dict[str, pathlib.Path]:
+    return {path.name: path for path in paths}
+
+
+def test_every_lua_script_exists_in_both_languages():
+    """A server-side script is one wire contract with two copies.
+
+    Neither language can import the other's file, so each ships its own;
+    the pair is what keeps a Redis-side behavior from having two
+    meanings. A script added to one tree and forgotten in the other
+    fails here rather than at runtime on whichever host is missing it.
+    """
+    assert PY_LUA, "no lua scripts found under python/mirage"
+    assert sorted(_by_name(PY_LUA)) == sorted(_by_name(TS_LUA))
+
+
+def test_lua_basenames_are_unique_within_each_tree():
+    """tsup copies each script to a flat `dist/<name>.lua`.
+
+    Two scripts sharing a basename would silently overwrite each other
+    in the bundle, so the name has to be unique even though the source
+    directories differ.
+    """
+    for tree in (PY_LUA, TS_LUA):
+        names = [path.name for path in tree]
+        assert len(names) == len(set(names))
+
+
+def test_each_lua_pair_is_byte_identical():
+    """One wire schema, two copies: the two files must never drift."""
+    ts = _by_name(TS_LUA)
+    for path in PY_LUA:
+        twin = ts[path.name]
+        assert path.read_text(encoding="utf-8") == twin.read_text(
+            encoding="utf-8"), f"{path.name} differs between python and ts"

--- a/typescript/packages/node/src/cache/redis/add.lua
+++ b/typescript/packages/node/src/cache/redis/add.lua
@@ -1,0 +1,16 @@
+-- Insert one cache entry only when the data key is absent: the bytes go
+-- under KEYS[1], their fingerprint under KEYS[2], and ARGV[3] carries the
+-- TTL in seconds ('' for none). Keeping the check, both writes and both
+-- expirations in one execution is what makes add() insert-only across
+-- processes: a background drain finishing late cannot land between the
+-- check and the write and overwrite a newer fill.
+if redis.call('EXISTS', KEYS[1]) ~= 0 then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('SET', KEYS[2], ARGV[2])
+if ARGV[3] ~= '' then
+  redis.call('EXPIRE', KEYS[1], ARGV[3])
+  redis.call('EXPIRE', KEYS[2], ARGV[3])
+end
+return 1

--- a/typescript/packages/node/src/cache/redis/file.test.ts
+++ b/typescript/packages/node/src/cache/redis/file.test.ts
@@ -65,6 +65,33 @@ describe.skipIf(skip)('RedisFileCacheStore', () => {
     expect(await cache.add('k', data)).toBe(false)
   })
 
+  it('gives concurrent add calls exactly one winner', async () => {
+    const contenders = Array.from({ length: 32 }, (_, i) => ({
+      data: new TextEncoder().encode(`value-${String(i)}`),
+      fingerprint: `fingerprint-${String(i)}`,
+    }))
+    const inserted = await Promise.all(
+      contenders.map(({ data, fingerprint }) => cache.add('shared', data, { fingerprint })),
+    )
+
+    expect(inserted.filter(Boolean)).toHaveLength(1)
+    const winner = contenders.find((_value, index) => inserted[index])
+    if (winner === undefined) throw new Error('expected one add call to win')
+    expect(await cache.get('shared')).toEqual(winner.data)
+    expect(await cache.isFresh('shared', winner.fingerprint)).toBe(true)
+  })
+
+  it('preserves binary data and applies ttl to data and metadata on add', async () => {
+    const data = new Uint8Array([0x00, 0xff, 0x80, 0x42])
+    expect(await cache.add('binary', data, { fingerprint: 'binary-fp', ttl: 1 })).toBe(true)
+    expect(await cache.get('binary')).toEqual(data)
+    expect(await cache.isFresh('binary', 'binary-fp')).toBe(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 1100))
+    expect(await cache.get('binary')).toBeNull()
+    expect(await cache.isFresh('binary', 'binary-fp')).toBe(false)
+  })
+
   it('remove deletes data and meta', async () => {
     await cache.set('k', new Uint8Array([9]))
     expect(await cache.exists('k')).toBe(true)

--- a/typescript/packages/node/src/cache/redis/file.ts
+++ b/typescript/packages/node/src/cache/redis/file.ts
@@ -21,6 +21,19 @@ import { registerFileCacheStore } from '@struktoai/mirage-core/workspace/workspa
 import type { RedisClientType } from 'redis'
 import { RedisResource, type RedisResourceOptions } from '../../resource/redis/redis.ts'
 
+const ADD_SCRIPT = `
+if redis.call('EXISTS', KEYS[1]) ~= 0 then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('SET', KEYS[2], ARGV[2])
+if ARGV[3] ~= '' then
+  redis.call('EXPIRE', KEYS[1], ARGV[3])
+  redis.call('EXPIRE', KEYS[2], ARGV[3])
+end
+return 1
+`
+
 export interface RedisFileCacheOptions extends RedisResourceOptions {
   cacheLimit?: string | number
   maxDrainBytes?: number | null
@@ -109,10 +122,21 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
     options: { fingerprint?: string | null; ttl?: number | null } = {},
   ): Promise<boolean> {
     const c = await this.cacheClient()
-    const exists = await c.exists(`${this.dataPrefix}${key}`)
-    if (exists) return false
-    await this.set(key, data, options)
-    return true
+    const dk = `${this.dataPrefix}${key}`
+    const mk = `${this.metaPrefix}${key}`
+    const fp = options.fingerprint ?? defaultFingerprint(data)
+    // A background drain is insert-only: an older drain finishing late must
+    // not overwrite a newer cache fill. Execute the check, bytes, fingerprint
+    // and TTL atomically so shared-cache writers cannot interleave.
+    const inserted = await c.eval(ADD_SCRIPT, {
+      keys: [dk, mk],
+      arguments: [
+        Buffer.from(data.buffer, data.byteOffset, data.byteLength),
+        fp,
+        options.ttl === null || options.ttl === undefined ? '' : String(options.ttl),
+      ],
+    })
+    return inserted === 1
   }
 
   async remove(key: string): Promise<void> {

--- a/typescript/packages/node/src/cache/redis/file.ts
+++ b/typescript/packages/node/src/cache/redis/file.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { readFileSync } from 'node:fs'
 import { CacheType } from '@struktoai/mirage-core/cache/file/config'
 import { validateMaxDrainBytes } from '@struktoai/mirage-core/cache/file/mixin'
 import type { FileCache } from '@struktoai/mirage-core/cache/file/mixin'
@@ -21,18 +22,13 @@ import { registerFileCacheStore } from '@struktoai/mirage-core/workspace/workspa
 import type { RedisClientType } from 'redis'
 import { RedisResource, type RedisResourceOptions } from '../../resource/redis/redis.ts'
 
-const ADD_SCRIPT = `
-if redis.call('EXISTS', KEYS[1]) ~= 0 then
-  return 0
-end
-redis.call('SET', KEYS[1], ARGV[1])
-redis.call('SET', KEYS[2], ARGV[2])
-if ARGV[3] ~= '' then
-  redis.call('EXPIRE', KEYS[1], ARGV[3])
-  redis.call('EXPIRE', KEYS[2], ARGV[3])
-end
-return 1
-`
+// Shipped next to this module in src and copied beside the bundle in
+// dist (tsup onSuccess); byte-identical to the Python add.lua.
+const ADD_LUA = readFileSync(new URL('./add.lua', import.meta.url), 'utf8')
+
+function toBuffer(data: Uint8Array): Buffer {
+  return Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+}
 
 export interface RedisFileCacheOptions extends RedisResourceOptions {
   cacheLimit?: string | number
@@ -82,6 +78,14 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
     return this.store.client()
   }
 
+  private dataKey(key: string): string {
+    return `${this.dataPrefix}${key}`
+  }
+
+  private metaKey(key: string): string {
+    return `${this.metaPrefix}${key}`
+  }
+
   async get(key: string): Promise<Uint8Array | null> {
     const c = await this.cacheClient()
     const mod = await this.module()
@@ -92,7 +96,7 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
         get: (k: string) => Promise<Buffer | null>
       }
     }
-    const raw = await typed.withTypeMapping(mapping).get(`${this.dataPrefix}${key}`)
+    const raw = await typed.withTypeMapping(mapping).get(this.dataKey(key))
     if (raw === null) return null
     return new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength)
   }
@@ -104,10 +108,10 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
   ): Promise<void> {
     const fp = options.fingerprint ?? defaultFingerprint(data)
     const c = await this.cacheClient()
-    const dk = `${this.dataPrefix}${key}`
-    const mk = `${this.metaPrefix}${key}`
+    const dk = this.dataKey(key)
+    const mk = this.metaKey(key)
     const pipe = c.multi()
-    pipe.set(dk, Buffer.from(data.buffer, data.byteOffset, data.byteLength))
+    pipe.set(dk, toBuffer(data))
     pipe.set(mk, fp)
     if (options.ttl !== null && options.ttl !== undefined) {
       pipe.expire(dk, options.ttl)
@@ -122,16 +126,14 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
     options: { fingerprint?: string | null; ttl?: number | null } = {},
   ): Promise<boolean> {
     const c = await this.cacheClient()
-    const dk = `${this.dataPrefix}${key}`
-    const mk = `${this.metaPrefix}${key}`
     const fp = options.fingerprint ?? defaultFingerprint(data)
     // A background drain is insert-only: an older drain finishing late must
-    // not overwrite a newer cache fill. Execute the check, bytes, fingerprint
-    // and TTL atomically so shared-cache writers cannot interleave.
-    const inserted = await c.eval(ADD_SCRIPT, {
-      keys: [dk, mk],
+    // not overwrite a newer cache fill. add.lua keeps the check, bytes,
+    // fingerprint and TTL in one execution so writers cannot interleave.
+    const inserted = await c.eval(ADD_LUA, {
+      keys: [this.dataKey(key), this.metaKey(key)],
       arguments: [
-        Buffer.from(data.buffer, data.byteOffset, data.byteLength),
+        toBuffer(data),
         fp,
         options.ttl === null || options.ttl === undefined ? '' : String(options.ttl),
       ],
@@ -146,20 +148,20 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
     this.drainTasks.delete(key)
     const c = await this.cacheClient()
     const pipe = c.multi()
-    pipe.del(`${this.dataPrefix}${key}`)
-    pipe.del(`${this.metaPrefix}${key}`)
+    pipe.del(this.dataKey(key))
+    pipe.del(this.metaKey(key))
     await pipe.exec()
   }
 
   override async exists(key: string | PathSpec): Promise<boolean> {
     const k = typeof key === 'string' ? key : key.mountPath
     const c = await this.cacheClient()
-    return (await c.exists(`${this.dataPrefix}${k}`)) > 0
+    return (await c.exists(this.dataKey(k))) > 0
   }
 
   async isFresh(key: string, remoteFingerprint: string): Promise<boolean> {
     const c = await this.cacheClient()
-    const fp = await c.get(`${this.metaPrefix}${key}`)
+    const fp = await c.get(this.metaKey(key))
     if (fp === null) return false
     return fp === remoteFingerprint
   }

--- a/typescript/packages/node/tsup.config.ts
+++ b/typescript/packages/node/tsup.config.ts
@@ -31,5 +31,6 @@ export default defineConfig({
   // module in src.
   onSuccess:
     'cp src/workspace/session/cas.lua dist/cas.lua && ' +
-    'cp src/shell/console/redis/append.lua dist/append.lua',
+    'cp src/shell/console/redis/append.lua dist/append.lua && ' +
+    'cp src/cache/redis/add.lua dist/add.lua',
 })


### PR DESCRIPTION
## Summary

- make `RedisFileCacheStore.add()` atomic in Python and TypeScript with one Redis Lua execution
- write the data and fingerprint keys together and apply matching TTLs only when the insert wins
- add concurrent, binary-payload, fingerprint-consistency, and TTL regression coverage in both implementations

## Root cause

`add()` previously issued `EXISTS` and `SET` as separate Redis operations. A late background drain could observe an empty key, pause, and then overwrite fresher bytes inserted by another process. This broke the insert-only contract when Redis was shared across processes.

The Lua script keeps the existence check, both writes, and both expirations in one atomic Redis execution, so exactly one concurrent caller wins and its data/fingerprint pair remains consistent.

Closes #438.

## Validation

- Python Redis regression suite on Linux/Redis 7: 16 passed
- Python cache/file suite on Linux/Redis 7: 97 passed
- TypeScript Redis regression suite on Redis 7: 14 passed
- Node package TypeScript typecheck
- Prettier, ESLint, and Knip
- Python format, import, Flake8, Ruff, and PathSpec checks
- mypy: changed Python source passes
- `git diff --check`

## AI assistance

Implementation and test preparation were assisted by OpenAI Codex using GPT-5.6Sol. The resulting changes and validation output were reviewed before submission.
