### PR TITLE
test(cache): service-free pins for the recursive-delete subtree evict

### DIFF
--- a/python/tests/core/ram/test_rm.py
+++ b/python/tests/core/ram/test_rm.py
@@ -1,0 +1,75 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.accessor.ram import RAMAccessor
+from mirage.cache.context import push_cache_manager
+from mirage.cache.file.ram import RAMFileCacheStore
+from mirage.cache.index.config import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.cache.manager import CacheManager
+from mirage.core.ram.rm import rm_r
+from mirage.resource.ram.store import RAMStore
+from mirage.types import PathSpec
+
+
+def _spec(virtual: str) -> PathSpec:
+    return PathSpec(resource_path=virtual.strip("/"),
+                    virtual=virtual,
+                    directory="/",
+                    pattern=None,
+                    resolved=True)
+
+
+async def _seeded(
+) -> tuple[RAMAccessor, RAMFileCacheStore, RAMIndexCacheStore]:
+    store = RAMStore()
+    store.dirs.add("/a")
+    store.dirs.add("/a/b")
+    store.files["/a/b/f.txt"] = b"hi\n"
+    cache = RAMFileCacheStore()
+    index = RAMIndexCacheStore(ttl=600)
+    await cache.set("/data/a/b/f.txt", b"hi\n")
+    entry = IndexEntry(id="1", name="f.txt", resource_type="file")
+    await index.set_dir("/data/a", [("b", entry)])
+    await index.set_dir("/data/a/b", [("f.txt", entry)])
+    return RAMAccessor(store), cache, index
+
+
+async def _rm_r_case() -> tuple[bool, bool, bool]:
+    accessor, cache, index = await _seeded()
+    manager = CacheManager(cache, index, "/data/", True)
+    prev = push_cache_manager(manager)
+    try:
+        await rm_r(accessor, _spec("/a"))
+    finally:
+        push_cache_manager(prev)
+    return (
+        (await index.list_dir("/data/a/b")).entries is not None,
+        await cache.exists("/data/a/b/f.txt"),
+        (await index.list_dir("/data/a")).entries is not None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rm_r_evicts_listings_and_bodies_inside_the_subtree():
+    # A recursive remove takes directories the caller never named, and
+    # their listings were cached independently: evicting only the target
+    # and its parent leaves `/data/a/b` answering for a directory the
+    # backend no longer has.
+    nested, body, own = await _rm_r_case()
+    assert nested is False
+    assert body is False
+    assert own is False

--- a/python/tests/workspace/test_cache_invalidation.py
+++ b/python/tests/workspace/test_cache_invalidation.py
@@ -132,3 +132,47 @@ def test_ls_reports_enoent_for_an_emptied_implicit_directory(s3_endpoint):
     assert code == 2, f"exit {code}, stdout: {out!r}"
     assert err == ("ls: cannot access '/data/imp': "
                    "No such file or directory\n")
+
+
+async def _rm_r_then_read_nested(ws: Workspace) -> tuple[int, str, str]:
+    setup = await _exec(
+        ws, "mkdir -p /data/a/b"
+        " && echo hi | tee /data/a/b/f.txt > /dev/null"
+        " && ls /data/a/b")
+    assert setup[0] == 0, setup
+    rm = await _exec(ws, "rm -r /data/a")
+    assert rm[0] == 0, rm
+    return await _exec(ws, "cat /data/a/b/f.txt")
+
+
+def test_cat_does_not_serve_a_file_from_a_removed_subtree(s3_endpoint):
+    # `rm -r` removes directories the operand never named. The first ls
+    # cached a listing for "/data/a/b" and the read cached its body, and
+    # invalidating the operand plus its parent reaches neither: cat kept
+    # printing "hi" for a key the bucket no longer had, without issuing a
+    # single request.
+    ws = _s3_workspace(s3_endpoint, "bucket-rm-r-subtree")
+    code, out, err = asyncio.run(_rm_r_then_read_nested(ws))
+    assert code == 1, f"exit {code}, stdout: {out!r}"
+    assert out == ""
+    assert err == "cat: /data/a/b/f.txt: No such file or directory\n"
+
+
+async def _rm_r_then_ls_nested(ws: Workspace) -> tuple[int, str, str]:
+    setup = await _exec(
+        ws, "mkdir -p /data/x/y"
+        " && echo hi | tee /data/x/y/f.txt > /dev/null"
+        " && ls /data/x/y")
+    assert setup[0] == 0, setup
+    rm = await _exec(ws, "rm -r /data/x")
+    assert rm[0] == 0, rm
+    return await _exec(ws, "ls /data/x/y")
+
+
+def test_ls_reports_enoent_for_a_directory_inside_a_removed_subtree(
+        s3_endpoint):
+    ws = _s3_workspace(s3_endpoint, "bucket-rm-r-listing")
+    code, out, err = asyncio.run(_rm_r_then_ls_nested(ws))
+    assert code == 2, f"exit {code}, stdout: {out!r}"
+    assert err == ("ls: cannot access '/data/x/y': "
+                   "No such file or directory\n")

--- a/typescript/packages/core/src/core/ram/rm.test.ts
+++ b/typescript/packages/core/src/core/ram/rm.test.ts
@@ -1,0 +1,57 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+// Mirror of python/tests/core/ram/test_rm.py.
+
+import { describe, expect, it } from 'vitest'
+import { RAMAccessor } from '../../accessor/ram.ts'
+import { runWithCacheManager } from '../../cache/context.ts'
+import { RAMFileCacheStore } from '../../cache/file/ram.ts'
+import { IndexEntry } from '../../cache/index/config.ts'
+import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
+import { CacheManager } from '../../cache/manager.ts'
+import { RAMStore } from '../../resource/ram/store.ts'
+import { PathSpec } from '../../types.ts'
+import { rmR } from './rm.ts'
+
+const ENC = new TextEncoder()
+
+async function seeded(): Promise<[RAMAccessor, RAMFileCacheStore, RAMIndexCacheStore]> {
+  const store = new RAMStore()
+  store.dirs.add('/a')
+  store.dirs.add('/a/b')
+  store.files.set('/a/b/f.txt', ENC.encode('hi\n'))
+  const cache = new RAMFileCacheStore()
+  const index = new RAMIndexCacheStore({ ttl: 600 })
+  await cache.set('/data/a/b/f.txt', ENC.encode('hi\n'))
+  const entry = new IndexEntry({ id: '1', name: 'f.txt', resourceType: 'file' })
+  await index.setDir('/data/a', [['b', entry]])
+  await index.setDir('/data/a/b', [['f.txt', entry]])
+  return [new RAMAccessor(store), cache, index]
+}
+
+describe('ram rmR cache invalidation', () => {
+  it('evicts listings and bodies inside the removed subtree', async () => {
+    // A recursive remove takes directories the caller never named, and
+    // their listings were cached independently: evicting only the target
+    // and its parent leaves `/data/a/b` answering for a directory the
+    // backend no longer has.
+    const [accessor, cache, index] = await seeded()
+    const manager = new CacheManager(cache, index, '/data/', true)
+    await runWithCacheManager(manager, () => rmR(accessor, PathSpec.fromStrPath('/a')))
+    expect((await index.listDir('/data/a/b')).entries).toBeUndefined()
+    expect(await cache.exists('/data/a/b/f.txt')).toBe(false)
+    expect((await index.listDir('/data/a')).entries).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Follow-up to #864, which fixed this bug and pinned it in
`integ/resources/cache/subtree_evict.json`. That battery needs a live minio or
mongo, so the guarantee only holds when the integ job has a container. These
three tests add the same guarantee to a plain `pytest` / `vitest` run.

**No production code** — #864 owns the fix. This PR is coverage only.

## What each one holds

`python/tests/workspace/test_cache_invalidation.py` (+2) — the two shell-visible
symptoms end to end against moto S3, matching the file's existing pattern. A
warm `ls` caches the nested listing, `rm -r` takes the parent, and the reads
that follow used to be answered from cache without touching the bucket:

```
ls /data/a/b         -> 0, "f.txt"      # stale listing
cat /data/a/b/f.txt  -> 0, "hi"         # deleted bytes served
find /data           -> /data           # the backend disagreed, same session
```

`python/tests/core/ram/test_rm.py` and
`typescript/packages/core/src/core/ram/rm.test.ts` — a mirrored pair one layer
down: the real `rm_r` driven through a real `CacheManager` over a RAM index and
file cache, asserting the nested listing and the nested body are both gone. RAM
needs no service, so the path from a backend mutator through `cache/context` to
the manager is exercised on every run.

## Falsifiability

Each was checked against the **merged** implementation, not my own:

- reverting `make_remove_prefix` to `invalidate_after_unlink` fails both moto
  tests
- reverting `core/ram/rm.ts` to `invalidateAfterUnlink` fails the vitest one

## Not included

An earlier revision of this branch carried its own `rm_r` sweep and an
`integ/unix/consistency/subtree.json` case. Both are dropped: #864's sweep is
broader (it covers `rename` too) and its 16-case battery pins the same
behaviour across the same four targets, so the integ case was redundant and its
case-target baseline bump is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
