### PR TITLE
fix(search): gate the remaining grep/rg/find push-downs on operand count

### DIFF
--- a/integ/resources/discord/scope.json
+++ b/integ/resources/discord/scope.json
@@ -14,7 +14,7 @@
       }
     },
     {
-      "id": "dc_grep_w_day_file_native",
+      "id": "dc_grep_w_day_file_scans_only_that_day",
       "seq": 690201,
       "targets": [
         "discord"
@@ -22,7 +22,7 @@
       "command": "grep -w standup '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/2026-06-02/chat.jsonl'",
       "expect": {
         "exit": 0,
-        "stdout": "/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/2026-06-02/chat.jsonl:[bob] second day standup\n",
+        "stdout": "{\"id\":\"1511278195507200000\",\"channel_id\":\"200000000000000001\",\"author\":{\"id\":\"300000000000000002\",\"username\":\"bob\",\"global_name\":\"Bob\",\"bot\":false},\"content\":\"second day standup\",\"timestamp\":\"2026-06-02T08:00:00.000000+00:00\",\"edited_timestamp\":null,\"tts\":false,\"pinned\":false,\"mention_everyone\":false,\"mentions\":[],\"mention_roles\":[],\"attachments\":[],\"embeds\":[],\"type\":0}\n",
         "stderr": ""
       }
     },
@@ -88,6 +88,45 @@
       "expect": {
         "exit": 0,
         "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_grep_two_channels_cover_the_second",
+      "seq": 690207,
+      "targets": [
+        "discord"
+      ],
+      "command": "grep -rw standup '/discord/Mirage HQ__100000000000000001/channels/releases__200000000000000002' '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/2026-06-02/chat.jsonl:{\"id\":\"1511278195507200000\",\"channel_id\":\"200000000000000001\",\"author\":{\"id\":\"300000000000000002\",\"username\":\"bob\",\"global_name\":\"Bob\",\"bot\":false},\"content\":\"second day standup\",\"timestamp\":\"2026-06-02T08:00:00.000000+00:00\",\"edited_timestamp\":null,\"tts\":false,\"pinned\":false,\"mention_everyone\":false,\"mentions\":[],\"mention_roles\":[],\"attachments\":[],\"embeds\":[],\"type\":0}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_grep_w_second_day_file_only",
+      "seq": 690208,
+      "targets": [
+        "discord"
+      ],
+      "command": "grep -w released '/discord/Mirage HQ__100000000000000001/channels/releases__200000000000000002/2026-06-02/chat.jsonl'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"id\":\"1511285744391782400\",\"channel_id\":\"200000000000000002\",\"author\":{\"id\":\"900000000000000001\",\"username\":\"mirage-bot\",\"global_name\":null,\"bot\":true},\"content\":\"v1.2.1 hotfix released\",\"timestamp\":\"2026-06-02T09:00:00.000000+00:00\",\"edited_timestamp\":null,\"tts\":false,\"pinned\":false,\"mention_everyone\":false,\"mentions\":[],\"mention_roles\":[],\"attachments\":[],\"embeds\":[],\"type\":0}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_grep_wn_defers_to_scan",
+      "seq": 690209,
+      "targets": [
+        "discord"
+      ],
+      "command": "grep -rwn green '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/2026-06-01/chat.jsonl:1:{\"id\":\"1510934682009600000\",\"channel_id\":\"200000000000000001\",\"author\":{\"id\":\"300000000000000001\",\"username\":\"alice\",\"global_name\":\"Alice\",\"bot\":false},\"content\":\"deploy is green\",\"timestamp\":\"2026-06-01T09:15:00.000000+00:00\",\"edited_timestamp\":null,\"tts\":false,\"pinned\":false,\"mention_everyone\":false,\"mentions\":[],\"mention_roles\":[],\"attachments\":[],\"embeds\":[],\"type\":0}\n",
         "stderr": ""
       }
     }

--- a/integ/resources/email/basic.json
+++ b/integ/resources/email/basic.json
@@ -629,6 +629,71 @@
         "stdout": "Q2 Budget Review\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "em_grep_two_folders_cover_the_second",
+      "seq": 540207,
+      "targets": [
+        "email"
+      ],
+      "command": "grep -rw parser /mail/Sent /mail/INBOX",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mail/INBOX/2026-01-05/Standup_notes__2.email.json:{\"from\":{\"name\":\"\",\"email\":\"marcus@example.com\"},\"reply_to\":[],\"to\":[{\"name\":\"\",\"email\":\"integ@example.com\"}],\"cc\":[],\"subject\":\"Standup notes\",\"date\":\"Mon, 05 Jan 2026 14:00:00 +0000\",\"body_text\":\"yesterday shipped the parser\\ntoday reviewing the budget forecast\",\"body_html\":\"\",\"snippet\":\"yesterday shipped the parser\\ntoday reviewing the budget forecast\",\"message_id\":\"\",\"in_reply_to\":null,\"references\":[],\"has_attachments\":false,\"attachments\":[],\"uid\":\"2\",\"flags\":[\"\\\\Seen\"]}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "em_rg_root_scans_instead_of_no_match",
+      "seq": 540208,
+      "targets": [
+        "email"
+      ],
+      "command": "rg -w parser /mail",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mail/INBOX/2026-01-05/Standup_notes__2.email.json:{\"from\":{\"name\":\"\",\"email\":\"marcus@example.com\"},\"reply_to\":[],\"to\":[{\"name\":\"\",\"email\":\"integ@example.com\"}],\"cc\":[],\"subject\":\"Standup notes\",\"date\":\"Mon, 05 Jan 2026 14:00:00 +0000\",\"body_text\":\"yesterday shipped the parser\\ntoday reviewing the budget forecast\",\"body_html\":\"\",\"snippet\":\"yesterday shipped the parser\\ntoday reviewing the budget forecast\",\"message_id\":\"\",\"in_reply_to\":null,\"references\":[],\"has_attachments\":false,\"attachments\":[],\"uid\":\"2\",\"flags\":[\"\\\\Seen\"]}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "em_grep_c_defers_to_scan",
+      "seq": 540209,
+      "targets": [
+        "email"
+      ],
+      "command": "grep -rc parser /mail/INBOX/2026-01-05",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mail/INBOX/2026-01-05/Q2_Budget_Review__1.email.json:0\n/mail/INBOX/2026-01-05/Q2_Budget_Review__1/budget.csv:0\n/mail/INBOX/2026-01-05/Q2_Budget_Review__1/notes.txt:0\n/mail/INBOX/2026-01-05/Standup_notes__2.email.json:1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "em_find_two_folders_cover_the_second",
+      "seq": 540210,
+      "targets": [
+        "email"
+      ],
+      "command": "find /mail/Sent /mail/INBOX -name 'Standup*'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mail/INBOX/2026-01-05/Standup_notes__2.email.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "em_find_root_name_walks",
+      "seq": 540211,
+      "targets": [
+        "email"
+      ],
+      "command": "find /mail -name 'Standup*'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mail/INBOX/2026-01-05/Standup_notes__2.email.json\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/resources/gmail/basic.json
+++ b/integ/resources/gmail/basic.json
@@ -617,6 +617,32 @@
         "stdout": "Q2 Budget Review\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "gm_grep_two_labels_cover_the_second",
+      "seq": 530205,
+      "targets": [
+        "gmail"
+      ],
+      "command": "grep -rw handbook /mail/INBOX /mail/SENT",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mail/SENT/2026-01-06/Re_onboarding__msg0004.gmail.json:{\"id\":\"msg0004\",\"thread_id\":\"msg0004\",\"from\":{\"name\":\"\",\"email\":\"integ@example.com\"},\"to\":[{\"name\":\"\",\"email\":\"lila@example.com\"}],\"cc\":[],\"subject\":\"Re: onboarding\",\"date\":\"Tue, 06 Jan 2026 11:00:00 +0000\",\"body_text\":\"welcome aboard, the handbook is on its way\",\"snippet\":\"welcome aboard, the handbook is on its way\",\"labels\":[\"SENT\"],\"attachments\":[]}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gm_grep_glob_operand_scans",
+      "seq": 530206,
+      "targets": [
+        "gmail"
+      ],
+      "command": "grep -w budget /mail/INBOX/2026-01-05/*.gmail.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mail/INBOX/2026-01-05/Q2_Budget_Review__msg0001.gmail.json:{\"id\":\"msg0001\",\"thread_id\":\"msg0001\",\"from\":{\"name\":\"\",\"email\":\"lila@example.com\"},\"to\":[{\"name\":\"\",\"email\":\"integ@example.com\"}],\"cc\":[],\"subject\":\"Q2 Budget Review\",\"date\":\"Mon, 05 Jan 2026 09:30:00 +0000\",\"body_text\":\"please find the budget attached\\nfinal numbers due friday\",\"snippet\":\"please find the budget attached final numbers due friday\",\"labels\":[\"INBOX\",\"UNREAD\"],\"attachments\":[{\"id\":\"att0001\",\"filename\":\"budget.csv\",\"path\":\"attachments/att0001_budget.csv\",\"mime_type\":\"text/plain\",\"size\":36},{\"id\":\"att0002\",\"filename\":\"notes.txt\",\"path\":\"attachments/att0002_notes.txt\",\"mime_type\":\"text/plain\",\"size\":37}]}\n/mail/INBOX/2026-01-05/Standup_notes__msg0002.gmail.json:{\"id\":\"msg0002\",\"thread_id\":\"msg0002\",\"from\":{\"name\":\"\",\"email\":\"marcus@example.com\"},\"to\":[{\"name\":\"\",\"email\":\"integ@example.com\"}],\"cc\":[],\"subject\":\"Standup notes\",\"date\":\"Mon, 05 Jan 2026 14:00:00 +0000\",\"body_text\":\"yesterday shipped the parser\\ntoday reviewing the budget forecast\",\"snippet\":\"yesterday shipped the parser today reviewing the budget forecast\",\"labels\":[\"INBOX\"],\"attachments\":[]}\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/resources/slack/grep.json
+++ b/integ/resources/slack/grep.json
@@ -51,6 +51,32 @@
         "stdout": "/slack/users/alice__U1.json:1:{\"id\":\"U1\",\"name\":\"alice\",\"real_name\":\"Alice Anderson\",\"is_bot\":false,\"deleted\":false,\"profile\":{\"real_name\":\"Alice Anderson\",\"display_name\":\"alice\",\"email\":\"alice@kestrel.example.com\"}}\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "slack_grep_two_channels_cover_the_second",
+      "seq": 520026,
+      "targets": [
+        "slack"
+      ],
+      "command": "grep -rw milestone /slack/channels/general__C1 /slack/channels/product-runtime__C7",
+      "expect": {
+        "exit": 0,
+        "stdout": "/slack/channels/product-runtime__C7/2026-01-08/chat.jsonl:{\"type\":\"message\",\"user\":\"U11\",\"text\":\"quokka milestone 27 is basically done\",\"ts\":\"1767863370.000558\",\"reactions\":[{\"name\":\"thinking_face\",\"users\":[\"U1\",\"U13\",\"U7\"],\"count\":3}]}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "slack_grep_n_defers_to_scan",
+      "seq": 520027,
+      "targets": [
+        "slack"
+      ],
+      "command": "grep -rwn Quokka /slack/channels/product-runtime__C7",
+      "expect": {
+        "exit": 0,
+        "stdout": "/slack/channels/product-runtime__C7/2026-01-15/files/runtime_spec__F6.md:1:# Kestrel Runtime Spec (Quokka)\n/slack/channels/product-runtime__C7/2026-01-08/chat.jsonl:2:{\"type\":\"message\",\"user\":\"U8\",\"text\":\"kicking off project Quokka, the runtime for building agents over company tools\",\"ts\":\"1767878065.000559\"}\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/python/mirage/commands/builtin/discord/grep.py
+++ b/python/mirage/commands/builtin/discord/grep.py
@@ -20,7 +20,7 @@ from mirage.commands.builtin.discord._provision import file_read_provision
 from mirage.commands.builtin.discord.io import resolve_glob
 from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import pattern_arg
+from mirage.commands.builtin.grep_helper import pattern_arg, pushdown_operand
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
@@ -31,7 +31,7 @@ from mirage.core.discord.entry import channel_dirname
 from mirage.core.discord.formatters import format_grep_results
 from mirage.core.discord.read import read as discord_read
 from mirage.core.discord.readdir import readdir as _readdir
-from mirage.core.discord.scope import coalesce_scopes, detect_scope
+from mirage.core.discord.scope import detect_scope
 from mirage.core.discord.search import search_guild
 from mirage.core.discord.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult, materialize
@@ -40,6 +40,21 @@ from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
 
 logger = logging.getLogger(__name__)
+
+# Discord guild search answers with whole messages and the push-down prints
+# that answer verbatim, so it can stand in for a scan only when the line names
+# one concrete operand and no flag reshapes the output. -w is the exception
+# the provider itself supplies: the search matches whole words, so a bare
+# literal would under-report and only -w makes the two agree.
+#
+# `coalesce_scopes` used to widen a set of same-channel chat.jsonl operands
+# into one channel-wide search, and it is deliberately not consulted here.
+# `search_guild` takes a channel but no date, so folding two named days
+# returned every day the channel ever had — and a single chat.jsonl operand
+# was widened the same way. Reporting messages the line did not ask for is not
+# a better failure than dropping an operand. One operand or the generic scan.
+SEARCH_HONORED = ("w", )
+SEARCH_MAX_RESULTS = 100
 
 
 async def grep_provision(accessor: DiscordAccessor, paths: list[PathSpec],
@@ -59,30 +74,24 @@ async def grep(accessor: DiscordAccessor, paths: list[PathSpec],
                opts: CommandOpts) -> tuple[ByteSource | None, IOResult]:
     fl = FlagView(opts.flags, spec=SPECS["grep"])
     pattern = pattern_arg(texts, fl)
-    max_count = fl.as_int("m")
 
     pushdown_warnings: list[str] = []
-    if paths and pattern is not None and "\n" not in pattern:
-        scope = detect_scope(paths[0])
-        if scope.level == "messages":
-            scope = coalesce_scopes(paths) or scope
-
-        # Provider search matches whole words while grep matches
-        # substrings, and the native path returns search results verbatim
-        # as the output, so a bare literal would under-report. Only -w
-        # makes the two agree; otherwise fall through to the scan.
-        if (scope.use_native and scope.guild_id is not None
-                and fl.as_bool("w")):
+    # Output-shaping flags, a glob operand and a multi-operand line all need
+    # the generic scan; see SEARCH_HONORED above.
+    operand = pushdown_operand(paths, opts.flags, pattern, SEARCH_HONORED)
+    if pattern is not None and operand is not None and fl.as_bool("w"):
+        scope = detect_scope(operand)
+        if scope.use_native and scope.guild_id is not None:
             try:
                 msgs = await search_guild(
                     accessor.config,
                     scope.guild_id,
                     pattern,
                     channel_id=scope.channel_id,
-                    limit=max_count or 100,
+                    limit=SEARCH_MAX_RESULTS,
                 )
-                file_prefix = mount_prefix_of(paths[0].virtual,
-                                              paths[0].resource_path) or ""
+                file_prefix = mount_prefix_of(operand.virtual,
+                                              operand.resource_path) or ""
                 resource_first = scope.resource_path.split("/", 1)[0]
                 channels = await list_channels(accessor.config, scope.guild_id)
                 channel_map = {c["id"]: channel_dirname(c) for c in channels}

--- a/python/mirage/commands/builtin/discord/rg.py
+++ b/python/mirage/commands/builtin/discord/rg.py
@@ -15,10 +15,12 @@
 import logging
 
 from mirage.accessor.discord import DiscordAccessor
+from mirage.commands.builtin.discord.grep import (SEARCH_HONORED,
+                                                  SEARCH_MAX_RESULTS)
 from mirage.commands.builtin.discord.io import resolve_glob
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import pattern_arg
+from mirage.commands.builtin.grep_helper import pattern_arg, pushdown_operand
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
 from mirage.commands.errors import UsageError
@@ -30,7 +32,7 @@ from mirage.core.discord.entry import channel_dirname
 from mirage.core.discord.formatters import format_grep_results
 from mirage.core.discord.read import read as discord_read
 from mirage.core.discord.readdir import readdir as _readdir
-from mirage.core.discord.scope import coalesce_scopes, detect_scope
+from mirage.core.discord.scope import detect_scope
 from mirage.core.discord.search import search_guild
 from mirage.core.discord.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
@@ -48,30 +50,24 @@ async def rg(accessor: DiscordAccessor, paths: list[PathSpec],
     pattern_str = pattern_arg(texts, fl)
     if pattern_str is None:
         raise UsageError("rg: usage: rg [flags] pattern [path]")
-    max_count = fl.as_int("m")
 
     pushdown_warnings: list[str] = []
-    if paths and "\n" not in pattern_str:
-        scope = detect_scope(paths[0])
-        if scope.level == "messages":
-            scope = coalesce_scopes(paths) or scope
-
-        # Provider search matches whole words while grep matches
-        # substrings, and the native path returns search results verbatim
-        # as the output, so a bare literal would under-report. Only -w
-        # makes the two agree; otherwise fall through to the scan.
-        if (scope.use_native and scope.guild_id is not None
-                and fl.as_bool("w")):
+    # Output-shaping flags, a glob operand and a multi-operand line all need
+    # the generic scan; see SEARCH_HONORED above.
+    operand = pushdown_operand(paths, opts.flags, pattern_str, SEARCH_HONORED)
+    if operand is not None and fl.as_bool("w"):
+        scope = detect_scope(operand)
+        if scope.use_native and scope.guild_id is not None:
             try:
                 msgs = await search_guild(
                     accessor.config,
                     scope.guild_id,
                     pattern_str,
                     channel_id=scope.channel_id,
-                    limit=max_count or 100,
+                    limit=SEARCH_MAX_RESULTS,
                 )
-                file_prefix = mount_prefix_of(paths[0].virtual,
-                                              paths[0].resource_path) or ""
+                file_prefix = mount_prefix_of(operand.virtual,
+                                              operand.resource_path) or ""
                 resource_first = scope.resource_path.split("/", 1)[0]
                 channels = await list_channels(accessor.config, scope.guild_id)
                 channel_map = {c["id"]: channel_dirname(c) for c in channels}

--- a/python/mirage/commands/builtin/email/find.py
+++ b/python/mirage/commands/builtin/email/find.py
@@ -20,6 +20,7 @@ from mirage.commands.builtin.email._provision import metadata_provision
 from mirage.commands.builtin.email.io import resolve_glob
 from mirage.commands.builtin.generic.find import (is_link, parse_find_args,
                                                   resolve_start, walk_find)
+from mirage.commands.builtin.grep_helper import lone_operand
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
@@ -28,7 +29,6 @@ from mirage.commands.spec.types import FlagView
 from mirage.core.email.client import fetch_headers
 from mirage.core.email.readdir import _date_bucket, _sanitize
 from mirage.core.email.readdir import readdir as _readdir
-from mirage.core.email.scope import extract_folder
 from mirage.core.email.search import search_messages
 from mirage.core.email.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
@@ -38,12 +38,30 @@ from mirage.utils.fnmatch import fnmatch
 from mirage.utils.key_prefix import mount_prefix_of
 
 
-def _is_folder_level(paths: list[PathSpec]) -> bool:
-    if not paths:
-        return False
-    key = paths[0].mount_path.strip("/")
-    parts = [x for x in key.split("/") if x]
-    return len(parts) <= 1
+def _folder_operand(paths: list[PathSpec]) -> PathSpec | None:
+    """The one folder operand the IMAP subject search may answer for.
+
+    Shares ``lone_operand``'s rule with the grep/rg push-downs, for the
+    same reason: the search answers one whole-folder question and prints
+    its entire answer, so a second operand was dropped in silence
+    (``find /mail/INBOX /mail/Sent -name '*x*'`` searched INBOX only).
+    On top of that the operand must name exactly one path segment, the
+    folder. The mount root used to reach here too and then answer with
+    an empty result and exit 0, reporting "nothing matched" for a search
+    it never ran; it now takes the walk below like any other path the
+    push-down cannot serve.
+
+    Args:
+        paths (list[PathSpec]): operands, already glob-resolved.
+
+    Returns:
+        PathSpec | None: the sole folder-level operand, or None to walk.
+    """
+    operand = lone_operand(paths)
+    if operand is None:
+        return None
+    parts = [x for x in operand.mount_path.strip("/").split("/") if x]
+    return operand if len(parts) == 1 else None
 
 
 async def find_provision(accessor: EmailAccessor, paths: list[PathSpec],
@@ -80,10 +98,11 @@ async def find(
     # falls through to the local walk so nothing is silently dropped.
     name_only = not (texts or size or mtime or type or iname or path
                      or mindepth or maxdepth or empty)
-    if name and name_only and _is_folder_level(paths):
-        p0 = paths[0]
-        search_prefix = mount_prefix_of(p0.virtual, p0.resource_path)
-        return await _find_server_side(accessor, paths, name, search_prefix)
+    if name and name_only:
+        operand = _folder_operand(paths)
+        if operand is not None:
+            prefix = mount_prefix_of(operand.virtual, operand.resource_path)
+            return await _find_server_side(accessor, operand, name, prefix)
 
     args = parse_find_args(tuple(texts),
                            name=name,
@@ -122,14 +141,12 @@ async def find(
 
 async def _find_server_side(
     accessor: EmailAccessor,
-    paths: list[PathSpec],
+    operand: PathSpec,
     name_pattern: str,
     prefix: str,
 ) -> tuple[ByteSource | None, IOResult]:
-    folder = extract_folder(paths)
-    if not folder:
-        return b"", IOResult()
-
+    # One non-empty segment, guaranteed by _folder_operand.
+    folder = operand.mount_path.strip("/")
     subject_query = name_pattern.replace("*", "").replace("?", "").replace(
         ".email.json", "").replace("__", " ").strip("_")
     if not subject_query:

--- a/python/mirage/commands/builtin/email/grep.py
+++ b/python/mirage/commands/builtin/email/grep.py
@@ -20,9 +20,8 @@ from mirage.commands.builtin.email._provision import file_read_provision
 from mirage.commands.builtin.email.io import resolve_glob
 from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_count_has_matches,
-                                                 grep_lines, pattern_arg)
+from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
+                                                 pattern_arg, pushdown_operand)
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
@@ -37,6 +36,19 @@ from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
+
+# The email push-down is not a "print the provider's answer" push-down: IMAP
+# search only picks the candidate messages, and `grep_lines` then runs the
+# real compiled pattern over each one. So the rule for honoring a flag is
+# whether it can make a message the search did NOT return contribute output.
+# -n/-l/-w/-o/-m cannot: each only narrows within a message already listed,
+# and -m is per-file here, which is GNU's own reading of it. -v and -c both
+# can, and were wrong before this: -v reports the lines that do not match, so
+# it needs every message rather than the ones containing the pattern, and
+# GNU's -c prints a `path:0` row for the files with no match at all. They
+# defer now, along with -q, -H/-h, -A/-B/-C, rg's -I and the file filters,
+# which the open-coded version ignored outright.
+SEARCH_HONORED = ("n", "args_l", "w", "o", "m")
 
 
 async def grep_provision(accessor: EmailAccessor, paths: list[PathSpec],
@@ -58,18 +70,21 @@ async def grep(accessor: EmailAccessor, paths: list[PathSpec],
     fl = FlagView(opts.flags, spec=SPECS["grep"])
     pattern = pattern_arg(texts, fl)
 
-    if paths and pattern is not None and "\n" not in pattern and (
-            fl.as_bool("r") or fl.as_bool("R")):
-        scope = detect_scope(paths[0])
+    # A directory operand is only searched at all under -r/-R, so the
+    # push-down waits for it too; every other reason to defer is the shared
+    # gate's. A scope that names no folder falls through to the generic scan
+    # rather than answering, which is what the mount root does.
+    operand = pushdown_operand(paths, opts.flags, pattern, SEARCH_HONORED)
+    if (pattern is not None and operand is not None
+            and (fl.as_bool("r") or fl.as_bool("R"))):
+        scope = detect_scope(operand)
         if scope.use_native and scope.folder:
             return await _grep_server_side(accessor,
                                            scope.folder,
                                            pattern,
-                                           paths,
+                                           operand,
                                            i=fl.as_bool("i"),
-                                           v=fl.as_bool("v"),
                                            n=fl.as_bool("n"),
-                                           c=fl.as_bool("c"),
                                            args_l=fl.as_bool("args_l"),
                                            w=fl.as_bool("w"),
                                            F=fl.as_bool("F"),
@@ -93,19 +108,16 @@ async def _grep_server_side(
     accessor: EmailAccessor,
     folder: str,
     pattern: str,
-    paths: list[PathSpec],
+    operand: PathSpec,
     i: bool = False,
-    v: bool = False,
     n: bool = False,
-    c: bool = False,
     args_l: bool = False,
     w: bool = False,
     F: bool = False,
     o: bool = False,
     max_count: int | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
-    file_prefix = mount_prefix_of(paths[0].virtual,
-                                  paths[0].resource_path) if paths else ""
+    file_prefix = mount_prefix_of(operand.virtual, operand.resource_path)
     pairs = await search_and_format(
         accessor,
         EmailScope(use_native=True, folder=folder),
@@ -124,17 +136,12 @@ async def _grep_server_side(
         matched = grep_lines(vfs_path,
                              lines,
                              pat,
-                             invert=v,
+                             invert=False,
                              line_numbers=n,
-                             count_only=c,
+                             count_only=False,
                              files_only=args_l,
                              only_matching=o,
                              max_count=max_count)
-        if c:
-            all_results.append(f"{vfs_path}:{matched[0]}")
-            if grep_count_has_matches(matched):
-                any_match = True
-            continue
         if not matched:
             continue
         any_match = True

--- a/python/mirage/commands/builtin/email/rg.py
+++ b/python/mirage/commands/builtin/email/rg.py
@@ -13,12 +13,12 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.email import EmailAccessor
+from mirage.commands.builtin.email.grep import SEARCH_HONORED
 from mirage.commands.builtin.email.io import resolve_glob
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_count_has_matches,
-                                                 grep_lines, pattern_arg)
+from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
+                                                 pattern_arg, pushdown_operand)
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
 from mirage.commands.errors import UsageError
@@ -29,7 +29,7 @@ from mirage.core.email.client import fetch_message
 from mirage.core.email.read import read as email_read
 from mirage.core.email.readdir import readdir as _readdir
 from mirage.core.email.render import message_json_text
-from mirage.core.email.scope import extract_folder
+from mirage.core.email.scope import detect_scope
 from mirage.core.email.search import _build_vfs_path, search_messages
 from mirage.core.email.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
@@ -45,9 +45,7 @@ async def rg(accessor: EmailAccessor, paths: list[PathSpec], texts: list[str],
     if pattern_str is None:
         raise UsageError("rg: usage: rg [flags] pattern [path]")
     i = fl.as_bool("i")
-    v = fl.as_bool("v")
     n = fl.as_bool("n")
-    c = fl.as_bool("c")
     args_l = fl.as_bool("args_l")
     w = fl.as_bool("w")
     F = fl.as_bool("F")
@@ -55,13 +53,17 @@ async def rg(accessor: EmailAccessor, paths: list[PathSpec], texts: list[str],
     max_count = fl.as_int("m")
     pat = compile_pattern(pattern_str, i, F, w)
 
-    # IMAP text search takes one pattern; a newline-joined multi -e set
-    # must fall through to the generic so each pattern matches (#347).
-    if paths and "\n" not in pattern_str:
-        folder = extract_folder(paths)
-        if not folder:
-            return b"", IOResult(exit_code=1)
-
+    # IMAP text search takes one pattern; a newline-joined multi -e set must
+    # fall through to the generic so each pattern matches (#347). The rest of
+    # the gate is grep's, from the same table, and reads the scope the same
+    # way: a line the push-down cannot answer takes the generic scan below.
+    # It used to return exit 1 instead, reporting "nothing matched" for a
+    # search it had not run.
+    operand = pushdown_operand(paths, opts.flags, pattern_str, SEARCH_HONORED)
+    scope = detect_scope(operand) if operand is not None else None
+    if (operand is not None and scope is not None and scope.use_native
+            and scope.folder):
+        folder = scope.folder
         uids = await search_messages(accessor,
                                      folder,
                                      text=pattern_str,
@@ -71,8 +73,7 @@ async def rg(accessor: EmailAccessor, paths: list[PathSpec], texts: list[str],
 
         all_results: list[str] = []
         any_match = False
-        file_prefix = mount_prefix_of(paths[0].virtual,
-                                      paths[0].resource_path) if paths else ""
+        file_prefix = mount_prefix_of(operand.virtual, operand.resource_path)
         for uid in uids:
             msg = await fetch_message(accessor, folder, uid)
             msg_text = message_json_text(msg)
@@ -81,18 +82,12 @@ async def rg(accessor: EmailAccessor, paths: list[PathSpec], texts: list[str],
             matched = grep_lines(vfs_path,
                                  lines,
                                  pat,
-                                 invert=v,
+                                 invert=False,
                                  line_numbers=n,
-                                 count_only=c,
+                                 count_only=False,
                                  files_only=args_l,
                                  only_matching=o,
                                  max_count=max_count)
-            if c:
-                if not grep_count_has_matches(matched):
-                    continue
-                any_match = True
-                all_results.append(f"{vfs_path}:{matched[0]}")
-                continue
             if not matched:
                 continue
             any_match = True

--- a/python/mirage/commands/builtin/gmail/grep.py
+++ b/python/mirage/commands/builtin/gmail/grep.py
@@ -19,7 +19,7 @@ from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.generic_bind.adapter import bound_op
 from mirage.commands.builtin.gmail._provision import file_read_provision
 from mirage.commands.builtin.gmail.io import resolve_glob
-from mirage.commands.builtin.grep_helper import pattern_arg
+from mirage.commands.builtin.grep_helper import pattern_arg, pushdown_operand
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
@@ -34,6 +34,14 @@ from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
+
+# Gmail search answers with whole messages and the push-down prints that
+# answer verbatim, so it can stand in for a scan only when the line names one
+# concrete operand and no flag reshapes the output. -w is the exception the
+# provider itself supplies: Gmail matches whole words, so a bare literal would
+# under-report and only -w makes the two agree.
+SEARCH_HONORED = ("w", )
+SEARCH_MAX_RESULTS = 50
 
 
 async def grep_provision(accessor: GmailAccessor, paths: list[PathSpec],
@@ -53,28 +61,20 @@ async def grep(accessor: GmailAccessor, paths: list[PathSpec],
                opts: CommandOpts) -> tuple[ByteSource | None, IOResult]:
     fl = FlagView(opts.flags, spec=SPECS["grep"])
     pattern = pattern_arg(texts, fl)
-    max_count = fl.as_int("m")
-    # Output-shaping flags need real per-line matching, which the search-API
-    # push-down cannot emulate; fall through to the generic grep over
-    # rendered files instead.
-    shaping = (fl.as_bool("args_l") or fl.as_bool("c") or fl.as_bool("n")
-               or fl.as_bool("o") or fl.as_bool("v") or fl.as_bool("q"))
-
-    if paths and pattern is not None and "\n" not in pattern and not shaping:
-        scope = detect_scope(paths[0])
-        # Provider search matches whole words while grep matches
-        # substrings, and the native path returns search results verbatim
-        # as the output, so a bare literal would under-report. Only -w
-        # makes the two agree; otherwise fall through to the scan.
-        if scope.use_native and fl.as_bool("w"):
-            file_prefix = mount_prefix_of(paths[0].virtual,
-                                          paths[0].resource_path) or ""
+    # Output-shaping flags, a glob operand and a multi-operand line all need
+    # the generic grep over rendered files; see SEARCH_HONORED above.
+    operand = pushdown_operand(paths, opts.flags, pattern, SEARCH_HONORED)
+    if pattern is not None and operand is not None and fl.as_bool("w"):
+        scope = detect_scope(operand)
+        if scope.use_native:
+            file_prefix = mount_prefix_of(operand.virtual,
+                                          operand.resource_path) or ""
             rows = await search_messages(
                 accessor.token_manager,
                 pattern,
                 label_name=scope.label_name,
                 date_str=scope.date_str,
-                max_results=max_count or 50,
+                max_results=SEARCH_MAX_RESULTS,
             )
             lines = format_grep_results(rows, scope, file_prefix, pattern)
             if not lines:

--- a/python/mirage/commands/builtin/gmail/rg.py
+++ b/python/mirage/commands/builtin/gmail/rg.py
@@ -15,8 +15,10 @@
 from mirage.accessor.gmail import GmailAccessor
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.generic_bind.adapter import bound_op
+from mirage.commands.builtin.gmail.grep import (SEARCH_HONORED,
+                                                SEARCH_MAX_RESULTS)
 from mirage.commands.builtin.gmail.io import resolve_glob
-from mirage.commands.builtin.grep_helper import pattern_arg
+from mirage.commands.builtin.grep_helper import pattern_arg, pushdown_operand
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
 from mirage.commands.errors import UsageError
@@ -40,28 +42,20 @@ async def rg(accessor: GmailAccessor, paths: list[PathSpec], texts: list[str],
     pattern_str = pattern_arg(texts, fl)
     if pattern_str is None:
         raise UsageError("rg: usage: rg [flags] pattern [path]")
-    max_count = fl.as_int("m")
-    # Output-shaping flags need real per-line matching, which the search-API
-    # push-down cannot emulate; fall through to the generic rg over
-    # rendered files instead.
-    shaping = (fl.as_bool("args_l") or fl.as_bool("c") or fl.as_bool("n")
-               or fl.as_bool("o") or fl.as_bool("v"))
-
-    if paths and "\n" not in pattern_str and not shaping:
-        scope = detect_scope(paths[0])
-        # Provider search matches whole words while grep matches
-        # substrings, and the native path returns search results verbatim
-        # as the output, so a bare literal would under-report. Only -w
-        # makes the two agree; otherwise fall through to the scan.
-        if scope.use_native and fl.as_bool("w"):
-            file_prefix = mount_prefix_of(paths[0].virtual,
-                                          paths[0].resource_path) or ""
+    # Same gate as gmail grep, from the same table: only a lone concrete
+    # operand with no reshaping flag may be answered by the search API.
+    operand = pushdown_operand(paths, opts.flags, pattern_str, SEARCH_HONORED)
+    if operand is not None and fl.as_bool("w"):
+        scope = detect_scope(operand)
+        if scope.use_native:
+            file_prefix = mount_prefix_of(operand.virtual,
+                                          operand.resource_path) or ""
             rows = await search_messages(
                 accessor.token_manager,
                 pattern_str,
                 label_name=scope.label_name,
                 date_str=scope.date_str,
-                max_results=max_count or 50,
+                max_results=SEARCH_MAX_RESULTS,
             )
             lines = format_grep_results(rows, scope, file_prefix, pattern_str)
             if not lines:

--- a/python/mirage/commands/builtin/grep_helper.py
+++ b/python/mirage/commands/builtin/grep_helper.py
@@ -267,7 +267,10 @@ _PUSHDOWN_FILTER_STR = ("type", "glob")
 _PUSHDOWN_FILTER_LIST = ("include", "exclude", "exclude_dir")
 
 
-def has_search_shaping_flags(flags: Mapping[str, FlagValue] | None) -> bool:
+def has_search_shaping_flags(
+        flags: Mapping[str, FlagValue] | None,
+        honored: Sequence[str] = (),
+) -> bool:
     """True when a flag alters the match set or output shape of grep/rg.
 
     A search push-down prints each matching record as one whole line, so it
@@ -277,17 +280,31 @@ def has_search_shaping_flags(flags: Mapping[str, FlagValue] | None) -> bool:
     spec-less FlagView so the shared key set works for both the grep and rg
     specs (rg simply never sets the grep-only keys).
 
+    ``honored`` names the flags this particular push-down implements itself,
+    so their presence is not a reason to defer. Two shapes need it. A provider
+    whose search is word-based (gmail, slack, discord) is faithful only *with*
+    ``-w``, so for those the flag in this list is the one that turns the
+    push-down on rather than off. A push-down that uses the search only to
+    pick candidates and then runs the real compiled matcher over each one
+    (email) honors whatever that local scan implements. Everything left out of
+    the list still defers, which is what keeps the exemption honest.
+
     Args:
         flags (Mapping[str, FlagValue] | None): raw flag kwargs.
+        honored (Sequence[str]): dests this push-down reproduces exactly.
     """
     fl = FlagView(flags)
-    if any(fl.as_bool(k) for k in _PUSHDOWN_SHAPING_BOOL):
+    if any(fl.as_bool(k) for k in _PUSHDOWN_SHAPING_BOOL if k not in honored):
         return True
-    if any(fl.as_int(k) is not None for k in _PUSHDOWN_SHAPING_INT):
+    if any(
+            fl.as_int(k) is not None for k in _PUSHDOWN_SHAPING_INT
+            if k not in honored):
         return True
-    if any(fl.as_list(k) for k in _PUSHDOWN_FILTER_LIST):
+    if any(fl.as_list(k) for k in _PUSHDOWN_FILTER_LIST if k not in honored):
         return True
-    return any(fl.as_str(k) is not None for k in _PUSHDOWN_FILTER_STR)
+    return any(
+        fl.as_str(k) is not None for k in _PUSHDOWN_FILTER_STR
+        if k not in honored)
 
 
 def search_pushdown_ok(flags: Mapping[str, FlagValue] | None,
@@ -312,7 +329,7 @@ def search_pushdown_ok(flags: Mapping[str, FlagValue] | None,
             and not has_search_shaping_flags(flags))
 
 
-def _lone_operand(paths: list[PathSpec]) -> PathSpec | None:
+def lone_operand(paths: list[PathSpec]) -> PathSpec | None:
     """The one operand a search push-down may answer for, or None.
 
     A push-down asks the backend a single whole-container question and
@@ -340,9 +357,10 @@ def _lone_operand(paths: list[PathSpec]) -> PathSpec | None:
 
 
 def pushdown_operand(
-    paths: list[PathSpec],
-    flags: Mapping[str, FlagValue] | None,
-    pattern: str | None,
+        paths: list[PathSpec],
+        flags: Mapping[str, FlagValue] | None,
+        pattern: str | None,
+        honored: Sequence[str] = (),
 ) -> PathSpec | None:
     """The operand a regex push-down may answer for, or None.
 
@@ -356,15 +374,17 @@ def pushdown_operand(
         flags (Mapping[str, FlagValue] | None): raw flag kwargs.
         pattern (str | None): the resolved pattern, None when the line
             supplied none.
+        honored (Sequence[str]): dests this push-down reproduces exactly,
+            passed through to ``has_search_shaping_flags``.
 
     Returns:
         PathSpec | None: the operand to push down for, or None to defer.
     """
     if pattern is None or "\n" in pattern:
         return None
-    if has_search_shaping_flags(flags):
+    if has_search_shaping_flags(flags, honored):
         return None
-    return _lone_operand(paths)
+    return lone_operand(paths)
 
 
 def literal_pushdown_operand(
@@ -374,7 +394,7 @@ def literal_pushdown_operand(
 ) -> PathSpec | None:
     """The operand a literal-substring push-down may answer for, or None.
 
-    ``_lone_operand``'s rule plus ``search_pushdown_ok``'s, which is the
+    ``lone_operand``'s rule plus ``search_pushdown_ok``'s, which is the
     stricter flag gate LIKE/ILIKE needs (postgres): a real regex is
     treated literally by LIKE, so only a verbatim pattern may push down.
 
@@ -389,7 +409,7 @@ def literal_pushdown_operand(
     """
     if pattern is None or not search_pushdown_ok(flags, pattern):
         return None
-    return _lone_operand(paths)
+    return lone_operand(paths)
 
 
 def pattern_arg(texts: Sequence[str], flags: FlagView) -> str | None:

--- a/python/mirage/commands/builtin/slack/grep.py
+++ b/python/mirage/commands/builtin/slack/grep.py
@@ -18,7 +18,7 @@ from dataclasses import replace
 from mirage.accessor.slack import SlackAccessor
 from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import pattern_arg
+from mirage.commands.builtin.grep_helper import pattern_arg, pushdown_operand
 from mirage.commands.builtin.slack._provision import file_read_provision
 from mirage.commands.builtin.slack.io import resolve_glob
 from mirage.commands.builtin.utils.output import format_records
@@ -31,7 +31,7 @@ from mirage.core.slack.formatters import (build_query,
                                           format_grep_results)
 from mirage.core.slack.read import read as slack_read
 from mirage.core.slack.readdir import readdir as _readdir
-from mirage.core.slack.scope import coalesce_scopes, detect_scope
+from mirage.core.slack.scope import detect_scope
 from mirage.core.slack.search import (search_available, search_files,
                                       search_messages)
 from mirage.core.slack.stat import stat as _stat
@@ -41,6 +41,23 @@ from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
 
 logger = logging.getLogger(__name__)
+
+# Slack search answers with whole messages and the push-down prints that
+# answer verbatim, so it can stand in for a scan only when the line names one
+# concrete operand and no flag reshapes the output. -w is the exception the
+# provider itself supplies: Slack matches whole words, so a bare literal would
+# under-report and only -w makes the two agree.
+#
+# `coalesce_scopes` used to widen a set of same-channel operands into one
+# channel-wide search, and it is deliberately not consulted here. It cannot
+# answer a line whose operands name two different channels (it returns None
+# and the first operand won anyway), and where it did fold it dropped the
+# date: `build_query` carries only `in:#channel`, so two named days became
+# every day the channel ever had. Reporting messages the line did not ask for
+# is not a better failure than dropping an operand. One operand or the
+# generic scan.
+SEARCH_HONORED = ("w", )
+SEARCH_MAX_RESULTS = 100
 
 
 async def grep_provision(accessor: SlackAccessor, paths: list[PathSpec],
@@ -60,39 +77,36 @@ async def grep(accessor: SlackAccessor, paths: list[PathSpec],
                opts: CommandOpts) -> tuple[ByteSource | None, IOResult]:
     fl = FlagView(opts.flags, spec=SPECS["grep"])
     pattern = pattern_arg(texts, fl)
-    max_count = fl.as_int("m")
 
-    if paths and pattern is not None and "\n" not in pattern:
-        scope = detect_scope(paths[0])
-        if not scope.use_native:
-            scope = coalesce_scopes(paths) or scope
-
-        # Slack search matches whole words while grep matches substrings,
-        # so native results are a strict subset of the real matches for a
-        # bare literal. Only -w makes the two agree; otherwise fall
-        # through to the per-message scan.
-        if (scope.use_native and fl.as_bool("w")
-                and getattr(scope, "target", None) != "files"
+    # Output-shaping flags, a glob operand and a multi-operand line all need
+    # the per-message scan; see SEARCH_HONORED above.
+    operand = pushdown_operand(paths, opts.flags, pattern, SEARCH_HONORED)
+    if pattern is not None and operand is not None and fl.as_bool("w"):
+        scope = detect_scope(operand)
+        if (scope.use_native and scope.target != "files"
                 and search_available(accessor.config)):
-            file_prefix = mount_prefix_of(paths[0].virtual,
-                                          paths[0].resource_path) or ""
+            file_prefix = mount_prefix_of(operand.virtual,
+                                          operand.resource_path) or ""
             query = build_query(pattern, scope)
-            target = getattr(scope, "target", None)
-            do_msgs = target in (None, "date", "messages")
-            do_files = target in (None, "date", "files")
+            # Every scope that reaches here searches messages: the guard
+            # above ruled out the files leaf, and a "messages" target is a
+            # chat.jsonl leaf, which is not use_native. What is left is the
+            # channel, container and root scopes and the date directory --
+            # and those carry files too, so only the files half stays
+            # conditional.
+            do_files = scope.target in (None, "date")
             native_lines: list[str] = []
             err: Exception | None = None
             try:
-                if do_msgs:
-                    raw = await search_messages(accessor.config,
-                                                query,
-                                                count=max_count or 100)
-                    native_lines.extend(
-                        format_grep_results(raw, scope, file_prefix))
+                raw = await search_messages(accessor.config,
+                                            query,
+                                            count=SEARCH_MAX_RESULTS)
+                native_lines.extend(
+                    format_grep_results(raw, scope, file_prefix))
                 if do_files:
                     raw_f = await search_files(accessor.config,
                                                query,
-                                               count=max_count or 100)
+                                               count=SEARCH_MAX_RESULTS)
                     native_lines.extend(
                         format_file_grep_results(raw_f, scope, file_prefix))
             except Exception as exc:

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -17,7 +17,9 @@ import logging
 from mirage.accessor.slack import SlackAccessor
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.grep_helper import pattern_arg
+from mirage.commands.builtin.grep_helper import pattern_arg, pushdown_operand
+from mirage.commands.builtin.slack.grep import (SEARCH_HONORED,
+                                                SEARCH_MAX_RESULTS)
 from mirage.commands.builtin.slack.io import resolve_glob
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
@@ -30,7 +32,7 @@ from mirage.core.slack.formatters import (build_query,
                                           format_grep_results)
 from mirage.core.slack.read import read as slack_read
 from mirage.core.slack.readdir import readdir as _readdir
-from mirage.core.slack.scope import coalesce_scopes, detect_scope
+from mirage.core.slack.scope import detect_scope
 from mirage.core.slack.search import (search_available, search_files,
                                       search_messages)
 from mirage.core.slack.stat import stat as _stat
@@ -48,39 +50,36 @@ async def rg(accessor: SlackAccessor, paths: list[PathSpec], texts: list[str],
     pattern_str = pattern_arg(texts, fl)
     if pattern_str is None:
         raise UsageError("rg: usage: rg [flags] pattern [path]")
-    max_count = fl.as_int("m")
 
-    if paths and "\n" not in pattern_str:
-        scope = detect_scope(paths[0])
-        if not scope.use_native:
-            scope = coalesce_scopes(paths) or scope
-
-        # Slack search matches whole words while grep matches substrings,
-        # so native results are a strict subset of the real matches for a
-        # bare literal. Only -w makes the two agree; otherwise fall
-        # through to the per-message scan.
-        if (scope.use_native and fl.as_bool("w")
-                and getattr(scope, "target", None) != "files"
+    # Same gate as slack grep, from the same table: only a lone concrete
+    # operand with no reshaping flag may be answered by the search API.
+    operand = pushdown_operand(paths, opts.flags, pattern_str, SEARCH_HONORED)
+    if operand is not None and fl.as_bool("w"):
+        scope = detect_scope(operand)
+        if (scope.use_native and scope.target != "files"
                 and search_available(accessor.config)):
-            file_prefix = mount_prefix_of(paths[0].virtual,
-                                          paths[0].resource_path) or ""
+            file_prefix = mount_prefix_of(operand.virtual,
+                                          operand.resource_path) or ""
             query = build_query(pattern_str, scope)
-            target = getattr(scope, "target", None)
-            do_msgs = target in (None, "date", "messages")
-            do_files = target in (None, "date", "files")
+            # Every scope that reaches here searches messages: the guard
+            # above ruled out the files leaf, and a "messages" target is a
+            # chat.jsonl leaf, which is not use_native. What is left is the
+            # channel, container and root scopes and the date directory --
+            # and those carry files too, so only the files half stays
+            # conditional.
+            do_files = scope.target in (None, "date")
             native_lines: list[str] = []
             err: Exception | None = None
             try:
-                if do_msgs:
-                    raw = await search_messages(accessor.config,
-                                                query,
-                                                count=max_count or 100)
-                    native_lines.extend(
-                        format_grep_results(raw, scope, file_prefix))
+                raw = await search_messages(accessor.config,
+                                            query,
+                                            count=SEARCH_MAX_RESULTS)
+                native_lines.extend(
+                    format_grep_results(raw, scope, file_prefix))
                 if do_files:
                     raw_f = await search_files(accessor.config,
                                                query,
-                                               count=max_count or 100)
+                                               count=SEARCH_MAX_RESULTS)
                     native_lines.extend(
                         format_file_grep_results(raw_f, scope, file_prefix))
             except Exception as exc:

--- a/python/mirage/core/discord/scope.py
+++ b/python/mirage/core/discord/scope.py
@@ -246,34 +246,3 @@ def detect_scope(path: PathSpec) -> DiscordScope:
         )
 
     return DiscordScope(level="guild", use_native=False, resource_path=key)
-
-
-def coalesce_scopes(paths: list[PathSpec]) -> DiscordScope | None:
-    """Fold same-channel chat.jsonl operands into one channel scope.
-
-    Only message files coalesce: guild search answers questions about
-    message content, so widening any other leaf (an attachment blob, a
-    member JSON) to a channel-wide message search would return hits that
-    say nothing about the requested bytes.
-    """
-    if not paths:
-        return None
-    scopes = [detect_scope(p) for p in paths]
-    first = scopes[0]
-    if (first.level != "messages" or first.guild_id is None
-            or first.channel_id is None):
-        return None
-    for s in scopes[1:]:
-        if (s.level != "messages" or s.guild_id != first.guild_id
-                or s.channel_id != first.channel_id):
-            return None
-    return DiscordScope(
-        level="channel",
-        use_native=True,
-        guild_name=first.guild_name,
-        guild_id=first.guild_id,
-        channel_name=first.channel_name,
-        channel_id=first.channel_id,
-        container="channels",
-        resource_path=first.resource_path.rsplit("/", 1)[0],
-    )

--- a/python/mirage/core/email/scope.py
+++ b/python/mirage/core/email/scope.py
@@ -48,12 +48,3 @@ def detect_scope(path: PathSpec) -> EmailScope:
         folder=parts[0],
         resource_path=key,
     )
-
-
-def extract_folder(paths: list[PathSpec]) -> str | None:
-    if not paths:
-        return None
-    p = paths[0]
-    key = p.mount_path.strip("/")
-    parts = [x for x in key.split("/") if x]
-    return parts[0] if parts else None

--- a/python/mirage/core/slack/scope.py
+++ b/python/mirage/core/slack/scope.py
@@ -146,30 +146,3 @@ def detect_scope(path: PathSpec) -> SlackScope:
         )
 
     return SlackScope(use_native=False, resource_path=key)
-
-
-def coalesce_scopes(paths: list[PathSpec]) -> SlackScope | None:
-    if not paths:
-        return None
-    scopes = [detect_scope(p) for p in paths]
-    first = scopes[0]
-    container = first.container
-    channel = first.channel_name
-    cid = first.channel_id
-    target = first.target
-    if container is None or channel is None:
-        return None
-    for s in scopes[1:]:
-        if (s.container != container or s.channel_name != channel
-                or s.channel_id != cid or s.target != target):
-            return None
-    resource_path = (f"{container}/{channel}__{cid}"
-                     if cid else f"{container}/{channel}")
-    return SlackScope(
-        use_native=True,
-        container=container,
-        channel_name=channel,
-        channel_id=cid,
-        target=target,
-        resource_path=resource_path,
-    )

--- a/python/tests/commands/builtin/discord/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/discord/test_grep_pushdown.py
@@ -20,7 +20,7 @@ from mirage.commands.builtin.discord.grep import grep
 from mirage.commands.builtin.discord.rg import rg
 from mirage.commands.config import CommandOpts
 from mirage.commands.errors import UsageError
-from mirage.io.types import materialize
+from mirage.io.types import IOResult, materialize
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -39,8 +39,15 @@ def _concrete_paths(n: int = 7):
     return paths
 
 
+def _channel_path(name: str = "general__ch_456") -> PathSpec:
+    original = f"/discord/myguild__g_123/channels/{name}"
+    return PathSpec(resource_path=mount_key(original, "/discord"),
+                    virtual=original,
+                    directory=original)
+
+
 @pytest.mark.asyncio
-async def test_discord_grep_with_many_concrete_paths_uses_native_search():
+async def test_discord_grep_channel_dir_uses_native_search():
     accessor = AsyncMock()
     accessor.config = AsyncMock()
     fake_msgs = [{
@@ -60,14 +67,92 @@ async def test_discord_grep_with_many_concrete_paths_uses_native_search():
             "mirage.commands.builtin.discord.grep.list_channels",
             new=AsyncMock(return_value=fake_channels),
     ):
-        out, io = await grep(accessor, _concrete_paths(7), ['hello'],
-                             CommandOpts(flags={'w': True}))
+        out, io = await grep(accessor, [_channel_path()], ['hello'],
+                             CommandOpts(flags={
+                                 'w': True,
+                                 'r': True
+                             }))
     assert fake_search.await_count == 1
     assert io.exit_code == 0
     assert b"hello" in out
     assert out.endswith(b"\n")
     assert (b"/discord/myguild__g_123/channels/general__ch_456/"
             b"2026-01-15/chat.jsonl:") in out
+
+
+@pytest.mark.asyncio
+async def test_discord_grep_with_many_concrete_paths_defers_to_scan():
+    # These used to fold into one channel-wide search (`coalesce_scopes`).
+    # `search_guild` takes a channel but no date, so seven named days were
+    # answered with every day the channel ever had. The scan reads the seven.
+    accessor = AsyncMock()
+    accessor.config = AsyncMock()
+    with patch(
+            "mirage.commands.builtin.discord.grep.search_guild",
+            new=AsyncMock(),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.discord.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.discord.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(accessor, _concrete_paths(7), ['hello'],
+                   CommandOpts(flags={'w': True}))
+    fake_search.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_grep_second_channel_operand_defers_to_scan():
+    # Two channels never coalesced at all, so the first operand won and the
+    # second was dropped in silence.
+    accessor = AsyncMock()
+    accessor.config = AsyncMock()
+    with patch(
+            "mirage.commands.builtin.discord.grep.search_guild",
+            new=AsyncMock(),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.discord.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.discord.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(
+            accessor,
+            [_channel_path(), _channel_path("random__ch_789")], ['hello'],
+            CommandOpts(flags={
+                'w': True,
+                'r': True
+            }))
+    fake_search.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_grep_shaping_flag_defers_to_scan():
+    # -n reshapes each output line, which a verbatim search answer cannot do.
+    accessor = AsyncMock()
+    accessor.config = AsyncMock()
+    with patch(
+            "mirage.commands.builtin.discord.grep.search_guild",
+            new=AsyncMock(),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.discord.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.discord.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(accessor, [_channel_path()], ['hello'],
+                   CommandOpts(flags={
+                       'w': True,
+                       'r': True,
+                       'n': True
+                   }))
+    fake_search.assert_not_awaited()
+    generic.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -170,8 +255,11 @@ async def test_discord_grep_native_empty_does_not_trigger_fallback():
             "mirage.commands.builtin.discord.grep.discord_read",
             new=AsyncMock(return_value=b""),
     ) as fake_read:
-        out, io = await grep(accessor, _concrete_paths(7), ['missing'],
-                             CommandOpts(flags={'w': True}))
+        out, io = await grep(accessor, [_channel_path()], ['missing'],
+                             CommandOpts(flags={
+                                 'w': True,
+                                 'r': True
+                             }))
     assert fake_search.await_count == 1
     assert fake_read.await_count == 0
     assert io.exit_code == 1
@@ -221,7 +309,7 @@ async def test_discord_grep_multi_pattern_skips_native_search():
 
 
 @pytest.mark.asyncio
-async def test_discord_rg_with_many_concrete_paths_uses_native_search():
+async def test_discord_rg_channel_dir_uses_native_search():
     accessor = AsyncMock()
     accessor.config = AsyncMock()
     fake_msgs = [{
@@ -241,7 +329,7 @@ async def test_discord_rg_with_many_concrete_paths_uses_native_search():
             "mirage.commands.builtin.discord.rg.list_channels",
             new=AsyncMock(return_value=fake_channels),
     ):
-        out, io = await rg(accessor, _concrete_paths(7), ['hello'],
+        out, io = await rg(accessor, [_channel_path()], ['hello'],
                            CommandOpts(flags={'w': True}))
     assert fake_search.await_count == 1
     assert io.exit_code == 0

--- a/python/tests/commands/builtin/discord/test_search_pushdown_fallback.py
+++ b/python/tests/commands/builtin/discord/test_search_pushdown_fallback.py
@@ -34,10 +34,7 @@ def _path(path: str) -> PathSpec:
 async def test_grep_emits_token_hint_on_forbidden():
     accessor = AsyncMock()
     accessor.config = AsyncMock()
-    paths = [
-        _path("/discord/myguild__G1/channels/general__C1/"
-              "2026-01-01/chat.jsonl")
-    ]
+    paths = [_path("/discord/myguild__G1/channels/general__C1")]
     with patch(
             "mirage.commands.builtin.discord.grep.search_guild",
             new=AsyncMock(side_effect=RuntimeError("403 Forbidden")),
@@ -45,13 +42,13 @@ async def test_grep_emits_token_hint_on_forbidden():
             "mirage.commands.builtin.discord.grep.resolve_glob",
             new=AsyncMock(return_value=paths),
     ), patch(
-            "mirage.commands.builtin.discord.grep.discord_read",
-            new=AsyncMock(return_value=b""),
+            "mirage.commands.builtin.discord.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult(exit_code=1))),
     ):
         _out, io = await grep(accessor, paths, ['hi'],
                               CommandOpts(flags={
                                   'w': True,
-                                  'args_l': True
+                                  'r': True
                               }))
     stderr = (io.stderr or b"").decode()
     assert "push-down failed" in stderr
@@ -62,10 +59,7 @@ async def test_grep_emits_token_hint_on_forbidden():
 async def test_rg_emits_warning_on_rate_limit():
     accessor = AsyncMock()
     accessor.config = AsyncMock()
-    paths = [
-        _path("/discord/myguild__G1/channels/general__C1/"
-              "2026-01-01/chat.jsonl")
-    ]
+    paths = [_path("/discord/myguild__G1/channels/general__C1")]
     with patch(
             "mirage.commands.builtin.discord.rg.search_guild",
             new=AsyncMock(side_effect=RuntimeError("rate limited 429")),

--- a/python/tests/commands/builtin/email/test_find.py
+++ b/python/tests/commands/builtin/email/test_find.py
@@ -165,3 +165,50 @@ async def test_name_with_size_falls_through_to_walk():
                         }))
     search.assert_not_awaited()
     assert (stdout if isinstance(stdout, bytes) else b"") == b""
+
+
+@pytest.mark.asyncio
+async def test_second_folder_operand_falls_through_to_walk():
+    # The IMAP subject search answers for one folder, so the second operand
+    # used to be dropped in silence: `find /INBOX /Sent -name '*x*'` searched
+    # INBOX only.
+    search = AsyncMock(return_value=[])
+    with patch("mirage.commands.builtin.email.find.search_messages", search), \
+         patch("mirage.core.email.readdir.list_folders",
+               new_callable=AsyncMock,
+               return_value=["INBOX", "Sent"]), \
+         patch("mirage.core.email.stat.list_folders",
+               new_callable=AsyncMock,
+               return_value=["INBOX", "Sent"]), \
+         patch("mirage.core.email.readdir.list_message_uids",
+               new_callable=AsyncMock,
+               return_value=[]):
+        await find(
+            _accessor(), [_spec('/INBOX'), _spec('/Sent')], [],
+            CommandOpts(index=RAMIndexCacheStore(), flags={'name':
+                                                           '*report*'}))
+    search.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mount_root_walks_instead_of_reporting_no_match():
+    # The root reached the push-down too, where `extract_folder` returned
+    # None and it answered with an empty result and exit 0 — "nothing
+    # matched" for a search it never ran. It has to walk.
+    search = AsyncMock(return_value=[])
+    with patch("mirage.commands.builtin.email.find.search_messages", search), \
+         patch("mirage.core.email.readdir.list_folders",
+               new_callable=AsyncMock,
+               return_value=["INBOX", "Sent"]), \
+         patch("mirage.core.email.stat.list_folders",
+               new_callable=AsyncMock,
+               return_value=["INBOX", "Sent"]), \
+         patch("mirage.core.email.readdir.list_message_uids",
+               new_callable=AsyncMock,
+               return_value=[]):
+        stdout, _io = await find(
+            _accessor(), [_spec('/')], [],
+            CommandOpts(index=RAMIndexCacheStore(), flags={'name': 'Sent'}))
+    search.assert_not_awaited()
+    lines = (stdout if isinstance(stdout, bytes) else b"").decode().split()
+    assert "/Sent" in lines

--- a/python/tests/commands/builtin/email/test_grep.py
+++ b/python/tests/commands/builtin/email/test_grep.py
@@ -5,7 +5,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from mirage.commands.config import CommandOpts
 from mirage.io.stream import materialize
+from mirage.io.types import IOResult
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -18,12 +20,19 @@ sys.modules.setdefault(
     SimpleNamespace(SMTP=object, send=AsyncMock()),
 )
 
-_grep_server_side = importlib.import_module(
-    "mirage.commands.builtin.email.grep")._grep_server_side
+_email_grep = importlib.import_module("mirage.commands.builtin.email.grep")
+_grep_server_side = _email_grep._grep_server_side
+grep = _email_grep.grep
+
+
+def _folder(name: str = "INBOX") -> PathSpec:
+    return PathSpec(resource_path=mount_key(f"/email/{name}", "/email"),
+                    virtual=f"/email/{name}",
+                    directory=f"/email/{name}")
 
 
 @pytest.mark.asyncio
-async def test_grep_server_side_count_uses_real_count():
+async def test_grep_server_side_matches_real_lines():
     accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
     pairs = [
         ("/email/INBOX/msg1.email.json", "foo foo\nfoo bar\nbaz\n"),
@@ -33,17 +42,102 @@ async def test_grep_server_side_count_uses_real_count():
             "mirage.commands.builtin.email.grep.search_and_format",
             new=AsyncMock(return_value=pairs),
     ):
-        stdout, io = await _grep_server_side(
-            accessor,
-            "INBOX",
-            "foo",
-            [
-                PathSpec(resource_path=mount_key("/email/INBOX", "/email"),
-                         virtual="/email/INBOX",
-                         directory="/email/INBOX")
-            ],
-            c=True,
-        )
-    assert await materialize(stdout) == (b"/email/INBOX/msg1.email.json:2\n"
-                                         b"/email/INBOX/msg2.email.json:0\n")
+        stdout, io = await _grep_server_side(accessor, "INBOX", "foo",
+                                             _folder())
+    # Both matching lines of msg1; msg2 contains no "foo" at all.
+    assert await materialize(stdout) == (
+        b"/email/INBOX/msg1.email.json:foo foo\n"
+        b"/email/INBOX/msg1.email.json:foo bar\n")
     assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_grep_count_flag_defers_to_generic():
+    # -c used to run over the search's own candidate list, so a message the
+    # IMAP search did not return simply had no row — where GNU prints
+    # `path:0` for it. Only the generic scan sees every message.
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    with patch(
+            "mirage.commands.builtin.email.grep.search_and_format",
+            new=AsyncMock(return_value=[]),
+    ) as search, patch(
+            "mirage.commands.builtin.email.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.email.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(accessor, [_folder()], ["foo"],
+                   CommandOpts(flags={
+                       "r": True,
+                       "c": True
+                   }))
+    search.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_invert_flag_defers_to_generic():
+    # -v reports the lines that do NOT match, so it needs every message —
+    # the candidate list is exactly the messages that DO contain the text.
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    with patch(
+            "mirage.commands.builtin.email.grep.search_and_format",
+            new=AsyncMock(return_value=[]),
+    ) as search, patch(
+            "mirage.commands.builtin.email.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.email.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(accessor, [_folder()], ["foo"],
+                   CommandOpts(flags={
+                       "r": True,
+                       "v": True
+                   }))
+    search.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_second_folder_operand_defers_to_generic():
+    # The push-down answers for one folder, so the second operand used to be
+    # dropped in silence: this line reported INBOX and never mentioned Sent.
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    with patch(
+            "mirage.commands.builtin.email.grep.search_and_format",
+            new=AsyncMock(return_value=[]),
+    ) as search, patch(
+            "mirage.commands.builtin.email.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.email.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(accessor,
+                   [_folder("INBOX"), _folder("Sent")], ["foo"],
+                   CommandOpts(flags={"r": True}))
+    search.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_mount_root_defers_to_generic():
+    # The root names no folder, so there is nothing to search: it takes the
+    # scan rather than answering for whatever folder came first.
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    root = PathSpec(resource_path="", virtual="/email", directory="/email")
+    with patch(
+            "mirage.commands.builtin.email.grep.search_and_format",
+            new=AsyncMock(return_value=[]),
+    ) as search, patch(
+            "mirage.commands.builtin.email.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.email.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(accessor, [root], ["foo"], CommandOpts(flags={"r": True}))
+    search.assert_not_awaited()
+    generic.assert_awaited_once()

--- a/python/tests/commands/builtin/email/test_rg.py
+++ b/python/tests/commands/builtin/email/test_rg.py
@@ -94,3 +94,77 @@ async def test_rg_single_pattern_uses_imap_search():
 
     assert io.exit_code == 1
     search.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rg_second_folder_operand_defers_to_generic():
+    # The push-down answers for one folder, so the second operand used to be
+    # dropped in silence: this line reported INBOX and never mentioned Sent.
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    with patch("mirage.commands.builtin.email.rg.search_messages",
+               new=AsyncMock(return_value=[])) as search, \
+            patch("mirage.commands.builtin.email.rg.resolve_glob",
+                  new=AsyncMock(return_value=[])), \
+            patch("mirage.commands.builtin.email.rg.generic_rg",
+                  new=AsyncMock(return_value=(b"", IOResult()))) as generic:
+        await rg(accessor, [_path("/email/INBOX"),
+                            _path("/email/Sent")], ["foo"],
+                 CommandOpts(index=RAMIndexCacheStore(), flags={}))
+    search.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rg_mount_root_scans_instead_of_reporting_no_match():
+    # The root names no folder. `extract_folder` returned None for it and rg
+    # answered exit 1 — "nothing matched" for a search it never ran. It has
+    # to reach the generic scan instead.
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    root = PathSpec(resource_path="", virtual="/email", directory="/email")
+    with patch("mirage.commands.builtin.email.rg.search_messages",
+               new=AsyncMock(return_value=[])) as search, \
+            patch("mirage.commands.builtin.email.rg.resolve_glob",
+                  new=AsyncMock(return_value=[])), \
+            patch("mirage.commands.builtin.email.rg.generic_rg",
+                  new=AsyncMock(return_value=(b"", IOResult()))) as generic:
+        _out, io = await rg(accessor, [root], ["foo"],
+                            CommandOpts(index=RAMIndexCacheStore(), flags={}))
+    search.assert_not_awaited()
+    generic.assert_awaited_once()
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_rg_message_file_operand_defers_to_generic():
+    # A single .email.json is not a folder scope, so it reads the one file
+    # rather than reporting exit 1 without searching.
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    msg = _path("/email/INBOX/2026-01-05/Q2__1.email.json")
+    with patch("mirage.commands.builtin.email.rg.search_messages",
+               new=AsyncMock(return_value=[])) as search, \
+            patch("mirage.commands.builtin.email.rg.resolve_glob",
+                  new=AsyncMock(return_value=[])), \
+            patch("mirage.commands.builtin.email.rg.generic_rg",
+                  new=AsyncMock(return_value=(b"", IOResult()))) as generic:
+        _out, io = await rg(accessor, [msg], ["foo"],
+                            CommandOpts(index=RAMIndexCacheStore(), flags={}))
+    search.assert_not_awaited()
+    generic.assert_awaited_once()
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_rg_invert_flag_defers_to_generic():
+    # -v reports the lines that do NOT match, so it needs every message —
+    # the candidate list is exactly the messages that DO contain the text.
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    with patch("mirage.commands.builtin.email.rg.search_messages",
+               new=AsyncMock(return_value=[])) as search, \
+            patch("mirage.commands.builtin.email.rg.resolve_glob",
+                  new=AsyncMock(return_value=[])), \
+            patch("mirage.commands.builtin.email.rg.generic_rg",
+                  new=AsyncMock(return_value=(b"", IOResult()))) as generic:
+        await rg(accessor, [_path()], ["foo"],
+                 CommandOpts(index=RAMIndexCacheStore(), flags={"v": True}))
+    search.assert_not_awaited()
+    generic.assert_awaited_once()

--- a/python/tests/commands/builtin/gmail/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/gmail/test_grep_pushdown.py
@@ -21,6 +21,7 @@ from mirage.commands.builtin.gmail.grep import grep
 from mirage.commands.builtin.gmail.rg import rg
 from mirage.commands.config import CommandOpts
 from mirage.commands.errors import UsageError
+from mirage.io.types import IOResult
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -92,3 +93,112 @@ async def test_rg_without_word_flag_skips_native_search():
             await rg(accessor, [_label_scope()], ['hello'],
                      CommandOpts(index=RAMIndexCacheStore()))
     spy.assert_not_awaited()
+
+
+def _glob_scope() -> PathSpec:
+    # A glob whose directory IS searchable, so only the glob half of the gate
+    # can defer it.
+    original = "/gmail/INBOX/2026-01-01/*.gmail.json"
+    return PathSpec(resource_path=mount_key(original, "/gmail"),
+                    virtual=original,
+                    directory="/gmail/INBOX/2026-01-01",
+                    pattern="*.gmail.json",
+                    resolved=False)
+
+
+@pytest.mark.asyncio
+async def test_grep_second_operand_defers_to_generic():
+    # The push-down answers for one label, so a second operand used to be
+    # dropped in silence: this line reported INBOX and never mentioned Sent.
+    accessor = AsyncMock()
+    sent = PathSpec(resource_path=mount_key("/gmail/Sent", "/gmail"),
+                    virtual="/gmail/Sent",
+                    directory="/gmail/Sent")
+    with patch("mirage.commands.builtin.gmail.grep.search_messages",
+               new=AsyncMock(return_value=ROWS)) as spy, \
+            patch("mirage.commands.builtin.gmail.grep.resolve_glob",
+                  new=AsyncMock(return_value=[])), \
+            patch("mirage.commands.builtin.gmail.grep.generic_grep",
+                  new=AsyncMock(return_value=(b"", IOResult()))) as generic:
+        await grep(accessor, [_label_scope(), sent], ['hello'],
+                   CommandOpts(index=RAMIndexCacheStore(), flags={'w': True}))
+    spy.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rg_second_operand_defers_to_generic():
+    accessor = AsyncMock()
+    sent = PathSpec(resource_path=mount_key("/gmail/Sent", "/gmail"),
+                    virtual="/gmail/Sent",
+                    directory="/gmail/Sent")
+    with patch("mirage.commands.builtin.gmail.rg.search_messages",
+               new=AsyncMock(return_value=ROWS)) as spy, \
+            patch("mirage.commands.builtin.gmail.rg.resolve_glob",
+                  new=AsyncMock(return_value=[])), \
+            patch("mirage.commands.builtin.gmail.rg.generic_rg",
+                  new=AsyncMock(return_value=(b"", IOResult()))) as generic:
+        await rg(accessor, [_label_scope(), sent], ['hello'],
+                 CommandOpts(index=RAMIndexCacheStore(), flags={'w': True}))
+    spy.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_unresolved_glob_defers_to_generic():
+    # There was no glob check at all: the unexpanded `*.gmail.json` segment
+    # reached the native search, which reads it as a literal.
+    accessor = AsyncMock()
+    with patch("mirage.commands.builtin.gmail.grep.search_messages",
+               new=AsyncMock(return_value=ROWS)) as spy, \
+            patch("mirage.commands.builtin.gmail.grep.resolve_glob",
+                  new=AsyncMock(return_value=[])), \
+            patch("mirage.commands.builtin.gmail.grep.generic_grep",
+                  new=AsyncMock(return_value=(b"", IOResult()))) as generic:
+        await grep(accessor, [_glob_scope()], ['hello'],
+                   CommandOpts(index=RAMIndexCacheStore(), flags={'w': True}))
+    spy.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_context_flag_defers_to_generic():
+    # -A was not in the open-coded shaping list, so the push-down ran and the
+    # context lines were dropped without a word.
+    accessor = AsyncMock()
+    with patch("mirage.commands.builtin.gmail.grep.search_messages",
+               new=AsyncMock(return_value=ROWS)) as spy, \
+            patch("mirage.commands.builtin.gmail.grep.resolve_glob",
+                  new=AsyncMock(return_value=[])), \
+            patch("mirage.commands.builtin.gmail.grep.generic_grep",
+                  new=AsyncMock(return_value=(b"", IOResult()))) as generic:
+        await grep(
+            accessor, [_label_scope()], ['hello'],
+            CommandOpts(index=RAMIndexCacheStore(),
+                        flags={
+                            'w': True,
+                            'A': "2"
+                        }))
+    spy.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rg_quiet_flag_defers_to_generic():
+    # py grep checked -q and py rg did not; both read the one shared table.
+    accessor = AsyncMock()
+    with patch("mirage.commands.builtin.gmail.rg.search_messages",
+               new=AsyncMock(return_value=ROWS)) as spy, \
+            patch("mirage.commands.builtin.gmail.rg.resolve_glob",
+                  new=AsyncMock(return_value=[])), \
+            patch("mirage.commands.builtin.gmail.rg.generic_rg",
+                  new=AsyncMock(return_value=(b"", IOResult()))) as generic:
+        await rg(
+            accessor, [_label_scope()], ['hello'],
+            CommandOpts(index=RAMIndexCacheStore(),
+                        flags={
+                            'w': True,
+                            'q': True
+                        }))
+    spy.assert_not_awaited()
+    generic.assert_awaited_once()

--- a/python/tests/commands/builtin/slack/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/slack/test_grep_pushdown.py
@@ -20,6 +20,7 @@ from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.commands.builtin.slack.grep import grep
 from mirage.commands.builtin.slack.rg import rg
 from mirage.commands.config import CommandOpts
+from mirage.io.types import IOResult
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -39,47 +40,122 @@ def _concrete_paths(n: int = 7):
 
 
 @pytest.mark.asyncio
-async def test_grep_with_many_concrete_paths_uses_native_search():
+async def test_grep_with_many_concrete_paths_defers_to_scan():
+    # These used to fold into one channel-wide search (`coalesce_scopes`).
+    # That search carries `in:#general` and no date, so seven named days were
+    # answered with every day the channel ever had. The scan reads the seven.
     accessor = AsyncMock()
     accessor.config = AsyncMock()
-    fake_payload = (b'{"messages":{"matches":[{"channel":{"name":"general",'
-                    b'"id":"C1"},"ts":"1700000000.0","text":"hello there"}]}}')
     with patch(
             "mirage.commands.builtin.slack.grep.search_messages",
-            new=AsyncMock(return_value=fake_payload),
-    ) as fake_search:
-        out, io = await grep(
+            new=AsyncMock(),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.slack.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.slack.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(
             accessor, _concrete_paths(7), ['hello'],
             CommandOpts(index=RAMIndexCacheStore(),
                         flags={
                             'w': True,
                             'i': True
                         }))
-    assert fake_search.await_count == 1
-    assert io.exit_code == 0
-    assert b"hello there" in out
+    fake_search.assert_not_awaited()
+    generic.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_rg_with_many_concrete_paths_uses_native_search():
+async def test_rg_with_many_concrete_paths_defers_to_scan():
     accessor = AsyncMock()
     accessor.config = AsyncMock()
-    fake_payload = (b'{"messages":{"matches":[{"channel":{"name":"general",'
-                    b'"id":"C1"},"ts":"1700000000.0","text":"hello rg"}]}}')
     with patch(
             "mirage.commands.builtin.slack.rg.search_messages",
-            new=AsyncMock(return_value=fake_payload),
-    ) as fake_search:
-        out, io = await rg(
+            new=AsyncMock(),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.slack.rg.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.slack.rg.generic_rg",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await rg(
             accessor, _concrete_paths(7), ['hello'],
             CommandOpts(index=RAMIndexCacheStore(),
                         flags={
                             'w': True,
                             'i': True
                         }))
-    assert fake_search.await_count == 1
-    assert io.exit_code == 0
-    assert b"hello rg" in out
+    fake_search.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_second_channel_operand_defers_to_scan():
+    # Two channels never coalesced at all, so the first operand won and the
+    # second was dropped in silence.
+    accessor = AsyncMock()
+    accessor.config = AsyncMock()
+    channels = [
+        PathSpec(resource_path=mount_key(f"/slack/channels/{name}", "/slack"),
+                 virtual=f"/slack/channels/{name}",
+                 directory=f"/slack/channels/{name}")
+        for name in ("general__C1", "random__C2")
+    ]
+    with patch(
+            "mirage.commands.builtin.slack.grep.search_messages",
+            new=AsyncMock(),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.slack.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.slack.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(
+            accessor, channels, ['hello'],
+            CommandOpts(index=RAMIndexCacheStore(),
+                        flags={
+                            'w': True,
+                            'r': True
+                        }))
+    fake_search.assert_not_awaited()
+    generic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_shaping_flag_defers_to_scan():
+    # -n reshapes each output line, which a verbatim search answer cannot do.
+    accessor = AsyncMock()
+    accessor.config = AsyncMock()
+    channel = [
+        PathSpec(resource_path=mount_key("/slack/channels/general__C1",
+                                         "/slack"),
+                 virtual="/slack/channels/general__C1",
+                 directory="/slack/channels/general__C1")
+    ]
+    with patch(
+            "mirage.commands.builtin.slack.grep.search_messages",
+            new=AsyncMock(),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.slack.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ), patch(
+            "mirage.commands.builtin.slack.grep.generic_grep",
+            new=AsyncMock(return_value=(b"", IOResult())),
+    ) as generic:
+        await grep(
+            accessor, channel, ['hello'],
+            CommandOpts(index=RAMIndexCacheStore(),
+                        flags={
+                            'w': True,
+                            'r': True,
+                            'n': True
+                        }))
+    fake_search.assert_not_awaited()
+    generic.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -128,16 +204,24 @@ async def test_grep_falls_back_when_native_search_raises():
 async def test_grep_native_empty_does_not_trigger_fallback():
     accessor = AsyncMock()
     accessor.config = AsyncMock()
-    empty_payload = b'{"messages":{"matches":[]}}'
+    channel = [
+        PathSpec(resource_path=mount_key("/slack/channels/general__C1",
+                                         "/slack"),
+                 virtual="/slack/channels/general__C1",
+                 directory="/slack/channels/general__C1")
+    ]
     with patch(
             "mirage.commands.builtin.slack.grep.search_messages",
-            new=AsyncMock(return_value=empty_payload),
+            new=AsyncMock(return_value=b'{"messages":{"matches":[]}}'),
     ) as fake_search, patch(
+            "mirage.commands.builtin.slack.grep.search_files",
+            new=AsyncMock(return_value=b'{"files":{"matches":[]}}'),
+    ), patch(
             "mirage.commands.builtin.slack.grep.slack_read",
             new=AsyncMock(return_value=b""),
     ) as fake_read:
         out, io = await grep(
-            accessor, _concrete_paths(7), ['missing'],
+            accessor, channel, ['missing'],
             CommandOpts(index=RAMIndexCacheStore(), flags={'w': True}))
     assert fake_search.await_count == 1
     assert fake_read.await_count == 0

--- a/python/tests/commands/builtin/slack/test_rg_files.py
+++ b/python/tests/commands/builtin/slack/test_rg_files.py
@@ -37,14 +37,21 @@ def index():
 
 
 @pytest.mark.asyncio
-async def test_rg_messages_only_when_chat_jsonl(accessor, index):
-    msgs_payload = b'{"messages":{"matches":[]}}'
+async def test_rg_chat_jsonl_scans_the_named_day(accessor, index):
+    # One day's chat.jsonl used to be widened to a channel-wide search
+    # (`coalesce_scopes`), which answered with every day the channel ever
+    # had. It is one file: read it and grep it.
     with (
             patch("mirage.commands.builtin.slack.rg.search_messages",
-                  new_callable=AsyncMock,
-                  return_value=msgs_payload) as mock_msgs,
+                  new_callable=AsyncMock) as mock_msgs,
             patch("mirage.commands.builtin.slack.rg.search_files",
                   new_callable=AsyncMock) as mock_files,
+            patch("mirage.commands.builtin.slack.rg.resolve_glob",
+                  new_callable=AsyncMock,
+                  return_value=[]),
+            patch("mirage.commands.builtin.slack.rg.generic_rg",
+                  new_callable=AsyncMock,
+                  return_value=(b"", None)) as mock_generic,
     ):
         await rg(accessor, [
             PathSpec(resource_path=mount_key(
@@ -52,8 +59,9 @@ async def test_rg_messages_only_when_chat_jsonl(accessor, index):
                      virtual='/channels/general__C001/2026-04-10/chat.jsonl',
                      directory='/channels/general__C001/2026-04-10/chat.jsonl')
         ], ['foo'], CommandOpts(index=index, flags={'w': True}))
-    assert mock_msgs.await_count == 1
+    assert mock_msgs.await_count == 0
     assert mock_files.await_count == 0
+    assert mock_generic.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -101,14 +109,18 @@ async def test_rg_both_when_channel_or_day_root(accessor, index):
 
 
 @pytest.mark.asyncio
-async def test_grep_messages_only_when_chat_jsonl(accessor, index):
-    msgs_payload = b'{"messages":{"matches":[]}}'
+async def test_grep_chat_jsonl_scans_the_named_day(accessor, index):
     with (
             patch("mirage.commands.builtin.slack.grep.search_messages",
-                  new_callable=AsyncMock,
-                  return_value=msgs_payload) as mock_msgs,
+                  new_callable=AsyncMock) as mock_msgs,
             patch("mirage.commands.builtin.slack.grep.search_files",
                   new_callable=AsyncMock) as mock_files,
+            patch("mirage.commands.builtin.slack.grep.resolve_glob",
+                  new_callable=AsyncMock,
+                  return_value=[]),
+            patch("mirage.commands.builtin.slack.grep.generic_grep",
+                  new_callable=AsyncMock,
+                  return_value=(b"", None)) as mock_generic,
     ):
         from mirage.commands.builtin.slack.grep import grep
         await grep(accessor, [
@@ -117,7 +129,9 @@ async def test_grep_messages_only_when_chat_jsonl(accessor, index):
                      virtual='/channels/general__C001/2026-04-10/chat.jsonl',
                      directory='/channels/general__C001/2026-04-10/chat.jsonl')
         ], ['foo'], CommandOpts(index=index, flags={'w': True}))
-    assert mock_msgs.await_count == 1
+    assert mock_msgs.await_count == 0
+    assert mock_files.await_count == 0
+    assert mock_generic.await_count == 1
     assert mock_files.await_count == 0
 
 

--- a/python/tests/commands/builtin/test_grep_helper.py
+++ b/python/tests/commands/builtin/test_grep_helper.py
@@ -715,3 +715,42 @@ def test_parse_file_globs_reads_dests_in_typed_order():
         grep_helper.FileGlob(glob="*.tex", admit=True),
         grep_helper.FileGlob(glob="notes.*", admit=False),
     )
+
+
+EMAIL_HONORED = ("n", "args_l", "w", "o", "m")
+
+
+def test_has_search_shaping_flags_exempts_only_the_named_dests():
+    # gmail/slack/discord: the provider's search is word-based, so -w is what
+    # makes the push-down faithful rather than what breaks it.
+    assert not grep_helper.has_search_shaping_flags({"w": True}, ("w", ))
+    assert grep_helper.has_search_shaping_flags({
+        "w": True,
+        "n": True
+    }, ("w", ))
+    # email: the local re-scan implements these, so they ride along.
+    assert not grep_helper.has_search_shaping_flags(
+        {
+            "n": True,
+            "o": True,
+            "m": "3"
+        }, EMAIL_HONORED)
+    # ...but never -v or -c, which need messages the search did not return.
+    assert grep_helper.has_search_shaping_flags({"v": True}, EMAIL_HONORED)
+    assert grep_helper.has_search_shaping_flags({"c": True}, EMAIL_HONORED)
+
+
+def test_honored_never_exempts_the_operand_rule():
+    # An exemption is about flags only: two operands still defer.
+    assert grep_helper.pushdown_operand([TRACES, SESSIONS], {"w": True}, "ada",
+                                        ("w", )) is None
+    assert grep_helper.pushdown_operand([TRACES], {"w": True}, "ada",
+                                        ("w", )) is TRACES
+
+
+def test_lone_operand_is_the_operand_rule_on_its_own():
+    # email's find push-down has no grep pattern and no shaping flags.
+    assert grep_helper.lone_operand([TRACES]) is TRACES
+    assert grep_helper.lone_operand([TRACES, SESSIONS]) is None
+    assert grep_helper.lone_operand([]) is None
+    assert grep_helper.lone_operand([_operand("/traces/*", "*")]) is None

--- a/python/tests/core/discord/test_scope.py
+++ b/python/tests/core/discord/test_scope.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.discord.scope import coalesce_scopes, detect_scope
+from mirage.core.discord.scope import detect_scope
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -201,64 +201,7 @@ def test_glob_non_jsonl():
     assert scope.level != "channel"
 
 
-# ── coalesce ──────────────────────────────────
-
-
 def _spec(path: str, prefix: str = "/discord") -> PathSpec:
     return PathSpec(resource_path=mount_key(path, prefix),
                     virtual=path,
                     directory=path)
-
-
-def test_coalesce_concrete_jsonl_paths_same_channel():
-    paths = [
-        _spec(f"/discord/myserver__G1/channels/general__C1/"
-              f"2026-01-{d:02d}/chat.jsonl") for d in range(1, 8)
-    ]
-    scope = coalesce_scopes(paths)
-    assert scope is not None
-    assert scope.level == "channel"
-    assert scope.use_native is True
-    assert scope.guild_id == "G1"
-    assert scope.channel_id == "C1"
-
-
-def test_coalesce_returns_none_for_mixed_channels():
-    paths = [
-        _spec("/discord/myserver__G1/channels/general__C1/"
-              "2026-01-01/chat.jsonl"),
-        _spec("/discord/myserver__G1/channels/random__C2/"
-              "2026-01-01/chat.jsonl"),
-    ]
-    assert coalesce_scopes(paths) is None
-
-
-def test_coalesce_returns_none_without_ids():
-    paths = [
-        _spec("/discord/myserver/channels/general/2026-01-01/chat.jsonl"),
-    ]
-    assert coalesce_scopes(paths) is None
-
-
-def test_coalesce_empty_list_returns_none():
-    assert coalesce_scopes([]) is None
-
-
-def test_coalesce_returns_none_for_file_blobs():
-    # Guild search answers questions about message content; an attachment
-    # operand must scan its bytes, not widen to a channel message search.
-    paths = [
-        _spec("/discord/myserver__G1/channels/general__C1/2026-01-01/files/"
-              "img__A1.png"),
-    ]
-    assert coalesce_scopes(paths) is None
-
-
-def test_coalesce_returns_none_for_mixed_levels():
-    paths = [
-        _spec("/discord/myserver__G1/channels/general__C1/"
-              "2026-01-01/chat.jsonl"),
-        _spec("/discord/myserver__G1/channels/general__C1/2026-01-01/files/"
-              "img__A1.png"),
-    ]
-    assert coalesce_scopes(paths) is None

--- a/python/tests/core/slack/test_scope.py
+++ b/python/tests/core/slack/test_scope.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.slack.scope import coalesce_scopes, detect_scope
+from mirage.core.slack.scope import detect_scope
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -115,47 +115,6 @@ def _spec(path: str, prefix: str = "/slack") -> PathSpec:
     return PathSpec(resource_path=mount_key(path, prefix),
                     virtual=path,
                     directory=path)
-
-
-def test_coalesce_concrete_jsonl_paths_same_channel():
-    paths = [
-        _spec(f"/slack/channels/general__C1/2026-01-{day:02d}/chat.jsonl")
-        for day in range(1, 8)
-    ]
-    scope = coalesce_scopes(paths)
-    assert scope is not None
-    assert scope.use_native is True
-    assert scope.channel_name == "general"
-    assert scope.channel_id == "C1"
-    assert scope.container == "channels"
-
-
-def test_coalesce_returns_none_for_mixed_channels():
-    paths = [
-        _spec("/slack/channels/general__C1/2026-01-01/chat.jsonl"),
-        _spec("/slack/channels/random__C2/2026-01-01/chat.jsonl"),
-    ]
-    assert coalesce_scopes(paths) is None
-
-
-def test_coalesce_returns_none_for_mixed_containers():
-    paths = [
-        _spec("/slack/channels/general__C1/2026-01-01/chat.jsonl"),
-        _spec("/slack/dms/alice__D1/2026-01-01/chat.jsonl"),
-    ]
-    assert coalesce_scopes(paths) is None
-
-
-def test_coalesce_single_path_delegates_to_detect_scope():
-    p = _spec("/slack/channels/general__C1/2026-01-01/chat.jsonl")
-    scope = coalesce_scopes([p])
-    assert scope is not None
-    assert scope.use_native is True
-    assert scope.channel_name == "general"
-
-
-def test_coalesce_empty_list_returns_none():
-    assert coalesce_scopes([]) is None
 
 
 def test_date_dir():

--- a/python/tests/e2e/test_search_pushdown_iteration.py
+++ b/python/tests/e2e/test_search_pushdown_iteration.py
@@ -18,26 +18,44 @@ import pytest
 
 from mirage import MountMode, Workspace
 from mirage.resource.slack import SlackConfig, SlackResource
+from mirage.types import FileStat, FileType
+
+DAYS = [f"2026-{m:02d}-{d:02d}" for m in range(1, 5) for d in range(1, 16)]
 
 
 @pytest.mark.asyncio
-async def test_slack_grep_glob_expanded_to_60_paths_is_one_native_call():
+async def test_slack_grep_glob_expanded_to_60_paths_reads_those_60_days():
+    # This line used to become ONE channel-wide search: `coalesce_scopes`
+    # folded the 60 same-channel operands into a channel scope, and
+    # `build_query` carries only `in:#general` with no date. So the answer
+    # covered every day the channel ever had — including the ones the glob
+    # did not match, since slack search also reaches past the browse window.
+    # It is 60 named files: read them. The saving was real and is gone with
+    # it; the answer it bought was not the question asked.
     slack = SlackResource(
         config=SlackConfig(token="xoxb-test", search_token="xoxp-test"))
     ws = Workspace({"/slack": (slack, MountMode.READ)}, mode=MountMode.READ)
-    fake_payload = (b'{"messages":{"matches":[{"channel":{"name":"general",'
-                    b'"id":"C1"},"ts":"1700000000.0","text":"hello"}]}}')
-    expanded = " ".join(
-        f"/slack/channels/general__C1/2026-{m:02d}-{d:02d}/chat.jsonl"
-        for m in range(1, 5) for d in range(1, 16))
+    expanded = " ".join(f"/slack/channels/general__C1/{day}/chat.jsonl"
+                        for day in DAYS)
+    read = AsyncMock(return_value=b'{"text":"hello there"}\n')
+    stat = AsyncMock(
+        return_value=FileStat(name="chat.jsonl", type=FileType.TEXT, size=23))
     try:
         with patch(
                 "mirage.commands.builtin.slack.grep.search_messages",
-                new=AsyncMock(return_value=fake_payload),
-        ) as fake_search:
+                new=AsyncMock(),
+        ) as fake_search, patch(
+                "mirage.commands.builtin.slack.grep.slack_read",
+                new=read), patch("mirage.commands.builtin.slack.grep._stat",
+                                 new=stat):
             result = await ws.execute(f"grep -iw hello {expanded}")
-        assert fake_search.await_count == 1
+        fake_search.assert_not_awaited()
+        assert read.await_count == len(DAYS)
         assert result.exit_code == 0
-        assert b"hello" in (result.stdout or b"")
+        out = (result.stdout or b"").decode()
+        assert out.count("hello there") == len(DAYS)
+        # Every line names an operand the command line actually carried.
+        assert f"/slack/channels/general__C1/{DAYS[0]}/chat.jsonl:" in out
+        assert f"/slack/channels/general__C1/{DAYS[-1]}/chat.jsonl:" in out
     finally:
         await ws.close()

--- a/typescript/packages/core/src/commands/builtin/discord/grep.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.test.ts
@@ -132,26 +132,18 @@ describe('discord grep', () => {
     }
   })
 
-  it('coalesces concrete chat.jsonl paths into one channel-wide native search', async () => {
-    const transport = new FakeDiscordTransport((_method, endpoint) => {
-      if (endpoint === '/guilds/G1/messages/search') {
-        return {
-          total_results: 1,
-          messages: [
-            [
-              {
-                id: '175928847299117056',
-                content: 'hello world',
-                channel_id: 'C1',
-                timestamp: '2016-04-30T12:00:00.000+00:00',
-                author: { username: 'alice' },
-              },
-            ],
-          ],
-        }
-      }
-      return null
+  it('two chat.jsonl operands take the scan rather than one widened search', async () => {
+    // They used to coalesce into one channel-wide search, which answered for
+    // every day the channel ever had — `searchGuild` takes a channel but no
+    // date. The scan reads exactly the two days the line named.
+    const idx = new RAMIndexCacheStore()
+    await seedGuild(idx, '/mnt/discord', 'My Server__G1', 'G1')
+    await seedChannel(idx, '/mnt/discord', 'My Server__G1', 'general__C1', 'C1', {
+      dates: ['2016-04-29', '2016-04-30'],
     })
+    const transport = new FakeDiscordTransport((_method, endpoint) =>
+      endpoint === '/channels/C1/messages' ? [] : null,
+    )
     const mk = (date: string): PathSpec =>
       new PathSpec({
         virtual: `/mnt/discord/My Server__G1/channels/general__C1/${date}/chat.jsonl`,
@@ -162,19 +154,52 @@ describe('discord grep', () => {
           '/mnt/discord',
         ),
       })
-    const out = await runGrep(
+    await runGrep(
       [mk('2016-04-29'), mk('2016-04-30')],
       ['hello'],
       { w: true },
-      { transport },
+      {
+        index: idx,
+        transport,
+      },
     )
-    expect(transport.calls[0]?.endpoint).toBe('/guilds/G1/messages/search')
-    expect(transport.calls[0]?.params?.channel_id).toBe('C1')
-    const lines = out.stdout.split('\n').filter((l) => l !== '')
-    expect(lines).toHaveLength(1)
-    expect(lines[0]).toContain(
-      '/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/chat.jsonl:',
+    const searches = transport.calls.filter((c) => c.endpoint.includes('/messages/search'))
+    expect(searches).toHaveLength(0)
+  })
+
+  it('a second operand defers the whole line to the scan', async () => {
+    // The push-down answers for one channel, so the second operand used to be
+    // dropped in silence: this line reported general and never mentioned
+    // random at all.
+    const idx = new RAMIndexCacheStore()
+    await seedGuild(idx, '/mnt/discord', 'My Server__G1', 'G1')
+    await seedChannel(idx, '/mnt/discord', 'My Server__G1', 'general__C1', 'C1', {
+      dates: ['2016-04-30'],
+    })
+    await seedChannel(idx, '/mnt/discord', 'My Server__G1', 'random__C2', 'C2', {
+      dates: ['2016-04-30'],
+    })
+    const transport = new FakeDiscordTransport((_method, endpoint) =>
+      endpoint.endsWith('/messages') ? [] : null,
     )
+    const dir = (name: string): PathSpec =>
+      new PathSpec({
+        virtual: `/mnt/discord/My Server__G1/channels/${name}`,
+        directory: `/mnt/discord/My Server__G1/channels/${name}`,
+        resolved: false,
+        resourcePath: mountKey(`/mnt/discord/My Server__G1/channels/${name}`, '/mnt/discord'),
+      })
+    await runGrep(
+      [dir('general__C1'), dir('random__C2')],
+      ['hello'],
+      { w: true, r: true },
+      {
+        index: idx,
+        transport,
+      },
+    )
+    const searches = transport.calls.filter((c) => c.endpoint.includes('/messages/search'))
+    expect(searches).toHaveLength(0)
   })
 
   it('scans attachment blobs instead of widening to a message search', async () => {

--- a/typescript/packages/core/src/commands/builtin/discord/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.ts
@@ -21,7 +21,7 @@ import { resolveGlobOf } from '../generic_bind/index.ts'
 import { DISCORD_IO } from './io.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
-import { coalesceScopes, detectScope } from '../../../core/discord/scope.ts'
+import { detectScope } from '../../../core/discord/scope.ts'
 import { formatGrepResults, searchGuild } from '../../../core/discord/search.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
 import { IOResult } from '../../../io/types.ts'
@@ -29,7 +29,7 @@ import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { grepGeneric } from '../generic/grep.ts'
-import { patternArg } from '../grep_helper.ts'
+import { patternArg, pushdownOperand } from '../grep_helper.ts'
 import { prependStderr } from '../utils/output.ts'
 import { fileReadProvision } from './_provision.ts'
 import { FlagView } from '../../spec/types.ts'
@@ -37,6 +37,21 @@ import { FlagView } from '../../spec/types.ts'
 const resolveDiscordGlob = resolveGlobOf(DISCORD_IO)
 
 const ENC = new TextEncoder()
+
+// Discord guild search answers with whole messages and the push-down prints
+// that answer verbatim, so it can stand in for a scan only when the line
+// names one concrete operand and no flag reshapes the output. -w is the
+// exception the provider itself supplies: the search matches whole words, so
+// a bare literal would under-report and only -w makes the two agree.
+//
+// `coalesceScopes` used to widen a set of same-channel chat.jsonl operands
+// into one channel-wide search, and it is gone. `searchGuild` takes a channel
+// but no date, so folding two named days returned every day the channel ever
+// had — and a single chat.jsonl operand was widened the same way. Reporting
+// messages the line did not ask for is not a better failure than dropping an
+// operand. One operand or the generic scan.
+export const SEARCH_HONORED = ['w'] as const
+export const SEARCH_MAX_RESULTS = 100
 
 async function* discordStream(
   accessor: DiscordAccessor,
@@ -54,19 +69,16 @@ async function grepCommand(
 ): Promise<CommandFnResult> {
   const pattern = patternArg(texts, opts.flags)
   const fl = new FlagView(opts.flags, specOf('grep'))
-  const maxCount = fl.asInt('m') ?? null
 
   const pushdownWarnings: string[] = []
-  const firstPath = paths[0]
-  if (firstPath !== undefined && pattern !== null && !pattern.includes('\n')) {
-    let scope = detectScope(firstPath)
-    if (scope.level === 'messages') scope = coalesceScopes(paths) ?? scope
-    // Discord search matches whole words while grep matches substrings,
-    // and the native path returns search results verbatim as the output, so
-    // a bare literal would under-report. Only -w makes the two agree.
-    if (scope.useNative && scope.guildId !== undefined && fl.asBool('w')) {
+  // Output-shaping flags, a glob operand and a multi-operand line all need
+  // the generic scan; see SEARCH_HONORED above.
+  const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
+  if (pattern !== null && operand !== null && fl.asBool('w')) {
+    const scope = detectScope(operand)
+    if (scope.useNative && scope.guildId !== undefined) {
       try {
-        const count = maxCount ?? 100
+        const count = SEARCH_MAX_RESULTS
         const raw = await searchGuild(accessor, scope.guildId, pattern, scope.channelId, count)
         const channelMap = new Map<string, string>()
         if (scope.channelId === undefined) {
@@ -77,7 +89,7 @@ async function grepCommand(
         const lines = formatGrepResults(
           raw,
           scope,
-          mountPrefixOf(firstPath.virtual, firstPath.resourcePath),
+          mountPrefixOf(operand.virtual, operand.resourcePath),
           channelMap,
         )
         if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]

--- a/typescript/packages/core/src/commands/builtin/discord/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/rg.ts
@@ -21,15 +21,16 @@ import { DISCORD_IO } from './io.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
-import { coalesceScopes, detectScope } from '../../../core/discord/scope.ts'
+import { detectScope } from '../../../core/discord/scope.ts'
 import { listChannels } from '../../../core/discord/channels.ts'
 import { formatGrepResults, searchGuild } from '../../../core/discord/search.ts'
 import { IOResult } from '../../../io/types.ts'
 import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { patternArg } from '../grep_helper.ts'
+import { patternArg, pushdownOperand } from '../grep_helper.ts'
 import { rgGeneric } from '../generic/rg.ts'
+import { SEARCH_HONORED, SEARCH_MAX_RESULTS } from './grep.ts'
 import { FlagView } from '../../spec/types.ts'
 
 const resolveDiscordGlob = resolveGlobOf(DISCORD_IO)
@@ -58,54 +59,49 @@ async function rgCommand(
     ]
   }
   const fl = new FlagView(opts.flags, specOf('rg'))
-  const maxCount = fl.asInt('m') ?? null
 
   const pushdownWarnings: string[] = []
-  if (paths.length > 0 && !pattern.includes('\n')) {
-    const firstPath = paths[0]
-    if (firstPath !== undefined) {
-      let scope = detectScope(firstPath)
-      if (scope.level === 'messages') scope = coalesceScopes(paths) ?? scope
-      // Discord search matches whole words while grep matches substrings,
-      // and the native path returns search results verbatim as the output, so
-      // a bare literal would under-report. Only -w makes the two agree.
-      if (scope.useNative && scope.guildId !== undefined && fl.asBool('w')) {
-        try {
-          const count = maxCount ?? 100
-          const raw = await searchGuild(accessor, scope.guildId, pattern, scope.channelId, count)
-          const channelMap = new Map<string, string>()
-          if (scope.channelId === undefined) {
-            for (const ch of await listChannels(accessor, scope.guildId)) {
-              if (ch.name !== undefined) channelMap.set(ch.id, ch.name)
-            }
+  // Same gate as discord grep, from the same table: only a lone concrete
+  // operand with no reshaping flag may be answered by the search API.
+  const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
+  if (operand !== null && fl.asBool('w')) {
+    const scope = detectScope(operand)
+    if (scope.useNative && scope.guildId !== undefined) {
+      try {
+        const count = SEARCH_MAX_RESULTS
+        const raw = await searchGuild(accessor, scope.guildId, pattern, scope.channelId, count)
+        const channelMap = new Map<string, string>()
+        if (scope.channelId === undefined) {
+          for (const ch of await listChannels(accessor, scope.guildId)) {
+            if (ch.name !== undefined) channelMap.set(ch.id, ch.name)
           }
-          const lines = formatGrepResults(
-            raw,
-            scope,
-            mountPrefixOf(firstPath.virtual, firstPath.resourcePath),
-            channelMap,
-          )
-          if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-          return [ENC.encode(lines.join('\n') + '\n'), new IOResult()]
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err)
+        }
+        const lines = formatGrepResults(
+          raw,
+          scope,
+          mountPrefixOf(operand.virtual, operand.resourcePath),
+          channelMap,
+        )
+        if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+        return [ENC.encode(lines.join('\n') + '\n'), new IOResult()]
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        pushdownWarnings.push(
+          `discord: native search push-down failed (${msg}); falling back to per-file scan`,
+        )
+        const status = err instanceof DiscordApiError ? err.status : null
+        const lower = msg.toLowerCase()
+        if (
+          status === 403 ||
+          lower.includes('forbidden') ||
+          lower.includes('missing permissions') ||
+          lower.includes('missing access')
+        ) {
           pushdownWarnings.push(
-            `discord: native search push-down failed (${msg}); falling back to per-file scan`,
+            'discord: hint - ensure the bot has the READ_MESSAGE_HISTORY ' +
+              'permission for this guild and the MESSAGE CONTENT privileged ' +
+              'intent enabled',
           )
-          const status = err instanceof DiscordApiError ? err.status : null
-          const lower = msg.toLowerCase()
-          if (
-            status === 403 ||
-            lower.includes('forbidden') ||
-            lower.includes('missing permissions') ||
-            lower.includes('missing access')
-          ) {
-            pushdownWarnings.push(
-              'discord: hint - ensure the bot has the READ_MESSAGE_HISTORY ' +
-                'permission for this guild and the MESSAGE CONTENT privileged ' +
-                'intent enabled',
-            )
-          }
         }
       }
     }

--- a/typescript/packages/core/src/commands/builtin/discord/search_pushdown_fallback.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/search_pushdown_fallback.test.ts
@@ -62,7 +62,7 @@ describe('discord grep push-down fallback', () => {
       ['hi'],
       {
         stdin: null,
-        flags: { args_l: true, w: true },
+        flags: { w: true },
         filetypeFns: null,
         cwd: '/',
         index: idx,

--- a/typescript/packages/core/src/commands/builtin/gmail/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/grep.ts
@@ -27,11 +27,19 @@ import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { grepGeneric } from '../generic/grep.ts'
-import { patternArg } from '../grep_helper.ts'
+import { patternArg, pushdownOperand } from '../grep_helper.ts'
 import { fileReadProvision } from './_provision.ts'
 import { FlagView } from '../../spec/types.ts'
 
 const resolveGlob = resolveGlobOf(GMAIL_IO)
+
+// Gmail search answers with whole messages and the push-down prints that
+// answer verbatim, so it can stand in for a scan only when the line names one
+// concrete operand and no flag reshapes the output. -w is the exception the
+// provider itself supplies: Gmail matches whole words, so a bare literal
+// would under-report and only -w makes the two agree.
+export const SEARCH_HONORED = ['w'] as const
+export const SEARCH_MAX_RESULTS = 50
 
 const ENC = new TextEncoder()
 
@@ -51,29 +59,19 @@ async function grepCommand(
 ): Promise<CommandFnResult> {
   const pattern = patternArg(texts, opts.flags)
   const fl = new FlagView(opts.flags, specOf('grep'))
-  const maxCount = fl.asInt('m') ?? null
-  // Output-shaping flags need real per-line matching, which the search-API
-  // push-down cannot emulate; fall through to the generic grep over
-  // rendered files instead.
-  const shaping = ['args_l', 'c', 'n', 'o', 'v', 'q'].some((flag) => fl.asBool(flag))
-
-  const first = paths[0]
-  if (first !== undefined && pattern !== null && !pattern.includes('\n') && !shaping) {
-    const scope = detectScope(first)
-    // Gmail search matches whole words while grep matches substrings,
-    // and the native path returns search results verbatim as the output, so
-    // a bare literal would under-report. Only -w makes the two agree.
-    if (scope.useNative && fl.asBool('w')) {
-      const filePrefix =
-        mountPrefixOf(first.virtual, first.resourcePath) !== ''
-          ? mountPrefixOf(first.virtual, first.resourcePath)
-          : ''
+  // Output-shaping flags, a glob operand and a multi-operand line all need
+  // the generic grep over rendered files; see SEARCH_HONORED above.
+  const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
+  if (pattern !== null && operand !== null && fl.asBool('w')) {
+    const scope = detectScope(operand)
+    if (scope.useNative) {
+      const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
       const rows = await searchMessages(
         accessor.tokenManager,
         pattern,
         scope.labelName,
         scope.dateStr,
-        maxCount ?? 50,
+        SEARCH_MAX_RESULTS,
       )
       const lines = formatGrepResults(rows, scope, filePrefix, pattern)
       if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]

--- a/typescript/packages/core/src/commands/builtin/gmail/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/rg.ts
@@ -24,7 +24,8 @@ import { detectScope } from '../../../core/gmail/scope.ts'
 import { formatGrepResults, searchMessages } from '../../../core/gmail/search.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
-import { patternArg } from '../grep_helper.ts'
+import { patternArg, pushdownOperand } from '../grep_helper.ts'
+import { SEARCH_HONORED, SEARCH_MAX_RESULTS } from './grep.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { rgGeneric } from '../generic/rg.ts'
@@ -56,36 +57,24 @@ async function rgCommand(
     ]
   }
   const fl = new FlagView(opts.flags, specOf('rg'))
-  const maxCount = fl.asInt('m') ?? null
-  // Output-shaping flags need real per-line matching, which the search-API
-  // push-down cannot emulate; fall through to the generic rg over rendered
-  // files instead.
-  const shaping = ['args_l', 'c', 'n', 'o', 'v'].some((flag) => fl.asBool(flag))
-
-  if (paths.length > 0 && !pattern.includes('\n') && !shaping) {
-    const first = paths[0]
-    if (first !== undefined) {
-      const scope = detectScope(first)
-      // Gmail search matches whole words while grep matches substrings,
-      // and the native path returns search results verbatim as the output, so
-      // a bare literal would under-report. Only -w makes the two agree.
-      if (scope.useNative && fl.asBool('w')) {
-        const filePrefix =
-          mountPrefixOf(first.virtual, first.resourcePath) !== ''
-            ? mountPrefixOf(first.virtual, first.resourcePath)
-            : ''
-        const rows = await searchMessages(
-          accessor.tokenManager,
-          pattern,
-          scope.labelName,
-          scope.dateStr,
-          maxCount ?? 50,
-        )
-        const lines = formatGrepResults(rows, scope, filePrefix, pattern)
-        if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-        const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-        return [out, new IOResult()]
-      }
+  // Same gate as gmail grep, from the same table: only a lone concrete
+  // operand with no reshaping flag may be answered by the search API.
+  const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
+  if (operand !== null && fl.asBool('w')) {
+    const scope = detectScope(operand)
+    if (scope.useNative) {
+      const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
+      const rows = await searchMessages(
+        accessor.tokenManager,
+        pattern,
+        scope.labelName,
+        scope.dateStr,
+        SEARCH_MAX_RESULTS,
+      )
+      const lines = formatGrepResults(rows, scope, filePrefix, pattern)
+      if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+      const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
+      return [out, new IOResult()]
     }
   }
 

--- a/typescript/packages/core/src/commands/builtin/grep_helper.test.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.test.ts
@@ -26,6 +26,7 @@ import {
   isLiteralPattern,
   isRegexPattern,
   literalPushdownOperand,
+  loneOperand,
   mergePatternList,
   NEVER_MATCH,
   NO_FILTERS,
@@ -238,7 +239,9 @@ describe('hasSearchShapingFlags', () => {
     [{ n: true }, true],
     [{ c: true }, true],
     [{ args_l: true }, true],
-    [{ l: true }, true],
+    // A bare `l` key is one the parser never emits: -l is short-only, so
+    // it lands on the disambiguated `args_l` dest (`AMBIGUOUS_NAMES`).
+    [{ l: true }, false],
     [{ w: true }, true],
     [{ o: true }, true],
     [{ q: true }, true],
@@ -282,6 +285,8 @@ function operand(virtual: string, pattern: string | null = null): PathSpec {
   })
 }
 
+const EMAIL_HONORED = ['n', 'args_l', 'w', 'o', 'm']
+
 const TRACES = operand('/traces')
 const SESSIONS = operand('/sessions')
 
@@ -308,6 +313,36 @@ describe('pushdownOperand', () => {
     expect(pushdownOperand([TRACES], { c: true }, 'ada')).toBe(null)
     expect(pushdownOperand([TRACES], {}, 'ada\nbob')).toBe(null)
     expect(pushdownOperand([TRACES], {}, null)).toBe(null)
+  })
+})
+
+describe('hasSearchShapingFlags honored', () => {
+  it('exempts only the named dests', () => {
+    // gmail/slack/discord: the provider's search is word-based, so -w is what
+    // makes the push-down faithful rather than what breaks it.
+    expect(hasSearchShapingFlags({ w: true }, ['w'])).toBe(false)
+    expect(hasSearchShapingFlags({ w: true, n: true }, ['w'])).toBe(true)
+    // email: the local re-scan implements these, so they ride along.
+    expect(hasSearchShapingFlags({ n: true, o: true, m: '3' }, EMAIL_HONORED)).toBe(false)
+    // ...but never -v or -c, which need messages the search did not return.
+    expect(hasSearchShapingFlags({ v: true }, EMAIL_HONORED)).toBe(true)
+    expect(hasSearchShapingFlags({ c: true }, EMAIL_HONORED)).toBe(true)
+  })
+
+  it('never exempts the operand rule', () => {
+    // An exemption is about flags only: two operands still defer.
+    expect(pushdownOperand([TRACES, SESSIONS], { w: true }, 'ada', ['w'])).toBe(null)
+    expect(pushdownOperand([TRACES], { w: true }, 'ada', ['w'])).toBe(TRACES)
+  })
+})
+
+describe('loneOperand', () => {
+  it('is the operand rule on its own, for a caller with no pattern', () => {
+    // email's find push-down has no grep pattern and no shaping flags.
+    expect(loneOperand([TRACES])).toBe(TRACES)
+    expect(loneOperand([TRACES, SESSIONS])).toBe(null)
+    expect(loneOperand([])).toBe(null)
+    expect(loneOperand([operand('/traces/*', '*')])).toBe(null)
   })
 })
 

--- a/typescript/packages/core/src/commands/builtin/grep_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.ts
@@ -321,39 +321,45 @@ export function isLiteralPattern(pattern: string, fixedString: boolean): boolean
   return pt === PatternType.EXACT || (pt === PatternType.SIMPLE && !pattern.includes('.'))
 }
 
+const PUSHDOWN_SHAPING_BOOL = [
+  'v',
+  'n',
+  'c',
+  'args_l',
+  'w',
+  'o',
+  'q',
+  'H',
+  'h',
+  'args_I',
+  'text',
+] as const
+const PUSHDOWN_SHAPING_INT = ['m', 'A', 'B', 'C'] as const
+const PUSHDOWN_FILTER = ['type', 'glob', 'include', 'exclude', 'exclude_dir'] as const
+
 // True when a flag alters the match set or output shape of grep/rg. A search
 // push-down prints each matching record as one whole line, so it cannot honor
 // -v/-n/-c/-l/-w/-o/-m/-A/-B/-C/-q/-H/-h, rg's -I (no filename), nor rg's
 // file-filtering --glob/--type; the wrapper must defer to the generic scan
 // when any is present.
-export function hasSearchShapingFlags(flags: Record<string, FlagValue>): boolean {
-  if (
-    flags.v === true ||
-    flags.n === true ||
-    flags.c === true ||
-    flags.args_l === true ||
-    flags.l === true ||
-    flags.w === true ||
-    flags.o === true ||
-    flags.q === true ||
-    flags.H === true ||
-    flags.h === true ||
-    flags.args_I === true
-  ) {
+//
+// `honored` names the flags this particular push-down implements itself, so
+// their presence is not a reason to defer. Two shapes need it. A provider
+// whose search is word-based (gmail, slack, discord) is faithful only *with*
+// -w, so for those the flag in this list is the one that turns the push-down
+// on rather than off. A push-down that uses the search only to pick
+// candidates and then runs the real compiled matcher over each one (email)
+// honors whatever that local scan implements. Everything left out of the list
+// still defers, which is what keeps the exemption honest.
+export function hasSearchShapingFlags(
+  flags: Record<string, FlagValue>,
+  honored: readonly string[] = [],
+): boolean {
+  const gated = (name: string): boolean => !honored.includes(name)
+  if (PUSHDOWN_SHAPING_BOOL.some((name) => gated(name) && flags[name] === true)) return true
+  if (PUSHDOWN_SHAPING_INT.some((name) => gated(name) && typeof flags[name] === 'string'))
     return true
-  }
-  return (
-    typeof flags.m === 'string' ||
-    typeof flags.A === 'string' ||
-    typeof flags.B === 'string' ||
-    typeof flags.C === 'string' ||
-    flags.type !== undefined ||
-    flags.glob !== undefined ||
-    flags.text === true ||
-    flags.include !== undefined ||
-    flags.exclude !== undefined ||
-    flags.exclude_dir !== undefined
-  )
+  return PUSHDOWN_FILTER.some((name) => gated(name) && flags[name] !== undefined)
 }
 
 // True when a literal-substring push-down (LIKE/ILIKE) faithfully reproduces
@@ -378,7 +384,7 @@ export function searchPushdownOk(flags: Record<string, FlagValue>, pattern: stri
 // operand in turn the way GNU does. A glob operand defers for the older
 // reason: an unexpanded pattern segment would be read as a literal entity
 // name.
-function loneOperand(paths: PathSpec[]): PathSpec | null {
+export function loneOperand(paths: PathSpec[]): PathSpec | null {
   if (paths.length !== 1 || hasUnresolvedGlob(paths)) return null
   return paths[0] ?? null
 }
@@ -391,9 +397,10 @@ export function pushdownOperand(
   paths: PathSpec[],
   flags: Record<string, FlagValue>,
   pattern: string | null,
+  honored: readonly string[] = [],
 ): PathSpec | null {
   if (pattern === null || pattern.includes('\n')) return null
-  if (hasSearchShapingFlags(flags)) return null
+  if (hasSearchShapingFlags(flags, honored)) return null
   return loneOperand(paths)
 }
 

--- a/typescript/packages/core/src/commands/builtin/slack/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/grep.ts
@@ -32,7 +32,7 @@ import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { grepGeneric } from '../generic/grep.ts'
-import { patternArg } from '../grep_helper.ts'
+import { patternArg, pushdownOperand } from '../grep_helper.ts'
 import { prependStderr } from '../utils/output.ts'
 import { fileReadProvision } from './_provision.ts'
 import { FlagView } from '../../spec/types.ts'
@@ -40,6 +40,21 @@ import { FlagView } from '../../spec/types.ts'
 const resolveSlackGlob = resolveGlobOf(SLACK_IO)
 
 const ENC = new TextEncoder()
+
+// Slack search answers with whole messages and the push-down prints that
+// answer verbatim, so it can stand in for a scan only when the line names one
+// concrete operand and no flag reshapes the output. -w is the exception the
+// provider itself supplies: Slack matches whole words, so a bare literal
+// would under-report and only -w makes the two agree.
+//
+// Python's twin used to widen a set of same-channel operands into one
+// channel-wide search (`coalesce_scopes`); this side never had it and now
+// neither does. It cannot answer a line naming two different channels, and
+// where it did fold it dropped the date — `buildQuery` carries only
+// `in:#channel`, so two named days became every day the channel ever had.
+// One operand or the generic scan.
+export const SEARCH_HONORED = ['w'] as const
+export const SEARCH_MAX_RESULTS = 100
 
 async function* slackStream(
   accessor: SlackAccessor,
@@ -57,28 +72,30 @@ async function grepCommand(
 ): Promise<CommandFnResult> {
   const pattern = patternArg(texts, opts.flags)
   const fl = new FlagView(opts.flags, specOf('grep'))
-  const maxCount = fl.asInt('m') ?? null
 
   const pushdownWarnings: string[] = []
-  const firstPath = paths[0]
-  if (firstPath !== undefined && pattern !== null && !pattern.includes('\n')) {
-    const scope = detectScope(firstPath)
-    // Slack search matches whole words while grep matches substrings, and
-    // the native path returns search results verbatim as the output, so a
-    // bare literal would under-report. Only -w makes the two agree.
-    if (scope.useNative && fl.asBool('w')) {
-      const filePrefix = mountPrefixOf(firstPath.virtual, firstPath.resourcePath)
+  // Output-shaping flags, a glob operand and a multi-operand line all need
+  // the per-message scan; see SEARCH_HONORED above.
+  const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
+  if (pattern !== null && operand !== null && fl.asBool('w')) {
+    const scope = detectScope(operand)
+    if (
+      scope.useNative &&
+      scope.target !== 'files' &&
+      (accessor.transport.searchAvailable?.() ?? true)
+    ) {
+      const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
       const query = buildQuery(pattern, scope)
-      const count = maxCount ?? 100
-      const target = scope.target
-      const doMessages = target === undefined || target === 'date' || target === 'messages'
-      const doFiles = target === undefined || target === 'date' || target === 'files'
+      const count = SEARCH_MAX_RESULTS
+      // Every scope that reaches here searches messages: the guard above
+      // ruled out the files leaf, and a 'messages' target is a chat.jsonl
+      // leaf, which is not useNative. What is left is the channel, container
+      // and root scopes and the date directory — and those carry files too,
+      // so only the files half stays conditional.
+      const doFiles = scope.target === undefined || scope.target === 'date'
       try {
-        const nativeLines: string[] = []
-        if (doMessages) {
-          const raw = await searchMessages(accessor, query, count)
-          nativeLines.push(...formatGrepResults(raw, scope, filePrefix))
-        }
+        const raw = await searchMessages(accessor, query, count)
+        const nativeLines: string[] = [...formatGrepResults(raw, scope, filePrefix)]
         if (doFiles) {
           const rawF = await searchFiles(accessor, query, count)
           nativeLines.push(...formatFileGrepResults(rawF, scope, filePrefix))

--- a/typescript/packages/core/src/commands/builtin/slack/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/rg.ts
@@ -31,8 +31,9 @@ import { IOResult } from '../../../io/types.ts'
 import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { patternArg } from '../grep_helper.ts'
+import { patternArg, pushdownOperand } from '../grep_helper.ts'
 import { rgGeneric } from '../generic/rg.ts'
+import { SEARCH_HONORED, SEARCH_MAX_RESULTS } from './grep.ts'
 import { FlagView } from '../../spec/types.ts'
 
 const resolveSlackGlob = resolveGlobOf(SLACK_IO)
@@ -61,45 +62,45 @@ async function rgCommand(
     ]
   }
   const fl = new FlagView(opts.flags, specOf('rg'))
-  const maxCount = fl.asInt('m') ?? null
 
   const pushdownWarnings: string[] = []
-  if (paths.length > 0 && !pattern.includes('\n')) {
-    const firstPath = paths[0]
-    if (firstPath !== undefined) {
-      const scope = detectScope(firstPath)
-      // Slack search matches whole words while grep matches substrings, and
-      // the native path returns search results verbatim as the output, so a
-      // bare literal would under-report. Only -w makes the two agree.
-      if (scope.useNative && fl.asBool('w')) {
-        const filePrefix = mountPrefixOf(firstPath.virtual, firstPath.resourcePath)
-        const query = buildQuery(pattern, scope)
-        const count = maxCount ?? 100
-        const target = scope.target
-        const doMessages = target === undefined || target === 'date' || target === 'messages'
-        const doFiles = target === undefined || target === 'date' || target === 'files'
-        try {
-          const nativeLines: string[] = []
-          if (doMessages) {
-            const raw = await searchMessages(accessor, query, count)
-            nativeLines.push(...formatGrepResults(raw, scope, filePrefix))
-          }
-          if (doFiles) {
-            const rawF = await searchFiles(accessor, query, count)
-            nativeLines.push(...formatFileGrepResults(rawF, scope, filePrefix))
-          }
-          if (nativeLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-          return [ENC.encode(nativeLines.join('\n') + '\n'), new IOResult()]
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err)
+  // Same gate as slack grep, from the same table: only a lone concrete
+  // operand with no reshaping flag may be answered by the search API.
+  const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
+  if (operand !== null && fl.asBool('w')) {
+    const scope = detectScope(operand)
+    if (
+      scope.useNative &&
+      scope.target !== 'files' &&
+      (accessor.transport.searchAvailable?.() ?? true)
+    ) {
+      const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
+      const query = buildQuery(pattern, scope)
+      const count = SEARCH_MAX_RESULTS
+      // Every scope that reaches here searches messages: the guard above
+      // ruled out the files leaf, and a 'messages' target is a chat.jsonl
+      // leaf, which is not useNative. What is left is the channel, container
+      // and root scopes and the date directory — and those carry files too,
+      // so only the files half stays conditional.
+      const doFiles = scope.target === undefined || scope.target === 'date'
+      try {
+        const raw = await searchMessages(accessor, query, count)
+        const nativeLines: string[] = [...formatGrepResults(raw, scope, filePrefix)]
+        if (doFiles) {
+          const rawF = await searchFiles(accessor, query, count)
+          nativeLines.push(...formatFileGrepResults(rawF, scope, filePrefix))
+        }
+        if (nativeLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+        return [ENC.encode(nativeLines.join('\n') + '\n'), new IOResult()]
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        pushdownWarnings.push(
+          `slack: native search push-down failed (${msg}); falling back to per-file scan`,
+        )
+        if (msg.includes('not_allowed_token_type') || msg.includes('missing_scope')) {
           pushdownWarnings.push(
-            `slack: native search push-down failed (${msg}); falling back to per-file scan`,
+            'slack: hint - set SLACK_USER_TOKEN (xoxp-) with search:read scope to enable workspace search',
           )
-          if (msg.includes('not_allowed_token_type') || msg.includes('missing_scope')) {
-            pushdownWarnings.push(
-              'slack: hint - set SLACK_USER_TOKEN (xoxp-) with search:read scope to enable workspace search',
-            )
-          }
         }
       }
     }

--- a/typescript/packages/core/src/commands/builtin/slack/search_pushdown_fallback.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/search_pushdown_fallback.test.ts
@@ -34,7 +34,7 @@ async function runGrep(
   const resource = makeFakeResource(options.transport)
   const result = await cmd.fn(resource.accessor, paths, texts, {
     stdin: null,
-    flags: { args_l: true, w: true },
+    flags: { w: true },
     filetypeFns: null,
     cwd: '/',
     index: options.index,
@@ -65,7 +65,7 @@ async function runRg(
   const resource = makeFakeResource(options.transport)
   const result = await cmd.fn(resource.accessor, paths, texts, {
     stdin: null,
-    flags: { args_l: true, w: true },
+    flags: { w: true },
     filetypeFns: null,
     cwd: '/',
     index: options.index,

--- a/typescript/packages/core/src/core/discord/scope.test.ts
+++ b/typescript/packages/core/src/core/discord/scope.test.ts
@@ -15,7 +15,7 @@
 import { stripSlash } from '../../utils/slash.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
-import { coalesceScopes, detectScope } from './scope.ts'
+import { detectScope } from './scope.ts'
 import { PathSpec } from '../../types.ts'
 
 describe('detectScope', () => {
@@ -216,56 +216,5 @@ describe('detectScope', () => {
     expect(s.level).toBe('guild')
     expect(s.guildName).toBe('myserver')
     expect(s.guildId).toBeUndefined()
-  })
-})
-
-describe('coalesceScopes', () => {
-  const spec = (path: string): PathSpec =>
-    new PathSpec({
-      resourcePath: mountKey(path, '/discord'),
-      virtual: path,
-      directory: path,
-    })
-
-  it('coalesces concrete chat.jsonl paths of one channel into a channel scope', () => {
-    const paths = ['2026-01-01', '2026-01-02', '2026-01-03'].map((d) =>
-      spec(`/discord/myserver__G1/channels/general__C1/${d}/chat.jsonl`),
-    )
-    const s = coalesceScopes(paths)
-    expect(s).not.toBeNull()
-    expect(s?.level).toBe('channel')
-    expect(s?.useNative).toBe(true)
-    expect(s?.guildId).toBe('G1')
-    expect(s?.channelId).toBe('C1')
-  })
-
-  it('returns null for paths spanning channels', () => {
-    const paths = [
-      spec('/discord/myserver__G1/channels/general__C1/2026-01-01/chat.jsonl'),
-      spec('/discord/myserver__G1/channels/random__C2/2026-01-01/chat.jsonl'),
-    ]
-    expect(coalesceScopes(paths)).toBeNull()
-  })
-
-  it('returns null when the dirnames carry no ids', () => {
-    const paths = [spec('/discord/myserver/channels/general/2026-01-01/chat.jsonl')]
-    expect(coalesceScopes(paths)).toBeNull()
-  })
-
-  it('returns null for attachment blobs — message search cannot answer them', () => {
-    const paths = [spec('/discord/myserver__G1/channels/general__C1/2026-01-01/files/img__A1.png')]
-    expect(coalesceScopes(paths)).toBeNull()
-  })
-
-  it('returns null when message files are mixed with blobs', () => {
-    const paths = [
-      spec('/discord/myserver__G1/channels/general__C1/2026-01-01/chat.jsonl'),
-      spec('/discord/myserver__G1/channels/general__C1/2026-01-01/files/img__A1.png'),
-    ]
-    expect(coalesceScopes(paths)).toBeNull()
-  })
-
-  it('returns null for an empty list', () => {
-    expect(coalesceScopes([])).toBeNull()
   })
 })

--- a/typescript/packages/core/src/core/discord/scope.ts
+++ b/typescript/packages/core/src/core/discord/scope.ts
@@ -263,36 +263,3 @@ export function detectScope(path: PathSpec): DiscordScope {
 
   return { level: 'guild', useNative: false, resourcePath: key }
 }
-
-/**
- * Fold same-channel chat.jsonl operands into one channel scope.
- *
- * Only message files coalesce: guild search answers questions about message
- * content, so widening any other leaf (an attachment blob, a member JSON) to
- * a channel-wide message search would return hits that say nothing about the
- * requested bytes.
- */
-export function coalesceScopes(paths: readonly PathSpec[]): DiscordScope | null {
-  if (paths.length === 0) return null
-  const scopes = paths.map((p) => detectScope(p))
-  const first = scopes[0]
-  if (first?.guildId === undefined || first.channelId === undefined || first.level !== 'messages') {
-    return null
-  }
-  for (const s of scopes.slice(1)) {
-    if (s.level !== 'messages' || s.guildId !== first.guildId || s.channelId !== first.channelId) {
-      return null
-    }
-  }
-  const cut = first.resourcePath.lastIndexOf('/')
-  return {
-    level: 'channel',
-    useNative: true,
-    ...(first.guildName !== undefined ? { guildName: first.guildName } : {}),
-    guildId: first.guildId,
-    ...(first.channelName !== undefined ? { channelName: first.channelName } : {}),
-    channelId: first.channelId,
-    container: 'channels',
-    resourcePath: cut !== -1 ? first.resourcePath.slice(0, cut) : first.resourcePath,
-  }
-}

--- a/typescript/packages/core/src/core/slack/client.ts
+++ b/typescript/packages/core/src/core/slack/client.ts
@@ -71,6 +71,12 @@ function slackHttpError(endpoint: string, response: Response, text: string): Sla
 export interface SlackTransport {
   call(endpoint: string, params?: Record<string, string>, body?: unknown): Promise<SlackResponse>
   downloadFile?(url: string, offset?: number, size?: number | null): Promise<Uint8Array>
+  // Whether this transport's credentials can reach search.* at all. Slack
+  // rejects a bot token there, so a doomed call is worth not making; the
+  // python twin is `search_available(config)`. A transport that cannot tell
+  // (the browser one holds no token, the proxy does) leaves it unimplemented
+  // and callers read that as "try it".
+  searchAvailable?(): boolean
 }
 
 export abstract class HttpSlackTransport implements SlackTransport {
@@ -148,5 +154,9 @@ export class NodeSlackTransport extends HttpSlackTransport {
         ? this.searchToken
         : this.token
     return { Authorization: `Bearer ${token}` }
+  }
+  searchAvailable(): boolean {
+    if (this.searchToken !== undefined && this.searchToken !== '') return true
+    return this.token.startsWith('xoxp-')
   }
 }

--- a/typescript/packages/node/src/commands/builtin/email/grep.ts
+++ b/typescript/packages/node/src/commands/builtin/email/grep.ts
@@ -16,11 +16,16 @@ import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
 import { prefixAggregate } from '@struktoai/mirage-core/commands/builtin/aggregators'
 import { grepGeneric } from '@struktoai/mirage-core/commands/builtin/generic/grep'
 import { resolveGlobOf } from '@struktoai/mirage-core/commands/builtin/generic_bind/index'
-import { compilePattern, grepLines } from '@struktoai/mirage-core/commands/builtin/grep_helper'
+import {
+  compilePattern,
+  grepLines,
+  patternArg,
+  pushdownOperand,
+} from '@struktoai/mirage-core/commands/builtin/grep_helper'
+import type { GrepLinesOptions } from '@struktoai/mirage-core/commands/builtin/grep_helper'
+import { FlagView, specOf } from '@struktoai/mirage-core/commands/spec/index'
 import { command } from '@struktoai/mirage-core/commands/config'
 import type { CommandFnResult, CommandOpts } from '@struktoai/mirage-core/commands/config'
-import { specOf } from '@struktoai/mirage-core/commands/spec/index'
-import type { FlagValue } from '@struktoai/mirage-core/commands/spec/index'
 import { IOResult } from '@struktoai/mirage-core/io/types'
 import type { ByteSource } from '@struktoai/mirage-core/io/types'
 import { ResourceName } from '@struktoai/mirage-core/types'
@@ -39,6 +44,26 @@ const resolveGlob = resolveGlobOf(EMAIL_IO)
 
 const ENC = new TextEncoder()
 
+// The email push-down is not a "print the provider's answer" push-down: IMAP
+// search only picks the candidate messages, and `grepLines` then runs the
+// real compiled pattern over each one. So the rule for honoring a flag is
+// whether it can make a message the search did NOT return contribute output.
+// -n/-l/-w/-o/-m cannot: each only narrows within a message already listed,
+// and -m is per-file here, which is GNU's own reading of it. -v and -c both
+// can, and were wrong before this: -v reports the lines that do not match, so
+// it needs every message rather than the ones containing the pattern, and
+// GNU's -c prints a `path:0` row for the files with no match at all. They
+// defer now, along with -q, -H/-h, -A/-B/-C, rg's -I and the file filters.
+export const SEARCH_HONORED = ['n', 'args_l', 'w', 'o', 'm'] as const
+
+// Messages are greped line by line, as python's `splitlines()` does; passing
+// the whole message as one line made -n report 1 for every hit and printed
+// the entire message as the matching line.
+export function messageLines(text: string): string[] {
+  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
+  return stripped === '' ? [] : stripped.split('\n')
+}
+
 async function* emailStream(
   accessor: EmailAccessor,
   p: PathSpec,
@@ -47,88 +72,53 @@ async function* emailStream(
   yield await emailRead(accessor, p, index)
 }
 
-interface FlagSet {
-  ignoreCase: boolean
-  invert: boolean
-  lineNumbers: boolean
-  countOnly: boolean
-  filesOnly: boolean
-  wholeWord: boolean
-  fixedString: boolean
-  onlyMatching: boolean
-  maxCount: number | null
-  quiet: boolean
-  afterContext: number
-  beforeContext: number
-}
-
-function parseFlags(flags: Record<string, FlagValue>): FlagSet {
-  const toInt = (v: string | boolean | number | string[] | undefined): number | null =>
-    typeof v === 'string' ? Number.parseInt(v, 10) : null
-  const aCtx = toInt(flags.A)
-  const bCtx = toInt(flags.B)
-  const cCtx = toInt(flags.C)
-  return {
-    ignoreCase: flags.i === true,
-    invert: flags.v === true,
-    lineNumbers: flags.n === true,
-    countOnly: flags.c === true,
-    filesOnly: flags.args_l === true || flags.l === true,
-    wholeWord: flags.w === true,
-    fixedString: flags.F === true,
-    onlyMatching: flags.o === true,
-    maxCount: toInt(flags.m),
-    quiet: flags.q === true,
-    afterContext: aCtx ?? cCtx ?? 0,
-    beforeContext: bCtx ?? cCtx ?? 0,
-  }
-}
-
-function getPattern(texts: readonly string[], flags: Record<string, FlagValue>): string {
-  if (typeof flags.e === 'string') return flags.e
-  if (texts.length > 0 && texts[0] !== undefined) return texts[0]
-  throw new Error('grep: usage: grep [flags] pattern [path]')
-}
-
 async function grepCommand(
   accessor: EmailAccessor,
   paths: PathSpec[],
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let pattern: string
-  try {
-    pattern = getPattern(texts, opts.flags)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode(`${msg}\n`) })]
-  }
-  const f = parseFlags(opts.flags)
+  const pattern = patternArg(texts, opts.flags)
+  const fl = new FlagView(opts.flags, specOf('grep'))
 
-  if (paths.length > 0) {
-    const first = paths[0]
-    if (first !== undefined) {
-      const scope = detectScope(first)
-      if (scope.useNative && !pattern.includes('\n')) {
-        const filePrefix =
-          mountPrefixOf(first.virtual, first.resourcePath) !== ''
-            ? mountPrefixOf(first.virtual, first.resourcePath)
-            : ''
-        const pairs = await searchAndFormat(accessor, scope, pattern, filePrefix, f.maxCount ?? 50)
-        const lines: string[] = []
-        for (const [vfsPath, msgText] of pairs) {
-          const matched = grepLines(
-            vfsPath,
-            [msgText],
-            compilePattern(pattern, f.ignoreCase, f.fixedString, f.wholeWord),
-            f,
-          )
-          for (const line of matched) lines.push(`${vfsPath}:${line}`)
-        }
-        if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-        const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-        return [out, new IOResult()]
+  // A directory operand is only searched at all under -r/-R, so the push-down
+  // waits for it too; every other reason to defer is the shared gate's. A
+  // scope that names no folder falls through to the generic scan rather than
+  // answering, which is what the mount root does.
+  const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
+  if (pattern !== null && operand !== null && (fl.asBool('r') || fl.asBool('R'))) {
+    const scope = detectScope(operand)
+    if (scope.useNative && scope.folder !== null && scope.folder !== '') {
+      const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
+      const pairs = await searchAndFormat(
+        accessor,
+        scope,
+        pattern,
+        filePrefix,
+        accessor.config.maxMessages,
+      )
+      const pat = compilePattern(pattern, fl.asBool('i'), fl.asBool('F'), fl.asBool('w'))
+      const lineOpts: GrepLinesOptions = {
+        invert: false,
+        lineNumbers: fl.asBool('n'),
+        countOnly: false,
+        filesOnly: fl.asBool('args_l'),
+        onlyMatching: fl.asBool('o'),
+        maxCount: fl.asInt('m') ?? null,
       }
+      const lines: string[] = []
+      for (const [vfsPath, msgText] of pairs) {
+        const matched = grepLines(vfsPath, messageLines(msgText), pat, lineOpts)
+        if (matched.length === 0) continue
+        if (lineOpts.filesOnly) {
+          lines.push(vfsPath)
+          continue
+        }
+        for (const line of matched) lines.push(`${vfsPath}:${line}`)
+      }
+      if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+      const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
+      return [out, new IOResult()]
     }
   }
 

--- a/typescript/packages/node/src/commands/builtin/email/rg.ts
+++ b/typescript/packages/node/src/commands/builtin/email/rg.ts
@@ -19,6 +19,7 @@ import {
   compilePattern,
   grepLines,
   patternArg,
+  pushdownOperand,
 } from '@struktoai/mirage-core/commands/builtin/grep_helper'
 import type { GrepLinesOptions } from '@struktoai/mirage-core/commands/builtin/grep_helper'
 import { command } from '@struktoai/mirage-core/commands/config'
@@ -36,6 +37,7 @@ import { stat as emailStat } from '../../../core/email/stat.ts'
 import { detectScope } from '../../../core/email/scope.ts'
 import { searchAndFormat } from '../../../core/email/search.ts'
 import { EMAIL_IO } from './io.ts'
+import { SEARCH_HONORED, messageLines } from './grep.ts'
 
 const resolveGlob = resolveGlobOf(EMAIL_IO)
 
@@ -63,47 +65,45 @@ async function rgCommand(
     ]
   }
   const fl = new FlagView(opts.flags, specOf('rg'))
-  const ignoreCase = fl.asBool('i')
-  const invert = fl.asBool('v')
-  const lineNumbers = fl.asBool('n')
-  const countOnly = fl.asBool('c')
   // -l is short-only, so it lands on the disambiguated `args_l` dest
   // (`AMBIGUOUS_NAMES`); a plain `l` key is one the parser never emits.
-  const filesOnly = fl.asBool('args_l')
-  const wholeWord = fl.asBool('w')
-  const fixedString = fl.asBool('F')
-  const onlyMatching = fl.asBool('o')
-  const maxCount = fl.asInt('m') ?? null
-  const pat = compilePattern(pattern, ignoreCase, fixedString, wholeWord)
-
   const lineOpts: GrepLinesOptions = {
-    invert,
-    lineNumbers,
-    countOnly,
-    filesOnly,
-    onlyMatching,
-    maxCount,
+    invert: false,
+    lineNumbers: fl.asBool('n'),
+    countOnly: false,
+    filesOnly: fl.asBool('args_l'),
+    onlyMatching: fl.asBool('o'),
+    maxCount: fl.asInt('m') ?? null,
   }
 
-  if (paths.length > 0) {
-    const first = paths[0]
-    if (first !== undefined) {
-      const scope = detectScope(first)
-      if (scope.useNative && !pattern.includes('\n')) {
-        const filePrefix =
-          mountPrefixOf(first.virtual, first.resourcePath) !== ''
-            ? mountPrefixOf(first.virtual, first.resourcePath)
-            : ''
-        const pairs = await searchAndFormat(accessor, scope, pattern, filePrefix, maxCount ?? 50)
-        const lines: string[] = []
-        for (const [vfsPath, msgText] of pairs) {
-          const matched = grepLines(vfsPath, [msgText], pat, lineOpts)
-          for (const line of matched) lines.push(`${vfsPath}:${line}`)
+  // Same gate as email grep, from the same table, and it reads the scope the
+  // same way: a line the push-down cannot answer takes the generic scan.
+  const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
+  if (operand !== null) {
+    const scope = detectScope(operand)
+    if (scope.useNative && scope.folder !== null && scope.folder !== '') {
+      const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
+      const pairs = await searchAndFormat(
+        accessor,
+        scope,
+        pattern,
+        filePrefix,
+        accessor.config.maxMessages,
+      )
+      const pat = compilePattern(pattern, fl.asBool('i'), fl.asBool('F'), fl.asBool('w'))
+      const lines: string[] = []
+      for (const [vfsPath, msgText] of pairs) {
+        const matched = grepLines(vfsPath, messageLines(msgText), pat, lineOpts)
+        if (matched.length === 0) continue
+        if (lineOpts.filesOnly) {
+          lines.push(vfsPath)
+          continue
         }
-        if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-        const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-        return [out, new IOResult()]
+        for (const line of matched) lines.push(`${vfsPath}:${line}`)
       }
+      if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+      const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
+      return [out, new IOResult()]
     }
   }
 


### PR DESCRIPTION
## What

The grep/rg search push-downs in **gmail, slack, discord and email** answered
from `paths[0]` and silently dropped every additional operand, plus **email
`find`**, which did the same thing through `extract_folder`. So:

```bash
grep -rw foo /slack/channels/alpha /slack/channels/beta
```

searched `alpha` only and printed the result as though it covered both. This
routes all five through the shared gate the companion PR (#851) added for
langfuse/mongodb/postgres — `pushdown_operand` / `pushdownOperand` — instead of
adding a second one.

Each backend got its own decision, because their gates differed in ways that
matter. They are written down below.

## The `honored` parameter

`has_search_shaping_flags` refuses a push-down whenever a flag would alter the
match set or the output shape. But it lists `w`, and gmail/slack/discord
*require* `-w` to push down at all — provider search is word-based, so `-w` is
precisely the flag that makes a verbatim provider answer faithful rather than
approximate. Rather than fork the predicate, it grew a `honored` sequence of
flag names the caller has already accounted for.

Two families use it differently, and the distinction sets each backend's list:

- **Verbatim-answer** (gmail, slack, discord — and langfuse/mongodb/postgres):
  the provider's search result is printed directly, so the only honored flag is
  the one that shapes the query itself, `w`.
- **Narrow-then-scan** (email): IMAP search only picks candidate messages;
  `grep_lines` then runs the real compiled pattern locally. So a flag may be
  honored whenever it *cannot make a message the search did not return
  contribute output* — `n`, `args_l`, `w`, `o`, `m`.

`-v` and `-c` are deliberately **not** honored for email even though the local
scan implements both: `-v` reports lines that do not match, which needs every
message rather than the candidates, and GNU `-c` prints a `path:0` row for
files with no match. Both need the full set, so both defer.

## Per-backend decisions

### gmail — `paths[0]` → gated operand

Was reading `paths[0]` for both the scope and the output `file_prefix`,
open-coding a partial shaping check, and had **no `has_unresolved_glob` check
at all**, so an unexpanded glob reached the native search. Now uses the shared
gate. The py/ts drift is closed by making `SEARCH_HONORED` / `SEARCH_MAX_RESULTS`
module constants that `rg` imports from `grep` on both sides, so the two commands
cannot disagree again. Dropping the open-coded check also means `-m` now defers
rather than being half-honored.

### slack — `coalesce_scopes` deleted, not promoted

This one already had a multi-operand mechanism, consulted only when
`detect_scope(paths[0])` was *not* native. The tempting fix is "always
coalesce". **It is unsound**, for three reasons:

1. `build_query` emits only `in:#channel`. `search_guild` takes no date. So
   folding `.../alpha/2026-01-08` into its channel **drops the date** and widens
   the search to the whole channel.
2. It widened a lone leaf operand the same way — a single `chat.jsonl` path was
   being answered with its channel's entire history.
3. It never actually fixed the cross-channel drop it looked like it addressed,
   because two different channels cannot fold into one `in:#` term.

Coalescing was producing a *wider* answer while looking like a narrower one, so
it is removed in both languages and multi-operand lines take the generic scan.

Also closed the real py/ts divergence: TS never called `coalesceScopes` at all
and was missing python's `target != "files"` and `search_available` terms.
`SlackTransport` gained an optional `searchAvailable?()` — the node transport
answers from its token (Slack rejects a bot token on `search.*`, so a doomed
call is worth not making), and the browser transport leaves it unimplemented,
which callers read as "try it".

### discord — same shape, same answer

`coalesce_scopes` was consulted only when `scope.level == "messages"`, so any
guild or channel directory operand was decided from `paths[0]` alone. Same
reasoning as slack, same removal.

### email grep/rg — the exit-1 bug

`email/rg.py` called `extract_folder(paths)` and, on a falsy folder,
**returned exit 1 (no match) instead of falling through to the generic scan** —
so a line the push-down could not answer reported "nothing matched" for a search
it never ran. It also had no shaping gate and no `use_native` term, unlike
`email/grep.py`. Both now share one gate and one `SEARCH_HONORED`.

`extract_folder` had no callers left and is deleted.

While rewriting the TS side to use `patternArg` + `FlagView` (it carried a
bespoke `parseFlags`/`FlagSet`/`getPattern`), a TS-only bug surfaced: it greped
each message as **one line**, so `-n` reported `1` for every hit and printed the
entire message as the matching line. `messageLines()` now splits the way
python's `splitlines()` does.

### email find — python is right, TS gains nothing

`_is_folder_level(paths)` read only `paths[0].mount_path` and `_find_server_side`
called the same `paths[0]`-only `extract_folder`, so
`find /email/INBOX /email/Sent -name '*x*'` searched INBOX and dropped Sent.
Replaced with `_folder_operand`, built on the shared `lone_operand`.

The TS counterpart has no push-down at all. **Python is the right side** — the
IMAP subject search is a real saving over walking every message — so TS is left
as-is rather than having the push-down removed from python; the gate makes the
two agree on every line python now declines to push down.

A second bug fell out: the mount root reached `_find_server_side` and answered
with an **empty result and exit 0**, reporting "nothing matched" for a search it
never ran. It now takes the walk like any other path the push-down cannot serve.

## Tests

Unit tests mirror `langfuse/test_grep.py`: a multi-operand invocation must not
reach the native fetch and must land in the generic scan. Added/updated across
gmail, slack, discord, email (grep, rg and find), the shared helper, and both
scope modules in both languages.

`tests/e2e/test_search_pushdown_iteration.py` was pinning the coalescing
behavior; it is rewritten to assert the opposite — a glob expanded to 60 day
paths now reads those 60 days, makes no native search call, and every output
line names an operand the line actually carried.

13 integ cases pin it byte-identically on both hosts, captured empirically with
`--emit`:

| file | cases |
|---|---|
| `integ/resources/discord/scope.json` | `dc_grep_two_channels_cover_the_second`, `dc_grep_w_second_day_file_only`, `dc_grep_wn_defers_to_scan`, and `dc_grep_w_day_file_native` re-pinned as `dc_grep_w_day_file_scans_only_that_day` |
| `integ/resources/slack/grep.json` | `slack_grep_two_channels_cover_the_second`, `slack_grep_n_defers_to_scan` |
| `integ/resources/gmail/basic.json` | `gm_grep_two_labels_cover_the_second`, `gm_grep_glob_operand_scans` |
| `integ/resources/email/basic.json` | `em_grep_two_folders_cover_the_second`, `em_rg_root_scans_instead_of_no_match`, `em_grep_c_defers_to_scan`, `em_find_two_folders_cover_the_second`, `em_find_root_name_walks` |

## Verification

- Python suite green (`--ignore=tests/fuse`, no macFUSE on this host); e2e green.
- `pnpm -r typecheck` clean; core 9086 passed, node 2370 passed, browser 231 passed.
- `pre-commit run --all-files`: all hooks pass, mypy `Success: no issues found in 1892 source files`.
- Integ battery, discord + slack + gmail + email, **320 passed / 0 failed on
  each host**, byte-identical.
- Both ratchet gates unchanged at baseline: case-targets 2295, layout parity 259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
