### PR TITLE
fix(deps): override deepmerge-ts to >=8 for GHSA-ggr8-5vv4-36mx

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -48,6 +48,7 @@
       "nanoid@>=3.0.0 <3.3.18": ">=3.3.18 <4",
       "find-my-way@<=9.6.0": ">=9.7.0 <10",
       "postcss@<=8.5.17": ">=8.5.18 <9",
+      "deepmerge-ts@<8.0.0": ">=8.0.0 <9",
       "@deepseek-ai/dsh-invariants": "0.1.0-rc.6",
       "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
       "@deepseek-ai/dsh-sandbox": "0.1.0-rc.6",

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -36,6 +36,7 @@ overrides:
   nanoid@>=3.0.0 <3.3.18: '>=3.3.18 <4'
   find-my-way@<=9.6.0: '>=9.7.0 <10'
   postcss@<=8.5.17: '>=8.5.18 <9'
+  deepmerge-ts@<8.0.0: '>=8.0.0 <9'
   '@deepseek-ai/dsh-invariants': 0.1.0-rc.6
   '@deepseek-ai/dsh-llm': 0.1.0-rc.6
   '@deepseek-ai/dsh-sandbox': 0.1.0-rc.6
@@ -4165,8 +4166,8 @@ packages:
       langchain: ^1.5.0
       langsmith: ^0.7.1
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   deepmerge@4.3.1:
@@ -9668,7 +9669,7 @@ snapshots:
   '@prisma/config@6.19.3':
     dependencies:
       c12: 3.1.0
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       effect: 3.21.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -11044,7 +11045,7 @@ snapshots:
       yaml: 2.9.0
       zod: 4.4.3
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   deepmerge@4.3.1: {}
 


### PR DESCRIPTION
## Summary

- `@prisma/config` pins `deepmerge-ts` to exactly `7.1.5`, which is vulnerable to stack exhaustion on recursive object graphs (GHSA-ggr8-5vv4-36mx, high).
- Latest prisma (7.9.1) pins the same exact version, so a prisma bump does not fix it. Added a `pnpm.overrides` entry instead, matching the existing entries.
- v8 is a superset of v7's exports; `@prisma/config`'s only use is `deepmerge` as c12's `merger`.

## Test plan

- `pnpm audit` -> No known vulnerabilities found (was 1 high)
- `pnpm install --frozen-lockfile` -> exit 0
- `prisma generate --schema prisma/schema.prisma` (the integ CI step) -> exit 0