### PR TITLE
fix(dropbox): bound the emptiness probe's walk, not just its page

### DIFF
--- a/python/mirage/core/dropbox/api.py
+++ b/python/mirage/core/dropbox/api.py
@@ -115,17 +115,37 @@ async def list_folder(
     tm: DropboxTokenManager,
     path: str,
     recursive: bool = False,
-    limit: int = 2000,
+    page_size: int = 2000,
+    limit: int | None = None,
 ) -> list[dict[str, Any]]:
+    """List a folder's entries, following every continuation cursor.
+
+    Args:
+        tm (DropboxTokenManager): Dropbox token manager.
+        path (str): folder to list; "/" and "" both mean the account root.
+        recursive (bool): list every descendant, not just the children.
+        page_size (int): entries per request.
+        limit (int | None): stop once this many entries are in hand and do
+            not request another page. An emptiness probe wants one entry,
+            and ``page_size`` alone cannot express that: it caps the page,
+            not the walk, so a small page turned a listing of a large
+            folder into many requests instead of fewer.
+
+    Returns:
+        list[dict]: entry metadata dicts.
+    """
     api_path = "" if path in ("/", "") else path
     out: list[dict[str, Any]] = []
-    resp = await dropbox_rpc(tm, "/files/list_folder", {
-        "path": api_path,
-        "recursive": recursive,
-        "limit": limit,
-    })
+    resp = await dropbox_rpc(
+        tm, "/files/list_folder", {
+            "path": api_path,
+            "recursive": recursive,
+            "limit": page_size if limit is None else min(page_size, limit),
+        })
     out.extend(resp["entries"])
     while resp.get("has_more"):
+        if limit is not None and len(out) >= limit:
+            break
         resp = await dropbox_rpc(tm, "/files/list_folder/continue",
                                  {"cursor": resp["cursor"]})
         out.extend(resp["entries"])

--- a/python/tests/core/dropbox/conftest.py
+++ b/python/tests/core/dropbox/conftest.py
@@ -1,0 +1,104 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Any
+
+import pytest
+
+from mirage.accessor.dropbox import DropboxAccessor
+from mirage.core.dropbox.client import DropboxApiError, DropboxTokenManager
+from mirage.resource.dropbox.config import DropboxConfig
+
+
+class FakeDropboxRpc:
+    """A ``dropbox_rpc`` stand-in that pages ``/files/list_folder``.
+
+    Stands in for the transport rather than for ``list_folder`` itself,
+    because the walk is what a probe has to bound and only the real
+    ``list_folder`` performs it: a stub in its place answers in one call
+    whatever the caller asked for, so it cannot tell a bounded probe from
+    an unbounded one.
+
+    Pages every request on the limit the first one carried, as the real
+    API does (the cursor retains the original request's parameters), and
+    records both the cap each caller asked for and how many requests the
+    walk actually made. ``page_size`` cannot express a bound on the walk:
+    it caps the page, not the walk, so a small page turns a listing of a
+    large folder into more requests rather than fewer.
+
+    Args:
+        entries (list[dict] | None): the folder's listing.
+        metadata (dict | None): what ``/files/get_metadata`` answers.
+        move_errors (list[DropboxApiError | None] | None): one entry per
+            ``/files/move_v2`` call; a ``DropboxApiError`` is raised.
+    """
+
+    def __init__(
+        self,
+        entries: list[dict[str, Any]] | None = None,
+        metadata: dict[str, Any] | None = None,
+        move_errors: list[DropboxApiError | None] | None = None,
+    ) -> None:
+        self.entries = list(entries or [])
+        self.metadata = metadata
+        self.move_errors = list(move_errors or [])
+        # Every `limit` a caller asked for, so a test can pin that an
+        # emptiness probe is bounded, and the request count, which is the
+        # half an unbounded walk gets wrong.
+        self.list_limits: list[int] = []
+        self.list_requests = 0
+        self.deleted: list[str] = []
+        self.moves: list[tuple[str, str]] = []
+        self._cursors: dict[str, list[dict[str, Any]]] = {}
+        self._limits: dict[str, int] = {}
+
+    def _page(self, rest: list[dict[str, Any]], limit: int) -> dict[str, Any]:
+        self.list_requests += 1
+        head, tail = rest[:limit], rest[limit:]
+        token = f"cursor-{len(self._cursors)}"
+        self._cursors[token] = tail
+        self._limits[token] = limit
+        return {"entries": head, "cursor": token, "has_more": bool(tail)}
+
+    async def __call__(self, tm: DropboxTokenManager, endpoint: str,
+                       body: dict[str, Any]) -> dict[str, Any]:
+        if endpoint == "/files/list_folder":
+            limit = int(body.get("limit") or 2000)
+            self.list_limits.append(limit)
+            self._cursors = {}
+            self._limits = {}
+            return self._page(self.entries, limit)
+        if endpoint == "/files/list_folder/continue":
+            token = body["cursor"]
+            return self._page(self._cursors.pop(token), self._limits[token])
+        if endpoint == "/files/get_metadata":
+            if self.metadata is None:
+                raise DropboxApiError("nf", 409, "path/not_found/...")
+            return self.metadata
+        if endpoint == "/files/delete_v2":
+            self.deleted.append(body["path"])
+            return {}
+        if endpoint == "/files/move_v2":
+            self.moves.append((body["from_path"], body["to_path"]))
+            error = (self.move_errors.pop(0) if self.move_errors else None)
+            if error is not None:
+                raise error
+            return {}
+        raise AssertionError(f"unexpected endpoint {endpoint}")
+
+
+@pytest.fixture
+def dropbox_accessor() -> DropboxAccessor:
+    config = DropboxConfig(client_id="c", client_secret="s", refresh_token="r")
+    return DropboxAccessor(config, DropboxTokenManager(config))

--- a/python/tests/core/dropbox/test_rename.py
+++ b/python/tests/core/dropbox/test_rename.py
@@ -21,6 +21,7 @@ from mirage.core.dropbox.client import DropboxApiError, DropboxTokenManager
 from mirage.core.dropbox.rename import rename
 from mirage.resource.dropbox.config import DropboxConfig
 from mirage.types import PathSpec
+from tests.core.dropbox.conftest import FakeDropboxRpc
 
 
 def make_accessor() -> DropboxAccessor:
@@ -109,3 +110,27 @@ async def test_rename_missing_source_raises_enoent():
         with pytest.raises(FileNotFoundError):
             await rename(make_accessor(), PathSpec.from_str_path("/ghost"),
                          PathSpec.from_str_path("/b.txt"))
+
+
+@pytest.mark.asyncio
+async def test_rename_conflict_probe_is_bounded_to_one_entry(dropbox_accessor):
+    # The conflict probe is bounded, not a full listing: `list_folder`
+    # follows every continuation cursor, so asking it with a small page
+    # size made one request per child to answer a yes/no.
+    conflict = DropboxApiError("conflict", 409, "to/conflict/folder/...")
+    rpc = FakeDropboxRpc(entries=[{
+        ".tag": "file",
+        "name": "keep.txt"
+    }] * 3,
+                         metadata={
+                             ".tag": "folder",
+                             "name": "dst"
+                         },
+                         move_errors=[conflict])
+    with patch("mirage.core.dropbox.api.dropbox_rpc", new=rpc):
+        with pytest.raises(DropboxApiError):
+            await rename(dropbox_accessor, PathSpec.from_str_path("/src"),
+                         PathSpec.from_str_path("/dst"))
+    assert rpc.list_limits == [1]
+    assert rpc.list_requests == 1
+    assert rpc.deleted == []

--- a/python/tests/core/dropbox/test_rmdir.py
+++ b/python/tests/core/dropbox/test_rmdir.py
@@ -22,6 +22,7 @@ from mirage.core.dropbox.client import DropboxTokenManager
 from mirage.core.dropbox.rmdir import rmdir
 from mirage.resource.dropbox.config import DropboxConfig
 from mirage.types import PathSpec
+from tests.core.dropbox.conftest import FakeDropboxRpc
 
 FOLDER = {".tag": "folder", "name": "docs"}
 FILE = {".tag": "file", "name": "a.txt", "size": 1}
@@ -70,3 +71,18 @@ async def test_rmdir_file_raises_enotdir():
                return_value=FILE):
         with pytest.raises(NotADirectoryError):
             await rmdir(make_accessor(), PathSpec.from_str_path("/a.txt"))
+
+
+@pytest.mark.asyncio
+async def test_rmdir_probe_is_bounded_to_one_entry(dropbox_accessor):
+    # The emptiness probe is bounded, not a full listing: `list_folder`
+    # follows every continuation cursor, so asking it with a small page
+    # size made one request per child to answer a yes/no.
+    rpc = FakeDropboxRpc(entries=[FILE, FILE, FILE], metadata=FOLDER)
+    with patch("mirage.core.dropbox.api.dropbox_rpc", new=rpc):
+        with pytest.raises(OSError) as excinfo:
+            await rmdir(dropbox_accessor, PathSpec.from_str_path("/docs"))
+    assert excinfo.value.errno == errno.ENOTEMPTY
+    assert rpc.list_limits == [1]
+    assert rpc.list_requests == 1
+    assert rpc.deleted == []

--- a/spec/layout_exceptions.json
+++ b/spec/layout_exceptions.json
@@ -47,6 +47,11 @@
    "python_only": {
     "sdk": "The asyncssh import shim (None when the ssh extra is absent), the same shape daytona and e2b carry in their baselined sdk modules; TypeScript loads ssh2 through loadOptionalPeer inside runtime.ts, so there is no ts twin."
    }
+  },
+  "core/dropbox": {
+   "typescript_only": {
+    "_test_util": "The FakeDropboxRpc transport fake shared by rmdir.test.ts and rename.test.ts. TypeScript colocates tests with sources, so a shared test helper lands in the source directory; python keeps the same fake in tests/core/dropbox/conftest.py, which this gate does not scan. core/gdrive carries an identical _test_util.ts, still counted in the baseline rather than excused here."
+   }
   }
  }
 }

--- a/typescript/packages/core/src/core/dropbox/_test_util.ts
+++ b/typescript/packages/core/src/core/dropbox/_test_util.ts
@@ -1,0 +1,107 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { DropboxApiError } from './client.ts'
+import type { DropboxEntry } from './api.ts'
+
+/**
+ * A `dropboxRpc` stand-in that pages `/files/list_folder`.
+ *
+ * Stands in for the transport rather than for `listFolder` itself,
+ * because the walk is what a probe has to bound and only the real
+ * `listFolder` performs it: a stub in its place answers in one call
+ * whatever the caller asked for, so it cannot tell a bounded probe from
+ * an unbounded one.
+ *
+ * Pages every request on the limit the first one carried, as the real API
+ * does (the cursor retains the original request's parameters), and
+ * records both the cap each caller asked for and how many requests the
+ * walk actually made. `pageSize` cannot express a bound on the walk: it
+ * caps the page, not the walk, so a small page turns a listing of a large
+ * folder into more requests rather than fewer.
+ */
+export class FakeDropboxRpc {
+  entries: DropboxEntry[]
+  metadata: DropboxEntry | null
+  moveErrors: (DropboxApiError | null)[]
+  listLimits: number[] = []
+  listRequests = 0
+  deleted: string[] = []
+  moves: [string, string][] = []
+  private cursors = new Map<string, DropboxEntry[]>()
+  private limits = new Map<string, number>()
+
+  constructor(
+    opts: {
+      entries?: DropboxEntry[]
+      metadata?: DropboxEntry | null
+      moveErrors?: (DropboxApiError | null)[]
+    } = {},
+  ) {
+    this.entries = opts.entries ?? []
+    this.metadata = opts.metadata ?? null
+    this.moveErrors = opts.moveErrors ?? []
+  }
+
+  private page(rest: DropboxEntry[], limit: number): unknown {
+    this.listRequests += 1
+    const head = rest.slice(0, limit)
+    const tail = rest.slice(limit)
+    const token = `cursor-${String(this.cursors.size)}`
+    this.cursors.set(token, tail)
+    this.limits.set(token, limit)
+    return { entries: head, cursor: token, has_more: tail.length > 0 }
+  }
+
+  handle = (_tm: unknown, endpoint: string, body: unknown): Promise<unknown> => {
+    const req = body as Record<string, unknown>
+    if (endpoint === '/files/list_folder') {
+      const limit = Number(req.limit ?? 2000)
+      this.listLimits.push(limit)
+      this.cursors.clear()
+      this.limits.clear()
+      return Promise.resolve(this.page(this.entries, limit))
+    }
+    if (endpoint === '/files/list_folder/continue') {
+      const token = String(req.cursor)
+      const rest = this.cursors.get(token)
+      if (rest === undefined) throw new DropboxApiError('reset', 409, 'reset/...')
+      this.cursors.delete(token)
+      return Promise.resolve(this.page(rest, this.limits.get(token) ?? 2000))
+    }
+    if (endpoint === '/files/get_metadata') {
+      if (this.metadata === null) throw new DropboxApiError('nf', 409, 'path/not_found/...')
+      return Promise.resolve(this.metadata)
+    }
+    if (endpoint === '/files/delete_v2') {
+      this.deleted.push(String(req.path))
+      return Promise.resolve({})
+    }
+    if (endpoint === '/files/move_v2') {
+      this.moves.push([String(req.from_path), String(req.to_path)])
+      const error = this.moveErrors.shift() ?? null
+      if (error !== null) throw error
+      return Promise.resolve({})
+    }
+    throw new Error(`unexpected endpoint ${endpoint}`)
+  }
+}
+
+export function folderEntry(name: string): DropboxEntry {
+  return { '.tag': 'folder', name }
+}
+
+export function fileEntry(name: string, size = 1): DropboxEntry {
+  return { '.tag': 'file', name, size }
+}

--- a/typescript/packages/core/src/core/dropbox/api.ts
+++ b/typescript/packages/core/src/core/dropbox/api.ts
@@ -48,22 +48,41 @@ interface SearchResponseV2 {
   cursor?: string
 }
 
+/**
+ * List a folder's entries, following every continuation cursor.
+ *
+ * `/` and `''` both mean the account root.
+ */
 export async function listFolder(
   tm: DropboxTokenManager,
   path: string,
-  opts: { recursive?: boolean; limit?: number } = {},
+  opts: {
+    recursive?: boolean
+    /** Entries per request. */
+    pageSize?: number
+    /**
+     * Stop once this many entries are in hand and do not request another
+     * page. An emptiness probe wants one entry, and `pageSize` alone
+     * cannot express that: it caps the page, not the walk, so a small
+     * page turned a listing of a large folder into many requests instead
+     * of fewer.
+     */
+    limit?: number | null
+  } = {},
 ): Promise<DropboxEntry[]> {
   const apiPath = path === '/' || path === '' ? '' : path
   const recursive = opts.recursive === true
-  const limit = opts.limit ?? 2000
+  const pageSize = opts.pageSize ?? 2000
+  const limit = opts.limit ?? null
   const out: DropboxEntry[] = []
   let resp = (await dropboxRpc(tm, '/files/list_folder', {
     path: apiPath,
     recursive,
-    limit,
+    limit: limit === null ? pageSize : Math.min(pageSize, limit),
   })) as ListFolderResponse
   out.push(...resp.entries)
   while (resp.has_more) {
+    if (limit !== null && out.length >= limit) break
     resp = (await dropboxRpc(tm, '/files/list_folder/continue', {
       cursor: resp.cursor,
     })) as ListFolderResponse

--- a/typescript/packages/core/src/core/dropbox/rename.test.ts
+++ b/typescript/packages/core/src/core/dropbox/rename.test.ts
@@ -1,0 +1,58 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './client.ts'
+
+vi.mock('./client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./client.ts')
+  return { ...actual, dropboxRpc: vi.fn() }
+})
+
+import { DropboxAccessor } from '../../accessor/dropbox.ts'
+import { PathSpec } from '../../types.ts'
+import * as client from './client.ts'
+import { DropboxApiError, type DropboxTokenManager } from './client.ts'
+import { rename } from './rename.ts'
+import { FakeDropboxRpc, fileEntry, folderEntry } from './_test_util.ts'
+
+const STUB_TM = {} as DropboxTokenManager
+
+function makeAccessor(): DropboxAccessor {
+  return new DropboxAccessor({ tokenManager: STUB_TM })
+}
+
+function spec(virtual: string): PathSpec {
+  return PathSpec.fromStrPath(virtual)
+}
+
+describe('dropbox rename conflict probe', () => {
+  it('is bounded to one entry', async () => {
+    // The probe is bounded, not a full listing: listFolder follows every
+    // continuation cursor, so asking it with a small page size made one
+    // request per child to answer a yes/no.
+    const fake = new FakeDropboxRpc({
+      entries: [fileEntry('a.txt'), fileEntry('b.txt'), fileEntry('c.txt')],
+      metadata: folderEntry('dst'),
+      moveErrors: [new DropboxApiError('conflict', 409, 'to/conflict/folder/...')],
+    })
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    await expect(rename(makeAccessor(), spec('/src'), spec('/dst'))).rejects.toBeInstanceOf(
+      DropboxApiError,
+    )
+    expect(fake.listLimits).toEqual([1])
+    expect(fake.listRequests).toBe(1)
+    expect(fake.deleted).toEqual([])
+  })
+})

--- a/typescript/packages/core/src/core/dropbox/rmdir.test.ts
+++ b/typescript/packages/core/src/core/dropbox/rmdir.test.ts
@@ -1,0 +1,57 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './client.ts'
+
+vi.mock('./client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./client.ts')
+  return { ...actual, dropboxRpc: vi.fn() }
+})
+
+import { DropboxAccessor } from '../../accessor/dropbox.ts'
+import { PathSpec } from '../../types.ts'
+import * as client from './client.ts'
+import type { DropboxTokenManager } from './client.ts'
+import { rmdir } from './rmdir.ts'
+import { FakeDropboxRpc, fileEntry, folderEntry } from './_test_util.ts'
+
+const STUB_TM = {} as DropboxTokenManager
+
+function makeAccessor(): DropboxAccessor {
+  return new DropboxAccessor({ tokenManager: STUB_TM })
+}
+
+function spec(virtual: string): PathSpec {
+  return PathSpec.fromStrPath(virtual)
+}
+
+describe('dropbox rmdir emptiness probe', () => {
+  it('is bounded to one entry', async () => {
+    // The probe is bounded, not a full listing: listFolder follows every
+    // continuation cursor, so asking it with a small page size made one
+    // request per child to answer a yes/no.
+    const fake = new FakeDropboxRpc({
+      entries: [fileEntry('a.txt'), fileEntry('b.txt'), fileEntry('c.txt')],
+      metadata: folderEntry('docs'),
+    })
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    await expect(rmdir(makeAccessor(), spec('/docs'))).rejects.toMatchObject({
+      code: 'ENOTEMPTY',
+    })
+    expect(fake.listLimits).toEqual([1])
+    expect(fake.listRequests).toBe(1)
+    expect(fake.deleted).toEqual([])
+  })
+})


### PR DESCRIPTION
## The defect

`list_folder` / `listFolder` took a `limit`, passed it to `/files/list_folder` as **that endpoint's page-size hint**, and then looped `while has_more` calling `/files/list_folder/continue`, accumulating every entry.

So `limit` capped the page, not the walk. Four callers used it as a bounded emptiness probe and got the exact opposite of what they wanted — **one request per child of the folder** to answer a yes/no:

- `python/mirage/core/dropbox/rmdir.py:47` — `list_folder(..., limit=1)`
- `python/mirage/core/dropbox/rename.py:56` — `limit=1`
- `typescript/.../dropbox/rmdir.ts:38` — `{ limit: 1 }`
- `typescript/.../dropbox/rename.ts:46` — `{ limit: 1 }`

This is the same defect fixed for Google Drive and Microsoft Graph in #854.

## The fix

Modelled on Drive's, including the docstring that explains the page-vs-walk distinction. The page hint keeps its own name and the new cap is `limit`:

- page hint renamed `limit` → `page_size` / `pageSize` (still spelled `limit` on Dropbox's wire, where the field genuinely is a page hint)
- new `limit` / `limit` is the **walk cap**: the wire hint becomes `min(page_size, limit)` and the continuation loop breaks once `len(out) >= limit`

Renaming rather than introducing a third name means `limit` denotes the same thing in Drive and Dropbox, and it makes the four probe call sites correct **as already written** — `limit=1` now means the bound they always intended, so none of the four needed an edit.

`readdir` and `watch` pass no cap, so `limit` stays `None`/`null` and the walk still runs to completion. No entries dropped.

## Pinning it — and why the obvious pin is a dud

The pins record the cap each caller asked for, as #854 does for Drive. But a recording-only assertion **does not work here**, and the difference is worth stating:

Because the call sites still read `limit=1` verbatim, the bug lives entirely *inside* `list_folder`. Any fake substituted **for** `list_folder` answers in one call whatever it is handed, so it cannot distinguish a bounded probe from an unbounded one. Confirmed empirically: `assert rpc.list_limits == [1]` **passes against the unbounded form**.

So the fakes stand in for the **transport** (`dropbox_rpc` / `dropboxRpc`) and let the real `list_folder` run, paging the way the live API does (the cursor retains the original request's parameters). They record both the cap and the request count — and it is the count that bites.

Each pin was verified to fail before the fix and pass after:

| pin | unbounded | fixed |
|---|---|---|
| py `test_rmdir_probe_is_bounded_to_one_entry` | `assert 3 == 1` | pass |
| py `test_rename_conflict_probe_is_bounded_to_one_entry` | `assert 3 == 1` | pass |
| ts `rmdir.test.ts` → is bounded to one entry | `expected 3 to be 1` | pass |
| ts `rename.test.ts` → is bounded to one entry | `expected 3 to be 1` | pass |

New fakes: `python/tests/core/dropbox/conftest.py` and `typescript/.../dropbox/_test_util.ts` (named after gdrive's). The TS rmdir/rename tests are new files because the existing `write.test.ts` mocks `./api.ts` wholesale, which is precisely the substitution that cannot see this bug; as a side effect the TS test layout now mirrors python's `test_rmdir.py` / `test_rename.py`.

## One reviewer note

The new `_test_util.ts` lands in a source directory (TypeScript colocates tests), pushing the layout gate 259 → 260. I added a 5-line excuse to `spec/layout_exceptions.json` and **left the baseline at 259**.

Worth knowing: `core/gdrive` carries an identical `_test_util.ts` that sits *unexcused* in the baseline. Excusing both would be more coherent but would mean moving the baseline number, so I left it and said so in the exception's reason text. Happy to do that as a follow-up.

## Verification

- Python **16,129 passed** (`tests/fuse` excluded — no macFUSE on this machine; untouched by this change)
- TS core **9,188 passed** / 702 files · node **2,386** · browser **231**
- `pnpm -r typecheck`, eslint, prettier, knip, `check_spec_parity.py`, `check_layout_parity.py --strict` — all exit 0
- `pre-commit run --all-files` passing; mypy clean on 1,971 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
