### PR TITLE
fix(s3): refuse a version-pinned read on the browser presigned client

### DIFF
--- a/typescript/packages/core/src/core/s3/client_browser.test.ts
+++ b/typescript/packages/core/src/core/s3/client_browser.test.ts
@@ -169,6 +169,56 @@ describe('createBrowserS3Client — command dispatch', () => {
     ).rejects.toMatchObject({ $metadata: { httpStatusCode: 404 } })
   })
 
+  // A presigned URL is signed for a key, not a version. Before this refusal the
+  // shim read only Key, so a snapshot-pinned read fetched and returned whichever
+  // version was current -- no error, no log, just the wrong bytes. Asserting
+  // that neither the provider nor fetch ran is what distinguishes refusing from
+  // answering: the old code reached both and resolved.
+  it('GET refuses a version-pinned read instead of returning the current object', async () => {
+    const { provider, calls } = makeProvider(() => 'https://signed/get')
+    fetchHandle = installFetch(() => new Response(new Uint8Array([104, 105]), { status: 200 }))
+    const client = createBrowserS3Client(cfg(provider))
+    const { GetObjectCommand } = BROWSER_S3_MODULE
+    await expect(
+      client.send(new GetObjectCommand({ Bucket: 'b', Key: 'pinned.txt', VersionId: 'v2' })),
+    ).rejects.toThrow(/cannot serve a version-pinned read/)
+    expect(calls).toEqual([])
+    expect(fetchHandle.calls).toEqual([])
+  })
+
+  it('HEAD refuses a version-pinned stat for the same reason', async () => {
+    const { provider, calls } = makeProvider(() => 'https://signed/head')
+    fetchHandle = installFetch(() => new Response('', { status: 200 }))
+    const client = createBrowserS3Client(cfg(provider))
+    const { HeadObjectCommand } = BROWSER_S3_MODULE
+    await expect(
+      client.send(new HeadObjectCommand({ Bucket: 'b', Key: 'pinned.txt', VersionId: 'v2' })),
+    ).rejects.toThrow(/cannot serve a version-pinned read/)
+    expect(calls).toEqual([])
+    expect(fetchHandle.calls).toEqual([])
+  })
+
+  // MaxKeys is the counter-example the refusal must not swallow: `stat`'s
+  // directory probe sends it, the shim ignores it, and ignoring it returns more
+  // data but the same answer. Only fields that change the answer may refuse.
+  it('LIST still ignores a MaxKeys hint rather than refusing it', async () => {
+    const { provider } = makeProvider(() => 'https://signed/list')
+    fetchHandle = installFetch(
+      () =>
+        new Response(
+          '<?xml version="1.0"?><ListBucketResult><Contents><Key>a.txt</Key>' +
+            '<Size>1</Size></Contents></ListBucketResult>',
+          { status: 200 },
+        ),
+    )
+    const client = createBrowserS3Client(cfg(provider))
+    const { ListObjectsV2Command } = BROWSER_S3_MODULE
+    const resp = await client.send(
+      new ListObjectsV2Command({ Bucket: 'b', Prefix: '', Delimiter: '/', MaxKeys: 1 }),
+    )
+    expect((resp.Contents as unknown[]).length).toBe(1)
+  })
+
   it('HEAD returns only metadata (no Body)', async () => {
     const { provider, calls } = makeProvider(() => 'https://signed/head')
     fetchHandle = installFetch(

--- a/typescript/packages/core/src/core/s3/client_browser.ts
+++ b/typescript/packages/core/src/core/s3/client_browser.ts
@@ -184,6 +184,22 @@ function keyFromInput(input: Record<string, unknown>): string {
   return typeof k === 'string' ? k : ''
 }
 
+// A presigned URL is signed for a key, not for a version: the provider takes
+// `(path, operation, options)` and has no slot to carry one. Serving the
+// request anyway returns whichever version is current, which is the opposite
+// of what a pinned read asked for and is indistinguishable from a correct
+// answer — so refuse instead. Only fields that change the *answer* belong
+// here; a hint like MaxKeys, whose omission returns more data but the same
+// answer, must keep being ignored or `stat`'s List probe would break.
+function refuseVersionPin(op: string, key: string, input: { VersionId?: unknown }): void {
+  if (input.VersionId === undefined) return
+  throw new Error(
+    `S3 ${op} ${key}: the presigned-fetch client cannot serve a version-pinned ` +
+      'read, so it would silently return the current object; a snapshot-pinned ' +
+      'read needs an SDK-backed config rather than presignedUrlProvider',
+  )
+}
+
 function makeNotFound(path: string): Error & { $metadata: { httpStatusCode: number } } {
   const e = new Error(`S3 object not found: ${path}`) as Error & {
     $metadata: { httpStatusCode: number }
@@ -207,8 +223,9 @@ async function sendBrowserCommand(
   const tag = browserCmd.__mirageTag
   switch (tag) {
     case 'Get': {
-      const input = browserCmd.input as { Key?: unknown; Range?: unknown }
+      const input = browserCmd.input as { Key?: unknown; Range?: unknown; VersionId?: unknown }
       const key = typeof input.Key === 'string' ? input.Key : ''
+      refuseVersionPin('GET', key, input)
       // A presigned GET carries no Range: the header would make the request
       // non-simple and trip a CORS preflight presigned deployments generally
       // do not allow. Serving it anyway would return the whole object as if it
@@ -241,6 +258,7 @@ async function sendBrowserCommand(
     }
     case 'Head': {
       const key = keyFromInput(browserCmd.input)
+      refuseVersionPin('HEAD', key, browserCmd.input)
       const url = await provider(`/${key}`, 'HEAD')
       const resp = await fetch(url, { method: 'HEAD' })
       if (resp.status === 404) throw makeNotFound(key)


### PR DESCRIPTION
The presigned-fetch S3 client's `Get` case read only `Key` and `Range`, so a `VersionId` was **silently dropped** and the request returned whichever version was current. No error, no log — just the wrong bytes.

That is reachable today: `core/s3/read.ts:65` and `core/s3/stream.ts:50` both set `input.VersionId = pinnedRevision` when `revisionFor()` returns a pin, so every snapshot-pinned browser read resolved against the live object instead. It affects all **15** browser resources that route through `createBrowserS3Client` — s3, r2, gcs, minio, ceph, backblaze, wasabi, digitalocean, scaleway, supabase, aliyun, tencent, oci, qingstor, seaweedfs. The node/SDK path is correct, so it never reproduces outside a browser runtime.

## The fix

Refuse, exactly as #742 did for `Range`. A presigned URL is signed for a key, not a version: the provider is `(path, operation, options)` and has no slot to carry one, so there is nothing to pass through and no way to answer honestly.

`Head` is guarded through the same helper. `stat` does not pin a revision today (`stat.ts:101` sends a bare `Bucket`/`Key`), but a version-pinned stat would be wrong in precisely the same way, and the shim is the chokepoint where that has to be caught.

## The rule this does *not* over-apply

Only fields that change the **answer** may refuse. `stat`'s directory probe sends `MaxKeys: 1` (`stat.ts:88-92`) and the shim ignores it — ignoring it returns *more* data but the *same* answer, and refusing it would break `stat` outright. A test pins that counter-example so a later reading of "never accept-and-ignore" does not turn every ignored hint into an error.

## Behavior change

Browser snapshot restores that were silently returning current-version bytes now fail loudly. That is the point of the change, but it is a visible difference for anyone who had a pinned read quietly "working".

There is no python twin: python has no browser runtime and no presigned shim.

## Verification

- `client_browser.test.ts` — 22 passed; whole `core/s3` suite 67 passed across 8 files
- `tsc --noEmit`, eslint, prettier — clean
- **Discriminating check**: with the two `refuseVersionPin` calls commented out, exactly the 2 new refusal tests fail and the MaxKeys counter-example still passes. The tests assert that neither the provider nor `fetch` runs, which is what separates *refusing* from *answering* — the pre-fix path reached both and resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
