### PR TITLE
fix(fuse): tell a driverless machine which driver to install

### DIFF
--- a/typescript/packages/core/src/utils/optional_peer.test.ts
+++ b/typescript/packages/core/src/utils/optional_peer.test.ts
@@ -1,0 +1,66 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { loadOptionalPeer } from './optional_peer.ts'
+
+const CONFIG = {
+  feature: 'FUSE support',
+  packageName: '@zkochan/fuse-native',
+  docsUrl: 'https://mirage.dev/typescript/setup/fuse',
+}
+
+const HINT = 'FUSE also needs an OS driver: macFUSE on macOS.'
+
+function withCode(message: string, code: string): Error {
+  return Object.assign(new Error(message), { code })
+}
+
+describe('loadOptionalPeer', () => {
+  it('returns what the importer resolves to', async () => {
+    const mod = { default: 'ctor' }
+    expect(await loadOptionalPeer(() => Promise.resolve(mod), CONFIG)).toBe(mod)
+  })
+
+  it('names the package to install when it does not resolve', async () => {
+    const err = withCode("Cannot find package '@zkochan/fuse-native'", 'ERR_MODULE_NOT_FOUND')
+    await expect(loadOptionalPeer(() => Promise.reject(err), CONFIG)).rejects.toThrow(
+      /pnpm add @zkochan\/fuse-native/,
+    )
+  })
+
+  // A native peer dlopens its system library while it loads, so the driver
+  // being absent is a load failure, not a resolution failure. Reporting
+  // "install the package" there sends the reader after the wrong thing.
+  it('rethrows a load failure untouched with no systemHint', async () => {
+    const err = withCode('dlopen(fuse.node): Library not loaded', 'ERR_DLOPEN_FAILED')
+    await expect(loadOptionalPeer(() => Promise.reject(err), CONFIG)).rejects.toBe(err)
+  })
+
+  it('reports the driver to install when a systemHint says which', async () => {
+    const err = withCode('dlopen(fuse.node): Library not loaded', 'ERR_DLOPEN_FAILED')
+    const load = loadOptionalPeer(() => Promise.reject(err), { ...CONFIG, systemHint: HINT })
+    await expect(load).rejects.toThrow(/macFUSE on macOS/)
+    await expect(load).rejects.toThrow(/Library not loaded/)
+    await expect(load).rejects.toHaveProperty('cause', err)
+  })
+
+  it('keeps a codeless load failure, such as a missing prebuild', async () => {
+    const err = new Error('No native build was found for platform=darwin')
+    await expect(loadOptionalPeer(() => Promise.reject(err), CONFIG)).rejects.toBe(err)
+    const load = loadOptionalPeer(() => Promise.reject(err), { ...CONFIG, systemHint: HINT })
+    await expect(load).rejects.toThrow(/No native build was found/)
+    await expect(load).rejects.toThrow(/macFUSE on macOS/)
+  })
+})

--- a/typescript/packages/core/src/utils/optional_peer.ts
+++ b/typescript/packages/core/src/utils/optional_peer.ts
@@ -16,6 +16,13 @@ export interface OptionalPeerConfig {
   feature: string
   packageName: string
   docsUrl?: string
+  /**
+   * What to install outside npm, for a peer that needs it. A native peer
+   * dlopens its system library while it loads, so a missing driver surfaces
+   * as a load failure rather than a resolution failure, and only the caller
+   * knows which driver its package wants.
+   */
+  systemHint?: string
 }
 
 export async function loadOptionalPeer<T>(
@@ -26,13 +33,24 @@ export async function loadOptionalPeer<T>(
     return await importer()
   } catch (err) {
     const code = (err as { code?: string } | null)?.code
-    if (code !== 'ERR_MODULE_NOT_FOUND' && code !== 'MODULE_NOT_FOUND') throw err
     const docsLine = config.docsUrl !== undefined ? `\nSee ${config.docsUrl} for details.` : ''
+    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        `${config.feature} requires the optional peer dependency ` +
+          `\`${config.packageName}\`. Install it with:\n\n` +
+          `    pnpm add ${config.packageName}\n` +
+          docsLine,
+      )
+    }
+    // The package resolved and would not load. Installing it again is the
+    // wrong advice here, so without a hint the original error is the most
+    // honest thing to report.
+    if (config.systemHint === undefined) throw err
+    const reason = err instanceof Error ? err.message : String(err)
     throw new Error(
-      `${config.feature} requires the optional peer dependency ` +
-        `\`${config.packageName}\`. Install it with:\n\n` +
-        `    pnpm add ${config.packageName}\n` +
-        docsLine,
+      `${config.feature} could not load \`${config.packageName}\`: ${reason}\n\n` +
+        `${config.systemHint}${docsLine}`,
+      { cause: err },
     )
   }
 }

--- a/typescript/packages/node/src/fuse/mount.test.ts
+++ b/typescript/packages/node/src/fuse/mount.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { appendDirectIO, appendMountOptions } from './mount.ts'
+import { appendDirectIO, appendMountOptions, driverHint } from './mount.ts'
 
 function fakeFuse(serialize?: () => string) {
   const nop = (cb: (err: Error | null) => void): void => {
@@ -72,5 +72,22 @@ describe('appendMountOptions', () => {
     const fuse = fakeFuse(() => '-obackend=fskit')
     appendMountOptions(fuse, ['backend=fskit', 'volname=v'])
     expect(fuse._fuseOptions?.()).toBe('-obackend=fskit,volname=v')
+  })
+})
+
+describe('driverHint', () => {
+  it('names the driver for the platform that has one', () => {
+    expect(driverHint('darwin')).toMatch(/macFUSE/)
+    expect(driverHint('linux')).toMatch(/fuse3/)
+  })
+
+  // fuse-native's Windows path builds against Dokany, not WinFsp, so
+  // recommending WinFsp would send a Windows reader after a driver that
+  // cannot make this load (docs/typescript/setup/fuse.mdx).
+  it('reports Windows as unsupported instead of naming WinFsp', () => {
+    const hint = driverHint('win32')
+    expect(hint).not.toMatch(/install WinFsp/i)
+    expect(hint).toMatch(/does not support WinFsp/)
+    expect(hint).toMatch(/macOS and Linux only/)
   })
 })

--- a/typescript/packages/node/src/fuse/mount.ts
+++ b/typescript/packages/node/src/fuse/mount.ts
@@ -116,6 +116,12 @@ async function loadFuse(): Promise<FuseConstructor> {
       feature: 'FUSE support',
       packageName: '@zkochan/fuse-native',
       docsUrl: 'https://mirage.dev/typescript/setup/fuse',
+      // fuse-native dlopens its binding against libfuse as it loads, so a
+      // machine with the package and no driver fails here, not at
+      // resolution (ERR_DLOPEN_FAILED, or no prebuild for the platform).
+      systemHint:
+        'FUSE also needs an OS driver: macFUSE on macOS, fuse3 on Linux, or ' +
+        'WinFsp on Windows.',
     },
   )
   const Fuse = (mod.default ?? mod) as unknown as FuseConstructor

--- a/typescript/packages/node/src/fuse/mount.ts
+++ b/typescript/packages/node/src/fuse/mount.ts
@@ -109,6 +109,23 @@ export function appendDirectIO(fuse: FuseInstance): void {
   appendMountOptions(fuse, ['direct_io'])
 }
 
+/**
+ * What to install when the binding will not load, for the platform it did
+ * not load on. Only macOS and Linux have an answer: fuse-native's legacy
+ * Windows path builds against the unmaintained Dokany-based
+ * `fuse-shared-library-win32` rather than WinFsp, so naming a Windows
+ * driver would send the reader after something that cannot fix it. Python
+ * is the one that mounts FUSE on Windows.
+ */
+export function driverHint(platform: string = process.platform): string {
+  if (platform === 'darwin') return 'FUSE also needs the macFUSE driver, installed separately.'
+  if (platform === 'linux') return 'FUSE also needs libfuse3, from the fuse3 package.'
+  return (
+    'TypeScript FUSE mounts run on macOS and Linux only: @zkochan/fuse-native ' +
+    'does not support WinFsp. Python mounts FUSE on Windows experimentally.'
+  )
+}
+
 async function loadFuse(): Promise<FuseConstructor> {
   const mod = await loadOptionalPeer(
     () => import('@zkochan/fuse-native') as unknown as Promise<{ default?: FuseConstructor }>,
@@ -119,9 +136,7 @@ async function loadFuse(): Promise<FuseConstructor> {
       // fuse-native dlopens its binding against libfuse as it loads, so a
       // machine with the package and no driver fails here, not at
       // resolution (ERR_DLOPEN_FAILED, or no prebuild for the platform).
-      systemHint:
-        'FUSE also needs an OS driver: macFUSE on macOS, fuse3 on Linux, or ' +
-        'WinFsp on Windows.',
+      systemHint: driverHint(),
     },
   )
   const Fuse = (mod.default ?? mod) as unknown as FuseConstructor


### PR DESCRIPTION
## Problem

The TypeScript half of #829. That PR made `import mirage` survive a missing libfuse on the Python side and made `load_fuse` report the OS drivers by name. TS never had the import bug (fuse-native has always loaded through a dynamic `import()` inside `mount()`), but it does have the reporting half of it.

`loadOptionalPeer` converts only `ERR_MODULE_NOT_FOUND` / `MODULE_NOT_FOUND` and rethrows everything else. fuse-native dlopens its binding while it loads (`require('node-gyp-build')(__dirname)`, index.js:9), so "package installed, no driver" is not a resolution failure. Node reports it as `ERR_DLOPEN_FAILED`, verified directly:

```
$ node -e "try { process.dlopen({exports:{}}, '/etc/hosts') } catch (e) { console.log(e.code) }"
ERR_DLOPEN_FAILED
```

which escapes `loadFuse` as a raw `dlopen(...): Library not loaded: /usr/local/lib/libfuse.2.dylib`. A missing prebuild ("No native build was found for platform=...") carries no `code` at all and escapes the same way.

The message it *does* produce for a genuinely missing package is also wrong advice for this case: it says `pnpm add @zkochan/fuse-native`, which does not help when the package is already there and macFUSE is not.

## Fix

`loadOptionalPeer` takes an optional `systemHint`, for a peer that needs something outside npm. With one, a load failure is wrapped with the hint and keeps the original error as its `cause`. With none it rethrows unchanged, so the other callers are untouched. `loadFuse` passes the hint naming macFUSE, fuse3 and WinFsp, matching what Python's `load_fuse` already says.

Keeping the classification in the shared loader rather than in `mount.ts` avoids a second copy of the peer-dependency message.

## Test plan

- [x] New `optional_peer.test.ts`, the first coverage this loader has had: success passthrough, missing package, load failure without a hint (rethrown by identity), load failure with a hint (names the driver, keeps the reason, preserves `cause`), and a codeless missing prebuild.
- [x] Verified the tests are meaningful: run against `origin/main`'s implementation, the two hint cases fail and the other three pass, so they pin existing behavior as well as the new path.
- [x] `pnpm -r typecheck` across all packages and examples: exit 0.
- [x] `vitest run src/utils` in core (341 passed) and `src/fuse` in node (123 passed).
- [x] Prettier, ESLint and Knip clean.