### PR TITLE
fix(core): rmdir refuses a non-empty directory at the op, not just in the builder

### DIFF
--- a/integ/runtime/guestops.json
+++ b/integ/runtime/guestops.json
@@ -495,6 +495,104 @@
           "expect": { "exit": 0, "stdout": "seed\nmore\n" }
         }
       ]
+    },
+    {
+      "note": "rmdir(2) refuses a non-empty directory, and the refusal has to come from the op, not from the command builder. The shell battery cannot see this: `rmdir` the builtin checks emptiness itself before it calls the op, so it passes on a backend whose op deletes the whole subtree. The facade is the surface FUSE, ws.ops and the sandbox runtimes share, and it calls the op directly.",
+      "id": "facade_rmdir_refuses_a_nonempty_directory",
+      "world": {
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "mkdir -p /data/qrmdop && echo keep > /data/qrmdop/keep.txt",
+          "expect": { "exit": 0, "stdout": "", "stderr": "" }
+        },
+        {
+          "facade": { "method": "rmdir", "path": "/data/qrmdop" },
+          "expect": { "errno": "ENOTEMPTY" }
+        },
+        {
+          "command": "cat /data/qrmdop/keep.txt",
+          "expect": { "exit": 0, "stdout": "keep\n" }
+        }
+      ]
+    },
+    {
+      "id": "facade_rmdir_removes_an_empty_directory",
+      "world": {
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "mkdir -p /data/qrmdhollow",
+          "expect": { "exit": 0, "stdout": "", "stderr": "" }
+        },
+        {
+          "facade": { "method": "rmdir", "path": "/data/qrmdhollow" },
+          "expect": {}
+        },
+        {
+          "facade": { "method": "is_dir", "path": "/data/qrmdhollow" },
+          "expect": { "value": false }
+        }
+      ]
+    },
+    {
+      "id": "facade_rmdir_on_a_missing_directory_is_enoent",
+      "world": {
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "facade": { "method": "rmdir", "path": "/data/qrmdnever" },
+          "expect": { "errno": "ENOENT" }
+        }
+      ]
+    },
+    {
+      "note": "A guest calling os.rmdir reaches the same op through the runtime VFS, so the refusal has to survive that path too -- and the errno the guest sees is the one the backend stamped.",
+      "id": "monty_rmdir_refuses_a_nonempty_directory",
+      "hosts": ["python"],
+      "world": {
+        "runtimes": ["monty", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "mkdir -p /data/qrmdguest && echo keep > /data/qrmdguest/keep.txt",
+          "expect": { "exit": 0, "stdout": "", "stderr": "" }
+        },
+        {
+          "command": "python3 -c \"from pathlib import Path; Path('/data/qrmdguest').rmdir()\"",
+          "expect": { "exit": 1, "stderr_contains": "Directory not empty" }
+        },
+        {
+          "command": "cat /data/qrmdguest/keep.txt",
+          "expect": { "exit": 0, "stdout": "keep\n" }
+        }
+      ]
+    },
+    {
+      "id": "qjs_rmdir_refuses_a_nonempty_directory",
+      "hosts": ["typescript"],
+      "world": {
+        "runtimes": ["quickjs", "vfs"],
+        "mounts": { "/data": { "resource": "ram", "files": { "seed.txt": "seed\n" } } }
+      },
+      "steps": [
+        {
+          "command": "mkdir -p /data/qrmdguest && echo keep > /data/qrmdguest/keep.txt",
+          "expect": { "exit": 0, "stdout": "", "stderr": "" }
+        },
+        {
+          "command": "js -e \"console.log(os.remove('/data/qrmdguest') !== 0)\"",
+          "expect": { "exit": 0, "stdout": "true\n" }
+        },
+        {
+          "command": "cat /data/qrmdguest/keep.txt",
+          "expect": { "exit": 0, "stdout": "keep\n" }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/run.py
+++ b/integ/runtime/run.py
@@ -28,6 +28,7 @@ from typing import Any  # noqa: E402
 
 from mirage import MountMode, Workspace  # noqa: E402
 from mirage.commands.cli.types import CLISpec  # noqa: E402
+from mirage.errors import classify  # noqa: E402
 from mirage.policy import Policy  # noqa: E402
 from mirage.policy.types import CommandContext  # noqa: E402
 from mirage.policy.types import Deny  # noqa: E402
@@ -407,6 +408,22 @@ async def _run_facade(ws: Workspace, expect: dict[str, Any],
     args: list[Any] = [spec["path"]]
     if "data" in spec:
         args.append(spec["data"].encode())
+    if "errno" in expect:
+        # The cross-language error assertion. `throws_contains` reads the
+        # message, which the two languages word differently for the same
+        # condition (python's OSError renders the strerror, the TypeScript
+        # FsError carries only the path), so an errno case must name the
+        # condition instead.
+        try:
+            await method(*args)
+            name = "NONE"
+        except Exception as exc:
+            condition = classify(exc)
+            name = (condition.name
+                    if condition is not None else type(exc).__name__)
+        if name != expect["errno"]:
+            return [f"facade errno {name}, expected {expect['errno']}"]
+        return []
     if "throws_contains" in expect:
         try:
             await method(*args)

--- a/integ/runtime/run.ts
+++ b/integ/runtime/run.ts
@@ -477,6 +477,21 @@ async function runFacade(ws: Workspace, expect: Expect, spec: FacadeSpec): Promi
   if (method === undefined) return [`facade has no method ${spec.method}`];
   const args: unknown[] = [spec.path];
   if (spec.data !== undefined) args.push(ENC.encode(spec.data));
+  if (expect.errno !== undefined) {
+    // The cross-language error assertion. `throws_contains` reads the
+    // message, which the two languages word differently for the same
+    // condition (python's OSError renders the strerror, the TypeScript
+    // FsError carries only the path), so an errno case must name the
+    // condition instead.
+    let name = "NONE";
+    try {
+      await method.apply(ws.fs, args);
+    } catch (err) {
+      name = (err as { code?: string }).code ?? (err as Error).constructor.name;
+    }
+    if (name !== expect.errno) return [`facade errno ${name}, expected ${expect.errno}`];
+    return [];
+  }
   if (expect.throws_contains !== undefined) {
     try {
       await method.apply(ws.fs, args);

--- a/python/mirage/core/box/rmdir.py
+++ b/python/mirage/core/box/rmdir.py
@@ -15,9 +15,10 @@
 from mirage.accessor.box import BoxAccessor
 from mirage.cache.context import invalidate_after_unlink
 from mirage.core.box.api import delete_file, delete_folder
+from mirage.core.box.client import BoxApiError
 from mirage.core.box.resolve import path_parts, resolve_item
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent
+from mirage.utils.errors import enoent, enotdir, enotempty
 
 
 async def rmdir(accessor: BoxAccessor, path: PathSpec) -> None:
@@ -26,9 +27,20 @@ async def rmdir(accessor: BoxAccessor, path: PathSpec) -> None:
     if item is None:
         raise enoent(path.virtual)
     if item.get("type") != "folder":
-        raise NotADirectoryError(path.virtual)
+        raise enotdir(path.virtual)
     # recursive=false: Box 409s on a non-empty folder, matching POSIX rmdir.
-    await delete_folder(accessor.token_manager, item["id"], recursive=False)
+    # The refusal is the service's, but naming it is ours: BoxApiError is a
+    # bare RuntimeError, so an unmapped 409 reached the caller as a condition
+    # `classify` could not name -- EIO over FUSE, no errno at all for
+    # `ws.ops` and the sandbox runtimes.
+    try:
+        await delete_folder(accessor.token_manager,
+                            item["id"],
+                            recursive=False)
+    except BoxApiError as exc:
+        if exc.status == 409:
+            raise enotempty(path) from exc
+        raise
     await invalidate_after_unlink(path)
 
 

--- a/python/mirage/core/databricks_volume/rmdir.py
+++ b/python/mirage/core/databricks_volume/rmdir.py
@@ -22,7 +22,7 @@ from mirage.core.databricks_volume.errors import is_not_found
 from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.stat import stat
 from mirage.types import FileType, PathSpec
-from mirage.utils.errors import enoent, enotdir
+from mirage.utils.errors import enoent, enotdir, enotempty
 
 
 def _list_directory_sync(
@@ -56,7 +56,7 @@ async def rmdir(
             raise enoent(path) from exc
         raise
     if entries:
-        raise OSError(f"directory not empty: {path.virtual}")
+        raise enotempty(path)
     try:
         await asyncio.to_thread(_delete_directory_sync, accessor, remote_path)
     except Exception as exc:

--- a/python/mirage/core/dropbox/rmdir.py
+++ b/python/mirage/core/dropbox/rmdir.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import errno
-import os
 import time
 
 from mirage.accessor.dropbox import DropboxAccessor
@@ -23,7 +21,7 @@ from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.paths import dropbox_path_of
 from mirage.observe.context import record
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent, enotdir
+from mirage.utils.errors import enoent, enotdir, enotempty
 
 
 async def rmdir(accessor: DropboxAccessor, path: PathSpec) -> None:
@@ -48,8 +46,7 @@ async def rmdir(accessor: DropboxAccessor, path: PathSpec) -> None:
         raise enotdir(path.virtual)
     children = await list_folder(accessor.token_manager, api_path, limit=1)
     if children:
-        raise OSError(errno.ENOTEMPTY, os.strerror(errno.ENOTEMPTY),
-                      path.virtual)
+        raise enotempty(path)
     start_ms = int(time.monotonic() * 1000)
     await delete_path(accessor.token_manager, api_path)
     record("rmdir", path.virtual, "dropbox", 0, start_ms)

--- a/python/mirage/core/gdrive/rename.py
+++ b/python/mirage/core/gdrive/rename.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import errno
-import os
 import posixpath
 
 from mirage.accessor.gdrive import GDriveAccessor
@@ -22,7 +20,7 @@ from mirage.core.gdrive.resolve import (drive_target_name, eacces_on_denied,
                                         resolve_key, resolve_parent)
 from mirage.core.google.drive import delete_file, list_files, patch_file
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent
+from mirage.utils.errors import enoent, enotempty
 
 
 @eacces_on_denied
@@ -41,10 +39,9 @@ async def rename(accessor: GDriveAccessor, src: PathSpec,
             children = await list_files(token_manager,
                                         folder_id=dst_node.id,
                                         drive_id=dst_node.drive_id,
-                                        page_size=1)
+                                        limit=1)
             if children:
-                raise OSError(errno.ENOTEMPTY, os.strerror(errno.ENOTEMPTY),
-                              dst.virtual)
+                raise enotempty(dst)
         await delete_file(token_manager, dst_node.id)
     src_parent_id, _ = await resolve_parent(accessor, src)
     dst_parent_id, _ = await resolve_parent(accessor, dst)

--- a/python/mirage/core/gdrive/rmdir.py
+++ b/python/mirage/core/gdrive/rmdir.py
@@ -15,13 +15,28 @@
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.context import invalidate_after_unlink
 from mirage.core.gdrive.resolve import eacces_on_denied, resolve_key
-from mirage.core.google.drive import delete_file
+from mirage.core.google.drive import delete_file, list_files
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent, enotdir
+from mirage.utils.errors import enoent, enotdir, enotempty
 
 
 @eacces_on_denied
 async def rmdir(accessor: GDriveAccessor, path: PathSpec) -> None:
+    """Remove an empty folder.
+
+    A Drive ``files.delete`` on a folder removes every descendant with
+    it, so this is the same request ``rm_r`` sends and the emptiness
+    check is the only thing separating them. Without it ``rmdir``
+    destroyed the whole subtree for every caller that does not pre-check
+    emptiness itself, and the command builders are the only callers that
+    do: FUSE, ``ws.ops`` and the sandbox runtimes all reach the op
+    directly. The probe is the one ``rename`` already makes before it
+    overwrites a directory, bounded to a single entry.
+
+    Args:
+        accessor (GDriveAccessor): Google Drive accessor.
+        path (PathSpec): folder to remove.
+    """
     virtual = path.virtual
     key = path.resource_path
     if not key:
@@ -31,5 +46,11 @@ async def rmdir(accessor: GDriveAccessor, path: PathSpec) -> None:
         raise enoent(virtual)
     if not node.is_folder:
         raise enotdir(virtual)
+    children = await list_files(accessor.token_manager,
+                                folder_id=node.id,
+                                drive_id=node.drive_id,
+                                limit=1)
+    if children:
+        raise enotempty(path)
     await delete_file(accessor.token_manager, node.id)
     await invalidate_after_unlink(path)

--- a/python/mirage/core/google/drive.py
+++ b/python/mirage/core/google/drive.py
@@ -72,6 +72,7 @@ async def list_files(
     modified_after: str | None = None,
     modified_before: str | None = None,
     name: str | None = None,
+    limit: int | None = None,
 ) -> list[dict[str, Any]]:
     """List files via Drive API.
 
@@ -88,6 +89,11 @@ async def list_files(
         modified_before (str | None): RFC3339 timestamp; include only files
             with modifiedTime < this.
         name (str | None): exact file name filter.
+        limit (int | None): stop once this many files are in hand and do
+            not request another page. An emptiness probe wants one
+            entry, and ``page_size`` alone cannot express that: it caps
+            the page, not the walk, so a small page turned a listing of
+            a large folder into many requests instead of fewer.
 
     Returns:
         list[dict]: file metadata dicts.
@@ -110,7 +116,7 @@ async def list_files(
         params: dict[str, str | int] = {
             "q": q,
             "fields": FIELDS,
-            "pageSize": page_size,
+            "pageSize": page_size if limit is None else min(page_size, limit),
             "orderBy": "modifiedTime desc",
         }
         if drive_id:
@@ -123,6 +129,8 @@ async def list_files(
         url = f"{drive_base(token_manager)}/files"
         data = await google_get(token_manager, url, params=params)
         files.extend(data.get("files", []))
+        if limit is not None and len(files) >= limit:
+            break
         page_token = data.get("nextPageToken")
         if not page_token:
             break

--- a/python/mirage/core/gridfs/rmdir.py
+++ b/python/mirage/core/gridfs/rmdir.py
@@ -13,6 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.core.gridfs.driver import DRIVER
-from mirage.core.object_store.remove import make_remove_prefix
+from mirage.core.object_store.remove import make_rmdir
 
-rmdir = make_remove_prefix(DRIVER)
+rmdir = make_rmdir(DRIVER)

--- a/python/mirage/core/msgraph/drive_ops.py
+++ b/python/mirage/core/msgraph/drive_ops.py
@@ -536,13 +536,26 @@ async def find_items(
 
 
 async def drive_root_empty(config: MsGraphConfig, loc: DriveLoc) -> bool:
-    """Whether a drive item has no children.
+    """Whether a drive item has no children, in one request.
+
+    One bounded page, not ``graph_list``: the answer is a yes/no, and
+    ``graph_list`` follows every ``@odata.nextLink``, so asking it made
+    a large folder download its whole listing to produce one boolean.
+    ``$top`` through that helper is worse rather than better -- it only
+    shrinks each page, so the walk pages more times, not fewer -- which
+    is why this sends the request itself. ``$select`` drops a driveItem
+    payload this never reads.
 
     Args:
         config (MsGraphConfig): Graph config.
         loc (DriveLoc): the folder to probe.
     """
-    return not await graph_list(config, loc.item("/children"))
+    page = await graph_get(config, loc.item("/children"), {
+        "$top": 1,
+        "$select": "id"
+    })
+    children = page.get("value")
+    return not (isinstance(children, list) and children)
 
 
 async def _item_or_none(config: MsGraphConfig, loc: DriveLoc,

--- a/python/mirage/core/nextcloud/mkdir.py
+++ b/python/mirage/core/nextcloud/mkdir.py
@@ -6,10 +6,23 @@ from mirage.types import PathSpec
 async def mkdir(accessor: NextcloudAccessor,
                 path: PathSpec,
                 parents: bool = False) -> None:
-    # opendal create_dir creates missing parents; parents is implicit.
+    """Create a collection; opendal creates missing parents either way.
+
+    ``parents`` is accepted for the op signature and ignored, because
+    ``create_dir`` is MKCOL over every missing level whatever it says.
+    That is also why the ancestor invalidation is unconditional: a bare
+    ``mkdir a/b/c`` materializes a whole chain here, and gating the walk
+    on ``parents`` (as the backends whose mkdir really does create one
+    level correctly do) left every ancestor above the parent serving a
+    cached listing that hid the new levels until the index TTL expired.
+
+    Args:
+        accessor (NextcloudAccessor): Nextcloud accessor.
+        path (PathSpec): collection to create.
+        parents (bool): ignored; opendal always creates parents.
+    """
     key = path.mount_path.strip("/") + "/"
     op = accessor.operator()
     await op.create_dir(key)
     await invalidate_after_write(path)
-    if parents:
-        await invalidate_ancestors(path)
+    await invalidate_ancestors(path)

--- a/python/mirage/core/nextcloud/rmdir.py
+++ b/python/mirage/core/nextcloud/rmdir.py
@@ -3,15 +3,41 @@ from opendal.exceptions import NotFound
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.context import invalidate_after_unlink
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent
+from mirage.utils.errors import enoent, enotempty
 
 
 async def rmdir(accessor: NextcloudAccessor, path: PathSpec) -> None:
-    raw = path.mount_path
-    key = raw.strip("/") + "/"
+    """Remove an empty collection.
+
+    WebDAV DELETE on a collection is recursive (RFC 4918 9.6.1), so this
+    is the same request ``rm_r`` sends and the emptiness check is the
+    only thing separating them. Without it ``rmdir`` destroyed the whole
+    subtree for every caller that does not pre-check emptiness itself,
+    and the command builders are the only callers that do: FUSE,
+    ``ws.ops`` and the sandbox runtimes all reach the op directly.
+
+    PROPFIND on a collection returns the collection itself, so the
+    listing is read for the first entry that is not the collection --
+    the same self-entry rule ``readdir`` documents -- and stops there
+    rather than paging a large directory to answer a yes/no question.
+
+    Args:
+        accessor (NextcloudAccessor): Nextcloud accessor.
+        path (PathSpec): collection to remove.
+    """
+    key = path.mount_path.strip("/") + "/"
+    stem = key.strip("/")
     op = accessor.operator()
+    has_child = False
     try:
-        await op.delete(key)
+        async for entry in await op.list(key):
+            if entry.path.strip("/") != stem:
+                has_child = True
+                break
+        if not has_child:
+            await op.delete(key)
     except NotFound as exc:
         raise enoent(path) from exc
+    if has_child:
+        raise enotempty(path)
     await invalidate_after_unlink(path)

--- a/python/mirage/core/object_store/remove.py
+++ b/python/mirage/core/object_store/remove.py
@@ -104,8 +104,17 @@ def make_rmdir(driver: ObjectStoreDriver[A, C]) -> PathFn[A]:
                 if child.kind != "marker":
                     has_child = True
                     break
-            if not has_child and (saw_key or is_root):
-                await driver.delete_prefix(conn, pfx)
+            if not has_child and saw_key:
+                # The marker only, never the prefix. Between the listing
+                # above and this delete another writer may have created a
+                # child, and a prefix delete would take it down too --
+                # the subtree loss this function exists to stop, in a
+                # smaller window. Deleting the one key that spells
+                # "empty directory" cannot reach a child no matter what
+                # arrived after the probe. A root holding no key has no
+                # marker to delete and falls through as the no-op the
+                # prefix delete already was.
+                await driver.delete_file(conn, pfx)
         if has_child:
             raise enotempty(path_spec)
         if not saw_key and not is_root:

--- a/python/mirage/core/object_store/remove.py
+++ b/python/mirage/core/object_store/remove.py
@@ -16,6 +16,7 @@ from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
 from mirage.core.object_store.driver import A, C, ObjectStoreDriver, PathFn
 from mirage.types import PathSpec
 from mirage.utils import key_prefix as kp
+from mirage.utils.errors import enoent, enotempty
 
 
 def make_unlink(driver: ObjectStoreDriver[A, C]) -> PathFn[A]:
@@ -61,3 +62,55 @@ def make_remove_prefix(driver: ObjectStoreDriver[A, C]) -> PathFn[A]:
         await invalidate_ancestors(path_spec)
 
     return remove_prefix
+
+
+def make_rmdir(driver: ObjectStoreDriver[A, C]) -> PathFn[A]:
+    """Build POSIX ``rmdir`` over one driver: refuse a non-empty prefix.
+
+    Not ``make_remove_prefix``. On a keyed store an empty directory is
+    its zero-byte marker object, so a prefix delete removes an empty
+    directory correctly and a *non-empty* one recursively, which is
+    ``rm -r``, not ``rmdir``. Sharing one function between the two slots
+    made ``rmdir`` destroy a whole subtree for every caller that does
+    not pre-check emptiness itself, and the command builders are the
+    only callers that do: FUSE, ``ws.ops`` and the sandbox runtimes all
+    reach the op directly.
+
+    The listing is the same one ``readdir`` reads, so the two agree on
+    what a child is: a ``marker`` entry is the prefix's own marker (or a
+    key the delimiter listing could not classify) and proves only that
+    the directory exists, while any ``f`` or ``d`` entry is a child and
+    makes this ENOTEMPTY. The walk stops at the first child rather than
+    listing the whole directory to answer a yes/no question.
+
+    A prefix holding no key at all -- not even the marker -- is a
+    directory the store does not have, and rmdir(2) reports ENOENT for
+    it. ``make_remove_prefix`` stays silent there on purpose, because
+    ``rm -r`` owns that refusal through its own ``-f`` handling.
+
+    Args:
+        driver (ObjectStoreDriver): the store's native surface.
+    """
+
+    async def rmdir(accessor: A, path_spec: PathSpec) -> None:
+        path = path_spec.mount_path
+        pfx = kp.apply_dir(driver.key_prefix_of(accessor), path)
+        is_root = not path.strip("/")
+        saw_key = False
+        has_child = False
+        async with driver.connect(accessor) as conn:
+            async for child in driver.list_children(conn, pfx):
+                saw_key = True
+                if child.kind != "marker":
+                    has_child = True
+                    break
+            if not has_child and (saw_key or is_root):
+                await driver.delete_prefix(conn, pfx)
+        if has_child:
+            raise enotempty(path_spec)
+        if not saw_key and not is_root:
+            raise enoent(path_spec)
+        await invalidate_after_unlink(path_spec)
+        await invalidate_ancestors(path_spec)
+
+    return rmdir

--- a/python/mirage/core/onedrive/rmdir.py
+++ b/python/mirage/core/onedrive/rmdir.py
@@ -14,14 +14,34 @@
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.context import invalidate_after_unlink
-from mirage.core.onedrive.client import graph_delete, item_url, split_path
+from mirage.core.msgraph.drive_ops import drive_root_empty
+from mirage.core.onedrive.client import (drive_loc, graph_delete, item_url,
+                                         split_path)
 from mirage.types import PathSpec
+from mirage.utils.errors import enotempty
 
 
 async def rmdir(accessor: OneDriveAccessor, path: PathSpec) -> None:
+    """Remove an empty folder.
+
+    A Graph ``DELETE /drives/{id}/items/{item}`` removes a folder and
+    everything under it, so this is the same request ``rm_r`` sends and
+    the emptiness check is the only thing separating them. Without it
+    ``rmdir`` destroyed the whole subtree for every caller that does not
+    pre-check emptiness itself, and the command builders are the only
+    callers that do: FUSE, ``ws.ops`` and the sandbox runtimes all reach
+    the op directly.
+
+    Args:
+        accessor (OneDriveAccessor): OneDrive accessor.
+        path (PathSpec): folder to remove.
+    """
     _, stripped = split_path(path)
     if not stripped:
         return
+    loc = drive_loc(accessor.config, stripped)
+    if not await drive_root_empty(accessor.config, loc):
+        raise enotempty(path)
     await graph_delete(accessor.config,
                        item_url(accessor.config, "/" + stripped))
     await invalidate_after_unlink(path)

--- a/python/mirage/core/ram/rmdir.py
+++ b/python/mirage/core/ram/rmdir.py
@@ -15,6 +15,7 @@
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.context import invalidate_after_unlink
 from mirage.types import PathSpec
+from mirage.utils.errors import enotempty
 from mirage.utils.path import norm
 
 
@@ -30,6 +31,6 @@ async def rmdir(accessor: RAMAccessor, path_spec: PathSpec) -> None:
         if k.startswith(prefix) and k != p
     ]
     if children:
-        raise OSError(f"directory not empty: {p}")
+        raise enotempty(path_spec)
     store.dirs.discard(p)
     await invalidate_after_unlink(path_spec)

--- a/python/mirage/core/redis/rmdir.py
+++ b/python/mirage/core/redis/rmdir.py
@@ -15,6 +15,7 @@
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.context import invalidate_after_unlink
 from mirage.types import PathSpec
+from mirage.utils.errors import enotempty
 from mirage.utils.path import norm
 
 
@@ -32,6 +33,6 @@ async def rmdir(accessor: RedisAccessor, path_spec: PathSpec) -> None:
         if k.startswith(prefix) and k != p
     ]
     if children:
-        raise OSError(f"directory not empty: {p}")
+        raise enotempty(path_spec)
     await store.remove_dir(p)
     await invalidate_after_unlink(path_spec)

--- a/python/mirage/core/s3/rmdir.py
+++ b/python/mirage/core/s3/rmdir.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.object_store.remove import make_remove_prefix
+from mirage.core.object_store.remove import make_rmdir
 from mirage.core.s3.driver import DRIVER
 
-rmdir = make_remove_prefix(DRIVER)
+rmdir = make_rmdir(DRIVER)

--- a/python/mirage/core/sharepoint/rmdir.py
+++ b/python/mirage/core/sharepoint/rmdir.py
@@ -1,18 +1,36 @@
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import invalidate_after_unlink
+from mirage.core.msgraph.drive_ops import drive_root_empty
 from mirage.core.sharepoint.client import graph_delete, item_url, split_path
-from mirage.core.sharepoint.resolve import resolve
+from mirage.core.sharepoint.resolve import drive_loc, resolve
 from mirage.types import PathSpec
+from mirage.utils.errors import enotempty
 
 
 async def rmdir(accessor: SharePointAccessor, path: PathSpec) -> None:
-    path.virtual if isinstance(path, PathSpec) else path
+    """Remove an empty folder.
+
+    A Graph ``DELETE /drives/{id}/items/{item}`` removes a folder and
+    everything under it, so this is the same request ``rm_r`` sends and
+    the emptiness check is the only thing separating them. Without it
+    ``rmdir`` destroyed the whole subtree for every caller that does not
+    pre-check emptiness itself, and the command builders are the only
+    callers that do: FUSE, ``ws.ops`` and the sandbox runtimes all reach
+    the op directly.
+
+    Args:
+        accessor (SharePointAccessor): SharePoint accessor.
+        path (PathSpec): folder to remove.
+    """
     _, stripped = split_path(path)
     if not stripped:
         return
     resolved = await resolve(accessor, path)
     if resolved.drive_id is None or resolved.item_path is None:
         return
+    loc = drive_loc(accessor.config, resolved, path.virtual)
+    if not await drive_root_empty(accessor.config, loc):
+        raise enotempty(path)
     await graph_delete(
         accessor.config,
         item_url(accessor.config, resolved.drive_id, resolved.item_path))

--- a/python/mirage/core/ssh/rmdir.py
+++ b/python/mirage/core/ssh/rmdir.py
@@ -18,13 +18,31 @@ from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.context import invalidate_after_unlink
 from mirage.core.ssh.client import _abs
 from mirage.types import PathSpec
+from mirage.utils.errors import enoent, enotdir, enotempty
 
 
 async def rmdir(accessor: SSHAccessor, path: PathSpec) -> None:
+    """Remove an empty directory over SFTP.
+
+    The server enforces emptiness, so the work here is naming its
+    refusal in the same vocabulary every other backend uses. SFTP 3 has
+    one code for it (``SFTPFailure``, carrying only the server's message
+    string), and later protocol versions split ``SFTPDirNotEmpty`` out;
+    only the typed one can be mapped, so a version-3 server still
+    reaches the caller as itself.
+
+    Args:
+        accessor (SSHAccessor): SSH accessor.
+        path (PathSpec): directory to remove.
+    """
     config = accessor.config
     sftp = await accessor.sftp()
     try:
         await sftp.rmdir(_abs(config, path.mount_path))
-    except asyncssh.SFTPNoSuchFile:
-        raise FileNotFoundError(path)
+    except asyncssh.SFTPNoSuchFile as exc:
+        raise enoent(path) from exc
+    except asyncssh.SFTPDirNotEmpty as exc:
+        raise enotempty(path) from exc
+    except asyncssh.SFTPNotADirectory as exc:
+        raise enotdir(path) from exc
     await invalidate_after_unlink(path)

--- a/python/mirage/fuse/errors.py
+++ b/python/mirage/fuse/errors.py
@@ -19,8 +19,13 @@ from mirage.errors import FsCondition, classify, posix_errno
 # "attribute not found" errno: ENOATTR on macOS, ENODATA on Linux.
 NO_XATTR = posix_errno(FsCondition.NO_XATTR)
 
-# Genuine last resort, for a bare OSError whose only signal is its
-# message (ram/redis rmdir raise OSError("directory not empty: ...")).
+# Genuine last resort, for an error whose only signal is its message.
+# The repo's own backends no longer need it -- every rmdir refusal is
+# raised through mirage.utils.errors, which stamps the errno -- but a
+# third-party client can still hand up an untyped failure that carries
+# nothing else: SFTP 3 reports a non-empty directory as asyncssh's
+# SFTPFailure, which is not an OSError and has no code of its own, so
+# only the wording separates it from any other server-side failure.
 # The needles that duplicated a typed arm are gone: "read-only" and
 # "not allowed to access mount" arrive as PermissionError, "no mount"
 # as ValueError, and classify names all three.

--- a/python/tests/commands/test_rmdir_is_not_recursive.py
+++ b/python/tests/commands/test_rmdir_is_not_recursive.py
@@ -1,0 +1,81 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import importlib
+import pkgutil
+
+import mirage.commands.builtin as builtin_pkg
+from mirage.commands.builtin.generic_bind import CommandIO
+
+
+def _origin(fn: object) -> tuple[str, str]:
+    """Where a wired op's body was written.
+
+    ``(module, qualname)`` rather than the object, so a closure built by
+    calling one factory twice reports the one body it came from.
+    """
+    return (getattr(fn, "__module__", ""), getattr(fn, "__qualname__", ""))
+
+
+def _command_ios() -> dict[str, CommandIO]:
+    """Every backend's wired ``CommandIO``, keyed by backend package name."""
+    found: dict[str, CommandIO] = {}
+    for info in pkgutil.iter_modules(builtin_pkg.__path__):
+        if not info.ispkg:
+            continue
+        try:
+            module = importlib.import_module(
+                f"{builtin_pkg.__name__}.{info.name}.io")
+        except ModuleNotFoundError:
+            continue
+        io = getattr(module, "IO", None)
+        if isinstance(io, CommandIO):
+            found[info.name] = io
+    return found
+
+
+def test_every_backend_io_is_discovered():
+    ios = _command_ios()
+    # A guard on the guard: an import that silently stopped resolving would
+    # make every assertion below vacuous.
+    assert len(ios) > 20
+    assert {"ram", "s3", "nextcloud", "gdrive", "onedrive"} <= set(ios)
+
+
+def test_rmdir_is_never_the_recursive_removal():
+    """``rmdir`` and ``rm -r`` must not be one function.
+
+    rmdir(2) refuses a non-empty directory; ``rm -r`` is what empties one.
+    Wiring both slots to the same callable silently turns ``rmdir`` into a
+    subtree delete for every caller that does not pre-check emptiness
+    itself, and the command builders are the only callers that do -- FUSE,
+    ``ws.ops`` and the sandbox runtimes all reach the op directly. That is
+    the shape the bug took in five backends at once: two shared the object
+    store kit's prefix delete, three aliased the op outright.
+
+    Sharing was never load-bearing, even on a keyed store where an empty
+    directory is just its marker object: deleting the marker and deleting
+    the prefix are only the same request while the directory is empty,
+    which is exactly what rmdir cannot assume.
+
+    Provenance is compared, not object identity, because identity misses
+    the form the object store backends had: one factory called twice
+    yields two distinct closures that run the same body, so ``is not``
+    reads as two implementations where there is one.
+    """
+    shared = sorted(
+        name for name, io in _command_ios().items()
+        if io.rmdir is not None and _origin(io.rmdir) == _origin(io.rm_r))
+    assert not shared, ("these backends wire rmdir to their recursive "
+                        f"removal: {shared}")

--- a/python/tests/core/gdrive/conftest.py
+++ b/python/tests/core/gdrive/conftest.py
@@ -42,6 +42,11 @@ class FakeDrive:
     def __init__(self) -> None:
         self.items: dict[str, dict] = {}
         self._ids = itertools.count(1)
+        # Every `limit` a caller asked for, so a test can pin that an
+        # emptiness probe is bounded. `page_size` cannot express that: it
+        # caps the page, not the walk, so a small page turns a listing of
+        # a large folder into more requests rather than fewer.
+        self.list_limits: list[int | None] = []
 
     def add(self,
             name: str,
@@ -82,6 +87,7 @@ class FakeDrive:
                          modified_before: str | None = None,
                          name: str | None = None,
                          limit: int | None = None) -> list[dict]:
+        self.list_limits.append(limit)
         out = []
         for item in self.items.values():
             if folder_id not in item["parents"]:

--- a/python/tests/core/gdrive/conftest.py
+++ b/python/tests/core/gdrive/conftest.py
@@ -80,7 +80,8 @@ class FakeDrive:
                          page_size: int = 1000,
                          modified_after: str | None = None,
                          modified_before: str | None = None,
-                         name: str | None = None) -> list[dict]:
+                         name: str | None = None,
+                         limit: int | None = None) -> list[dict]:
         out = []
         for item in self.items.values():
             if folder_id not in item["parents"]:
@@ -90,6 +91,8 @@ class FakeDrive:
             if mime_type and item["mimeType"] != mime_type:
                 continue
             out.append(self.public(item["id"]))
+            if limit is not None and len(out) >= limit:
+                break
         return out
 
     async def list_shared_drives(self,
@@ -169,7 +172,7 @@ _PATCH_TARGETS = {
     write_mod: ("update_file_content", "upload_file"),
     mkdir_mod: ("create_folder", ),
     unlink_mod: ("delete_file", ),
-    rmdir_mod: ("delete_file", ),
+    rmdir_mod: ("delete_file", "list_files"),
     rm_mod: ("delete_file", ),
     rename_mod: ("delete_file", "list_files", "patch_file"),
     tree_mod: ("list_files", ),

--- a/python/tests/core/gdrive/test_rename.py
+++ b/python/tests/core/gdrive/test_rename.py
@@ -63,6 +63,10 @@ async def test_rename_over_nonempty_dir_raises(fake_drive, gdrive_accessor):
     with pytest.raises(OSError) as exc_info:
         await rename(gdrive_accessor, spec("/src.txt"), spec("/d"))
     assert exc_info.value.errno == errno.ENOTEMPTY
+    # The conflict probe is bounded, not a full listing: `list_files`
+    # follows every page token, so asking it with a small `page_size`
+    # made one request per child to answer a yes/no.
+    assert 1 in fake_drive.list_limits
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/gdrive/test_rmdir.py
+++ b/python/tests/core/gdrive/test_rmdir.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
+
 import pytest
 
 from mirage.core.gdrive.rmdir import rmdir
@@ -40,3 +42,27 @@ async def test_rmdir_file_raises(fake_drive, gdrive_accessor):
     fake_drive.add("f.txt", content=b"x")
     with pytest.raises(NotADirectoryError):
         await rmdir(gdrive_accessor, spec("/f.txt"))
+
+
+@pytest.mark.asyncio
+async def test_rmdir_refuses_a_folder_holding_a_file(fake_drive,
+                                                     gdrive_accessor):
+    folder = fake_drive.folder("d")
+    fake_drive.add("a.txt", parent=folder, content=b"a")
+    with pytest.raises(OSError) as excinfo:
+        await rmdir(gdrive_accessor, spec("/d"))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert fake_drive.find("d") is not None
+    assert fake_drive.find("a.txt") is not None
+
+
+@pytest.mark.asyncio
+async def test_rmdir_refuses_a_folder_holding_a_subfolder(
+        fake_drive, gdrive_accessor):
+    folder = fake_drive.folder("d")
+    fake_drive.folder("sub", parent=folder)
+    with pytest.raises(OSError) as excinfo:
+        await rmdir(gdrive_accessor, spec("/d"))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert fake_drive.find("d") is not None
+    assert fake_drive.find("sub") is not None

--- a/python/tests/core/nextcloud/test_mkdir.py
+++ b/python/tests/core/nextcloud/test_mkdir.py
@@ -1,0 +1,60 @@
+import pytest
+
+from mirage.cache.context import push_cache_manager
+from mirage.core.nextcloud.mkdir import mkdir
+from mirage.types import PathSpec
+
+
+class _RecordingInvalidator:
+    """Collects the paths each invalidation hook was told about."""
+
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+        self.unlinks: list[str] = []
+
+    async def invalidate_after_write(self, path: PathSpec) -> None:
+        self.writes.append(path.mount_path)
+
+    async def invalidate_after_unlink(self, path: PathSpec) -> None:
+        self.unlinks.append(path.mount_path)
+
+    async def cached_bytes(self, path: PathSpec) -> bytes | None:
+        return None
+
+
+async def _record(accessor, path: PathSpec,
+                  **kwargs: bool) -> _RecordingInvalidator:
+    recorder = _RecordingInvalidator()
+    previous = push_cache_manager(recorder)
+    try:
+        await mkdir(accessor, path, **kwargs)
+    finally:
+        push_cache_manager(previous)
+    return recorder
+
+
+@pytest.mark.asyncio
+async def test_mkdir_creates_the_collection(make_acc):
+    acc = make_acc({})
+    await mkdir(acc, PathSpec.from_str_path("/newdir"))
+    assert "newdir/" in acc._fake.dirs
+
+
+@pytest.mark.asyncio
+async def test_mkdir_invalidates_every_ancestor_without_parents(make_acc):
+    """opendal's create_dir is MKCOL over the whole chain either way.
+
+    So the ancestor walk cannot be gated on ``parents``: a bare
+    ``mkdir a/b/c`` materializes ``a`` and ``a/b`` too, and their cached
+    listings hid the new levels until the index TTL expired.
+    """
+    recorder = await _record(make_acc({}), PathSpec.from_str_path("/a/b/c"))
+    assert recorder.writes == ["/a/b/c", "/a/b", "/a"]
+
+
+@pytest.mark.asyncio
+async def test_mkdir_parents_invalidates_the_same_chain(make_acc):
+    recorder = await _record(make_acc({}),
+                             PathSpec.from_str_path("/a/b/c"),
+                             parents=True)
+    assert recorder.writes == ["/a/b/c", "/a/b", "/a"]

--- a/python/tests/core/nextcloud/test_rmdir.py
+++ b/python/tests/core/nextcloud/test_rmdir.py
@@ -1,0 +1,41 @@
+import errno
+
+import pytest
+
+from mirage.core.nextcloud.mkdir import mkdir
+from mirage.core.nextcloud.rmdir import rmdir
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_rmdir_removes_an_empty_collection(make_acc):
+    acc = make_acc({})
+    await mkdir(acc, PathSpec.from_str_path("/dir"))
+    await rmdir(acc, PathSpec.from_str_path("/dir"))
+    assert "dir/" not in acc._fake.dirs
+
+
+@pytest.mark.asyncio
+async def test_rmdir_refuses_a_collection_holding_a_file(make_acc):
+    acc = make_acc({"dir/a.txt": b"a", "keep.txt": b"k"})
+    with pytest.raises(OSError) as excinfo:
+        await rmdir(acc, PathSpec.from_str_path("/dir"))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert acc._fake.files == {"dir/a.txt": b"a", "keep.txt": b"k"}
+
+
+@pytest.mark.asyncio
+async def test_rmdir_refuses_a_collection_holding_only_a_subtree(make_acc):
+    acc = make_acc({"dir/sub/deep.txt": b"d"})
+    with pytest.raises(OSError) as excinfo:
+        await rmdir(acc, PathSpec.from_str_path("/dir"))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert acc._fake.files == {"dir/sub/deep.txt": b"d"}
+
+
+@pytest.mark.asyncio
+async def test_mkdir_then_rmdir_of_a_nested_chain(make_acc):
+    acc = make_acc({})
+    await mkdir(acc, PathSpec.from_str_path("/a/b/c"))
+    await rmdir(acc, PathSpec.from_str_path("/a/b/c"))
+    assert "a/b/c/" not in acc._fake.dirs

--- a/python/tests/core/object_store/test_remove.py
+++ b/python/tests/core/object_store/test_remove.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import errno
+from dataclasses import replace
 
 import pytest
 
@@ -118,3 +119,26 @@ def test_rmdir_on_an_empty_mount_root_is_a_no_op(accessor):
     store = FakeStore({})
     _managed(make_rmdir(make_driver(store))(accessor, spec("/")))
     assert store.objects == {}
+
+
+def test_rmdir_leaves_a_child_that_arrived_after_the_probe(accessor):
+    """The delete is the marker, not the prefix.
+
+    A concurrent writer can create a child between the emptiness listing
+    and the delete, and a prefix delete would take that child down with
+    it -- the subtree loss this function exists to stop, in a smaller
+    window. So rmdir deletes only the one key that spells "empty
+    directory", which nothing arriving after the probe can widen.
+    """
+    store = FakeStore({"a/b/": b""})
+    driver = make_driver(store)
+
+    async def racing_children(conn, pfx):
+        async for child in driver.list_children(conn, pfx):
+            yield child
+        conn.objects["a/b/late.txt"] = b"new"
+
+    rmdir = make_rmdir(replace(driver, list_children=racing_children))
+    _managed(rmdir(accessor, spec("/a/b")))
+    assert store.objects == {"a/b/late.txt": b"new"}
+    assert store.deletes == ["a/b/"]

--- a/python/tests/core/object_store/test_remove.py
+++ b/python/tests/core/object_store/test_remove.py
@@ -13,9 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import errno
+
+import pytest
 
 from mirage.cache.context import push_cache_manager
-from mirage.core.object_store.remove import make_remove_prefix, make_unlink
+from mirage.core.object_store.remove import (make_remove_prefix, make_rmdir,
+                                             make_unlink)
 from tests.core.object_store.conftest import (FakeManager, FakeStore,
                                               make_driver, spec)
 
@@ -48,3 +52,69 @@ def test_remove_prefix_deletes_the_subtree_and_ancestors_evict(accessor):
     assert store.objects == {}
     assert manager.unlinks == ["/a/b"]
     assert manager.writes == ["/a"]
+
+
+def test_rmdir_refuses_a_nonempty_prefix_and_keeps_every_key(accessor):
+    """rmdir is not make_remove_prefix.
+
+    On a keyed store an empty directory is its marker object, so a prefix
+    delete removes an empty directory correctly and a non-empty one
+    recursively -- which is ``rm -r``. The two slots shared one function,
+    so every caller that does not pre-check emptiness itself (FUSE,
+    ``ws.ops``, the sandbox runtimes) destroyed the subtree.
+    """
+    store = FakeStore({"a/b/": b"", "a/b/c.txt": b"hi", "a/b/d/e.txt": b"x"})
+    with pytest.raises(OSError) as excinfo:
+        _managed(make_rmdir(make_driver(store))(accessor, spec("/a/b")))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert store.objects == {
+        "a/b/": b"",
+        "a/b/c.txt": b"hi",
+        "a/b/d/e.txt": b"x",
+    }
+
+
+def test_rmdir_refuses_a_prefix_whose_only_child_is_a_subdirectory(accessor):
+    store = FakeStore({"a/b/": b"", "a/b/d/": b""})
+    with pytest.raises(OSError) as excinfo:
+        _managed(make_rmdir(make_driver(store))(accessor, spec("/a/b")))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert store.objects == {"a/b/": b"", "a/b/d/": b""}
+
+
+def test_rmdir_removes_the_marker_of_an_empty_prefix(accessor):
+    store = FakeStore({"a/b/": b"", "keep.txt": b"k"})
+    manager = _managed(make_rmdir(make_driver(store))(accessor, spec("/a/b")))
+    assert store.objects == {"keep.txt": b"k"}
+    assert manager.unlinks == ["/a/b"]
+    assert manager.writes == ["/a"]
+
+
+def test_rmdir_reports_enoent_for_a_prefix_holding_no_key(accessor):
+    store = FakeStore({"keep.txt": b"k"})
+    with pytest.raises(FileNotFoundError):
+        _managed(make_rmdir(make_driver(store))(accessor, spec("/a/b")))
+    assert store.objects == {"keep.txt": b"k"}
+
+
+def test_rmdir_on_a_populated_mount_root_destroys_nothing(accessor):
+    """The whole-store case, which the shared prefix delete got wrong.
+
+    A mount root resolves to the bare key prefix, so ``make_remove_prefix``
+    in this slot emptied the entire store. ``MountRootPolicy`` refuses a
+    mount root as an operand with EBUSY, but only on the command path;
+    FUSE and ``ws.ops`` reach the op. The root is also the one path that
+    cannot report ENOENT -- it exists because it is mounted -- so the
+    empty case below is a no-op rather than a refusal.
+    """
+    store = FakeStore({"a.txt": b"x", "d/f.txt": b"y"})
+    with pytest.raises(OSError) as excinfo:
+        _managed(make_rmdir(make_driver(store))(accessor, spec("/")))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert store.objects == {"a.txt": b"x", "d/f.txt": b"y"}
+
+
+def test_rmdir_on_an_empty_mount_root_is_a_no_op(accessor):
+    store = FakeStore({})
+    _managed(make_rmdir(make_driver(store))(accessor, spec("/")))
+    assert store.objects == {}

--- a/python/tests/core/onedrive/test_rmdir.py
+++ b/python/tests/core/onedrive/test_rmdir.py
@@ -11,6 +11,10 @@ _BASE = "https://graph.microsoft.com/v1.0/me/drive"
 
 _FILE = {"id": "c1", "name": "a.txt", "size": 1}
 _FOLDER = {"id": "c2", "name": "sub", "folder": {"childCount": 0}}
+# The emptiness probe is one bounded page, not a full listing walk, so the
+# query is part of the URL the stub has to match; a regression to
+# `graph_list` stops matching it.
+_PROBE = "?$top=1&$select=id"
 
 
 def _accessor(**kw) -> OneDriveAccessor:
@@ -20,7 +24,7 @@ def _accessor(**kw) -> OneDriveAccessor:
 @pytest.mark.asyncio
 async def test_rmdir_deletes_an_empty_folder():
     with aioresponses() as m:
-        m.get(_BASE + "/root:/dir:/children", payload={"value": []})
+        m.get(_BASE + "/root:/dir:/children" + _PROBE, payload={"value": []})
         m.delete(_BASE + "/root:/dir", status=204)
         await rmdir(_accessor(), PathSpec.from_str_path("/dir"))
 
@@ -28,7 +32,8 @@ async def test_rmdir_deletes_an_empty_folder():
 @pytest.mark.asyncio
 async def test_rmdir_refuses_a_folder_holding_a_file():
     with aioresponses() as m:
-        m.get(_BASE + "/root:/dir:/children", payload={"value": [_FILE]})
+        m.get(_BASE + "/root:/dir:/children" + _PROBE,
+              payload={"value": [_FILE]})
         with pytest.raises(OSError) as excinfo:
             await rmdir(_accessor(), PathSpec.from_str_path("/dir"))
     assert excinfo.value.errno == errno.ENOTEMPTY
@@ -37,7 +42,8 @@ async def test_rmdir_refuses_a_folder_holding_a_file():
 @pytest.mark.asyncio
 async def test_rmdir_refuses_a_folder_holding_a_subfolder():
     with aioresponses() as m:
-        m.get(_BASE + "/root:/dir:/children", payload={"value": [_FOLDER]})
+        m.get(_BASE + "/root:/dir:/children" + _PROBE,
+              payload={"value": [_FOLDER]})
         with pytest.raises(OSError) as excinfo:
             await rmdir(_accessor(), PathSpec.from_str_path("/dir"))
     assert excinfo.value.errno == errno.ENOTEMPTY
@@ -46,7 +52,8 @@ async def test_rmdir_refuses_a_folder_holding_a_subfolder():
 @pytest.mark.asyncio
 async def test_rmdir_sends_no_delete_when_it_refuses():
     with aioresponses() as m:
-        m.get(_BASE + "/root:/dir:/children", payload={"value": [_FILE]})
+        m.get(_BASE + "/root:/dir:/children" + _PROBE,
+              payload={"value": [_FILE]})
         with pytest.raises(OSError):
             await rmdir(_accessor(), PathSpec.from_str_path("/dir"))
         sent = [key[0] for key in m.requests]

--- a/python/tests/core/onedrive/test_rmdir.py
+++ b/python/tests/core/onedrive/test_rmdir.py
@@ -1,0 +1,53 @@
+import errno
+
+import pytest
+from aioresponses import aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive.rmdir import rmdir
+from mirage.types import PathSpec
+
+_BASE = "https://graph.microsoft.com/v1.0/me/drive"
+
+_FILE = {"id": "c1", "name": "a.txt", "size": 1}
+_FOLDER = {"id": "c2", "name": "sub", "folder": {"childCount": 0}}
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+@pytest.mark.asyncio
+async def test_rmdir_deletes_an_empty_folder():
+    with aioresponses() as m:
+        m.get(_BASE + "/root:/dir:/children", payload={"value": []})
+        m.delete(_BASE + "/root:/dir", status=204)
+        await rmdir(_accessor(), PathSpec.from_str_path("/dir"))
+
+
+@pytest.mark.asyncio
+async def test_rmdir_refuses_a_folder_holding_a_file():
+    with aioresponses() as m:
+        m.get(_BASE + "/root:/dir:/children", payload={"value": [_FILE]})
+        with pytest.raises(OSError) as excinfo:
+            await rmdir(_accessor(), PathSpec.from_str_path("/dir"))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+
+
+@pytest.mark.asyncio
+async def test_rmdir_refuses_a_folder_holding_a_subfolder():
+    with aioresponses() as m:
+        m.get(_BASE + "/root:/dir:/children", payload={"value": [_FOLDER]})
+        with pytest.raises(OSError) as excinfo:
+            await rmdir(_accessor(), PathSpec.from_str_path("/dir"))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+
+
+@pytest.mark.asyncio
+async def test_rmdir_sends_no_delete_when_it_refuses():
+    with aioresponses() as m:
+        m.get(_BASE + "/root:/dir:/children", payload={"value": [_FILE]})
+        with pytest.raises(OSError):
+            await rmdir(_accessor(), PathSpec.from_str_path("/dir"))
+        sent = [key[0] for key in m.requests]
+    assert "DELETE" not in sent

--- a/python/tests/core/onedrive/test_structural.py
+++ b/python/tests/core/onedrive/test_structural.py
@@ -58,6 +58,7 @@ async def test_unlink_deletes_item():
 @pytest.mark.asyncio
 async def test_rmdir_deletes_folder():
     with aioresponses() as m:
+        m.get(_BASE + "/root:/docs:/children", payload={"value": []})
         m.delete(_BASE + "/root:/docs", status=204)
         await rmdir(_accessor(), PathSpec.from_str_path("/docs"))
 

--- a/python/tests/core/onedrive/test_structural.py
+++ b/python/tests/core/onedrive/test_structural.py
@@ -11,6 +11,11 @@ from mirage.core.onedrive.rmdir import rmdir
 from mirage.core.onedrive.unlink import unlink
 from mirage.types import PathSpec
 
+# The emptiness probe is one bounded page, not a full listing walk, so the
+# query is part of the URL the stub has to match; a regression to
+# `graph_list` stops matching it.
+_PROBE = "?$top=1&$select=id"
+
 
 def _accessor(**kw) -> OneDriveAccessor:
     return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
@@ -58,7 +63,7 @@ async def test_unlink_deletes_item():
 @pytest.mark.asyncio
 async def test_rmdir_deletes_folder():
     with aioresponses() as m:
-        m.get(_BASE + "/root:/docs:/children", payload={"value": []})
+        m.get(_BASE + "/root:/docs:/children" + _PROBE, payload={"value": []})
         m.delete(_BASE + "/root:/docs", status=204)
         await rmdir(_accessor(), PathSpec.from_str_path("/docs"))
 

--- a/python/tests/core/ram/test_file_ops.py
+++ b/python/tests/core/ram/test_file_ops.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
+
 import pytest
 
 from mirage.accessor.ram import RAMAccessor
@@ -142,10 +144,11 @@ async def test_rmdir_empty():
 
 @pytest.mark.asyncio
 async def test_rmdir_not_empty(store):
-    with pytest.raises(OSError, match="directory not empty"):
+    with pytest.raises(OSError) as excinfo:
         await rmdir(
             store,
             PathSpec(resource_path="dir", virtual="/dir", directory="/dir"))
+    assert excinfo.value.errno == errno.ENOTEMPTY
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/redis/test_file_ops.py
+++ b/python/tests/core/redis/test_file_ops.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
 import os
 
 import pytest
@@ -163,10 +164,13 @@ async def test_rmdir_empty(mk_store):
 
 @pytest.mark.asyncio
 async def test_rmdir_not_empty(accessor):
-    with pytest.raises(OSError, match="directory not empty"):
+    # The condition, not the wording: this raised a bare OSError whose
+    # only signal was its message, which `classify` cannot name at all.
+    with pytest.raises(OSError) as excinfo:
         await rmdir(
             accessor,
             PathSpec(resource_path="dir", virtual="/dir", directory="/dir"))
+    assert excinfo.value.errno == errno.ENOTEMPTY
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/s3/test_rmdir.py
+++ b/python/tests/core/s3/test_rmdir.py
@@ -1,0 +1,99 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import errno
+from contextlib import ExitStack
+
+import pytest
+
+from mirage.accessor.s3 import S3Accessor
+from mirage.core.s3.rm import rm_r
+from mirage.core.s3.rmdir import rmdir
+from mirage.resource.s3 import S3Config
+from mirage.types import PathSpec
+from tests.e2e.s3_mock import patch_s3_multi
+
+
+def _accessor(key_prefix: str | None = None) -> S3Accessor:
+    return S3Accessor(
+        S3Config(
+            bucket="test-bucket",
+            region="us-east-1",
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            key_prefix=key_prefix,
+        ))
+
+
+def _path(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.strip("/"))
+
+
+def _run(fn, store: dict[str, bytes], virtual: str, key_prefix: str = ""):
+    stack = ExitStack()
+    stack.enter_context(patch_s3_multi({"test-bucket": store}))
+    try:
+        return asyncio.run(fn(_accessor(key_prefix or None), _path(virtual)))
+    finally:
+        stack.close()
+
+
+def test_rmdir_refuses_a_nonempty_prefix_and_keeps_every_key():
+    store = {"dir/": b"", "dir/f.txt": b"child", "dir/sub/g.txt": b"deeper"}
+    with pytest.raises(OSError) as excinfo:
+        _run(rmdir, store, "/dir")
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert store == {
+        "dir/": b"",
+        "dir/f.txt": b"child",
+        "dir/sub/g.txt": b"deeper",
+    }
+
+
+def test_rmdir_refuses_a_prefix_whose_only_child_is_a_subdirectory():
+    store = {"dir/": b"", "dir/sub/": b""}
+    with pytest.raises(OSError) as excinfo:
+        _run(rmdir, store, "/dir")
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert store == {"dir/": b"", "dir/sub/": b""}
+
+
+def test_rmdir_removes_the_marker_of_an_empty_prefix():
+    store = {"dir/": b"", "other.txt": b"keep"}
+    _run(rmdir, store, "/dir")
+    assert store == {"other.txt": b"keep"}
+
+
+def test_rmdir_on_a_prefix_holding_no_key_is_enoent():
+    store = {"other.txt": b"keep"}
+    with pytest.raises(FileNotFoundError):
+        _run(rmdir, store, "/nope")
+    assert store == {"other.txt": b"keep"}
+
+
+def test_rmdir_honors_the_mount_key_prefix():
+    store = {"tenant/dir/": b"", "tenant/dir/f.txt": b"child"}
+    with pytest.raises(OSError) as excinfo:
+        _run(rmdir, store, "/dir", key_prefix="tenant")
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert store == {"tenant/dir/": b"", "tenant/dir/f.txt": b"child"}
+
+
+def test_rm_r_still_deletes_the_whole_subtree():
+    store = {"dir/": b"", "dir/f.txt": b"child", "keep.txt": b"keep"}
+    _run(rm_r, store, "/dir")
+    assert store == {"keep.txt": b"keep"}

--- a/python/tests/core/sharepoint/test_rmdir.py
+++ b/python/tests/core/sharepoint/test_rmdir.py
@@ -16,6 +16,10 @@ _DRIVE = f"{_BASE}/drives/{_DRIVE_ID}"
 
 _FILE = {"id": "c1", "name": "a.txt", "size": 1}
 _FOLDER = {"id": "c2", "name": "sub", "folder": {"childCount": 0}}
+# The emptiness probe is one bounded page, not a full listing walk, so the
+# query is part of the URL the stub has to match; a regression to
+# `graph_list` stops matching it.
+_PROBE = "?$top=1&$select=id"
 
 
 def _accessor() -> SharePointAccessor:
@@ -43,7 +47,7 @@ def _seeded_caches():
 @pytest.mark.asyncio
 async def test_rmdir_deletes_an_empty_folder():
     with aioresponses() as m:
-        m.get(_DRIVE + "/root:/dir:/children", payload={"value": []})
+        m.get(_DRIVE + "/root:/dir:/children" + _PROBE, payload={"value": []})
         m.delete(_DRIVE + "/root:/dir", status=204)
         await rmdir(_accessor(), _spec("dir"))
 
@@ -51,7 +55,8 @@ async def test_rmdir_deletes_an_empty_folder():
 @pytest.mark.asyncio
 async def test_rmdir_refuses_a_folder_holding_a_file():
     with aioresponses() as m:
-        m.get(_DRIVE + "/root:/dir:/children", payload={"value": [_FILE]})
+        m.get(_DRIVE + "/root:/dir:/children" + _PROBE,
+              payload={"value": [_FILE]})
         with pytest.raises(OSError) as excinfo:
             await rmdir(_accessor(), _spec("dir"))
         sent = [key[0] for key in m.requests]
@@ -62,7 +67,8 @@ async def test_rmdir_refuses_a_folder_holding_a_file():
 @pytest.mark.asyncio
 async def test_rmdir_refuses_a_folder_holding_a_subfolder():
     with aioresponses() as m:
-        m.get(_DRIVE + "/root:/dir:/children", payload={"value": [_FOLDER]})
+        m.get(_DRIVE + "/root:/dir:/children" + _PROBE,
+              payload={"value": [_FOLDER]})
         with pytest.raises(OSError) as excinfo:
             await rmdir(_accessor(), _spec("dir"))
     assert excinfo.value.errno == errno.ENOTEMPTY

--- a/python/tests/core/sharepoint/test_rmdir.py
+++ b/python/tests/core/sharepoint/test_rmdir.py
@@ -1,0 +1,68 @@
+import errno
+
+import pytest
+from aioresponses import aioresponses
+
+from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
+from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
+from mirage.core.sharepoint.rmdir import rmdir
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import mount_key
+
+_BASE = "https://graph.microsoft.com/v1.0"
+_SITE_ID = "tenant.sharepoint.com,site-guid,web-guid"
+_DRIVE_ID = "b!driveXYZ"
+_DRIVE = f"{_BASE}/drives/{_DRIVE_ID}"
+
+_FILE = {"id": "c1", "name": "a.txt", "size": 1}
+_FOLDER = {"id": "c2", "name": "sub", "folder": {"childCount": 0}}
+
+
+def _accessor() -> SharePointAccessor:
+    return SharePointAccessor(SharePointConfig(access_token="tok"))
+
+
+def _spec(rel: str) -> PathSpec:
+    virtual = f"/sp/Engineering/Documents/{rel}"
+    return PathSpec(resource_path=mount_key(virtual, "/sp"),
+                    virtual=virtual,
+                    directory=virtual)
+
+
+@pytest.fixture(autouse=True)
+def _seeded_caches():
+    _site_cache.clear()
+    _drive_cache.clear()
+    _site_cache["Engineering"] = _SITE_ID
+    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    yield
+    _site_cache.clear()
+    _drive_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_rmdir_deletes_an_empty_folder():
+    with aioresponses() as m:
+        m.get(_DRIVE + "/root:/dir:/children", payload={"value": []})
+        m.delete(_DRIVE + "/root:/dir", status=204)
+        await rmdir(_accessor(), _spec("dir"))
+
+
+@pytest.mark.asyncio
+async def test_rmdir_refuses_a_folder_holding_a_file():
+    with aioresponses() as m:
+        m.get(_DRIVE + "/root:/dir:/children", payload={"value": [_FILE]})
+        with pytest.raises(OSError) as excinfo:
+            await rmdir(_accessor(), _spec("dir"))
+        sent = [key[0] for key in m.requests]
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert "DELETE" not in sent
+
+
+@pytest.mark.asyncio
+async def test_rmdir_refuses_a_folder_holding_a_subfolder():
+    with aioresponses() as m:
+        m.get(_DRIVE + "/root:/dir:/children", payload={"value": [_FOLDER]})
+        with pytest.raises(OSError) as excinfo:
+            await rmdir(_accessor(), _spec("dir"))
+    assert excinfo.value.errno == errno.ENOTEMPTY

--- a/typescript/packages/browser/src/core/opfs/rmdir.ts
+++ b/typescript/packages/browser/src/core/opfs/rmdir.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { PathSpec } from '@struktoai/mirage-core/types'
+import { enotempty } from '@struktoai/mirage-core/utils/errors'
 import type { OPFSAccessor } from '../../accessor/opfs.ts'
 import { isNotFound, resolveParentDirHandle } from './utils.ts'
 
@@ -32,6 +33,13 @@ export async function rmdir(accessor: OPFSAccessor, path: PathSpec): Promise<voi
     await parentDir.removeEntry(name, { recursive: false })
   } catch (err) {
     if (isNotFound(err)) return
+    // OPFS enforces the emptiness itself under `recursive: false`, but names
+    // its refusal InvalidModificationError. Rethrown raw it reached the
+    // caller as an untyped DOMException that `classify` could not name, so
+    // FUSE reported EIO and the sandbox runtimes saw no errno at all.
+    if (err instanceof DOMException && err.name === 'InvalidModificationError') {
+      throw enotempty(path)
+    }
     throw err
   }
 }

--- a/typescript/packages/core/src/commands/rmdir_is_not_recursive.test.ts
+++ b/typescript/packages/core/src/commands/rmdir_is_not_recursive.test.ts
@@ -1,0 +1,82 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// rmdir(2) refuses a non-empty directory; `rm -r` is what empties one.
+// Implementing rmdir AS the recursive removal silently turns it into a
+// subtree delete for every caller that does not pre-check emptiness itself,
+// and the command builders are the only callers that do -- FUSE, `ws.ops`
+// and the sandbox runtimes all reach the op directly. That is the shape the
+// bug took in five backends at once: two took the object store kit's prefix
+// delete, three called their own recursive removal.
+//
+// This is a source scan rather than an import-and-compare, because the
+// backends live in three packages and `core` cannot import from `node` or
+// `browser`. Mirrors python's
+// tests/commands/test_rmdir_is_not_recursive.py, which compares the wired
+// functions' provenance directly.
+const PACKAGES = ['core', 'node', 'browser']
+
+// `export const rmdir = makeRemovePrefix(DRIVER)` — the kit's recursive
+// prefix delete standing in for rmdir.
+const KIT_ALIAS = /\brmdir\s*=\s*makeRemovePrefix\s*\(/
+
+// `export async function rmdir(...) { await rmR(accessor, path) }` — a body
+// whose only statement hands off to the recursive removal.
+const BODY_ALIAS =
+  /function\s+rmdir\b[^{]*\{\s*(?:return\s+)?(?:await\s+)?(?:this\.)?rm(?:R|_r)\s*\([^)]*\)\s*;?\s*\}/
+
+function* sourceFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      yield* sourceFiles(full)
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      yield full
+    }
+  }
+}
+
+function coreRoots(): string[] {
+  const packagesDir = join(import.meta.dirname, '..', '..', '..')
+  return PACKAGES.map((name) => join(packagesDir, name, 'src', 'core')).filter((dir) =>
+    existsSync(dir),
+  )
+}
+
+describe('rmdir is not the recursive removal', () => {
+  it('scans every package that ships backends', () => {
+    // A guard on the guard: a path that stopped resolving would make the
+    // assertion below vacuous.
+    const roots = coreRoots()
+    expect(roots.length).toBe(PACKAGES.length)
+    const files = roots.flatMap((root) => [...sourceFiles(root)])
+    expect(files.length).toBeGreaterThan(100)
+  })
+
+  it('no backend implements rmdir as its recursive removal', () => {
+    const offenders: string[] = []
+    for (const root of coreRoots()) {
+      for (const file of sourceFiles(root)) {
+        const src = readFileSync(file, 'utf8')
+        if (KIT_ALIAS.test(src)) offenders.push(`${file}: rmdir = makeRemovePrefix(...)`)
+        if (BODY_ALIAS.test(src)) offenders.push(`${file}: rmdir body only calls rmR`)
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/typescript/packages/core/src/core/box/write.ts
+++ b/typescript/packages/core/src/core/box/write.ts
@@ -16,7 +16,8 @@ import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { BoxAccessor } from '../../accessor/box.ts'
 import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
 import { PathSpec } from '../../types.ts'
-import { eisdir, enoent, enotdir } from '../../utils/errors.ts'
+import { eisdir, enoent, enotdir, enotempty } from '../../utils/errors.ts'
+import { BoxApiError } from './client.ts'
 import {
   copyFile,
   copyFolder,
@@ -113,7 +114,16 @@ export async function rmdir(accessor: BoxAccessor, path: PathSpec): Promise<void
   if (item === null) throw enoent(path.virtual)
   if (item.type !== 'folder') throw enotdir(path.virtual)
   // recursive=false: Box 409s on a non-empty folder, matching POSIX rmdir.
-  await deleteFolder(accessor.tokenManager, item.id, false)
+  // The refusal is the service's, but naming it is ours: BoxApiError is a
+  // bare Error with no code, so an unmapped 409 reached the caller as a
+  // condition `classify` could not name -- EIO over FUSE, no code at all for
+  // `ws.ops` and the sandbox runtimes.
+  try {
+    await deleteFolder(accessor.tokenManager, item.id, false)
+  } catch (error) {
+    if (error instanceof BoxApiError && error.status === 409) throw enotempty(path)
+    throw error
+  }
   await invalidateAfterUnlink(path)
 }
 

--- a/typescript/packages/core/src/core/gdrive/_test_util.ts
+++ b/typescript/packages/core/src/core/gdrive/_test_util.ts
@@ -34,6 +34,11 @@ export interface FakeItem {
 // ../google/drive.ts and delegate its functions to the current instance.
 export class FakeDrive {
   items = new Map<string, FakeItem>()
+  // Every `limit` a caller asked for, so a test can pin that an emptiness
+  // probe is bounded. `pageSize` cannot express that: it caps the page, not
+  // the walk, so a small page turns a listing of a large folder into more
+  // requests rather than fewer.
+  listLimits: (number | null | undefined)[] = []
   private counter = 0
 
   add(
@@ -89,6 +94,7 @@ export class FakeDrive {
       limit?: number | null
     } = {},
   ): Promise<DriveFile[]> {
+    this.listLimits.push(opts.limit)
     const folderId = opts.folderId ?? 'root'
     const out: DriveFile[] = []
     for (const item of this.items.values()) {

--- a/typescript/packages/core/src/core/gdrive/_test_util.ts
+++ b/typescript/packages/core/src/core/gdrive/_test_util.ts
@@ -82,7 +82,12 @@ export class FakeDrive {
 
   listFiles(
     _tm: TokenManager,
-    opts: { folderId?: string; mimeType?: string | null; name?: string | null } = {},
+    opts: {
+      folderId?: string
+      mimeType?: string | null
+      name?: string | null
+      limit?: number | null
+    } = {},
   ): Promise<DriveFile[]> {
     const folderId = opts.folderId ?? 'root'
     const out: DriveFile[] = []
@@ -91,6 +96,7 @@ export class FakeDrive {
       if (opts.name != null && item.name !== opts.name) continue
       if (opts.mimeType != null && item.mimeType !== opts.mimeType) continue
       out.push(this.public(item.id))
+      if (opts.limit != null && out.length >= opts.limit) break
     }
     return Promise.resolve(out)
   }

--- a/typescript/packages/core/src/core/gdrive/rename.test.ts
+++ b/typescript/packages/core/src/core/gdrive/rename.test.ts
@@ -70,6 +70,10 @@ describe('gdrive rename', () => {
     await expect(rename(accessor, spec('/src.txt'), spec('/d'))).rejects.toMatchObject({
       code: 'ENOTEMPTY',
     })
+    // The conflict probe is bounded, not a full listing: listFiles follows
+    // every nextPageToken, so asking it with a small `pageSize` made one
+    // request per child to answer a yes/no.
+    expect(fake.listLimits).toContain(1)
   })
 
   it('replaces an empty dir', async () => {

--- a/typescript/packages/core/src/core/gdrive/rename.ts
+++ b/typescript/packages/core/src/core/gdrive/rename.ts
@@ -32,7 +32,7 @@ async function renameImpl(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec
       const children = await listFiles(tm, {
         folderId: dstNode.id,
         driveId: dstNode.driveId,
-        pageSize: 1,
+        limit: 1,
       })
       if (children.length > 0) throw enotempty(dst)
     }

--- a/typescript/packages/core/src/core/gdrive/rmdir.test.ts
+++ b/typescript/packages/core/src/core/gdrive/rmdir.test.ts
@@ -53,4 +53,20 @@ describe('gdrive rmdir', () => {
     fake.add('f.txt', 'root', undefined, ENC.encode('x'))
     await expect(rmdir(accessor, spec('/f.txt'))).rejects.toMatchObject({ code: 'ENOTDIR' })
   })
+
+  it('refuses a folder holding a file and keeps both', async () => {
+    const folder = fake.folder('d')
+    fake.add('a.txt', folder, undefined, ENC.encode('a'))
+    await expect(rmdir(accessor, spec('/d'))).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    expect(fake.find('d')).not.toBeNull()
+    expect(fake.find('a.txt')).not.toBeNull()
+  })
+
+  it('refuses a folder holding a subfolder', async () => {
+    const folder = fake.folder('d')
+    fake.folder('sub', folder)
+    await expect(rmdir(accessor, spec('/d'))).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    expect(fake.find('d')).not.toBeNull()
+    expect(fake.find('sub')).not.toBeNull()
+  })
 })

--- a/typescript/packages/core/src/core/gdrive/rmdir.ts
+++ b/typescript/packages/core/src/core/gdrive/rmdir.ts
@@ -15,16 +15,33 @@
 import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
-import { enoent, enotdir } from '../../utils/errors.ts'
-import { deleteFile } from '../google/drive.ts'
+import { enoent, enotdir, enotempty } from '../../utils/errors.ts'
+import { deleteFile, listFiles } from '../google/drive.ts'
 import { eaccesOnDenied, isFolder, resolveKey } from './resolve.ts'
 
+/**
+ * Remove an empty folder.
+ *
+ * A Drive `files.delete` on a folder removes every descendant with it, so
+ * this is the same request `rmR` sends and the emptiness check is the only
+ * thing separating them. Without it `rmdir` destroyed the whole subtree for
+ * every caller that does not pre-check emptiness itself, and the command
+ * builders are the only callers that do: FUSE, `ws.ops` and the sandbox
+ * runtimes all reach the op directly. The probe is the one `rename` already
+ * makes before it overwrites a directory, bounded to a single entry.
+ */
 async function rmdirImpl(accessor: GDriveAccessor, path: PathSpec): Promise<void> {
   const key = path.resourcePath
   if (key === '') return
   const node = await resolveKey(accessor, key)
   if (node === null) throw enoent(path)
   if (!isFolder(node)) throw enotdir(path)
+  const children = await listFiles(accessor.tokenManager, {
+    folderId: node.id,
+    driveId: node.driveId,
+    limit: 1,
+  })
+  if (children.length > 0) throw enotempty(path)
   await deleteFile(accessor.tokenManager, node.id)
   await invalidateAfterUnlink(path)
 }

--- a/typescript/packages/core/src/core/google/drive.ts
+++ b/typescript/packages/core/src/core/google/drive.ts
@@ -99,6 +99,14 @@ export async function listFiles(
     modifiedAfter?: string | null
     modifiedBefore?: string | null
     name?: string | null
+    /**
+     * Stop once this many files are in hand and do not request another
+     * page. An emptiness probe wants one entry, and `pageSize` alone
+     * cannot express that: it caps the page, not the walk, so a small
+     * page turned a listing of a large folder into many requests
+     * instead of fewer.
+     */
+    limit?: number | null
   } = {},
 ): Promise<DriveFile[]> {
   const folderId = opts.folderId ?? 'root'
@@ -109,6 +117,7 @@ export async function listFiles(
   const modifiedAfter = opts.modifiedAfter ?? null
   const modifiedBefore = opts.modifiedBefore ?? null
   const name = opts.name ?? null
+  const limit = opts.limit ?? null
   const parts: string[] = [`'${folderId}' in parents`]
   if (name !== null) parts.push(`name='${escapeQueryValue(name)}'`)
   if (mimeType !== null) parts.push(`mimeType='${mimeType}'`)
@@ -122,7 +131,7 @@ export async function listFiles(
     const params: Record<string, string | number> = {
       q,
       fields: FIELDS,
-      pageSize,
+      pageSize: limit === null ? pageSize : Math.min(pageSize, limit),
       orderBy: 'modifiedTime desc',
     }
     if (driveId !== null) {
@@ -135,6 +144,7 @@ export async function listFiles(
     const url = `${driveBase(tm)}/files`
     const data = (await googleGet(tm, url, params)) as ListResponse
     if (data.files !== undefined) files.push(...data.files)
+    if (limit !== null && files.length >= limit) break
     pageToken = data.nextPageToken ?? null
     if (pageToken === null) break
   }

--- a/typescript/packages/core/src/core/msgraph/drive.ts
+++ b/typescript/packages/core/src/core/msgraph/drive.ts
@@ -513,11 +513,18 @@ export async function findItems(
   return results.sort(compareCodePoints)
 }
 
+// One bounded page, not graphList: the answer is a yes/no, and graphList
+// follows every @odata.nextLink, so asking it made a large folder download
+// its whole listing to produce one boolean. $top through that helper is
+// worse rather than better -- it only shrinks each page, so the walk pages
+// more times, not fewer -- which is why this sends the request itself.
+// $select drops a driveItem payload this never reads.
 export async function driveRootEmpty(
   config: MsGraphConfigResolved,
   loc: DriveLoc,
 ): Promise<boolean> {
-  return (await graphList(config, loc.item('/children'))).length === 0
+  const page = await graphGet(config, loc.item('/children'), { $top: 1, $select: 'id' })
+  return !(Array.isArray(page.value) && page.value.length > 0)
 }
 
 async function itemOrNull(

--- a/typescript/packages/core/src/core/object_store/remove.test.ts
+++ b/typescript/packages/core/src/core/object_store/remove.test.ts
@@ -96,4 +96,23 @@ describe('object_store remove', () => {
     await managed(() => makeRmdir(makeDriver(store))(accessor, spec('/')))
     expect(store.contents()).toEqual({})
   })
+
+  it('rmdir leaves a child that arrived after the probe', async () => {
+    // The delete is the marker, not the prefix. A concurrent writer can
+    // create a child between the emptiness listing and the delete, and a
+    // prefix delete would take that child down with it -- the subtree loss
+    // this function exists to stop, in a smaller window. So rmdir deletes
+    // only the one key that spells "empty directory", which nothing
+    // arriving after the probe can widen.
+    const store = new FakeStore({ 'a/b/': '' })
+    const driver = makeDriver(store)
+    async function* racingChildren(conn: FakeStore, pfx: string) {
+      yield* driver.listChildren(conn, pfx)
+      conn.objects.set('a/b/late.txt', new TextEncoder().encode('new'))
+    }
+    const rmdir = makeRmdir({ ...driver, listChildren: racingChildren })
+    await managed(() => rmdir(accessor, spec('/a/b')))
+    expect(store.contents()).toEqual({ 'a/b/late.txt': 'new' })
+    expect(store.deletes).toEqual(['a/b/'])
+  })
 })

--- a/typescript/packages/core/src/core/object_store/remove.test.ts
+++ b/typescript/packages/core/src/core/object_store/remove.test.ts
@@ -14,8 +14,8 @@
 
 import { describe, expect, it } from 'vitest'
 import { runWithCacheManager } from '../../cache/context.ts'
-import { FakeAccessor, FakeManager, FakeStore, makeDriver, spec } from './fakes.ts'
-import { makeRemovePrefix, makeUnlink } from './remove.ts'
+import { codeOf, FakeAccessor, FakeManager, FakeStore, makeDriver, spec } from './fakes.ts'
+import { makeRemovePrefix, makeRmdir, makeUnlink } from './remove.ts'
 
 const accessor = new FakeAccessor()
 
@@ -42,5 +42,58 @@ describe('object_store remove', () => {
     expect(store.contents()).toEqual({})
     expect(manager.unlinks).toEqual(['/a/b'])
     expect(manager.writes).toEqual(['/a'])
+  })
+
+  // rmdir is not removePrefix. On a keyed store an empty directory is its
+  // marker object, so a prefix delete removes an empty directory correctly
+  // and a non-empty one recursively -- which is `rm -r`. The two slots
+  // shared one function, so every caller that does not pre-check emptiness
+  // itself (FUSE, `ws.ops`, the sandbox runtimes) destroyed the subtree.
+  it('rmdir refuses a non-empty prefix and keeps every key', async () => {
+    const store = new FakeStore({ 'a/b/': '', 'a/b/c.txt': 'hi', 'a/b/d/e.txt': 'x' })
+    const code = await codeOf(makeRmdir(makeDriver(store))(accessor, spec('/a/b')))
+    expect(code).toBe('ENOTEMPTY')
+    expect(store.contents()).toEqual({ 'a/b/': '', 'a/b/c.txt': 'hi', 'a/b/d/e.txt': 'x' })
+  })
+
+  it('rmdir refuses a prefix whose only child is a subdirectory', async () => {
+    const store = new FakeStore({ 'a/b/': '', 'a/b/d/': '' })
+    const code = await codeOf(makeRmdir(makeDriver(store))(accessor, spec('/a/b')))
+    expect(code).toBe('ENOTEMPTY')
+    expect(store.contents()).toEqual({ 'a/b/': '', 'a/b/d/': '' })
+  })
+
+  it('rmdir removes the marker of an empty prefix', async () => {
+    const store = new FakeStore({ 'a/b/': '', 'keep.txt': 'k' })
+    const manager = await managed(() => makeRmdir(makeDriver(store))(accessor, spec('/a/b')))
+    expect(store.contents()).toEqual({ 'keep.txt': 'k' })
+    expect(manager.unlinks).toEqual(['/a/b'])
+    expect(manager.writes).toEqual(['/a'])
+  })
+
+  it('rmdir reports ENOENT for a prefix holding no key', async () => {
+    const store = new FakeStore({ 'keep.txt': 'k' })
+    const code = await codeOf(makeRmdir(makeDriver(store))(accessor, spec('/a/b')))
+    expect(code).toBe('ENOENT')
+    expect(store.contents()).toEqual({ 'keep.txt': 'k' })
+  })
+
+  // The whole-store case, which the shared prefix delete got wrong. A mount
+  // root resolves to the bare key prefix, so `makeRemovePrefix` in this slot
+  // emptied the entire store. MountRootPolicy refuses a mount root as an
+  // operand with EBUSY, but only on the command path; FUSE and `ws.ops`
+  // reach the op. The root is also the one path that cannot report ENOENT --
+  // it exists because it is mounted -- so an empty root is a no-op.
+  it('rmdir on a populated mount root destroys nothing', async () => {
+    const store = new FakeStore({ 'a.txt': 'x', 'd/f.txt': 'y' })
+    const code = await codeOf(makeRmdir(makeDriver(store))(accessor, spec('/')))
+    expect(code).toBe('ENOTEMPTY')
+    expect(store.contents()).toEqual({ 'a.txt': 'x', 'd/f.txt': 'y' })
+  })
+
+  it('rmdir on an empty mount root is a no-op', async () => {
+    const store = new FakeStore({})
+    await managed(() => makeRmdir(makeDriver(store))(accessor, spec('/')))
+    expect(store.contents()).toEqual({})
   })
 })

--- a/typescript/packages/core/src/core/object_store/remove.ts
+++ b/typescript/packages/core/src/core/object_store/remove.ts
@@ -100,7 +100,12 @@ export function makeRmdir<A extends Accessor, C>(driver: ObjectStoreDriver<A, C>
           break
         }
       }
-      if (!hasChild && (sawKey || isRoot)) await driver.deletePrefix(conn, pfx)
+      // The marker only, never the prefix: a child created between the
+      // listing above and this delete would be taken down with it, which
+      // is the subtree loss this function exists to stop in a smaller
+      // window. A root holding no key has no marker and falls through as
+      // the no-op the prefix delete already was.
+      if (!hasChild && sawKey) await driver.deleteFile(conn, pfx)
     } finally {
       await close()
     }

--- a/typescript/packages/core/src/core/object_store/remove.ts
+++ b/typescript/packages/core/src/core/object_store/remove.ts
@@ -14,7 +14,9 @@
 
 import type { Accessor } from '../../accessor/base.ts'
 import { invalidateAfterUnlink, invalidateAncestors } from '../../cache/context.ts'
+import { enoent, enotempty } from '../../utils/errors.ts'
 import * as kp from '../../utils/key_prefix.ts'
+import { rstripSlash } from '../../utils/slash.ts'
 import type { ObjectStoreDriver, PathFn } from './driver.ts'
 
 /** Build single-key deletion over one driver. */
@@ -56,6 +58,55 @@ export function makeRemovePrefix<A extends Accessor, C>(
     await invalidateAfterUnlink(path)
     // Same rationale as unlink: ancestors that existed only as this
     // prefix are gone now.
+    await invalidateAncestors(path)
+  }
+}
+
+/**
+ * Build POSIX `rmdir` over one driver: refuse a non-empty prefix.
+ *
+ * Not `makeRemovePrefix`. On a keyed store an empty directory is its
+ * zero-byte marker object, so a prefix delete removes an empty directory
+ * correctly and a *non-empty* one recursively, which is `rm -r`, not
+ * `rmdir`. Sharing one function between the two slots made `rmdir` destroy
+ * a whole subtree for every caller that does not pre-check emptiness
+ * itself, and the command builders are the only callers that do: FUSE,
+ * `ws.ops` and the sandbox runtimes all reach the op directly.
+ *
+ * The listing is the same one `readdir` reads, so the two agree on what a
+ * child is: a `marker` entry is the prefix's own marker (or a key the
+ * delimiter listing could not classify) and proves only that the directory
+ * exists, while any `f` or `d` entry is a child and makes this ENOTEMPTY.
+ * The walk stops at the first child rather than listing the whole directory
+ * to answer a yes/no question.
+ *
+ * A prefix holding no key at all -- not even the marker -- is a directory
+ * the store does not have, and rmdir(2) reports ENOENT for it.
+ * `makeRemovePrefix` stays silent there on purpose, because `rm -r` owns
+ * that refusal through its own `-f` handling.
+ */
+export function makeRmdir<A extends Accessor, C>(driver: ObjectStoreDriver<A, C>): PathFn<A> {
+  return async function rmdir(accessor, path) {
+    const pfx = kp.applyDir(driver.keyPrefixOf(accessor), path.mountPath)
+    const isRoot = rstripSlash(path.mountPath) === ''
+    const { conn, close } = await driver.connect(accessor)
+    let sawKey = false
+    let hasChild = false
+    try {
+      for await (const child of driver.listChildren(conn, pfx)) {
+        sawKey = true
+        if (child.kind !== 'marker') {
+          hasChild = true
+          break
+        }
+      }
+      if (!hasChild && (sawKey || isRoot)) await driver.deletePrefix(conn, pfx)
+    } finally {
+      await close()
+    }
+    if (hasChild) throw enotempty(path)
+    if (!sawKey && !isRoot) throw enoent(path)
+    await invalidateAfterUnlink(path)
     await invalidateAncestors(path)
   }
 }

--- a/typescript/packages/core/src/core/onedrive/index.ts
+++ b/typescript/packages/core/src/core/onedrive/index.ts
@@ -23,13 +23,14 @@ import { startBasename } from '../../commands/builtin/find_eval.ts'
 import { record } from '../../observe/context.ts'
 import type { FindOptions } from '../../resource/base.ts'
 import { FileStat, FileType, type PathSpec } from '../../types.ts'
-import { enoent } from '../../utils/errors.ts'
+import { enoent, enotempty } from '../../utils/errors.ts'
 import { mountPrefixOf } from '../../utils/key_prefix.ts'
 import { GraphError, graphDelete, graphGet } from '../msgraph/client.ts'
 import {
   asNumber,
   copyTree,
   createChildFolder,
+  driveRootEmpty,
   duTreeEntries,
   duTreeTotal,
   findItems,
@@ -209,8 +210,23 @@ export async function rmR(accessor: OneDriveAccessor, path: PathSpec): Promise<v
   await invalidateAfterUnlink(path)
 }
 
+/**
+ * Remove an empty folder.
+ *
+ * A Graph `DELETE /drives/{id}/items/{item}` removes a folder and
+ * everything under it, so this is the same request `rmR` sends and the
+ * emptiness check is the only thing separating them. Aliasing the two --
+ * which this was -- destroyed the whole subtree for every caller that does
+ * not pre-check emptiness itself, and the command builders are the only
+ * callers that do: FUSE, `ws.ops` and the sandbox runtimes all reach the op
+ * directly.
+ */
 export async function rmdir(accessor: OneDriveAccessor, path: PathSpec): Promise<void> {
-  await rmR(accessor, path)
+  if (path.resourcePath === '') return
+  const loc = accessor.loc(path.resourcePath)
+  if (!(await driveRootEmpty(accessor.config, loc))) throw enotempty(path)
+  await graphDelete(accessor.config, loc.item())
+  await invalidateAfterUnlink(path)
 }
 
 export async function exists(accessor: OneDriveAccessor, path: PathSpec): Promise<boolean> {

--- a/typescript/packages/core/src/core/ram/rmdir.test.ts
+++ b/typescript/packages/core/src/core/ram/rmdir.test.ts
@@ -1,0 +1,63 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { RAMAccessor } from '../../accessor/ram.ts'
+import { RAMStore } from '../../resource/ram/store.ts'
+import { PathSpec } from '../../types.ts'
+import { mkdir } from './mkdir.ts'
+import { rmdir } from './rmdir.ts'
+import { writeBytes } from './write.ts'
+
+const ENC = new TextEncoder()
+
+function spec(virtual: string): PathSpec {
+  return PathSpec.fromStrPath(virtual)
+}
+
+function accessor(): RAMAccessor {
+  return new RAMAccessor(new RAMStore())
+}
+
+describe('ram rmdir', () => {
+  it('removes an empty directory', async () => {
+    const acc = accessor()
+    await mkdir(acc, spec('/dir'))
+    await rmdir(acc, spec('/dir'))
+    expect(acc.store.dirs.has('/dir')).toBe(false)
+  })
+
+  it('refuses a directory holding a file, leaving the file reachable', async () => {
+    const acc = accessor()
+    await mkdir(acc, spec('/dir'))
+    await writeBytes(acc, spec('/dir/f.txt'), ENC.encode('keep'))
+    await expect(rmdir(acc, spec('/dir'))).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    // The directory has to survive too: dropping it while its children
+    // stay keyed is what left them addressable but unreachable.
+    expect(acc.store.dirs.has('/dir')).toBe(true)
+    expect(acc.store.files.has('/dir/f.txt')).toBe(true)
+  })
+
+  it('refuses a directory holding only a subdirectory', async () => {
+    const acc = accessor()
+    await mkdir(acc, spec('/dir'))
+    await mkdir(acc, spec('/dir/sub'))
+    await expect(rmdir(acc, spec('/dir'))).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    expect(acc.store.dirs.has('/dir/sub')).toBe(true)
+  })
+
+  it('reports ENOENT for a directory the store does not have', async () => {
+    await expect(rmdir(accessor(), spec('/nope'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})

--- a/typescript/packages/core/src/core/ram/rmdir.ts
+++ b/typescript/packages/core/src/core/ram/rmdir.ts
@@ -12,15 +12,30 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { RAMAccessor } from '../../accessor/ram.ts'
 import type { PathSpec } from '../../types.ts'
+import { enoent, enotempty } from '../../utils/errors.ts'
+import { rstripSlash } from '../../utils/slash.ts'
 import { norm } from './utils.ts'
-import { invalidateAfterUnlink } from '../../cache/context.ts'
 
+/**
+ * Remove an empty directory, mirroring the python backend.
+ *
+ * The store is flat, so dropping the directory key is not the whole of
+ * rmdir: the children are keyed independently and survive it. Without the
+ * two checks below, `rmdir` on a populated directory reported success and
+ * left every child addressable but unreachable -- `readdir` then raised,
+ * because the directory they hang off had been erased.
+ */
 export async function rmdir(accessor: RAMAccessor, path: PathSpec): Promise<void> {
   const p = norm(path.mountPath)
-  accessor.store.dirs.delete(p)
-  accessor.store.modified.delete(p)
+  const store = accessor.store
+  if (!store.dirs.has(p)) throw enoent(path)
+  const prefix = `${rstripSlash(p)}/`
+  const keys = [...store.files.keys(), ...store.dirs]
+  if (keys.some((k) => k !== p && k.startsWith(prefix))) throw enotempty(path)
+  store.dirs.delete(p)
+  store.modified.delete(p)
   await invalidateAfterUnlink(path)
-  return Promise.resolve()
 }

--- a/typescript/packages/core/src/core/s3/rmdir.ts
+++ b/typescript/packages/core/src/core/s3/rmdir.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { makeRemovePrefix } from '../object_store/remove.ts'
+import { makeRmdir } from '../object_store/remove.ts'
 import { DRIVER } from './driver.ts'
 
-export const rmdir = makeRemovePrefix(DRIVER)
+export const rmdir = makeRmdir(DRIVER)

--- a/typescript/packages/core/src/core/sharepoint/index.ts
+++ b/typescript/packages/core/src/core/sharepoint/index.ts
@@ -31,7 +31,7 @@ import {
 import { record } from '../../observe/context.ts'
 import type { FindOptions } from '../../resource/base.ts'
 import { FileStat, FileType, type PathSpec } from '../../types.ts'
-import { enoent } from '../../utils/errors.ts'
+import { enoent, enotempty } from '../../utils/errors.ts'
 import { mountPrefixOf } from '../../utils/key_prefix.ts'
 import { stripSlash } from '../../utils/slash.ts'
 import { GraphError, graphDelete } from '../msgraph/client.ts'
@@ -290,8 +290,25 @@ export async function rmR(accessor: SharePointAccessor, path: PathSpec): Promise
   await invalidateAfterUnlink(path)
 }
 
+/**
+ * Remove an empty folder.
+ *
+ * A Graph `DELETE /drives/{id}/items/{item}` removes a folder and
+ * everything under it, so this is the same request `rmR` sends and the
+ * emptiness check is the only thing separating them. Aliasing the two --
+ * which this was -- destroyed the whole subtree for every caller that does
+ * not pre-check emptiness itself, and the command builders are the only
+ * callers that do: FUSE, `ws.ops` and the sandbox runtimes all reach the op
+ * directly.
+ */
 export async function rmdir(accessor: SharePointAccessor, path: PathSpec): Promise<void> {
-  await rmR(accessor, path)
+  if (path.resourcePath === '') return
+  const resolved = await accessor.resolve(path.resourcePath)
+  if (resolved.driveId === null || resolved.itemPath === null) return
+  const loc = accessor.loc(resolved, path.resourcePath)
+  if (!(await driveRootEmpty(accessor.config, loc))) throw enotempty(path)
+  await graphDelete(accessor.config, loc.item())
+  await invalidateAfterUnlink(path)
 }
 
 export async function exists(accessor: SharePointAccessor, path: PathSpec): Promise<boolean> {

--- a/typescript/packages/node/src/core/gridfs/rmdir.ts
+++ b/typescript/packages/node/src/core/gridfs/rmdir.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { makeRemovePrefix } from '@struktoai/mirage-core/core/object_store/remove'
+import { makeRmdir } from '@struktoai/mirage-core/core/object_store/remove'
 import { DRIVER } from './driver.ts'
 
-export const rmdir = makeRemovePrefix(DRIVER)
+export const rmdir = makeRmdir(DRIVER)

--- a/typescript/packages/node/src/core/nextcloud/mkdir.test.ts
+++ b/typescript/packages/node/src/core/nextcloud/mkdir.test.ts
@@ -1,0 +1,65 @@
+import { runWithCacheManager, type CacheInvalidator } from '@struktoai/mirage-core/cache/context'
+import { PathSpec } from '@struktoai/mirage-core/types'
+import { describe, expect, it } from 'vitest'
+import { NextcloudAccessor } from '../../accessor/nextcloud.ts'
+import { mkdir } from './mkdir.ts'
+import { FakeNextcloudOperator, installFakeOperator } from './mock.ts'
+
+function accessorWith(fake: FakeNextcloudOperator): NextcloudAccessor {
+  const accessor = new NextcloudAccessor({
+    url: 'https://cloud.example/remote.php/dav/files/user/',
+  })
+  installFakeOperator(accessor, fake)
+  return accessor
+}
+
+// Collects the paths each invalidation hook was told about.
+class RecordingInvalidator implements CacheInvalidator {
+  readonly writes: string[] = []
+  readonly unlinks: string[] = []
+
+  invalidateAfterWrite(path: string | PathSpec): Promise<void> {
+    this.writes.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  invalidateAfterUnlink(path: string | PathSpec): Promise<void> {
+    this.unlinks.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  cachedBytes(): Promise<Uint8Array | null> {
+    return Promise.resolve(null)
+  }
+}
+
+async function record(path: string, parents?: boolean): Promise<RecordingInvalidator> {
+  const recorder = new RecordingInvalidator()
+  const accessor = accessorWith(new FakeNextcloudOperator())
+  await runWithCacheManager(recorder, async () => {
+    await mkdir(accessor, PathSpec.fromStrPath(path), parents)
+  })
+  return recorder
+}
+
+describe('nextcloud mkdir', () => {
+  it('creates the collection', async () => {
+    const fake = new FakeNextcloudOperator()
+    await mkdir(accessorWith(fake), PathSpec.fromStrPath('/newdir'))
+    expect(fake.directories.has('newdir/')).toBe(true)
+  })
+
+  // opendal's createDir is MKCOL over the whole chain either way, so the
+  // ancestor walk cannot be gated on `parents`: a bare `mkdir a/b/c`
+  // materializes `a` and `a/b` too, and their cached listings hid the new
+  // levels until the index TTL expired.
+  it('invalidates every ancestor without parents', async () => {
+    const recorder = await record('/a/b/c')
+    expect(recorder.writes).toEqual(['/a/b/c', '/a/b', '/a'])
+  })
+
+  it('invalidates the same chain with parents', async () => {
+    const recorder = await record('/a/b/c', true)
+    expect(recorder.writes).toEqual(['/a/b/c', '/a/b', '/a'])
+  })
+})

--- a/typescript/packages/node/src/core/nextcloud/mkdir.ts
+++ b/typescript/packages/node/src/core/nextcloud/mkdir.ts
@@ -4,14 +4,25 @@ import { rstripSlash } from '@struktoai/mirage-core/utils/slash'
 import type { NextcloudAccessor } from '../../accessor/nextcloud.ts'
 import { nextcloudKey } from './util.ts'
 
+/**
+ * Create a collection; opendal creates missing parents either way.
+ *
+ * `parents` is accepted for the op signature and ignored, because
+ * `createDir` is MKCOL over every missing level whatever it says. That is
+ * also why the ancestor invalidation is unconditional: a bare `mkdir a/b/c`
+ * materializes a whole chain here, and gating the walk on `parents` (as the
+ * backends whose mkdir really does create one level correctly do) left every
+ * ancestor above the parent serving a cached listing that hid the new levels
+ * until the index TTL expired.
+ */
 export async function mkdir(
   accessor: NextcloudAccessor,
   path: PathSpec,
-  parents = false,
+  _parents = false,
 ): Promise<void> {
   const key = `${rstripSlash(nextcloudKey(path))}/`
   const op = await accessor.operator()
   await op.createDir(key)
   await invalidateAfterWrite(path)
-  if (parents) await invalidateAncestors(path)
+  await invalidateAncestors(path)
 }

--- a/typescript/packages/node/src/core/nextcloud/mock.ts
+++ b/typescript/packages/node/src/core/nextcloud/mock.ts
@@ -42,6 +42,10 @@ const DIRECTORY_METADATA: FakeMetadata = {
 
 export class FakeNextcloudOperator {
   readonly files = new Map<string, Buffer>()
+  // Collections that hold no key of their own. WebDAV can represent one and
+  // the python fake tracks the same set; without it the mock could not model
+  // an empty directory at all, so nothing that removes one was testable.
+  readonly directories = new Set<string>()
 
   constructor(initial: Record<string, string | Buffer> = {}) {
     for (const [key, value] of Object.entries(initial)) {
@@ -49,9 +53,36 @@ export class FakeNextcloudOperator {
     }
   }
 
+  createDir(key: string): Promise<void> {
+    this.directories.add(`${rstripSlash(key)}/`)
+    return Promise.resolve()
+  }
+
+  // MKCOL creates missing parents, so the fake records them too.
+  delete(key: string): Promise<void> {
+    if (key.endsWith('/')) {
+      this.directories.delete(key)
+      return Promise.resolve()
+    }
+    this.files.delete(key)
+    return Promise.resolve()
+  }
+
+  removeAll(prefix: string): Promise<void> {
+    const stem = rstripSlash(prefix)
+    for (const key of [...this.files.keys()]) {
+      if (key === stem || key.startsWith(`${stem}/`)) this.files.delete(key)
+    }
+    for (const key of [...this.directories]) {
+      if (key === `${stem}/` || key.startsWith(`${stem}/`)) this.directories.delete(key)
+    }
+    return Promise.resolve()
+  }
+
   private hasDirectory(key: string): boolean {
     const prefix = key === '' ? '' : key.endsWith('/') ? key : `${key}/`
-    return prefix === '' || [...this.files.keys()].some((path) => path.startsWith(prefix))
+    if (prefix === '' || this.directories.has(prefix)) return true
+    return [...this.files.keys()].some((path) => path.startsWith(prefix))
   }
 
   stat(key: string): Promise<FakeMetadata> {

--- a/typescript/packages/node/src/core/nextcloud/rmdir.test.ts
+++ b/typescript/packages/node/src/core/nextcloud/rmdir.test.ts
@@ -1,0 +1,45 @@
+import { PathSpec } from '@struktoai/mirage-core/types'
+import { describe, expect, it } from 'vitest'
+import { NextcloudAccessor } from '../../accessor/nextcloud.ts'
+import { mkdir } from './mkdir.ts'
+import { FakeNextcloudOperator, installFakeOperator } from './mock.ts'
+import { rmR } from './rm.ts'
+import { rmdir } from './rmdir.ts'
+
+function accessorWith(fake: FakeNextcloudOperator): NextcloudAccessor {
+  const accessor = new NextcloudAccessor({
+    url: 'https://cloud.example/remote.php/dav/files/user/',
+  })
+  installFakeOperator(accessor, fake)
+  return accessor
+}
+
+describe('nextcloud rmdir', () => {
+  it('removes an empty collection', async () => {
+    const fake = new FakeNextcloudOperator()
+    const accessor = accessorWith(fake)
+    await mkdir(accessor, PathSpec.fromStrPath('/dir'))
+    await rmdir(accessor, PathSpec.fromStrPath('/dir'))
+    expect(fake.directories.has('dir/')).toBe(false)
+  })
+
+  it('refuses a collection holding a file and keeps every key', async () => {
+    const fake = new FakeNextcloudOperator({ 'dir/a.txt': 'a', 'keep.txt': 'k' })
+    const promise = rmdir(accessorWith(fake), PathSpec.fromStrPath('/dir'))
+    await expect(promise).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    expect([...fake.files.keys()].sort()).toEqual(['dir/a.txt', 'keep.txt'])
+  })
+
+  it('refuses a collection holding only a subtree', async () => {
+    const fake = new FakeNextcloudOperator({ 'dir/sub/deep.txt': 'd' })
+    const promise = rmdir(accessorWith(fake), PathSpec.fromStrPath('/dir'))
+    await expect(promise).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    expect([...fake.files.keys()]).toEqual(['dir/sub/deep.txt'])
+  })
+
+  it('rmR still takes the whole subtree', async () => {
+    const fake = new FakeNextcloudOperator({ 'dir/a.txt': 'a', 'keep.txt': 'k' })
+    await rmR(accessorWith(fake), PathSpec.fromStrPath('/dir'))
+    expect([...fake.files.keys()]).toEqual(['keep.txt'])
+  })
+})

--- a/typescript/packages/node/src/core/nextcloud/rmdir.ts
+++ b/typescript/packages/node/src/core/nextcloud/rmdir.ts
@@ -1,18 +1,37 @@
 import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
-import { enoent } from '@struktoai/mirage-core/utils/errors'
-import { rstripSlash } from '@struktoai/mirage-core/utils/slash'
+import { enoent, enotempty } from '@struktoai/mirage-core/utils/errors'
+import { rstripSlash, stripSlash } from '@struktoai/mirage-core/utils/slash'
 import type { NextcloudAccessor } from '../../accessor/nextcloud.ts'
 import { isNotFound, nextcloudKey } from './util.ts'
 
+/**
+ * Remove an empty collection.
+ *
+ * WebDAV DELETE on a collection is recursive (RFC 4918 9.6.1), so this is
+ * the same request `rmR` sends and the emptiness check is the only thing
+ * separating them. Without it `rmdir` destroyed the whole subtree for
+ * every caller that does not pre-check emptiness itself, and the command
+ * builders are the only callers that do: FUSE, `ws.ops` and the sandbox
+ * runtimes all reach the op directly.
+ *
+ * PROPFIND on a collection returns the collection itself, so an entry
+ * naming the collection is not a child -- the same self-entry rule
+ * `readdir` documents.
+ */
 export async function rmdir(accessor: NextcloudAccessor, path: PathSpec): Promise<void> {
   const key = `${rstripSlash(nextcloudKey(path))}/`
+  const stem = stripSlash(key)
   const op = await accessor.operator()
+  let hasChild = false
   try {
-    await op.delete(key)
+    const entries = await op.list(key)
+    hasChild = entries.some((entry) => stripSlash(entry.path()) !== stem)
+    if (!hasChild) await op.delete(key)
   } catch (error) {
     if (isNotFound(error)) throw enoent(path)
     throw error
   }
+  if (hasChild) throw enotempty(path)
   await invalidateAfterUnlink(path)
 }

--- a/typescript/packages/node/src/core/redis/core.test.ts
+++ b/typescript/packages/node/src/core/redis/core.test.ts
@@ -146,14 +146,16 @@ describe.skipIf(skip)('core/redis ops', () => {
   it('rmdir refuses non-empty and removes empty', async () => {
     await mkdir(acc, spec('/dir'))
     await writeBytes(acc, spec('/dir/f'), ENC.encode('.'))
-    await expect(rmdir(acc, spec('/dir'))).rejects.toThrow(/directory not empty/)
+    await expect(rmdir(acc, spec('/dir'))).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    // The refusal must leave the child addressable, not orphan it.
+    expect(await exists(acc, spec('/dir/f'))).toBe(true)
     await unlink(acc, spec('/dir/f'))
     await rmdir(acc, spec('/dir'))
     expect(await exists(acc, spec('/dir'))).toBe(false)
   })
 
   it('rmdir fails on missing dir', async () => {
-    await expect(rmdir(acc, spec('/ghost'))).rejects.toThrow(/not a directory/)
+    await expect(rmdir(acc, spec('/ghost'))).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('unlink removes files', async () => {

--- a/typescript/packages/node/src/core/redis/rmdir.ts
+++ b/typescript/packages/node/src/core/redis/rmdir.ts
@@ -14,25 +14,31 @@
 
 import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
+import { enoent, enotempty } from '@struktoai/mirage-core/utils/errors'
 import { rstripSlash } from '@struktoai/mirage-core/utils/slash'
 import type { RedisAccessor } from '../../accessor/redis.ts'
 import { norm } from './utils.ts'
 
+/**
+ * Remove an empty directory, mirroring the python backend.
+ *
+ * Both refusals go through the shared error helpers so they carry an
+ * errno. They used to be bare `Error`s whose only signal was the wording,
+ * which left the FUSE adapter sniffing message text to recover ENOTEMPTY
+ * and left every other caller -- `ws.ops`, the sandbox runtimes -- with an
+ * error `classify` could not name at all. A missing directory is ENOENT,
+ * not ENOTDIR: the path resolves to nothing, which is also what python
+ * reports here.
+ */
 export async function rmdir(accessor: RedisAccessor, path: PathSpec): Promise<void> {
   const p = norm(path.mountPath)
   const store = accessor.store
-  if (!(await store.hasDir(p))) {
-    throw new Error(`not a directory: ${p}`)
-  }
-  const prefix = rstripSlash(p) + '/'
+  if (!(await store.hasDir(p))) throw enoent(path)
+  const prefix = `${rstripSlash(p)}/`
   const files = await store.listFiles()
   const dirs = await store.listDirs()
   const candidates = [...files, ...dirs]
-  for (const k of candidates) {
-    if (k !== p && k.startsWith(prefix)) {
-      throw new Error(`directory not empty: ${p}`)
-    }
-  }
+  if (candidates.some((k) => k !== p && k.startsWith(prefix))) throw enotempty(path)
   await store.removeDir(p)
   await invalidateAfterUnlink(path)
 }

--- a/typescript/packages/node/src/fuse/core.ts
+++ b/typescript/packages/node/src/fuse/core.ts
@@ -411,20 +411,11 @@ export class MountCore {
     }
   }
 
+  // No emptiness pre-check here, matching the python MountCore. Every
+  // backend's rmdir op refuses a non-empty directory itself, so a listing
+  // first was one extra round trip per call on an API-backed mount, and the
+  // catch that wrapped it swallowed whatever readdir raised.
   async rmdir(path: string): Promise<void> {
-    // Detect non-empty directories up front so we can signal ENOTEMPTY
-    // cleanly. Message-string sniffing alone is unreliable across backends;
-    // check contents first.
-    try {
-      const entries = await this.ops.readdir(this.resolve(path))
-      if (entries.length > 0) {
-        throw errnoError('ENOTEMPTY', `directory not empty: ${path}`)
-      }
-    } catch (err) {
-      if ((err as { code?: string }).code === 'ENOTEMPTY') throw err
-      // readdir failure — fall through to rmdir and let it raise the real
-      // error (e.g. ENOENT for missing path).
-    }
     await this.ops.rmdir(this.resolve(path))
     this.xattrs.delete(path)
   }


### PR DESCRIPTION
`rmdir` checked emptiness in the `generic_bind` builder, so the whole shell battery passed while **six backends per language** implemented the core `rmdir` op as a recursive delete. Three callers reach an op without passing a builder — `MountCore` (FUSE), `Ops`/`ws.fs`, and the runtime VFS (`os.rmdir` / `os.remove` inside a sandbox) — and all three destroyed the subtree.

The `Ops` docstring already calls the dispatcher "the one door". The guard was sitting above it.

## The slot aliasing, two forms

| Backend | How `rmdir` became `rm -r` |
| --- | --- |
| s3, gridfs | took the object-store kit's `make_remove_prefix` |
| nextcloud | `op.delete(key)` — WebDAV DELETE on a collection is recursive (RFC 4918 9.6.1) |
| gdrive | `files.delete` on a folder removes every descendant |
| onedrive, sharepoint | `rmdir = rmR` verbatim in TS; the same `graph_delete` in py |

On a keyed store the worst case was the **mount root**, which resolves to the bare key prefix: `rmdir` there emptied the whole bucket. `MountRootPolicy` refuses a mount root as an operand with EBUSY, but only on the command path.

TS `ram` was wrong differently from its python twin — it dropped the directory key with **no checks at all**, leaving every child keyed but unreachable (`readdir` then raised, because the directory they hung off had been erased).

## Fixes

Each backend probes with the cheapest thing it already had:

- **`make_rmdir` / `makeRmdir`** in the object-store kit reuses the same `list_children` listing `readdir` reads, so the two agree on what a child is, and stops at the first non-`marker` entry. It also reports ENOENT for a prefix holding no key at all — which `make_remove_prefix` cannot do, because `rm -r` owns that refusal through its own `-f`.
- **msgraph** already shipped `drive_root_empty`; onedrive and sharepoint just call it.
- **gdrive** reuses the probe `rename` already makes before overwriting a directory. That needed a new `limit` on `list_files`: `page_size` caps the *page*, not the walk, so a small page turned a listing of a large folder into *more* requests, not fewer.

## One error vocabulary

`ram`, `redis` and `databricks_volume` raised a bare `OSError`/`Error` whose only signal was its wording, which `classify` cannot name at all — no errno for `ws.ops` or the sandbox runtimes, and EIO over FUSE unless the adapter's message needle happened to catch it. `box` and `ssh` had the same gap from the other direction, refusing correctly but letting an untyped service error through. All now name the condition, and dropbox's hand-rolled `OSError` becomes the shared helper, so **`enotempty` is the only spelling left outside the vocabulary modules**.

The message needle stays, but only for SFTP 3's single failure code — `asyncssh.SFTPFailure`, which is not an `OSError` and carries nothing but the server's string. It no longer covers for the repo's own backends.

`MountCore.rmdir` in TS drops its emptiness pre-check, matching python's: it cost a listing per call on an API mount, and its `catch` swallowed whatever `readdir` raised. Its two existing FUSE tests still pass, which is the proof the op layer covers what the pre-check did.

## Also: nextcloud `mkdir` ancestor invalidation

opendal's `create_dir` is MKCOL over every missing level whatever `parents` says, so a bare `mkdir a/b/c` materialized a whole chain while every ancestor above the parent kept serving a cached listing that hid it. The walk is unconditional now. dropbox already had this right and its comment says why.

## Gates, so the class cannot come back

- `python/tests/commands/test_rmdir_is_not_recursive.py` compares the **provenance** (`__module__`, `__qualname__`) of every backend's wired `CommandIO.rmdir` against its `rm_r`. Object identity misses the factory form: one factory called twice yields two distinct closures running one body.
- `typescript/.../commands/rmdir_is_not_recursive.test.ts` is a source scan, because `core` cannot import from `node` or `browser`.

Both were confirmed to fail against each reverted form.

## integ

The shell battery **structurally cannot see this bug** — `rmdir` the builtin checks emptiness itself before calling the op, so it passes on a backend whose op deletes the subtree. The pins therefore live in `integ/runtime`, whose `facade` step calls `ws.ops` directly and whose guest lines reach the same op through the runtime VFS — the only integ surfaces that bypass the builders. Four cases, all failing without the fix on both hosts.

The `facade` step gained an `errno` expectation in both harnesses: `throws_contains` reads the message, and the two languages word one condition differently (python's `OSError` renders the strerror, the TS `FsError` carries only the path), so an errno case has to name the condition instead.

## Verification

| Check | Result |
| --- | --- |
| python suite | exit 0, zero FAILED/ERROR |
| mypy (`--frozen`) | clean, 1888 files |
| TS core + node | 9153 + 2377 tests, 0 failures |
| `pnpm -r typecheck` | 9/9 projects |
| pre-commit | 18 hooks, 0 failed |
| layout / spec / case-target gates | on baseline |
| integ runtime, both hosts | 90 py + 116 ts, 0 failed |

## Notes for review

- The nextcloud probe is tested against the repo fake, not a live server. The fake's self-entry rule it depends on (`op.list("d/")` answers `["d/"]` for an empty collection and `[]` for a missing one) was probed against Nextcloud 30 by whoever wrote the conftest; I did not re-probe. Worth a live check with a fresh container before this is trusted on the real service.
- `databricks_volume/errors.ts` still keeps five local error builders that duplicate the canonical helpers across ~15 call sites. Left alone deliberately — folding it in would have buried a data-loss fix in an unrelated backend.
- The broader delete-side `invalidate_ancestors` asymmetry is still open: nextcloud's `rm`/`unlink`/`rename`/`copy` call only `invalidate_after_*`. `make_rmdir` covers the object-store side.

## Review follow-ups (`fa22d38`)

Two findings from the automated review, both real, both fixed in a second commit and pinned.

**The kit's delete was still a prefix delete.** The emptiness listing proves nothing about the moment of the delete, so a child created in between was destroyed anyway — the same subtree loss, in a smaller window. `make_rmdir` now deletes the directory's own marker key (`delete_file(conn, pfx)`), which cannot reach a child whatever arrived after the probe. The `is_root` arm of the guard went with it: a root holding no key has no marker, and `delete_file("")` is an invalid S3 request where `delete_prefix("")` was a harmless no-op, so the empty root falls through as the no-op it already was. `is_root` still gates the ENOENT refusal.

New test in both languages wraps `list_children` in a generator that creates a child *after* the listing drains, then asserts the late child survived **and** that exactly one key was deleted. Confirmed failing against the prefix-delete version in both languages before restoring.

**The Graph emptiness probe walked the whole folder.** `drive_root_empty` went through `graph_list`, which follows every `@odata.nextLink`, so a large folder downloaded its entire listing to produce one boolean. Note that `$top=1` *through that helper* would be worse rather than better — it shrinks each page, so the walk pages more times, not fewer — so the probe now issues its own single `graph_get` with `$top=1&$select=id`. `graph_list` stays where a caller needs every child (the copy/move conflict machinery). The onedrive and sharepoint stubs now register the query with the URL, making each a pin on the boundedness itself.

Real-store coverage for the changed delete already exists: `integ/unix/rmdir/basic.json` runs the empty-directory removal against `s3`, `gridfs` and both prefixed variants on live minio and mongo, which is exactly the path `delete_file(pfx)` replaced. The race invariant is not something integ can stage, which is why it is a unit pin.

## CI

`test` failed on `3e85cd0` for one reason: redis `test_rmdir_not_empty` asserted the old bare `"directory not empty"` wording, which `enotempty` replaced with the errno-bearing form. Now asserts the errno, matching its `ram` twin. It skips without `REDIS_URL`, so it passed locally and ran in CI — verified this time against a live redis (132 tests, exit 0). `test-python-gate` was that job's aggregator.

`cli-gate` was not a code failure: the snapshot-interop job spent 30 minutes in `apt-get update` installing libfuse and was cancelled, and the gate refuses `cancelled` alongside `failure`. Everything else was green, including all of integ.

Rebased onto `3820f00` (upstream had advanced by 354 files across #851/#855, with zero overlap with the 57 here). Post-rebase: both ratchet gates exactly on baseline (layout 259/259, case-targets 2289/2289), spec parity 93 commands, spec/width drift clean, barrel and docs gates pass, mypy clean over 1889 files, TS core 9188 and node 2386 tests with zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
