### PR TITLE
refactor(watch): let the cache manager walk the ancestor chain

### DIFF
--- a/python/mirage/watch/base.py
+++ b/python/mirage/watch/base.py
@@ -34,6 +34,9 @@ class CacheInvalidator(Protocol):
     async def invalidate_subtree(self, path: PathSpec) -> None:
         ...
 
+    async def invalidate_ancestors(self, path: PathSpec) -> None:
+        ...
+
 
 class WatchMount(Protocol):
     """What the watch runtime needs from one mount entry.

--- a/python/mirage/watch/watcher.py
+++ b/python/mirage/watch/watcher.py
@@ -108,23 +108,6 @@ class Watcher:
         root = root.rstrip("/")
         return virtual == root or virtual.startswith(root + "/")
 
-    def _ancestors(self, entry: WatchMount, virtual: str) -> list[PathSpec]:
-        """Framed ancestor directories of ``virtual`` below the mount
-        root, nearest first.
-
-        Args:
-            entry (WatchMount): Mount owning the path.
-            virtual (str): Workspace-virtual path of the change.
-        """
-        prefix = entry.prefix.rstrip("/")
-        specs: list[PathSpec] = []
-        current = virtual.rstrip("/")
-        while True:
-            current = current.rsplit("/", 1)[0]
-            if len(current) <= len(prefix):
-                return specs
-            specs.append(self._frame(entry, current))
-
     async def _evict(self, entry: WatchMount, path: PathSpec,
                      kind: FileChangeKind) -> None:
         """Evict one path and every cached ancestor listing above it.
@@ -134,7 +117,11 @@ class Watcher:
         nested create/delete implies intermediate directories appeared
         or vanished with it, so every cached listing up to the mount
         root may be stale (a consumer forwarding only file events from
-        a Nextcloud webhook hits exactly this).
+        a Nextcloud webhook hits exactly this). The chain itself is the
+        cache manager's to walk, not this class's: it already walks one
+        for the keyed stores that materialize a missing level on write,
+        and a second walk here would be the same rule kept in two places
+        with two stopping conditions to keep in step.
 
         How far down the eviction reaches is the change's kind. UNKNOWN
         means precision was lost and everything under the path must be
@@ -157,8 +144,7 @@ class Watcher:
             await manager.invalidate_subtree(path)
         else:
             await manager.invalidate_after_write(path)
-        for ancestor in self._ancestors(entry, path.virtual):
-            await manager.invalidate_after_write(ancestor)
+        await manager.invalidate_ancestors(path)
 
     async def _invalidate(self, entry: WatchMount, change: FileEvent) -> None:
         """Evict cache for one change before it is delivered.

--- a/python/tests/watch/test_watcher.py
+++ b/python/tests/watch/test_watcher.py
@@ -4,6 +4,9 @@ from datetime import datetime, timezone
 
 import pytest
 
+from mirage.cache.index.config import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.cache.manager import CacheManager
 from mirage.types import FileChangeKind, FileEvent, PathSpec
 from mirage.watch.source import Subscriber
 from mirage.watch.watcher import Watcher
@@ -24,6 +27,9 @@ class FakeCacheManager:
 
     async def invalidate_subtree(self, path):
         self._log.append(f"inv-subtree:{path.virtual}")
+
+    async def invalidate_ancestors(self, path):
+        self._log.append(f"inv-ancestors:{path.virtual}")
 
 
 class PlainResource:
@@ -91,8 +97,34 @@ async def test_notify_invalidate_before_deliver():
     await w.notify(_change(FileChangeKind.CREATE, "/nc/data/x.txt"))
     await asyncio.wait_for(task, timeout=2)
     log.append("deliver")
-    assert log == ["inv:/nc/data/x.txt", "inv:/nc/data", "deliver"]
+    assert log == [
+        "inv:/nc/data/x.txt", "inv-ancestors:/nc/data/x.txt", "deliver"
+    ]
     await agen.aclose()
+    await w.close()
+
+
+@pytest.mark.asyncio
+async def test_a_nested_create_drops_every_listing_to_the_mount_root():
+    # A nested external create implies intermediate dirs appeared, so
+    # every cached listing up to the mount root must go, not just the
+    # file's immediate parent. Asserted against a real CacheManager
+    # rather than the fake above, because the walk itself lives there
+    # now and a fake would only prove the call was made.
+    index = RAMIndexCacheStore()
+    levels = ("/nc", "/nc/data", "/nc/data/sub")
+    for level in levels:
+        await index.set_dir(level, [
+            ("child", IndexEntry(id="1", name="child", resource_type="file"))
+        ])
+    entry = FakeMountEntry(prefix="/nc/",
+                           resource=PlainResource(),
+                           cache_manager=CacheManager(None, index, "/nc/",
+                                                      False))
+    w = Watcher(FakeRegistry(entry))
+    await w.notify(_change(FileChangeKind.CREATE, "/nc/data/sub/deep.txt"))
+    for level in levels:
+        assert (await index.list_dir(level)).entries is None
     await w.close()
 
 
@@ -103,7 +135,7 @@ async def test_notify_delete_routes_to_unlink():
     agen, task = await _start_blocked_watch(w)
     await w.notify(_change(FileChangeKind.DELETE, "/nc/data/x.txt"))
     await asyncio.wait_for(task, timeout=2)
-    assert log == ["inv-unlink:/nc/data/x.txt", "inv:/nc/data"]
+    assert log == ["inv-unlink:/nc/data/x.txt", "inv-ancestors:/nc/data/x.txt"]
     await agen.aclose()
     await w.close()
 
@@ -115,7 +147,7 @@ async def test_notify_unknown_routes_to_subtree():
     agen, task = await _start_blocked_watch(w)
     await w.notify(_change(FileChangeKind.UNKNOWN, "/nc/data/day"))
     await asyncio.wait_for(task, timeout=2)
-    assert log == ["inv-subtree:/nc/data/day", "inv:/nc/data"]
+    assert log == ["inv-subtree:/nc/data/day", "inv-ancestors:/nc/data/day"]
     await agen.aclose()
     await w.close()
 
@@ -127,7 +159,7 @@ async def test_notify_update_does_not_reach_the_subtree():
     agen, task = await _start_blocked_watch(w)
     await w.notify(_change(FileChangeKind.UPDATE, "/nc/data/day"))
     await asyncio.wait_for(task, timeout=2)
-    assert log == ["inv:/nc/data/day", "inv:/nc/data"]
+    assert log == ["inv:/nc/data/day", "inv-ancestors:/nc/data/day"]
     await agen.aclose()
     await w.close()
 
@@ -144,6 +176,9 @@ async def test_notify_reframes_resource_path():
         async def invalidate_after_unlink(self, path):
             seen.append(path.resource_path)
 
+        async def invalidate_ancestors(self, path):
+            return None
+
     entry = FakeMountEntry(prefix="/nc/",
                            resource=PlainResource(),
                            cache_manager=RecordingManager())
@@ -151,34 +186,7 @@ async def test_notify_reframes_resource_path():
     agen, task = await _start_blocked_watch(w)
     await w.notify(_change(FileChangeKind.CREATE, "/nc/data/x.txt"))
     await asyncio.wait_for(task, timeout=2)
-    assert seen == ["data/x.txt", "data"]
-    await agen.aclose()
-    await w.close()
-
-
-@pytest.mark.asyncio
-async def test_notify_invalidates_ancestor_chain():
-    # A nested external create implies intermediate dirs appeared, so
-    # every cached listing up to the mount root must be evicted, not
-    # just the file's immediate parent.
-    seen: list[str] = []
-
-    class RecordingManager:
-
-        async def invalidate_after_write(self, path):
-            seen.append(path.virtual)
-
-        async def invalidate_after_unlink(self, path):
-            seen.append(f"unlink:{path.virtual}")
-
-    entry = FakeMountEntry(prefix="/nc/",
-                           resource=PlainResource(),
-                           cache_manager=RecordingManager())
-    w = Watcher(FakeRegistry(entry))
-    agen, task = await _start_blocked_watch(w)
-    await w.notify(_change(FileChangeKind.CREATE, "/nc/data/sub/deep.txt"))
-    await asyncio.wait_for(task, timeout=2)
-    assert seen == ["/nc/data/sub/deep.txt", "/nc/data/sub", "/nc/data"]
+    assert seen == ["data/x.txt"]
     await agen.aclose()
     await w.close()
 
@@ -199,9 +207,9 @@ async def test_notify_move_evicts_both_sides():
     await asyncio.wait_for(task, timeout=2)
     assert log == [
         "inv:/nc/data/new.txt",
-        "inv:/nc/data",
+        "inv-ancestors:/nc/data/new.txt",
         "inv-unlink:/nc/old/orig.txt",
-        "inv:/nc/old",
+        "inv-ancestors:/nc/old/orig.txt",
     ]
     await agen.aclose()
     await w.close()

--- a/typescript/packages/core/src/watch/base.ts
+++ b/typescript/packages/core/src/watch/base.ts
@@ -19,6 +19,7 @@ export interface CacheInvalidator {
   invalidateAfterWrite(path: PathSpec): Promise<void>
   invalidateAfterUnlink(path: PathSpec): Promise<void>
   invalidateSubtree(path: PathSpec): Promise<void>
+  invalidateAncestors(path: PathSpec): Promise<void>
 }
 
 export interface WatchMount {

--- a/typescript/packages/core/src/watch/watcher.test.ts
+++ b/typescript/packages/core/src/watch/watcher.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { IndexEntry } from '../cache/index/config.ts'
+import { RAMIndexCacheStore } from '../cache/index/ram.ts'
+import { CacheManager } from '../cache/manager.ts'
 import { FileChangeKind, FileEvent, PathSpec } from '../types.ts'
 import type { CacheInvalidator, WatchMount, WatchRegistry } from './base.ts'
 import { Watcher } from './watcher.ts'
@@ -20,6 +23,11 @@ class RecordingCache implements CacheInvalidator {
 
   invalidateSubtree(path: PathSpec): Promise<void> {
     this.log.push(`subtree:${path.virtual}:${path.resourcePath}`)
+    return Promise.resolve()
+  }
+
+  invalidateAncestors(path: PathSpec): Promise<void> {
+    this.log.push(`ancestors:${path.virtual}:${path.resourcePath}`)
     return Promise.resolve()
   }
 }
@@ -60,9 +68,31 @@ describe('Watcher', () => {
     expect(delivered.value.path.resourcePath).toBe('data/sub/x.txt')
     expect(cache.log).toEqual([
       'write:/nc/data/sub/x.txt:data/sub/x.txt',
-      'write:/nc/data/sub:data/sub',
-      'write:/nc/data:data',
+      'ancestors:/nc/data/sub/x.txt:data/sub/x.txt',
     ])
+    await watcher.close()
+  })
+
+  it('drops every listing up to the mount root for a nested create', async () => {
+    // A nested external create implies intermediate dirs appeared, so every
+    // cached listing up to the mount root must go, not just the file's
+    // immediate parent. Asserted against a real CacheManager rather than the
+    // recorder above, because the walk itself lives there now and a fake would
+    // only prove the call was made.
+    const index = new RAMIndexCacheStore({ ttl: 600 })
+    const levels = ['/nc', '/nc/data', '/nc/data/sub']
+    for (const level of levels) {
+      await index.setDir(level, [
+        ['child', new IndexEntry({ id: '1', name: 'child', resourceType: 'file' })],
+      ])
+    }
+    const manager = new CacheManager(null, index, '/nc/', false)
+    const watcher = new Watcher(new FakeRegistry({ prefix: '/nc/', cacheManager: manager }))
+    await watcher.notify(change(FileChangeKind.CREATE, '/nc/data/sub/deep.txt'))
+    for (const level of levels) {
+      const listing = await index.listDir(level)
+      expect(listing.entries ?? null).toBeNull()
+    }
     await watcher.close()
   })
 
@@ -72,7 +102,7 @@ describe('Watcher', () => {
     const pending = await begin(watcher, '/nc')
     await watcher.notify(change(FileChangeKind.UNKNOWN, '/nc/data/day'))
     await pending.next
-    expect(cache.log).toEqual(['subtree:/nc/data/day:data/day', 'write:/nc/data:data'])
+    expect(cache.log).toEqual(['subtree:/nc/data/day:data/day', 'ancestors:/nc/data/day:data/day'])
     await watcher.close()
   })
 
@@ -82,7 +112,7 @@ describe('Watcher', () => {
     const pending = await begin(watcher, '/nc')
     await watcher.notify(change(FileChangeKind.UPDATE, '/nc/data/day'))
     await pending.next
-    expect(cache.log).toEqual(['write:/nc/data/day:data/day', 'write:/nc/data:data'])
+    expect(cache.log).toEqual(['write:/nc/data/day:data/day', 'ancestors:/nc/data/day:data/day'])
     await watcher.close()
   })
 
@@ -100,7 +130,7 @@ describe('Watcher', () => {
     )
     await pending.next
     expect(cache.log).toContain('unlink:/nc/old/original.txt:old/original.txt')
-    expect(cache.log).toContain('write:/nc/old:old')
+    expect(cache.log).toContain('ancestors:/nc/old/original.txt:old/original.txt')
     await watcher.close()
   })
 

--- a/typescript/packages/core/src/watch/watcher.ts
+++ b/typescript/packages/core/src/watch/watcher.ts
@@ -61,19 +61,13 @@ export class Watcher implements WatchRuntime {
     return subscriber.roots.some((root) => this.inScope(root, change.path.virtual))
   }
 
-  private ancestors(mount: WatchMount, virtual: string): PathSpec[] {
-    const prefix = rstripSlash(mount.prefix)
-    const ancestors: PathSpec[] = []
-    let current = rstripSlash(virtual)
-    for (;;) {
-      current = current.slice(0, current.lastIndexOf('/'))
-      if (current.length <= prefix.length) return ancestors
-      ancestors.push(this.frame(mount, current))
-    }
-  }
-
   /**
    * Evict one path and every cached ancestor listing above it.
+   *
+   * The chain itself is the cache manager's to walk, not this class's: it
+   * already walks one for the keyed stores that materialize a missing level on
+   * write, and a second walk here would be the same rule kept in two places
+   * with two stopping conditions to keep in step.
    *
    * How far down the eviction reaches is the change's kind. UNKNOWN means
    * precision was lost and everything under the path must be re-inventoried,
@@ -87,9 +81,7 @@ export class Watcher implements WatchRuntime {
     if (kind === FileChangeKind.DELETE) await manager.invalidateAfterUnlink(path)
     else if (kind === FileChangeKind.UNKNOWN) await manager.invalidateSubtree(path)
     else await manager.invalidateAfterWrite(path)
-    for (const ancestor of this.ancestors(mount, path.virtual)) {
-      await manager.invalidateAfterWrite(ancestor)
-    }
+    await manager.invalidateAncestors(path)
   }
 
   private async invalidate(mount: WatchMount, change: FileEvent): Promise<void> {


### PR DESCRIPTION
The watcher built its own ancestor list and evicted each entry with `invalidate_after_write`, which is what `CacheManager.invalidate_ancestors` already does.

Probed before changing anything: the two produce the identical set of dropped directory keys.

```
watcher loop   dirs: ['/m', '/m/', '/m/data', '/m/data/', '/m/data/sub', '/m/data/sub/']
invalidate_anc dirs: ['/m', '/m/', '/m/data', '/m/data/', '/m/data/sub', '/m/data/sub/']
```

So the watcher's copy added a second stopping rule to keep in step, plus one file-cache `remove` per ancestor *directory* key, which can never hit.

- `invalidate_ancestors` / `invalidateAncestors` joins the `CacheInvalidator` protocol in both languages.
- `Watcher._ancestors` / `Watcher.ancestors` deleted.
- The reach is now pinned against a real `CacheManager` (seeded `RAMIndexCacheStore`, assert every listing up to the mount root is gone) rather than only through a fake, since the walk lives there now. Confirmed non-vacuous by removing the call: 6 of 9 Python and 5 of 8 TypeScript watcher tests go red.

## Gates

| | |
| --- | --- |
| pre-commit (all files) | exit 0, stable on re-run |
| layout parity | 286 = baseline |
| Python suite | exit 0, 0 failures |
| `pnpm -r typecheck` | all 11 packages |
| TS core | 8912 passed, 10 skipped |
| TS node | 2448 passed, 4 skipped |
| TS browser | 184 passed |