### PR TITLE
fix(cache): a recursive delete or directory rename evicts its subtree

### DIFF
--- a/integ/resources/cache/subtree_evict.json
+++ b/integ/resources/cache/subtree_evict.json
@@ -1,0 +1,260 @@
+{
+  "cases": [
+    {
+      "id": "cache_subtree_seed",
+      "seq": 942000,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "mkdir -p {mount}/sub_dir/a/b/deep",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_seed_body",
+      "seq": 942001,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "printf 'hello' > {mount}/sub_dir/a/b/deep/c.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_warm_listing",
+      "seq": 942002,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "ls {mount}/sub_dir/a/b/deep",
+      "expect": {
+        "exit": 0,
+        "stdout": "c.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_warm_body",
+      "seq": 942003,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "cat {mount}/sub_dir/a/b/deep/c.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "hello",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_remove_recursive",
+      "seq": 942004,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "rm -r {mount}/sub_dir/a/b",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_listing_gone_not_stale",
+      "seq": 942005,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "ls {mount}/sub_dir/a/b/deep",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '{mount}/sub_dir/a/b/deep': No such file or directory\n"
+      }
+    },
+    {
+      "id": "cache_subtree_body_gone_not_stale",
+      "seq": 942006,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "cat {mount}/sub_dir/a/b/deep/c.txt",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "cat: {mount}/sub_dir/a/b/deep/c.txt: No such file or directory\n"
+      }
+    },
+    {
+      "id": "cache_subtree_mv_seed",
+      "seq": 942007,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "mkdir -p {mount}/sub_mv/a/b/deep",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_mv_seed_body",
+      "seq": 942008,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "printf 'hello' > {mount}/sub_mv/a/b/deep/c.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_mv_warm_listing",
+      "seq": 942009,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "ls {mount}/sub_mv/a/b/deep",
+      "expect": {
+        "exit": 0,
+        "stdout": "c.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_mv_warm_body",
+      "seq": 942010,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "cat {mount}/sub_mv/a/b/deep/c.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "hello",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_mv_directory",
+      "seq": 942011,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "mv {mount}/sub_mv/a/b {mount}/sub_mv/a/z",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_mv_source_listing_not_stale",
+      "seq": 942012,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "ls {mount}/sub_mv/a/b/deep",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '{mount}/sub_mv/a/b/deep': No such file or directory\n"
+      }
+    },
+    {
+      "id": "cache_subtree_mv_source_body_not_stale",
+      "seq": 942013,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "cat {mount}/sub_mv/a/b/deep/c.txt",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "cat: {mount}/sub_mv/a/b/deep/c.txt: No such file or directory\n"
+      }
+    },
+    {
+      "id": "cache_subtree_mv_destination_reachable",
+      "seq": 942014,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "ls {mount}/sub_mv/a/z/deep",
+      "expect": {
+        "exit": 0,
+        "stdout": "c.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "cache_subtree_cleanup",
+      "seq": 942015,
+      "targets": [
+        "s3",
+        "s3-prefix",
+        "gridfs",
+        "gridfs-prefix"
+      ],
+      "command": "rm -rf {mount}/sub_dir {mount}/sub_mv",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/python/mirage/cache/context.py
+++ b/python/mirage/cache/context.py
@@ -32,6 +32,9 @@ class CacheInvalidator(Protocol):
     async def invalidate_after_unlink(self, path: PathSpec) -> None:
         ...
 
+    async def invalidate_subtree(self, path: PathSpec) -> None:
+        ...
+
     async def cached_bytes(self, path: PathSpec) -> bytes | None:
         ...
 
@@ -90,6 +93,29 @@ async def invalidate_after_unlink(path: PathSpec) -> None:
     manager = _active.get()
     if manager is not None:
         await manager.invalidate_after_unlink(path)
+
+
+async def invalidate_subtree(path: PathSpec) -> None:
+    """Report a backend deletion that took a whole subtree with it.
+
+    ``invalidate_after_unlink`` evicts the path's own listing and its
+    parent's, which is the whole story for a file. A recursive delete
+    or a directory rename also strands every listing and every cached
+    body *below* the path, and those were cached under their own keys,
+    so nothing above them evicts one: ``ls`` kept printing a deleted
+    directory's contents and ``cat`` kept serving a deleted file's
+    bytes until the index TTL expired.
+
+    Unlike :func:`invalidate_ancestors`, this cannot be assembled from
+    ``invalidate_after_write`` calls, because the set of keys beneath
+    the path is only known to the caches themselves.
+
+    Args:
+        path (PathSpec): Root of the subtree that is gone.
+    """
+    manager = _active.get()
+    if manager is not None:
+        await manager.invalidate_subtree(path)
 
 
 async def invalidate_ancestors(path: PathSpec) -> None:

--- a/python/mirage/cache/manager.py
+++ b/python/mirage/cache/manager.py
@@ -139,13 +139,14 @@ class CacheManager:
     async def invalidate_subtree(self, path: PathSpec) -> None:
         """Drop ``path`` and everything cached beneath it.
 
-        For an observed change that names a scope rather than a file: a
-        push notification often says only which folder moved, and the
-        listings below it were cached independently, so evicting the
-        path and its parent leaves stale entries one level down. The
-        cheaper ``invalidate_after_write`` cannot be widened to do this,
-        because it also runs on every ordinary write, where a file has
-        no subtree to drop.
+        Two callers, one shape. A push notification often says only
+        which folder moved, and a recursive delete or a directory
+        rename takes a whole tree with it; either way the listings and
+        bodies below the path were cached independently, so evicting
+        the path and its parent leaves stale entries one level down.
+        The cheaper ``invalidate_after_write`` cannot be widened to do
+        this, because it also runs on every ordinary write, where a
+        file has no subtree to drop.
 
         Args:
             path (PathSpec): Root of the stale subtree; only ``virtual``

--- a/python/mirage/core/box/rename.py
+++ b/python/mirage/core/box/rename.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.box import BoxAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.box.api import (delete_file, delete_folder, update_file,
                                  update_folder)
 from mirage.core.box.resolve import path_parts, resolve_item, resolve_parent_id
@@ -47,5 +47,5 @@ async def rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec) -> None:
                             parent_id=dst_parent)
     else:
         await update_file(tm, item["id"], name=new_name, parent_id=dst_parent)
-    await invalidate_after_unlink(dst)
-    await invalidate_after_unlink(src)
+    await invalidate_subtree(dst)
+    await invalidate_subtree(src)

--- a/python/mirage/core/box/rmdir.py
+++ b/python/mirage/core/box/rmdir.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.box import BoxAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_after_unlink, invalidate_subtree
 from mirage.core.box.api import delete_file, delete_folder
 from mirage.core.box.client import BoxApiError
 from mirage.core.box.resolve import path_parts, resolve_item
@@ -55,4 +55,4 @@ async def rm_r(accessor: BoxAccessor, path: PathSpec) -> None:
         await delete_folder(accessor.token_manager, item["id"], recursive=True)
     else:
         await delete_file(accessor.token_manager, item["id"])
-    await invalidate_after_unlink(path)
+    await invalidate_subtree(path)

--- a/python/mirage/core/databricks_volume/rename.py
+++ b/python/mirage/core/databricks_volume/rename.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.databricks_volume.copy import copy
 from mirage.core.databricks_volume.path import backend_path
@@ -52,5 +52,5 @@ async def rename(
     else:
         await copy(accessor, src, dst, index)
         await unlink(accessor, src, index)
-    await invalidate_after_unlink(dst)
-    await invalidate_after_unlink(src)
+    await invalidate_subtree(dst)
+    await invalidate_subtree(src)

--- a/python/mirage/core/databricks_volume/rm.py
+++ b/python/mirage/core/databricks_volume/rm.py
@@ -16,7 +16,7 @@ import asyncio
 from typing import Any
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.databricks_volume.errors import is_not_found
 from mirage.core.databricks_volume.path import backend_path, virtual_path
@@ -88,5 +88,5 @@ async def rm_recursive(
         if is_not_found(exc):
             raise enoent(path) from exc
         raise
-    await invalidate_after_unlink(path)
+    await invalidate_subtree(path)
     return [virtual_path(accessor.config, backend, "") for backend in removed]

--- a/python/mirage/core/disk/rename.py
+++ b/python/mirage/core/disk/rename.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import aiofiles.os
 
 from mirage.accessor.disk import DiskAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.types import PathSpec
 
 
@@ -33,8 +33,9 @@ async def rename(accessor: DiskAccessor, src_spec: PathSpec,
     src = src_spec.mount_path
     dst = dst_spec.mount_path
     root = accessor.root
-    await invalidate_after_unlink(src_spec)
-    # The unlink flavor on dst: a rename destroys the destination's previous
-    # identity, so a replaced empty directory loses its cached listing too.
-    await invalidate_after_unlink(dst_spec)
+    await invalidate_subtree(src_spec)
+    # Both sides are subtree evictions: a rename destroys the destination's
+    # previous identity and relocates everything under the source, so a
+    # listing or body cached below either name is now stale.
+    await invalidate_subtree(dst_spec)
     await aiofiles.os.rename(_resolve(root, src), _resolve(root, dst))

--- a/python/mirage/core/disk/rm.py
+++ b/python/mirage/core/disk/rm.py
@@ -20,7 +20,7 @@ import aiofiles.os
 from aiofiles.os import path as aio_path
 
 from mirage.accessor.disk import DiskAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.types import PathSpec
 
 
@@ -38,4 +38,4 @@ async def rm_r(accessor: DiskAccessor, path_spec: PathSpec) -> None:
         await asyncio.to_thread(shutil.rmtree, p)
     elif await aio_path.exists(p):
         await aiofiles.os.remove(p)
-    await invalidate_after_unlink(path_spec)
+    await invalidate_subtree(path_spec)

--- a/python/mirage/core/dropbox/rename.py
+++ b/python/mirage/core/dropbox/rename.py
@@ -15,7 +15,7 @@
 import time
 
 from mirage.accessor.dropbox import DropboxAccessor
-from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
+from mirage.cache.context import invalidate_ancestors, invalidate_subtree
 from mirage.core.dropbox.api import (delete_path, get_metadata, list_folder,
                                      move_path)
 from mirage.core.dropbox.client import DropboxApiError
@@ -59,7 +59,7 @@ async def rename(accessor: DropboxAccessor, src: PathSpec,
         await delete_path(accessor.token_manager, to_path)
         await move_path(accessor.token_manager, from_path, to_path)
     record("rename", src.virtual, "dropbox", 0, start_ms)
-    await invalidate_after_unlink(src)
+    await invalidate_subtree(src)
     await invalidate_ancestors(src)
-    await invalidate_after_unlink(dst)
+    await invalidate_subtree(dst)
     await invalidate_ancestors(dst)

--- a/python/mirage/core/dropbox/rm.py
+++ b/python/mirage/core/dropbox/rm.py
@@ -15,7 +15,7 @@
 import time
 
 from mirage.accessor.dropbox import DropboxAccessor
-from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
+from mirage.cache.context import invalidate_ancestors, invalidate_subtree
 from mirage.core.dropbox.api import delete_path
 from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.paths import dropbox_path_of
@@ -35,5 +35,5 @@ async def rm_r(accessor: DropboxAccessor, path: PathSpec) -> None:
             raise enoent(path.virtual) from exc
         raise
     record("rm_r", path.virtual, "dropbox", 0, start_ms)
-    await invalidate_after_unlink(path)
+    await invalidate_subtree(path)
     await invalidate_ancestors(path)

--- a/python/mirage/core/gdrive/rename.py
+++ b/python/mirage/core/gdrive/rename.py
@@ -15,7 +15,7 @@
 import posixpath
 
 from mirage.accessor.gdrive import GDriveAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.gdrive.resolve import (drive_target_name, eacces_on_denied,
                                         resolve_key, resolve_parent)
 from mirage.core.google.drive import delete_file, list_files, patch_file
@@ -52,5 +52,5 @@ async def rename(accessor: GDriveAccessor, src: PathSpec,
                      src_node.id, {"name": name},
                      add_parents=add_parents,
                      remove_parents=remove_parents)
-    await invalidate_after_unlink(dst)
-    await invalidate_after_unlink(src)
+    await invalidate_subtree(dst)
+    await invalidate_subtree(src)

--- a/python/mirage/core/gdrive/rm.py
+++ b/python/mirage/core/gdrive/rm.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.gdrive import GDriveAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.gdrive.resolve import eacces_on_denied, resolve_key
 from mirage.core.google.drive import delete_file
 from mirage.types import PathSpec
@@ -31,4 +31,4 @@ async def rm_r(accessor: GDriveAccessor, path: PathSpec) -> None:
     if node is None:
         raise enoent(virtual)
     await delete_file(accessor.token_manager, node.id)
-    await invalidate_after_unlink(path)
+    await invalidate_subtree(path)

--- a/python/mirage/core/nextcloud/rename.py
+++ b/python/mirage/core/nextcloud/rename.py
@@ -1,7 +1,7 @@
 from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -15,5 +15,5 @@ async def rename(accessor: NextcloudAccessor, src: PathSpec,
         await op.rename(src_key, dst_key)
     except NotFound as exc:
         raise enoent(src) from exc
-    await invalidate_after_unlink(dst)
-    await invalidate_after_unlink(src)
+    await invalidate_subtree(dst)
+    await invalidate_subtree(src)

--- a/python/mirage/core/nextcloud/rm.py
+++ b/python/mirage/core/nextcloud/rm.py
@@ -1,7 +1,7 @@
 from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -14,4 +14,4 @@ async def rm_r(accessor: NextcloudAccessor, path: PathSpec) -> None:
         await op.remove_all(key)
     except NotFound as exc:
         raise enoent(path) from exc
-    await invalidate_after_unlink(path)
+    await invalidate_subtree(path)

--- a/python/mirage/core/object_store/remove.py
+++ b/python/mirage/core/object_store/remove.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
+from mirage.cache.context import (invalidate_after_unlink,
+                                  invalidate_ancestors, invalidate_subtree)
 from mirage.core.object_store.driver import A, C, ObjectStoreDriver, PathFn
 from mirage.types import PathSpec
 from mirage.utils import key_prefix as kp
@@ -56,7 +57,10 @@ def make_remove_prefix(driver: ObjectStoreDriver[A, C]) -> PathFn[A]:
         pfx = kp.apply_dir(driver.key_prefix_of(accessor), path)
         async with driver.connect(accessor) as conn:
             await driver.delete_prefix(conn, pfx)
-        await invalidate_after_unlink(path_spec)
+        # Not invalidate_after_unlink: a prefix delete takes every key
+        # below with it, and each of those listings and bodies was
+        # cached under its own key, so nothing above them evicts one.
+        await invalidate_subtree(path_spec)
         # Same rationale as unlink: ancestors that existed only as this
         # prefix are gone now.
         await invalidate_ancestors(path_spec)

--- a/python/mirage/core/object_store/rename.py
+++ b/python/mirage/core/object_store/rename.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
+from mirage.cache.context import invalidate_ancestors, invalidate_subtree
 from mirage.core.object_store.driver import (A, C, ExistsFn, ObjectStoreDriver,
                                              PairFn)
 from mirage.types import PathSpec
@@ -61,8 +61,12 @@ def make_rename(driver: ObjectStoreDriver[A, C],
                 if not await move_prefix(conn, kp.apply_dir(kpfx, src),
                                          kp.apply_dir(kpfx, dst)):
                     raise enoent(src_spec.virtual)
-        await invalidate_after_unlink(dst_spec)
-        await invalidate_after_unlink(src_spec)
+        # Subtrees, not single paths: move_prefix relocates every key
+        # under src, so each listing and body cached below the old name
+        # names something that is no longer there, and each one below
+        # the new name predates the move.
+        await invalidate_subtree(dst_spec)
+        await invalidate_subtree(src_spec)
         # The move can create the destination's missing ancestors and
         # erase the source's prefix-only ones in the same call.
         await invalidate_ancestors(dst_spec)

--- a/python/mirage/core/onedrive/rename.py
+++ b/python/mirage/core/onedrive/rename.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.msgraph.drive_ops import rename_replace
 from mirage.core.onedrive.client import drive_loc, split_path
 from mirage.types import PathSpec
@@ -26,5 +26,5 @@ async def rename(accessor: OneDriveAccessor, src: PathSpec,
     config = accessor.config
     await rename_replace(config, drive_loc(config, src_s),
                          drive_loc(config, dst_s))
-    await invalidate_after_unlink(dst)
-    await invalidate_after_unlink(src)
+    await invalidate_subtree(dst)
+    await invalidate_subtree(src)

--- a/python/mirage/core/onedrive/rm.py
+++ b/python/mirage/core/onedrive/rm.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.onedrive.client import graph_delete, item_url, split_path
 from mirage.types import PathSpec
 
@@ -24,4 +24,4 @@ async def rm_r(accessor: OneDriveAccessor, path: PathSpec) -> None:
         return
     await graph_delete(accessor.config,
                        item_url(accessor.config, "/" + stripped))
-    await invalidate_after_unlink(path)
+    await invalidate_subtree(path)

--- a/python/mirage/core/ram/rename.py
+++ b/python/mirage/core/ram/rename.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.ram import RAMAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.ram.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
 from mirage.resource.ram.store import RAMStore
@@ -75,5 +75,5 @@ async def rename(accessor: RAMAccessor, src_spec: PathSpec,
         _move_subtree(store, s, d)
     else:
         raise FileNotFoundError(s)
-    await invalidate_after_unlink(dst_spec)
-    await invalidate_after_unlink(src_spec)
+    await invalidate_subtree(dst_spec)
+    await invalidate_subtree(src_spec)

--- a/python/mirage/core/ram/rm.py
+++ b/python/mirage/core/ram/rm.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.ram import RAMAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
@@ -33,4 +33,4 @@ async def rm_r(accessor: RAMAccessor, path_spec: PathSpec) -> None:
             store.dirs.discard(key)
             store.modified.pop(key, None)
             store.attrs.pop(key, None)
-    await invalidate_after_unlink(path_spec)
+    await invalidate_subtree(path_spec)

--- a/python/mirage/core/redis/rename.py
+++ b/python/mirage/core/redis/rename.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.redis import RedisAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.redis.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
 from mirage.resource.redis.store import RedisStore
@@ -101,5 +101,5 @@ async def rename(
         await _move_subtree(store, s, d)
     else:
         raise FileNotFoundError(s)
-    await invalidate_after_unlink(dst_spec)
-    await invalidate_after_unlink(src_spec)
+    await invalidate_subtree(dst_spec)
+    await invalidate_subtree(src_spec)

--- a/python/mirage/core/redis/rm.py
+++ b/python/mirage/core/redis/rm.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.redis import RedisAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
@@ -33,4 +33,4 @@ async def rm_r(accessor: RedisAccessor, path_spec: PathSpec) -> None:
             await store.remove_dir(key)
             await store.del_modified(key)
             await store.del_attrs(key)
-    await invalidate_after_unlink(path_spec)
+    await invalidate_subtree(path_spec)

--- a/python/mirage/core/sharepoint/rename.py
+++ b/python/mirage/core/sharepoint/rename.py
@@ -1,5 +1,5 @@
 from mirage.accessor.sharepoint import SharePointAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.msgraph.drive_ops import rename_replace
 from mirage.core.sharepoint.copy import drive_loc
 from mirage.core.sharepoint.resolve import resolve
@@ -20,5 +20,5 @@ async def rename(accessor: SharePointAccessor, src: PathSpec,
     await rename_replace(accessor.config,
                          drive_loc(accessor.config, src_resolved, src_virt),
                          drive_loc(accessor.config, dst_resolved, dst_virt))
-    await invalidate_after_unlink(dst)
-    await invalidate_after_unlink(src)
+    await invalidate_subtree(dst)
+    await invalidate_subtree(src)

--- a/python/mirage/core/sharepoint/rm.py
+++ b/python/mirage/core/sharepoint/rm.py
@@ -1,5 +1,5 @@
 from mirage.accessor.sharepoint import SharePointAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.sharepoint.client import graph_delete, item_url, split_path
 from mirage.core.sharepoint.resolve import resolve
 from mirage.types import PathSpec
@@ -16,4 +16,4 @@ async def rm_r(accessor: SharePointAccessor, path: PathSpec) -> None:
     await graph_delete(
         accessor.config,
         item_url(accessor.config, resolved.drive_id, resolved.item_path))
-    await invalidate_after_unlink(path)
+    await invalidate_subtree(path)

--- a/python/mirage/core/ssh/rename.py
+++ b/python/mirage/core/ssh/rename.py
@@ -15,7 +15,7 @@
 import asyncssh
 
 from mirage.accessor.ssh import SSHAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.ssh.client import _abs
 from mirage.types import PathSpec
 
@@ -37,7 +37,8 @@ async def rename(accessor: SSHAccessor, src_spec: PathSpec,
             raise FileNotFoundError(src)
     except asyncssh.SFTPNoSuchFile:
         raise FileNotFoundError(src)
-    # The unlink flavor on dst: a rename destroys the destination's previous
-    # identity, so a replaced empty directory loses its cached listing too.
-    await invalidate_after_unlink(dst_spec)
-    await invalidate_after_unlink(src_spec)
+    # Both sides are subtree evictions: a rename destroys the destination's
+    # previous identity and relocates everything under the source, so a
+    # listing or body cached below either name is now stale.
+    await invalidate_subtree(dst_spec)
+    await invalidate_subtree(src_spec)

--- a/python/mirage/core/ssh/rm.py
+++ b/python/mirage/core/ssh/rm.py
@@ -15,7 +15,7 @@
 import asyncssh
 
 from mirage.accessor.ssh import SSHAccessor
-from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.context import invalidate_subtree
 from mirage.core.ssh.client import _abs
 from mirage.types import PathSpec
 
@@ -28,7 +28,7 @@ async def rm_r(accessor: SSHAccessor, path_spec: PathSpec) -> None:
         await _rm_r_inner(sftp, config, path)
     except asyncssh.SFTPNoSuchFile:
         raise FileNotFoundError(path)
-    await invalidate_after_unlink(path_spec)
+    await invalidate_subtree(path_spec)
 
 
 async def _rm_r_inner(sftp, config, path: str) -> None:

--- a/python/mirage/ops/generic/factory.py
+++ b/python/mirage/ops/generic/factory.py
@@ -210,8 +210,9 @@ def make_generic_ops(
             HF family registers one surface for four resources).
         table (OpsTable): the backend's IO table (its ``CommandIO``).
         emulate_truncate (bool): synthesize ``truncate`` from
-            ``read_bytes`` + ``write`` for backends with no native
-            partial write (s3/ssh/ram/redis today).
+            ``read_bytes`` + ``write`` for a backend with no native
+            partial write (dropbox is the only one; the rest grew a
+            real ``truncate`` in their table, which wins outright).
         mkdir_parents (bool): forward ``parents=True`` to the core
             mkdir (disk).
         overrides (set[str] | None): op names to skip because the

--- a/python/tests/cache/test_context.py
+++ b/python/tests/cache/test_context.py
@@ -17,7 +17,7 @@ import asyncio
 from mirage.cache.context import (active_cache_manager,
                                   invalidate_after_unlink,
                                   invalidate_after_write, invalidate_ancestors,
-                                  push_cache_manager)
+                                  invalidate_subtree, push_cache_manager)
 from mirage.types import PathSpec
 
 
@@ -30,12 +30,16 @@ class FakeManager:
     def __init__(self) -> None:
         self.writes: list[PathSpec] = []
         self.unlinks: list[PathSpec] = []
+        self.subtrees: list[PathSpec] = []
 
     async def invalidate_after_write(self, path: PathSpec) -> None:
         self.writes.append(path)
 
     async def invalidate_after_unlink(self, path: PathSpec) -> None:
         self.unlinks.append(path)
+
+    async def invalidate_subtree(self, path: PathSpec) -> None:
+        self.subtrees.append(path)
 
 
 def _spec(virtual: str) -> PathSpec:
@@ -51,6 +55,7 @@ async def _delegates() -> FakeManager:
     prev = push_cache_manager(manager)
     await invalidate_after_write(_spec("/a.txt"))
     await invalidate_after_unlink(_spec("/b.txt"))
+    await invalidate_subtree(_spec("/c"))
     push_cache_manager(prev)
     return manager
 
@@ -59,12 +64,14 @@ def test_delegates_to_active_manager():
     manager = _run(_delegates())
     assert [p.mount_path for p in manager.writes] == ["/a.txt"]
     assert [p.mount_path for p in manager.unlinks] == ["/b.txt"]
+    assert [p.mount_path for p in manager.subtrees] == ["/c"]
 
 
 async def _noop_without_manager() -> None:
     push_cache_manager(None)
     await invalidate_after_write(_spec("/a.txt"))
     await invalidate_after_unlink(_spec("/b.txt"))
+    await invalidate_subtree(_spec("/c"))
 
 
 def test_noop_without_active_manager():

--- a/python/tests/core/box/test_write.py
+++ b/python/tests/core/box/test_write.py
@@ -175,7 +175,7 @@ async def test_rm_r_recursive_on_folder(root_accessor):
     with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
          patch("mirage.core.box.rmdir.delete_folder",
                new_callable=AsyncMock) as df, \
-         patch("mirage.core.box.rmdir.invalidate_after_unlink",
+         patch("mirage.core.box.rmdir.invalidate_subtree",
                new_callable=AsyncMock):
         await rm_r(root_accessor, _spec("/data/sub"))
     df.assert_awaited_once_with(root_accessor.token_manager,
@@ -188,7 +188,7 @@ async def test_rename_moves_file(root_accessor):
     with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
          patch("mirage.core.box.rename.update_file",
                new_callable=AsyncMock) as uf, \
-         patch("mirage.core.box.rename.invalidate_after_unlink",
+         patch("mirage.core.box.rename.invalidate_subtree",
                new_callable=AsyncMock):
         await rename(root_accessor, _spec("/data/a.txt"), _spec("/data/b.txt"))
     uf.assert_awaited_once_with(root_accessor.token_manager,

--- a/python/tests/core/databricks_volume/test_copy.py
+++ b/python/tests/core/databricks_volume/test_copy.py
@@ -27,12 +27,16 @@ class _FakeManager:
     def __init__(self) -> None:
         self.writes: list[str] = []
         self.unlinks: list[str] = []
+        self.subtrees: list[str] = []
 
     async def invalidate_after_write(self, path: PathSpec) -> None:
         self.writes.append(path.mount_path)
 
     async def invalidate_after_unlink(self, path: PathSpec) -> None:
         self.unlinks.append(path.mount_path)
+
+    async def invalidate_subtree(self, path: PathSpec) -> None:
+        self.subtrees.append(path.mount_path)
 
 
 def _path(path: str) -> PathSpec:

--- a/python/tests/core/disk/test_rename.py
+++ b/python/tests/core/disk/test_rename.py
@@ -25,12 +25,16 @@ class _FakeManager:
     def __init__(self) -> None:
         self.writes: list[str] = []
         self.unlinks: list[str] = []
+        self.subtrees: list[str] = []
 
     async def invalidate_after_write(self, path: PathSpec) -> None:
         self.writes.append(path.mount_path)
 
     async def invalidate_after_unlink(self, path: PathSpec) -> None:
         self.unlinks.append(path.mount_path)
+
+    async def invalidate_subtree(self, path: PathSpec) -> None:
+        self.subtrees.append(path.mount_path)
 
 
 def _spec(path: str) -> PathSpec:
@@ -62,6 +66,6 @@ async def test_rename_evicts_both_identities(tmp_path):
         push_cache_manager(prev)
     # A replaced empty directory loses its own cached listing, not just
     # its parent's: both sides of a rename take the unlink flavor.
-    assert manager.unlinks == ["/src", "/dst"]
+    assert manager.subtrees == ["/src", "/dst"]
     assert manager.writes == []
     assert (tmp_path / "dst" / "f.txt").read_bytes() == b"x"

--- a/python/tests/core/gridfs/test_rename.py
+++ b/python/tests/core/gridfs/test_rename.py
@@ -32,6 +32,9 @@ class _FakeManager:
     async def invalidate_after_unlink(self, path: PathSpec) -> None:
         return None
 
+    async def invalidate_subtree(self, path: PathSpec) -> None:
+        return None
+
 
 class _FakeFiles:
 

--- a/python/tests/core/gridfs/test_write.py
+++ b/python/tests/core/gridfs/test_write.py
@@ -26,12 +26,16 @@ class _FakeManager:
     def __init__(self) -> None:
         self.writes: list[str] = []
         self.unlinks: list[str] = []
+        self.subtrees: list[str] = []
 
     async def invalidate_after_write(self, path: PathSpec) -> None:
         self.writes.append(path.mount_path)
 
     async def invalidate_after_unlink(self, path: PathSpec) -> None:
         self.unlinks.append(path.mount_path)
+
+    async def invalidate_subtree(self, path: PathSpec) -> None:
+        self.subtrees.append(path.mount_path)
 
 
 class _FakeBucket:

--- a/python/tests/core/nextcloud/test_mkdir.py
+++ b/python/tests/core/nextcloud/test_mkdir.py
@@ -11,12 +11,16 @@ class _RecordingInvalidator:
     def __init__(self) -> None:
         self.writes: list[str] = []
         self.unlinks: list[str] = []
+        self.subtrees: list[str] = []
 
     async def invalidate_after_write(self, path: PathSpec) -> None:
         self.writes.append(path.mount_path)
 
     async def invalidate_after_unlink(self, path: PathSpec) -> None:
         self.unlinks.append(path.mount_path)
+
+    async def invalidate_subtree(self, path: PathSpec) -> None:
+        self.subtrees.append(path.mount_path)
 
     async def cached_bytes(self, path: PathSpec) -> bytes | None:
         return None

--- a/python/tests/core/object_store/conftest.py
+++ b/python/tests/core/object_store/conftest.py
@@ -185,12 +185,16 @@ class FakeManager:
     def __init__(self) -> None:
         self.writes: list[str] = []
         self.unlinks: list[str] = []
+        self.subtrees: list[str] = []
 
     async def invalidate_after_write(self, path: PathSpec) -> None:
         self.writes.append(path.mount_path)
 
     async def invalidate_after_unlink(self, path: PathSpec) -> None:
         self.unlinks.append(path.mount_path)
+
+    async def invalidate_subtree(self, path: PathSpec) -> None:
+        self.subtrees.append(path.mount_path)
 
     async def cached_bytes(self, path: PathSpec) -> Any:
         return None

--- a/python/tests/core/object_store/test_remove.py
+++ b/python/tests/core/object_store/test_remove.py
@@ -51,7 +51,10 @@ def test_remove_prefix_deletes_the_subtree_and_ancestors_evict(accessor):
     manager = _managed(
         make_remove_prefix(make_driver(store))(accessor, spec("/a/b")))
     assert store.objects == {}
-    assert manager.unlinks == ["/a/b"]
+    # A subtree evict, not an unlink: every key below /a/b went with it,
+    # and each one was cached under its own key.
+    assert manager.subtrees == ["/a/b"]
+    assert manager.unlinks == []
     assert manager.writes == ["/a"]
 
 

--- a/python/tests/core/object_store/test_rename.py
+++ b/python/tests/core/object_store/test_rename.py
@@ -45,7 +45,7 @@ def test_rename_moves_a_file(accessor):
     manager = _managed(
         _rename_for(store)(accessor, spec("/a/src.txt"), spec("/b/dst.txt")))
     assert store.objects == {"b/dst.txt": b"hi"}
-    assert manager.unlinks == ["/b/dst.txt", "/a/src.txt"]
+    assert manager.subtrees == ["/b/dst.txt", "/a/src.txt"]
     assert manager.writes == ["/b", "/a"]
 
 
@@ -67,6 +67,7 @@ def test_rename_onto_the_same_key_is_a_guarded_no_op(accessor):
         _rename_for(store)(accessor, spec("/a.txt"), spec("/a.txt")))
     assert store.objects == {"a.txt": b"hi"}
     assert manager.unlinks == []
+    assert manager.subtrees == []
 
 
 def test_rename_onto_the_same_key_still_fails_when_absent(accessor):

--- a/python/tests/core/s3/test_write.py
+++ b/python/tests/core/s3/test_write.py
@@ -26,12 +26,16 @@ class _FakeManager:
     def __init__(self) -> None:
         self.writes: list[str] = []
         self.unlinks: list[str] = []
+        self.subtrees: list[str] = []
 
     async def invalidate_after_write(self, path: PathSpec) -> None:
         self.writes.append(path.mount_path)
 
     async def invalidate_after_unlink(self, path: PathSpec) -> None:
         self.unlinks.append(path.mount_path)
+
+    async def invalidate_subtree(self, path: PathSpec) -> None:
+        self.subtrees.append(path.mount_path)
 
 
 class _FakeClient:

--- a/typescript/packages/core/src/cache/context.test.ts
+++ b/typescript/packages/core/src/cache/context.test.ts
@@ -20,12 +20,14 @@ import {
   invalidateAfterUnlink,
   invalidateAfterWrite,
   invalidateAncestors,
+  invalidateSubtree,
   runWithCacheManager,
 } from './context.ts'
 
 class FakeManager {
   writes: string[] = []
   unlinks: string[] = []
+  subtrees: string[] = []
 
   invalidateAfterWrite(path: string | PathSpec): Promise<void> {
     this.writes.push(path as string)
@@ -34,6 +36,11 @@ class FakeManager {
 
   invalidateAfterUnlink(path: string | PathSpec): Promise<void> {
     this.unlinks.push(path as string)
+    return Promise.resolve()
+  }
+
+  invalidateSubtree(path: string | PathSpec): Promise<void> {
+    this.subtrees.push(path as string)
     return Promise.resolve()
   }
 
@@ -48,14 +55,17 @@ describe('cache context', () => {
     await runWithCacheManager(manager, async () => {
       await invalidateAfterWrite('/a.txt')
       await invalidateAfterUnlink('/b.txt')
+      await invalidateSubtree('/c')
     })
     expect(manager.writes).toEqual(['/a.txt'])
     expect(manager.unlinks).toEqual(['/b.txt'])
+    expect(manager.subtrees).toEqual(['/c'])
   })
 
   it('no-ops without an active manager', async () => {
     await invalidateAfterWrite('/a.txt')
     await invalidateAfterUnlink('/b.txt')
+    await invalidateSubtree('/c')
   })
 
   it('scopes the manager to the run', async () => {

--- a/typescript/packages/core/src/cache/context.ts
+++ b/typescript/packages/core/src/cache/context.ts
@@ -24,6 +24,7 @@ import { createAsyncContext } from '../utils/async_context.ts'
 export interface CacheInvalidator {
   invalidateAfterWrite(path: string | PathSpec): Promise<void>
   invalidateAfterUnlink(path: string | PathSpec): Promise<void>
+  invalidateSubtree(path: string | PathSpec): Promise<void>
   cachedBytes(path: PathSpec): Promise<Uint8Array | null>
 }
 
@@ -70,6 +71,28 @@ export async function invalidateAfterUnlink(path: string | PathSpec): Promise<vo
   const manager = storage.getStore()?.manager
   if (manager !== null && manager !== undefined) {
     await manager.invalidateAfterUnlink(path)
+  }
+}
+
+/**
+ * Report a backend deletion that took a whole subtree with it.
+ *
+ * `invalidateAfterUnlink` evicts the path's own listing and its
+ * parent's, which is the whole story for a file. A recursive delete or a
+ * directory rename also strands every listing and every cached body
+ * *below* the path, and those were cached under their own keys, so
+ * nothing above them evicts one: `ls` kept printing a deleted
+ * directory's contents and `cat` kept serving a deleted file's bytes
+ * until the index TTL expired.
+ *
+ * Unlike {@link invalidateAncestors}, this cannot be assembled from
+ * `invalidateAfterWrite` calls, because the set of keys beneath the path
+ * is only known to the caches themselves.
+ */
+export async function invalidateSubtree(path: string | PathSpec): Promise<void> {
+  const manager = storage.getStore()?.manager
+  if (manager !== null && manager !== undefined) {
+    await manager.invalidateSubtree(path)
   }
 }
 

--- a/typescript/packages/core/src/cache/manager.ts
+++ b/typescript/packages/core/src/cache/manager.ts
@@ -128,12 +128,13 @@ export class CacheManager {
   /**
    * Drop `path` and everything cached beneath it.
    *
-   * For an observed change that names a scope rather than a file: a push
-   * notification often says only which folder moved, and the listings below it
-   * were cached independently, so evicting the path and its parent leaves
-   * stale entries one level down. The cheaper `invalidateAfterWrite` cannot be
-   * widened to do this, because it also runs on every ordinary write, where a
-   * file has no subtree to drop.
+   * Two callers, one shape. A push notification often says only which folder
+   * moved, and a recursive delete or a directory rename takes a whole tree
+   * with it; either way the listings and bodies below the path were cached
+   * independently, so evicting the path and its parent leaves stale entries
+   * one level down. The cheaper `invalidateAfterWrite` cannot be widened to do
+   * this, because it also runs on every ordinary write, where a file has no
+   * subtree to drop.
    *
    * Mirrors Python `CacheManager.invalidate_subtree`.
    */

--- a/typescript/packages/core/src/core/box/write.test.ts
+++ b/typescript/packages/core/src/core/box/write.test.ts
@@ -31,11 +31,19 @@ vi.mock('./api.ts', async () => {
 })
 
 vi.mock('../../cache/context.ts', () => {
-  return { invalidateAfterWrite: vi.fn(), invalidateAfterUnlink: vi.fn() }
+  return {
+    invalidateAfterWrite: vi.fn(),
+    invalidateAfterUnlink: vi.fn(),
+    invalidateSubtree: vi.fn(),
+  }
 })
 
 import { BoxAccessor } from '../../accessor/box.ts'
-import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
+import {
+  invalidateAfterUnlink,
+  invalidateAfterWrite,
+  invalidateSubtree,
+} from '../../cache/context.ts'
 import { PathSpec } from '../../types.ts'
 import type { BoxTokenManager } from './client.ts'
 import * as api from './api.ts'
@@ -122,14 +130,18 @@ describe('box write ops', () => {
     })
   })
 
-  it('rename evicts both identities so a replaced empty dir loses its listing', async () => {
+  it('rename evicts both identities as subtrees, so a replaced dir loses its listing', async () => {
     vi.mocked(invalidateAfterWrite).mockClear()
     vi.mocked(invalidateAfterUnlink).mockClear()
+    vi.mocked(invalidateSubtree).mockClear()
     await rename(makeAccessor(), spec('/data/a.txt'), spec('/data/b.txt'))
+    // Subtrees rather than unlinks: renaming a directory strands every
+    // listing and body cached below the old name, and below the new one.
     const evicted = vi
-      .mocked(invalidateAfterUnlink)
+      .mocked(invalidateSubtree)
       .mock.calls.map(([path]) => (typeof path === 'string' ? path : path.virtual))
     expect(evicted).toEqual(['/data/b.txt', '/data/a.txt'])
+    expect(vi.mocked(invalidateAfterUnlink)).not.toHaveBeenCalled()
     expect(vi.mocked(invalidateAfterWrite)).not.toHaveBeenCalled()
   })
 

--- a/typescript/packages/core/src/core/box/write.ts
+++ b/typescript/packages/core/src/core/box/write.ts
@@ -14,7 +14,11 @@
 
 import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { BoxAccessor } from '../../accessor/box.ts'
-import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
+import {
+  invalidateAfterUnlink,
+  invalidateAfterWrite,
+  invalidateSubtree,
+} from '../../cache/context.ts'
 import { PathSpec } from '../../types.ts'
 import { eisdir, enoent, enotdir, enotempty } from '../../utils/errors.ts'
 import { BoxApiError } from './client.ts'
@@ -137,7 +141,7 @@ export async function rmR(accessor: BoxAccessor, path: PathSpec): Promise<void> 
   } else {
     await deleteFile(accessor.tokenManager, item.id)
   }
-  await invalidateAfterUnlink(path)
+  await invalidateSubtree(path)
 }
 
 async function clearDest(accessor: BoxAccessor, dstParts: string[], srcId: string): Promise<void> {
@@ -163,8 +167,8 @@ export async function rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec
   else await updateFile(tm, item.id, { name: newName, parentId: dstParent })
   // The unlink flavor on dst: a rename destroys the destination's previous
   // identity, so a replaced empty directory loses its cached listing too.
-  await invalidateAfterUnlink(dst)
-  await invalidateAfterUnlink(src)
+  await invalidateSubtree(dst)
+  await invalidateSubtree(src)
 }
 
 function childSpec(parent: PathSpec, name: string): PathSpec {

--- a/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
@@ -35,6 +35,7 @@ const resolveGlob = resolveGlobOf(DATABRICKS_VOLUME_IO)
 class FakeManager {
   writes: string[] = []
   unlinks: string[] = []
+  subtrees: string[] = []
 
   invalidateAfterWrite(path: string | PathSpec): Promise<void> {
     this.writes.push(typeof path === 'string' ? path : path.mountPath)
@@ -43,6 +44,11 @@ class FakeManager {
 
   invalidateAfterUnlink(path: string | PathSpec): Promise<void> {
     this.unlinks.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  invalidateSubtree(path: string | PathSpec): Promise<void> {
+    this.subtrees.push(typeof path === 'string' ? path : path.mountPath)
     return Promise.resolve()
   }
 

--- a/typescript/packages/core/src/core/databricks_volume/rename.ts
+++ b/typescript/packages/core/src/core/databricks_volume/rename.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterUnlink } from '../../cache/context.ts'
+import { invalidateSubtree } from '../../cache/context.ts'
 import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileType, type PathSpec } from '../../types.ts'
@@ -55,6 +55,6 @@ export async function rename(
     await copy(accessor, s, d, index)
     await unlink(accessor, s, index)
   }
-  await invalidateAfterUnlink(d)
-  await invalidateAfterUnlink(s)
+  await invalidateSubtree(d)
+  await invalidateSubtree(s)
 }

--- a/typescript/packages/core/src/core/databricks_volume/rm.ts
+++ b/typescript/packages/core/src/core/databricks_volume/rm.ts
@@ -15,7 +15,7 @@
 import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileType, type PathSpec } from '../../types.ts'
-import { invalidateAfterUnlink } from '../../cache/context.ts'
+import { invalidateSubtree } from '../../cache/context.ts'
 import { dbxFetch } from './client.ts'
 import { ensurePathSpec } from './_helpers.ts'
 import { isNotFound, notFoundError } from './errors.ts'
@@ -60,6 +60,6 @@ export async function rmRecursive(
     if (isNotFound(exc)) throw notFoundError(p.virtual)
     throw exc
   }
-  await invalidateAfterUnlink(p)
+  await invalidateSubtree(p)
   return removed.map((backend) => virtualPath(accessor.config, backend, ''))
 }

--- a/typescript/packages/core/src/core/dropbox/rename.ts
+++ b/typescript/packages/core/src/core/dropbox/rename.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
-import { invalidateAfterUnlink } from '../../cache/context.ts'
+import { invalidateSubtree } from '../../cache/context.ts'
 import { record } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
@@ -50,8 +50,8 @@ export async function rename(
     await movePath(accessor.tokenManager, from, to)
   }
   record('rename', src.virtual, 'dropbox', 0, startMs)
-  await invalidateAfterUnlink(src)
+  await invalidateSubtree(src)
   await invalidateAncestors(src)
-  await invalidateAfterUnlink(dst)
+  await invalidateSubtree(dst)
   await invalidateAncestors(dst)
 }

--- a/typescript/packages/core/src/core/dropbox/rm.ts
+++ b/typescript/packages/core/src/core/dropbox/rm.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
-import { invalidateAfterUnlink } from '../../cache/context.ts'
+import { invalidateSubtree } from '../../cache/context.ts'
 import { record } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
@@ -33,6 +33,6 @@ export async function rmR(accessor: DropboxAccessor, path: PathSpec): Promise<vo
     throw err
   }
   record('rm_r', path.virtual, 'dropbox', 0, startMs)
-  await invalidateAfterUnlink(path)
+  await invalidateSubtree(path)
   await invalidateAncestors(path)
 }

--- a/typescript/packages/core/src/core/gdrive/rename.ts
+++ b/typescript/packages/core/src/core/gdrive/rename.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GDriveAccessor } from '../../accessor/gdrive.ts'
-import { invalidateAfterUnlink } from '../../cache/context.ts'
+import { invalidateSubtree } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent, enotempty } from '../../utils/errors.ts'
 import { deleteFile, listFiles, patchFile } from '../google/drive.ts'
@@ -48,8 +48,8 @@ async function renameImpl(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec
     body: { name },
     ...(move ? { addParents: dstParentId, removeParents: srcParentId } : {}),
   })
-  await invalidateAfterUnlink(dst)
-  await invalidateAfterUnlink(src)
+  await invalidateSubtree(dst)
+  await invalidateSubtree(src)
 }
 
 export const rename = eaccesOnDenied(renameImpl)

--- a/typescript/packages/core/src/core/gdrive/rm.ts
+++ b/typescript/packages/core/src/core/gdrive/rm.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GDriveAccessor } from '../../accessor/gdrive.ts'
-import { invalidateAfterUnlink } from '../../cache/context.ts'
+import { invalidateSubtree } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
 import { deleteFile } from '../google/drive.ts'
@@ -26,7 +26,7 @@ async function rmRImpl(accessor: GDriveAccessor, path: PathSpec): Promise<void> 
   const node = await resolveKey(accessor, key)
   if (node === null) throw enoent(path)
   await deleteFile(accessor.tokenManager, node.id)
-  await invalidateAfterUnlink(path)
+  await invalidateSubtree(path)
 }
 
 export const rmR = eaccesOnDenied(rmRImpl)

--- a/typescript/packages/core/src/core/object_store/fakes.ts
+++ b/typescript/packages/core/src/core/object_store/fakes.ts
@@ -249,6 +249,7 @@ export function makeDriver(
 export class FakeManager {
   readonly writes: string[] = []
   readonly unlinks: string[] = []
+  readonly subtrees: string[] = []
 
   invalidateAfterWrite(path: string | PathSpec): Promise<void> {
     this.writes.push(typeof path === 'string' ? path : path.mountPath)
@@ -257,6 +258,11 @@ export class FakeManager {
 
   invalidateAfterUnlink(path: string | PathSpec): Promise<void> {
     this.unlinks.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  invalidateSubtree(path: string | PathSpec): Promise<void> {
+    this.subtrees.push(typeof path === 'string' ? path : path.mountPath)
     return Promise.resolve()
   }
 

--- a/typescript/packages/core/src/core/object_store/remove.test.ts
+++ b/typescript/packages/core/src/core/object_store/remove.test.ts
@@ -40,7 +40,10 @@ describe('object_store remove', () => {
     const store = new FakeStore({ 'a/b/c.txt': 'hi', 'a/b/d/e.txt': 'x' })
     const manager = await managed(() => makeRemovePrefix(makeDriver(store))(accessor, spec('/a/b')))
     expect(store.contents()).toEqual({})
-    expect(manager.unlinks).toEqual(['/a/b'])
+    // A subtree evict, not an unlink: every key below /a/b went with it,
+    // and each one was cached under its own key.
+    expect(manager.subtrees).toEqual(['/a/b'])
+    expect(manager.unlinks).toEqual([])
     expect(manager.writes).toEqual(['/a'])
   })
 

--- a/typescript/packages/core/src/core/object_store/remove.ts
+++ b/typescript/packages/core/src/core/object_store/remove.ts
@@ -13,7 +13,11 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { Accessor } from '../../accessor/base.ts'
-import { invalidateAfterUnlink, invalidateAncestors } from '../../cache/context.ts'
+import {
+  invalidateAfterUnlink,
+  invalidateAncestors,
+  invalidateSubtree,
+} from '../../cache/context.ts'
 import { enoent, enotempty } from '../../utils/errors.ts'
 import * as kp from '../../utils/key_prefix.ts'
 import { rstripSlash } from '../../utils/slash.ts'
@@ -55,7 +59,10 @@ export function makeRemovePrefix<A extends Accessor, C>(
     } finally {
       await close()
     }
-    await invalidateAfterUnlink(path)
+    // Not invalidateAfterUnlink: a prefix delete takes every key below
+    // with it, and each of those listings and bodies was cached under
+    // its own key, so nothing above them evicts one.
+    await invalidateSubtree(path)
     // Same rationale as unlink: ancestors that existed only as this
     // prefix are gone now.
     await invalidateAncestors(path)

--- a/typescript/packages/core/src/core/object_store/rename.test.ts
+++ b/typescript/packages/core/src/core/object_store/rename.test.ts
@@ -39,7 +39,7 @@ describe('object_store rename', () => {
       renameFor(store)(accessor, spec('/a/src.txt'), spec('/b/dst.txt')),
     )
     expect(store.contents()).toEqual({ 'b/dst.txt': 'hi' })
-    expect(manager.unlinks).toEqual(['/b/dst.txt', '/a/src.txt'])
+    expect(manager.subtrees).toEqual(['/b/dst.txt', '/a/src.txt'])
     expect(manager.writes).toEqual(['/b', '/a'])
   })
 
@@ -61,6 +61,7 @@ describe('object_store rename', () => {
     const manager = await managed(() => renameFor(store)(accessor, spec('/a.txt'), spec('/a.txt')))
     expect(store.contents()).toEqual({ 'a.txt': 'hi' })
     expect(manager.unlinks).toEqual([])
+    expect(manager.subtrees).toEqual([])
   })
 
   it('renaming onto the same key still fails when absent', async () => {

--- a/typescript/packages/core/src/core/object_store/rename.ts
+++ b/typescript/packages/core/src/core/object_store/rename.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { Accessor } from '../../accessor/base.ts'
-import { invalidateAfterUnlink, invalidateAncestors } from '../../cache/context.ts'
+import { invalidateAncestors, invalidateSubtree } from '../../cache/context.ts'
 import { enoent } from '../../utils/errors.ts'
 import * as kp from '../../utils/key_prefix.ts'
 import type { ExistsFn, ObjectStoreDriver, PairFn } from './driver.ts'
@@ -64,8 +64,12 @@ export function makeRename<A extends Accessor, C>(
     } finally {
       await close()
     }
-    await invalidateAfterUnlink(dst)
-    await invalidateAfterUnlink(src)
+    // Subtrees, not single paths: movePrefix relocates every key under
+    // src, so each listing and body cached below the old name names
+    // something that is no longer there, and each one below the new name
+    // predates the move.
+    await invalidateSubtree(dst)
+    await invalidateSubtree(src)
     // The move can create the destination's missing ancestors and erase
     // the source's prefix-only ones in the same call.
     await invalidateAncestors(dst)

--- a/typescript/packages/core/src/core/onedrive/index.ts
+++ b/typescript/packages/core/src/core/onedrive/index.ts
@@ -17,6 +17,7 @@ import {
   invalidateAfterUnlink,
   invalidateAfterWrite,
   invalidateAncestors,
+  invalidateSubtree,
 } from '../../cache/context.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { startBasename } from '../../commands/builtin/find_eval.ts'
@@ -207,7 +208,7 @@ export async function unlink(accessor: OneDriveAccessor, path: PathSpec): Promis
 export async function rmR(accessor: OneDriveAccessor, path: PathSpec): Promise<void> {
   if (path.resourcePath === '') return
   await graphDelete(accessor.config, accessor.loc(path.resourcePath).item())
-  await invalidateAfterUnlink(path)
+  await invalidateSubtree(path)
 }
 
 /**
@@ -249,8 +250,8 @@ export async function rename(
     accessor.loc(src.resourcePath),
     accessor.loc(dst.resourcePath),
   )
-  await invalidateAfterUnlink(dst)
-  await invalidateAfterUnlink(src)
+  await invalidateSubtree(dst)
+  await invalidateSubtree(src)
 }
 
 export async function copy(

--- a/typescript/packages/core/src/core/ram/rename.ts
+++ b/typescript/packages/core/src/core/ram/rename.ts
@@ -18,7 +18,7 @@ import { norm, nowIso } from './utils.ts'
 import { rstripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 import { checkDestParents } from './dest.ts'
-import { invalidateAfterUnlink } from '../../cache/context.ts'
+import { invalidateSubtree } from '../../cache/context.ts'
 
 function moveAttrs(accessor: RAMAccessor, src: string, dst: string): void {
   const attrs = accessor.store.attrs.get(src)
@@ -76,8 +76,8 @@ export async function rename(accessor: RAMAccessor, src: PathSpec, dst: PathSpec
     accessor.store.modified.set(d, accessor.store.modified.get(s) ?? now)
     accessor.store.modified.delete(s)
     moveAttrs(accessor, s, d)
-    await invalidateAfterUnlink(src)
-    await invalidateAfterUnlink(dst)
+    await invalidateSubtree(src)
+    await invalidateSubtree(dst)
     return Promise.resolve()
   }
   if (accessor.store.dirs.has(s)) {
@@ -87,8 +87,8 @@ export async function rename(accessor: RAMAccessor, src: PathSpec, dst: PathSpec
     accessor.store.modified.delete(s)
     moveAttrs(accessor, s, d)
     moveSubtree(accessor, s, d)
-    await invalidateAfterUnlink(src)
-    await invalidateAfterUnlink(dst)
+    await invalidateSubtree(src)
+    await invalidateSubtree(dst)
     return Promise.resolve()
   }
   throw enoent(src)

--- a/typescript/packages/core/src/core/ram/rm.ts
+++ b/typescript/packages/core/src/core/ram/rm.ts
@@ -16,7 +16,7 @@ import type { RAMAccessor } from '../../accessor/ram.ts'
 import type { PathSpec } from '../../types.ts'
 import { norm } from './utils.ts'
 import { rstripSlash } from '../../utils/slash.ts'
-import { invalidateAfterUnlink } from '../../cache/context.ts'
+import { invalidateSubtree } from '../../cache/context.ts'
 
 export async function rmR(accessor: RAMAccessor, path: PathSpec): Promise<void> {
   const p = norm(path.mountPath)
@@ -28,7 +28,7 @@ export async function rmR(accessor: RAMAccessor, path: PathSpec): Promise<void> 
       accessor.store.attrs.delete(key)
     }
   }
-  await invalidateAfterUnlink(path)
+  await invalidateSubtree(path)
   for (const key of [...accessor.store.dirs]) {
     if (key === p || key.startsWith(prefix)) {
       accessor.store.dirs.delete(key)

--- a/typescript/packages/core/src/core/s3/write.test.ts
+++ b/typescript/packages/core/src/core/s3/write.test.ts
@@ -39,6 +39,10 @@ class FakeManager {
     return Promise.resolve()
   }
 
+  invalidateSubtree(_path: PathSpec): Promise<void> {
+    return Promise.resolve()
+  }
+
   cachedBytes(_path: PathSpec): Promise<Uint8Array | null> {
     return Promise.resolve(null)
   }

--- a/typescript/packages/core/src/core/sharepoint/index.ts
+++ b/typescript/packages/core/src/core/sharepoint/index.ts
@@ -17,6 +17,7 @@ import {
   invalidateAfterUnlink,
   invalidateAfterWrite,
   invalidateAncestors,
+  invalidateSubtree,
 } from '../../cache/context.ts'
 import { IndexEntry, ResourceType } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
@@ -287,7 +288,7 @@ export async function rmR(accessor: SharePointAccessor, path: PathSpec): Promise
   const resolved = await accessor.resolve(path.resourcePath)
   if (resolved.driveId === null || resolved.itemPath === null) return
   await graphDelete(accessor.config, accessor.loc(resolved, path.resourcePath).item())
-  await invalidateAfterUnlink(path)
+  await invalidateSubtree(path)
 }
 
 /**
@@ -333,8 +334,8 @@ export async function rename(
     accessor.loc(srcResolved, src.resourcePath),
     accessor.loc(dstResolved, dst.resourcePath),
   )
-  await invalidateAfterUnlink(dst)
-  await invalidateAfterUnlink(src)
+  await invalidateSubtree(dst)
+  await invalidateSubtree(src)
 }
 
 export async function copy(

--- a/typescript/packages/core/src/ops/generic/factory.ts
+++ b/typescript/packages/core/src/ops/generic/factory.ts
@@ -51,7 +51,11 @@ export interface OpsTable<A extends Accessor = Accessor> {
 }
 
 export interface MakeGenericOpsOptions {
-  /** Synthesize truncate from readBytes + write (no native partial write). */
+  /**
+   * Synthesize truncate from readBytes + write for a backend with no
+   * native partial write (dropbox is the only one; a table carrying a
+   * real `truncate` wins outright).
+   */
   emulateTruncate?: boolean
   /** Forward `parents=true` to the core mkdir (disk). */
   mkdirParents?: boolean

--- a/typescript/packages/node/src/core/disk/rename.test.ts
+++ b/typescript/packages/node/src/core/disk/rename.test.ts
@@ -24,6 +24,7 @@ import { rename } from './rename.ts'
 class FakeManager {
   writes: string[] = []
   unlinks: string[] = []
+  subtrees: string[] = []
 
   invalidateAfterWrite(path: string | PathSpec): Promise<void> {
     this.writes.push(typeof path === 'string' ? path : path.mountPath)
@@ -32,6 +33,11 @@ class FakeManager {
 
   invalidateAfterUnlink(path: string | PathSpec): Promise<void> {
     this.unlinks.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  invalidateSubtree(path: string | PathSpec): Promise<void> {
+    this.subtrees.push(typeof path === 'string' ? path : path.mountPath)
     return Promise.resolve()
   }
 
@@ -71,7 +77,7 @@ describe('core/disk/rename', () => {
     await runWithCacheManager(manager, async () => {
       await rename(accessor, spec('/src'), spec('/dst'))
     })
-    expect(manager.unlinks).toEqual(['/src', '/dst'])
+    expect(manager.subtrees).toEqual(['/src', '/dst'])
     expect(manager.writes).toEqual([])
     expect(await readFile(join(root, 'dst', 'f.txt'), 'utf-8')).toBe('x')
   })

--- a/typescript/packages/node/src/core/disk/rename.ts
+++ b/typescript/packages/node/src/core/disk/rename.ts
@@ -14,7 +14,7 @@
 
 import type { DiskAccessor } from '../../accessor/disk.ts'
 import { rename as fsRename } from 'node:fs/promises'
-import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
+import { invalidateSubtree } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
 import { resolveSafe } from './utils.ts'
@@ -30,8 +30,9 @@ export async function rename(accessor: DiskAccessor, src: PathSpec, dst: PathSpe
     }
     throw err
   }
-  await invalidateAfterUnlink(src)
-  // The unlink flavor on dst: a rename destroys the destination's previous
-  // identity, so a replaced empty directory loses its cached listing too.
-  await invalidateAfterUnlink(dst)
+  await invalidateSubtree(src)
+  // Both sides are subtree evictions: a rename destroys the destination's
+  // previous identity and relocates everything under the source, so a
+  // listing or body cached below either name is now stale.
+  await invalidateSubtree(dst)
 }

--- a/typescript/packages/node/src/core/disk/rm.ts
+++ b/typescript/packages/node/src/core/disk/rm.ts
@@ -14,12 +14,12 @@
 
 import type { DiskAccessor } from '../../accessor/disk.ts'
 import { rm } from 'node:fs/promises'
-import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
+import { invalidateSubtree } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { resolveSafe } from './utils.ts'
 
 export async function rmR(accessor: DiskAccessor, path: PathSpec): Promise<void> {
   const full = resolveSafe(accessor.root, path.mountPath)
   await rm(full, { recursive: true, force: true })
-  await invalidateAfterUnlink(path)
+  await invalidateSubtree(path)
 }

--- a/typescript/packages/node/src/core/gridfs/write.test.ts
+++ b/typescript/packages/node/src/core/gridfs/write.test.ts
@@ -39,6 +39,10 @@ class FakeManager {
     return Promise.resolve()
   }
 
+  invalidateSubtree(_path: PathSpec): Promise<void> {
+    return Promise.resolve()
+  }
+
   cachedBytes(_path: PathSpec): Promise<Uint8Array | null> {
     return Promise.resolve(null)
   }

--- a/typescript/packages/node/src/core/nextcloud/mkdir.test.ts
+++ b/typescript/packages/node/src/core/nextcloud/mkdir.test.ts
@@ -17,6 +17,7 @@ function accessorWith(fake: FakeNextcloudOperator): NextcloudAccessor {
 class RecordingInvalidator implements CacheInvalidator {
   readonly writes: string[] = []
   readonly unlinks: string[] = []
+  readonly subtrees: string[] = []
 
   invalidateAfterWrite(path: string | PathSpec): Promise<void> {
     this.writes.push(typeof path === 'string' ? path : path.mountPath)
@@ -25,6 +26,11 @@ class RecordingInvalidator implements CacheInvalidator {
 
   invalidateAfterUnlink(path: string | PathSpec): Promise<void> {
     this.unlinks.push(typeof path === 'string' ? path : path.mountPath)
+    return Promise.resolve()
+  }
+
+  invalidateSubtree(path: string | PathSpec): Promise<void> {
+    this.subtrees.push(typeof path === 'string' ? path : path.mountPath)
     return Promise.resolve()
   }
 

--- a/typescript/packages/node/src/core/nextcloud/rename.ts
+++ b/typescript/packages/node/src/core/nextcloud/rename.ts
@@ -1,4 +1,4 @@
-import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
+import { invalidateSubtree } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
 import type { NextcloudAccessor } from '../../accessor/nextcloud.ts'
@@ -16,6 +16,6 @@ export async function rename(
     if (isNotFound(error)) throw enoent(source)
     throw error
   }
-  await invalidateAfterUnlink(destination)
-  await invalidateAfterUnlink(source)
+  await invalidateSubtree(destination)
+  await invalidateSubtree(source)
 }

--- a/typescript/packages/node/src/core/nextcloud/rm.ts
+++ b/typescript/packages/node/src/core/nextcloud/rm.ts
@@ -1,4 +1,4 @@
-import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
+import { invalidateSubtree } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
 import { rstripSlash } from '@struktoai/mirage-core/utils/slash'
@@ -14,5 +14,5 @@ export async function rmR(accessor: NextcloudAccessor, path: PathSpec): Promise<
     if (isNotFound(error)) throw enoent(path)
     throw error
   }
-  await invalidateAfterUnlink(path)
+  await invalidateSubtree(path)
 }

--- a/typescript/packages/node/src/core/redis/rename.ts
+++ b/typescript/packages/node/src/core/redis/rename.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
+import { invalidateSubtree } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
 import { rstripSlash } from '@struktoai/mirage-core/utils/slash'
@@ -74,8 +74,8 @@ export async function rename(accessor: RedisAccessor, src: PathSpec, dst: PathSp
     await store.setFile(d, data)
     await store.setModified(d, mod ?? now)
     if (Object.keys(attrs).length > 0) await store.setAttrs(d, attrs)
-    await invalidateAfterUnlink(s)
-    await invalidateAfterUnlink(d)
+    await invalidateSubtree(s)
+    await invalidateSubtree(d)
     return
   }
   if (await store.hasDir(s)) {
@@ -88,8 +88,8 @@ export async function rename(accessor: RedisAccessor, src: PathSpec, dst: PathSp
     await store.setModified(d, mod ?? now)
     if (Object.keys(attrs).length > 0) await store.setAttrs(d, attrs)
     await moveSubtree(store, s, d)
-    await invalidateAfterUnlink(s)
-    await invalidateAfterUnlink(d)
+    await invalidateSubtree(s)
+    await invalidateSubtree(d)
     return
   }
   throw enoent(src)

--- a/typescript/packages/node/src/core/redis/rm.ts
+++ b/typescript/packages/node/src/core/redis/rm.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
+import { invalidateSubtree } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { rstripSlash } from '@struktoai/mirage-core/utils/slash'
 import type { RedisAccessor } from '../../accessor/redis.ts'
@@ -38,5 +38,5 @@ export async function rmR(accessor: RedisAccessor, path: PathSpec): Promise<void
       await store.delAttrs(key)
     }
   }
-  await invalidateAfterUnlink(path)
+  await invalidateSubtree(path)
 }

--- a/typescript/packages/node/src/core/ssh/rename.ts
+++ b/typescript/packages/node/src/core/ssh/rename.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
+import { invalidateSubtree } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
@@ -41,8 +41,9 @@ export async function rename(accessor: SSHAccessor, src: PathSpec, dst: PathSpec
       sftp.rename(remoteSrc, remoteDst, done)
     }
   })
-  // The unlink flavor on dst: a rename destroys the destination's previous
-  // identity, so a replaced empty directory loses its cached listing too.
-  await invalidateAfterUnlink(dst)
-  await invalidateAfterUnlink(src)
+  // Both sides are subtree evictions: a rename destroys the destination's
+  // previous identity and relocates everything under the source, so a
+  // listing or body cached below either name is now stale.
+  await invalidateSubtree(dst)
+  await invalidateSubtree(src)
 }

--- a/typescript/packages/node/src/core/ssh/rm.ts
+++ b/typescript/packages/node/src/core/ssh/rm.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { FileEntryWithStats, SFTPWrapper, Stats } from 'ssh2'
-import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
+import { invalidateSubtree } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
@@ -80,5 +80,5 @@ export async function rmR(accessor: SSHAccessor, p: PathSpec): Promise<void> {
     if (isNoSuchFile(err)) throw enoent(p)
     throw err
   }
-  await invalidateAfterUnlink(p)
+  await invalidateSubtree(p)
 }


### PR DESCRIPTION
## Summary

A recursive delete or a directory rename left **everything cached below the path
still being served**. `ls` printed a deleted directory's contents and `cat`
returned a deleted file's bytes, both exit 0, until the index TTL expired.

The cause: `invalidate_subtree` existed on the cache manager but had exactly one
caller — the watcher. No `rm -r`, no recursive prefix delete, and no `rename`
reached it, in either language. Every mutation site reported
`invalidate_after_unlink`, which evicts the path's own listing and its parent's.
That is complete for a file and blind for a subtree, because each listing and
body beneath the path was cached under its own key and nothing above them evicts
one.

Reproduced against a live minio, with the bucket verified empty through boto3 so
the reads are provably cache and not survival:

```
$ rm -r /s3/a/b                       # bucket now holds zero keys
$ ls /s3/a/b/deep                     # (0) c.txt
$ cat /s3/a/b/deep/c.txt              # (0) hello
$ mv /s3/mv/a/b /s3/mv/a/z            # keys really moved to mv/a/z/
$ ls /s3/mv/a/b/deep                  # (0) c.txt
```

Blast radius is every backend that indexes listings — API backends serve
`readdir` straight from `index.list_dir` — and 30 resources set
`caches_reads = true`, so the body half applies to them too.

## The fix

`cache/context` gains an `invalidate_subtree` free function alongside the two it
already had, and the `CacheInvalidator` protocol/interface gains the method.
Unlike `invalidate_ancestors`, this one **delegates to the manager rather than
walking**: ancestors can be assembled from `invalidate_after_write` calls
because the caller knows the chain, but only the caches know which keys lie
*beneath* a path.

Then one uniform rule, applied in both languages: **an op that destroys or moves
a whole subtree evicts that subtree.**

- every `rm_r` / `remove_prefix` site swaps `invalidate_after_unlink` →
  `invalidate_subtree`
- every `rename` swaps **both** endpoints, because the destination may have
  replaced something that was cached

`invalidate_subtree` is a strict superset of `invalidate_after_unlink`, so the
swap degrades to exactly the old behavior on a file path — the extra prefix
eviction matches nothing. `under_path` boundary checks mean `/a/b` never evicts
`/a/bc.txt`.

Untouched on purpose: `unlink`, non-recursive `rmdir` (the keyed-store one
deletes a marker and nothing else), and `copy`, whose destination-side staleness
is a different symptom I did not reproduce and did not want to fix on a guess.

## The sweep this came out of, and the plan correction

This started as the kit plan's PR-K1b item *"delete-side `invalidate_ancestors`
asymmetry sweep — nextcloud, box, onedrive, sharepoint"*. **That premise was
wrong and the item should not be reopened.**

`invalidate_ancestors` exists because one op can materialize *several* levels at
once: `mkdir -p a/b/c`, and on a keyed store any write, since a put creates every
missing prefix. Nothing on the delete side removes an *ancestor* level on a
real-directory backend, so `invalidate_after_unlink` is already complete there.
The one delete that does need it is the keyed-store one, and
`object_store/remove.py` already had it. The manager's own docstring says as
much: *a backend with real directories cannot gain a level that way, so there
this is a handful of spare evictions.*

box and gdrive only *looked* like they were missing it — their multi-level
`mkdir -p` invalidates per created level in a bespoke loop instead of calling the
shared helper. databricks needed no special re-derivation; its delete side is an
ordinary real-directory delete.

## `emulate_truncate`

The other half of this plan item was the five dead python-only `emulate_truncate`
flags. **#858 already removed them**; only dropbox's live one remains. All that
was left was two docstrings still naming `s3/ssh/ram/redis` as the emulating
backends, corrected here.

## Verification

- **Both hosts, byte-identical, against the committed goldens.** The 16 new
  cases were run as literal shell lines through a python `Workspace` and a
  TypeScript `Workspace` over the same minio bucket: 16/16 agree with each other
  and with `integ/resources/cache/subtree_evict.json`.
- **Prefixed mount checked separately**, since the two `*-prefix` targets are
  pinned here and an unprefixed mount cannot see a key-prefix bug: a mount
  carrying `key_prefix="team/reports/data"` produces the same 16 rows, so the
  manager's cache-key derivation is carrying the prefix through.
- **The pin is falsifiable.** Reverting just the two `object_store` files and
  rebuilding makes all four assertion cases return the stale content at exit 0.
  The first draft of the case file was *not* falsifiable on the rename half — it
  warmed the body but not the listing, so `ls` never had a stale entry to serve.
  Both warms are now present, with a comment saying why.
- Unit tests updated where the assertion moved: a rename and a prefix delete now
  report a subtree rather than an unlink, which is the stronger guarantee.
- `pnpm -r typecheck` clean; widening the interface made tsc enumerate every TS
  fake, python's structural Protocol needed the test run to find its own.
- **Call-site parity checked per backend, not in total.** Python has 36 swapped
  calls and TypeScript 40; every backend matches three-for-three except `ram`
  and `redis`, whose TS `rename` has two return branches to python's one. Both
  branches are covered — the delta is the pre-existing shape, not a gap.
- Both ratchets unchanged: case-targets 2289/2289 (the new file reuses
  `resources/cache/`'s existing 4-target modal set), layout parity 259/259.

## Known coverage gap

The integ pin targets `s3`, `s3-prefix`, `gridfs`, `gridfs-prefix` — the same set
`ancestor_evict.json` uses, which is also what keeps the case-target ratchet flat.
A hierarchy backend with `caches_reads` (nextcloud) exercises the same code path
and is fixed by the same change, but is not pinned here.
