### PR TITLE
fix(ls): list a nested mount's root in its parent's -R listing

### DIFF
--- a/integ/crossmount/nested/basic.json
+++ b/integ/crossmount/nested/basic.json
@@ -67,6 +67,7 @@
     },
     {
       "id": "nest_ls_recursive_renders_both_groups",
+      "note": "A mount root is an ordinary directory entry of its parent, so `inner` is a row of `/data` as well as a group of its own. Pinned on coreutils 9.7 over a tmpfs mounted at `base/nested`: `ls -R base` prints `nested` then `top.txt`, then the mounted directory under its own header. `-R` used to withhold the namespace merge and leave the whole nested mount to the cross-mount fan-out, which contributes the group but not the parent's row, so the row went missing here where `/data`'s backend holds no `inner` key. Non-recursive `ls /data` (seq 950002) always listed it.",
       "seq": 950006,
       "targets": [
         "ram-nested"
@@ -74,7 +75,7 @@
       "command": "ls -R /data",
       "expect": {
         "exit": 0,
-        "stdout": "/data:\ntop.txt\n\n/data/inner:\nleaf.txt\n",
+        "stdout": "/data:\ninner\ntop.txt\n\n/data/inner:\nleaf.txt\n",
         "stderr": ""
       }
     },

--- a/python/mirage/commands/builtin/generic/crossmount/relay/ls.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/ls.py
@@ -89,7 +89,12 @@ async def run_ls(scopes: list[PathSpec], flag_kwargs: dict[str, FlagValue],
         ns (NamespaceView | None): Name-plane facts no backend can see.
             The attr overlay matters most here: without it a relayed row
             would report the raw backend mode and silently lose a chmod
-            the namespace holds.
+            the namespace holds. Every fact but ``mounts``, which names
+            the boundaries a walk's readdir cannot cross: this one's
+            does cross them, so the relay descends a nested mount
+            itself, and it has to, because nothing runs behind a relay
+            to contribute that group the way the fan-out does for a
+            single-mount run.
     """
     p = functools.partial
     stat_fn: Stat = p(relayed_stat, dispatch)

--- a/python/mirage/commands/builtin/generic/ls.py
+++ b/python/mirage/commands/builtin/generic/ls.py
@@ -10,7 +10,7 @@ from mirage.commands.config import CommandOpts
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagValue, FlagView
 from mirage.io.types import IOResult
-from mirage.ops.types import ChildMounts, LinkView
+from mirage.ops.types import ChildMounts, LinkView, MountView, StatPath
 from mirage.types import FileStat, FileType, LsSortBy, PathSpec
 from mirage.utils.errors import fs_strerror
 from mirage.utils.key_prefix import rekey
@@ -272,6 +272,40 @@ def _child_spec(path: PathSpec, name: str) -> PathSpec:
                                         child))
 
 
+async def _mount_row(
+    directory: PathSpec,
+    name: str,
+    stat_path: StatPath | None,
+) -> FileStat:
+    """The row for a child mount, carrying its real type.
+
+    No backend can supply it: the parent's cannot see into the child
+    mount, and the child's own answers its root with that mount's name
+    for itself (``/``), which is why the row is renamed here the way the
+    relay renames one. So the fact comes through the dispatcher, which
+    routes to whichever mount owns the path.
+
+    A mount root is not always a directory -- every workspace mounts
+    ``/.bash_history`` as a whole mount serving one file -- and calling
+    one a directory suffixes it with ``/`` under ``-F``, renders it
+    ``drwxr-xr-x`` under ``-l``, and offers it to ``-R`` as something to
+    descend. GNU lists a file that happens to be a mountpoint as an
+    ordinary file row (pinned on coreutils 9.7 over a ``mount --bind``
+    of one file onto another). Directory is the fallback for a caller
+    with no dispatcher, which is the only thing that absence can mean.
+
+    Args:
+        directory (PathSpec): the directory being listed.
+        name (str): the child's own name.
+        stat_path (StatPath | None): dispatcher-backed stat of one path.
+    """
+    if stat_path is not None:
+        row = await stat_path(directory.child(name))
+        if row is not None:
+            return row.model_copy(update={"name": name})
+    return FileStat(name=name, type=FileType.DIRECTORY)
+
+
 async def _stat_entries(
     path: PathSpec,
     names: list[str],
@@ -282,6 +316,7 @@ async def _stat_entries(
     links: LinkView | None = None,
     deref: bool = False,
     child_mounts: ChildMounts | None = None,
+    stat_path: StatPath | None = None,
 ) -> tuple[list[FileStat], list[LsWarning]]:
     """Stat every name in a directory, plus the symlinks living there.
 
@@ -302,7 +337,13 @@ async def _stat_entries(
         child_mounts (ChildMounts | None): session-filtered child-mount
             names under a directory. A nested mount is namespace
             structure the backend readdir cannot name, merged here like
-            a link row.
+            a link row. GNU lists a mountpoint as an ordinary entry of
+            its parent, so the merge is unconditional: withholding it
+            under ``-R`` dropped the row whenever the parent's backend
+            held no key of that name.
+        stat_path (StatPath | None): dispatcher-backed stat, which is
+            the only way to learn a child mount's real type. See
+            ``_mount_row``.
     """
     stats: list[FileStat] = []
     warnings: list[LsWarning] = []
@@ -342,7 +383,7 @@ async def _stat_entries(
         if not all_files and name.startswith("."):
             continue
         seen.add(name)
-        stats.append(FileStat(name=name, type=FileType.DIRECTORY))
+        stats.append(await _mount_row(path, name, stat_path))
     return stats, warnings
 
 
@@ -360,6 +401,8 @@ async def probe_operand(
     links: LinkView | None = None,
     deref: bool = False,
     child_mounts: ChildMounts | None = None,
+    mounts: MountView | None = None,
+    stat_path: StatPath | None = None,
 ) -> tuple[Operand, list[LsWarning]]:
     """List one operand and report whether it turned out to be a directory.
 
@@ -376,11 +419,18 @@ async def probe_operand(
         index (IndexCacheStore): listing cache.
         links (LinkView | None): the namespace's symlink facts.
         child_mounts (ChildMounts | None): session-filtered child-mount
-            names. Under ``-R`` a backend-served listing withholds the
-            merge and a child-mount root is never descended (the walk
-            cannot read another mount's backend, so the cross-mount
-            fan-out assembles those groups); a directory only the
-            namespace serves still renders its own group from it.
+            names, merged into every listing: a mountpoint is an
+            ordinary directory entry of its parent, ``-R`` or not.
+        mounts (MountView | None): the mount boundaries this walk's
+            ``readdir`` cannot cross. Under ``-R`` such a root is listed
+            but never descended, because that listing is another
+            backend's and the cross-mount fan-out assembles the group;
+            a namespace-only directory *above* one is descended, since
+            no other run renders it. None for a walk that can cross --
+            the relay's readdir routes per path, so it descends a
+            nested mount itself.
+        stat_path (StatPath | None): dispatcher-backed stat, for the
+            child-mount rows no backend can supply.
     """
     warnings: list[LsWarning] = []
     structure_only = False
@@ -402,10 +452,7 @@ async def probe_operand(
         # No backend serves it, but the namespace owes it children (a
         # nested mount, a link's ancestors), so the door lists it as a
         # directory and ls must agree: the merge below renders those
-        # rows from an empty backend listing. Under -R this group still
-        # renders; only descent into a child-mount root is withheld,
-        # because that listing is another backend's and the cross-mount
-        # fan-out assembles it.
+        # rows from an empty backend listing.
         names = []
         structure_only = True
 
@@ -420,16 +467,15 @@ async def probe_operand(
         if link_row is not None:
             return Operand(path, link_row, []), warnings
 
-    entries, entry_ws = await _stat_entries(
-        path,
-        names,
-        stat=stat,
-        all_files=all_files,
-        index=index,
-        links=links,
-        deref=deref,
-        child_mounts=child_mounts if structure_only else
-        (None if recursive else child_mounts))
+    entries, entry_ws = await _stat_entries(path,
+                                            names,
+                                            stat=stat,
+                                            all_files=all_files,
+                                            index=index,
+                                            links=links,
+                                            deref=deref,
+                                            child_mounts=child_mounts,
+                                            stat_path=stat_path)
     warnings.extend(entry_ws)
     entries = sort_stats(entries, sort_by, reverse)
     groups: list[tuple[PathSpec, list[FileStat]]] = [(path, entries)]
@@ -438,10 +484,10 @@ async def probe_operand(
             if entry.type != FileType.DIRECTORY:
                 continue
             child_path = _child_spec(path, entry.name)
-            if structure_only and (child_mounts is None
-                                   or not child_mounts(child_path.virtual)):
-                # A child-mount root: its listing is another backend's,
-                # so the cross-mount fan-out renders that group.
+            if mounts is not None and mounts.is_root(child_path.virtual):
+                # A nested mount's root. Its row belongs here, but its
+                # listing is another backend's, which this walk cannot
+                # read: the cross-mount fan-out renders that group.
                 continue
             child, child_ws = await probe_operand(child_path,
                                                   readdir=readdir,
@@ -454,7 +500,9 @@ async def probe_operand(
                                                   index=index,
                                                   links=links,
                                                   deref=deref,
-                                                  child_mounts=child_mounts)
+                                                  child_mounts=child_mounts,
+                                                  mounts=mounts,
+                                                  stat_path=stat_path)
             groups.extend(child.groups)
             warnings.extend(child_ws)
     return Operand(path, None, groups), warnings
@@ -475,6 +523,8 @@ async def walk(
     links: LinkView | None = None,
     deref: bool = False,
     child_mounts: ChildMounts | None = None,
+    mounts: MountView | None = None,
+    stat_path: StatPath | None = None,
 ) -> WalkResult:
     """Flat listing for one operand: a directory's entries, or the operand
     itself when it is not one. ``recursive`` flattens the whole subtree in
@@ -495,6 +545,11 @@ async def walk(
         links (LinkView | None): the namespace's symlink facts.
         child_mounts (ChildMounts | None): session-filtered child-mount
             names to merge into a directory listing.
+        mounts (MountView | None): the boundaries this walk's readdir
+            cannot cross, so ``-R`` lists a nested mount's root without
+            descending it.
+        stat_path (StatPath | None): dispatcher-backed stat, for the
+            child-mount rows no backend can supply.
     """
     if list_dir:
         link_row = _link_row(path, links)
@@ -529,7 +584,9 @@ async def walk(
                                             index=index,
                                             links=links,
                                             deref=deref,
-                                            child_mounts=child_mounts)
+                                            child_mounts=child_mounts,
+                                            mounts=mounts,
+                                            stat_path=stat_path)
     if operand.row is not None:
         return WalkResult([operand.row], warnings)
     entries = [e for _, group in operand.groups for e in group]
@@ -612,6 +669,8 @@ async def ls(
     links: LinkView | None = None,
     deref: bool = False,
     child_mounts: ChildMounts | None = None,
+    mounts: MountView | None = None,
+    stat_path: StatPath | None = None,
 ) -> tuple[bytes, IOResult]:
     results: list[str] = []
     warnings: list[LsWarning] = []
@@ -628,7 +687,9 @@ async def ls(
                                 index=index,
                                 links=links,
                                 deref=deref,
-                                child_mounts=child_mounts)
+                                child_mounts=child_mounts,
+                                mounts=mounts,
+                                stat_path=stat_path)
             rows.extend(result.entries)
             warnings.extend(result.warnings)
         if len(rows) > 1:
@@ -653,7 +714,9 @@ async def ls(
                                             index=index,
                                             links=links,
                                             deref=deref,
-                                            child_mounts=child_mounts)
+                                            child_mounts=child_mounts,
+                                            mounts=mounts,
+                                            stat_path=stat_path)
         warnings.extend(p_ws)
         operands.append(operand)
     if len(operands) > 1:
@@ -722,6 +785,8 @@ async def ls_generic(
         index=opts.index,
         links=opts.ns.links if opts.ns is not None else None,
         child_mounts=opts.ns.child_mounts if opts.ns is not None else None,
+        mounts=opts.ns.mounts if opts.ns is not None else None,
+        stat_path=opts.stat_path,
         **ls_options(opts.flags))
 
 

--- a/python/mirage/workspace/executor/fanout.py
+++ b/python/mirage/workspace/executor/fanout.py
@@ -81,6 +81,37 @@ async def _mount_dirs(descendants: Sequence[MountEntry],
     return out
 
 
+async def _ls_block_mounts(descendants: Sequence[MountEntry],
+                           stat_path: StatPath | None) -> list[MountEntry]:
+    """The descendants `ls -R` should render a block for.
+
+    A mount root is not always a directory (`/.bash_history` is a whole
+    mount serving one file), and GNU lists a file that happens to be a
+    mountpoint as an ordinary row of its parent with no block of its own
+    -- pinned on coreutils 9.7 over a `mount --bind` of one file onto
+    another. The parent's listing already carries that row, because ls
+    stats every child mount through this same dispatcher, so a sub-run
+    would print the name a second time.
+
+    Only a *confirmed* non-directory is dropped: a root the dispatcher
+    cannot stat keeps its block rather than vanishing on a failed probe,
+    and without a dispatcher at all the question cannot be asked and
+    every descendant stands.
+
+    Args:
+        descendants (Sequence[MountEntry]): the mounts under the operand.
+        stat_path (StatPath | None): dispatcher-backed stat.
+    """
+    if stat_path is None:
+        return list(descendants)
+    kept: list[MountEntry] = []
+    for m in descendants:
+        stat = await stat_path(m.prefix.rstrip("/") or "/")
+        if stat is None or stat.type is FileType.DIRECTORY:
+            kept.append(m)
+    return kept
+
+
 def _allowed_descendants(registry: MountRegistry,
                          path: str) -> list[MountEntry]:
     """Descendant mounts the current session may see.
@@ -412,6 +443,8 @@ async def _fan_out_traversal(
     """
     target_path = paths[0].virtual
     descendants = _allowed_descendants(registry, target_path)
+    if cmd_name == "ls":
+        descendants = await _ls_block_mounts(descendants, stat_path)
     # The shadow filter keeps the raw list on purpose: a mount the
     # session cannot see still shadows the primary backend's keys under
     # its prefix, the walk just never descends into it.

--- a/python/tests/commands/builtin/generic/crossmount/relay/test_ls.py
+++ b/python/tests/commands/builtin/generic/crossmount/relay/test_ls.py
@@ -16,7 +16,7 @@ import asyncio
 import errno
 
 from mirage.commands.builtin.generic.crossmount.relay.ls import run_ls
-from mirage.ops.types import NamespaceView
+from mirage.ops.types import MountView, NamespaceView
 from mirage.types import FileStat, FileType, PathSpec
 
 # Two mounts, /a/ and /b/, as a plain virtual-path tree. The relayed
@@ -153,6 +153,26 @@ def test_a_nested_mount_root_keeps_the_name_its_parent_lists_it_by():
     nested = frozenset({"/a/one"})
     assert run(["/a", "/b"], roots=nested)[0] == run(["/a", "/b"])[0]
     out, _, _ = run(["/a", "/b"], flags={"R": True}, roots=nested)
+    assert out == ("/a:\none\nz.txt\n\n/a/one:\nx.txt\n\n"
+                   "/b:\ntwo\n\n/b/two:\ny.txt\n")
+
+
+def test_a_full_namespace_does_not_stop_the_relay_at_a_mount_root():
+    """The mount table names the boundaries a walk's readdir cannot
+    cross, and a relayed one crosses them: readdir and stat route per
+    path. Handed the whole namespace -- which is what the workspace
+    offers -- the relay must still descend `/a/one` and render its
+    group, because nothing runs behind a relay to contribute it the way
+    the fan-out does for a single-mount run.
+    """
+    nested = frozenset({"/a/one"})
+    ns = NamespaceView(mounts=MountView(
+        descendants=lambda p: [],
+        is_root=lambda p: p.rstrip("/") in nested,
+        root_of=lambda p: "/"),
+                       child_mounts=lambda p: ["one"] if p == "/a" else [])
+    out, io, _ = run(["/a", "/b"], flags={"R": True}, ns=ns, roots=nested)
+    assert io.exit_code == 0
     assert out == ("/a:\none\nz.txt\n\n/a/one:\nx.txt\n\n"
                    "/b:\ntwo\n\n/b/two:\ny.txt\n")
 

--- a/python/tests/commands/builtin/generic/test_ls.py
+++ b/python/tests/commands/builtin/generic/test_ls.py
@@ -8,7 +8,7 @@ from mirage.commands.builtin.generic.ls import (LS_FAILURE, LS_MINOR_PROBLEM,
                                                 LS_OK, LsWarning,
                                                 exit_status_for, format_simple,
                                                 ls, walk)
-from mirage.ops.types import LinkView
+from mirage.ops.types import LinkView, MountView
 from mirage.types import (LINK_TARGET_KEY, FileStat, FileType, LsSortBy,
                           PathSpec)
 
@@ -684,6 +684,19 @@ async def test_ls_l_no_filetype_enrichment():
     assert "data.parquet" in decoded
 
 
+def _mount_view(*roots: str) -> MountView:
+    """A mount table holding exactly ``roots``.
+
+    Only ``is_root`` is exercised: it is what tells a nested mount's root
+    (whose listing belongs to another backend) from a directory the
+    namespace merely owes children, which -R must still descend.
+    """
+    return MountView(descendants=lambda p:
+                     [r for r in roots if r.startswith(p.rstrip("/") + "/")],
+                     is_root=lambda p: p.rstrip("/") in roots,
+                     root_of=lambda p: "/")
+
+
 def _link_view(link: FileStat) -> LinkView:
     """A namespace holding exactly one link, named flink."""
 
@@ -753,8 +766,8 @@ async def test_structure_only_directory_lists_its_children():
 @pytest.mark.asyncio
 async def test_structure_only_directory_renders_group_under_recursive():
     """Under -R the group still renders from the namespace fact; only
-    descent into the child-mount root is withheld, because that listing
-    is another backend's and the cross-mount fan-out assembles it."""
+    descent into the mount root is withheld, because that listing is
+    another backend's and the cross-mount fan-out assembles it."""
 
     async def readdir(p, index=None):
         raise FileNotFoundError(p.virtual)
@@ -769,7 +782,8 @@ async def test_structure_only_directory_renders_group_under_recursive():
                        readdir=readdir,
                        stat=stat,
                        recursive=True,
-                       child_mounts=child_mounts)
+                       child_mounts=child_mounts,
+                       mounts=_mount_view("/ghost/deep"))
     assert io.exit_code == 0
     assert out.decode() == "/ghost:\ndeep\n"
 
@@ -777,7 +791,7 @@ async def test_structure_only_directory_renders_group_under_recursive():
 @pytest.mark.asyncio
 async def test_structure_only_chain_descends_under_recursive():
     """A structure chain (a link's ancestors) continues below the first
-    level, so -R descends it: only a child-mount root stops the walk."""
+    level, so -R descends it: only a mount root stops the walk."""
 
     async def readdir(p, index=None):
         raise FileNotFoundError(p.virtual)
@@ -796,9 +810,89 @@ async def test_structure_only_chain_descends_under_recursive():
                        readdir=readdir,
                        stat=stat,
                        recursive=True,
-                       child_mounts=child_mounts)
+                       child_mounts=child_mounts,
+                       mounts=_mount_view("/ghost/deep/lnk"))
     assert io.exit_code == 0
     assert out.decode() == "/ghost:\ndeep\n\n/ghost/deep:\nlnk\n"
+
+
+@pytest.mark.asyncio
+async def test_mount_root_is_listed_but_not_descended_under_recursive():
+    """A mount root is an ordinary entry of a backend-served directory.
+
+    GNU (coreutils 9.7, tmpfs at `base/nested`) prints `nested` in
+    `base`'s own listing and then its group. The merge used to be
+    withheld whenever the walk was recursive, on the theory that the
+    cross-mount fan-out contributed the whole nested mount; it
+    contributes the group, not the parent's row, so the row went missing
+    wherever the backend held no key of that name. Descent is what the
+    fan-out owns, and the mount table is what says where to stop.
+    """
+    tree = {
+        "/base": _dir("base"),
+        "/base/top.txt": _file("top.txt", 2),
+    }
+    readdir, stat = _make_fs_backend(tree)
+    out, io = await ls([PathSpec.from_str_path("/base")],
+                       readdir=readdir,
+                       stat=stat,
+                       recursive=True,
+                       child_mounts=lambda d: ["nested"]
+                       if d == "/base" else [],
+                       mounts=_mount_view("/base/nested"))
+    assert io.exit_code == 0
+    assert out.decode() == "/base:\nnested\ntop.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_a_child_mount_serving_one_file_is_not_a_directory_row():
+    """A mount root is not always a directory.
+
+    Every workspace mounts `/.bash_history` as a whole mount serving one
+    file, and no backend can stat it: the parent's cannot see into the
+    child mount and the child's own calls its root `/`. Synthesizing the
+    row as a directory suffixed it with `/` under -F, rendered it
+    `drwxr-xr-x` under -l, and offered it to -R as something to descend.
+    GNU (coreutils 9.7, `mount --bind` of one file onto another) lists it
+    as an ordinary file row of its parent.
+    """
+    tree = {
+        "/base": _dir("base"),
+        "/base/top.txt": _file("top.txt", 2),
+    }
+    readdir, stat = _make_fs_backend(tree)
+
+    async def stat_path(virtual: str) -> FileStat | None:
+        if virtual != "/base/hist":
+            return None
+        # The child mount answers its own root with its name for it.
+        return _file("/", 7)
+
+    out, io = await ls([PathSpec.from_str_path("/base")],
+                       readdir=readdir,
+                       stat=stat,
+                       recursive=True,
+                       classify=True,
+                       child_mounts=lambda d: ["hist"] if d == "/base" else [],
+                       mounts=_mount_view("/base/hist"),
+                       stat_path=stat_path)
+    assert io.exit_code == 0
+    assert out.decode() == "/base:\nhist\ntop.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_a_child_mount_row_falls_back_to_directory_with_no_dispatcher():
+    """Absence of the door can only mean "nobody can answer", so the row
+    keeps the shape every caller outside a workspace already saw."""
+    tree = {"/base": _dir("base")}
+    readdir, stat = _make_fs_backend(tree)
+    out, io = await ls([PathSpec.from_str_path("/base")],
+                       readdir=readdir,
+                       stat=stat,
+                       classify=True,
+                       child_mounts=lambda d: ["hist"] if d == "/base" else [])
+    assert io.exit_code == 0
+    assert out.decode() == "hist/\n"
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/executor/test_fanout.py
+++ b/python/tests/workspace/executor/test_fanout.py
@@ -482,6 +482,109 @@ def test_ls_r_drops_the_shadowed_group_whole():
                            "/base/inner:\nreal.txt\n")
 
 
+def _unnamed_mountpoint_workspace() -> Workspace:
+    """A nested mount whose name the parent's backend does not hold.
+
+    The mirror image of `_shadowed_workspace`, where the parent owns keys
+    under `inner/` and so names the mountpoint from its own readdir
+    whatever the namespace says.
+    """
+    parent = RAMResource()
+    parent._store.files["/top.txt"] = b"T\n"
+    child = RAMResource()
+    child._store.files["/real.txt"] = b"hit\n"
+    return Workspace(
+        resources={
+            "/base/": (parent, MountMode.EXEC),
+            "/base/nested/": (child, MountMode.EXEC),
+        })
+
+
+def test_ls_r_lists_a_mountpoint_the_parent_backend_cannot_name():
+    """A mount root is an ordinary directory entry of its parent.
+
+    Pinned on coreutils 9.7 over a tmpfs mounted at `base/nested`:
+    `ls -R base` prints `nested` in `base`'s own listing, then its group.
+    `-R` used to withhold the namespace merge and leave the whole nested
+    mount to the fan-out, which contributes the group but not the row, so
+    the row went missing wherever the parent's backend held no key of
+    that name.
+    """
+    ws = _unnamed_mountpoint_workspace()
+    io = asyncio.run(ws.execute("ls -R /base"))
+    assert _stdout(io) == ("/base:\nnested\ntop.txt\n\n"
+                           "/base/nested:\nreal.txt\n")
+
+
+def test_ls_r_lists_a_mountpoint_below_the_operand():
+    """The merge is per directory listed, not per operand.
+
+    Pinned on coreutils 9.7 over a tmpfs mounted at `base/sub/deep`:
+    `deep` is a row of `base/sub`, which is a directory the parent's own
+    backend serves.
+    """
+    parent = RAMResource()
+    parent._store.dirs.add("/sub")
+    parent._store.files["/sub/p.txt"] = b"P\n"
+    child = RAMResource()
+    child._store.files["/real.txt"] = b"hit\n"
+    ws = Workspace(
+        resources={
+            "/base/": (parent, MountMode.EXEC),
+            "/base/sub/deep/": (child, MountMode.EXEC),
+        })
+    io = asyncio.run(ws.execute("ls -R /base"))
+    assert _stdout(io) == ("/base:\nsub\n\n"
+                           "/base/sub:\ndeep\np.txt\n\n"
+                           "/base/sub/deep:\nreal.txt\n")
+
+
+def test_ls_r_lists_a_namespace_only_ancestor_under_a_served_root():
+    """`/ghost` exists only because a mount lives below it, and `/` is
+    served by a backend, so the withheld merge dropped the row and the
+    two groups the walk renders from it. Only a mount root is left to the
+    fan-out; the namespace-only directories above one are this walk's,
+    because no other run renders them."""
+    ws = _nested_ghost_workspace()
+    io = asyncio.run(ws.execute("ls -R /"))
+    assert _stdout(io).startswith("/:\ndev\nghost\ntop.txt\n\n"
+                                  "/ghost:\nvery\n\n"
+                                  "/ghost/very:\ndeep\n")
+
+
+def test_ls_r_relative_operand_never_descends_the_mount_root():
+    """A mount root is listed but not descended, so the shadowed group is
+    never produced rather than produced and filtered.
+
+    `_drop_shadowed_ls_groups` only recognizes an absolute header, so a
+    relative operand printed `base/inner:` twice: once with the parent's
+    shadowed `leftover.txt`, once with the mount's own listing. GNU 9.7
+    prints the mounted directory once.
+    """
+    ws = _shadowed_workspace()
+    io = asyncio.run(ws.execute("ls -R base"))
+    assert _stdout(io) == ("base:\ninner\ntop.txt\n\n"
+                           "base/inner:\nreal.txt\n")
+
+
+def test_ls_r_renders_a_file_mount_as_one_row_and_no_group():
+    """`/.bash_history` is a whole mount serving a single file.
+
+    GNU (coreutils 9.7, `mount --bind` of one file onto another) lists a
+    file that happens to be a mountpoint as an ordinary row of its
+    parent -- no `/` under -F, no block of its own. The row used to be
+    synthesized as a directory, and the fan-out ran a sub-run for the
+    mount on top of it, so the same name arrived twice in two wrong
+    shapes.
+    """
+    root = RAMResource()
+    root._store.files["/top.txt"] = b"T\n"
+    ws = Workspace(resources={"/": (root, MountMode.EXEC)})
+    io = asyncio.run(ws.execute("ls -aRF /"))
+    assert _stdout(io) == ("/:\n.bash_history\ndev/\ntop.txt\n\n"
+                           "/dev:\nnull\nzero\n")
+
+
 def test_tree_renders_one_document_across_a_nested_mount():
     """`tree` is not fanned out at all: one root line, one drawing, one
     summary, with the nested mount crossed inside the generic. Pinned on

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/ls.test.ts
@@ -157,6 +157,27 @@ describe('runLs — cross-mount ls', () => {
     expect(rec.out).toBe('/a:\none\nz.txt\n\n/a/one:\nx.txt\n\n/b:\ntwo\n\n/b/two:\ny.txt\n')
   })
 
+  // The mount table names the boundaries a walk's readdir cannot cross,
+  // and a relayed one crosses them: readdir and stat route per path.
+  // Handed the whole namespace — which is what the workspace offers —
+  // the relay must still descend `/a/one` and render its group, because
+  // nothing runs behind a relay to contribute it the way the fan-out
+  // does for a single-mount run.
+  it('is not stopped at a mount root by a full namespace', async () => {
+    const nested = new Set(['/a/one'])
+    const ns: NamespaceView = {
+      mounts: {
+        descendants: () => [],
+        isRoot: (p) => nested.has(rstripSlash(p)),
+        rootOf: () => '/',
+      },
+      childMounts: (parent) => (parent === '/a' ? ['one'] : []),
+    }
+    const { out, io } = await run(['/a', '/b'], { R: true }, ns, nested)
+    expect(io.exitCode).toBe(0)
+    expect(out).toBe('/a:\none\nz.txt\n\n/a/one:\nx.txt\n\n/b:\ntwo\n\n/b/two:\ny.txt\n')
+  })
+
   it('lists each operand once', async () => {
     // Relaying replaces a native run per operand; it must not turn into a
     // listing per operand per mount.

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/ls.ts
@@ -39,6 +39,15 @@ function namedByPath(stat: (p: PathSpec) => Promise<FileStat>) {
   }
 }
 
+// The name-plane facts minus the mount boundaries; see `runLs`.
+function crossingNs(ns: NamespaceView): NamespaceView {
+  return {
+    ...(ns.links !== undefined ? { links: ns.links } : {}),
+    ...(ns.statOverlay !== undefined ? { statOverlay: ns.statOverlay } : {}),
+    ...(ns.childMounts !== undefined ? { childMounts: ns.childMounts } : {}),
+  }
+}
+
 // List operands spanning mounts through the shared generic ls. ls relays
 // rather than fans out because its layout is decided across all operands at
 // once: GNU prints non-directory operands first as one globally sorted
@@ -50,6 +59,14 @@ function namedByPath(stat: (p: PathSpec) => Promise<FileStat>) {
 // `ns` carries the name-plane facts no backend can see. The attr overlay
 // matters most here: without it a relayed row would report the raw backend
 // mode and silently lose a chmod the namespace holds.
+//
+// Every fact but `mounts`, which names the boundaries a walk's readdir
+// cannot cross. This one's does cross them -- readdir and stat route per
+// path -- so the relay descends a nested mount itself, and it has to:
+// nothing runs behind a relay to contribute that group the way the
+// fan-out does for a single-mount run. Handing it the boundaries would
+// stop the descent and drop the group. Python says the same thing by
+// omission, calling the generic with explicit keywords.
 export async function runLs(
   scopes: PathSpec[],
   flagKwargs: Record<string, FlagValue>,
@@ -58,7 +75,7 @@ export async function runLs(
 ): Promise<CrossResult> {
   const opts: CommandOpts = {
     ...crossOpts(flagKwargs),
-    ...(ns !== undefined ? { ns } : {}),
+    ...(ns !== undefined ? { ns: crossingNs(ns) } : {}),
   }
   const result = await lsGeneric(
     flatten(scopes),

--- a/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
@@ -15,7 +15,7 @@
 import { mountKey } from '../../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
 import { FileStat, FileType, LINK_TARGET_KEY, PathSpec } from '../../../types.ts'
-import type { LinkView } from '../../../ops/types.ts'
+import type { LinkView, MountView } from '../../../ops/types.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 import type { CommandOpts } from '../../config.ts'
 import { LS_FAILURE, LS_MINOR_PROBLEM, LS_OK, exitStatusFor, lsGeneric } from './ls.ts'
@@ -423,6 +423,14 @@ describe('structure-only directories', () => {
     return Promise.reject(err)
   }
   const childMounts = (parent: string): string[] => (parent === '/ghost' ? ['deep'] : [])
+  // Only `isRoot` is exercised: it is what tells a nested mount's root
+  // (whose listing belongs to another backend) from a directory the
+  // namespace merely owes children, which -R must still descend.
+  const mountsAt = (...roots: string[]): MountView => ({
+    descendants: (p) => roots.filter((r) => r.startsWith(`${rstripSlash(p)}/`)),
+    isRoot: (p) => roots.includes(rstripSlash(p)),
+    rootOf: () => '/',
+  })
 
   // A directory no backend serves still lists when the namespace owes it
   // children (a nested mount, a link's ancestors): the door already names
@@ -440,12 +448,16 @@ describe('structure-only directories', () => {
   })
 
   // Under -R the group still renders from the namespace fact; only
-  // descent into the child-mount root is withheld, because that listing
-  // is another backend's and the cross-mount fan-out assembles it.
+  // descent into the mount root is withheld, because that listing is
+  // another backend's and the cross-mount fan-out assembles it.
   it('-R renders the namespace-only group and leaves descent to fan-out', async () => {
     const result = await lsGeneric(
       [PathSpec.fromStrPath('/ghost')],
-      { flags: { R: true }, cwd: '/', ns: { childMounts } } as never,
+      {
+        flags: { R: true },
+        cwd: '/',
+        ns: { childMounts, mounts: mountsAt('/ghost/deep') },
+      } as never,
       missing,
       missing,
     )
@@ -454,18 +466,121 @@ describe('structure-only directories', () => {
   })
 
   // A structure chain (a link's ancestors) continues below the first
-  // level, so -R descends it: only a child-mount root stops the walk.
+  // level, so -R descends it: only a mount root stops the walk.
   it('-R descends structure that continues below', async () => {
     const chain = (parent: string): string[] =>
       parent === '/ghost' ? ['deep'] : parent === '/ghost/deep' ? ['lnk'] : []
     const result = await lsGeneric(
       [PathSpec.fromStrPath('/ghost')],
-      { flags: { R: true }, cwd: '/', ns: { childMounts: chain } } as never,
+      {
+        flags: { R: true },
+        cwd: '/',
+        ns: { childMounts: chain, mounts: mountsAt('/ghost/deep/lnk') },
+      } as never,
       missing,
       missing,
     )
     expect(result?.[1].exitCode).toBe(LS_OK)
     expect(DEC.decode(result?.[0] as Uint8Array)).toBe('/ghost:\ndeep\n\n/ghost/deep:\nlnk\n')
+  })
+
+  // A mount root is an ordinary entry of a backend-served directory. GNU
+  // (coreutils 9.7, tmpfs at `base/nested`) prints `nested` in `base`'s
+  // own listing and then its group. The merge used to be withheld
+  // whenever the walk was recursive, on the theory that the cross-mount
+  // fan-out contributed the whole nested mount; it contributes the group,
+  // not the parent's row, so the row went missing wherever the backend
+  // held no key of that name. Descent is what the fan-out owns, and the
+  // mount table is what says where to stop.
+  it('-R lists a mount root without descending it', async () => {
+    const served: Record<string, FileType> = {
+      '/base': FileType.DIRECTORY,
+      '/base/top.txt': FileType.TEXT,
+    }
+    const servedStat = (p: PathSpec): Promise<FileStat> => {
+      const type = served[rstripSlash(p.virtual)]
+      if (type === undefined) return missing(p)
+      return Promise.resolve(
+        new FileStat({ name: rstripSlash(p.virtual).split('/').pop() ?? '', type }),
+      )
+    }
+    const servedReaddir = (p: PathSpec): Promise<string[]> =>
+      rstripSlash(p.virtual) === '/base' ? Promise.resolve(['/base/top.txt']) : missing(p)
+    const result = await lsGeneric(
+      [PathSpec.fromStrPath('/base')],
+      {
+        flags: { R: true },
+        cwd: '/',
+        ns: {
+          childMounts: (parent: string) => (parent === '/base' ? ['nested'] : []),
+          mounts: mountsAt('/base/nested'),
+        },
+      } as never,
+      servedReaddir,
+      servedStat,
+    )
+    expect(result?.[1].exitCode).toBe(LS_OK)
+    expect(DEC.decode(result?.[0] as Uint8Array)).toBe('/base:\nnested\ntop.txt\n')
+  })
+
+  // A mount root is not always a directory. Every workspace mounts
+  // `/.bash_history` as a whole mount serving one file, and no backend can
+  // stat it: the parent's cannot see into the child mount and the child's
+  // own calls its root '/'. Synthesizing the row as a directory suffixed it
+  // with '/' under -F, rendered it `drwxr-xr-x` under -l, and offered it to
+  // -R as something to descend. GNU (coreutils 9.7, `mount --bind` of one
+  // file onto another) lists it as an ordinary file row of its parent.
+  it('does not render a child mount serving one file as a directory', async () => {
+    const served: Record<string, FileType> = {
+      '/base': FileType.DIRECTORY,
+      '/base/top.txt': FileType.TEXT,
+    }
+    const servedStat = (p: PathSpec): Promise<FileStat> => {
+      const type = served[rstripSlash(p.virtual)]
+      if (type === undefined) return missing(p)
+      return Promise.resolve(
+        new FileStat({ name: rstripSlash(p.virtual).split('/').pop() ?? '', type }),
+      )
+    }
+    const servedReaddir = (p: PathSpec): Promise<string[]> =>
+      rstripSlash(p.virtual) === '/base' ? Promise.resolve(['/base/top.txt']) : missing(p)
+    const result = await lsGeneric(
+      [PathSpec.fromStrPath('/base')],
+      {
+        flags: { R: true, F: true },
+        cwd: '/',
+        // The child mount answers its own root with its name for it.
+        statPath: (virtual: string) =>
+          Promise.resolve(
+            virtual === '/base/hist' ? new FileStat({ name: '/', type: FileType.TEXT }) : null,
+          ),
+        ns: {
+          childMounts: (parent: string) => (parent === '/base' ? ['hist'] : []),
+          mounts: mountsAt('/base/hist'),
+        },
+      } as never,
+      servedReaddir,
+      servedStat,
+    )
+    expect(result?.[1].exitCode).toBe(LS_OK)
+    expect(DEC.decode(result?.[0] as Uint8Array)).toBe('/base:\nhist\ntop.txt\n')
+  })
+
+  // Absence of the door can only mean "nobody can answer", so the row keeps
+  // the shape every caller outside a workspace already saw.
+  it('falls back to a directory row with no dispatcher', async () => {
+    const result = await lsGeneric(
+      [PathSpec.fromStrPath('/ghost')],
+      {
+        flags: { F: true },
+        cwd: '/',
+        ns: { childMounts: (parent: string) => (parent === '/ghost' ? ['deep'] : []) },
+      } as never,
+      missing,
+      missing,
+    )
+    expect(result?.[1].exitCode).toBe(LS_OK)
+    expect(DEC.decode(result?.[0] as Uint8Array)).toBe('deep/\n')
   })
 
   // -d stats the operand itself; the namespace fact is what says the

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -18,7 +18,7 @@ import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { FileStat, FileType, PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
-import type { ChildMounts, LinkView } from '../../../ops/types.ts'
+import type { ChildMounts, LinkView, MountView, StatPath } from '../../../ops/types.ts'
 import { formatLsLong } from '../utils/formatting.ts'
 import { gnuStrerror, isWalkError } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
@@ -56,12 +56,21 @@ interface WalkOpts {
   // is what makes -R descend it.
   deref: boolean
   // Session-filtered child-mount names: the other half of namespace
-  // structure beside links, merged as directory rows. Under -R a
-  // backend-served listing withholds the merge and a child-mount root
-  // is never descended (the cross-mount fan-out assembles those
-  // groups); a directory only the namespace serves still renders its
-  // own group from it.
+  // structure beside links, merged as directory rows in every listing.
+  // GNU lists a mountpoint as an ordinary entry of its parent, -R or
+  // not, so the merge is unconditional: withholding it under -R dropped
+  // the row whenever the parent's backend held no key of that name.
   childMounts: ChildMounts | null
+  // The mount boundaries this walk's readdir cannot cross. Under -R such
+  // a root is listed but never descended, because that listing is another
+  // backend's and the cross-mount fan-out assembles the group; a
+  // namespace-only directory above one is descended, since no other run
+  // renders it. Null for a walk that can cross -- the relay's readdir
+  // routes per path, so it descends a nested mount itself.
+  mounts: MountView | null
+  // Dispatcher-backed stat, the only way to learn a child mount's real
+  // type. See `mountRow`.
+  statPath: StatPath | null
 }
 
 // One ls operand once its kind is known. `row` is set when the operand is not
@@ -170,6 +179,34 @@ function asOperand(s: FileStat, path: PathSpec): FileStat {
   return s.with({ name: path.rawPath })
 }
 
+// The row for a child mount, carrying its real type.
+//
+// No backend can supply it: the parent's cannot see into the child mount,
+// and the child's own answers its root with that mount's name for itself
+// ('/'), which is why the row is renamed here the way the relay renames
+// one. So the fact comes through the dispatcher, which routes to whichever
+// mount owns the path.
+//
+// A mount root is not always a directory — every workspace mounts
+// `/.bash_history` as a whole mount serving one file — and calling one a
+// directory suffixes it with '/' under -F, renders it `drwxr-xr-x` under
+// -l, and offers it to -R as something to descend. GNU lists a file that
+// happens to be a mountpoint as an ordinary file row (pinned on coreutils
+// 9.7 over a `mount --bind` of one file onto another). Directory is the
+// fallback for a caller with no dispatcher, which is the only thing that
+// absence can mean.
+async function mountRow(
+  directory: PathSpec,
+  name: string,
+  statPath: StatPath | null,
+): Promise<FileStat> {
+  if (statPath !== null) {
+    const row = await statPath(`${rstripSlash(directory.virtual)}/${name}`)
+    if (row !== null) return row.with({ name })
+  }
+  return new FileStat({ name, type: FileType.DIRECTORY })
+}
+
 // An entry that cannot be stat'd is skipped with its own diagnostic rather
 // than failing the whole directory: GNU keeps listing the siblings and exits
 // 1. Mirrors the per-entry tolerance of Python ls `_stat_entries`.
@@ -183,7 +220,7 @@ async function listDir(
   deref: boolean,
   stat2: Stat,
   childMounts: ChildMounts | null,
-  recursive: boolean,
+  statPath: StatPath | null,
 ): Promise<{ stats: FileStat[]; structureOnly: boolean }> {
   let entries: string[]
   let structureOnly = false
@@ -194,10 +231,7 @@ async function listDir(
     // No backend serves it, but the namespace owes it children (a
     // nested mount, a link's ancestors), so the door lists it as a
     // directory and ls must agree: the merge below renders those rows
-    // from an empty backend listing. Under -R this group still renders;
-    // only descent into a child-mount root is withheld, because that
-    // listing is another backend's and the cross-mount fan-out
-    // assembles it.
+    // from an empty backend listing.
     entries = []
     structureOnly = true
   }
@@ -226,12 +260,10 @@ async function listDir(
     const resolved = deref && links !== null ? await derefEntry(dir, link, links, stat2) : null
     stats.push(resolved ?? link)
   }
-  if (!recursive || structureOnly) {
-    for (const name of childMounts?.(dir.virtual) ?? []) {
-      if (seen.has(name)) continue
-      seen.add(name)
-      stats.push(new FileStat({ name, type: FileType.DIRECTORY }))
-    }
+  for (const name of childMounts?.(dir.virtual) ?? []) {
+    if (seen.has(name)) continue
+    seen.add(name)
+    stats.push(await mountRow(dir, name, statPath))
   }
   return {
     stats: all ? stats : stats.filter((s) => !s.name.startsWith('.')),
@@ -303,7 +335,7 @@ async function probeOperand(
       opts.deref,
       stat,
       opts.childMounts,
-      opts.recursive,
+      opts.statPath,
     )
     stats = listed.stats
     structureOnly = listed.structureOnly
@@ -319,7 +351,7 @@ async function probeOperand(
     })
     return { path, row: null, groups: [] }
   }
-  if (stats.length === 0) {
+  if (stats.length === 0 && !structureOnly) {
     const row = await fileEntry(stat, path)
     if (row !== null) return { path, row, groups: [] }
     // Backends without real directories answer readdir on a link with
@@ -334,8 +366,9 @@ async function probeOperand(
     for (const s of entries) {
       if (s.type !== FileType.DIRECTORY) continue
       const childPath = `${rstripSlash(path.virtual)}/${s.name}`
-      if (structureOnly && (opts.childMounts?.(childPath) ?? []).length === 0) {
-        // A child-mount root: its listing is another backend's, so the
+      if (opts.mounts?.isRoot(childPath) ?? false) {
+        // A nested mount's root. Its row belongs here, but its listing
+        // is another backend's, which this walk cannot read: the
         // cross-mount fan-out renders that group.
         continue
       }
@@ -470,6 +503,8 @@ export async function lsGeneric(
     links,
     deref,
     childMounts: opts.ns?.childMounts ?? null,
+    mounts: opts.ns?.mounts ?? null,
+    statPath: opts.statPath ?? null,
   }
   const probed: Operand[] = []
   for (const p of targets) {

--- a/typescript/packages/core/src/workspace/executor/fanout.test.ts
+++ b/typescript/packages/core/src/workspace/executor/fanout.test.ts
@@ -447,3 +447,106 @@ describe('fanOutTraversal operands spanning mounts', () => {
     )
   })
 })
+
+// Direct port of the ls cases in tests/workspace/executor/test_fanout.py:
+// a mount root is an ordinary directory entry of its parent, listed by
+// the walk but never descended by it.
+describe('ls -R across a mount boundary', () => {
+  async function runLine(mounts: Record<string, RAMResource>, cmd: string): Promise<string> {
+    const parser = await getTestParser()
+    const registry = new OpsRegistry()
+    for (const resource of Object.values(mounts)) registry.registerResource(resource)
+    const ws = new Workspace(mounts, { mode: MountMode.WRITE, ops: registry, shellParser: parser })
+    try {
+      return stdoutStr(await ws.execute(cmd))
+    } finally {
+      await ws.close()
+    }
+  }
+
+  function ram(files: Record<string, string>, dirs: string[] = []): RAMResource {
+    const resource = new RAMResource()
+    for (const dir of dirs) resource.store.dirs.add(dir)
+    for (const [key, text] of Object.entries(files)) {
+      resource.store.files.set(key, new TextEncoder().encode(text))
+    }
+    return resource
+  }
+
+  // Pinned on coreutils 9.7 over a tmpfs mounted at `base/nested`:
+  // `ls -R base` prints `nested` in `base`'s own listing, then its group.
+  // `-R` used to withhold the namespace merge and leave the whole nested
+  // mount to the fan-out, which contributes the group but not the row, so
+  // the row went missing wherever the parent's backend held no key of that
+  // name. The mirror image of the shadowed fixture above, where the parent
+  // owns keys under `inner/` and so names the mountpoint from its own
+  // readdir whatever the namespace says.
+  it('lists a mountpoint the parent backend cannot name', async () => {
+    const mounts = {
+      '/base': ram({ '/top.txt': 'T\n' }),
+      '/base/nested': ram({ '/real.txt': 'hit\n' }),
+    }
+    expect(await runLine(mounts, 'ls -R /base')).toBe(
+      '/base:\nnested\ntop.txt\n\n/base/nested:\nreal.txt\n',
+    )
+  })
+
+  // The merge is per directory listed, not per operand. Pinned on
+  // coreutils 9.7 over a tmpfs mounted at `base/sub/deep`: `deep` is a row
+  // of `base/sub`, which is a directory the parent's own backend serves.
+  it('lists a mountpoint below the operand', async () => {
+    const mounts = {
+      '/base': ram({ '/sub/p.txt': 'P\n' }, ['/sub']),
+      '/base/sub/deep': ram({ '/real.txt': 'hit\n' }),
+    }
+    expect(await runLine(mounts, 'ls -R /base')).toBe(
+      '/base:\nsub\n\n/base/sub:\ndeep\np.txt\n\n/base/sub/deep:\nreal.txt\n',
+    )
+  })
+
+  // `/ghost` exists only because a mount lives below it, and `/` is served
+  // by a backend, so the withheld merge dropped the row and the two groups
+  // the walk renders from it. Only a mount root is left to the fan-out;
+  // the namespace-only directories above one are this walk's, because no
+  // other run renders them.
+  it('lists a namespace-only ancestor under a served root', async () => {
+    const mounts = {
+      '/': ram({ '/top.txt': 'hello\n' }),
+      '/ghost/very/deep': ram({ '/leaf.txt': 'deep\n' }),
+    }
+    expect(await runLine(mounts, 'ls -R /')).toMatch(
+      /^\/:\ndev\nghost\ntop\.txt\n\n\/ghost:\nvery\n\n\/ghost\/very:\ndeep\n/,
+    )
+  })
+
+  // `/.bash_history` is a whole mount serving a single file. GNU
+  // (coreutils 9.7, `mount --bind` of one file onto another) lists a file
+  // that happens to be a mountpoint as an ordinary row of its parent — no
+  // '/' under -F, no block of its own. The row used to be synthesized as a
+  // directory, and the fan-out ran a sub-run for the mount on top of it,
+  // so the same name arrived twice in two wrong shapes.
+  it('renders a file mount as one row and no group', async () => {
+    const mounts = { '/': ram({ '/top.txt': 'T\n' }) }
+    expect(await runLine(mounts, 'ls -aRF /')).toBe(
+      '/:\n.bash_history\ndev/\ntop.txt\n\n/dev:\nnull\nzero\n',
+    )
+  })
+
+  // A mount root is listed but not descended, so the shadowed group is
+  // never produced rather than produced and filtered. `dropShadowedLsGroups`
+  // only recognizes an absolute header, so a relative operand printed
+  // `base/inner:` twice: once with the parent's shadowed `leftover.txt`,
+  // once with the mount's own listing. GNU 9.7 prints the mounted
+  // directory once.
+  it('never descends the mount root under a relative operand', async () => {
+    const mounts = {
+      '/base': ram({ '/top.txt': 'TTTTTTTTTT', '/inner/leftover.txt': 'S'.repeat(1000) }, [
+        '/inner',
+      ]),
+      '/base/inner': ram({ '/real.txt': 'RRRRRRR' }),
+    }
+    expect(await runLine(mounts, 'ls -R base')).toBe(
+      'base:\ninner\ntop.txt\n\nbase/inner:\nreal.txt\n',
+    )
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/fanout.ts
+++ b/typescript/packages/core/src/workspace/executor/fanout.ts
@@ -90,6 +90,33 @@ function allowedDescendants(registry: MountRegistry, path: string): MountEntry[]
     .filter((m) => mountAllowed(m.prefix) && pathAllowed('/' + stripSlash(m.prefix)))
 }
 
+// The descendants `ls -R` should render a block for.
+//
+// A mount root is not always a directory (`/.bash_history` is a whole
+// mount serving one file), and GNU lists a file that happens to be a
+// mountpoint as an ordinary row of its parent with no block of its own —
+// pinned on coreutils 9.7 over a `mount --bind` of one file onto another.
+// The parent's listing already carries that row, because ls stats every
+// child mount through this same dispatcher, so a sub-run would print the
+// name a second time.
+//
+// Only a *confirmed* non-directory is dropped: a root the dispatcher
+// cannot stat keeps its block rather than vanishing on a failed probe, and
+// without a dispatcher at all the question cannot be asked and every
+// descendant stands.
+async function lsBlockMounts(
+  descendants: readonly MountEntry[],
+  statPath: StatPath | null,
+): Promise<MountEntry[]> {
+  if (statPath === null) return [...descendants]
+  const kept: MountEntry[] = []
+  for (const m of descendants) {
+    const stat = await statPath(rstripSlash(m.prefix) || '/')
+    if (stat === null || stat.type === FileType.DIRECTORY) kept.push(m)
+  }
+  return kept
+}
+
 export function shouldFanOut(
   cmdName: string,
   paths: readonly PathSpec[],
@@ -324,7 +351,8 @@ export async function fanOutTraversal(
   statPath: StatPath | null = null,
 ): Promise<Result> {
   const targetPath = paths[0]?.virtual ?? cwd
-  const descendants = allowedDescendants(registry, targetPath)
+  let descendants = allowedDescendants(registry, targetPath)
+  if (cmdName === 'ls') descendants = await lsBlockMounts(descendants, statPath)
   // The shadow filter keeps the raw list on purpose: a mount the
   // session cannot see still shadows the primary backend's keys under
   // its prefix, the walk just never descends into it.


### PR DESCRIPTION
`ls -R` on a directory holding a nested mount omitted the mount's own row while still printing its group:

```
$ ls -R /base          # mounts: /base/, /base/nested/
/base:
top.txt                # <- `nested` missing

/base/nested:
real.txt
```

GNU lists a mountpoint as an ordinary directory entry of its parent, `-R` or not. Pinned on coreutils 9.7 over a real tmpfs in `debian:stable-slim`:

```
base:
nested
top.txt

base/nested:
real.txt
```

Non-recursive `ls /base` was always right, which is what makes this specifically the recursive case.

## Root cause

The generic conflated two different things: **listing** a mount root as a row, and **descending** into it. `-R` withheld the whole `child_mounts` merge on a backend-served listing, on the theory that the cross-mount fan-out contributed the nested mount whole. It contributes the *group*, not the parent's *row*, so the row survived only by accident — whenever the parent's own backend happened to hold a key of that name (which is why the existing shadowed-mount fixture never caught it).

Splitting the two:

- **The merge is unconditional.** A mountpoint is an ordinary entry of its parent.
- **Descent stops at a mount root**, read from the mount table (`MountView.is_root`) instead of inferred from `child_mounts` being empty. A namespace-only directory *above* a mount root is still descended, because nothing else renders it.

## Three more shapes, same cause

- `ls -R /` dropped `ghost` **and** both the `/ghost:` and `/ghost/very:` groups whenever a backend served `/` (mount at `/ghost/very/deep`).
- `/base/sub`'s group dropped a mount at `/base/sub/deep` — the merge is per directory listed, not per operand.
- A relative operand **leaked shadowed content**: `ls -R base` printed `base/inner:` twice, once with the parent's hidden `leftover.txt` and once with the mount's own listing, because `_drop_shadowed_ls_groups` only recognizes an absolute header. That group is now never produced rather than produced and filtered.

## A mountpoint is not always a directory

Follow-up from review. The merged row was synthesized as `FileType.DIRECTORY`, but a mount root can serve a single file — every workspace mounts `/.bash_history` that way — so `ls -aF /` printed `.bash_history/` and `ls -l` rendered it `drwxr-xr-x`.

No backend can answer that question: the parent's cannot see into the child mount, and the child's own names its root `/`. So the row is stat'd through the dispatcher (`opts.stat_path` / `opts.statPath`), which routes to whichever mount owns the path, and is renamed the way the relay renames one. Directory stays the fallback for a caller with no dispatcher — the only thing that absence can mean.

The same fact settles what `-R` descends: the `ls` fan-out no longer emits a block for a mount that is not a directory, which otherwise printed the name a second time as its own group. Only a **confirmed** non-directory is dropped, so a root the dispatcher cannot stat keeps its block rather than vanishing on a failed probe.

GNU is pinned the same way, over a `mount --bind` of one file onto another: one ordinary row in the parent, no group of its own.

```
$ ls -aRF /
/:
.bash_history          # <- no '/', and no `/.bash_history:` group below
dev/
top.txt

/dev:
null
zero
```

## The contract, and why the relay differs

`ls` takes `mounts` beside `links` and `child_mounts`, and it names the boundaries **this walk's readdir cannot cross**, not the boundaries that exist. That distinction is the whole contract, because the two entry points differ:

| entry point | readdir | mount root under `-R` |
| --- | --- | --- |
| `ls_generic` | bound to one backend | stop — the fan-out renders the group |
| cross-mount relay (#844) | routes per path | descend — nothing else will |

Python already said this by omission, calling the generic with explicit keywords. The TypeScript relay hands the generic a whole `CommandOpts`, so it now builds one carrying every name-plane fact **except** the boundaries. Without that, `ls -R /base /other` dropped `/base/inner:` entirely — caught by the existing `fanout.test.ts` spanning-mounts case, and now pinned directly in both relay suites too.

## Tests

- 4 end-to-end cases in `test_fanout.py` and its TS twin, one per shape above. All four fail on the pre-fix source (verified by reverting).
- 1 generic-level unit test per side: a mount root is listed but not descended out of a backend-served directory.
- 1 relay case per side: handed a **full** namespace, the relay still descends the mount root. Both existing relay suites passed while broken because they defaulted `ns` to none.
- 3 more per side for the row's type: a mount root is listed but not descended; a mount serving one file is not a directory row; the row falls back to directory with no dispatcher wired. Plus one end-to-end case pinning `ls -aRF /` byte-for-byte, which is the one that fails on both counts before the fix (`.bash_history/` in the parent, then a `/.bash_history:` group).
- Two unit tests that passed a bare `child_mounts` now supply a mount table, since the fact moved to its real source.
- `integ/crossmount/nested/basic.json` seq 950006 **pinned the bug**; it now pins GNU's answer, with a `note` recording the tmpfs pin.

## Verification

Both hosts, both languages, byte-identical output on every probe.

- Full Python suite green (`--ignore=tests/fuse`; `test_darwin.py` needs mfusepy, absent on this machine).
- Full TS suite green: core 674 files / 8990 tests, plus browser, node, server, dsh, agents, cli, opencode.
- `pnpm -r typecheck`, eslint, prettier, `pre-commit --all-files`.
- Integ battery on `ram`, `ram-root`, `ram-alias`, `ram-nested`, `ram-history`, `disk`, `statvfs`, `git-disk`, `git-ram` — **5871 passed, 0 failed on each host**.

## Out of scope

Group *ordering* across mounts is still the fan-out's concatenation rather than GNU's pre-order DFS: `ls -R /` emits `/`, `/ghost`, `/ghost/very`, then `/dev`, `/ghost/very/deep`. That is the fan-out's shape, not this row's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

