### PR TITLE
Run the two integ CLI hosts concurrently

### DIFF
--- a/integ/runtime/cli.sh
+++ b/integ/runtime/cli.sh
@@ -288,10 +288,56 @@ run_host() {
 
   $cli daemon stop >/dev/null 2>&1 </dev/null || true
   sleep 1
+
+  # Each host runs in its own subshell, so its tally has to leave through
+  # the filesystem: a subshell's variables die with it.
+  printf '%s %s %s\n' "$pass" "$fail" "$skipped" > "$RESULT_DIR/$host.tally"
+  : > "$RESULT_DIR/$host.failures"
+  for line in "${failures[@]:-}"; do
+    [ -n "$line" ] && printf '%s\n' "$line" >> "$RESULT_DIR/$host.failures"
+  done
 }
 
-run_host "$PY_CLI" "python" 8791
-run_host "$TS_CLI" "typescript" 8792
+# The two hosts are independent: separate daemon ports, a MIRAGE_HOME each,
+# and only ram mounts reach the CLI (see cli_expressible), so they share no
+# store. The docker suite is the one thing they do share, and its cases are
+# stateless execs (echo, exit, wc, uname) rather than writes, so two
+# `docker exec` sessions in the one container cannot collide. Running them
+# together halves the longest step in the integ workflow.
+RESULT_DIR="$(mktemp -d "/tmp/rt-cli-results.XXXXXX")"
+
+(run_host "$PY_CLI" "python" 8791) > "$RESULT_DIR/python.log" 2>&1 &
+py_pid=$!
+(run_host "$TS_CLI" "typescript" 8792) > "$RESULT_DIR/typescript.log" 2>&1 &
+ts_pid=$!
+wait "$py_pid"
+wait "$ts_pid"
+
+# Printed per host rather than interleaved, which is what makes a failure
+# readable: the two hosts would otherwise write over each other's lines.
+for host in python typescript; do
+  echo "=== $host ==="
+  cat "$RESULT_DIR/$host.log"
+done
+
+pass=0
+fail=0
+skipped=0
+failures=()
+for host in python typescript; do
+  if [ ! -s "$RESULT_DIR/$host.tally" ]; then
+    failures+=("$host: no tally written (the host died before finishing)")
+    fail=$((fail + 1))
+    continue
+  fi
+  read -r host_pass host_fail host_skipped < "$RESULT_DIR/$host.tally"
+  pass=$((pass + host_pass))
+  fail=$((fail + host_fail))
+  skipped=$((skipped + host_skipped))
+  while IFS= read -r line; do
+    [ -n "$line" ] && failures+=("$line")
+  done < "$RESULT_DIR/$host.failures"
+done
 
 echo ""
 echo "$pass passed, $fail failed, $skipped skipped"


### PR DESCRIPTION
## Summary

`integ-runtime` is the longest job in the Integ workflow, and one step is essentially all of it. On a healthy run, `Run every runtime through the CLI and both daemons` is **27 minutes of a 30 minute job**, while the two JSON-suite steps beside it take 16 and 32 seconds.

`cli.sh` spent that time running the python host to completion and then the typescript host. The two share nothing that matters: separate daemon ports (8791/8792), a `MIRAGE_HOME` each, and only ram mounts reach the CLI at all (`cli_expressible`), so no store is common to them. The docker suite is the one thing they do share, and its six cases are stateless execs (`echo`, `exit 7`, `wc -l`, `uname`) rather than writes, so two `docker exec` sessions in the one container cannot collide.

Both hosts now run at once. A host's tally has to leave its subshell through the filesystem, so each writes one, and the parent sums them, treats a missing tally as a failure rather than a zero, and prints each host's log whole instead of letting the two interleave.

## Measured

Same suites, same machine:

| | elapsed | result |
|---|---|---|
| sequential | 465s | 171 passed, 0 failed, 37 skipped |
| concurrent | 273s | 171 passed, 0 failed, 37 skipped |

41% faster with an identical tally. Pointing one host at a CLI that does not exist still exits 1 and still attributes every failure line to that host.

## What this does not fix

`integ-data` is 29 minutes, so the workflow's critical path only moves from ~30 to ~29. The rest of that time is the nextcloud declarative battery (22.3m python, 17.8m typescript, 2479 cases at ~0.54s each against live WebDAV), and it is **not shardable as the corpus stands**: the suite runs one workspace per target in `seq` order, and reversing the order changes the result of 501 of 2816 ram cases. The cases are an ordered transaction, not a set, so splitting them across jobs would silently change what they assert. Cutting nextcloud needs the corpus to be made order-independent first, which is its own piece of work.

There is also no duplicated work to delete: `integ-data` and `integ-ts` both run "the nextcloud battery" but on the python and typescript hosts respectively, and the core facet's split across jobs is already declared through `--allow-skip`.

## Test plan

- `bash -n integ/runtime/cli.sh`
- Ran the suite both ways locally against the same CLIs, comparing tallies (above)
- Ran with a deliberately broken host CLI to confirm the step still exits 1 and reports that host's failures