### PR TITLE
fix(dsh): make the providers behave inside a real dsh composition

### DIFF
--- a/docs/typescript/agents/dsh.mdx
+++ b/docs/typescript/agents/dsh.mdx
@@ -53,6 +53,17 @@ await ctx.plugin(MirageShellExecutor, { sessionId: 'agent-1' }).await()
 
 A bound session keeps its cwd, exports, and functions across calls. It is created on first use (an existing session is adopted as is), and two executors bound to different sessions stay fully apart on one workspace.
 
+dsh sends a working directory and a set of managed `DSH_*` variables with every call, and in Mirage a per-call directory or environment forks a subshell. Taken at face value, a bound session would therefore have nothing left to persist, so both are checked first. The workdir dsh computed on its own machine is not a directory in this world, so it is ignored: the executor's own `workdir` when unbound, the session's cwd when bound, and `ctx.fs` resolves relative paths against the same base. The `DSH_*` variables are set in the session once instead of riding along per call. A workdir that does exist here, or any other per-call variable, still forks a subshell, which is what "only this command" should mean.
+
+```ts
+// dsh sends its own machine's cwd, a path this world does not contain
+const host = '/Users/somebody/host-project'
+
+await shell.run(shell.resolve({ command: 'cd /tmp && export TOKEN=abc', workdir: host }))
+const result = await shell.run(shell.resolve({ command: 'pwd; echo $TOKEN', workdir: host }))
+// result.stdout.text === '/tmp\nabc\n'
+```
+
 ## Run Python with monty
 
 The `runtimes` entry above sets [monty](https://github.com/pydantic/monty), a sandboxed Python interpreter with no host access, up to capture `python` and `python3`; the catch-all `vfs` runtime serving the shell commands is always present and needs no entry. A captured invocation (a script file, inline `-c` code, or code piped on stdin) runs inside the workspace, never on the machine. A script can live on any mount: upload `example.py` to a Slack channel and run it straight off the mount, with the shell's redirection filing its stdout back into Redis:
@@ -91,7 +102,23 @@ The bundle's default world is one RAM scratch mount at `/tmp`. Mount real resour
       - { name: monty, captures: [python, python3] }
 ```
 
-The same blocks work in code, beside live instances, in `MirageService`'s `mounts`. The shell executor reports a `workspace-write` sandbox to dsh whenever every runtime in the world stays inside the VFS (each runtime's `reach` is `vfs`), which is what lets dsh's permission presets compose over it: a command cannot then reach anything but the mounts, under their modes. Adding a host-reaching runtime such as `local` python drops the claim, since a script could act outside the mounts, and dsh is told there is no sandbox rather than a false one.
+The same blocks work in code, beside live instances, in `MirageService`'s `mounts`.
+
+Both seams tell dsh they are a `workspace-write` sandbox, which is what lets dsh's permission presets compose over them. The claim holds only while every runtime stays inside the VFS (each runtime's `reach` is `vfs`). Add a host-reaching one, such as `local` Python, and both seams drop the claim, since a script could then act outside the mounts: dsh is better told there is no sandbox than a false one.
+
+The claim is enforced per call, not merely advertised. dsh resolves a policy for every command and every file edit, and Mirage applies it. Under `read-only` the shell runs in a session where every mount is granted read, and `ctx.fs` refuses a write or an edit with `FS_SANDBOX_DENIED`, the same error dsh's own sandboxed backend raises:
+
+```ts
+const policy = { mode: 'read-only', workspaceRoot: '/Users/somebody/host-project' } as const
+
+const denied = await shell.run(shell.resolve({ command: 'echo hi > /tmp/out.txt', sandboxPolicy: policy }))
+// nonzero exitCode, and denied.sandbox is { mode: 'read-only', denied: true, ... }
+
+await ctx.fs.writeText(await ctx.fs.resolve('/tmp/out.txt'), 'hi', undefined, undefined, policy)
+// throws FsError, code FS_SANDBOX_DENIED
+```
+
+So `DSH_PERMISSION_MODE=read-only` confines a Mirage world, and the result reports the mode the command actually ran under. The `/dev` null sink stays writable, as that mode requires. The policy's `workspaceRoot` is a directory on the host and is deliberately never consulted: here the mounts and their modes are the boundary.
 
 ## Custom backends
 

--- a/docs/typescript/agents/dsh.mdx
+++ b/docs/typescript/agents/dsh.mdx
@@ -106,7 +106,7 @@ The same blocks work in code, beside live instances, in `MirageService`'s `mount
 
 Both seams tell dsh they are a `workspace-write` sandbox, which is what lets dsh's permission presets compose over them. The claim holds only while every runtime stays inside the VFS (each runtime's `reach` is `vfs`). Add a host-reaching one, such as `local` Python, and both seams drop the claim, since a script could then act outside the mounts: dsh is better told there is no sandbox than a false one.
 
-The claim is enforced per call, not merely advertised. dsh resolves a policy for every command and every file edit, and Mirage applies it. Under `read-only` the shell runs in a session where every mount is granted read, and `ctx.fs` refuses a write or an edit with `FS_SANDBOX_DENIED`, the same error dsh's own sandboxed backend raises:
+The claim is enforced per call, not merely advertised. dsh resolves a policy for every command and every file edit, and Mirage applies it. Under `read-only` the shell runs in a twin of its own session with every grant narrowed to read, so a session already confined to some mounts stays confined (the twin narrows, it never widens), and `ctx.fs` refuses a write or an edit with `FS_SANDBOX_DENIED`, the same error dsh's own sandboxed backend raises:
 
 ```ts
 const policy = { mode: 'read-only', workspaceRoot: '/Users/somebody/host-project' } as const

--- a/typescript/packages/dsh/cordis.patch.yml
+++ b/typescript/packages/dsh/cordis.patch.yml
@@ -19,6 +19,22 @@
 #           config: { token: !!js process.env.SLACK_BOT_TOKEN }
 #       runtimes:
 #         - { name: monty, captures: [python, python3] }
+#
+# Two facts about how the mirage providers read the surrounding dsh
+# composition, neither of which needs a row here:
+#
+#   * The standing file policy is enforced, not merely reported. Both
+#     seams narrow every mount grant to read for a `read-only` call
+#     (leaving the null sink writable, as that mode's definition
+#     requires), so dsh-base's `DSH_PERMISSION_MODE=read-only` now
+#     actually confines a mirage world instead of being ignored. The
+#     policy's `workspaceRoot` is a directory on the host and is never
+#     consulted: the mounts and their modes are the boundary here.
+#
+#   * A workdir dsh resolved on its own machine (an unspecified one
+#     comes from the calling session's cwd) names nothing in this world,
+#     so it is ignored in favour of the workspace default rather than
+#     run in a directory the agent cannot reach.
 
 # The host filesystem and bash providers step aside; mirage provides the
 # same ctx.fs and ctx.shell seams over the workspace.

--- a/typescript/packages/dsh/src/errors.test.ts
+++ b/typescript/packages/dsh/src/errors.test.ts
@@ -1,0 +1,70 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { FsError } from '@deepseek-ai/dsh-fs'
+import { assertNotAborted, mapMirageError } from './errors.ts'
+
+function stamped(code: string, message = 'boom'): Error {
+  return Object.assign(new Error(message), { code })
+}
+
+describe('assertNotAborted', () => {
+  it('throws FS_ABORTED for a fired signal and passes otherwise', () => {
+    const controller = new AbortController()
+    expect(() => {
+      assertNotAborted(controller.signal, 'read')
+    }).not.toThrow()
+    expect(() => {
+      assertNotAborted(undefined, 'read')
+    }).not.toThrow()
+    controller.abort()
+    try {
+      assertNotAborted(controller.signal, 'read')
+      throw new Error('expected rejection')
+    } catch (err) {
+      expect((err as FsError).code).toBe('FS_ABORTED')
+    }
+  })
+})
+
+describe('mapMirageError', () => {
+  it('recognizes both abort shapes', () => {
+    const asDom = new DOMException('stopped', 'AbortError')
+    expect(mapMirageError(asDom, 'read', '/a').code).toBe('FS_ABORTED')
+    const asError = Object.assign(new Error('stopped'), { name: 'AbortError' })
+    expect(mapMirageError(asError, 'read', '/a').code).toBe('FS_ABORTED')
+  })
+
+  it('maps POSIX stamps to the dsh taxonomy', () => {
+    expect(mapMirageError(stamped('EISDIR'), 'read', '/a').code).toBe('FS_NOT_REGULAR_FILE')
+    expect(mapMirageError(stamped('ENOTDIR'), 'read', '/a').code).toBe('FS_NOT_DIRECTORY')
+    expect(mapMirageError(stamped('EACCES'), 'write', '/a').code).toBe('FS_PERMISSION_DENIED')
+    expect(mapMirageError(stamped('EPERM'), 'write', '/a').code).toBe('FS_PERMISSION_DENIED')
+    expect(mapMirageError(stamped('ENOENT'), 'read', '/a').code).toBe('FS_NOT_FOUND')
+    expect(mapMirageError(stamped('EXDEV'), 'write', '/a').code).toBe('FS_IO_ERROR')
+  })
+
+  it('passes an FsError through untouched', () => {
+    const original = new FsError('already typed', 'FS_NOT_TEXT')
+    expect(mapMirageError(original, 'read', '/a')).toBe(original)
+  })
+
+  it('names the operation and path, and keeps the cause', () => {
+    const cause = stamped('EIO', 'disk died')
+    const mapped = mapMirageError(cause, 'read', '/data/a.txt')
+    expect(mapped.message).toBe('cannot read "/data/a.txt": disk died')
+    expect(mapped.cause).toBe(cause)
+  })
+})

--- a/typescript/packages/dsh/src/errors.ts
+++ b/typescript/packages/dsh/src/errors.ts
@@ -49,7 +49,11 @@ function codeFor(err: unknown): FsErrorCode {
 
 export function mapMirageError(err: unknown, operation: string, displayPath: string): FsError {
   if (err instanceof FsError) return err
-  if (err instanceof DOMException && err.name === 'AbortError') {
+  // Matched by name, not by class: mirage's own executor throws a
+  // `DOMException`, but an aborted fetch or a backend SDK may throw a
+  // plain `Error` named the same, and reporting that as FS_IO_ERROR
+  // would tell the caller its own cancellation was a backend failure.
+  if (err instanceof Error && err.name === 'AbortError') {
     return new FsError(`${operation} aborted`, 'FS_ABORTED', { cause: err })
   }
   const message = err instanceof Error ? err.message : String(err)

--- a/typescript/packages/dsh/src/fs.test.ts
+++ b/typescript/packages/dsh/src/fs.test.ts
@@ -18,7 +18,7 @@ import { FsError, FsTargetKey, FsVersion } from '@deepseek-ai/dsh-fs'
 import type { FsErrorCode } from '@deepseek-ai/dsh-fs'
 import { RAMResource } from '@struktoai/mirage-core/resource/ram/ram'
 import { MountMode } from '@struktoai/mirage-core/types'
-import { Workspace, registerResourceFactory } from '@struktoai/mirage-node'
+import { LocalRuntime, Workspace, registerResourceFactory } from '@struktoai/mirage-node'
 import { MirageFileSystem } from './fs.ts'
 import type { MirageFsConfig } from './fs.ts'
 import { MirageService } from './service.ts'
@@ -85,6 +85,31 @@ describe('resolve', () => {
     const target = await fs.resolve('a.txt')
     expect(String(target.targetKey)).toBe('/data/a.txt')
     expect(target.displayPath).toBe('/data/a.txt')
+  })
+
+  it('ignores a caller cwd that names nothing in this world', async () => {
+    const { fs } = await makeFs({ 'a.txt': 'hello' }, { cwd: '/data' })
+    const target = await fs.resolve('a.txt', { cwd: '/Users/somebody/host-project' })
+    expect(String(target.targetKey)).toBe('/data/a.txt')
+    expect(await fs.readText(target)).toBe('hello')
+  })
+
+  it('honors a caller cwd that is a real directory here', async () => {
+    const { fs } = await makeFs({ 'sub/b.txt': 'nested' }, { cwd: '/' })
+    const target = await fs.resolve('b.txt', { cwd: '/data/sub' })
+    expect(String(target.targetKey)).toBe('/data/sub/b.txt')
+  })
+
+  it('leaves an absolute path alone whatever the caller cwd says', async () => {
+    const { fs } = await makeFs({ 'a.txt': 'hello' }, { cwd: '/' })
+    const target = await fs.resolve('/data/a.txt', { cwd: '/Users/somebody/host-project' })
+    expect(String(target.targetKey)).toBe('/data/a.txt')
+  })
+
+  it('ignores a host cwd for lstat too', async () => {
+    const { fs } = await makeFs({ 'a.txt': 'hello' }, { cwd: '/data' })
+    const info = await fs.lstat('a.txt', { cwd: '/Users/somebody/host-project' })
+    expect(info?.type).toBe('file')
   })
 
   it('yields one target key for aliased spellings', async () => {
@@ -435,5 +460,86 @@ describe('cancellation across readiness', () => {
     const ws = await ctx.mirage.ready
     expect(await ws.fs.exists('/data/out.txt')).toBe(false)
     await fiber.dispose()
+  })
+})
+
+describe('sandbox policy', () => {
+  const READ_ONLY = { mode: 'read-only', workspaceRoot: '/Users/somebody/host-project' } as const
+  const WORKSPACE_WRITE = { mode: 'workspace-write', workspaceRoot: '/Users/somebody' } as const
+
+  it('reports the same confinement the shell executor does', async () => {
+    const { fs } = await makeFs()
+    expect(fs.sandboxMode).toBe('workspace-write')
+  })
+
+  it('makes no claim once a runtime executes beyond the workspace', async () => {
+    const { fs, ws } = await makeFs()
+    ws.addRuntime(new LocalRuntime({ captures: ['python'] }))
+    expect(fs.sandboxMode).toBeUndefined()
+  })
+
+  it('refuses a write under a read-only policy', async () => {
+    const { fs, ws } = await makeFs()
+    const target = await fs.resolve('/data/new.txt')
+    expect(await errorCode(fs.writeText(target, 'x', undefined, undefined, READ_ONLY))).toBe(
+      'FS_SANDBOX_DENIED',
+    )
+    expect(await ws.fs.exists('/data/new.txt')).toBe(false)
+  })
+
+  it('refuses an edit under a read-only policy', async () => {
+    const { fs, ws } = await makeFs({ 'a.txt': 'one' })
+    const target = await fs.resolve('/data/a.txt')
+    const edit = { oldString: 'one', newString: 'two', replaceAll: false }
+    expect(await errorCode(fs.editText(target, edit, undefined, undefined, READ_ONLY))).toBe(
+      'FS_SANDBOX_DENIED',
+    )
+    expect(await ws.fs.readFileText('/data/a.txt')).toBe('one')
+  })
+
+  it('reads under a read-only policy, since only mutations are fenced', async () => {
+    const { fs } = await makeFs({ 'a.txt': 'visible' })
+    const target = await fs.resolve('/data/a.txt')
+    expect(await fs.readText(target)).toBe('visible')
+  })
+
+  it('allows a write under a workspace-write policy', async () => {
+    const { fs } = await makeFs()
+    const target = await fs.resolve('/data/new.txt')
+    const outcome = await fs.writeText(target, 'x', undefined, undefined, WORKSPACE_WRITE)
+    expect(outcome.operation).toBe('create')
+  })
+
+  it('allows an unguarded write when the caller supplies no policy', async () => {
+    const { fs } = await makeFs()
+    const target = await fs.resolve('/data/new.txt')
+    const outcome = await fs.writeText(target, 'x')
+    expect(outcome.operation).toBe('create')
+  })
+})
+
+describe('listDir cancellation', () => {
+  it('stops walking children once the signal fires', async () => {
+    const { fs, ws } = await makeFs({ 'a.txt': 'x', 'b.txt': 'y', 'c.txt': 'z' })
+    const target = await fs.resolve('/data')
+    const controller = new AbortController()
+    // The walk's per-entry stats are index hits the readdir just warmed,
+    // so the only deterministic window is the moment the listing lands.
+    // Aborting as `readdir` returns puts the signal exactly there: with
+    // the walk unguarded it would classify every child regardless.
+    const ops = ws.fs
+    const inner = ops.readdir.bind(ops)
+    ops.readdir = async (path: string): Promise<string[]> => {
+      const listing = await inner(path)
+      controller.abort()
+      return listing
+    }
+    expect(await errorCode(fs.listDir(target, controller.signal))).toBe('FS_ABORTED')
+  })
+
+  it('lists the whole directory when nothing aborts', async () => {
+    const { fs } = await makeFs({ 'a.txt': 'x', 'b.txt': 'y' })
+    const entries = await fs.listDir(await fs.resolve('/data'), new AbortController().signal)
+    expect(entries.map((e) => e.name)).toEqual(['a.txt', 'b.txt'])
   })
 })

--- a/typescript/packages/dsh/src/fs.ts
+++ b/typescript/packages/dsh/src/fs.ts
@@ -43,6 +43,12 @@ import type {} from './service.ts'
 
 type LinksSeam = NonNullable<Ops['links']>
 
+// Read off the seam's own signature rather than imported: the policy type
+// lives in `@deepseek-ai/dsh-sandbox`, which reaches this package only as a
+// transitive dependency of dsh-fs, and naming a fourth exact-pinned peer to
+// spell one parameter would couple the adapter to a package it never calls.
+type SandboxPolicy = Parameters<FileSystem['writeText']>[4]
+
 const DEFAULT_DIFF_BASIS_MAX_BYTES = 10 * 1024 * 1024
 
 /** Configuration for the mirage filesystem backend. */
@@ -96,6 +102,12 @@ function tooLarge(displayPath: string, maxBytes: number, size?: number): FsError
  * post-write invalidation all fire exactly as they do for a shell command —
  * and `processPath` answers in the same virtual path space the mirage shell
  * executes in, so the two providers share one execution world.
+ *
+ * One limit worth stating: mirage's op facade takes no `AbortSignal`, so
+ * cancellation is honored at this adapter's own boundaries (before a
+ * dispatch, between listing entries) and not inside a single op. A long
+ * read from a remote backend therefore runs to completion after the
+ * signal fires, and the caller learns of the abort when it returns.
  */
 export class MirageFileSystem extends FileSystem {
   static readonly inject = ['mirage']
@@ -132,8 +144,65 @@ export class MirageFileSystem extends FileSystem {
     return this.fsOps.links
   }
 
-  private normalize(path: string, cwd?: string): string {
-    return posix.resolve(cwd ?? this.cwd, path)
+  /**
+   * The same confinement claim `MirageShellExecutor` makes, off the same
+   * fact and for the same reason: with every runtime reaching only the
+   * vfs, a mutation cannot land anywhere but a mount, under its mode.
+   *
+   * The two seams sit over one world, so answering differently here
+   * would let dsh fence a bash write and wave an identical `ctx.fs`
+   * write straight through.
+   */
+  override get sandboxMode(): FileSystem['sandboxMode'] {
+    return this.ctx.mirage.vfsOnly ? 'workspace-write' : undefined
+  }
+
+  /**
+   * Refuse a mutation the call's sandbox policy does not allow.
+   *
+   * `workspaceRoot` is deliberately not consulted: it is a directory on
+   * the harness's own machine, so containment against it says nothing
+   * about this world. The mounts and their modes are the boundary, and
+   * `read-only` is the one mode that narrows them further. Wording and
+   * code mirror `dsh-fs-sandbox`, so the tool layer renders one denial
+   * marker whichever backend refused.
+   *
+   * @param policy the per-call policy, absent for an unguarded mutation.
+   * @param displayPath the path to name in the refusal.
+   */
+  private assertMutable(policy: SandboxPolicy, displayPath: string): void {
+    if (policy?.mode !== 'read-only') return
+    throw new FsError(
+      `cannot write "${displayPath}": file access denied under read-only mode`,
+      'FS_SANDBOX_DENIED',
+    )
+  }
+
+  /**
+   * The base a relative path resolves against.
+   *
+   * dsh hands `ctx.fs` either the calling session's cwd or the sandbox
+   * policy's workspace root, and both are directories on the harness's
+   * own machine that name nothing here. Resolving `notes.txt` against
+   * one yields `/Users/.../notes.txt`, which every read then reports as
+   * absent. So a base that is not a directory in this world falls back
+   * to the configured one, the same rule the shell executor applies to
+   * a workdir.
+   *
+   * An absolute path ignores its base, so it never pays for the probe.
+   *
+   * @param path the path being resolved.
+   * @param cwd the caller's base, if any.
+   * @returns the base to resolve against.
+   */
+  private async resolveBase(path: string, cwd: string | undefined): Promise<string> {
+    if (cwd === undefined || posix.isAbsolute(path)) return this.cwd
+    const ws = await this.ctx.mirage.ready
+    return (await ws.fs.isDir(cwd)) ? cwd : this.cwd
+  }
+
+  private normalize(path: string, base: string): string {
+    return posix.resolve(base, path)
   }
 
   private follow(path: string): string {
@@ -166,7 +235,7 @@ export class MirageFileSystem extends FileSystem {
   async resolve(path: string, opts?: { cwd?: string; signal?: AbortSignal }): Promise<FsTarget> {
     assertNotAborted(opts?.signal, 'resolve')
     await this.ops(opts?.signal, 'resolve')
-    const followed = this.follow(this.normalize(path, opts?.cwd))
+    const followed = this.follow(this.normalize(path, await this.resolveBase(path, opts?.cwd)))
     return { targetKey: FsTargetKey(followed), displayPath: followed }
   }
 
@@ -211,7 +280,7 @@ export class MirageFileSystem extends FileSystem {
   ): Promise<FsPathInfo | undefined> {
     assertNotAborted(signal, 'lstat')
     await this.ops(signal, 'lstat')
-    const normalized = this.normalize(path, opts?.cwd)
+    const normalized = this.normalize(path, await this.resolveBase(path, opts?.cwd))
     // Follow every component except the last: the probe is about the path
     // entry itself, so a link at the leaf must report as one.
     const parentFollowed =
@@ -331,12 +400,20 @@ export class MirageFileSystem extends FileSystem {
     }
     const entries: FsDirEntry[] = []
     for (const name of [...names].sort(compareCodePoints)) {
-      entries.push(await this.dirEntry(key, name))
+      // Per entry, not just at the door: a listing is one classification
+      // round trip per child on a backend the readdir did not warm, and
+      // a caller that gave up should stop paying for them.
+      assertNotAborted(signal, 'list')
+      entries.push(await this.dirEntry(key, name, signal))
     }
     return entries
   }
 
-  private async dirEntry(parentKey: string, name: string): Promise<FsDirEntry> {
+  private async dirEntry(
+    parentKey: string,
+    name: string,
+    signal?: AbortSignal,
+  ): Promise<FsDirEntry> {
     const childPath = parentKey === '/' ? `/${name}` : `${parentKey}/${name}`
     let followed: string
     try {
@@ -353,8 +430,12 @@ export class MirageFileSystem extends FileSystem {
     const target: FsTarget = { targetKey: FsTargetKey(followed), displayPath: childPath }
     let stat: FileStat
     try {
-      stat = await (await this.ops()).stat(followed)
-    } catch {
+      stat = await (await this.ops(signal, 'list')).stat(followed)
+    } catch (err) {
+      // An abort is the caller withdrawing, not a child this listing
+      // failed to classify, so it ends the walk instead of landing as
+      // one more entry of unknown kind.
+      if (err instanceof FsError && err.code === 'FS_ABORTED') throw err
       // A child the listing named but stat cannot classify (a broken link,
       // a race with a delete) still lists, as an entry of unknown kind.
       return { name, type: 'other', target }
@@ -373,9 +454,11 @@ export class MirageFileSystem extends FileSystem {
     content: string,
     expected?: FsWriteIntent,
     signal?: AbortSignal,
+    sandboxPolicy?: SandboxPolicy,
   ): Promise<FsWriteOutcome> {
     return this.withLock(target.targetKey, async () => {
       assertNotAborted(signal, 'write')
+      this.assertMutable(sandboxPolicy, target.displayPath)
       const key = String(target.targetKey)
       const existing = await this.stat(target, signal)
       if (existing !== undefined && existing.type !== 'file') {
@@ -445,9 +528,11 @@ export class MirageFileSystem extends FileSystem {
     edit: FsEditRequest,
     expected?: { version: FsVersion },
     signal?: AbortSignal,
+    sandboxPolicy?: SandboxPolicy,
   ): Promise<FsEditOutcome> {
     return this.withLock(target.targetKey, async () => {
       assertNotAborted(signal, 'edit')
+      this.assertMutable(sandboxPolicy, target.displayPath)
       const key = String(target.targetKey)
       const existing = await this.stat(target, signal)
       // Stale guard before literal matching: an edit based on an old read

--- a/typescript/packages/dsh/src/service.test.ts
+++ b/typescript/packages/dsh/src/service.test.ts
@@ -130,4 +130,42 @@ describe('MirageService', () => {
     await expect(ctx.plugin(MirageService, {}).await()).rejects.toThrow('required')
     await ws.close()
   })
+  it('does not emit an unhandled rejection when a mount fails to build', async () => {
+    const seen: unknown[] = []
+    const onUnhandled = (err: unknown): void => {
+      seen.push(err)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    const ctx = new Context()
+    const fiber = ctx.plugin(MirageService, {
+      mounts: { '/x': { resource: 'no-such-resource-xyz' } },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    process.off('unhandledRejection', onUnhandled)
+    expect(seen).toEqual([])
+    await expect(ctx.mirage.ready).rejects.toThrow(/unknown resource/)
+    await fiber.dispose()
+  })
+
+  it('still rejects `ready` for a caller that awaits it', async () => {
+    const ctx = new Context()
+    const fiber = ctx.plugin(MirageService, {
+      mounts: { '/x': { resource: 'no-such-resource-xyz' } },
+    })
+    await fiber.await()
+    await expect(ctx.mirage.ready).rejects.toThrow(/unknown resource/)
+    await fiber.dispose()
+  })
+
+  it('refuses runtimes or workspace options beside an adopted workspace', async () => {
+    const ws = new Workspace({ '/data': [new RAMResource(), MountMode.WRITE] })
+    const ctx = new Context()
+    await expect(
+      ctx.plugin(MirageService, { workspace: ws, runtimes: ['monty'] }).await(),
+    ).rejects.toThrow(/adopted workspace/)
+    await expect(
+      ctx.plugin(MirageService, { workspace: ws, workspaceOptions: {} }).await(),
+    ).rejects.toThrow(/adopted workspace/)
+    await ws.close()
+  })
 })

--- a/typescript/packages/dsh/src/service.ts
+++ b/typescript/packages/dsh/src/service.ts
@@ -125,6 +125,15 @@ export class MirageService extends Service {
       throw new Error('mirage: pass either workspace or mounts, not both')
     }
     if (config.workspace !== undefined) {
+      // An adopted workspace is already built, so runtimes and constructor
+      // options can no longer reach it. Saying so beats accepting a config
+      // whose runtimes silently never load, which is what the workspace and
+      // mounts pair above already refuses to do.
+      if (config.runtimes !== undefined || config.workspaceOptions !== undefined) {
+        throw new Error(
+          'mirage: runtimes and workspaceOptions configure a service-owned workspace, not an adopted workspace',
+        )
+      }
       this.built = config.workspace
       this.ready = Promise.resolve(config.workspace)
       return
@@ -144,6 +153,13 @@ export class MirageService extends Service {
     const blocks = Object.values(config.mounts).some(isMountBlock)
     if (blocks) {
       this.ready = this.open(config.mounts, options)
+      // A declarative mount resolves asynchronously and nothing awaits
+      // `ready` until a provider's first call, so a failure here would
+      // reach the process as an unhandled rejection and take the whole
+      // harness down over a typo in a patch file. This only marks the
+      // rejection observed; `ready` still rejects for every real caller,
+      // and the disposer below still sees it.
+      void this.ready.catch(() => undefined)
     } else {
       const owned = new Workspace(config.mounts as Record<string, MountSpec | Mount>, options)
       this.built = owned

--- a/typescript/packages/dsh/src/shell.test.ts
+++ b/typescript/packages/dsh/src/shell.test.ts
@@ -68,6 +68,171 @@ describe('resolve', () => {
   })
 })
 
+describe('workdir', () => {
+  const HOST_WORKDIR = '/Users/somebody/host-project'
+
+  it('ignores a workdir that names nothing in this world', async () => {
+    const { shell } = await makeShell()
+    const result = await shell.run(shell.resolve({ command: 'pwd', workdir: HOST_WORKDIR }))
+    expect(result.stdout.text.trim()).toBe('/')
+  })
+
+  it('leaves relative paths reachable when the harness sends a host workdir', async () => {
+    const { shell } = await makeShell({ 'a.txt': 'x' }, { workdir: '/data' })
+    const result = await shell.run(shell.resolve({ command: 'ls .', workdir: HOST_WORKDIR }))
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.text.trim()).toBe('a.txt')
+  })
+
+  it('still honors a workdir inside the world', async () => {
+    const { shell } = await makeShell()
+    const result = await shell.run(shell.resolve({ command: 'pwd', workdir: '/data' }))
+    expect(result.stdout.text.trim()).toBe('/data')
+  })
+
+  it('keeps a bound session persistent when the harness sends a host workdir', async () => {
+    const { shell } = await makeShell({}, { sessionId: 'agent', workdir: '/data' })
+    await shell.run(shell.resolve({ command: 'export MARK=one; cd /', workdir: HOST_WORKDIR }))
+    const echoed = await shell.run(
+      shell.resolve({ command: 'echo "[$MARK][$(pwd)]"', workdir: HOST_WORKDIR }),
+    )
+    expect(echoed.stdout.text.trim()).toBe('[one][/]')
+  })
+
+  it('keeps a bound session persistent through the managed env dsh sends every call', async () => {
+    const { shell } = await makeShell({}, { sessionId: 'agent', workdir: '/data' })
+    const dshEnv = { DSH_HOME: '/home/.dsh', DSH_SHELL: '1' } as const
+    await shell.run(shell.resolve({ command: 'export MARK=one; cd /', dshEnv }))
+    const echoed = await shell.run(
+      shell.resolve({ command: 'echo "[$MARK][$(pwd)][$DSH_HOME]"', dshEnv }),
+    )
+    expect(echoed.stdout.text.trim()).toBe('[one][/][/home/.dsh]')
+  })
+
+  it('drops a managed fact the newest snapshot omits', async () => {
+    const { shell } = await makeShell({}, { sessionId: 'agent' })
+    await shell.run(
+      shell.resolve({ command: 'true', dshEnv: { DSH_HOME: '/a', DSH_SESSION_ID: 'x' } }),
+    )
+    const echoed = await shell.run(
+      shell.resolve({ command: 'echo "[$DSH_SESSION_ID][$DSH_HOME]"', dshEnv: { DSH_HOME: '/a' } }),
+    )
+    expect(echoed.stdout.text.trim()).toBe('[][/a]')
+  })
+
+  it('still forks for a per-call env override on a bound session', async () => {
+    const { shell } = await makeShell({}, { sessionId: 'agent' })
+    await shell.run(shell.resolve({ command: 'export KEEP=yes' }))
+    const forked = await shell.run(
+      shell.resolve({ command: 'echo "[$ONCE][$KEEP]"', env: { ONCE: 'x' } }),
+    )
+    expect(forked.stdout.text.trim()).toBe('[x][yes]')
+    const after = await shell.run(shell.resolve({ command: 'echo "[$ONCE]"' }))
+    expect(after.stdout.text.trim()).toBe('[]')
+  })
+
+  it('ignores a host workdir for a background command too', async () => {
+    const { shell } = await makeShell()
+    const proc = shell.start(shell.resolve({ command: 'pwd', workdir: HOST_WORKDIR }))
+    await proc.done
+    expect(proc.readOutput().delta.trim()).toBe('/')
+  })
+})
+
+describe('sandbox policy', () => {
+  const READ_ONLY = { mode: 'read-only', workspaceRoot: '/Users/somebody/host-project' } as const
+  const WORKSPACE_WRITE = { mode: 'workspace-write', workspaceRoot: '/Users/somebody' } as const
+
+  it('refuses a write under a read-only policy', async () => {
+    const { shell, ws } = await makeShell()
+    const result = await shell.run(
+      shell.resolve({ command: 'echo written > /data/x.txt', sandboxPolicy: READ_ONLY }),
+    )
+    expect(result.exitCode).not.toBe(0)
+    expect(result.sandbox?.mode).toBe('read-only')
+    expect(result.sandbox?.denied).toBe(true)
+    expect(await ws.fs.exists('/data/x.txt')).toBe(false)
+  })
+
+  it('refuses a mutating command under a read-only policy', async () => {
+    const { shell } = await makeShell({ 'a.txt': 'seed' })
+    const result = await shell.run(
+      shell.resolve({ command: 'rm /data/a.txt', sandboxPolicy: READ_ONLY }),
+    )
+    expect(result.exitCode).not.toBe(0)
+    expect(result.sandbox?.denied).toBe(true)
+  })
+
+  it('still reads under a read-only policy', async () => {
+    const { shell } = await makeShell({ 'a.txt': 'visible' })
+    const result = await shell.run(
+      shell.resolve({ command: 'cat /data/a.txt', sandboxPolicy: READ_ONLY }),
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.text).toBe('visible')
+    expect(result.sandbox?.denied).toBe(false)
+  })
+
+  it('keeps the null sink writable under a read-only policy', async () => {
+    const { shell } = await makeShell()
+    const result = await shell.run(
+      shell.resolve({ command: 'echo noise > /dev/null', sandboxPolicy: READ_ONLY }),
+    )
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('allows a write under a workspace-write policy and stamps that mode', async () => {
+    const { shell } = await makeShell()
+    const result = await shell.run(
+      shell.resolve({
+        command: 'echo written > /data/x.txt && cat /data/x.txt',
+        sandboxPolicy: WORKSPACE_WRITE,
+      }),
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.text.trim()).toBe('written')
+    expect(result.sandbox?.mode).toBe('workspace-write')
+  })
+
+  it('stamps the executor default when the caller supplies no policy', async () => {
+    const { shell } = await makeShell()
+    const result = await shell.run(shell.resolve({ command: 'true' }))
+    expect(result.sandbox?.mode).toBe('workspace-write')
+  })
+
+  it('makes no sandbox claim once a runtime executes beyond the workspace', async () => {
+    const { shell, ws } = await makeShell()
+    ws.addRuntime(new LocalRuntime({ captures: ['python'] }))
+    const result = await shell.run(
+      shell.resolve({ command: 'echo written > /data/x.txt', sandboxPolicy: READ_ONLY }),
+    )
+    expect(result.sandbox).toBeUndefined()
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('binds a background command to the policy too', async () => {
+    const { shell, ws } = await makeShell()
+    const proc = shell.start(
+      shell.resolve({ command: 'echo written > /data/bg.txt', sandboxPolicy: READ_ONLY }),
+    )
+    await proc.done
+    expect(proc.exitCode).not.toBe(0)
+    expect(proc.sandbox?.mode).toBe('read-only')
+    expect(await ws.fs.exists('/data/bg.txt')).toBe(false)
+  })
+
+  it('keeps a bound session out of the read-only twin it narrowed into', async () => {
+    const { shell } = await makeShell({}, { sessionId: 'agent' })
+    await shell.run(shell.resolve({ command: 'export MARK=writable' }))
+    const confined = await shell.run(
+      shell.resolve({ command: 'echo "[$MARK]"', sandboxPolicy: READ_ONLY }),
+    )
+    expect(confined.stdout.text.trim()).toBe('[]')
+    const back = await shell.run(shell.resolve({ command: 'echo "[$MARK]"' }))
+    expect(back.stdout.text.trim()).toBe('[writable]')
+  })
+})
+
 describe('run', () => {
   it('executes a command against the mounted workspace', async () => {
     const { shell } = await makeShell({ 'a.txt': 'mounted content' })
@@ -450,5 +615,127 @@ describe('sandbox facts', () => {
       enforcement: 'full',
       runnerFailed: false,
     })
+  })
+})
+
+describe('foreground output fidelity', () => {
+  it('returns the output a timed-out command already produced', async () => {
+    const { shell } = await makeShell()
+    const result = await shell.run(
+      shell.resolve({ command: 'echo early-output; sleep 30', timeoutMs: 300 }),
+    )
+    expect(result.timedOut).toBe(true)
+    expect(result.exitCode).toBeNull()
+    expect(result.stdout.text).toContain('early-output')
+  })
+
+  it('returns the output an aborted command already produced', async () => {
+    const { shell } = await makeShell()
+    const controller = new AbortController()
+    const pending = shell.run(
+      shell.resolve({ command: 'echo before-abort; sleep 30', signal: controller.signal }),
+    )
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    controller.abort()
+    const result = await pending
+    expect(result.aborted).toBe(true)
+    expect(result.stdout.text).toContain('before-abort')
+  })
+
+  it('keeps stderr of a killed command too', async () => {
+    const { shell } = await makeShell()
+    const result = await shell.run(
+      shell.resolve({ command: 'cat /data/nope; sleep 30', timeoutMs: 400 }),
+    )
+    expect(result.timedOut).toBe(true)
+    expect(result.stderr.text).toContain('No such file')
+  })
+
+  it('spills a truncated foreground run to the workspace', async () => {
+    const { shell, ws } = await makeShell({}, { spillDir: '/data/spill' })
+    const result = await shell.run(
+      shell.resolve({ command: 'printf "%s" aaaaabbbbb', stdoutMaxBytes: 5 }),
+    )
+    expect(result.stdout.truncated).toBe(true)
+    expect(result.stdout.text).toBe('bbbbb')
+    const path = result.stdout.spillPath
+    if (path === undefined) throw new Error('expected a spill path')
+    expect(await ws.fs.readFileText(path)).toBe('aaaaabbbbb')
+  })
+
+  it('leaves spillPath unset when nothing was truncated', async () => {
+    const { shell } = await makeShell({}, { spillDir: '/data/spill' })
+    const result = await shell.run(shell.resolve({ command: 'echo small' }))
+    expect(result.stdout.truncated).toBe(false)
+    expect(result.stdout.spillPath).toBeUndefined()
+  })
+
+  it('leaves spillPath unset when no spill directory is configured', async () => {
+    const { shell } = await makeShell()
+    const result = await shell.run(
+      shell.resolve({ command: 'printf "%s" aaaaabbbbb', stdoutMaxBytes: 5 }),
+    )
+    expect(result.stdout.truncated).toBe(true)
+    expect(result.stdout.spillPath).toBeUndefined()
+  })
+
+  it('retains a large configured budget instead of a fixed constant', async () => {
+    const { shell } = await makeShell({}, { stdoutMaxBytes: 2_000_000 })
+    const proc = shell.start(shell.resolve({ command: 'printf "%0.sx" $(seq 1 300000)' }))
+    await proc.done
+    const read = proc.readOutput()
+    expect(read.lossy).toBe(false)
+    expect(read.delta.length).toBe(300_000)
+  })
+})
+
+describe('background delta bounding', () => {
+  it('caps the delta at the budget, keeping the tail', async () => {
+    const { shell } = await makeShell()
+    const proc = shell.start(
+      shell.resolve({ command: 'printf "%s" abcdefghij', stdoutMaxBytes: 4 }),
+    )
+    await proc.done
+    const read = proc.readOutput()
+    expect(read.delta).toBe('ghij')
+    expect(read.lossy).toBe(true)
+  })
+
+  it('never splits a multi-byte character across the cap', async () => {
+    const { shell } = await makeShell()
+    // "aaaé" is five bytes; the last three are "a" plus the two-byte "é",
+    // so the cap lands on a character boundary rather than half of one.
+    const proc = shell.start(shell.resolve({ command: 'printf "%s" aaaé', stdoutMaxBytes: 3 }))
+    await proc.done
+    expect(proc.readOutput().delta).toBe('aé')
+  })
+
+  it('re-aligns when the cap lands mid-character', async () => {
+    const { shell } = await makeShell()
+    // Budget 3 over "aaéé" (six bytes) would start inside the second "é",
+    // so the leading continuation byte is dropped rather than decoded as
+    // a replacement character.
+    const proc = shell.start(shell.resolve({ command: 'printf "%s" aaéé', stdoutMaxBytes: 3 }))
+    await proc.done
+    expect(proc.readOutput().delta).toBe('é')
+  })
+
+  it('marks a stderr run once and keeps both streams in order', async () => {
+    const { shell } = await makeShell()
+    const proc = shell.start(shell.resolve({ command: 'echo out; cat /data/nope; echo out2' }))
+    await proc.done
+    const delta = proc.readOutput().delta
+    expect(delta).toContain('out')
+    expect(delta).toContain('--- stderr ---')
+    expect(delta).toContain('out2')
+    expect(delta.split('--- stderr ---').length - 1).toBe(1)
+  })
+
+  it('drains consuming, so a second read returns nothing new', async () => {
+    const { shell } = await makeShell()
+    const proc = shell.start(shell.resolve({ command: 'echo once' }))
+    await proc.done
+    expect(proc.readOutput().delta.trim()).toBe('once')
+    expect(proc.readOutput().delta).toBe('')
   })
 })

--- a/typescript/packages/dsh/src/shell.test.ts
+++ b/typescript/packages/dsh/src/shell.test.ts
@@ -221,6 +221,46 @@ describe('sandbox policy', () => {
     expect(await ws.fs.exists('/data/bg.txt')).toBe(false)
   })
 
+  it('narrows a confined session without widening it', async () => {
+    const ws = new Workspace({
+      '/allowed': [new RAMResource(), MountMode.WRITE],
+      '/secret': [new RAMResource(), MountMode.WRITE],
+    })
+    workspaces.push(ws)
+    await ws.fs.writeFile('/allowed/a.txt', 'granted')
+    await ws.fs.writeFile('/secret/a.txt', 'classified')
+    ws.createSession('confined', { mounts: { '/allowed': 'exec' } })
+    const shell = await attachShell(ws, { sessionId: 'confined' })
+    const granted = await shell.run(
+      shell.resolve({ command: 'cat /allowed/a.txt', sandboxPolicy: READ_ONLY }),
+    )
+    expect(granted.exitCode).toBe(0)
+    expect(granted.stdout.text).toBe('granted')
+    const secret = await shell.run(
+      shell.resolve({ command: 'cat /secret/a.txt', sandboxPolicy: READ_ONLY }),
+    )
+    expect(secret.exitCode).not.toBe(0)
+    expect(secret.stdout.text).not.toContain('classified')
+  })
+
+  it('keeps an unbound read-only call one-shot', async () => {
+    const { shell } = await makeShell()
+    const leak = shell.resolve({
+      command: 'cd /data && export MARK=leaked',
+      workdir: '/Users/somebody/host-project',
+      sandboxPolicy: READ_ONLY,
+    })
+    await shell.run(leak)
+    const next = await shell.run(
+      shell.resolve({
+        command: 'pwd; echo "[$MARK]"',
+        workdir: '/Users/somebody/host-project',
+        sandboxPolicy: READ_ONLY,
+      }),
+    )
+    expect(next.stdout.text.trim().split('\n')).toEqual(['/', '[]'])
+  })
+
   it('keeps a bound session out of the read-only twin it narrowed into', async () => {
     const { shell } = await makeShell({}, { sessionId: 'agent' })
     await shell.run(shell.resolve({ command: 'export MARK=writable' }))
@@ -661,6 +701,20 @@ describe('foreground output fidelity', () => {
     const path = result.stdout.spillPath
     if (path === undefined) throw new Error('expected a spill path')
     expect(await ws.fs.readFileText(path)).toBe('aaaaabbbbb')
+  })
+
+  it('keeps a foreground stream larger than any console retention budget', async () => {
+    const { shell, ws } = await makeShell(
+      { 'big.txt': 'x'.repeat(4000) },
+      { stdoutMaxBytes: 64, stderrMaxBytes: 64, spillDir: '/data/spill' },
+    )
+    const result = await shell.run(shell.resolve({ command: 'cat /data/big.txt' }))
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.truncated).toBe(true)
+    expect(result.stdout.text).toBe('x'.repeat(64))
+    const path = result.stdout.spillPath
+    if (path === undefined) throw new Error('expected a spill path')
+    expect(await ws.fs.readFileText(path)).toBe('x'.repeat(4000))
   })
 
   it('leaves spillPath unset when nothing was truncated', async () => {

--- a/typescript/packages/dsh/src/shell.ts
+++ b/typescript/packages/dsh/src/shell.ts
@@ -136,6 +136,7 @@ function executeOptions(
   workdir: string,
   signal: AbortSignal,
   sessionId: string | undefined,
+  bound: boolean,
   fallbackWorkdir: string,
   sink?: JobConsole,
 ): ExecuteOptions & { provision?: false } {
@@ -146,13 +147,15 @@ function executeOptions(
   // that per call would fork every command and quietly undo the binding.
   // Those facts are seeded into the session instead, by `applyManagedEnv`.
   const managed = (spec.dshEnv as Record<string, string> | undefined) ?? {}
-  const env =
-    sessionId === undefined ? { ...(spec.env ?? {}), ...managed } : { ...(spec.env ?? {}) }
+  const env = bound ? { ...(spec.env ?? {}) } : { ...(spec.env ?? {}), ...managed }
   // Unbound, `cwd` is always present so every command runs in an ephemeral
-  // fork of the default session: isolation must not hinge on a spec
-  // happening to carry a workdir. Bound, an absent workdir runs in the
-  // session itself, which is what lets its state persist.
-  const cwd = workdir !== '' ? workdir : sessionId === undefined ? fallbackWorkdir : undefined
+  // fork: isolation must not hinge on a spec happening to carry a workdir,
+  // and a read-only call runs in a *named* twin session, so without a cwd
+  // its `cd` and exports would persist into the next nominally one-shot
+  // call. Bound, an absent workdir runs in the session itself, which is
+  // what lets its state persist. Either way the decision is the binding's,
+  // never the session this particular call happens to land in.
+  const cwd = workdir !== '' ? workdir : bound ? undefined : fallbackWorkdir
   return {
     signal,
     ...(sessionId !== undefined ? { sessionId } : {}),
@@ -366,14 +369,13 @@ export class MirageShellExecutor extends ShellExecutor {
    * default when unbound, the session's own cwd when bound.
    *
    * @param spec the resolved spec whose workdir is being placed.
-   * @param sessionId the session this call runs in, if any.
    * @returns the workdir to execute under, `''` meaning the session's own.
    */
-  private async worldWorkdir(spec: ShellExecSpec, sessionId: string | undefined): Promise<string> {
+  private async worldWorkdir(spec: ShellExecSpec): Promise<string> {
     if (spec.workdir === '') return ''
     const ws = await this.workspace()
     if (await ws.fs.isDir(spec.workdir)) return spec.workdir
-    return sessionId === undefined ? this.workdir : ''
+    return this.sessionId === undefined ? this.workdir : ''
   }
 
   // A spill sink for one background command, or null when no spill
@@ -471,6 +473,18 @@ export class MirageShellExecutor extends ShellExecutor {
     return { mode, denied, enforcement: 'full', runnerFailed: false }
   }
 
+  /**
+   * The retention budget of a background command's console.
+   *
+   * Only the background path caps retention: there a follow loop drains
+   * the console while the command still runs, so the budget bounds what
+   * the loop has not reached yet, and a chunk lost to it is reported as
+   * a gap in the sequence. A foreground console is read once, after the
+   * fact, with nothing to bound.
+   *
+   * @param spec the resolved spec carrying the stdout budget.
+   * @returns the retention budget in bytes.
+   */
   private retentionFor(spec: ShellExecSpec): number {
     return Math.max(spec.stdoutMaxBytes, this.stderrMaxBytes) * CONSOLE_RETENTION_DELTAS
   }
@@ -484,9 +498,8 @@ export class MirageShellExecutor extends ShellExecutor {
    * had already printed are recoverable from a sink and nowhere else.
    * Only a truncated stream spills, since an untruncated one is already
    * whole in `text` and writing a file for it would put a copy of every
-   * command's output on a mount. The spill can only hold what the
-   * console retained, so a run that also outran retention is short by
-   * the difference.
+   * command's output on a mount. The console this reads is untrimmed, so
+   * a spill is the whole stream rather than the tail of one.
    *
    * @param console_ the console this run streamed into.
    * @param spec the resolved spec carrying the stdout budget.
@@ -604,15 +617,20 @@ export class MirageShellExecutor extends ShellExecutor {
   }
 
   /**
-   * Create (once) the session a read-only call runs in: a twin of this
-   * executor's binding whose every mount is granted `read`, so mirage's
-   * own dispatch is what refuses the write rather than a second
-   * permission layer bolted on here.
+   * Create (once) the session a read-only call runs in: a twin of the
+   * session this executor would otherwise use, with every grant it holds
+   * narrowed to `read`, so mirage's own dispatch is what refuses the
+   * write rather than a second permission layer bolted on here.
    *
-   * Every mount has to appear in the map: a prefix the map omits is not
-   * narrowed, it is invisible, and a session that cannot see `/` cannot
-   * even run `pwd`. The one mount that keeps its own mode is the null
-   * sink, per {@link SINK_PREFIX}.
+   * The twin narrows, never widens. Its grants are the source session's
+   * own, so a binding confined to `/allowed` stays confined: reading the
+   * mount table instead would hand a read-only call every mount in the
+   * workspace, which is a wider world than the same command gets outside
+   * read-only mode. Only an unconfined source falls back to the mount
+   * table, and then every mount has to appear in the map, since a prefix
+   * the map omits is not narrowed but invisible, and a session that
+   * cannot see `/` cannot even run `pwd`. The one mount that keeps its
+   * own mode is the null sink, per {@link SINK_PREFIX}.
    *
    * The policy's `workspaceRoot` is deliberately not consulted anywhere:
    * it is a directory on the harness's machine, so containment against
@@ -625,9 +643,11 @@ export class MirageShellExecutor extends ShellExecutor {
     const sessionId = `${this.sessionId ?? 'mirage-dsh'}::read-only`
     await ws.ensureSessionsLoaded()
     if (ws.listSessions().some((s) => s.sessionId === sessionId)) return sessionId
+    const source = ws.getSession(this.sessionId ?? ws.defaultSessionId).mountModes
+    const prefixes = source === null ? ws.mounts().map((entry) => entry.prefix) : [...source.keys()]
     const grants: Record<string, string> = {}
-    for (const entry of ws.mounts()) {
-      grants[entry.prefix] = entry.prefix.replace(/\/+$/, '') === SINK_PREFIX ? 'exec' : 'read'
+    for (const prefix of prefixes) {
+      grants[prefix] = prefix.replace(/\/+$/, '') === SINK_PREFIX ? 'exec' : 'read'
     }
     setCwd(ws.createSession(sessionId, { mounts: grants }), this.workdir)
     return sessionId
@@ -660,7 +680,16 @@ export class MirageShellExecutor extends ShellExecutor {
     // The command streams into a console instead of returning its output
     // whole, because mirage answers an abort by throwing: what a killed
     // command already printed survives only in a sink.
-    const console_ = new JobConsole(new RAMConsoleStore(this.retentionFor(spec)))
+    //
+    // Retention is deliberately unbounded here, unlike the background
+    // console: nothing drains this one, `collectFrom` reads it once the
+    // command is over, and the store evicts whole chunks, so a budget
+    // would silently drop an entire buffered stream larger than itself
+    // and report empty output as untruncated. Holding the full stream
+    // for the length of one call is what the executor did anyway before
+    // a sink was attached, and it is what lets a truncated run spill
+    // every byte rather than only the tail a budget kept.
+    const console_ = new JobConsole(new RAMConsoleStore(null))
     let timedOut = false
     let aborted = false
     const timer = setTimeout(() => {
@@ -678,11 +707,12 @@ export class MirageShellExecutor extends ShellExecutor {
       await this.ensureSession()
       const ws = await this.workspace()
       const sessionId = await this.sessionFor(spec)
-      if (sessionId !== undefined) await this.applyManagedEnv(ws, sessionId, spec)
-      const workdir = await this.worldWorkdir(spec, sessionId)
+      const bound = this.sessionId !== undefined
+      if (bound && sessionId !== undefined) await this.applyManagedEnv(ws, sessionId, spec)
+      const workdir = await this.worldWorkdir(spec)
       const result = await ws.execute(
         spec.command,
-        executeOptions(spec, workdir, controller.signal, sessionId, this.workdir, console_),
+        executeOptions(spec, workdir, controller.signal, sessionId, bound, this.workdir, console_),
       )
       const captured = await this.collectFrom(console_, spec)
       const settled = this.sandboxInfo(spec, this.wasDenied(spec, captured.stderr.text))
@@ -727,9 +757,7 @@ export class MirageShellExecutor extends ShellExecutor {
     // has not drained yet (nothing, when the loop keeps up). Its own
     // retention budget is what bounds that, since reading a chunk does
     // not release it.
-    const console_ = new JobConsole(
-      new RAMConsoleStore(spec.stdoutMaxBytes * CONSOLE_RETENTION_DELTAS),
-    )
+    const console_ = new JobConsole(new RAMConsoleStore(this.retentionFor(spec)))
     const spill = this.newSpill()
     if (spec.signal?.aborted === true) {
       controller.abort()
@@ -750,13 +778,22 @@ export class MirageShellExecutor extends ShellExecutor {
       .then(async () => {
         const sessionId = await this.sessionFor(spec)
         const ws = await this.workspace()
-        if (sessionId !== undefined) await this.applyManagedEnv(ws, sessionId, spec)
-        return { ws, sessionId, workdir: await this.worldWorkdir(spec, sessionId) }
+        const bound = this.sessionId !== undefined
+        if (bound && sessionId !== undefined) await this.applyManagedEnv(ws, sessionId, spec)
+        return { ws, sessionId, bound, workdir: await this.worldWorkdir(spec) }
       })
-      .then(({ ws, sessionId, workdir }) =>
+      .then(({ ws, sessionId, bound, workdir }) =>
         ws.execute(
           spec.command,
-          executeOptions(spec, workdir, controller.signal, sessionId, this.workdir, console_),
+          executeOptions(
+            spec,
+            workdir,
+            controller.signal,
+            sessionId,
+            bound,
+            this.workdir,
+            console_,
+          ),
         ),
       )
       .finally(() => spec.signal?.removeEventListener('abort', onAbort))

--- a/typescript/packages/dsh/src/shell.ts
+++ b/typescript/packages/dsh/src/shell.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { Context } from '@deepseek-ai/cordis'
-import { ShellExecutor } from '@deepseek-ai/dsh-shell'
+import { DSH_ENV_PREFIX, ShellExecutor } from '@deepseek-ai/dsh-shell'
 import type {
   CollectedOutput,
   ShellExecRequest,
@@ -33,12 +33,13 @@ import {
 } from '@struktoai/mirage-core/shell/console/index'
 import type { ConsoleChunk } from '@struktoai/mirage-core/shell/console/index'
 import { setCwd } from '@struktoai/mirage-core/workspace/session/shell_dirs'
+import { sessionView } from '@struktoai/mirage-core/workspace/session/state'
 import type {
   ExecuteOptions,
   ExecuteResult,
 } from '@struktoai/mirage-core/workspace/workspace/workspace'
 import type { Workspace } from '@struktoai/mirage-node'
-import { tailCap } from './text.ts'
+import { TailBuffer, tailCap } from './text.ts'
 import { SpillSink, ensureDirPath, type SpillTarget } from './spill.ts'
 import type {} from './service.ts'
 
@@ -46,19 +47,34 @@ const DEFAULT_TIMEOUT_MS = 120_000
 const MAX_TIMEOUT_MS = 600_000
 const DEFAULT_STDOUT_MAX_BYTES = 200_000
 const DEFAULT_STDERR_MAX_BYTES = 64_000
-const STDERR_MARKER = '\n--- stderr ---\n'
-// What the console may hold that the drain loop has not consumed yet.
-// Capping the delta does not bound this: a reader's cursor advances but
-// frees nothing, so an uncapped store keeps every chunk of a noisy
-// command for the life of the process. Five deltas' worth, because the
-// drain awaits the spill's own writes and has to be free to fall
-// briefly behind, and bounded, so a command that outruns it forever
-// cannot grow the heap.
-const CONSOLE_RETENTION_BYTES = 5 * DEFAULT_STDOUT_MAX_BYTES
+const STDERR_MARKER = new TextEncoder().encode('\n--- stderr ---\n')
+// What a console may hold that its reader has not consumed yet. Capping
+// the delta does not bound this: a reader's cursor advances but frees
+// nothing, so an uncapped store keeps every chunk of a noisy command for
+// the life of the process. Five deltas' worth, because a drain awaits the
+// spill's own writes and has to be free to fall briefly behind, and
+// bounded, so a command that outruns it forever cannot grow the heap.
+// Derived from the call's own budget rather than fixed: a retention
+// smaller than one delta would make a slow reader lossy by construction.
+const CONSOLE_RETENTION_DELTAS = 5
 
 // Monotonic within the process, so concurrent background commands never
 // collide on a spill filename. Not reset, so it needs no time or randomness.
 let spillCounter = 0
+
+// The mount whose writability a `read-only` policy keeps, because dsh's
+// own definition of that mode keeps it: "permits only required sinks such
+// as /dev/null". Narrowing it too would make `cmd > /dev/null` fail, which
+// no read-only sandbox anywhere does.
+const SINK_PREFIX = '/dev'
+
+// How mirage refuses a write the session's mount grants do not allow.
+// Two spellings, because the refusal is raised in two places: a command
+// names the mount it would not write to, while a redirection is refused
+// as the shell opens the file. Only consulted for a call that ran under
+// `read-only`, so the only permission error these can catch is the one
+// this executor just imposed.
+const DENIAL_SIGNATURES = ['read-only mount at ', ': Permission denied']
 
 /** Configuration for the mirage shell executor. */
 export interface MirageShellConfig {
@@ -83,9 +99,17 @@ export interface MirageShellConfig {
    * dsh's bash tool. With a session bound, `cd`, `export`, and function
    * definitions persist across calls, the persistent-shell contract. The
    * session is created on first use if the workspace does not have it; an
-   * existing session is adopted as is. A spec carrying an explicit
-   * `workdir` or `env` still runs as a one-call subshell of the bound
-   * session, per mirage's `ExecuteOptions` semantics.
+   * existing session is adopted as is.
+   *
+   * A spec carrying an explicit `env`, or a `workdir` that names a real
+   * directory in this world, still runs as a one-call subshell of the
+   * bound session, per mirage's `ExecuteOptions` semantics: both say
+   * "just for this command". The two things dsh injects on every call
+   * are deliberately not read that way, since neither carries that
+   * intent and either would fork every command and leave the binding
+   * with nothing to persist. A workdir resolved on the harness's own
+   * machine names nothing here and is dropped; the managed `DSH_*`
+   * snapshot is seeded into the session instead.
    */
   sessionId?: string
   /**
@@ -109,21 +133,26 @@ function collect(text: string, maxBytes: number): CollectedOutput {
 
 function executeOptions(
   spec: ShellExecSpec,
+  workdir: string,
   signal: AbortSignal,
   sessionId: string | undefined,
   fallbackWorkdir: string,
   sink?: JobConsole,
 ): ExecuteOptions & { provision?: false } {
-  const env = {
-    ...(spec.env ?? {}),
-    ...((spec.dshEnv as Record<string, string> | undefined) ?? {}),
-  }
+  // A per-call `env` makes mirage fork a subshell, exactly as `cwd` does,
+  // so what goes in it decides whether anything can persist. Bound to a
+  // session, only a genuine per-call override belongs here: dsh sends a
+  // non-empty managed `DSH_*` snapshot on every single call, and carrying
+  // that per call would fork every command and quietly undo the binding.
+  // Those facts are seeded into the session instead, by `applyManagedEnv`.
+  const managed = (spec.dshEnv as Record<string, string> | undefined) ?? {}
+  const env =
+    sessionId === undefined ? { ...(spec.env ?? {}), ...managed } : { ...(spec.env ?? {}) }
   // Unbound, `cwd` is always present so every command runs in an ephemeral
   // fork of the default session: isolation must not hinge on a spec
   // happening to carry a workdir. Bound, an absent workdir runs in the
   // session itself, which is what lets its state persist.
-  const cwd =
-    spec.workdir !== '' ? spec.workdir : sessionId === undefined ? fallbackWorkdir : undefined
+  const cwd = workdir !== '' ? workdir : sessionId === undefined ? fallbackWorkdir : undefined
   return {
     signal,
     ...(sessionId !== undefined ? { sessionId } : {}),
@@ -164,7 +193,7 @@ class MirageShellProcess implements ShellProcess {
   private readonly spill: SpillSink | null
   private readonly sandboxInfo: ShellSandboxInfo | undefined
   private readonly consumed: Promise<void>
-  private pending = ''
+  private readonly pending: TailBuffer
   private lossy = false
   private inStderr = false
   private settled = false
@@ -181,6 +210,7 @@ class MirageShellProcess implements ShellProcess {
     this.controller = controller
     this.console = console_
     this.budget = budget
+    this.pending = new TailBuffer(budget)
     this.spill = spill
     this.sandboxInfo = sandboxInfo
     this.consumed = this.consume()
@@ -214,25 +244,23 @@ class MirageShellProcess implements ShellProcess {
     // before the delta is capped, so nothing dropped from the delta is
     // lost to a reader that follows the spill path.
     if (this.spill !== null) await this.spill.ingest(chunk.channel, chunk.data)
-    const text = new TextDecoder().decode(chunk.data)
     // stderr rides the same delta as stdout, opened by a marker so the
     // reader can tell the two apart; a run of stderr chunks marks once.
+    let dropped = false
     if (chunk.channel === Channel.STDERR) {
       if (!this.inStderr) {
-        this.pending += STDERR_MARKER
+        dropped = this.pending.append(STDERR_MARKER)
         this.inStderr = true
       }
-      this.pending += text
     } else {
       this.inStderr = false
-      this.pending += text
     }
-    // Bound the unread backlog: a reader that never drains cannot grow
-    // `pending` without limit. The tail is kept (the freshest output),
-    // matching what the buffered path did at completion.
-    const capped = tailCap(this.pending, this.budget)
-    if (capped.truncated) {
-      this.pending = capped.text
+    // The backlog bounds itself as it grows, so a reader that never
+    // drains cannot grow it without limit and an append costs the chunk
+    // rather than everything buffered before it. The tail is kept (the
+    // freshest output), matching what the buffered path did at completion.
+    dropped = this.pending.append(chunk.data) || dropped
+    if (dropped) {
       this.lossy = true
       // The delta just dropped bytes; move the full stream to files so
       // the reader can still recover them from the spill path.
@@ -263,8 +291,7 @@ class MirageShellProcess implements ShellProcess {
   }
 
   readOutput(): ShellProcessRead {
-    const delta = this.pending
-    this.pending = ''
+    const delta = this.pending.take()
     const lossy = this.lossy
     this.lossy = false
     return {
@@ -307,6 +334,7 @@ export class MirageShellExecutor extends ShellExecutor {
   private readonly sessionId: string | undefined
   private readonly spillDir: string | undefined
   private sessionReady: Promise<void> | null = null
+  private readOnlyReady: Promise<string> | null = null
 
   constructor(ctx: Context, config: MirageShellConfig = {}) {
     super(ctx)
@@ -323,6 +351,29 @@ export class MirageShellExecutor extends ShellExecutor {
   // asynchronously), so every execution awaits the service's `ready`.
   private workspace(): Promise<Workspace> {
     return this.ctx.mirage.ready
+  }
+
+  /**
+   * The directory this command actually runs in.
+   *
+   * dsh fills an unspecified workdir from the calling session's cwd (by
+   * way of the sandbox policy's workspace root), and that is a directory
+   * on the harness's own machine, which names nothing here. Running
+   * there leaves `pwd` reporting a path the agent cannot reach and every
+   * relative path failing, and, because a per-call cwd forks a subshell,
+   * it also defeats a bound session on every call. So a workdir that is
+   * not a directory in this world is treated as unset: the configured
+   * default when unbound, the session's own cwd when bound.
+   *
+   * @param spec the resolved spec whose workdir is being placed.
+   * @param sessionId the session this call runs in, if any.
+   * @returns the workdir to execute under, `''` meaning the session's own.
+   */
+  private async worldWorkdir(spec: ShellExecSpec, sessionId: string | undefined): Promise<string> {
+    if (spec.workdir === '') return ''
+    const ws = await this.workspace()
+    if (await ws.fs.isDir(spec.workdir)) return spec.workdir
+    return sessionId === undefined ? this.workdir : ''
   }
 
   // A spill sink for one background command, or null when no spill
@@ -346,7 +397,10 @@ export class MirageShellExecutor extends ShellExecutor {
       },
     }
     spillCounter += 1
-    return new SpillSink(target, dir, `mirage-shell-${spillCounter.toString()}`)
+    const log = this.ctx.logger('mirage-dsh')
+    return new SpillSink(target, dir, `mirage-shell-${spillCounter.toString()}`, (err: unknown) => {
+      log.debug('spill to %s failed, output will not be recoverable: %o', dir, err)
+    })
   }
 
   /**
@@ -366,24 +420,120 @@ export class MirageShellExecutor extends ShellExecutor {
   }
 
   /**
+   * The mode this one call runs under: the policy the caller resolved
+   * for it, or this executor's own default when the call carried none.
+   * Undefined keeps the "no claim" answer for a world some runtime can
+   * act outside of, where no mode would be true.
+   *
+   * @param spec the resolved spec whose policy is being read.
+   * @returns the effective mode, or undefined when nothing is claimed.
+   */
+  private modeFor(spec: ShellExecSpec): ShellExecutor['sandboxMode'] {
+    const declared = this.sandboxMode
+    if (declared === undefined) return undefined
+    return spec.sandboxPolicy?.mode ?? declared
+  }
+
+  /**
+   * The session this call runs in: the read-only twin when the policy
+   * confines it to reads, else this executor's own binding.
+   *
+   * `workspace-write` and `danger-full-access` both run in the ordinary
+   * session, because the mounts and their modes already are the
+   * workspace boundary and mirage has nothing wider to grant.
+   *
+   * @param spec the resolved spec whose policy selects the session.
+   * @returns the session id to execute under, or undefined for the default.
+   */
+  private async sessionFor(spec: ShellExecSpec): Promise<string | undefined> {
+    if (this.modeFor(spec) !== 'read-only') return this.sessionId
+    return this.readOnlySession()
+  }
+
+  /**
    * The sandbox facts to stamp on this run's result and process handle,
    * or undefined when the world is not fully workspace-bound (no claim).
    *
    * `enforcement` is 'full': when every runtime reaches only the vfs, the
    * workspace gate cannot be bypassed, so unlike an OS sandbox on an older
-   * kernel there is no promised effect it fails to govern. `denied` is
-   * false because mirage has no out-of-band denial channel: a refused write
-   * (a read-only mount) fails in-band as an ordinary command error with a
-   * nonzero exit, the way EROFS would, not as a separate sandbox verdict,
-   * so there is nothing here to distinguish from the command's own failure.
-   * `runnerFailed` is false because the workspace executor is the runner
-   * and a failure to run surfaces as a rejected/aborted execution, not a
-   * runner that never started.
+   * kernel there is no promised effect it fails to govern. `runnerFailed`
+   * is false because the workspace executor is the runner and a failure to
+   * run surfaces as a rejected/aborted execution, not a runner that never
+   * started.
+   *
+   * @param spec the resolved spec this run was built from.
+   * @param denied whether the run was refused a write by the narrowing.
+   * @returns the facts to stamp, or undefined when nothing is claimed.
    */
-  private sandboxInfo(): ShellSandboxInfo | undefined {
-    const mode = this.sandboxMode
+  private sandboxInfo(spec: ShellExecSpec, denied = false): ShellSandboxInfo | undefined {
+    const mode = this.modeFor(spec)
     if (mode === undefined) return undefined
-    return { mode, denied: false, enforcement: 'full', runnerFailed: false }
+    return { mode, denied, enforcement: 'full', runnerFailed: false }
+  }
+
+  private retentionFor(spec: ShellExecSpec): number {
+    return Math.max(spec.stdoutMaxBytes, this.stderrMaxBytes) * CONSOLE_RETENTION_DELTAS
+  }
+
+  /**
+   * Take a finished run's two streams off its console, capped, and spill
+   * whichever one lost bytes.
+   *
+   * A foreground run streams into a console rather than returning its
+   * output whole, because mirage throws on abort: bytes a killed command
+   * had already printed are recoverable from a sink and nowhere else.
+   * Only a truncated stream spills, since an untruncated one is already
+   * whole in `text` and writing a file for it would put a copy of every
+   * command's output on a mount. The spill can only hold what the
+   * console retained, so a run that also outran retention is short by
+   * the difference.
+   *
+   * @param console_ the console this run streamed into.
+   * @param spec the resolved spec carrying the stdout budget.
+   * @returns the capped streams, each with a spill path when it lost bytes.
+   */
+  private async collectFrom(
+    console_: JobConsole,
+    spec: ShellExecSpec,
+  ): Promise<{ stdout: CollectedOutput; stderr: CollectedOutput }> {
+    const decoder = new TextDecoder()
+    const outBytes = await console_.snapshot(Channel.STDOUT)
+    const errBytes = await console_.snapshot(Channel.STDERR)
+    const stdout = collect(decoder.decode(outBytes), spec.stdoutMaxBytes)
+    const stderr = collect(decoder.decode(errBytes), this.stderrMaxBytes)
+    if (!stdout.truncated && !stderr.truncated) return { stdout, stderr }
+    const spill = this.newSpill()
+    if (spill === null) return { stdout, stderr }
+    if (stdout.truncated) await spill.ingest(Channel.STDOUT, outBytes)
+    if (stderr.truncated) await spill.ingest(Channel.STDERR, errBytes)
+    await spill.begin()
+    return {
+      stdout: {
+        ...stdout,
+        ...(spill.stdoutPath !== undefined ? { spillPath: spill.stdoutPath } : {}),
+      },
+      stderr: {
+        ...stderr,
+        ...(spill.stderrPath !== undefined ? { spillPath: spill.stderrPath } : {}),
+      },
+    }
+  }
+
+  /**
+   * Whether this run was refused a write by the read-only narrowing.
+   *
+   * mirage has no out-of-band denial channel: a refused write fails
+   * in-band with a nonzero exit, the way EROFS would. So the fact is
+   * read back off stderr, and only for a call that ran read-only, where
+   * this executor is what imposed the narrowing in the first place.
+   *
+   * @param spec the resolved spec this run was built from.
+   * @param stderr the run's captured standard error.
+   * @returns true when the narrowing refused something.
+   */
+  private wasDenied(spec: ShellExecSpec, stderr: string): boolean {
+    if (this.modeFor(spec) !== 'read-only') return false
+    return DENIAL_SIGNATURES.some((signature) => stderr.includes(signature))
   }
 
   resolve(request: ShellExecRequest): ShellExecSpec {
@@ -413,6 +563,76 @@ export class MirageShellExecutor extends ShellExecutor {
     return this.sessionReady
   }
 
+  /**
+   * Seed this call's managed `DSH_*` snapshot into the bound session.
+   *
+   * These are harness facts about the session (its home, its id), not
+   * overrides for one command, and on a bound session they have to live
+   * in the session: handed over as a per-call `env` they would fork a
+   * subshell on every call, since dsh never sends an empty snapshot.
+   *
+   * The snapshot replaces rather than merges, per the seam's own rule
+   * that a fact absent from the current snapshot must not inherit a
+   * stale value from an earlier one. Only the managed namespace is
+   * touched, so a variable the agent exported itself is left alone.
+   *
+   * @param ws the live workspace holding the session.
+   * @param sessionId the session this call runs in.
+   * @param spec the resolved spec carrying the snapshot.
+   */
+  private async applyManagedEnv(
+    ws: Workspace,
+    sessionId: string,
+    spec: ShellExecSpec,
+  ): Promise<void> {
+    const managed = spec.dshEnv as Record<string, string> | undefined
+    if (managed === undefined) return
+    const session = ws.getSession(sessionId)
+    const view = sessionView(session)
+    for (const key of Object.keys(session.env)) {
+      if (key.startsWith(DSH_ENV_PREFIX) && !(key in managed)) await view.unset(key)
+    }
+    for (const [key, value] of Object.entries(managed)) await view.set(key, value)
+  }
+
+  private readOnlySession(): Promise<string> {
+    this.readOnlyReady ??= this.provisionReadOnly().catch((err: unknown) => {
+      this.readOnlyReady = null
+      throw err
+    })
+    return this.readOnlyReady
+  }
+
+  /**
+   * Create (once) the session a read-only call runs in: a twin of this
+   * executor's binding whose every mount is granted `read`, so mirage's
+   * own dispatch is what refuses the write rather than a second
+   * permission layer bolted on here.
+   *
+   * Every mount has to appear in the map: a prefix the map omits is not
+   * narrowed, it is invisible, and a session that cannot see `/` cannot
+   * even run `pwd`. The one mount that keeps its own mode is the null
+   * sink, per {@link SINK_PREFIX}.
+   *
+   * The policy's `workspaceRoot` is deliberately not consulted anywhere:
+   * it is a directory on the harness's machine, so containment against
+   * it says nothing about this world. The mounts are the boundary.
+   *
+   * @returns the id of the read-only session.
+   */
+  private async provisionReadOnly(): Promise<string> {
+    const ws = await this.workspace()
+    const sessionId = `${this.sessionId ?? 'mirage-dsh'}::read-only`
+    await ws.ensureSessionsLoaded()
+    if (ws.listSessions().some((s) => s.sessionId === sessionId)) return sessionId
+    const grants: Record<string, string> = {}
+    for (const entry of ws.mounts()) {
+      grants[entry.prefix] = entry.prefix.replace(/\/+$/, '') === SINK_PREFIX ? 'exec' : 'read'
+    }
+    setCwd(ws.createSession(sessionId, { mounts: grants }), this.workdir)
+    return sessionId
+  }
+
   private async provisionSession(sessionId: string): Promise<void> {
     const ws = await this.workspace()
     await ws.ensureSessionsLoaded()
@@ -421,7 +641,7 @@ export class MirageShellExecutor extends ShellExecutor {
   }
 
   async run(spec: ShellExecSpec): Promise<ShellRunResult> {
-    const sandbox = this.sandboxInfo()
+    const sandbox = this.sandboxInfo(spec)
     // An already-aborted signal never fires its listener, so answer before
     // dispatch: the command must not run at all.
     if (spec.signal?.aborted === true) {
@@ -437,6 +657,10 @@ export class MirageShellExecutor extends ShellExecutor {
       }
     }
     const controller = new AbortController()
+    // The command streams into a console instead of returning its output
+    // whole, because mirage answers an abort by throwing: what a killed
+    // command already printed survives only in a sink.
+    const console_ = new JobConsole(new RAMConsoleStore(this.retentionFor(spec)))
     let timedOut = false
     let aborted = false
     const timer = setTimeout(() => {
@@ -453,19 +677,23 @@ export class MirageShellExecutor extends ShellExecutor {
     try {
       await this.ensureSession()
       const ws = await this.workspace()
+      const sessionId = await this.sessionFor(spec)
+      if (sessionId !== undefined) await this.applyManagedEnv(ws, sessionId, spec)
+      const workdir = await this.worldWorkdir(spec, sessionId)
       const result = await ws.execute(
         spec.command,
-        executeOptions(spec, controller.signal, this.sessionId, this.workdir),
+        executeOptions(spec, workdir, controller.signal, sessionId, this.workdir, console_),
       )
+      const captured = await this.collectFrom(console_, spec)
+      const settled = this.sandboxInfo(spec, this.wasDenied(spec, captured.stderr.text))
       return {
         exitCode: result.exitCode,
         signal: null,
         timedOut: false,
         aborted: false,
         timeoutMs: spec.timeoutMs,
-        stdout: collect(result.stdoutText, spec.stdoutMaxBytes),
-        stderr: collect(result.stderrText, this.stderrMaxBytes),
-        ...(sandbox !== undefined ? { sandbox } : {}),
+        ...captured,
+        ...(settled !== undefined ? { sandbox: settled } : {}),
       }
     } catch (err) {
       if (!controller.signal.aborted) throw err
@@ -477,8 +705,10 @@ export class MirageShellExecutor extends ShellExecutor {
         timedOut,
         aborted,
         timeoutMs: spec.timeoutMs,
-        stdout: { text: '', truncated: false },
-        stderr: { text: '', truncated: false },
+        // Whatever the command printed before the kill landed. GNU's own
+        // timeout keeps it, and a model that watched a build run for two
+        // minutes is owed the log rather than an empty string.
+        ...(await this.collectFrom(console_, spec)),
         ...(sandbox !== undefined ? { sandbox } : {}),
       }
     } finally {
@@ -488,13 +718,18 @@ export class MirageShellExecutor extends ShellExecutor {
   }
 
   start(spec: ShellExecSpec): ShellProcess {
-    const sandbox = this.sandboxInfo()
+    // A background handle has no aggregated stderr to read a denial back
+    // off, so its facts carry the mode without the verdict; a reader that
+    // needs it sees the refusal in the streamed output.
+    const sandbox = this.sandboxInfo(spec)
     const controller = new AbortController()
     // The console is the streaming conduit, holding what the follow loop
     // has not drained yet (nothing, when the loop keeps up). Its own
     // retention budget is what bounds that, since reading a chunk does
     // not release it.
-    const console_ = new JobConsole(new RAMConsoleStore(CONSOLE_RETENTION_BYTES))
+    const console_ = new JobConsole(
+      new RAMConsoleStore(spec.stdoutMaxBytes * CONSOLE_RETENTION_DELTAS),
+    )
     const spill = this.newSpill()
     if (spec.signal?.aborted === true) {
       controller.abort()
@@ -512,11 +747,16 @@ export class MirageShellExecutor extends ShellExecutor {
     }
     spec.signal?.addEventListener('abort', onAbort, { once: true })
     const run = this.ensureSession()
-      .then(() => this.workspace())
-      .then((ws) =>
+      .then(async () => {
+        const sessionId = await this.sessionFor(spec)
+        const ws = await this.workspace()
+        if (sessionId !== undefined) await this.applyManagedEnv(ws, sessionId, spec)
+        return { ws, sessionId, workdir: await this.worldWorkdir(spec, sessionId) }
+      })
+      .then(({ ws, sessionId, workdir }) =>
         ws.execute(
           spec.command,
-          executeOptions(spec, controller.signal, this.sessionId, this.workdir, console_),
+          executeOptions(spec, workdir, controller.signal, sessionId, this.workdir, console_),
         ),
       )
       .finally(() => spec.signal?.removeEventListener('abort', onAbort))

--- a/typescript/packages/dsh/src/spill.test.ts
+++ b/typescript/packages/dsh/src/spill.test.ts
@@ -141,3 +141,47 @@ describe('ensureDirPath', () => {
     await expect(ensureDirPath(dirs, '/data/spill')).rejects.toThrow('read-only mount')
   })
 })
+
+describe('SpillSink failure reporting', () => {
+  it('reports the failure that disabled it instead of swallowing it', async () => {
+    const seen: unknown[] = []
+    const sink = new SpillSink(
+      {
+        ensureDir: () => Promise.reject(new Error('no writable mount at /nope')),
+        write: () => Promise.resolve(),
+        append: () => Promise.resolve(),
+      },
+      '/nope',
+      'job-1',
+      (err) => seen.push(err),
+    )
+    await sink.ingest(Channel.STDOUT, new TextEncoder().encode('data'))
+    await sink.begin()
+    expect(seen).toHaveLength(1)
+    expect((seen[0] as Error).message).toContain('no writable mount')
+    expect(sink.stdoutPath).toBeUndefined()
+  })
+
+  it('stays quiet when the spill succeeds', async () => {
+    const seen: unknown[] = []
+    const written = new Map<string, Uint8Array>()
+    const sink = new SpillSink(
+      {
+        ensureDir: () => Promise.resolve(),
+        write: (path, bytes) => {
+          written.set(path, bytes)
+          return Promise.resolve()
+        },
+        append: () => Promise.resolve(),
+      },
+      '/tmp',
+      'job-2',
+      (err) => seen.push(err),
+    )
+    await sink.ingest(Channel.STDOUT, new TextEncoder().encode('data'))
+    await sink.begin()
+    expect(seen).toHaveLength(0)
+    expect(sink.stdoutPath).toBe('/tmp/job-2.stdout')
+    expect(written.get('/tmp/job-2.stdout')).toEqual(new TextEncoder().encode('data'))
+  })
+})

--- a/typescript/packages/dsh/src/spill.ts
+++ b/typescript/packages/dsh/src/spill.ts
@@ -88,15 +88,22 @@ export class SpillSink {
   private readonly target: SpillTarget
   private readonly dir: string
   private readonly base: string
+  private readonly onFailure: (err: unknown) => void
   private started = false
   private failed = false
   private stdoutParts: Uint8Array[] = []
   private stderrParts: Uint8Array[] = []
 
-  constructor(target: SpillTarget, dir: string, base: string) {
+  constructor(
+    target: SpillTarget,
+    dir: string,
+    base: string,
+    onFailure: (err: unknown) => void = () => undefined,
+  ) {
     this.target = target
     this.dir = dir
     this.base = base
+    this.onFailure = onFailure
   }
 
   /** Buffer a chunk before spill starts, or append it to the file after. */
@@ -126,7 +133,10 @@ export class SpillSink {
       this.started = true
       this.stdoutParts = []
       this.stderrParts = []
-    } catch {
+    } catch (err) {
+      // Reported, never swallowed: a spill quietly vanishing reads later
+      // as "the harness lost my output" with nothing to explain it.
+      this.onFailure(err)
       this.disable()
     }
   }
@@ -148,7 +158,8 @@ export class SpillSink {
           await this.target.append(this.stdoutPath, data)
         }
       }
-    } catch {
+    } catch (err) {
+      this.onFailure(err)
       this.disable()
     }
   }

--- a/typescript/packages/dsh/src/text.test.ts
+++ b/typescript/packages/dsh/src/text.test.ts
@@ -1,0 +1,75 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { TailBuffer, tailCap } from './text.ts'
+
+const bytes = (text: string): Uint8Array => new TextEncoder().encode(text)
+
+describe('TailBuffer', () => {
+  it('keeps everything while it fits', () => {
+    const buffer = new TailBuffer(16)
+    expect(buffer.append(bytes('abc'))).toBe(false)
+    expect(buffer.append(bytes('def'))).toBe(false)
+    expect(buffer.take()).toBe('abcdef')
+  })
+
+  it('drains empty and stays empty', () => {
+    const buffer = new TailBuffer(16)
+    expect(buffer.take()).toBe('')
+    buffer.append(bytes('x'))
+    expect(buffer.take()).toBe('x')
+    expect(buffer.take()).toBe('')
+  })
+
+  it('reports the drop and keeps the newest bytes', () => {
+    const buffer = new TailBuffer(4)
+    expect(buffer.append(bytes('abc'))).toBe(false)
+    expect(buffer.append(bytes('def'))).toBe(true)
+    expect(buffer.take()).toBe('cdef')
+  })
+
+  it('drops whole chunks and then part of one', () => {
+    const buffer = new TailBuffer(3)
+    buffer.append(bytes('aaaa'))
+    buffer.append(bytes('bb'))
+    buffer.append(bytes('cc'))
+    expect(buffer.take()).toBe('bcc')
+  })
+
+  it('drops a chunk larger than the whole budget down to its tail', () => {
+    const buffer = new TailBuffer(3)
+    expect(buffer.append(bytes('abcdefgh'))).toBe(true)
+    expect(buffer.take()).toBe('fgh')
+  })
+
+  it('re-aligns a head that lands mid-character', () => {
+    const buffer = new TailBuffer(3)
+    // "aaéé" is six bytes; the last three start inside the third character.
+    buffer.append(bytes('aaéé'))
+    expect(buffer.take()).toBe('é')
+  })
+
+  it('keeps a multi-byte character whole when the cap lands on its boundary', () => {
+    const buffer = new TailBuffer(3)
+    buffer.append(bytes('aaaé'))
+    expect(buffer.take()).toBe('aé')
+  })
+
+  it('agrees with tailCap on the same input', () => {
+    const buffer = new TailBuffer(5)
+    buffer.append(bytes('hello world'))
+    expect(buffer.take()).toBe(tailCap('hello world', 5).text)
+  })
+})

--- a/typescript/packages/dsh/src/text.ts
+++ b/typescript/packages/dsh/src/text.ts
@@ -86,15 +86,93 @@ export function applyLiteralEdit(
     : content.replace(oldString, newString)
 }
 
+// The first index at or after `from` that starts a UTF-8 sequence, so a tail
+// taken from there decodes as characters rather than as replacement marks.
+function charBoundary(bytes: Uint8Array, from: number): number {
+  let start = from
+  while (start < bytes.byteLength && ((bytes[start] ?? 0) & 0xc0) === 0x80) start++
+  return start
+}
+
 // Byte-accurate tail cap: keep the LAST maxBytes bytes of the encoded text,
 // re-aligned to a UTF-8 sequence boundary so the kept tail still decodes.
 export function tailCap(text: string, maxBytes: number): { text: string; truncated: boolean } {
   const bytes = new TextEncoder().encode(text)
   if (bytes.byteLength <= maxBytes) return { text, truncated: false }
-  let start = bytes.byteLength - maxBytes
-  while (start < bytes.byteLength && ((bytes[start] ?? 0) & 0xc0) === 0x80) start++
+  const start = charBoundary(bytes, bytes.byteLength - maxBytes)
   return {
     text: new TextDecoder('utf-8', { fatal: false }).decode(bytes.subarray(start)),
     truncated: true,
+  }
+}
+
+/**
+ * A bounded backlog of output bytes: the newest `budget` bytes, with the
+ * oldest dropped as they overflow.
+ *
+ * Held as bytes rather than as a string because the string form had to
+ * re-encode everything already buffered on every append to measure it,
+ * which is quadratic in a command's output and lands on the same event
+ * loop that serves the workspace. Appending here costs the chunk, not
+ * the backlog.
+ */
+export class TailBuffer {
+  private readonly budget: number
+  private parts: Uint8Array[] = []
+  private bytes = 0
+
+  constructor(budget: number) {
+    this.budget = budget
+  }
+
+  /**
+   * Append a chunk, dropping the oldest bytes that no longer fit.
+   *
+   * @param data the bytes to append.
+   * @returns true when bytes were dropped to make room.
+   */
+  append(data: Uint8Array): boolean {
+    this.parts.push(data)
+    this.bytes += data.byteLength
+    if (this.bytes <= this.budget) return false
+    let excess = this.bytes - this.budget
+    while (excess > 0) {
+      const head = this.parts[0]
+      if (head === undefined) break
+      if (head.byteLength <= excess) {
+        this.parts.shift()
+        excess -= head.byteLength
+        this.bytes -= head.byteLength
+      } else {
+        this.parts[0] = head.subarray(excess)
+        this.bytes -= excess
+        excess = 0
+      }
+    }
+    return true
+  }
+
+  /**
+   * Drain everything held, decoded as text.
+   *
+   * The head may sit mid-character, since dropping is byte-exact, so it
+   * is re-aligned before decoding rather than rendered as a replacement
+   * mark.
+   *
+   * @returns the buffered text; the buffer is left empty.
+   */
+  take(): string {
+    if (this.parts.length === 0) return ''
+    const joined = new Uint8Array(this.bytes)
+    let at = 0
+    for (const part of this.parts) {
+      joined.set(part, at)
+      at += part.byteLength
+    }
+    this.parts = []
+    this.bytes = 0
+    return new TextDecoder('utf-8', { fatal: false }).decode(
+      joined.subarray(charBoundary(joined, 0)),
+    )
   }
 }


### PR DESCRIPTION
The mirage dsh providers were written against the seam's types and tested against hand-built specs. Read against what `tool-bash` and `tool-fs` actually send on every call, several assumptions turned out to be wrong. Each finding below was reproduced first, and the published rc artifacts (`dsh-tool-bash@0.0.1-rc.1`, `dsh-tool-fs@0.0.1-rc.1`, `dsh-shell-env@0.0.1-rc.3`) were checked, not just the newer source checkout.

## The agent worked in a directory that did not exist

`resolveWorkdir` fills an unspecified workdir from the calling session's cwd, which is a directory on the host. mirage accepted it:

```
pwd                | exit 0 | /Users/zecheng/proj      <- not a path in this world
ls                 | exit 2 | ls: cannot access '.': No such file or directory
cat notes.txt      | exit 1 | cat: notes.txt: No such file or directory
```

`pwd` exits 0, so nothing signalled that the cwd was fictional; absolute paths worked and relative ones did not. `tool-fs` passes the same host path as the base for relative `file_path` arguments, so `read`/`write`/`edit` resolved `notes.txt` to `/Users/zecheng/proj/notes.txt` and reported `FS_NOT_FOUND`. Both now fall back to the configured directory when the base is not a directory in this world; an absolute path never pays for the probe.

## A bound session persisted nothing

A per-call `cwd` **or** `env` makes mirage fork a subshell, and dsh sends both every call: `shellEnv.collect()` always returns at least `DSH_HOME` and `DSH_SHELL`. So `sessionId` silently degraded to one-shot.

The managed `DSH_*` snapshot is now seeded into the bound session (replacing rather than merging, per the seam's stale-fact rule) instead of riding along per call. A genuine per-call `env` still forks, matching `env FOO=1 cmd`.

## The sandbox policy was resolved, carried, and discarded

Because the executor declares `workspace-write`, `tool-bash` requires `ctx.sandboxPolicy`, resolves a policy per call, prompts a human for escalations, and puts the active mode in the system prompt. mirage never read it, and `ctx.fs` declared no confinement at all, so `tool-fs` fenced nothing either.

Under `read-only` the shell now runs in a session with every mount granted `read` (the null sink keeps `exec`, as that mode's definition requires), and `ctx.fs` refuses a mutation with `FS_SANDBOX_DENIED`, wording and code copied from `dsh-fs-sandbox` so the tool layer renders one denial marker. `ShellSandboxInfo` carries the mode the call actually ran under. `workspaceRoot` is deliberately never consulted: it is a host directory, so containment against it says nothing here.

The bundle patch needs no change. `dsh-base` already sets `mode: DSH_PERMISSION_MODE ?? 'workspace-write'`, so this is not a behaviour change for existing users; it is what finally makes `DSH_PERMISSION_MODE=read-only` mean something.

## Output fidelity

A killed run returned an empty string. A foreground run now streams into a `JobConsole`, because mirage answers an abort by throwing and the bytes survive only in a sink:

```
echo early-output; sleep 30   (300 ms timeout)
  before: stdout ""
  after:  stdout "early-output"
```

Truncated foreground streams spill to a file and report `spillPath`, which the bash tool description already promises the model. Console retention follows the configured budget instead of a fixed constant.

## Performance

The background delta re-encoded its whole backlog per chunk. Measured on 1 MB in 200-byte chunks:

```
string + tailCap per chunk   562 ms
TailBuffer (bytes)             1 ms
```

## Robustness

A declarative mount that fails to build reached the process as an unhandled rejection, taking the harness down over a typo in a patch file; `ready` still rejects for real callers. `runtimes` or `workspaceOptions` beside an adopted `workspace` are refused instead of silently dropped. `listDir` honours its abort signal per entry. `mapMirageError` recognises an `AbortError` by name, so a plain `Error` no longer reports as `FS_IO_ERROR`. A failed spill is logged rather than swallowed.

## Notes

Session writes go through `setCwd` and `sessionView`, not the frozen `session.env` projection. Rebasing surfaced this: the pre-rebase version wrote directly and throws `object is not extensible` on current main, which the tests catch.

Two upstream issues worth filing, not fixable here: `tool-bash` and `tool-fs` both compute paths from the harness cwd and never ask `ctx.fs`, though `resolve()`/`processPath()` exist for exactly that; and the bash tool description tells the model no state persists, which contradicts `sessionId`.

## Verification

- dsh tests 87 to 153; monorepo 12,381 passing
- `pnpm -r build`, `pnpm -r typecheck` exit 0
- pre-commit stable across runs, layout parity 268 = baseline
- Python untouched (zero `.py` files in the diff). The `py-mypy` hook reports 3 pre-existing `no-any-return` errors in `qdrant`/`gridfs`; reproduced identically on a clean `origin/main` worktree with the same hook command.
- Not covered: a live `dsh --profile` boot with a real agent. The composition question that mattered was checked against the published `tool-fs`, which demands `ctx.sandboxPolicy` once `ctx.fs.sandboxMode` is defined; `dsh-base` provides it and this patch does not disable it.