### PR TITLE
Fix permissions parser parity

### DIFF
--- a/integ/fixtures/config/rejected.json
+++ b/integ/fixtures/config/rejected.json
@@ -100,6 +100,13 @@
       }
     },
     {
+      "name": "profile: a mount ceiling is a mode name, not a list",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "profiles": { "a": { "mounts": { "/d": ["read"] } } }
+      }
+    },
+    {
       "name": "profile: the old hidden_paths spelling",
       "config": {
         "mounts": { "/d": { "resource": "ram" } },

--- a/integ/fixtures/config/rejected.json
+++ b/integ/fixtures/config/rejected.json
@@ -86,6 +86,20 @@
       }
     },
     {
+      "name": "permissions: deny is a list, not a scalar",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "permissions": { "commands": { "deny": "rm" } }
+      }
+    },
+    {
+      "name": "profile: mount lists contain only strings",
+      "config": {
+        "mounts": { "/d": { "resource": "ram" } },
+        "profiles": { "a": { "mounts": ["/d", 7] } }
+      }
+    },
+    {
       "name": "profile: the old hidden_paths spelling",
       "config": {
         "mounts": { "/d": { "resource": "ram" } },

--- a/python/mirage/workspace/session/permissions.py
+++ b/python/mirage/workspace/session/permissions.py
@@ -226,8 +226,13 @@ class SessionProfile(BaseModel):
             for prefix, mode in v.items():
                 if not isinstance(prefix, str):
                     raise ValueError("mounts keys must be strings")
+                if not isinstance(mode, str):
+                    raise ValueError(
+                        f"mounts[{prefix}] must be a mode name or alias")
                 modes[_norm_prefix(prefix)] = parse_mount_mode(mode)
             return modes
+        if not isinstance(v, (list, tuple)):
+            raise ValueError("mounts must be a mapping or a list of strings")
         return tuple(
             _norm_prefix(prefix) for prefix in _string_list(v, "mounts"))
 

--- a/python/mirage/workspace/session/permissions.py
+++ b/python/mirage/workspace/session/permissions.py
@@ -35,8 +35,23 @@ def _norm_prefix(prefix: str) -> str:
     return "/" + prefix.strip("/")
 
 
+def _list(value: Any, where: str, expected: str = "a list") -> tuple[Any, ...]:
+    """A document list, refused before a scalar can be iterated.
+
+    Args:
+        value (Any): the field as written, None when absent.
+        where (str): the field's name, for the message.
+        expected (str): the expected shape named in the message.
+    """
+    if value is None:
+        return ()
+    if not isinstance(value, (list, tuple)):
+        raise ValueError(f"{where} must be {expected}")
+    return tuple(value)
+
+
 def _string_list(value: Any, where: str) -> tuple[str, ...]:
-    """A rule's list field, refused unless it is a list of strings.
+    """A document list field, refused unless every item is a string.
 
     A scalar ``commands: rm`` would otherwise ``tuple()`` into
     ``('r', 'm')`` and the command it meant to refuse stay allowed, so
@@ -46,14 +61,11 @@ def _string_list(value: Any, where: str) -> tuple[str, ...]:
         value (Any): the field as written, None when absent.
         where (str): the field's name, for the message.
     """
-    if value is None:
-        return ()
-    if not isinstance(value, (list, tuple)):
-        raise ValueError(f"{where} must be a list of strings")
-    for i, entry in enumerate(value):
+    entries = _list(value, where, "a list of strings")
+    for i, entry in enumerate(entries):
         if not isinstance(entry, str):
             raise ValueError(f"{where}[{i}] must be a string")
-    return tuple(value)
+    return entries
 
 
 def _rule(entry: Any) -> Any:
@@ -132,9 +144,7 @@ class CommandsBlock(BaseModel):
     @field_validator("deny", mode="before")
     @classmethod
     def _v_deny(cls, v: Any) -> Any:
-        if v is None:
-            return ()
-        return tuple(_rule(entry) for entry in v)
+        return tuple(_rule(entry) for entry in _list(v, "commands.deny"))
 
 
 class MountPermissions(BaseModel):
@@ -212,11 +222,14 @@ class SessionProfile(BaseModel):
         if isinstance(v, str):
             return (_norm_prefix(v), )
         if isinstance(v, Mapping):
-            return {
-                _norm_prefix(str(p)): parse_mount_mode(m)
-                for p, m in v.items()
-            }
-        return tuple(_norm_prefix(str(p)) for p in v)
+            modes: dict[str, MountMode] = {}
+            for prefix, mode in v.items():
+                if not isinstance(prefix, str):
+                    raise ValueError("mounts keys must be strings")
+                modes[_norm_prefix(prefix)] = parse_mount_mode(mode)
+            return modes
+        return tuple(
+            _norm_prefix(prefix) for prefix in _string_list(v, "mounts"))
 
 
 @dataclass(frozen=True, slots=True)

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -14,8 +14,7 @@
 
 import asyncio
 import logging
-from collections.abc import (AsyncIterator, Callable, Iterable, Mapping,
-                             Sequence)
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from types import ModuleType, TracebackType
 from typing import Any, Literal, overload
 
@@ -644,7 +643,7 @@ class Workspace:
     def create_session(
         self,
         session_id: str,
-        mounts: Mapping[str, MountMode | str] | Iterable[str] | None = None,
+        mounts: Mapping[str, MountMode | str] | Sequence[str] | None = None,
         *,
         profile: str | SessionProfile | None = None,
         permissions: SessionProfile | None = None,
@@ -659,11 +658,13 @@ class Workspace:
 
         Args:
             session_id (str): unique id for the session.
-            mounts (Mapping[str, MountMode | str] | Iterable[str] | None):
+            mounts (Mapping[str, MountMode | str] | Sequence[str] | None):
                 sugar for ``permissions.mounts``: a mapping assigns each
                 prefix a mode ceiling ("read", "write", "exec", or the
-                filesystem aliases "r", "rw", "rwx"); a plain iterable
-                of prefixes keeps each mount at its own configured mode.
+                filesystem aliases "r", "rw", "rwx"); a list of prefixes
+                (or one bare prefix) keeps each mount at its own
+                configured mode. A set or a generator is refused, so
+                the same grant reads the same way in TypeScript.
             profile (str | SessionProfile | None): the role to create
                 the session from.
             permissions (SessionProfile | None): an inline document that

--- a/python/tests/workspace/session/test_permissions.py
+++ b/python/tests/workspace/session/test_permissions.py
@@ -66,6 +66,12 @@ def test_profile_mounts_list_form_keeps_each_mounts_own_mode():
     assert SessionProfile(mounts="/repo").mounts == ("/repo", )
 
 
+@pytest.mark.parametrize("mounts", [["/repo", 7], 7, {7: "read"}])
+def test_profile_mounts_rejects_non_string_prefixes(mounts):
+    with pytest.raises(ValidationError):
+        SessionProfile.model_validate({"mounts": mounts})
+
+
 def test_profile_rejects_unknown_and_unshipped_fields():
     for bad in ({
             "hidden_paths": {}
@@ -118,6 +124,11 @@ def test_workspace_permissions_deny_accepts_rules_and_bare_names():
     assert w.paths == PathsBlock(hide=("/shared/finance", ))
     assert WorkspacePermissions() == WorkspacePermissions(
         commands=CommandsBlock(), paths=PathsBlock())
+
+
+def test_workspace_permissions_deny_is_a_list_not_a_scalar():
+    with pytest.raises(ValidationError):
+        WorkspacePermissions.model_validate({"commands": {"deny": "rm"}})
 
 
 @pytest.mark.parametrize("rule", [

--- a/python/tests/workspace/session/test_permissions.py
+++ b/python/tests/workspace/session/test_permissions.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import re
 
 import pytest
 from pydantic import ValidationError
@@ -66,9 +67,26 @@ def test_profile_mounts_list_form_keeps_each_mounts_own_mode():
     assert SessionProfile(mounts="/repo").mounts == ("/repo", )
 
 
-@pytest.mark.parametrize("mounts", [["/repo", 7], 7, {7: "read"}])
-def test_profile_mounts_rejects_non_string_prefixes(mounts):
-    with pytest.raises(ValidationError):
+@pytest.mark.parametrize("mounts,message", [
+    (["/repo", 7], "mounts[1] must be a string"),
+    ({
+        7: "read"
+    }, "mounts keys must be strings"),
+    ({
+        "/repo": ["read"]
+    }, "mounts[/repo] must be a mode name or alias"),
+    ({
+        "/repo": 7
+    }, "mounts[/repo] must be a mode name or alias"),
+    (7, "mounts must be a mapping or a list of strings"),
+    ({"/repo"}, "mounts must be a mapping or a list of strings"),
+])
+def test_profile_mounts_rejects_what_typescript_rejects(mounts, message):
+    # The message is asserted, not just the type: a mode that is not a
+    # string used to reach parse_mount_mode and come back as a bare
+    # TypeError (unhashable dict/list key), which is not the ValueError
+    # the loader's contract promises.
+    with pytest.raises(ValidationError, match=re.escape(message)):
         SessionProfile.model_validate({"mounts": mounts})
 
 
@@ -126,9 +144,11 @@ def test_workspace_permissions_deny_accepts_rules_and_bare_names():
         commands=CommandsBlock(), paths=PathsBlock())
 
 
-def test_workspace_permissions_deny_is_a_list_not_a_scalar():
-    with pytest.raises(ValidationError):
-        WorkspacePermissions.model_validate({"commands": {"deny": "rm"}})
+@pytest.mark.parametrize("deny", ["rm", {"rm": "no"}, 7])
+def test_workspace_permissions_deny_is_a_list_not_a_scalar(deny):
+    with pytest.raises(ValidationError,
+                       match=re.escape("commands.deny must be a list")):
+        WorkspacePermissions.model_validate({"commands": {"deny": deny}})
 
 
 @pytest.mark.parametrize("rule", [

--- a/typescript/packages/core/src/workspace/session/permissions.test.ts
+++ b/typescript/packages/core/src/workspace/session/permissions.test.ts
@@ -60,6 +60,14 @@ describe('parseSessionProfile', () => {
     expect(parseProfileMounts(null)).toBeNull()
   })
 
+  it('rejects non-string mount prefixes', () => {
+    expect(() => parseSessionProfile({ mounts: ['/repo', 7] })).toThrow(
+      /mounts\[1\] must be a string/,
+    )
+    expect(() => parseSessionProfile({ mounts: 7 })).toThrow(/mounts must be a mapping/)
+    expect(() => parseProfileMounts(new Map([[7, 'read']]))).toThrow(/mounts keys must be strings/)
+  })
+
   it('rejects unknown and unshipped fields loudly', () => {
     expect(() => parseSessionProfile({ hidden_paths: {} })).toThrow(/unknown field `hidden_paths`/)
     expect(() => parseSessionProfile({ hiddenPaths: {} })).toThrow(/unknown field/)
@@ -95,6 +103,12 @@ describe('parseWorkspacePermissions', () => {
     ])
     expect(w.paths).toEqual({ hide: ['/shared/finance'] })
     expect(parseWorkspacePermissions({})).toEqual({ commands: { deny: [] }, paths: { hide: [] } })
+  })
+
+  it('requires deny itself to be a list', () => {
+    expect(() => parseWorkspacePermissions({ commands: { deny: 'rm' } })).toThrow(
+      /deny must be a list/,
+    )
   })
 
   it('rejects profile-only, unshipped and unknown fields', () => {

--- a/typescript/packages/core/src/workspace/session/permissions.test.ts
+++ b/typescript/packages/core/src/workspace/session/permissions.test.ts
@@ -60,12 +60,21 @@ describe('parseSessionProfile', () => {
     expect(parseProfileMounts(null)).toBeNull()
   })
 
-  it('rejects non-string mount prefixes', () => {
+  it('rejects the mount spellings python rejects', () => {
     expect(() => parseSessionProfile({ mounts: ['/repo', 7] })).toThrow(
       /mounts\[1\] must be a string/,
     )
-    expect(() => parseSessionProfile({ mounts: 7 })).toThrow(/mounts must be a mapping/)
     expect(() => parseProfileMounts(new Map([[7, 'read']]))).toThrow(/mounts keys must be strings/)
+    expect(() => parseSessionProfile({ mounts: { '/repo': ['read'] } })).toThrow(
+      /mounts\[\/repo\] must be a mode name or alias/,
+    )
+    // A Set has no own enumerable keys, so Object.entries used to read
+    // it as an empty mapping and the session silently granted nothing.
+    for (const bad of [7, new Set(['/repo']), new Date()]) {
+      expect(() => parseSessionProfile({ mounts: bad })).toThrow(
+        /mounts must be a mapping or a list of strings/,
+      )
+    }
   })
 
   it('rejects unknown and unshipped fields loudly', () => {
@@ -106,9 +115,9 @@ describe('parseWorkspacePermissions', () => {
   })
 
   it('requires deny itself to be a list', () => {
-    expect(() => parseWorkspacePermissions({ commands: { deny: 'rm' } })).toThrow(
-      /deny must be a list/,
-    )
+    for (const deny of ['rm', { rm: 'no' }, 7]) {
+      expect(() => parseWorkspacePermissions({ commands: { deny } })).toThrow(/deny must be a list/)
+    }
   })
 
   it('rejects profile-only, unshipped and unknown fields', () => {

--- a/typescript/packages/core/src/workspace/session/permissions.ts
+++ b/typescript/packages/core/src/workspace/session/permissions.ts
@@ -103,8 +103,14 @@ const MOUNT_PERMISSIONS_FIELDS = ['paths'] as const
 const WORKSPACE_PERMISSIONS_FIELDS = ['commands', 'paths'] as const
 const PROFILE_FIELDS = ['extends', 'cwd', 'env', 'mounts', 'paths', 'vars'] as const
 
+// A document mapping, not merely "an object": a Set, a Date or any class
+// instance has no own enumerable string keys, so Object.entries would read
+// one as an empty mapping and a `mounts` Set would compile to a session
+// granting nothing at all. Python refuses the same values loudly.
 function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null && !Array.isArray(v) && !(v instanceof Map)
+  if (typeof v !== 'object' || v === null) return false
+  const proto: unknown = Object.getPrototypeOf(v)
+  return proto === Object.prototype || proto === null
 }
 
 function rejectUnknownKeys(
@@ -124,10 +130,15 @@ function asObject(raw: unknown, where: string): Record<string, unknown> {
   return raw
 }
 
-function stringList(raw: unknown, where: string): readonly string[] {
+/** A document list, refused before a scalar can be iterated (python's `_list`). */
+function asList(raw: unknown, where: string, expected = 'a list'): readonly unknown[] {
   if (raw === undefined || raw === null) return []
-  if (!Array.isArray(raw)) throw new Error(`${where} must be a list of strings`)
-  return raw.map((entry, i) => {
+  if (!Array.isArray(raw)) throw new Error(`${where} must be ${expected}`)
+  return raw as readonly unknown[]
+}
+
+function stringList(raw: unknown, where: string): readonly string[] {
+  return asList(raw, where, 'a list of strings').map((entry, i) => {
     if (typeof entry !== 'string') throw new Error(`${where}[${String(i)}] must be a string`)
     return entry
   })
@@ -166,8 +177,7 @@ export function parseVarsBlock(raw: unknown, where = 'vars'): VarsBlock {
 export function parseCommandsBlock(raw: unknown, where = 'commands'): CommandsBlock {
   const obj = asObject(raw, where)
   rejectUnknownKeys(obj, COMMANDS_FIELDS, where)
-  const deny = obj.deny ?? []
-  if (!Array.isArray(deny)) throw new Error(`${where}.deny must be a list`)
+  const deny = asList(obj.deny, `${where}.deny`)
   return { deny: deny.map((entry, i) => parseRule(entry, `${where}.deny[${String(i)}]`)) }
 }
 
@@ -208,8 +218,10 @@ export function parseProfileMounts(
   if (raw === undefined || raw === null) return null
   if (typeof raw === 'string') return [normPrefix(raw)]
   if (Array.isArray(raw)) return stringList(raw, where).map(normPrefix)
-  const entries: [unknown, unknown][] =
-    raw instanceof Map ? [...raw.entries()] : Object.entries(asObject(raw, where))
+  let entries: [unknown, unknown][]
+  if (raw instanceof Map) entries = [...raw.entries()]
+  else if (isPlainObject(raw)) entries = Object.entries(raw)
+  else throw new Error(`${where} must be a mapping or a list of strings`)
   const modes = new Map<string, MountMode>()
   for (const [prefix, mode] of entries) {
     if (typeof prefix !== 'string') throw new Error(`${where} keys must be strings`)

--- a/typescript/packages/core/src/workspace/session/permissions.ts
+++ b/typescript/packages/core/src/workspace/session/permissions.ts
@@ -208,12 +208,11 @@ export function parseProfileMounts(
   if (raw === undefined || raw === null) return null
   if (typeof raw === 'string') return [normPrefix(raw)]
   if (Array.isArray(raw)) return stringList(raw, where).map(normPrefix)
-  const entries: [string, unknown][] =
-    raw instanceof Map
-      ? [...(raw as Map<string, unknown>).entries()]
-      : Object.entries(asObject(raw, where))
+  const entries: [unknown, unknown][] =
+    raw instanceof Map ? [...raw.entries()] : Object.entries(asObject(raw, where))
   const modes = new Map<string, MountMode>()
   for (const [prefix, mode] of entries) {
+    if (typeof prefix !== 'string') throw new Error(`${where} keys must be strings`)
     if (typeof mode !== 'string')
       throw new Error(`${where}[${prefix}] must be a mode name or alias`)
     modes.set(normPrefix(prefix), parseMountMode(mode))


### PR DESCRIPTION
## Summary

- reject scalar `commands.deny` values before Python can iterate them as command characters
- reject non-string profile mount prefixes consistently in Python and TypeScript
- add shared config fixtures and language-specific regression coverage

## Root cause

Python’s pre-validation iterated arbitrary deny values and stringified mount prefixes. That made `deny: rm` become rules for `r` and `m`, and made numeric mount entries such as `7` become `/7`. TypeScript already rejected array entries but did not explicitly validate programmatic `Map` keys.

## Impact

Malformed permission and profile documents now fail loudly and consistently across both implementations.

## Validation

- `./python/.venv/bin/pre-commit run --all-files`
- `cd python && uv run pytest` — 15,876 passed, 485 skipped, 1 xfailed
- TypeScript monorepo build
- strict layout parity check