### PR TITLE
fix(search): gate the grep/rg push-down on operand count

### DIFF
--- a/integ/resources/mongodb/grep.json
+++ b/integ/resources/mongodb/grep.json
@@ -103,6 +103,32 @@
         "stdout": "2\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "mdb_grep_two_collections_cover_both",
+      "seq": 620058,
+      "targets": [
+        "mongodb"
+      ],
+      "command": "grep ada /mongodb/mirage_integ/collections/books /mongodb/mirage_integ/collections/authors",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "grep: /mongodb/mirage_integ/collections/books: Is a directory\ngrep: /mongodb/mirage_integ/collections/authors: Is a directory\n"
+      }
+    },
+    {
+      "id": "mdb_grep_r_two_collections_cover_both",
+      "seq": 620059,
+      "targets": [
+        "mongodb"
+      ],
+      "command": "grep -r ada /mongodb/mirage_integ/collections/books /mongodb/mirage_integ/collections/authors | cut -d: -f1 | sort -u",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mongodb/mirage_integ/collections/authors/documents.jsonl\n/mongodb/mirage_integ/collections/books/documents.jsonl\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/resources/mongodb/rg.json
+++ b/integ/resources/mongodb/rg.json
@@ -64,6 +64,32 @@
         "stdout": "mirage_integ/collections/authors/documents.jsonl:{\"_id\": 1, \"name\": \"ada\", \"books\": 2}\nmirage_integ/collections/books/documents.jsonl:{\"_id\": 1, \"title\": \"alpha\", \"author\": \"ada\", \"year\": 2020, \"tags\": [\"fiction\", \"classic\"], \"rating\": 4.5}\nmirage_integ/collections/books/documents.jsonl:{\"_id\": 4, \"title\": \"delta\", \"author\": \"ada\", \"year\": 2023, \"tags\": [\"history\"], \"rating\": 4}\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "mdb_rg_two_collections_cover_both",
+      "seq": 620065,
+      "targets": [
+        "mongodb"
+      ],
+      "command": "rg ada /mongodb/mirage_integ/collections/books /mongodb/mirage_integ/collections/authors | cut -d: -f1 | sort -u",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mongodb/mirage_integ/collections/authors/documents.jsonl\n/mongodb/mirage_integ/collections/books/documents.jsonl\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "mdb_rg_lone_collection_uses_pushdown",
+      "seq": 620066,
+      "targets": [
+        "mongodb"
+      ],
+      "command": "rg ada /mongodb/mirage_integ/collections/authors",
+      "expect": {
+        "exit": 0,
+        "stdout": "mirage_integ/collections/authors/documents.jsonl:{\"_id\": 1, \"name\": \"ada\", \"books\": 2}\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/resources/observability/langfuse/search.json
+++ b/integ/resources/observability/langfuse/search.json
@@ -90,6 +90,71 @@
         "stdout": "sessions/session-one\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "lf_search_two_operands_cover_both",
+      "seq": 602107,
+      "targets": [
+        "langfuse"
+      ],
+      "command": "rg checkout-flow /lf/traces /lf/sessions | cut -d: -f1 | sort -u",
+      "expect": {
+        "exit": 0,
+        "stdout": "/lf/sessions/session-one/trace-alpha.json\n/lf/traces/trace-alpha.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "lf_search_two_operands_grep_names_dirs",
+      "seq": 602108,
+      "targets": [
+        "langfuse"
+      ],
+      "command": "grep checkout-flow /lf/traces /lf/sessions",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "grep: /lf/traces: Is a directory\ngrep: /lf/sessions: Is a directory\n"
+      }
+    },
+    {
+      "id": "lf_search_two_operands_grep_r_covers_both",
+      "seq": 602109,
+      "targets": [
+        "langfuse"
+      ],
+      "command": "grep -r checkout-flow /lf/traces /lf/sessions | cut -d: -f1 | sort -u",
+      "expect": {
+        "exit": 0,
+        "stdout": "/lf/sessions/session-one/trace-alpha.json\n/lf/traces/trace-alpha.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "lf_search_repeated_operand_searched_twice",
+      "seq": 602110,
+      "targets": [
+        "langfuse"
+      ],
+      "command": "rg checkout-flow /lf/traces /lf/traces | cut -d: -f1",
+      "expect": {
+        "exit": 0,
+        "stdout": "/lf/traces/trace-alpha.json\n/lf/traces/trace-alpha.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "lf_search_two_operands_across_families",
+      "seq": 602111,
+      "targets": [
+        "langfuse"
+      ],
+      "command": "rg greeting /lf/prompts /lf/datasets | cut -d: -f1 | sort -u",
+      "expect": {
+        "exit": 0,
+        "stdout": "/lf/prompts/greeting/1.json\n/lf/prompts/greeting/2.json\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/resources/postgres/grep.json
+++ b/integ/resources/postgres/grep.json
@@ -90,6 +90,32 @@
         "stdout": "2\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "pg_grep_two_tables_cover_both",
+      "seq": 610057,
+      "targets": [
+        "postgres"
+      ],
+      "command": "grep ada /pg/public/tables/books /pg/public/tables/authors",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "grep: /pg/public/tables/books: Is a directory\ngrep: /pg/public/tables/authors: Is a directory\n"
+      }
+    },
+    {
+      "id": "pg_grep_r_two_tables_cover_both",
+      "seq": 610058,
+      "targets": [
+        "postgres"
+      ],
+      "command": "grep -r ada /pg/public/tables/books /pg/public/tables/authors | cut -d: -f1 | sort -u",
+      "expect": {
+        "exit": 0,
+        "stdout": "/pg/public/tables/authors/rows.jsonl\n/pg/public/tables/books/rows.jsonl\n/pg/public/tables/books/semantic.json\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/resources/postgres/rg.json
+++ b/integ/resources/postgres/rg.json
@@ -77,6 +77,32 @@
         "stdout": "public/tables/books/semantic.json:  \"dimensions\": [\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "pg_rg_two_tables_cover_both",
+      "seq": 610066,
+      "targets": [
+        "postgres"
+      ],
+      "command": "rg ada /pg/public/tables/books /pg/public/tables/authors | cut -d: -f1 | sort -u",
+      "expect": {
+        "exit": 0,
+        "stdout": "/pg/public/tables/authors/rows.jsonl\n/pg/public/tables/books/rows.jsonl\n/pg/public/tables/books/semantic.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "pg_rg_lone_table_uses_pushdown",
+      "seq": 610067,
+      "targets": [
+        "postgres"
+      ],
+      "command": "rg ada /pg/public/tables/authors",
+      "expect": {
+        "exit": 0,
+        "stdout": "public/tables/authors/rows.jsonl:{\"id\":1,\"name\":\"ada\",\"books\":2}\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/python/mirage/commands/builtin/grep_helper.py
+++ b/python/mirage/commands/builtin/grep_helper.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 
 from mirage.commands.builtin.constants import PatternType
 from mirage.commands.builtin.grep_context import grep_context_lines
+from mirage.commands.builtin.utils.paths import has_unresolved_glob
 from mirage.commands.builtin.utils.types import (_AsyncReadBytes,
                                                  _AsyncReaddir, _AsyncStat)
 from mirage.commands.builtin.utils.wrap import call_read_bytes
@@ -309,6 +310,86 @@ def search_pushdown_ok(flags: Mapping[str, FlagValue] | None,
     fl = FlagView(flags)
     return (is_literal_pattern(pattern, fl.as_bool("F"))
             and not has_search_shaping_flags(flags))
+
+
+def _lone_operand(paths: list[PathSpec]) -> PathSpec | None:
+    """The one operand a search push-down may answer for, or None.
+
+    A push-down asks the backend a single whole-container question and
+    prints its entire answer, so it can only stand in for a line naming
+    exactly one operand. Given two it answered for the first and dropped
+    the rest in silence (``rg pat /lf/traces /lf/sessions`` reported only
+    traces). Running it once per operand is not the fix: several scopes
+    map to the same container search (langfuse routes both ``sessions``
+    and one ``session`` to "search every session"), so two operands in
+    one family would print that container twice. A multi-operand line
+    therefore takes the generic scan, which searches each operand in turn
+    the way GNU does. A glob operand defers for the older reason: an
+    unexpanded pattern segment would be read as a literal entity name.
+
+    Args:
+        paths (list[PathSpec]): operands as parsed.
+
+    Returns:
+        PathSpec | None: the sole concrete operand, or None when the line
+            named none, named several, or still carries a glob.
+    """
+    if len(paths) != 1 or has_unresolved_glob(paths):
+        return None
+    return paths[0]
+
+
+def pushdown_operand(
+    paths: list[PathSpec],
+    flags: Mapping[str, FlagValue] | None,
+    pattern: str | None,
+) -> PathSpec | None:
+    """The operand a regex push-down may answer for, or None.
+
+    For a backend that pushes the real regex down (mongodb, langfuse),
+    which is faithful for any single pattern with no shaping flags. A
+    newline-joined pattern list (-F with several -e) is a set of
+    independent alternatives the push-down cannot express.
+
+    Args:
+        paths (list[PathSpec]): operands as parsed.
+        flags (Mapping[str, FlagValue] | None): raw flag kwargs.
+        pattern (str | None): the resolved pattern, None when the line
+            supplied none.
+
+    Returns:
+        PathSpec | None: the operand to push down for, or None to defer.
+    """
+    if pattern is None or "\n" in pattern:
+        return None
+    if has_search_shaping_flags(flags):
+        return None
+    return _lone_operand(paths)
+
+
+def literal_pushdown_operand(
+    paths: list[PathSpec],
+    flags: Mapping[str, FlagValue] | None,
+    pattern: str | None,
+) -> PathSpec | None:
+    """The operand a literal-substring push-down may answer for, or None.
+
+    ``_lone_operand``'s rule plus ``search_pushdown_ok``'s, which is the
+    stricter flag gate LIKE/ILIKE needs (postgres): a real regex is
+    treated literally by LIKE, so only a verbatim pattern may push down.
+
+    Args:
+        paths (list[PathSpec]): operands as parsed.
+        flags (Mapping[str, FlagValue] | None): raw flag kwargs.
+        pattern (str | None): the resolved pattern, None when the line
+            supplied none.
+
+    Returns:
+        PathSpec | None: the operand to push down for, or None to defer.
+    """
+    if pattern is None or not search_pushdown_ok(flags, pattern):
+        return None
+    return _lone_operand(paths)
 
 
 def pattern_arg(texts: Sequence[str], flags: FlagView) -> str | None:

--- a/python/mirage/commands/builtin/langfuse/grep.py
+++ b/python/mirage/commands/builtin/langfuse/grep.py
@@ -20,13 +20,11 @@ from typing import Any
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 has_search_shaping_flags,
-                                                 pattern_arg)
+from mirage.commands.builtin.grep_helper import (compile_pattern, pattern_arg,
+                                                 pushdown_operand)
 from mirage.commands.builtin.langfuse._provision import file_read_provision
 from mirage.commands.builtin.langfuse.io import resolve_glob
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.paths import has_unresolved_glob
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -137,11 +135,11 @@ async def grep(accessor: LangfuseAccessor, paths: list[PathSpec],
     # The search push-down answers from the list endpoints (one call instead
     # of one read per entry), so it greps listing summaries: a pattern that
     # only occurs in a trace's observation bodies needs a file read to match.
-    # Output/match-shaping flags defer to the generic scan below.
-    if (paths and not has_unresolved_glob(paths) and pattern is not None
-            and "\n" not in pattern
-            and not has_search_shaping_flags(opts.flags)):
-        search = SEARCH_KINDS.get(detect_scope(paths[0]).kind)
+    # Output/match-shaping flags and a multi-operand line defer to the
+    # generic scan below.
+    operand = pushdown_operand(paths, opts.flags, pattern)
+    if pattern is not None and operand is not None:
+        search = SEARCH_KINDS.get(detect_scope(operand).kind)
         ignore_case = fl.as_bool("i")
         fixed_string = fl.as_bool("F")
         whole_word = fl.as_bool("w")

--- a/python/mirage/commands/builtin/langfuse/rg.py
+++ b/python/mirage/commands/builtin/langfuse/rg.py
@@ -15,15 +15,13 @@
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 has_search_shaping_flags,
-                                                 pattern_arg)
+from mirage.commands.builtin.grep_helper import (compile_pattern, pattern_arg,
+                                                 pushdown_operand)
 from mirage.commands.builtin.langfuse.grep import (_filter_traces,
                                                    _format_dataset_results,
                                                    _format_prompt_results,
                                                    _format_session_results)
 from mirage.commands.builtin.langfuse.io import resolve_glob
-from mirage.commands.builtin.utils.paths import has_unresolved_glob
 from mirage.commands.config import CommandOpts
 from mirage.commands.errors import UsageError
 from mirage.commands.registry import command
@@ -58,10 +56,11 @@ async def rg(accessor: LangfuseAccessor, paths: list[PathSpec],
     # The search push-down answers from the list endpoints (one call instead
     # of one read per entry), so it greps listing summaries: a pattern that
     # only occurs in a trace's observation bodies needs a file read to match.
-    # Output/match-shaping flags defer to the generic scan below.
-    if (paths and not has_unresolved_glob(paths) and "\n" not in pattern_str
-            and not has_search_shaping_flags(opts.flags)):
-        search = SEARCH_KINDS.get(detect_scope(paths[0]).kind)
+    # Output/match-shaping flags and a multi-operand line defer to the
+    # generic scan below.
+    operand = pushdown_operand(paths, opts.flags, pattern_str)
+    if operand is not None:
+        search = SEARCH_KINDS.get(detect_scope(operand).kind)
 
         if search == "traces":
             traces = await fetch_traces(

--- a/python/mirage/commands/builtin/mongodb/grep.py
+++ b/python/mirage/commands/builtin/mongodb/grep.py
@@ -17,11 +17,9 @@ import asyncio
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import (has_search_shaping_flags,
-                                                 pattern_arg)
+from mirage.commands.builtin.grep_helper import pattern_arg, pushdown_operand
 from mirage.commands.builtin.mongodb.io import resolve_glob
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.paths import has_unresolved_glob
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -54,15 +52,15 @@ async def grep(accessor: MongoDBAccessor, paths: list[PathSpec],
     limit = config.default_search_limit
 
     # The $regex push-down prints each matching document as a whole line, so
-    # output/match-shaping flags must defer to the generic scan below.
-    if (paths and not has_unresolved_glob(paths) and pattern is not None
-            and "\n" not in pattern
-            and not has_search_shaping_flags(opts.flags)):
-        scope = detect_scope(paths[0])
+    # output/match-shaping flags and a multi-operand line must defer to the
+    # generic scan below.
+    operand = pushdown_operand(paths, opts.flags, pattern)
+    if pattern is not None and operand is not None:
+        scope = detect_scope(operand)
 
         if isinstance(scope, SEARCHABLE_SCOPE_TYPES):
             if not isinstance(scope, MongoDBRootScope):
-                await _stat(accessor, paths[0], index=opts.index)
+                await _stat(accessor, operand, index=opts.index)
             if isinstance(scope, MongoDBEntityScope):
                 docs = await search_collection(
                     accessor.client,

--- a/python/mirage/commands/builtin/mongodb/rg.py
+++ b/python/mirage/commands/builtin/mongodb/rg.py
@@ -15,11 +15,9 @@
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import (has_search_shaping_flags,
-                                                 pattern_arg)
+from mirage.commands.builtin.grep_helper import pattern_arg, pushdown_operand
 from mirage.commands.builtin.mongodb.io import resolve_glob
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.paths import has_unresolved_glob
 from mirage.commands.config import CommandOpts
 from mirage.commands.errors import UsageError
 from mirage.commands.registry import command
@@ -54,10 +52,11 @@ async def rg(accessor: MongoDBAccessor, paths: list[PathSpec],
     limit = config.default_search_limit
 
     # The $regex push-down prints each matching document as a whole line, so
-    # output/match-shaping flags must defer to the generic scan below.
-    if (paths and not has_unresolved_glob(paths) and "\n" not in pattern_str
-            and not has_search_shaping_flags(opts.flags)):
-        scope = detect_scope(paths[0])
+    # output/match-shaping flags and a multi-operand line must defer to the
+    # generic scan below.
+    operand = pushdown_operand(paths, opts.flags, pattern_str)
+    if operand is not None:
+        scope = detect_scope(operand)
 
         if isinstance(scope, SEARCHABLE_SCOPE_TYPES):
             if isinstance(scope, MongoDBEntityScope):

--- a/python/mirage/commands/builtin/postgres/grep.py
+++ b/python/mirage/commands/builtin/postgres/grep.py
@@ -15,10 +15,10 @@
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import pattern_arg, search_pushdown_ok
+from mirage.commands.builtin.grep_helper import (literal_pushdown_operand,
+                                                 pattern_arg)
 from mirage.commands.builtin.postgres.io import resolve_glob
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.paths import has_unresolved_glob
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -48,14 +48,14 @@ async def grep(accessor: PostgresAccessor, paths: list[PathSpec],
 
     # The push-down is a literal-substring search (case-sensitive unless -i)
     # that prints each matching row as a whole line; it cannot honor
-    # output/match-shaping flags or a real regex, so those defer to the
-    # generic scan below.
-    if (paths and not has_unresolved_glob(paths) and pattern is not None
-            and search_pushdown_ok(opts.flags, pattern)):
-        scope = detect_scope(paths[0])
+    # output/match-shaping flags, a real regex, or a multi-operand line, so
+    # those defer to the generic scan below.
+    operand = literal_pushdown_operand(paths, opts.flags, pattern)
+    if pattern is not None and operand is not None:
+        scope = detect_scope(operand)
 
         if scope.level != "root":
-            await _stat(accessor, paths[0], index=opts.index)
+            await _stat(accessor, operand, index=opts.index)
 
         # Directory scopes cover every file under them, so the rendered
         # schema.json / semantic.json are searched alongside the row

--- a/python/mirage/commands/builtin/postgres/rg.py
+++ b/python/mirage/commands/builtin/postgres/rg.py
@@ -15,10 +15,10 @@
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import pattern_arg, search_pushdown_ok
+from mirage.commands.builtin.grep_helper import (literal_pushdown_operand,
+                                                 pattern_arg)
 from mirage.commands.builtin.postgres.io import resolve_glob
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.paths import has_unresolved_glob
 from mirage.commands.config import CommandOpts
 from mirage.commands.errors import UsageError
 from mirage.commands.registry import command
@@ -51,11 +51,12 @@ async def rg(accessor: PostgresAccessor, paths: list[PathSpec],
     ci = fl.as_bool("i")
 
     # Native search takes one literal pattern and prints each matching row as
-    # a whole line; a multi -e set (#347), a real regex, or any match/output
-    # shaping flag must fall through to the generic scan below.
-    if (paths and not has_unresolved_glob(paths)
-            and search_pushdown_ok(opts.flags, pattern_str)):
-        scope = detect_scope(paths[0])
+    # a whole line; a multi -e set (#347), a real regex, a multi-operand line,
+    # or any match/output shaping flag must fall through to the generic scan
+    # below.
+    operand = literal_pushdown_operand(paths, opts.flags, pattern_str)
+    if operand is not None:
+        scope = detect_scope(operand)
 
         # Directory scopes cover every file under them, so the rendered
         # schema.json / semantic.json are searched alongside the row

--- a/python/tests/commands/builtin/langfuse/test_grep.py
+++ b/python/tests/commands/builtin/langfuse/test_grep.py
@@ -36,6 +36,17 @@ def _spec(virtual: str) -> PathSpec:
                     resource_path=virtual.strip("/"))
 
 
+def _glob(virtual: str) -> PathSpec:
+    # A glob whose scope IS searchable, so only the glob half of the gate can
+    # defer it: "/traces/*" routes to `invalid` and would defer regardless,
+    # while "/sessions/*" routes to `session` and reaches the push-down.
+    return PathSpec(virtual=virtual,
+                    directory=virtual.rsplit("/", 1)[0],
+                    resource_path=virtual.strip("/"),
+                    pattern=virtual.rsplit("/", 1)[-1],
+                    resolved=False)
+
+
 def _opts(**flags) -> CommandOpts:
     return CommandOpts(index=RAMIndexCacheStore(), flags={**flags})
 
@@ -81,6 +92,23 @@ async def test_shaping_flag_defers_to_generic(accessor):
 
 @pytest.mark.asyncio
 async def test_unresolved_glob_defers_to_generic(accessor):
+    with patch("mirage.commands.builtin.langfuse.grep.fetch_sessions",
+               new=AsyncMock(return_value=[])) as fetch, patch(
+                   "mirage.commands.builtin.langfuse.grep.resolve_glob",
+                   new=AsyncMock(return_value=[])), patch(
+                       "mirage.commands.builtin.langfuse.grep.generic_grep",
+                       new=AsyncMock(return_value=(b"",
+                                                   IOResult()))) as generic:
+        await grep(accessor, [_glob("/sessions/*")], ["search-me"], _opts())
+    fetch.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_second_operand_defers_to_generic(accessor):
+    # The push-down answers for one container, so a second operand used to be
+    # dropped in silence: this line reported traces and never mentioned
+    # sessions at all.
     with patch("mirage.commands.builtin.langfuse.grep.fetch_traces",
                new=AsyncMock(return_value=SUMMARIES)) as fetch, patch(
                    "mirage.commands.builtin.langfuse.grep.resolve_glob",
@@ -88,6 +116,27 @@ async def test_unresolved_glob_defers_to_generic(accessor):
                        "mirage.commands.builtin.langfuse.grep.generic_grep",
                        new=AsyncMock(return_value=(b"",
                                                    IOResult()))) as generic:
-        await grep(accessor, [_spec("/traces/*")], ["search-me"], _opts())
+        await grep(accessor,
+                   [_spec("/traces"), _spec("/sessions")], ["search-me"],
+                   _opts())
+    fetch.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repeated_operand_defers_to_generic(accessor):
+    # Two operands in one family are the case a per-operand push-down would
+    # get wrong: both route to "search every trace", so it would print the
+    # whole container twice.
+    with patch("mirage.commands.builtin.langfuse.grep.fetch_traces",
+               new=AsyncMock(return_value=SUMMARIES)) as fetch, patch(
+                   "mirage.commands.builtin.langfuse.grep.resolve_glob",
+                   new=AsyncMock(return_value=[])), patch(
+                       "mirage.commands.builtin.langfuse.grep.generic_grep",
+                       new=AsyncMock(return_value=(b"",
+                                                   IOResult()))) as generic:
+        await grep(accessor,
+                   [_spec("/traces"), _spec("/traces")], ["search-me"],
+                   _opts())
     fetch.assert_not_awaited()
     generic.assert_awaited_once()

--- a/python/tests/commands/builtin/langfuse/test_rg.py
+++ b/python/tests/commands/builtin/langfuse/test_rg.py
@@ -36,6 +36,17 @@ def _spec(virtual: str) -> PathSpec:
                     resource_path=virtual.strip("/"))
 
 
+def _glob(virtual: str) -> PathSpec:
+    # A glob whose scope IS searchable, so only the glob half of the gate can
+    # defer it: "/traces/*" routes to `invalid` and would defer regardless,
+    # while "/sessions/*" routes to `session` and reaches the push-down.
+    return PathSpec(virtual=virtual,
+                    directory=virtual.rsplit("/", 1)[0],
+                    resource_path=virtual.strip("/"),
+                    pattern=virtual.rsplit("/", 1)[-1],
+                    resolved=False)
+
+
 def _opts(**flags) -> CommandOpts:
     return CommandOpts(index=RAMIndexCacheStore(), flags={**flags})
 
@@ -82,6 +93,23 @@ async def test_shaping_flag_defers_to_generic(accessor):
 
 @pytest.mark.asyncio
 async def test_unresolved_glob_defers_to_generic(accessor):
+    with patch("mirage.commands.builtin.langfuse.rg.fetch_sessions",
+               new=AsyncMock(return_value=[])) as fetch, patch(
+                   "mirage.commands.builtin.langfuse.rg.resolve_glob",
+                   new=AsyncMock(return_value=[])), patch(
+                       "mirage.commands.builtin.langfuse.rg.generic_rg",
+                       new=AsyncMock(return_value=(b"",
+                                                   IOResult()))) as generic:
+        await rg(accessor, [_glob("/sessions/*")], ["search-me"], _opts())
+    fetch.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_second_operand_defers_to_generic(accessor):
+    # The push-down answers for one container, so a second operand used to be
+    # dropped in silence: this line reported traces and never mentioned
+    # sessions at all.
     with patch("mirage.commands.builtin.langfuse.rg.fetch_traces",
                new=AsyncMock(return_value=SUMMARIES)) as fetch, patch(
                    "mirage.commands.builtin.langfuse.rg.resolve_glob",
@@ -89,6 +117,26 @@ async def test_unresolved_glob_defers_to_generic(accessor):
                        "mirage.commands.builtin.langfuse.rg.generic_rg",
                        new=AsyncMock(return_value=(b"",
                                                    IOResult()))) as generic:
-        await rg(accessor, [_spec("/traces/*")], ["search-me"], _opts())
+        await rg(accessor,
+                 [_spec("/traces"), _spec("/sessions")], ["search-me"],
+                 _opts())
+    fetch.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repeated_operand_defers_to_generic(accessor):
+    # Two operands in one family are the case a per-operand push-down would
+    # get wrong: both route to "search every trace", so it would print the
+    # whole container twice.
+    with patch("mirage.commands.builtin.langfuse.rg.fetch_traces",
+               new=AsyncMock(return_value=SUMMARIES)) as fetch, patch(
+                   "mirage.commands.builtin.langfuse.rg.resolve_glob",
+                   new=AsyncMock(return_value=[])), patch(
+                       "mirage.commands.builtin.langfuse.rg.generic_rg",
+                       new=AsyncMock(return_value=(b"",
+                                                   IOResult()))) as generic:
+        await rg(accessor,
+                 [_spec("/traces"), _spec("/traces")], ["search-me"], _opts())
     fetch.assert_not_awaited()
     generic.assert_awaited_once()

--- a/python/tests/commands/builtin/mongodb/test_grep.py
+++ b/python/tests/commands/builtin/mongodb/test_grep.py
@@ -21,6 +21,7 @@ from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import NULL_INDEX
 from mirage.commands.builtin.mongodb.grep import grep
 from mirage.commands.config import CommandOpts
+from mirage.io.types import IOResult
 from mirage.resource.mongodb.config import MongoDBConfig
 from mirage.types import FileStat, FileType, PathSpec
 
@@ -90,6 +91,60 @@ async def test_grep_m1_short_circuits_after_first_match(accessor):
         data = await _drain(source)
     assert b"FOUND" in data
     assert len(consumed) < 100
+
+
+@pytest.mark.asyncio
+async def test_grep_second_operand_skips_pushdown(accessor):
+    # Two collection operands are both searchable scopes, and the $regex
+    # push-down answers for one: this line silently reported only coll1.
+    seen: dict[str, list[str]] = {}
+    ops = [_path("/db1/collections/coll1"), _path("/db1/collections/coll2")]
+
+    async def fake_resolve(_accessor, _paths, index=None):
+        return ops
+
+    async def fake_generic(paths, _texts, _flags, **_kwargs):
+        seen["generic"] = [p.virtual for p in paths]
+        return b"", IOResult()
+
+    with patch(
+            "mirage.commands.builtin.mongodb.grep.search_collection",
+            new=AsyncMock(side_effect=AssertionError("pushdown ran on 2 ops")),
+    ), patch(
+            "mirage.commands.builtin.mongodb.grep._stat",
+            new=AsyncMock(side_effect=AssertionError("stat ran on 2 ops")),
+    ), patch(
+            "mirage.commands.builtin.mongodb.grep.resolve_glob",
+            new=fake_resolve,
+    ), patch(
+            "mirage.commands.builtin.mongodb.grep.generic_grep",
+            new=fake_generic,
+    ):
+        await grep(accessor, ops, ['target'], CommandOpts(index=NULL_INDEX))
+
+    assert seen["generic"] == [
+        "/db1/collections/coll1", "/db1/collections/coll2"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_grep_lone_collection_still_uses_pushdown(accessor):
+    search = AsyncMock(return_value=[])
+    with patch(
+            "mirage.commands.builtin.mongodb.grep.search_collection",
+            new=search,
+    ), patch(
+            "mirage.commands.builtin.mongodb.grep._stat",
+            new=AsyncMock(),
+    ), patch(
+            "mirage.commands.builtin.mongodb.grep.resolve_glob",
+            new=AsyncMock(side_effect=AssertionError("generic path ran")),
+    ):
+        _, io = await grep(accessor, [_path("/db1/collections/coll1")],
+                           ['target'], CommandOpts(index=NULL_INDEX))
+
+    search.assert_awaited_once()
+    assert io.exit_code == 1
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/mongodb/test_rg.py
+++ b/python/tests/commands/builtin/mongodb/test_rg.py
@@ -1,0 +1,128 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.cache.index import NULL_INDEX
+from mirage.commands.builtin.mongodb.rg import rg
+from mirage.commands.config import CommandOpts
+from mirage.io.types import IOResult
+from mirage.resource.mongodb.config import MongoDBConfig
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017"))
+
+
+def _path(s: str) -> PathSpec:
+    return PathSpec(virtual=s, directory=s, resource_path=s.strip("/"))
+
+
+def _glob_path() -> PathSpec:
+    return PathSpec(virtual="/db1/collections/*",
+                    directory="/db1/collections",
+                    resource_path="db1/collections/*",
+                    pattern="*",
+                    resolved=False)
+
+
+@pytest.mark.asyncio
+async def test_rg_lone_collection_uses_pushdown(accessor):
+    search = AsyncMock(return_value=[])
+    with patch(
+            "mirage.commands.builtin.mongodb.rg.search_collection",
+            new=search,
+    ), patch(
+            "mirage.commands.builtin.mongodb.rg._stat",
+            new=AsyncMock(),
+    ), patch(
+            "mirage.commands.builtin.mongodb.rg.resolve_glob",
+            new=AsyncMock(side_effect=AssertionError("generic path ran")),
+    ):
+        _, io = await rg(accessor, [_path("/db1/collections/coll1")],
+                         ['target'], CommandOpts(index=NULL_INDEX))
+
+    search.assert_awaited_once()
+    assert io.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_rg_second_operand_skips_pushdown(accessor):
+    # Two collection operands are both searchable scopes, and the $regex
+    # push-down answers for one: this line silently reported only coll1.
+    seen: dict[str, list[str]] = {}
+    ops = [_path("/db1/collections/coll1"), _path("/db1/collections/coll2")]
+
+    async def fake_resolve(_accessor, _paths, index=None):
+        return ops
+
+    async def fake_generic(paths, _texts, _flags, **_kwargs):
+        seen["generic"] = [p.virtual for p in paths]
+        return b"", IOResult()
+
+    with patch(
+            "mirage.commands.builtin.mongodb.rg.search_collection",
+            new=AsyncMock(side_effect=AssertionError("pushdown ran on 2 ops")),
+    ), patch(
+            "mirage.commands.builtin.mongodb.rg._stat",
+            new=AsyncMock(side_effect=AssertionError("stat ran on 2 ops")),
+    ), patch(
+            "mirage.commands.builtin.mongodb.rg.resolve_glob",
+            new=fake_resolve,
+    ), patch(
+            "mirage.commands.builtin.mongodb.rg.generic_rg",
+            new=fake_generic,
+    ):
+        await rg(accessor, ops, ['target'], CommandOpts(index=NULL_INDEX))
+
+    assert seen["generic"] == [
+        "/db1/collections/coll1", "/db1/collections/coll2"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rg_unresolved_glob_skips_pushdown(accessor):
+    seen: dict[str, list[str]] = {}
+    resolved = [_path("/db1/collections/coll1")]
+
+    async def fake_resolve(_accessor, _paths, index=None):
+        return resolved
+
+    async def fake_generic(paths, _texts, _flags, **_kwargs):
+        seen["generic"] = [p.virtual for p in paths]
+        return b"", IOResult()
+
+    with patch(
+            "mirage.commands.builtin.mongodb.rg.search_collection",
+            new=AsyncMock(side_effect=AssertionError("pushdown ran on glob")),
+    ), patch(
+            "mirage.commands.builtin.mongodb.rg._stat",
+            new=AsyncMock(side_effect=AssertionError("stat ran on glob")),
+    ), patch(
+            "mirage.commands.builtin.mongodb.rg.resolve_glob",
+            new=fake_resolve,
+    ), patch(
+            "mirage.commands.builtin.mongodb.rg.generic_rg",
+            new=fake_generic,
+    ):
+        await rg(accessor, [_glob_path()], ['target'],
+                 CommandOpts(index=NULL_INDEX))
+
+    assert seen["generic"] == ["/db1/collections/coll1"]

--- a/python/tests/commands/builtin/postgres/test_pushdown_glob.py
+++ b/python/tests/commands/builtin/postgres/test_pushdown_glob.py
@@ -193,6 +193,76 @@ async def test_grep_regex_pattern_skips_pushdown(accessor):
     assert seen["generic"] == [CONCRETE]
 
 
+def _second_path() -> PathSpec:
+    other = "/public/tables/authors/rows.jsonl"
+    return PathSpec(virtual=other,
+                    directory="/public/tables/authors",
+                    resource_path=other.strip("/"))
+
+
+@pytest.mark.asyncio
+async def test_grep_second_operand_skips_pushdown(accessor):
+    # The push-down answers for one operand and printed nothing about the
+    # rest, so a two-operand line silently reported only books.
+    seen: dict[str, object] = {}
+
+    async def fake_resolve(_accessor, _paths, index=None):
+        return [_concrete_path(), _second_path()]
+
+    async def fake_generic(paths, _texts, _flags, **_kwargs):
+        seen["generic"] = [p.virtual for p in paths]
+        return b"", IOResult()
+
+    with patch(
+            "mirage.commands.builtin.postgres.grep.search_entity",
+            new=AsyncMock(side_effect=AssertionError("pushdown ran on 2 ops")),
+    ), patch(
+            "mirage.commands.builtin.postgres.grep._stat",
+            new=AsyncMock(side_effect=AssertionError("stat ran on 2 ops")),
+    ), patch(
+            "mirage.commands.builtin.postgres.grep.resolve_glob",
+            new=fake_resolve,
+    ), patch(
+            "mirage.commands.builtin.postgres.grep.generic_grep",
+            new=fake_generic,
+    ):
+        await grep(accessor,
+                   [_concrete_path(), _second_path()], ['ada'],
+                   CommandOpts(index=NULL_INDEX))
+
+    assert seen["generic"] == [CONCRETE, "/public/tables/authors/rows.jsonl"]
+
+
+@pytest.mark.asyncio
+async def test_rg_second_operand_skips_pushdown(accessor):
+    seen: dict[str, object] = {}
+
+    async def fake_resolve(_accessor, _paths, index=None):
+        return [_concrete_path(), _second_path()]
+
+    async def fake_generic(paths, _texts, _flags, **_kwargs):
+        seen["generic"] = [p.virtual for p in paths]
+        return b"", IOResult()
+
+    with patch(
+            "mirage.commands.builtin.postgres.rg.search_entity",
+            new=AsyncMock(side_effect=AssertionError("pushdown ran on 2 ops")),
+    ), patch(
+            "mirage.commands.builtin.postgres.rg._stat",
+            new=AsyncMock(side_effect=AssertionError("stat ran on 2 ops")),
+    ), patch(
+            "mirage.commands.builtin.postgres.rg.resolve_glob",
+            new=fake_resolve,
+    ), patch(
+            "mirage.commands.builtin.postgres.rg.generic_rg",
+            new=fake_generic,
+    ):
+        await rg(accessor, [_concrete_path(), _second_path()], ['ada'],
+                 CommandOpts(index=NULL_INDEX))
+
+    assert seen["generic"] == [CONCRETE, "/public/tables/authors/rows.jsonl"]
+
+
 @pytest.mark.asyncio
 async def test_rg_glob_skips_pushdown_and_expands(accessor):
     seen: dict[str, object] = {}

--- a/python/tests/commands/builtin/test_grep_helper.py
+++ b/python/tests/commands/builtin/test_grep_helper.py
@@ -28,7 +28,7 @@ from mirage.core.ram.read import read
 from mirage.core.ram.readdir import readdir
 from mirage.core.ram.stat import stat
 from mirage.core.ram.write import write_bytes as _async_write_bytes
-from mirage.types import FileStat, FileType
+from mirage.types import FileStat, FileType, PathSpec
 
 from mirage.commands.builtin.grep_helper import (  # isort: skip
     NEVER_MATCH, classify_pattern, compile_pattern, extract_required_literal,
@@ -272,6 +272,56 @@ def test_search_pushdown_ok_rejects_shaping_flag():
 def test_search_pushdown_ok_rejects_regex_but_allows_fixed_string():
     assert grep_helper.search_pushdown_ok({}, "a.b") is False
     assert grep_helper.search_pushdown_ok({"F": True}, "a.b") is True
+
+
+def _operand(virtual: str, pattern: str | None = None) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual.rsplit("/", 1)[0] or "/",
+                    resource_path=virtual.strip("/"),
+                    pattern=pattern,
+                    resolved=pattern is None)
+
+
+TRACES = _operand("/traces")
+SESSIONS = _operand("/sessions")
+
+
+def test_pushdown_operand_admits_one_concrete_operand():
+    assert grep_helper.pushdown_operand([TRACES], {}, "ada") is TRACES
+
+
+def test_pushdown_operand_refuses_a_second_operand():
+    # The bug this gate exists for: the push-down answered for the first
+    # operand and dropped the rest in silence.
+    assert grep_helper.pushdown_operand([TRACES, SESSIONS], {}, "ada") is None
+    # Two operands in one family, which a per-operand push-down would have
+    # answered twice over.
+    assert grep_helper.pushdown_operand([TRACES, TRACES], {}, "ada") is None
+
+
+def test_pushdown_operand_refuses_no_operand():
+    assert grep_helper.pushdown_operand([], {}, "ada") is None
+
+
+def test_pushdown_operand_refuses_glob_shaping_and_pattern_list():
+    assert grep_helper.pushdown_operand([_operand("/traces/*", "*")], {},
+                                        "ada") is None
+    assert grep_helper.pushdown_operand([TRACES], {"c": True}, "ada") is None
+    assert grep_helper.pushdown_operand([TRACES], {}, "ada\nbob") is None
+    assert grep_helper.pushdown_operand([TRACES], {}, None) is None
+
+
+def test_literal_pushdown_operand_adds_the_like_pattern_rule():
+    assert grep_helper.literal_pushdown_operand([TRACES], {}, "ada") is TRACES
+    # Everything pushdown_operand refuses, this refuses too.
+    assert grep_helper.literal_pushdown_operand([TRACES, SESSIONS], {},
+                                                "ada") is None
+    assert grep_helper.literal_pushdown_operand([TRACES], {"c": True},
+                                                "ada") is None
+    # Plus the one it adds: LIKE matches a regex literally.
+    assert grep_helper.literal_pushdown_operand([TRACES], {}, "a.b") is None
+    assert grep_helper.literal_pushdown_operand([TRACES], {"F": True},
+                                                "a.b") is TRACES
 
 
 async def _write(backend, path, content):

--- a/typescript/packages/core/src/commands/builtin/grep_helper.test.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { FileStat, FileType } from '../../types.ts'
+import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { PatternType } from './constants.ts'
 import {
   classifyPattern,
@@ -25,10 +25,12 @@ import {
   hasSearchShapingFlags,
   isLiteralPattern,
   isRegexPattern,
+  literalPushdownOperand,
   mergePatternList,
   NEVER_MATCH,
   NO_FILTERS,
   parseFileGlobs,
+  pushdownOperand,
   searchPushdownOk,
   searchQuery,
 } from './grep_helper.ts'
@@ -267,6 +269,57 @@ describe('searchPushdownOk', () => {
   it('rejects a regex pattern but allows it under -F', () => {
     expect(searchPushdownOk({}, 'a.b')).toBe(false)
     expect(searchPushdownOk({ F: true }, 'a.b')).toBe(true)
+  })
+})
+
+function operand(virtual: string, pattern: string | null = null): PathSpec {
+  return new PathSpec({
+    virtual,
+    directory: virtual.slice(0, virtual.lastIndexOf('/')) || '/',
+    resourcePath: virtual.replace(/^\/+|\/+$/g, ''),
+    pattern,
+    resolved: pattern === null,
+  })
+}
+
+const TRACES = operand('/traces')
+const SESSIONS = operand('/sessions')
+
+describe('pushdownOperand', () => {
+  it('admits one concrete operand', () => {
+    expect(pushdownOperand([TRACES], {}, 'ada')).toBe(TRACES)
+  })
+
+  it('refuses a second operand', () => {
+    // The bug this gate exists for: the push-down answered for the first
+    // operand and dropped the rest in silence.
+    expect(pushdownOperand([TRACES, SESSIONS], {}, 'ada')).toBe(null)
+    // Two operands in one family, which a per-operand push-down would have
+    // answered twice over.
+    expect(pushdownOperand([TRACES, TRACES], {}, 'ada')).toBe(null)
+  })
+
+  it('refuses no operand', () => {
+    expect(pushdownOperand([], {}, 'ada')).toBe(null)
+  })
+
+  it('refuses a glob, a shaping flag and a pattern list', () => {
+    expect(pushdownOperand([operand('/traces/*', '*')], {}, 'ada')).toBe(null)
+    expect(pushdownOperand([TRACES], { c: true }, 'ada')).toBe(null)
+    expect(pushdownOperand([TRACES], {}, 'ada\nbob')).toBe(null)
+    expect(pushdownOperand([TRACES], {}, null)).toBe(null)
+  })
+})
+
+describe('literalPushdownOperand', () => {
+  it('adds the LIKE pattern rule to the same operand rule', () => {
+    expect(literalPushdownOperand([TRACES], {}, 'ada')).toBe(TRACES)
+    // Everything pushdownOperand refuses, this refuses too.
+    expect(literalPushdownOperand([TRACES, SESSIONS], {}, 'ada')).toBe(null)
+    expect(literalPushdownOperand([TRACES], { c: true }, 'ada')).toBe(null)
+    // Plus the one it adds: LIKE matches a regex literally.
+    expect(literalPushdownOperand([TRACES], {}, 'a.b')).toBe(null)
+    expect(literalPushdownOperand([TRACES], { F: true }, 'a.b')).toBe(TRACES)
   })
 })
 

--- a/typescript/packages/core/src/commands/builtin/grep_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.ts
@@ -22,6 +22,7 @@ import { fnmatch } from '../../utils/fnmatch.ts'
 import { getExtension } from '../resolve.ts'
 import { PatternType } from './constants.ts'
 import { grepContextLines } from './grep_context.ts'
+import { hasUnresolvedGlob } from './utils/operands.ts'
 import type { AsyncReadBytesFn, AsyncReaddirFn, AsyncStatFn } from './utils/types.ts'
 import type { FlagView } from '../spec/types.ts'
 import { type FlagValue } from '../spec/types.ts'
@@ -363,6 +364,50 @@ export function hasSearchShapingFlags(flags: Record<string, FlagValue>): boolean
 export function searchPushdownOk(flags: Record<string, FlagValue>, pattern: string): boolean {
   if (pattern.includes('\n')) return false
   return isLiteralPattern(pattern, flags.F === true) && !hasSearchShapingFlags(flags)
+}
+
+// The one operand a search push-down may answer for, or null. A push-down
+// asks the backend a single whole-container question and prints its entire
+// answer, so it can only stand in for a line naming exactly one operand.
+// Given two it answered for the first and dropped the rest in silence
+// (rg pat /lf/traces /lf/sessions reported only traces). Running it once per
+// operand is not the fix: several scopes map to the same container search
+// (langfuse routes both `sessions` and one `session` to "search every
+// session"), so two operands in one family would print that container twice.
+// A multi-operand line therefore takes the generic scan, which searches each
+// operand in turn the way GNU does. A glob operand defers for the older
+// reason: an unexpanded pattern segment would be read as a literal entity
+// name.
+function loneOperand(paths: PathSpec[]): PathSpec | null {
+  if (paths.length !== 1 || hasUnresolvedGlob(paths)) return null
+  return paths[0] ?? null
+}
+
+// The operand a regex push-down may answer for, or null. For a backend that
+// pushes the real regex down (mongodb, langfuse), which is faithful for any
+// single pattern with no shaping flags. A newline-joined pattern list (-F
+// with several -e) is a set of independent alternatives it cannot express.
+export function pushdownOperand(
+  paths: PathSpec[],
+  flags: Record<string, FlagValue>,
+  pattern: string | null,
+): PathSpec | null {
+  if (pattern === null || pattern.includes('\n')) return null
+  if (hasSearchShapingFlags(flags)) return null
+  return loneOperand(paths)
+}
+
+// The operand a literal-substring push-down may answer for, or null.
+// loneOperand's rule plus searchPushdownOk's, which is the stricter flag gate
+// LIKE/ILIKE needs (postgres): a real regex is treated literally by LIKE, so
+// only a verbatim pattern may push down.
+export function literalPushdownOperand(
+  paths: PathSpec[],
+  flags: Record<string, FlagValue>,
+  pattern: string | null,
+): PathSpec | null {
+  if (pattern === null || !searchPushdownOk(flags, pattern)) return null
+  return loneOperand(paths)
 }
 
 export interface GrepLinesOptions {

--- a/typescript/packages/core/src/commands/builtin/langfuse/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/langfuse/grep.ts
@@ -31,8 +31,7 @@ import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { grepGeneric } from '../generic/grep.ts'
-import { compilePattern, hasSearchShapingFlags, patternArg } from '../grep_helper.ts'
-import { hasUnresolvedGlob } from '../utils/operands.ts'
+import { compilePattern, patternArg, pushdownOperand } from '../grep_helper.ts'
 import { formatRecords } from '../utils/output.ts'
 import { fileReadProvision } from './_provision.ts'
 import { FlagView } from '../../spec/types.ts'
@@ -127,16 +126,11 @@ async function grepCommand(
   // The search push-down answers from the list endpoints (one call instead
   // of one read per entry), so it greps listing summaries: a pattern that
   // only occurs in a trace's observation bodies needs a file read to match.
-  // Output/match-shaping flags defer to the generic scan below.
-  const first = paths[0]
-  if (
-    first !== undefined &&
-    !hasUnresolvedGlob(paths) &&
-    pattern !== null &&
-    !pattern.includes('\n') &&
-    !hasSearchShapingFlags(opts.flags)
-  ) {
-    const search = SEARCH_KINDS[detectScope(first).kind]
+  // Output/match-shaping flags and a multi-operand line defer to the generic
+  // scan below.
+  const operand = pushdownOperand(paths, opts.flags, pattern)
+  if (pattern !== null && operand !== null) {
+    const search = SEARCH_KINDS[detectScope(operand).kind]
     const fl = new FlagView(opts.flags, specOf('grep'))
     const ignoreCase = fl.asBool('i')
     const fixedString = fl.asBool('F')

--- a/typescript/packages/core/src/commands/builtin/langfuse/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/langfuse/rg.ts
@@ -30,8 +30,7 @@ import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { rgGeneric } from '../generic/rg.ts'
-import { compilePattern, hasSearchShapingFlags, patternArg } from '../grep_helper.ts'
-import { hasUnresolvedGlob } from '../utils/operands.ts'
+import { compilePattern, patternArg, pushdownOperand } from '../grep_helper.ts'
 import { filterDatasets, filterPrompts, filterSessions, filterTraces } from './grep.ts'
 import { FlagView } from '../../spec/types.ts'
 
@@ -57,16 +56,11 @@ async function rgCommand(
   // The search push-down answers from the list endpoints (one call instead
   // of one read per entry), so it greps listing summaries: a pattern that
   // only occurs in a trace's observation bodies needs a file read to match.
-  // Output/match-shaping flags defer to the generic scan below.
-  const first = paths[0]
-  if (
-    first !== undefined &&
-    !hasUnresolvedGlob(paths) &&
-    pattern !== null &&
-    !pattern.includes('\n') &&
-    !hasSearchShapingFlags(opts.flags)
-  ) {
-    const search = SEARCH_KINDS[detectScope(first).kind]
+  // Output/match-shaping flags and a multi-operand line defer to the generic
+  // scan below.
+  const operand = pushdownOperand(paths, opts.flags, pattern)
+  if (pattern !== null && operand !== null) {
+    const search = SEARCH_KINDS[detectScope(operand).kind]
     const fl = new FlagView(opts.flags, specOf('rg'))
     const pat = compilePattern(pattern, fl.asBool('i'), fl.asBool('F'), fl.asBool('w'))
     if (search === 'traces') {

--- a/typescript/packages/core/src/commands/builtin/mongodb/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/grep.ts
@@ -16,7 +16,6 @@ import type { MongoDBAccessor } from '../../../accessor/mongodb.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { listDatabases } from '../../../core/mongodb/client.ts'
 import { resolveGlobOf } from '../generic_bind/index.ts'
-import { hasUnresolvedGlob } from '../utils/operands.ts'
 import { MONGODB_IO } from './io.ts'
 import { read as mongoRead } from '../../../core/mongodb/read.ts'
 import { readdir as mongoReaddir } from '../../../core/mongodb/readdir.ts'
@@ -33,7 +32,7 @@ import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { grepGeneric } from '../generic/grep.ts'
-import { hasSearchShapingFlags, patternArg } from '../grep_helper.ts'
+import { patternArg, pushdownOperand } from '../grep_helper.ts'
 import { formatRecords } from '../utils/output.ts'
 
 const resolveGlob = resolveGlobOf(MONGODB_IO)
@@ -56,19 +55,14 @@ async function grepCommand(
   const limit = accessor.config.defaultSearchLimit
 
   // The $regex push-down prints each matching document as a whole line, so
-  // output/match-shaping flags must defer to the generic scan below.
-  const first = paths[0]
-  if (
-    first !== undefined &&
-    !hasUnresolvedGlob(paths) &&
-    pattern !== null &&
-    !pattern.includes('\n') &&
-    !hasSearchShapingFlags(opts.flags)
-  ) {
-    const scope = detectScope(first)
+  // output/match-shaping flags and a multi-operand line must defer to the
+  // generic scan below.
+  const operand = pushdownOperand(paths, opts.flags, pattern)
+  if (pattern !== null && operand !== null) {
+    const scope = detectScope(operand)
 
     if (scope.level !== ScopeLevel.ROOT) {
-      await mongoStat(accessor, first, opts.index ?? undefined)
+      await mongoStat(accessor, operand, opts.index ?? undefined)
     }
 
     if (scope.level === ScopeLevel.ROOT) {

--- a/typescript/packages/core/src/commands/builtin/mongodb/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/rg.ts
@@ -15,7 +15,6 @@
 import type { MongoDBAccessor } from '../../../accessor/mongodb.ts'
 import { listDatabases } from '../../../core/mongodb/client.ts'
 import { resolveGlobOf } from '../generic_bind/index.ts'
-import { hasUnresolvedGlob } from '../utils/operands.ts'
 import { MONGODB_IO } from './io.ts'
 import { streamAny } from '../../../core/mongodb/read.ts'
 import { readdir as mongoReaddir } from '../../../core/mongodb/readdir.ts'
@@ -32,7 +31,7 @@ import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { rgGeneric } from '../generic/rg.ts'
-import { hasSearchShapingFlags, patternArg } from '../grep_helper.ts'
+import { patternArg, pushdownOperand } from '../grep_helper.ts'
 import { formatRecords } from '../utils/output.ts'
 
 const resolveGlob = resolveGlobOf(MONGODB_IO)
@@ -47,19 +46,14 @@ async function rgCommand(
   const limit = accessor.config.defaultSearchLimit
 
   // The $regex push-down prints each matching document as a whole line, so
-  // output/match-shaping flags must defer to the generic scan below.
-  const first = paths[0]
-  if (
-    first !== undefined &&
-    !hasUnresolvedGlob(paths) &&
-    pattern !== null &&
-    !pattern.includes('\n') &&
-    !hasSearchShapingFlags(opts.flags)
-  ) {
-    const scope = detectScope(first)
+  // output/match-shaping flags and a multi-operand line must defer to the
+  // generic scan below.
+  const operand = pushdownOperand(paths, opts.flags, pattern)
+  if (pattern !== null && operand !== null) {
+    const scope = detectScope(operand)
 
     if (scope.level !== ScopeLevel.ROOT) {
-      await mongoStat(accessor, first, opts.index ?? undefined)
+      await mongoStat(accessor, operand, opts.index ?? undefined)
     }
 
     if (scope.level === ScopeLevel.ROOT) {

--- a/typescript/packages/core/src/commands/builtin/postgres/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/grep.ts
@@ -15,7 +15,6 @@
 import type { PostgresAccessor } from '../../../accessor/postgres.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { resolveGlobOf } from '../generic_bind/index.ts'
-import { hasUnresolvedGlob } from '../utils/operands.ts'
 import { POSTGRES_IO } from './io.ts'
 import { read as postgresRead } from '../../../core/postgres/read.ts'
 import { readdir as postgresReaddir } from '../../../core/postgres/readdir.ts'
@@ -37,7 +36,7 @@ import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { grepGeneric } from '../generic/grep.ts'
-import { patternArg, searchPushdownOk } from '../grep_helper.ts'
+import { literalPushdownOperand, patternArg } from '../grep_helper.ts'
 import { formatRecords } from '../utils/output.ts'
 import { FlagView } from '../../spec/types.ts'
 
@@ -61,22 +60,17 @@ async function grepCommand(
   const limit = accessor.config.defaultSearchLimit
 
   // The push-down is a literal-substring search (case-sensitive unless -i)
-  // that prints
-  // each matching row as a whole line; it cannot honor output/match-shaping
-  // flags or a real regex, so those defer to the generic scan below.
-  const first = paths[0]
+  // that prints each matching row as a whole line; it cannot honor
+  // output/match-shaping flags, a real regex, or a multi-operand line, so
+  // those defer to the generic scan below.
   const fl = new FlagView(opts.flags, specOf('grep'))
   const ci = fl.asBool('i')
-  if (
-    first !== undefined &&
-    !hasUnresolvedGlob(paths) &&
-    pattern !== null &&
-    searchPushdownOk(opts.flags, pattern)
-  ) {
-    const scope = detectScope(first)
+  const operand = literalPushdownOperand(paths, opts.flags, pattern)
+  if (pattern !== null && operand !== null) {
+    const scope = detectScope(operand)
 
     if (scope.level !== 'root') {
-      await postgresStat(accessor, first, opts.index ?? undefined)
+      await postgresStat(accessor, operand, opts.index ?? undefined)
     }
 
     // Directory scopes cover every file under them, so the rendered

--- a/typescript/packages/core/src/commands/builtin/postgres/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/rg.ts
@@ -14,7 +14,6 @@
 
 import type { PostgresAccessor } from '../../../accessor/postgres.ts'
 import { resolveGlobOf } from '../generic_bind/index.ts'
-import { hasUnresolvedGlob } from '../utils/operands.ts'
 import { POSTGRES_IO } from './io.ts'
 import { readStream } from '../../../core/postgres/read.ts'
 import { readdir as postgresReaddir } from '../../../core/postgres/readdir.ts'
@@ -36,7 +35,7 @@ import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { rgGeneric } from '../generic/rg.ts'
-import { patternArg, searchPushdownOk } from '../grep_helper.ts'
+import { literalPushdownOperand, patternArg } from '../grep_helper.ts'
 import { formatRecords } from '../utils/output.ts'
 import { FlagView } from '../../spec/types.ts'
 
@@ -52,21 +51,16 @@ async function rgCommand(
   const limit = accessor.config.defaultSearchLimit
 
   // Native search takes one literal pattern and prints each matching row as a
-  // whole line; a multi -e set (#347), a real regex, or any match/output
-  // shaping flag must fall through to the generic scan below.
-  const first = paths[0]
+  // whole line; a multi -e set (#347), a real regex, a multi-operand line, or
+  // any match/output shaping flag must fall through to the generic scan below.
   const fl = new FlagView(opts.flags, specOf('rg'))
   const ci = fl.asBool('i')
-  if (
-    first !== undefined &&
-    !hasUnresolvedGlob(paths) &&
-    pattern !== null &&
-    searchPushdownOk(opts.flags, pattern)
-  ) {
-    const scope = detectScope(first)
+  const operand = literalPushdownOperand(paths, opts.flags, pattern)
+  if (pattern !== null && operand !== null) {
+    const scope = detectScope(operand)
 
     if (scope.level !== 'root') {
-      await postgresStat(accessor, first, opts.index ?? undefined)
+      await postgresStat(accessor, operand, opts.index ?? undefined)
     }
 
     // Directory scopes cover every file under them, so the rendered


### PR DESCRIPTION
## The bug

A search push-down asks the backend one whole-container question and prints its entire answer, so it can only stand in for a line naming exactly one operand. Given two it answered for the first and dropped the rest **in silence**:

```
$ rg checkout-flow /lf/traces /lf/sessions
traces/trace-alpha.json:{"id":"trace-alpha", ...}      # sessions never searched, nothing said so
```

## The fix, and the alternative that was rejected

Running the push-down once per operand is not the fix. Several scopes map to the same container search — langfuse routes both `sessions` and one `session` to "search every session" — so two operands in one family would print that container twice. A multi-operand line therefore **defers to the generic scan**, which searches each operand in turn the way GNU does, and which every backend without a push-down already used.

The gate is written once rather than per wrapper:

| helper | family | backends |
|---|---|---|
| `pushdown_operand` / `pushdownOperand` | regex push-down | langfuse, mongodb |
| `literal_pushdown_operand` / `literalPushdownOperand` | LIKE/ILIKE substring | postgres |

Both return the sole concrete operand or `None`, folding operand count in beside the glob, pattern-list and shaping-flag rules that the six wrappers were each open-coding as a five-clause boolean. Twelve gates collapse to twelve calls, so they cannot drift apart again.

## Scope

**postgres was not in the original report** and has the identical bug through the same `search_pushdown_ok` gate. It is fixed here because it shares the helper.

**Five more backends are affected and deliberately left alone**, because each needs its own decision rather than this one:

- **slack** and **discord** already carry a `coalesce_scopes` mechanism, consulted only when `paths[0]` is non-native — there "coalesce every operand" is the likely answer, not "defer". Their TS sides never call `coalesceScopes` at all.
- **email**'s `rg` returns exit 1 (no match) instead of falling through, so a line the push-down cannot answer reports "nothing matched" rather than searching.
- **gmail** open-codes a partial shaping check and has no glob check at all.
- **email**'s `find` has the same `paths[0]` walk, and its TS twin has no push-down — a py/ts divergence to settle.

These are filed as follow-up work.

## Verification

Pinned **empirically on both hosts** against a real Langfuse v3 stack, MongoDB and Postgres — 13 new integ cases, each captured from actual output rather than predicted:

- `integ/resources/observability/langfuse/search.json` (seq 602107–602111)
- `integ/resources/{mongodb,postgres}/{grep,rg}.json`

**All 5 langfuse cases and 6 of the 8 database cases fail on the unfixed tree**, showing the exact drop (`got 'traces/trace-alpha.json\n'` where both operands were expected). The two `lone_operand` cases pass either way on purpose: they guard against over-deferring, proving the push-down still fires for a single operand.

Multi-operand shapes were checked against the real tools, not assumed — **GNU grep 3.11** (`debian:stable-slim`) and **ripgrep 14.1.1**:

- two directory operands without `-r` → two `Is a directory` lines and exit 2 (matches mirage exactly)
- a repeated operand is searched **twice**, not deduped (both tools agree)
- `rg` parallelizes and so emits operands in nondeterministic order, which is why those cases normalize with `sort -u`

Also fixes a **misdirected test**: `test_unresolved_glob_defers_to_generic` built its `PathSpec` without a `pattern`, so `has_unresolved_glob` returned `False` and the deferral it asserted actually came from `/traces/*` routing to `invalid`. It now uses `/sessions/*`, which routes to a searchable scope, so only the glob half of the gate can defer it.

### Checks

- `pre-commit run --all-files` — all hooks pass (converged; no yapf/isort oscillation)
- `pytest` (python, excl. `tests/fuse` — no macFUSE on this host) — exit 0
- `pnpm -r typecheck` — clean
- `@struktoai/mirage-core` vitest — 691 files, 9088 passed
- `check_case_targets.py --strict` — 2295, on baseline
- langfuse / mongodb / postgres batteries — python **154/111 passed**, typescript **154/111 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
