### PR TITLE
feat(runtime): add the ssh sandbox provider

### DIFF
--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -1011,6 +1011,11 @@ jobs:
       MIRAGE_QUICKJS_HOME: /tmp/quickjs
       MIRAGE_WASI_HOME: /tmp/cpython-wasi
       MIRAGE_INTEG_DOCKER_CONTAINER: mirage-integ-runtime-box
+      # The ssh suite's sshd container publishes port 2222 (the suite
+      # json pins the port; env placeholders expand as strings only).
+      MIRAGE_INTEG_SSH_HOST: 127.0.0.1
+      MIRAGE_INTEG_SSH_USERNAME: root
+      MIRAGE_INTEG_SSH_KEY: /tmp/mirage-integ-ssh-key
       # Suites with unmet requirements fail instead of skipping, so a
       # broken build download cannot silently drop wasi/quickjs/docker
       # coverage.
@@ -1099,6 +1104,24 @@ jobs:
 
       - name: Start the docker sandbox container (user-provisioned)
         run: docker run -d --name "$MIRAGE_INTEG_DOCKER_CONTAINER" debian:stable-slim sleep infinity
+
+      - name: Start the ssh sandbox host (user-provisioned)
+        run: |
+          ssh-keygen -t ed25519 -N '' -f "$MIRAGE_INTEG_SSH_KEY"
+          docker run -d --name mirage-integ-ssh-box -p 2222:22 debian:stable-slim sleep infinity
+          docker exec mirage-integ-ssh-box sh -c \
+            'apt-get update -qq && apt-get install -y -qq openssh-server >/dev/null && mkdir -p /run/sshd /root/.ssh'
+          # docker cp keeps the host uid on the file; sshd's StrictModes
+          # refuses an authorized_keys the login user does not own.
+          docker cp "$MIRAGE_INTEG_SSH_KEY.pub" mirage-integ-ssh-box:/root/.ssh/authorized_keys
+          docker exec mirage-integ-ssh-box sh -c \
+            'chown -R root:root /root/.ssh && chmod 700 /root/.ssh && chmod 600 /root/.ssh/authorized_keys'
+          docker exec -d mirage-integ-ssh-box /usr/sbin/sshd -D -e
+          for i in $(seq 1 30); do
+            ssh -p 2222 -i "$MIRAGE_INTEG_SSH_KEY" -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null root@127.0.0.1 true && break
+            sleep 1
+          done
 
       - name: Run every runtime through the JSON suites (python)
         run: ./python/.venv/bin/python integ/runtime/run.py

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -417,7 +417,8 @@
                   "python/runtime/sandbox/docker",
                   "python/runtime/sandbox/smolvm",
                   "python/runtime/sandbox/daytona",
-                  "python/runtime/sandbox/e2b"
+                  "python/runtime/sandbox/e2b",
+                  "python/runtime/sandbox/ssh"
                 ]
               }
             ]
@@ -618,7 +619,8 @@
                   "typescript/runtime/sandbox/docker",
                   "typescript/runtime/sandbox/smolvm",
                   "typescript/runtime/sandbox/daytona",
-                  "typescript/runtime/sandbox/e2b"
+                  "typescript/runtime/sandbox/e2b",
+                  "typescript/runtime/sandbox/ssh"
                 ]
               }
             ]

--- a/docs/images/ssh-logo.svg
+++ b/docs/images/ssh-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="none" role="img" aria-label="SSH"><title>ssh</title>
+  <rect width="256" height="256" rx="48" fill="#455A64"/>
+  <path d="M60 84l52 44-52 44" stroke="#fff" stroke-width="22" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M136 172h60" stroke="#fff" stroke-width="22" stroke-linecap="round"/>
+</svg>

--- a/docs/python/runtime/sandbox.mdx
+++ b/docs/python/runtime/sandbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Run captured lines whole inside a sandbox (Docker, smolvm, Daytona, or e2b) you provision yourself.
+description: Run captured lines whole inside a sandbox (Docker, smolvm, Daytona, e2b, or any machine over SSH) you provision yourself.
 icon: server
 ---
 
@@ -10,7 +10,7 @@ command line and runs it inside a separate machine, a local container or
 microVM or a cloud sandbox. Reach for it when a line needs a real OS, heavy
 packages, or a GPU that the in-process interpreters cannot give it.
 
-Four sandbox runtimes ship today, all with the same surface:
+Five sandbox runtimes ship today, all with the same surface:
 
 | Runtime | Connects to | Config |
 | --- | --- | --- |
@@ -18,10 +18,12 @@ Four sandbox runtimes ship today, all with the same surface:
 | [`smolvm`](/python/runtime/sandbox/smolvm) | A [smolvm](https://smolmachines.com) microVM you started | `machine` |
 | [`daytona`](/python/runtime/sandbox/daytona) | A [Daytona](https://www.daytona.io) sandbox you created | `sandbox_id`, `api_key` |
 | [`e2b`](/python/runtime/sandbox/e2b) | An [E2B](https://e2b.dev) sandbox you created | `sandbox_id`, `api_key` |
+| [`ssh`](/python/runtime/sandbox/ssh) | Any machine running sshd | `host`, `username`, `identity_file` |
 
 `docker` and `smolvm` run on your own machine, Daytona and e2b in the
-cloud. The isolation differs too: a container shares your kernel, while a
-smolvm microVM boots its own.
+cloud, and `ssh` reaches anything you can already `ssh` into. The isolation
+differs too: a container shares your kernel, a smolvm microVM boots its
+own, and an ssh machine is whatever machine you point it at.
 
 <Note>
   [Sandlock](/python/runtime/sandbox/sandlock) is listed in this sidebar
@@ -86,6 +88,14 @@ mounts fails loud only when a path misses.
 
 This needs an image with `fuse3` and Mirage plus your backends installed
 (see [The sandbox image](#the-sandbox-image)).
+
+<Note>
+  The `ssh` provider can skip all of this when the files live on the ssh
+  machine itself: mount them over the ssh resource at a prefix equal to
+  their remote absolute path, and captured lines open them natively with no
+  FUSE and no remote Mirage. See
+  [Skip the FUSE](/python/runtime/sandbox/ssh#skip-the-fuse) on the SSH page.
+</Note>
 
 ## Paths inside the sandbox
 

--- a/docs/python/runtime/sandbox/ssh.mdx
+++ b/docs/python/runtime/sandbox/ssh.mdx
@@ -1,0 +1,91 @@
+---
+title: SSH
+description: Run captured command lines on any machine you can reach over SSH.
+icon: terminal
+---
+
+`SSHRuntime` connects to a machine running sshd and executes every captured
+line on it. Mirage does not start, size, or stop the machine; anything you
+can already `ssh` into works, with nothing to install on it. See the
+[Sandbox overview](/python/runtime/sandbox) first for routing and captures.
+
+## Skip the FUSE
+
+The other providers need Mirage and FUSE inside the sandbox to serve the
+workspace's mounts. SSH is the one provider whose machine usually **is** the
+fileserver: the [ssh resource](/python/resource/ssh) already mounts that
+machine's directory over SFTP. Mount it at a prefix **equal to its remote
+absolute path**, and the two sides agree about every path with no FUSE, no
+remote Mirage install, and no path rewriting anywhere:
+
+```yaml
+mounts:
+  /home/user/proj:            # prefix == the remote absolute path
+    resource: ssh
+    config:
+      host: mybox
+      root: /home/user/proj
+
+runtimes:
+  - name: ssh
+    captures: ["python3"]
+    config:
+      host: mybox             # the same machine
+  - vfs
+```
+
+The agent lists and greps `/home/user/proj` through the workspace (SFTP),
+and `python3 /home/user/proj/train.py` runs on the box, where that path is
+a real file the interpreter opens natively. One spelling of the path works
+on both sides because it names the same file on the same machine. Whether
+the remote directory is a plain disk, an NFS export, or itself a FUSE mount
+does not matter to either side.
+
+Nothing checks the alignment for you: a mount at a prefix that is not the
+remote path (or on a different host) fails only when a captured line misses
+a file. For mounts the machine cannot see natively (S3, Slack, ...) the
+[general recipe](/python/runtime/sandbox#the-workspace-inside-the-sandbox)
+still applies: serve them on the machine with Mirage + FUSE at the same
+prefixes.
+
+## Connect from Python
+
+```python
+from mirage import MountMode, Workspace
+from mirage.resource.ssh import SSHConfig, SSHResource
+from mirage.runtime.sandbox.ssh import SSHRuntime
+
+runtime = SSHRuntime(captures=["python3"],
+                     config={"host": "mybox", "username": "deploy",
+                             "identity_file": "~/.ssh/id_ed25519"})
+proj = SSHResource(SSHConfig(host="mybox", username="deploy",
+                             identity_file="~/.ssh/id_ed25519",
+                             root="/home/deploy/proj"))
+ws = Workspace({"/home/deploy/proj": proj},
+               mode=MountMode.EXEC,
+               runtimes=[runtime, "vfs"])
+await ws.execute("python3 train.py", cwd="/home/deploy/proj")
+```
+
+The config carries the ssh resource's fields minus `root`: `host` (required,
+also the address unless `hostname` overrides it, and matched against
+`~/.ssh/config`), `port`, `username`, `identity_file`, `timeout`, and the
+shared `env`. Auth is keys or an agent, never a password. Unknown config
+fields fail at construction.
+
+## How lines run
+
+The first captured line opens one SSH connection, and every line after it
+is one exec channel on that connection: real byte stdin, separated stderr,
+the remote command's own exit code. SSH exec has no docker-style `-w`/`-e`,
+so the session cwd and the merged environment ride the command itself as
+`cd 'cwd' && env 'K=V' ... sh -c 'line'`, every piece single-quoted. The
+remote login shell only needs to be POSIX-compatible.
+
+<Warning>
+  Host keys are **not verified**, matching the ssh2 transport on the
+  TypeScript side, so treat the network path to the machine as trusted. And
+  as with every provider, a Mirage timeout stops waiting without killing the
+  remote process; see
+  [Resource limits](/python/runtime/sandbox#resource-limits).
+</Warning>

--- a/docs/python/runtime/sandbox/ssh.mdx
+++ b/docs/python/runtime/sandbox/ssh.mdx
@@ -1,7 +1,7 @@
 ---
 title: SSH
 description: Run captured command lines on any machine you can reach over SSH.
-icon: terminal
+icon: /images/ssh-logo.svg
 ---
 
 `SSHRuntime` connects to a machine running sshd and executes every captured

--- a/docs/python/runtime/sandbox/ssh.mdx
+++ b/docs/python/runtime/sandbox/ssh.mdx
@@ -43,7 +43,11 @@ does not matter to either side.
 
 Nothing checks the alignment for you: a mount at a prefix that is not the
 remote path (or on a different host) fails only when a captured line misses
-a file. For mounts the machine cannot see natively (S3, Slack, ...) the
+a file. To expose a friendlier name, align from the remote side (place or
+symlink the directory at that path on the box) rather than renaming the
+mount: a captured line ships verbatim, and no rewrite could reach the paths
+a program reads from its own code or config. For mounts the machine cannot
+see natively (S3, Slack, ...) the
 [general recipe](/python/runtime/sandbox#the-workspace-inside-the-sandbox)
 still applies: serve them on the machine with Mirage + FUSE at the same
 prefixes.

--- a/docs/typescript/runtime/sandbox.mdx
+++ b/docs/typescript/runtime/sandbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Run captured lines whole inside a sandbox (Docker, smolvm, Daytona, or e2b) you provision yourself.
+description: Run captured lines whole inside a sandbox (Docker, smolvm, Daytona, e2b, or any machine over SSH) you provision yourself.
 icon: server
 ---
 
@@ -10,7 +10,7 @@ runs it inside a separate machine, a local container or microVM or a cloud
 sandbox. Reach for it when a line needs a real OS, heavy packages, or a GPU
 that the in-process interpreters cannot give it.
 
-Four sandbox runtimes ship from `@struktoai/mirage-node`, all with the same
+Five sandbox runtimes ship from `@struktoai/mirage-node`, all with the same
 surface:
 
 | Runtime | Connects to | Config |
@@ -19,10 +19,12 @@ surface:
 | [`smolvm`](/typescript/runtime/sandbox/smolvm) | A [smolvm](https://smolmachines.com) microVM you started | `machine` |
 | [`daytona`](/typescript/runtime/sandbox/daytona) | A [Daytona](https://www.daytona.io) sandbox you created | `sandboxId`, `apiKey` |
 | [`e2b`](/typescript/runtime/sandbox/e2b) | An [E2B](https://e2b.dev) sandbox you created | `sandboxId`, `apiKey` |
+| [`ssh`](/typescript/runtime/sandbox/ssh) | Any machine running sshd | `host`, `username`, `identityFile` |
 
 `docker` and `smolvm` run on your own machine, Daytona and e2b in the
-cloud. The isolation differs too: a container shares your kernel, while a
-smolvm microVM boots its own.
+cloud, and `ssh` reaches anything you can already `ssh` into. The isolation
+differs too: a container shares your kernel, a smolvm microVM boots its
+own, and an ssh machine is whatever machine you point it at.
 
 <Note>
   Looking for Sandlock? Mirage's
@@ -89,6 +91,15 @@ This needs an image with `fuse3` and Mirage plus your backends installed
 (see [The sandbox image](#the-sandbox-image)). The in-sandbox mount is
 served by the Python Mirage build, so the image is the same for both
 language SDKs.
+
+<Note>
+  The `ssh` provider can skip all of this when the files live on the ssh
+  machine itself: mount them over the ssh resource at a prefix equal to
+  their remote absolute path, and captured lines open them natively with no
+  FUSE and no remote Mirage. See
+  [Skip the FUSE](/typescript/runtime/sandbox/ssh#skip-the-fuse) on the SSH
+  page.
+</Note>
 
 ## Paths inside the sandbox
 

--- a/docs/typescript/runtime/sandbox/ssh.mdx
+++ b/docs/typescript/runtime/sandbox/ssh.mdx
@@ -1,0 +1,94 @@
+---
+title: SSH
+description: Run captured command lines on any machine you can reach over SSH.
+icon: terminal
+---
+
+`SSHRuntime` connects to a machine running sshd and executes every captured
+line on it. Mirage does not start, size, or stop the machine; anything you
+can already `ssh` into works, with nothing to install on it. See the
+[Sandbox overview](/typescript/runtime/sandbox) first for routing and
+captures.
+
+## Skip the FUSE
+
+The other providers need Mirage and FUSE inside the sandbox to serve the
+workspace's mounts. SSH is the one provider whose machine usually **is**
+the fileserver: the [ssh resource](/typescript/setup/ssh) already mounts
+that machine's directory over SFTP. Mount it at a prefix **equal to its
+remote absolute path**, and the two sides agree about every path with no
+FUSE, no remote Mirage install, and no path rewriting anywhere:
+
+```yaml
+mounts:
+  /home/user/proj:            # prefix == the remote absolute path
+    resource: ssh
+    config:
+      host: mybox
+      root: /home/user/proj
+
+runtimes:
+  - name: ssh
+    captures: ["python3"]
+    config:
+      host: mybox             # the same machine
+  - vfs
+```
+
+The agent lists and greps `/home/user/proj` through the workspace (SFTP),
+and `python3 /home/user/proj/train.py` runs on the box, where that path is
+a real file the interpreter opens natively. One spelling of the path works
+on both sides because it names the same file on the same machine. Whether
+the remote directory is a plain disk, an NFS export, or itself a FUSE mount
+does not matter to either side.
+
+Nothing checks the alignment for you: a mount at a prefix that is not the
+remote path (or on a different host) fails only when a captured line misses
+a file. For mounts the machine cannot see natively (S3, Slack, ...) the
+[general recipe](/typescript/runtime/sandbox#the-workspace-inside-the-sandbox)
+still applies: serve them on the machine with Mirage + FUSE at the same
+prefixes.
+
+## Connect from TypeScript
+
+```ts
+import { MountMode, SSHResource, SSHRuntime, Workspace } from '@struktoai/mirage-node'
+
+const runtime = new SSHRuntime({
+  captures: ['python3'],
+  config: { host: 'mybox', username: 'deploy', identityFile: '~/.ssh/id_ed25519' },
+})
+const proj = new SSHResource({
+  host: 'mybox',
+  username: 'deploy',
+  identityFile: '~/.ssh/id_ed25519',
+  root: '/home/deploy/proj',
+})
+const ws = new Workspace(
+  { '/home/deploy/proj': proj },
+  { mode: MountMode.EXEC, runtimes: [runtime, 'vfs'] },
+)
+await ws.execute('python3 train.py', { cwd: '/home/deploy/proj' })
+```
+
+The config carries the ssh resource's fields minus `root`: `host` (required,
+also the address unless `hostname` overrides it), `port`, `username`,
+`identityFile`, `timeout`, and the shared `env`. Auth is keys, never a
+password; `ssh2` is the transport and loads on first use (`pnpm add ssh2`).
+Unknown config fields fail at construction.
+
+## How lines run
+
+The first captured line opens one SSH connection, and every line after it
+is one exec channel on that connection: real byte stdin, separated stderr,
+the remote command's own exit code. SSH exec has no docker-style `-w`/`-e`,
+so the session cwd and the merged environment ride the command itself as
+`cd 'cwd' && env 'K=V' ... sh -c 'line'`, every piece single-quoted. The
+remote login shell only needs to be POSIX-compatible.
+
+<Warning>
+  Host keys are **not verified** (ssh2 never checks them), so treat the
+  network path to the machine as trusted. And as with every provider, a
+  Mirage timeout stops waiting without killing the remote process; see
+  [Resource limits](/typescript/runtime/sandbox#resource-limits).
+</Warning>

--- a/docs/typescript/runtime/sandbox/ssh.mdx
+++ b/docs/typescript/runtime/sandbox/ssh.mdx
@@ -44,7 +44,11 @@ does not matter to either side.
 
 Nothing checks the alignment for you: a mount at a prefix that is not the
 remote path (or on a different host) fails only when a captured line misses
-a file. For mounts the machine cannot see natively (S3, Slack, ...) the
+a file. To expose a friendlier name, align from the remote side (place or
+symlink the directory at that path on the box) rather than renaming the
+mount: a captured line ships verbatim, and no rewrite could reach the paths
+a program reads from its own code or config. For mounts the machine cannot
+see natively (S3, Slack, ...) the
 [general recipe](/typescript/runtime/sandbox#the-workspace-inside-the-sandbox)
 still applies: serve them on the machine with Mirage + FUSE at the same
 prefixes.
@@ -73,8 +77,10 @@ await ws.execute('python3 train.py', { cwd: '/home/deploy/proj' })
 
 The config carries the ssh resource's fields minus `root`: `host` (required,
 also the address unless `hostname` overrides it), `port`, `username`,
-`identityFile`, `timeout`, and the shared `env`. Auth is keys, never a
-password; `ssh2` is the transport and loads on first use (`pnpm add ssh2`).
+`identityFile`, `timeout`, and the shared `env`. Auth is keys or an agent,
+never a password: with no `identityFile`, `SSH_AUTH_SOCK` authenticates, and
+`username` defaults to the local user. `ssh2` is the transport and loads on
+first use (`pnpm add ssh2`).
 Unknown config fields fail at construction.
 
 ## How lines run

--- a/docs/typescript/runtime/sandbox/ssh.mdx
+++ b/docs/typescript/runtime/sandbox/ssh.mdx
@@ -1,7 +1,7 @@
 ---
 title: SSH
 description: Run captured command lines on any machine you can reach over SSH.
-icon: terminal
+icon: /images/ssh-logo.svg
 ---
 
 `SSHRuntime` connects to a machine running sshd and executes every captured

--- a/integ/runtime/ssh.json
+++ b/integ/runtime/ssh.json
@@ -1,0 +1,230 @@
+{
+  "suite": "ssh",
+  "requires": [
+    "env:MIRAGE_INTEG_SSH_HOST"
+  ],
+  "cases": [
+    {
+      "id": "echo",
+      "world": {
+        "runtimes": [
+          {
+            "name": "ssh",
+            "captures": [
+              "*"
+            ],
+            "config": {
+              "host": "${MIRAGE_INTEG_SSH_HOST}",
+              "port": 2222,
+              "username": "${MIRAGE_INTEG_SSH_USERNAME}",
+              "identity_file": "${MIRAGE_INTEG_SSH_KEY}"
+            }
+          },
+          "vfs"
+        ]
+      },
+      "steps": [
+        {
+          "command": "echo hi-from-ssh-box",
+          "expect": {
+            "exit": 0,
+            "stdout": "hi-from-ssh-box\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "exit_code",
+      "world": {
+        "runtimes": [
+          {
+            "name": "ssh",
+            "captures": [
+              "*"
+            ],
+            "config": {
+              "host": "${MIRAGE_INTEG_SSH_HOST}",
+              "port": 2222,
+              "username": "${MIRAGE_INTEG_SSH_USERNAME}",
+              "identity_file": "${MIRAGE_INTEG_SSH_KEY}"
+            }
+          },
+          "vfs"
+        ]
+      },
+      "steps": [
+        {
+          "command": "sh -c 'exit 7'",
+          "expect": {
+            "exit": 7
+          }
+        }
+      ]
+    },
+    {
+      "id": "stdin",
+      "world": {
+        "runtimes": [
+          {
+            "name": "ssh",
+            "captures": [
+              "*"
+            ],
+            "config": {
+              "host": "${MIRAGE_INTEG_SSH_HOST}",
+              "port": 2222,
+              "username": "${MIRAGE_INTEG_SSH_USERNAME}",
+              "identity_file": "${MIRAGE_INTEG_SSH_KEY}"
+            }
+          },
+          "vfs"
+        ]
+      },
+      "steps": [
+        {
+          "command": "wc -l",
+          "stdin": "a\nb\nc\n",
+          "expect": {
+            "exit": 0,
+            "stdout": "3\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "config_env",
+      "world": {
+        "runtimes": [
+          {
+            "name": "ssh",
+            "captures": [
+              "*"
+            ],
+            "config": {
+              "host": "${MIRAGE_INTEG_SSH_HOST}",
+              "port": 2222,
+              "username": "${MIRAGE_INTEG_SSH_USERNAME}",
+              "identity_file": "${MIRAGE_INTEG_SSH_KEY}",
+              "env": {
+                "BOX_MARKER": "from config"
+              }
+            }
+          },
+          "vfs"
+        ]
+      },
+      "steps": [
+        {
+          "command": "echo \"$BOX_MARKER\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "from config\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "quoting",
+      "world": {
+        "runtimes": [
+          {
+            "name": "ssh",
+            "captures": [
+              "*"
+            ],
+            "config": {
+              "host": "${MIRAGE_INTEG_SSH_HOST}",
+              "port": 2222,
+              "username": "${MIRAGE_INTEG_SSH_USERNAME}",
+              "identity_file": "${MIRAGE_INTEG_SSH_KEY}"
+            }
+          },
+          "vfs"
+        ]
+      },
+      "steps": [
+        {
+          "command": "printf '%s\\n' \"it's\" 'two  spaces'",
+          "expect": {
+            "exit": 0,
+            "stdout": "it's\ntwo  spaces\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "line_timeout",
+      "world": {
+        "runtimes": [
+          {
+            "name": "ssh",
+            "captures": [
+              "*"
+            ],
+            "config": {
+              "host": "${MIRAGE_INTEG_SSH_HOST}",
+              "port": 2222,
+              "username": "${MIRAGE_INTEG_SSH_USERNAME}",
+              "identity_file": "${MIRAGE_INTEG_SSH_KEY}"
+            }
+          },
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "limits": {
+              "sleep": {
+                "timeout_seconds": 1
+              }
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "sleep 5",
+          "expect": {
+            "exit": 124
+          }
+        }
+      ]
+    },
+    {
+      "id": "captured_only",
+      "world": {
+        "runtimes": [
+          {
+            "name": "ssh",
+            "captures": [
+              "uname"
+            ],
+            "config": {
+              "host": "${MIRAGE_INTEG_SSH_HOST}",
+              "port": 2222,
+              "username": "${MIRAGE_INTEG_SSH_USERNAME}",
+              "identity_file": "${MIRAGE_INTEG_SSH_KEY}"
+            }
+          },
+          "vfs"
+        ]
+      },
+      "steps": [
+        {
+          "command": "uname",
+          "expect": {
+            "exit": 0,
+            "stdout": "Linux\n"
+          }
+        },
+        {
+          "command": "echo local-vfs",
+          "expect": {
+            "exit": 0,
+            "stdout": "local-vfs\n"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/python/mirage/runtime/sandbox/ssh/__init__.py
+++ b/python/mirage/runtime/sandbox/ssh/__init__.py
@@ -1,0 +1,18 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.runtime.sandbox.ssh.config import SSHRuntimeConfig
+from mirage.runtime.sandbox.ssh.runtime import SSHRuntime
+
+__all__ = ["SSHRuntime", "SSHRuntimeConfig"]

--- a/python/mirage/runtime/sandbox/ssh/config.py
+++ b/python/mirage/runtime/sandbox/ssh/config.py
@@ -1,0 +1,46 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+
+from mirage.runtime.sandbox.config import SandboxConfig
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SSHRuntimeConfig(SandboxConfig):
+    """How to reach the machine that runs captured lines.
+
+    The same knobs as the ssh resource's config minus ``root`` (a
+    runtime has no mount root) and password auth (an exec surface
+    holds keys, never a password). ``host`` doubles as the address
+    unless ``hostname`` overrides it, mirroring OpenSSH's Host /
+    HostName split.
+
+    Args:
+        host (str): the machine to reach; also the address unless
+            hostname is set.
+        hostname (str | None): the real address when host is a label.
+        port (int | None): sshd port; None means 22.
+        username (str | None): login user; None lets the client pick.
+        identity_file (str | None): private key path (``~`` expands);
+            None uses the running agent and default keys.
+        timeout (int): connect timeout in seconds.
+    """
+
+    host: str
+    hostname: str | None = None
+    port: int | None = None
+    username: str | None = None
+    identity_file: str | None = None
+    timeout: int = 30

--- a/python/mirage/runtime/sandbox/ssh/constants.py
+++ b/python/mirage/runtime/sandbox/ssh/constants.py
@@ -1,0 +1,40 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.utils.quote import single_quote
+
+ASYNCSSH_HINT = ("the ssh runtime needs asyncssh; install with: "
+                 "pip install mirage-ai[ssh]")
+
+
+def wrap_line(line: str, env: dict[str, str], cwd: str) -> str:
+    """The line dressed to run on the remote host: cwd, env, then sh.
+
+    SSH exec has no docker-style ``-w``/``-e`` (the protocol's env
+    channel is AcceptEnv-gated server-side, so it silently drops
+    names), so the working directory and the merged environment ride
+    the command itself: ``cd 'cwd' && env 'K=V' ... sh -c 'line'``.
+    Every piece is sh_single_quoted, so the remote login shell reads
+    each as one word whatever it holds; the machine only needs a
+    POSIX-compatible shell.
+
+    Args:
+        line (str): the raw shell line.
+        env (dict[str, str]): the merged environment.
+        cwd (str): the working directory, passed through verbatim.
+    """
+    parts = ["cd", single_quote(cwd), "&&", "env"]
+    parts += [single_quote(f"{key}={value}") for key, value in env.items()]
+    parts += ["sh", "-c", single_quote(line)]
+    return " ".join(parts)

--- a/python/mirage/runtime/sandbox/ssh/runtime.py
+++ b/python/mirage/runtime/sandbox/ssh/runtime.py
@@ -1,0 +1,94 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pathlib import Path
+from typing import Any
+
+from mirage.runtime.sandbox.base import RemoteSandbox
+from mirage.runtime.sandbox.ssh import sdk
+from mirage.runtime.sandbox.ssh.config import SSHRuntimeConfig
+from mirage.runtime.sandbox.ssh.constants import ASYNCSSH_HINT, wrap_line
+from mirage.runtime.types import RunResult
+
+
+class SSHRuntime(RemoteSandbox):
+    """A machine reached over SSH as a whole-line runtime.
+
+    You run the machine and its sshd yourself; mirage only connects
+    (keys or agent, never a password) and execs lines. One connection
+    opens on the first captured line and is reused; each line is one
+    exec channel with real byte stdin and separated stderr, the merged
+    environment and session cwd dressed onto the command by wrap_line,
+    because SSH exec has no docker-style ``-w``/``-e``.
+
+    This is the one provider whose machine usually IS the fileserver:
+    mount the same host's directory over the ssh resource at a prefix
+    equal to its remote absolute path, and captured lines read and
+    write those files natively, with no FUSE and no mirage installed
+    remotely. Host keys are not verified (the TypeScript twin's ssh2
+    transport never does), so treat the network path as trusted.
+
+    Args:
+        options (Any): the RemoteSandbox constructor fields.
+    """
+
+    name = "ssh"
+    config_cls = SSHRuntimeConfig
+    config: SSHRuntimeConfig
+    _conn: Any = None
+
+    def _connect_kwargs(self) -> dict[str, Any]:
+        config = self.config
+        kwargs: dict[str, Any] = {"host": config.hostname or config.host}
+        if config.port:
+            kwargs["port"] = config.port
+        if config.username:
+            kwargs["username"] = config.username
+        if config.identity_file:
+            kwargs["client_keys"] = [
+                str(Path(config.identity_file).expanduser())
+            ]
+        kwargs["known_hosts"] = None
+        kwargs["login_timeout"] = config.timeout
+        return kwargs
+
+    async def connect(self) -> None:
+        if sdk.connect is None:
+            raise ImportError(ASYNCSSH_HINT)
+        self._conn = await sdk.connect(**self._connect_kwargs())
+
+    async def exec_line(self, line: str, stdin: bytes | None,
+                        env: dict[str, str], cwd: str) -> RunResult:
+        stdout, stderr, code = await self._ssh(wrap_line(line, env, cwd),
+                                               stdin)
+        return RunResult(stdout=stdout, stderr=stderr, exit_code=code)
+
+    async def _ssh(self, command: str,
+                   stdin: bytes | None) -> tuple[bytes, bytes, int]:
+        """One exec channel on the connection; the seam tests override."""
+        # No pipe still sends empty input, so stdin closes and a reader
+        # sees EOF immediately (docker's DEVNULL, without a second knob).
+        result = await self._conn.run(
+            command,
+            input=stdin if stdin is not None else b"",
+            encoding=None,
+            check=False)
+        code = result.returncode if result.returncode is not None else 1
+        return result.stdout, result.stderr, code
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            await self._conn.wait_closed()
+            self._conn = None

--- a/python/mirage/runtime/sandbox/ssh/sdk.py
+++ b/python/mirage/runtime/sandbox/ssh/sdk.py
@@ -1,0 +1,23 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Any
+
+connect: Any
+try:
+    from asyncssh import connect as _connect
+except ImportError:
+    connect = None
+else:
+    connect = _connect

--- a/python/mirage/runtime/table.py
+++ b/python/mirage/runtime/table.py
@@ -87,6 +87,7 @@ SANDBOX_MODULES: dict[str, str] = {
     "docker": "mirage.runtime.sandbox.docker:DockerRuntime",
     "e2b": "mirage.runtime.sandbox.e2b:E2BRuntime",
     "smolvm": "mirage.runtime.sandbox.smolvm:SmolvmRuntime",
+    "ssh": "mirage.runtime.sandbox.ssh:SSHRuntime",
 }
 
 # The python engine a default world registers, named rather than left

--- a/python/tests/runtime/sandbox/ssh/test_constants.py
+++ b/python/tests/runtime/sandbox/ssh/test_constants.py
@@ -1,0 +1,30 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.runtime.sandbox.ssh.constants import wrap_line
+
+
+def test_wrap_line_dresses_cwd_env_and_line():
+    assert wrap_line("echo hi", {"A": "1"},
+                     "/w") == "cd '/w' && env 'A=1' sh -c 'echo hi'"
+
+
+def test_wrap_line_quotes_hostile_values():
+    assert wrap_line(
+        "echo 'hi'", {"M": "two words"},
+        "/a b") == ("cd '/a b' && env 'M=two words' sh -c 'echo '\\''hi'\\'''")
+
+
+def test_wrap_line_with_no_env_still_runs_env():
+    assert wrap_line("pwd", {}, "/") == "cd '/' && env sh -c 'pwd'"

--- a/python/tests/runtime/sandbox/ssh/test_runtime.py
+++ b/python/tests/runtime/sandbox/ssh/test_runtime.py
@@ -1,0 +1,117 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+
+from mirage.runtime.sandbox.ssh import SSHRuntime, sdk
+
+
+class FakeSSHRuntime(SSHRuntime):
+
+    def __init__(self, **options):
+        super().__init__(**options)
+        self.calls: list[tuple[str, bytes | None]] = []
+
+    async def _ssh(self, command, stdin):
+        self.calls.append((command, stdin))
+        return f"out:{command}".encode(), b"warn", 0
+
+
+class FakeConn:
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+def test_host_is_required():
+    with pytest.raises(TypeError, match="host"):
+        SSHRuntime(config={})
+
+
+def test_connect_kwargs_map_the_config():
+    runtime = SSHRuntime(
+        config={
+            "host": "box",
+            "hostname": "10.0.0.5",
+            "port": 2222,
+            "username": "deploy",
+            "identity_file": "~/.ssh/id_ed25519",
+            "timeout": 5,
+        })
+    kwargs = runtime._connect_kwargs()
+    assert kwargs["host"] == "10.0.0.5"
+    assert kwargs["port"] == 2222
+    assert kwargs["username"] == "deploy"
+    assert kwargs["client_keys"] == [
+        str(Path("~/.ssh/id_ed25519").expanduser())
+    ]
+    assert kwargs["known_hosts"] is None
+    assert kwargs["login_timeout"] == 5
+
+
+def test_connect_kwargs_defaults_stay_out():
+    kwargs = SSHRuntime(config={"host": "box"})._connect_kwargs()
+    assert kwargs == {"host": "box", "known_hosts": None, "login_timeout": 30}
+
+
+@pytest.mark.asyncio
+async def test_connect_requires_asyncssh(monkeypatch):
+    monkeypatch.setattr(sdk, "connect", None)
+    runtime = SSHRuntime(config={"host": "box"})
+    with pytest.raises(ImportError, match=r"mirage-ai\[ssh\]"):
+        await runtime.connect()
+
+
+@pytest.mark.asyncio
+async def test_connect_opens_one_reused_connection(monkeypatch):
+    seen: dict = {}
+    conn = FakeConn()
+
+    async def fake_connect(**kwargs):
+        seen.update(kwargs)
+        return conn
+
+    monkeypatch.setattr(sdk, "connect", fake_connect)
+    runtime = SSHRuntime(config={"host": "box"})
+    await runtime.connect()
+    assert seen["host"] == "box"
+    assert runtime._conn is conn
+
+
+@pytest.mark.asyncio
+async def test_exec_line_dresses_the_line_and_threads_stdin():
+    runtime = FakeSSHRuntime(config={"host": "box"})
+    result = await runtime.exec_line("wc -l", b"a\nb\n", {"E": "1"}, "/w")
+    assert result.exit_code == 0
+    assert result.stdout == b"out:cd '/w' && env 'E=1' sh -c 'wc -l'"
+    assert result.stderr == b"warn"
+    assert runtime.calls[0][1] == b"a\nb\n"
+
+
+@pytest.mark.asyncio
+async def test_close_ends_the_connection():
+    runtime = SSHRuntime(config={"host": "box"})
+    conn = FakeConn()
+    runtime._conn = conn
+    await runtime.close()
+    assert conn.closed
+    assert runtime._conn is None

--- a/spec/layout_exceptions.json
+++ b/spec/layout_exceptions.json
@@ -1,47 +1,52 @@
 {
-  "baseline": 259,
-  "baseline_reason": "Every divergence below the excused ones predates the gate and each needs its own decision, so --strict fails on a rise rather than demanding zero. Lower this number whenever a divergence is closed; the gate fails on a drop too, so an improvement cannot be silently spent. Items 31-37 of the cleanup plan are scoped from this report. The unit is one module, never one directory: a one-sided directory counts once per module inside it, so it cannot absorb new modules without moving the number. An excused directory is the deliberate exception -- it excuses its whole subtree, because the excuse is that there is no counterpart to mirror, which makes growth inside it expected rather than drift.",
-  "directories": {
-    "python_only": {
-      "runtime/wasm": "The wasmtime WASI host. npm ships quickjs-emscripten and pyodide with their own hosts and python has no equivalent, so there is nothing to mirror. CLAUDE.md says do not port it.",
-      "runtime/python/sandlock": "Confines the host python3 with Landlock and seccomp, both Linux kernel features with no browser analogue and no node binding to mirror (sandlock ships python and go SDKs over its C ABI, and no npm package). The TypeScript python tier reaches the host through runtime/python/local.ts, which could wrap the same CLI; mirror this directory there if that lands.",
-      "bridge": "sync.py and thread.py exist to run an event loop on a worker thread for the FUSE callbacks, which python needs because its FUSE loop is threaded and node's is not.",
-      "agents/agno": "Ecosystem split: agno is a python-only framework.",
-      "agents/camel": "Ecosystem split: camel is a python-only framework, and pyproject declares it conflicting with the openai extra.",
-      "agents/openai_agents": "Ecosystem split: the openai-agents SDK is python-only.",
-      "agents/openhands": "Ecosystem split: openhands is a python-only framework.",
-      "agents/pydantic_ai": "Ecosystem split: pydantic-ai is a python-only framework.",
-      "commands/builtin/hf_buckets": "hf_buckets is python's name for the backend typescript calls hf; the alias is already declared in spec/parity_exceptions.json under command_io_aliases.",
-      "core/hf_buckets": "Same hf_buckets/hf alias as above.",
-      "core/hf_buckets/du": "Same hf_buckets/hf alias as above."
-    },
-    "typescript_only": {
-      "resource/opfs": "OPFS is the one typescript-only backend, declared in spec/parity_exceptions.json. There is no browser filesystem API for python to mirror.",
-      "core/opfs": "OPFS backend core, browser-only.",
-      "core/opfs/du": "OPFS backend core, browser-only.",
-      "ops/opfs": "OPFS op table, browser-only.",
-      "commands/builtin/opfs": "OPFS command wrappers, browser-only.",
-      "generated": "browser/src/generated/wasm.ts is a build artifact embedded for the browser bundle, not a source module.",
-      "workspace/fixtures": "Test-only helpers: unreachable from the barrel, absent from dist (tsup entry is src/index.ts and files is [\"dist\"]), and imported only by tests.",
-      "cli/bin": "An npm package declares its executable as a real file under bin/; python declares console_scripts in pyproject.toml instead.",
-      "server/bin": "Same npm bin convention as cli/bin.",
-      "commands/builtin/hf": "typescript's name for python's hf_buckets; see the alias in spec/parity_exceptions.json.",
-      "core/hf": "Same hf/hf_buckets alias as above.",
-      "core/hf/du": "Same hf/hf_buckets alias as above."
-    }
+ "baseline": 259,
+ "baseline_reason": "Every divergence below the excused ones predates the gate and each needs its own decision, so --strict fails on a rise rather than demanding zero. Lower this number whenever a divergence is closed; the gate fails on a drop too, so an improvement cannot be silently spent. Items 31-37 of the cleanup plan are scoped from this report. The unit is one module, never one directory: a one-sided directory counts once per module inside it, so it cannot absorb new modules without moving the number. An excused directory is the deliberate exception -- it excuses its whole subtree, because the excuse is that there is no counterpart to mirror, which makes growth inside it expected rather than drift.",
+ "directories": {
+  "python_only": {
+   "runtime/wasm": "The wasmtime WASI host. npm ships quickjs-emscripten and pyodide with their own hosts and python has no equivalent, so there is nothing to mirror. CLAUDE.md says do not port it.",
+   "runtime/python/sandlock": "Confines the host python3 with Landlock and seccomp, both Linux kernel features with no browser analogue and no node binding to mirror (sandlock ships python and go SDKs over its C ABI, and no npm package). The TypeScript python tier reaches the host through runtime/python/local.ts, which could wrap the same CLI; mirror this directory there if that lands.",
+   "bridge": "sync.py and thread.py exist to run an event loop on a worker thread for the FUSE callbacks, which python needs because its FUSE loop is threaded and node's is not.",
+   "agents/agno": "Ecosystem split: agno is a python-only framework.",
+   "agents/camel": "Ecosystem split: camel is a python-only framework, and pyproject declares it conflicting with the openai extra.",
+   "agents/openai_agents": "Ecosystem split: the openai-agents SDK is python-only.",
+   "agents/openhands": "Ecosystem split: openhands is a python-only framework.",
+   "agents/pydantic_ai": "Ecosystem split: pydantic-ai is a python-only framework.",
+   "commands/builtin/hf_buckets": "hf_buckets is python's name for the backend typescript calls hf; the alias is already declared in spec/parity_exceptions.json under command_io_aliases.",
+   "core/hf_buckets": "Same hf_buckets/hf alias as above.",
+   "core/hf_buckets/du": "Same hf_buckets/hf alias as above."
   },
-  "modules": {
-    "ops": {
-      "python_only": {
-        "file": "MirageFile: a sync file object over the Ops facade for embedding python code (with open-style usage). An npm consumer holds promises, not file objects, so there is nothing to mirror.",
-        "open": "The open() constructor for MirageFile; same embedding convenience as ops/file.",
-        "os_patch": "Patches the host interpreter's builtins.open/os functions onto a workspace, a CPython-only trick with no npm analogue."
-      }
-    },
-    "core/object_store": {
-      "typescript_only": {
-        "fakes": "Test-only in-memory driver shared by the kit's colocated *.test.ts files; python's twin is tests/core/object_store/conftest.py, which lives outside mirage/ and is not scanned."
-      }
-    }
+  "typescript_only": {
+   "resource/opfs": "OPFS is the one typescript-only backend, declared in spec/parity_exceptions.json. There is no browser filesystem API for python to mirror.",
+   "core/opfs": "OPFS backend core, browser-only.",
+   "core/opfs/du": "OPFS backend core, browser-only.",
+   "ops/opfs": "OPFS op table, browser-only.",
+   "commands/builtin/opfs": "OPFS command wrappers, browser-only.",
+   "generated": "browser/src/generated/wasm.ts is a build artifact embedded for the browser bundle, not a source module.",
+   "workspace/fixtures": "Test-only helpers: unreachable from the barrel, absent from dist (tsup entry is src/index.ts and files is [\"dist\"]), and imported only by tests.",
+   "cli/bin": "An npm package declares its executable as a real file under bin/; python declares console_scripts in pyproject.toml instead.",
+   "server/bin": "Same npm bin convention as cli/bin.",
+   "commands/builtin/hf": "typescript's name for python's hf_buckets; see the alias in spec/parity_exceptions.json.",
+   "core/hf": "Same hf/hf_buckets alias as above.",
+   "core/hf/du": "Same hf/hf_buckets alias as above."
   }
+ },
+ "modules": {
+  "ops": {
+   "python_only": {
+    "file": "MirageFile: a sync file object over the Ops facade for embedding python code (with open-style usage). An npm consumer holds promises, not file objects, so there is nothing to mirror.",
+    "open": "The open() constructor for MirageFile; same embedding convenience as ops/file.",
+    "os_patch": "Patches the host interpreter's builtins.open/os functions onto a workspace, a CPython-only trick with no npm analogue."
+   }
+  },
+  "core/object_store": {
+   "typescript_only": {
+    "fakes": "Test-only in-memory driver shared by the kit's colocated *.test.ts files; python's twin is tests/core/object_store/conftest.py, which lives outside mirage/ and is not scanned."
+   }
+  },
+  "runtime/sandbox/ssh": {
+   "python_only": {
+    "sdk": "The asyncssh import shim (None when the ssh extra is absent), the same shape daytona and e2b carry in their baselined sdk modules; TypeScript loads ssh2 through loadOptionalPeer inside runtime.ts, so there is no ts twin."
+   }
+  }
+ }
 }

--- a/typescript/packages/node/src/index.ts
+++ b/typescript/packages/node/src/index.ts
@@ -405,6 +405,8 @@ export { DockerRuntime } from './runtime/sandbox/docker/runtime.ts'
 export { DOCKER_CONFIG_KEYS, type DockerConfig } from './runtime/sandbox/docker/config.ts'
 export { SmolvmRuntime } from './runtime/sandbox/smolvm/runtime.ts'
 export { SMOLVM_CONFIG_KEYS, type SmolvmConfig } from './runtime/sandbox/smolvm/config.ts'
+export { SSHRuntime } from './runtime/sandbox/ssh/runtime.ts'
+export { SSH_RUNTIME_CONFIG_KEYS, type SSHRuntimeConfig } from './runtime/sandbox/ssh/config.ts'
 export {
   buildResource,
   knownResources,

--- a/typescript/packages/node/src/runtime/sandbox/ssh/config.ts
+++ b/typescript/packages/node/src/runtime/sandbox/ssh/config.ts
@@ -1,0 +1,48 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { SandboxConfig } from '@struktoai/mirage-core/runtime/sandbox/config'
+
+/**
+ * How to reach the machine that runs captured lines.
+ *
+ * The same knobs as the ssh resource's config minus `root` (a runtime
+ * has no mount root) and password auth (an exec surface holds keys,
+ * never a password). `host` doubles as the address unless `hostname`
+ * overrides it, mirroring OpenSSH's Host / HostName split.
+ */
+export interface SSHRuntimeConfig extends SandboxConfig {
+  /** The machine to reach; also the address unless hostname is set. */
+  host: string
+  /** The real address when host is a label. */
+  hostname?: string
+  /** sshd port; absent means 22. */
+  port?: number
+  /** Login user; absent lets the client pick. */
+  username?: string
+  /** Private key path (`~` expands). */
+  identityFile?: string
+  /** Connect timeout in seconds; absent means 30. */
+  timeout?: number
+}
+
+export const SSH_RUNTIME_CONFIG_KEYS: readonly string[] = [
+  'env',
+  'host',
+  'hostname',
+  'port',
+  'username',
+  'identityFile',
+  'timeout',
+]

--- a/typescript/packages/node/src/runtime/sandbox/ssh/constants.test.ts
+++ b/typescript/packages/node/src/runtime/sandbox/ssh/constants.test.ts
@@ -1,0 +1,32 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { wrapLine } from './constants.ts'
+
+describe('wrapLine', () => {
+  it('dresses cwd, env, and the line', () => {
+    expect(wrapLine('echo hi', { A: '1' }, '/w')).toBe("cd '/w' && env 'A=1' sh -c 'echo hi'")
+  })
+
+  it('quotes hostile values', () => {
+    expect(wrapLine("echo 'hi'", { M: 'two words' }, '/a b')).toBe(
+      "cd '/a b' && env 'M=two words' sh -c 'echo '\\''hi'\\'''",
+    )
+  })
+
+  it('still runs env with no assignments', () => {
+    expect(wrapLine('pwd', {}, '/')).toBe("cd '/' && env sh -c 'pwd'")
+  })
+})

--- a/typescript/packages/node/src/runtime/sandbox/ssh/constants.ts
+++ b/typescript/packages/node/src/runtime/sandbox/ssh/constants.ts
@@ -1,0 +1,32 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { singleQuote } from '@struktoai/mirage-core/utils/quote'
+
+/**
+ * The line dressed to run on the remote host: cwd, env, then sh.
+ *
+ * SSH exec has no docker-style `-w`/`-e` (the protocol's env channel
+ * is AcceptEnv-gated server-side, so it silently drops names), so the
+ * working directory and the merged environment ride the command
+ * itself: `cd 'cwd' && env 'K=V' ... sh -c 'line'`. Every piece is
+ * sh_single_quoted, so the remote login shell reads each as one word
+ * whatever it holds; the machine only needs a POSIX-compatible shell.
+ */
+export function wrapLine(line: string, env: Record<string, string>, cwd: string): string {
+  const parts = ['cd', singleQuote(cwd), '&&', 'env']
+  for (const [key, value] of Object.entries(env)) parts.push(singleQuote(`${key}=${value}`))
+  parts.push('sh', '-c', singleQuote(line))
+  return parts.join(' ')
+}

--- a/typescript/packages/node/src/runtime/sandbox/ssh/runtime.test.ts
+++ b/typescript/packages/node/src/runtime/sandbox/ssh/runtime.test.ts
@@ -1,0 +1,133 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildRuntime } from '@struktoai/mirage-core/runtime/table'
+import { describe, expect, it } from 'vitest'
+import { SSHRuntime, type Ssh2Sdk } from './runtime.ts'
+
+const DEC = new TextDecoder()
+const ENC = new TextEncoder()
+
+interface SshResult {
+  stdout: Uint8Array
+  stderr: Uint8Array
+  code: number
+}
+
+class FakeSSHRuntime extends SSHRuntime {
+  readonly calls: [string, Uint8Array | null][] = []
+
+  override connect(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  protected override ssh(command: string, stdin: Uint8Array | null): Promise<SshResult> {
+    this.calls.push([command, stdin])
+    return Promise.resolve({
+      stdout: ENC.encode(`out:${command}`),
+      stderr: ENC.encode('warn'),
+      code: 0,
+    })
+  }
+}
+
+const made: FakeClient[] = []
+
+class FakeClient {
+  opts: Record<string, unknown> | null = null
+  ended = false
+  private readonly handlers = new Map<string, (...args: unknown[]) => void>()
+
+  constructor() {
+    made.push(this)
+  }
+
+  on(event: string, fn: (...args: unknown[]) => void): this {
+    this.handlers.set(event, fn)
+    return this
+  }
+
+  connect(opts: Record<string, unknown>): void {
+    this.opts = opts
+    queueMicrotask(() => {
+      this.handlers.get('ready')?.()
+    })
+  }
+
+  end(): void {
+    this.ended = true
+  }
+}
+
+class SdkFakeRuntime extends SSHRuntime {
+  protected override loadSdk(): Promise<Ssh2Sdk> {
+    return Promise.resolve({ Client: FakeClient } as unknown as Ssh2Sdk)
+  }
+}
+
+describe('SSHRuntime', () => {
+  it('host is required', () => {
+    expect(() => new SSHRuntime({ config: {} })).toThrow('host')
+  })
+
+  it('dresses the line with cwd and env and threads stdin', async () => {
+    const runtime = new FakeSSHRuntime({ config: { host: 'box' } })
+    const result = await runtime.execLine('wc -l', ENC.encode('a\nb\n'), { E: '1' }, '/w')
+    expect(result.exitCode).toBe(0)
+    expect(DEC.decode(result.stdout)).toBe("out:cd '/w' && env 'E=1' sh -c 'wc -l'")
+    expect(DEC.decode(result.stderr ?? new Uint8Array())).toBe('warn')
+    const [, stdin] = runtime.calls[0] ?? ['', null]
+    expect(DEC.decode(stdin ?? new Uint8Array())).toBe('a\nb\n')
+  })
+
+  it('connect maps the config onto ssh2 connect options', async () => {
+    const runtime = new SdkFakeRuntime({
+      config: { host: 'box', hostname: '10.0.0.5', port: 2222, username: 'deploy', timeout: 5 },
+    })
+    await runtime.connect()
+    expect(made[made.length - 1]?.opts).toEqual({
+      host: '10.0.0.5',
+      port: 2222,
+      username: 'deploy',
+      readyTimeout: 5000,
+    })
+  })
+
+  it('connect reads the identity file into privateKey', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mirage-ssh-key-'))
+    const keyPath = join(dir, 'id_ed25519')
+    await writeFile(keyPath, 'fake-key')
+    try {
+      const runtime = new SdkFakeRuntime({ config: { host: 'box', identityFile: keyPath } })
+      await runtime.connect()
+      expect(made[made.length - 1]?.opts).toEqual({
+        host: 'box',
+        port: 22,
+        readyTimeout: 30000,
+        privateKey: Buffer.from('fake-key'),
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("registers under the config name 'ssh'", () => {
+    const runtime = buildRuntime('ssh', { config: { host: 'box' } })
+    expect(runtime).toBeInstanceOf(SSHRuntime)
+    expect(runtime.captures).toEqual(['*'])
+  })
+})

--- a/typescript/packages/node/src/runtime/sandbox/ssh/runtime.test.ts
+++ b/typescript/packages/node/src/runtime/sandbox/ssh/runtime.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { tmpdir, userInfo } from 'node:os'
 import { join } from 'node:path'
 import { buildRuntime } from '@struktoai/mirage-core/runtime/table'
 import { describe, expect, it } from 'vitest'
@@ -79,6 +79,18 @@ class SdkFakeRuntime extends SSHRuntime {
   }
 }
 
+async function withAgentSock<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+  const prior = process.env.SSH_AUTH_SOCK
+  if (value === undefined) delete process.env.SSH_AUTH_SOCK
+  else process.env.SSH_AUTH_SOCK = value
+  try {
+    return await fn()
+  } finally {
+    if (prior === undefined) delete process.env.SSH_AUTH_SOCK
+    else process.env.SSH_AUTH_SOCK = prior
+  }
+}
+
 describe('SSHRuntime', () => {
   it('host is required', () => {
     expect(() => new SSHRuntime({ config: {} })).toThrow('host')
@@ -98,7 +110,7 @@ describe('SSHRuntime', () => {
     const runtime = new SdkFakeRuntime({
       config: { host: 'box', hostname: '10.0.0.5', port: 2222, username: 'deploy', timeout: 5 },
     })
-    await runtime.connect()
+    await withAgentSock(undefined, () => runtime.connect())
     expect(made[made.length - 1]?.opts).toEqual({
       host: '10.0.0.5',
       port: 2222,
@@ -107,16 +119,29 @@ describe('SSHRuntime', () => {
     })
   })
 
-  it('connect reads the identity file into privateKey', async () => {
+  it('username defaults to the local user and the agent rides when no key is named', async () => {
+    const runtime = new SdkFakeRuntime({ config: { host: 'box' } })
+    await withAgentSock('/tmp/agent.sock', () => runtime.connect())
+    expect(made[made.length - 1]?.opts).toEqual({
+      host: 'box',
+      port: 22,
+      username: userInfo().username,
+      readyTimeout: 30000,
+      agent: '/tmp/agent.sock',
+    })
+  })
+
+  it('connect reads the identity file into privateKey and keeps the agent out', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'mirage-ssh-key-'))
     const keyPath = join(dir, 'id_ed25519')
     await writeFile(keyPath, 'fake-key')
     try {
       const runtime = new SdkFakeRuntime({ config: { host: 'box', identityFile: keyPath } })
-      await runtime.connect()
+      await withAgentSock('/tmp/agent.sock', () => runtime.connect())
       expect(made[made.length - 1]?.opts).toEqual({
         host: 'box',
         port: 22,
+        username: userInfo().username,
         readyTimeout: 30000,
         privateKey: Buffer.from('fake-key'),
       })

--- a/typescript/packages/node/src/runtime/sandbox/ssh/runtime.ts
+++ b/typescript/packages/node/src/runtime/sandbox/ssh/runtime.ts
@@ -1,0 +1,156 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { resolve } from 'node:path'
+import { RemoteSandbox } from '@struktoai/mirage-core/runtime/sandbox/base'
+import { registerRuntime } from '@struktoai/mirage-core/runtime/table'
+import type { RunResult, RuntimeOptions } from '@struktoai/mirage-core/runtime/types'
+import { loadOptionalPeer } from '@struktoai/mirage-core/utils/optional_peer'
+import { SSH_RUNTIME_CONFIG_KEYS, type SSHRuntimeConfig } from './config.ts'
+import { wrapLine } from './constants.ts'
+import type { Client, ClientChannel, ConnectConfig } from 'ssh2'
+import type * as Ssh2Mod from 'ssh2'
+
+export type Ssh2Sdk = typeof Ssh2Mod
+
+interface SshResult {
+  stdout: Uint8Array
+  stderr: Uint8Array
+  code: number
+}
+
+function expandHome(p: string): string {
+  if (p === '~') return homedir()
+  if (p.startsWith('~/')) return resolve(homedir(), p.slice(2))
+  return p
+}
+
+/**
+ * A machine reached over SSH as a whole-line runtime.
+ *
+ * You run the machine and its sshd yourself; mirage only connects
+ * (keys, never a password) and execs lines. One connection opens on
+ * the first captured line and is reused; each line is one exec
+ * channel with real byte stdin and separated stderr, the merged
+ * environment and session cwd dressed onto the command by wrapLine,
+ * because SSH exec has no docker-style `-w`/`-e`.
+ *
+ * This is the one provider whose machine usually IS the fileserver:
+ * mount the same host's directory over the ssh resource at a prefix
+ * equal to its remote absolute path, and captured lines read and
+ * write those files natively, with no FUSE and no mirage installed
+ * remotely. Host keys are not verified (ssh2 never does), so treat
+ * the network path as trusted.
+ */
+export class SSHRuntime extends RemoteSandbox<SSHRuntimeConfig> {
+  readonly name = 'ssh'
+  private client: Client | null = null
+
+  constructor(options: RuntimeOptions<SSHRuntimeConfig> | Record<string, unknown> = {}) {
+    super(options, SSH_RUNTIME_CONFIG_KEYS)
+    if (!this.config.host) {
+      throw new Error('ssh config needs host: the machine that runs captured lines')
+    }
+  }
+
+  // The SDK loader as a seam: tests substitute a fake module here.
+  protected loadSdk(): Promise<Ssh2Sdk> {
+    return loadOptionalPeer(() => import('ssh2'), {
+      feature: "the 'ssh' runtime",
+      packageName: 'ssh2',
+    })
+  }
+
+  private async connectOpts(): Promise<ConnectConfig> {
+    const opts: ConnectConfig = {
+      host: this.config.hostname ?? this.config.host,
+      port: this.config.port ?? 22,
+      readyTimeout: (this.config.timeout ?? 30) * 1000,
+    }
+    if (this.config.username !== undefined) opts.username = this.config.username
+    if (this.config.identityFile !== undefined) {
+      opts.privateKey = await readFile(expandHome(this.config.identityFile))
+    }
+    return opts
+  }
+
+  async connect(): Promise<void> {
+    const sdk = await this.loadSdk()
+    const client = new sdk.Client()
+    const opts = await this.connectOpts()
+    await new Promise<void>((resolveFn, rejectFn) => {
+      client.on('ready', () => {
+        resolveFn()
+      })
+      client.on('error', rejectFn)
+      client.connect(opts)
+    })
+    this.client = client
+  }
+
+  async execLine(
+    line: string,
+    stdin: Uint8Array | null,
+    env: Record<string, string>,
+    cwd: string,
+  ): Promise<RunResult> {
+    const result = await this.ssh(wrapLine(line, env, cwd), stdin)
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: result.code }
+  }
+
+  // One exec channel on the shared connection; the seam tests override.
+  protected ssh(command: string, stdin: Uint8Array | null): Promise<SshResult> {
+    const client = this.client
+    if (client === null) return Promise.reject(new Error('ssh runtime not connected'))
+    return new Promise((resolveFn, rejectFn) => {
+      client.exec(command, (err: Error | undefined, stream: ClientChannel) => {
+        if (err !== undefined) {
+          rejectFn(err)
+          return
+        }
+        const out: Buffer[] = []
+        const errs: Buffer[] = []
+        let code: number | null = null
+        stream.on('data', (chunk: Buffer) => out.push(chunk))
+        stream.stderr.on('data', (chunk: Buffer) => errs.push(chunk))
+        stream.on('exit', (c: number | null) => {
+          code = c
+        })
+        stream.on('close', () => {
+          resolveFn({
+            stdout: new Uint8Array(Buffer.concat(out)),
+            stderr: new Uint8Array(Buffer.concat(errs)),
+            code: code ?? 1,
+          })
+        })
+        stream.on('error', rejectFn)
+        // No pipe still closes stdin, so a reader sees EOF immediately.
+        if (stdin !== null) stream.write(stdin)
+        stream.end()
+      })
+    })
+  }
+
+  override close(): Promise<void> {
+    if (this.client !== null) {
+      this.client.end()
+      this.client = null
+    }
+    return Promise.resolve()
+  }
+}
+
+registerRuntime('ssh', SSHRuntime)

--- a/typescript/packages/node/src/runtime/sandbox/ssh/runtime.ts
+++ b/typescript/packages/node/src/runtime/sandbox/ssh/runtime.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { readFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
+import { homedir, userInfo } from 'node:os'
 import { resolve } from 'node:path'
 import { RemoteSandbox } from '@struktoai/mirage-core/runtime/sandbox/base'
 import { registerRuntime } from '@struktoai/mirage-core/runtime/table'
@@ -42,7 +42,7 @@ function expandHome(p: string): string {
  * A machine reached over SSH as a whole-line runtime.
  *
  * You run the machine and its sshd yourself; mirage only connects
- * (keys, never a password) and execs lines. One connection opens on
+ * (keys or an agent, never a password) and execs lines. One connection opens on
  * the first captured line and is reused; each line is one exec
  * channel with real byte stdin and separated stderr, the merged
  * environment and session cwd dressed onto the command by wrapLine,
@@ -78,11 +78,15 @@ export class SSHRuntime extends RemoteSandbox<SSHRuntimeConfig> {
     const opts: ConnectConfig = {
       host: this.config.hostname ?? this.config.host,
       port: this.config.port ?? 22,
+      username: this.config.username ?? userInfo().username,
       readyTimeout: (this.config.timeout ?? 30) * 1000,
     }
-    if (this.config.username !== undefined) opts.username = this.config.username
     if (this.config.identityFile !== undefined) {
       opts.privateKey = await readFile(expandHome(this.config.identityFile))
+    } else if (process.env.SSH_AUTH_SOCK) {
+      // The asyncssh twin's rule: a named key is used alone; with
+      // none, the ssh-agent authenticates.
+      opts.agent = process.env.SSH_AUTH_SOCK
     }
     return opts
   }


### PR DESCRIPTION
Adds `SSHRuntime` as the 5th sandbox provider (python + typescript): captured lines exec on any machine reachable over ssh, one reused connection, native byte stdin, separated stderr, and cwd/env dressed onto the command as `cd 'cwd' && env 'K=V' ... sh -c 'line'` (the SSH env channel is AcceptEnv-gated, so it never rides the protocol).

- The no-FUSE story: mount the same box over the ssh resource at a prefix equal to the remote absolute path, and captured lines open those files natively with nothing installed remotely. Documented as "Skip the FUSE" on the new sandbox/ssh docs pages; overview tables updated to five providers.
- `integ/runtime/ssh.json` (7 cases per host) runs against a real sshd the integ-runtime job now provisions; verified locally 7/7 on both hosts. The provisioning chowns authorized_keys because `docker cp` keeps the host uid and sshd's StrictModes refuses the file otherwise.
- Config mirrors the ssh resource minus `root`, named `SSHRuntimeConfig` (the resource already exports `SSHConfig`), keys only. `known_hosts` is omitted on both sides since ssh2 cannot verify host keys; the docs flag that the network path must be trusted.
- The asyncssh import shim (`sdk.py`) is excused in `spec/layout_exceptions.json`; strict layout parity stays at baseline 259.