### PR TITLE
chore(typescript): refuse a script run against a stale node_modules

### DIFF
--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -7,3 +7,11 @@ packages:
 
 onlyBuiltDependencies:
   - '@zkochan/fuse-native'
+
+# A node_modules older than the lockfile does not announce itself: it fails as
+# a type error inside whatever package the drifted dependency types, which
+# reads as a source bug in a file nobody touched. Refuse the script and name
+# the real cause instead. This has to live here rather than in .npmrc — inside
+# a workspace pnpm overwrites .npmrc settings from this file, so the
+# equivalent verify-deps-before-run= line there is silently inert.
+verifyDepsBeforeRun: error


### PR DESCRIPTION
## The failure this prevents

`pnpm -r build` on a clean `upstream/main` checkout:

```
packages/dsh build: src/fs.ts(88,5): error TS2345: Argument of type '"FS_TOO_LARGE"'
                    is not assignable to parameter of type 'FsErrorCode'.
packages/dsh build: DTS Build error
```

Nothing is wrong with the source. `node_modules` predated `3bbb79121`, which
bumped `@deepseek-ai/dsh-fs` `0.0.1-rc.1` → `0.1.0-rc.6`; that release added
`FS_TOO_LARGE` to `FsErrorCode`, and `88698fa08` started using it the same day.
`package.json`, the `pnpm.overrides` block and `pnpm-lock.yaml` all pinned
`0.1.0-rc.6` correctly. `pnpm install` was the entire fix.

The message is what makes this expensive. It names a file nobody touched, a
line that is correct, and a union that is not the one the reader will go
looking for — `@struktoai/mirage-core` exports its own unrelated `FsErrorCode`
(`FsCondition`, the POSIX errno vocabulary, `runtime/python/vfs/errors.ts:26`),
while the one at `fs.ts:88` belongs to `FsError` from `@deepseek-ai/dsh-fs`. It
reads as a missing enum member, and "add `FS_TOO_LARGE` to `FsCondition`" is a
plausible, wrong, and type-clean fix.

Only the DTS half of tsup fails, since esbuild strips types without checking —
so the ESM build reports success immediately above the error.

## The change

```yaml
verifyDepsBeforeRun: error
```

pnpm already knows the install is stale. This asks it to say so:

```
ERR_PNPM_VERIFY_DEPS_BEFORE_RUN  The installed dependencies in the modules
directory is not up-to-date with the lockfile in <dir>.

Run "pnpm install"
```

**It has to live in `pnpm-workspace.yaml`, not `.npmrc`.** Inside a workspace
pnpm reapplies settings from this file over the `.npmrc` ones, so a
`verify-deps-before-run=error` line in `.npmrc` resolves under
`pnpm config get` and is still never consulted. I put it there first and it was
inert; the comment records that so nobody moves it back.

## Verification

Both directions, on this branch:

- **Deps current** — `pnpm -r build` exit 0, `pnpm -r typecheck` clean across
  all 11 projects, `pnpm --filter @struktoai/mirage-dsh test` 93/93.
- **Deps stale** — restoring the pre-bump lockfile and touching a manifest (what
  a checkout does) makes `pnpm -r build` refuse with the message above instead
  of compiling into the TS2345.

The trigger is worth knowing: pnpm's fast path exits early unless some
`package.json` is newer than the last install, and only then compares against
the lockfile. A checkout, pull or rebase rewrites those mtimes, which is exactly
how this class of drift arrives. Editing the lockfile alone does not trip it —
my first test did that and produced a false negative.

## Scope

- **CI is unaffected**, and would never have hit the original break: the gated
  `test` job runs `pnpm install --frozen-lockfile` before `pnpm -r build`, so
  the install is current and the fast path short-circuits. Worth stating plainly
  since it was raised — `pnpm -r build`, `pnpm -r typecheck` and `pnpm test`
  already cover `dsh`; main was genuinely green, not accidentally so, and no
  gate needs a new job.
- **Pulling this commit does not force a reinstall.** `verifyDepsBeforeRun` is
  absent from pnpm's workspace-state settings snapshot, so it is not one of the
  values compared against the last install.
- No Python touched; `test_python.yml`'s path filter does not select this
  change, and I did not run the Python suite for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
