### PR TITLE
refactor(resource): collapse the 42 S3-alias resource bodies onto a shared base

### DIFF
--- a/python/mirage/resource/aliyun/aliyun.py
+++ b/python/mirage/resource/aliyun/aliyun.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
 from mirage.resource.aliyun.config import AliyunConfig
 from mirage.resource.aliyun.prompt import PROMPT
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 
 
-class AliyunResource(S3Resource):
+class AliyunResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: AliyunConfig) -> None:
-        self.aliyun_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.aliyun_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/backblaze/backblaze.py
+++ b/python/mirage/resource/backblaze/backblaze.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
 from mirage.resource.backblaze.config import BackblazeConfig
 from mirage.resource.backblaze.prompt import PROMPT
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 
 
-class BackblazeResource(S3Resource):
+class BackblazeResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: BackblazeConfig) -> None:
-        self.backblaze_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.backblaze_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/ceph/ceph.py
+++ b/python/mirage/resource/ceph/ceph.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
 from mirage.resource.ceph.config import CephConfig
 from mirage.resource.ceph.prompt import PROMPT
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 
 
-class CephResource(S3Resource):
+class CephResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: CephConfig) -> None:
-        self.ceph_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.ceph_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/digitalocean/digitalocean.py
+++ b/python/mirage/resource/digitalocean/digitalocean.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
 from mirage.resource.digitalocean.config import DigitalOceanConfig
 from mirage.resource.digitalocean.prompt import PROMPT
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 
 
-class DigitalOceanResource(S3Resource):
+class DigitalOceanResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: DigitalOceanConfig) -> None:
-        self.digitalocean_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.digitalocean_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/gcs/gcs.py
+++ b/python/mirage/resource/gcs/gcs.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
 from mirage.resource.gcs.config import GCSConfig
 from mirage.resource.gcs.prompt import PROMPT
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 
 
-class GCSResource(S3Resource):
+class GCSResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: GCSConfig) -> None:
-        self.gcs_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.gcs_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/minio/minio.py
+++ b/python/mirage/resource/minio/minio.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
 from mirage.resource.minio.config import MinIOConfig
 from mirage.resource.minio.prompt import PROMPT
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 
 
-class MinIOResource(S3Resource):
+class MinIOResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: MinIOConfig) -> None:
-        self.minio_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.minio_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/oci/oci.py
+++ b/python/mirage/resource/oci/oci.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
 from mirage.resource.oci.config import OCIConfig
 from mirage.resource.oci.prompt import PROMPT
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 
 
-class OCIResource(S3Resource):
+class OCIResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: OCIConfig) -> None:
-        self.oci_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.oci_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/qingstor/qingstor.py
+++ b/python/mirage/resource/qingstor/qingstor.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
 from mirage.resource.qingstor.config import QingStorConfig
 from mirage.resource.qingstor.prompt import PROMPT
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 
 
-class QingStorResource(S3Resource):
+class QingStorResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: QingStorConfig) -> None:
-        self.qingstor_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.qingstor_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/r2/r2.py
+++ b/python/mirage/resource/r2/r2.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
 from mirage.resource.r2.config import R2Config
 from mirage.resource.r2.prompt import PROMPT
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 
 
-class R2Resource(S3Resource):
+class R2Resource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: R2Config) -> None:
-        self.r2_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.r2_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/s3_alias.py
+++ b/python/mirage/resource/s3_alias.py
@@ -12,11 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from pydantic import BaseModel, ConfigDict, SecretStr
 
-from mirage.resource.s3 import S3Config
+from mirage.resource.s3 import S3Config, S3Resource
 
 
 class S3AliasConfig(BaseModel):
@@ -98,3 +98,24 @@ class FixedEndpointConfig(S3AliasConfig):
 
     def resolved_endpoint_url(self) -> str:
         return self.endpoint_url
+
+
+class S3AliasResource(S3Resource):
+    """The shared body of every S3-compatible provider resource.
+
+    A provider is an :class:`S3Resource` reached through a provider-shaped
+    config, so all it owns is that config and the redacted state built
+    from it; the conversion itself lives on :class:`S3AliasConfig`. A
+    subclass declares only its ``PROMPT`` and narrows the config type.
+
+    Mirrors the TypeScript ``S3AliasResource`` in
+    ``packages/{node,browser}/src/resource/s3_alias.ts``, which also has to
+    retag ops and commands onto the alias name.
+    """
+
+    def __init__(self, config: S3AliasConfig) -> None:
+        self.alias_config = config
+        super().__init__(config.to_s3_config())
+
+    def get_state(self) -> dict[str, Any]:
+        return self.config_state(self.alias_config)

--- a/python/mirage/resource/scaleway/scaleway.py
+++ b/python/mirage/resource/scaleway/scaleway.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 from mirage.resource.scaleway.config import ScalewayConfig
 from mirage.resource.scaleway.prompt import PROMPT
 
 
-class ScalewayResource(S3Resource):
+class ScalewayResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: ScalewayConfig) -> None:
-        self.scaleway_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.scaleway_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/seaweedfs/seaweedfs.py
+++ b/python/mirage/resource/seaweedfs/seaweedfs.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 from mirage.resource.seaweedfs.config import SeaweedFSConfig
 from mirage.resource.seaweedfs.prompt import PROMPT
 
 
-class SeaweedFSResource(S3Resource):
+class SeaweedFSResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: SeaweedFSConfig) -> None:
-        self.seaweedfs_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.seaweedfs_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/supabase/supabase.py
+++ b/python/mirage/resource/supabase/supabase.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 from mirage.resource.supabase.config import SupabaseConfig
 from mirage.resource.supabase.prompt import PROMPT
 
 
-class SupabaseResource(S3Resource):
+class SupabaseResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: SupabaseConfig) -> None:
-        self.supabase_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.supabase_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/tencent/tencent.py
+++ b/python/mirage/resource/tencent/tencent.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 from mirage.resource.tencent.config import TencentConfig
 from mirage.resource.tencent.prompt import PROMPT
 
 
-class TencentResource(S3Resource):
+class TencentResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: TencentConfig) -> None:
-        self.tencent_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.tencent_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/mirage/resource/wasabi/wasabi.py
+++ b/python/mirage/resource/wasabi/wasabi.py
@@ -12,23 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from typing import Any
-
-from mirage.resource.s3 import S3Resource
+from mirage.resource.s3_alias import S3AliasResource
 from mirage.resource.wasabi.config import WasabiConfig
 from mirage.resource.wasabi.prompt import PROMPT
 
 
-class WasabiResource(S3Resource):
+class WasabiResource(S3AliasResource):
 
     PROMPT: str = PROMPT
 
     def __init__(self, config: WasabiConfig) -> None:
-        self.wasabi_config = config
-        super().__init__(config.to_s3_config())
-
-    def get_state(self) -> dict[str, Any]:
-        return self.config_state(self.wasabi_config)
-
-    def load_state(self, state: dict[str, Any]) -> None:
-        pass
+        super().__init__(config)

--- a/python/tests/resource/ceph/test_ceph.py
+++ b/python/tests/resource/ceph/test_ceph.py
@@ -68,4 +68,4 @@ def test_ceph_resource_uses_s3_resource_type():
         ))
     assert resource.name == ResourceName.S3
     assert isinstance(resource.config, S3Config)
-    assert resource.ceph_config.endpoint_url == "https://ceph.example.com"
+    assert resource.alias_config.endpoint_url == "https://ceph.example.com"

--- a/python/tests/resource/gcs/test_gcs.py
+++ b/python/tests/resource/gcs/test_gcs.py
@@ -72,7 +72,7 @@ def test_gcs_resource_creates():
         secret_access_key="secret",
     )
     resource = GCSResource(c)
-    assert resource.gcs_config is c
+    assert resource.alias_config is c
     assert resource.accessor.config.bucket == "my-bucket"
     expected = "https://storage.googleapis.com"
     assert resource.accessor.config.endpoint_url == expected

--- a/python/tests/resource/minio/test_minio.py
+++ b/python/tests/resource/minio/test_minio.py
@@ -95,4 +95,4 @@ def test_minio_resource_preserves_original_config():
         secret_access_key="s",
     )
     resource = MinIOResource(config)
-    assert resource.minio_config is config
+    assert resource.alias_config is config

--- a/python/tests/resource/oci/test_oci.py
+++ b/python/tests/resource/oci/test_oci.py
@@ -106,4 +106,4 @@ def test_oci_resource_preserves_original_config():
         secret_access_key="secret-key",
     )
     resource = OCIResource(config)
-    assert resource.oci_config is config
+    assert resource.alias_config is config

--- a/python/tests/resource/r2/test_r2.py
+++ b/python/tests/resource/r2/test_r2.py
@@ -82,4 +82,4 @@ def test_r2resource_uses_s3_resource_type():
 def test_r2resource_preserves_original_config():
     config = R2Config(bucket="my-bucket", account_id="account-123")
     resource = R2Resource(config)
-    assert resource.r2_config is config
+    assert resource.alias_config is config

--- a/python/tests/resource/seaweedfs/test_seaweedfs.py
+++ b/python/tests/resource/seaweedfs/test_seaweedfs.py
@@ -95,4 +95,4 @@ def test_seaweedfs_resource_preserves_original_config():
         secret_access_key="s",
     )
     resource = SeaweedFSResource(config)
-    assert resource.seaweedfs_config is config
+    assert resource.alias_config is config

--- a/python/tests/resource/supabase/test_supabase.py
+++ b/python/tests/resource/supabase/test_supabase.py
@@ -106,7 +106,7 @@ def test_supabase_resource_preserves_original_config():
         secret_access_key="secret-key",
     )
     resource = SupabaseResource(config)
-    assert resource.supabase_config is config
+    assert resource.alias_config is config
 
 
 def test_s3_client_kwargs_support_path_style_and_session_token():

--- a/typescript/packages/browser/src/resource/aliyun/aliyun.ts
+++ b/typescript/packages/browser/src/resource/aliyun/aliyun.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   aliyunToS3Config,
   redactAliyunConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { ALIYUN_BROWSER_PROMPT } from './prompt.ts'
 
-export interface AliyunResourceState {
-  type: string
-  config: AliyunConfigRedacted
-}
+export type AliyunResourceState = S3AliasResourceState<AliyunConfigRedacted>
 
-export class AliyunResource extends S3Resource {
-  override readonly kind: string = ResourceName.ALIYUN
+export class AliyunResource extends S3AliasResource<AliyunConfig, AliyunConfigRedacted> {
   override readonly prompt: string = ALIYUN_BROWSER_PROMPT
-  readonly aliyunConfig: AliyunConfig
-  private readonly aliyunOps: readonly RegisteredOp[]
-  private readonly aliyunCommands: readonly RegisteredCommand[]
 
   constructor(config: AliyunConfig) {
-    super(aliyunToS3Config(config))
-    this.aliyunConfig = config
-    this.aliyunOps = remapOpsResource(super.ops(), ResourceName.ALIYUN)
-    this.aliyunCommands = remapCommandsResource(super.commands(), ResourceName.ALIYUN)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.aliyunOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.aliyunCommands
-  }
-
-  override getState(): Promise<AliyunResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactAliyunConfig(this.aliyunConfig),
-    })
-  }
-
-  override loadState(_state: AliyunResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.ALIYUN, config, aliyunToS3Config(config), redactAliyunConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/backblaze/backblaze.ts
+++ b/typescript/packages/browser/src/resource/backblaze/backblaze.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   backblazeToS3Config,
   redactBackblazeConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { BACKBLAZE_BROWSER_PROMPT } from './prompt.ts'
 
-export interface BackblazeResourceState {
-  type: string
-  config: BackblazeConfigRedacted
-}
+export type BackblazeResourceState = S3AliasResourceState<BackblazeConfigRedacted>
 
-export class BackblazeResource extends S3Resource {
-  override readonly kind: string = ResourceName.BACKBLAZE
+export class BackblazeResource extends S3AliasResource<BackblazeConfig, BackblazeConfigRedacted> {
   override readonly prompt: string = BACKBLAZE_BROWSER_PROMPT
-  readonly backblazeConfig: BackblazeConfig
-  private readonly backblazeOps: readonly RegisteredOp[]
-  private readonly backblazeCommands: readonly RegisteredCommand[]
 
   constructor(config: BackblazeConfig) {
-    super(backblazeToS3Config(config))
-    this.backblazeConfig = config
-    this.backblazeOps = remapOpsResource(super.ops(), ResourceName.BACKBLAZE)
-    this.backblazeCommands = remapCommandsResource(super.commands(), ResourceName.BACKBLAZE)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.backblazeOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.backblazeCommands
-  }
-
-  override getState(): Promise<BackblazeResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactBackblazeConfig(this.backblazeConfig),
-    })
-  }
-
-  override loadState(_state: BackblazeResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.BACKBLAZE, config, backblazeToS3Config(config), redactBackblazeConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/ceph/ceph.ts
+++ b/typescript/packages/browser/src/resource/ceph/ceph.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   cephToS3Config,
   redactCephConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { CEPH_BROWSER_PROMPT } from './prompt.ts'
 
-export interface CephResourceState {
-  type: string
-  config: CephConfigRedacted
-}
+export type CephResourceState = S3AliasResourceState<CephConfigRedacted>
 
-export class CephResource extends S3Resource {
-  override readonly kind: string = ResourceName.CEPH
+export class CephResource extends S3AliasResource<CephConfig, CephConfigRedacted> {
   override readonly prompt: string = CEPH_BROWSER_PROMPT
-  readonly cephConfig: CephConfig
-  private readonly cephOps: readonly RegisteredOp[]
-  private readonly cephCommands: readonly RegisteredCommand[]
 
   constructor(config: CephConfig) {
-    super(cephToS3Config(config))
-    this.cephConfig = config
-    this.cephOps = remapOpsResource(super.ops(), ResourceName.CEPH)
-    this.cephCommands = remapCommandsResource(super.commands(), ResourceName.CEPH)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.cephOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.cephCommands
-  }
-
-  override getState(): Promise<CephResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactCephConfig(this.cephConfig),
-    })
-  }
-
-  override loadState(_state: CephResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.CEPH, config, cephToS3Config(config), redactCephConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/digitalocean/digitalocean.ts
+++ b/typescript/packages/browser/src/resource/digitalocean/digitalocean.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   digitalOceanToS3Config,
   redactDigitalOceanConfig,
@@ -25,41 +22,20 @@ import {
 } from './config.ts'
 import { DIGITALOCEAN_BROWSER_PROMPT } from './prompt.ts'
 
-export interface DigitalOceanResourceState {
-  type: string
-  config: DigitalOceanConfigRedacted
-}
+export type DigitalOceanResourceState = S3AliasResourceState<DigitalOceanConfigRedacted>
 
-export class DigitalOceanResource extends S3Resource {
-  override readonly kind: string = ResourceName.DIGITALOCEAN
+export class DigitalOceanResource extends S3AliasResource<
+  DigitalOceanConfig,
+  DigitalOceanConfigRedacted
+> {
   override readonly prompt: string = DIGITALOCEAN_BROWSER_PROMPT
-  readonly digitalOceanConfig: DigitalOceanConfig
-  private readonly digitalOceanOps: readonly RegisteredOp[]
-  private readonly digitalOceanCommands: readonly RegisteredCommand[]
 
   constructor(config: DigitalOceanConfig) {
-    super(digitalOceanToS3Config(config))
-    this.digitalOceanConfig = config
-    this.digitalOceanOps = remapOpsResource(super.ops(), ResourceName.DIGITALOCEAN)
-    this.digitalOceanCommands = remapCommandsResource(super.commands(), ResourceName.DIGITALOCEAN)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.digitalOceanOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.digitalOceanCommands
-  }
-
-  override getState(): Promise<DigitalOceanResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactDigitalOceanConfig(this.digitalOceanConfig),
-    })
-  }
-
-  override loadState(_state: DigitalOceanResourceState): Promise<void> {
-    return Promise.resolve()
+    super(
+      ResourceName.DIGITALOCEAN,
+      config,
+      digitalOceanToS3Config(config),
+      redactDigitalOceanConfig,
+    )
   }
 }

--- a/typescript/packages/browser/src/resource/gcs/gcs.ts
+++ b/typescript/packages/browser/src/resource/gcs/gcs.ts
@@ -12,49 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import { gcsToS3Config, redactGcsConfig, type GCSConfig, type GCSConfigRedacted } from './config.ts'
 import { GCS_BROWSER_PROMPT } from './prompt.ts'
 
-export interface GCSResourceState {
-  type: string
-  config: GCSConfigRedacted
-}
+export type GCSResourceState = S3AliasResourceState<GCSConfigRedacted>
 
-export class GCSResource extends S3Resource {
-  override readonly kind: string = ResourceName.GCS
+export class GCSResource extends S3AliasResource<GCSConfig, GCSConfigRedacted> {
   override readonly prompt: string = GCS_BROWSER_PROMPT
-  readonly gcsConfig: GCSConfig
-  private readonly gcsOps: readonly RegisteredOp[]
-  private readonly gcsCommands: readonly RegisteredCommand[]
 
   constructor(config: GCSConfig) {
-    super(gcsToS3Config(config))
-    this.gcsConfig = config
-    this.gcsOps = remapOpsResource(super.ops(), ResourceName.GCS)
-    this.gcsCommands = remapCommandsResource(super.commands(), ResourceName.GCS)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.gcsOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.gcsCommands
-  }
-
-  override getState(): Promise<GCSResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactGcsConfig(this.gcsConfig),
-    })
-  }
-
-  override loadState(_state: GCSResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.GCS, config, gcsToS3Config(config), redactGcsConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/minio/minio.ts
+++ b/typescript/packages/browser/src/resource/minio/minio.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   minioToS3Config,
   redactMinIOConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { MINIO_BROWSER_PROMPT } from './prompt.ts'
 
-export interface MinIOResourceState {
-  type: string
-  config: MinIOConfigRedacted
-}
+export type MinIOResourceState = S3AliasResourceState<MinIOConfigRedacted>
 
-export class MinIOResource extends S3Resource {
-  override readonly kind: string = ResourceName.MINIO
+export class MinIOResource extends S3AliasResource<MinIOConfig, MinIOConfigRedacted> {
   override readonly prompt: string = MINIO_BROWSER_PROMPT
-  readonly minioConfig: MinIOConfig
-  private readonly minioOps: readonly RegisteredOp[]
-  private readonly minioCommands: readonly RegisteredCommand[]
 
   constructor(config: MinIOConfig) {
-    super(minioToS3Config(config))
-    this.minioConfig = config
-    this.minioOps = remapOpsResource(super.ops(), ResourceName.MINIO)
-    this.minioCommands = remapCommandsResource(super.commands(), ResourceName.MINIO)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.minioOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.minioCommands
-  }
-
-  override getState(): Promise<MinIOResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactMinIOConfig(this.minioConfig),
-    })
-  }
-
-  override loadState(_state: MinIOResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.MINIO, config, minioToS3Config(config), redactMinIOConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/oci/oci.ts
+++ b/typescript/packages/browser/src/resource/oci/oci.ts
@@ -12,49 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import { ociToS3Config, redactOciConfig, type OCIConfig, type OCIConfigRedacted } from './config.ts'
 import { OCI_BROWSER_PROMPT } from './prompt.ts'
 
-export interface OCIResourceState {
-  type: string
-  config: OCIConfigRedacted
-}
+export type OCIResourceState = S3AliasResourceState<OCIConfigRedacted>
 
-export class OCIResource extends S3Resource {
-  override readonly kind: string = ResourceName.OCI
+export class OCIResource extends S3AliasResource<OCIConfig, OCIConfigRedacted> {
   override readonly prompt: string = OCI_BROWSER_PROMPT
-  readonly ociConfig: OCIConfig
-  private readonly ociOps: readonly RegisteredOp[]
-  private readonly ociCommands: readonly RegisteredCommand[]
 
   constructor(config: OCIConfig) {
-    super(ociToS3Config(config))
-    this.ociConfig = config
-    this.ociOps = remapOpsResource(super.ops(), ResourceName.OCI)
-    this.ociCommands = remapCommandsResource(super.commands(), ResourceName.OCI)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.ociOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.ociCommands
-  }
-
-  override getState(): Promise<OCIResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactOciConfig(this.ociConfig),
-    })
-  }
-
-  override loadState(_state: OCIResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.OCI, config, ociToS3Config(config), redactOciConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/qingstor/qingstor.ts
+++ b/typescript/packages/browser/src/resource/qingstor/qingstor.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   qingStorToS3Config,
   redactQingStorConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { QINGSTOR_BROWSER_PROMPT } from './prompt.ts'
 
-export interface QingStorResourceState {
-  type: string
-  config: QingStorConfigRedacted
-}
+export type QingStorResourceState = S3AliasResourceState<QingStorConfigRedacted>
 
-export class QingStorResource extends S3Resource {
-  override readonly kind: string = ResourceName.QINGSTOR
+export class QingStorResource extends S3AliasResource<QingStorConfig, QingStorConfigRedacted> {
   override readonly prompt: string = QINGSTOR_BROWSER_PROMPT
-  readonly qingStorConfig: QingStorConfig
-  private readonly qingStorOps: readonly RegisteredOp[]
-  private readonly qingStorCommands: readonly RegisteredCommand[]
 
   constructor(config: QingStorConfig) {
-    super(qingStorToS3Config(config))
-    this.qingStorConfig = config
-    this.qingStorOps = remapOpsResource(super.ops(), ResourceName.QINGSTOR)
-    this.qingStorCommands = remapCommandsResource(super.commands(), ResourceName.QINGSTOR)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.qingStorOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.qingStorCommands
-  }
-
-  override getState(): Promise<QingStorResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactQingStorConfig(this.qingStorConfig),
-    })
-  }
-
-  override loadState(_state: QingStorResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.QINGSTOR, config, qingStorToS3Config(config), redactQingStorConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/r2/r2.ts
+++ b/typescript/packages/browser/src/resource/r2/r2.ts
@@ -12,49 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import { r2ToS3Config, redactR2Config, type R2Config, type R2ConfigRedacted } from './config.ts'
 import { R2_BROWSER_PROMPT } from './prompt.ts'
 
-export interface R2ResourceState {
-  type: string
-  config: R2ConfigRedacted
-}
+export type R2ResourceState = S3AliasResourceState<R2ConfigRedacted>
 
-export class R2Resource extends S3Resource {
-  override readonly kind: string = ResourceName.R2
+export class R2Resource extends S3AliasResource<R2Config, R2ConfigRedacted> {
   override readonly prompt: string = R2_BROWSER_PROMPT
-  readonly r2Config: R2Config
-  private readonly r2Ops: readonly RegisteredOp[]
-  private readonly r2Commands: readonly RegisteredCommand[]
 
   constructor(config: R2Config) {
-    super(r2ToS3Config(config))
-    this.r2Config = config
-    this.r2Ops = remapOpsResource(super.ops(), ResourceName.R2)
-    this.r2Commands = remapCommandsResource(super.commands(), ResourceName.R2)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.r2Ops
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.r2Commands
-  }
-
-  override getState(): Promise<R2ResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactR2Config(this.r2Config),
-    })
-  }
-
-  override loadState(_state: R2ResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.R2, config, r2ToS3Config(config), redactR2Config)
   }
 }

--- a/typescript/packages/browser/src/resource/s3_alias.ts
+++ b/typescript/packages/browser/src/resource/s3_alias.ts
@@ -12,8 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { S3Resource } from './s3/s3.ts'
+import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
+import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
+import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { redactConfigWithSchema, secretSchema, z } from '@struktoai/mirage-core/resource/secrets'
-import type { S3BrowserPresignedUrlProvider, S3Config } from './s3/config.ts'
+import type { S3BrowserPresignedUrlProvider, S3Config, S3ConfigRedacted } from './s3/config.ts'
 
 /**
  * Shared shape for the browser's S3-compatible providers.
@@ -133,5 +137,72 @@ export function makeBrowserS3Alias<
       }
     },
     redact: (config) => redactConfigWithSchema(schema, config) as unknown as R,
+  }
+}
+
+/**
+ * The snapshot state of an S3-compatible alias: its own kind and its own
+ * redacted config, not the `s3` kind and S3 config it delegates to.
+ */
+export interface S3AliasResourceState<TRedacted> {
+  type: string
+  config: TRedacted
+}
+
+/**
+ * The shared body of every S3-compatible provider resource (MinIO, Ceph,
+ * R2, Wasabi, ...). Each is an {@link S3Resource} reached through a
+ * provider-shaped config, so all it owns is its `kind`, that config, and
+ * ops/commands retagged from `s3` onto the kind. A subclass supplies its
+ * prompt as a plain field and hands the varying pieces to `super`.
+ *
+ * `toS3Config` and `redact` arrive as functions rather than as an
+ * {@link Alias}: the four providers whose region or endpoint rule fits
+ * neither {@link makeRegionAlias} nor {@link makeFixedAlias} write their
+ * own pair, so the resource layer takes the two functions every provider
+ * has either way. Mirrors python `S3AliasResource` in
+ * `mirage/resource/s3_alias.py`.
+ */
+export abstract class S3AliasResource<
+  TConfig,
+  TRedacted extends S3ConfigRedacted,
+> extends S3Resource {
+  override readonly kind: string
+  readonly aliasConfig: TConfig
+  private readonly aliasOps: readonly RegisteredOp[]
+  private readonly aliasCommands: readonly RegisteredCommand[]
+  private readonly redactAlias: (config: TConfig) => TRedacted
+
+  protected constructor(
+    kind: string,
+    config: TConfig,
+    s3Config: S3Config,
+    redact: (config: TConfig) => TRedacted,
+  ) {
+    super(s3Config)
+    this.kind = kind
+    this.aliasConfig = config
+    this.redactAlias = redact
+    this.aliasOps = remapOpsResource(super.ops(), kind)
+    this.aliasCommands = remapCommandsResource(super.commands(), kind)
+  }
+
+  override ops(): readonly RegisteredOp[] {
+    return this.aliasOps
+  }
+
+  override commands(): readonly RegisteredCommand[] {
+    return this.aliasCommands
+  }
+
+  override getState(): Promise<S3AliasResourceState<TRedacted>> {
+    return Promise.resolve({
+      type: this.kind,
+      config: this.redactAlias(this.aliasConfig),
+    })
+  }
+
+  override loadState(_state: S3AliasResourceState<TRedacted>): Promise<void> {
+    return Promise.resolve()
   }
 }

--- a/typescript/packages/browser/src/resource/scaleway/scaleway.ts
+++ b/typescript/packages/browser/src/resource/scaleway/scaleway.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactScalewayConfig,
   scalewayToS3Config,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { SCALEWAY_BROWSER_PROMPT } from './prompt.ts'
 
-export interface ScalewayResourceState {
-  type: string
-  config: ScalewayConfigRedacted
-}
+export type ScalewayResourceState = S3AliasResourceState<ScalewayConfigRedacted>
 
-export class ScalewayResource extends S3Resource {
-  override readonly kind: string = ResourceName.SCALEWAY
+export class ScalewayResource extends S3AliasResource<ScalewayConfig, ScalewayConfigRedacted> {
   override readonly prompt: string = SCALEWAY_BROWSER_PROMPT
-  readonly scalewayConfig: ScalewayConfig
-  private readonly scalewayOps: readonly RegisteredOp[]
-  private readonly scalewayCommands: readonly RegisteredCommand[]
 
   constructor(config: ScalewayConfig) {
-    super(scalewayToS3Config(config))
-    this.scalewayConfig = config
-    this.scalewayOps = remapOpsResource(super.ops(), ResourceName.SCALEWAY)
-    this.scalewayCommands = remapCommandsResource(super.commands(), ResourceName.SCALEWAY)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.scalewayOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.scalewayCommands
-  }
-
-  override getState(): Promise<ScalewayResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactScalewayConfig(this.scalewayConfig),
-    })
-  }
-
-  override loadState(_state: ScalewayResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.SCALEWAY, config, scalewayToS3Config(config), redactScalewayConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/seaweedfs/seaweedfs.ts
+++ b/typescript/packages/browser/src/resource/seaweedfs/seaweedfs.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactSeaweedFSConfig,
   seaweedfsToS3Config,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { SEAWEEDFS_BROWSER_PROMPT } from './prompt.ts'
 
-export interface SeaweedFSResourceState {
-  type: string
-  config: SeaweedFSConfigRedacted
-}
+export type SeaweedFSResourceState = S3AliasResourceState<SeaweedFSConfigRedacted>
 
-export class SeaweedFSResource extends S3Resource {
-  override readonly kind: string = ResourceName.SEAWEEDFS
+export class SeaweedFSResource extends S3AliasResource<SeaweedFSConfig, SeaweedFSConfigRedacted> {
   override readonly prompt: string = SEAWEEDFS_BROWSER_PROMPT
-  readonly seaweedfsConfig: SeaweedFSConfig
-  private readonly seaweedfsOps: readonly RegisteredOp[]
-  private readonly seaweedfsCommands: readonly RegisteredCommand[]
 
   constructor(config: SeaweedFSConfig) {
-    super(seaweedfsToS3Config(config))
-    this.seaweedfsConfig = config
-    this.seaweedfsOps = remapOpsResource(super.ops(), ResourceName.SEAWEEDFS)
-    this.seaweedfsCommands = remapCommandsResource(super.commands(), ResourceName.SEAWEEDFS)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.seaweedfsOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.seaweedfsCommands
-  }
-
-  override getState(): Promise<SeaweedFSResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactSeaweedFSConfig(this.seaweedfsConfig),
-    })
-  }
-
-  override loadState(_state: SeaweedFSResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.SEAWEEDFS, config, seaweedfsToS3Config(config), redactSeaweedFSConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/supabase/supabase.ts
+++ b/typescript/packages/browser/src/resource/supabase/supabase.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactSupabaseConfig,
   supabaseToS3Config,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { SUPABASE_BROWSER_PROMPT } from './prompt.ts'
 
-export interface SupabaseResourceState {
-  type: string
-  config: SupabaseConfigRedacted
-}
+export type SupabaseResourceState = S3AliasResourceState<SupabaseConfigRedacted>
 
-export class SupabaseResource extends S3Resource {
-  override readonly kind: string = ResourceName.SUPABASE
+export class SupabaseResource extends S3AliasResource<SupabaseConfig, SupabaseConfigRedacted> {
   override readonly prompt: string = SUPABASE_BROWSER_PROMPT
-  readonly supabaseConfig: SupabaseConfig
-  private readonly supabaseOps: readonly RegisteredOp[]
-  private readonly supabaseCommands: readonly RegisteredCommand[]
 
   constructor(config: SupabaseConfig) {
-    super(supabaseToS3Config(config))
-    this.supabaseConfig = config
-    this.supabaseOps = remapOpsResource(super.ops(), ResourceName.SUPABASE)
-    this.supabaseCommands = remapCommandsResource(super.commands(), ResourceName.SUPABASE)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.supabaseOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.supabaseCommands
-  }
-
-  override getState(): Promise<SupabaseResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactSupabaseConfig(this.supabaseConfig),
-    })
-  }
-
-  override loadState(_state: SupabaseResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.SUPABASE, config, supabaseToS3Config(config), redactSupabaseConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/tencent/tencent.ts
+++ b/typescript/packages/browser/src/resource/tencent/tencent.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactTencentConfig,
   tencentToS3Config,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { TENCENT_BROWSER_PROMPT } from './prompt.ts'
 
-export interface TencentResourceState {
-  type: string
-  config: TencentConfigRedacted
-}
+export type TencentResourceState = S3AliasResourceState<TencentConfigRedacted>
 
-export class TencentResource extends S3Resource {
-  override readonly kind: string = ResourceName.TENCENT
+export class TencentResource extends S3AliasResource<TencentConfig, TencentConfigRedacted> {
   override readonly prompt: string = TENCENT_BROWSER_PROMPT
-  readonly tencentConfig: TencentConfig
-  private readonly tencentOps: readonly RegisteredOp[]
-  private readonly tencentCommands: readonly RegisteredCommand[]
 
   constructor(config: TencentConfig) {
-    super(tencentToS3Config(config))
-    this.tencentConfig = config
-    this.tencentOps = remapOpsResource(super.ops(), ResourceName.TENCENT)
-    this.tencentCommands = remapCommandsResource(super.commands(), ResourceName.TENCENT)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.tencentOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.tencentCommands
-  }
-
-  override getState(): Promise<TencentResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactTencentConfig(this.tencentConfig),
-    })
-  }
-
-  override loadState(_state: TencentResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.TENCENT, config, tencentToS3Config(config), redactTencentConfig)
   }
 }

--- a/typescript/packages/browser/src/resource/wasabi/wasabi.ts
+++ b/typescript/packages/browser/src/resource/wasabi/wasabi.ts
@@ -12,54 +12,22 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactWasabiConfig,
-  wasabiToS3Config,
   type WasabiConfig,
   type WasabiConfigRedacted,
+  wasabiToS3Config,
 } from './config.ts'
 import { WASABI_BROWSER_PROMPT } from './prompt.ts'
 
-export interface WasabiResourceState {
-  type: string
-  config: WasabiConfigRedacted
-}
+export type WasabiResourceState = S3AliasResourceState<WasabiConfigRedacted>
 
-export class WasabiResource extends S3Resource {
-  override readonly kind: string = ResourceName.WASABI
+export class WasabiResource extends S3AliasResource<WasabiConfig, WasabiConfigRedacted> {
   override readonly prompt: string = WASABI_BROWSER_PROMPT
-  readonly wasabiConfig: WasabiConfig
-  private readonly wasabiOps: readonly RegisteredOp[]
-  private readonly wasabiCommands: readonly RegisteredCommand[]
 
   constructor(config: WasabiConfig) {
-    super(wasabiToS3Config(config))
-    this.wasabiConfig = config
-    this.wasabiOps = remapOpsResource(super.ops(), ResourceName.WASABI)
-    this.wasabiCommands = remapCommandsResource(super.commands(), ResourceName.WASABI)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.wasabiOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.wasabiCommands
-  }
-
-  override getState(): Promise<WasabiResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactWasabiConfig(this.wasabiConfig),
-    })
-  }
-
-  override loadState(_state: WasabiResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.WASABI, config, wasabiToS3Config(config), redactWasabiConfig)
   }
 }

--- a/typescript/packages/node/src/resource/aliyun/aliyun.ts
+++ b/typescript/packages/node/src/resource/aliyun/aliyun.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   aliyunToS3Config,
   redactAliyunConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { ALIYUN_PROMPT } from './prompt.ts'
 
-export interface AliyunResourceState {
-  type: string
-  config: AliyunConfigRedacted
-}
+export type AliyunResourceState = S3AliasResourceState<AliyunConfigRedacted>
 
-export class AliyunResource extends S3Resource {
-  override readonly kind: string = ResourceName.ALIYUN
+export class AliyunResource extends S3AliasResource<AliyunConfig, AliyunConfigRedacted> {
   override readonly prompt: string = ALIYUN_PROMPT
-  readonly aliyunConfig: AliyunConfig
-  private readonly aliyunOps: readonly RegisteredOp[]
-  private readonly aliyunCommands: readonly RegisteredCommand[]
 
   constructor(config: AliyunConfig) {
-    super(aliyunToS3Config(config))
-    this.aliyunConfig = config
-    this.aliyunOps = remapOpsResource(super.ops(), ResourceName.ALIYUN)
-    this.aliyunCommands = remapCommandsResource(super.commands(), ResourceName.ALIYUN)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.aliyunOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.aliyunCommands
-  }
-
-  override getState(): Promise<AliyunResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactAliyunConfig(this.aliyunConfig),
-    })
-  }
-
-  override loadState(_state: AliyunResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.ALIYUN, config, aliyunToS3Config(config), redactAliyunConfig)
   }
 }

--- a/typescript/packages/node/src/resource/backblaze/backblaze.ts
+++ b/typescript/packages/node/src/resource/backblaze/backblaze.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   backblazeToS3Config,
   redactBackblazeConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { BACKBLAZE_PROMPT } from './prompt.ts'
 
-export interface BackblazeResourceState {
-  type: string
-  config: BackblazeConfigRedacted
-}
+export type BackblazeResourceState = S3AliasResourceState<BackblazeConfigRedacted>
 
-export class BackblazeResource extends S3Resource {
-  override readonly kind: string = ResourceName.BACKBLAZE
+export class BackblazeResource extends S3AliasResource<BackblazeConfig, BackblazeConfigRedacted> {
   override readonly prompt: string = BACKBLAZE_PROMPT
-  readonly backblazeConfig: BackblazeConfig
-  private readonly backblazeOps: readonly RegisteredOp[]
-  private readonly backblazeCommands: readonly RegisteredCommand[]
 
   constructor(config: BackblazeConfig) {
-    super(backblazeToS3Config(config))
-    this.backblazeConfig = config
-    this.backblazeOps = remapOpsResource(super.ops(), ResourceName.BACKBLAZE)
-    this.backblazeCommands = remapCommandsResource(super.commands(), ResourceName.BACKBLAZE)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.backblazeOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.backblazeCommands
-  }
-
-  override getState(): Promise<BackblazeResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactBackblazeConfig(this.backblazeConfig),
-    })
-  }
-
-  override loadState(_state: BackblazeResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.BACKBLAZE, config, backblazeToS3Config(config), redactBackblazeConfig)
   }
 }

--- a/typescript/packages/node/src/resource/ceph/ceph.ts
+++ b/typescript/packages/node/src/resource/ceph/ceph.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   cephToS3Config,
   redactCephConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { CEPH_PROMPT } from './prompt.ts'
 
-export interface CephResourceState {
-  type: string
-  config: CephConfigRedacted
-}
+export type CephResourceState = S3AliasResourceState<CephConfigRedacted>
 
-export class CephResource extends S3Resource {
-  override readonly kind: string = ResourceName.CEPH
+export class CephResource extends S3AliasResource<CephConfig, CephConfigRedacted> {
   override readonly prompt: string = CEPH_PROMPT
-  readonly cephConfig: CephConfig
-  private readonly cephOps: readonly RegisteredOp[]
-  private readonly cephCommands: readonly RegisteredCommand[]
 
   constructor(config: CephConfig) {
-    super(cephToS3Config(config))
-    this.cephConfig = config
-    this.cephOps = remapOpsResource(super.ops(), ResourceName.CEPH)
-    this.cephCommands = remapCommandsResource(super.commands(), ResourceName.CEPH)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.cephOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.cephCommands
-  }
-
-  override getState(): Promise<CephResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactCephConfig(this.cephConfig),
-    })
-  }
-
-  override loadState(_state: CephResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.CEPH, config, cephToS3Config(config), redactCephConfig)
   }
 }

--- a/typescript/packages/node/src/resource/digitalocean/digitalocean.ts
+++ b/typescript/packages/node/src/resource/digitalocean/digitalocean.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   digitalOceanToS3Config,
   redactDigitalOceanConfig,
@@ -25,41 +22,20 @@ import {
 } from './config.ts'
 import { DIGITALOCEAN_PROMPT } from './prompt.ts'
 
-export interface DigitalOceanResourceState {
-  type: string
-  config: DigitalOceanConfigRedacted
-}
+export type DigitalOceanResourceState = S3AliasResourceState<DigitalOceanConfigRedacted>
 
-export class DigitalOceanResource extends S3Resource {
-  override readonly kind: string = ResourceName.DIGITALOCEAN
+export class DigitalOceanResource extends S3AliasResource<
+  DigitalOceanConfig,
+  DigitalOceanConfigRedacted
+> {
   override readonly prompt: string = DIGITALOCEAN_PROMPT
-  readonly digitalOceanConfig: DigitalOceanConfig
-  private readonly digitalOceanOps: readonly RegisteredOp[]
-  private readonly digitalOceanCommands: readonly RegisteredCommand[]
 
   constructor(config: DigitalOceanConfig) {
-    super(digitalOceanToS3Config(config))
-    this.digitalOceanConfig = config
-    this.digitalOceanOps = remapOpsResource(super.ops(), ResourceName.DIGITALOCEAN)
-    this.digitalOceanCommands = remapCommandsResource(super.commands(), ResourceName.DIGITALOCEAN)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.digitalOceanOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.digitalOceanCommands
-  }
-
-  override getState(): Promise<DigitalOceanResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactDigitalOceanConfig(this.digitalOceanConfig),
-    })
-  }
-
-  override loadState(_state: DigitalOceanResourceState): Promise<void> {
-    return Promise.resolve()
+    super(
+      ResourceName.DIGITALOCEAN,
+      config,
+      digitalOceanToS3Config(config),
+      redactDigitalOceanConfig,
+    )
   }
 }

--- a/typescript/packages/node/src/resource/gcs/gcs.ts
+++ b/typescript/packages/node/src/resource/gcs/gcs.ts
@@ -12,49 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import { gcsToS3Config, redactGcsConfig, type GCSConfig, type GCSConfigRedacted } from './config.ts'
 import { GCS_PROMPT } from './prompt.ts'
 
-export interface GCSResourceState {
-  type: string
-  config: GCSConfigRedacted
-}
+export type GCSResourceState = S3AliasResourceState<GCSConfigRedacted>
 
-export class GCSResource extends S3Resource {
-  override readonly kind: string = ResourceName.GCS
+export class GCSResource extends S3AliasResource<GCSConfig, GCSConfigRedacted> {
   override readonly prompt: string = GCS_PROMPT
-  readonly gcsConfig: GCSConfig
-  private readonly gcsOps: readonly RegisteredOp[]
-  private readonly gcsCommands: readonly RegisteredCommand[]
 
   constructor(config: GCSConfig) {
-    super(gcsToS3Config(config))
-    this.gcsConfig = config
-    this.gcsOps = remapOpsResource(super.ops(), ResourceName.GCS)
-    this.gcsCommands = remapCommandsResource(super.commands(), ResourceName.GCS)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.gcsOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.gcsCommands
-  }
-
-  override getState(): Promise<GCSResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactGcsConfig(this.gcsConfig),
-    })
-  }
-
-  override loadState(_state: GCSResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.GCS, config, gcsToS3Config(config), redactGcsConfig)
   }
 }

--- a/typescript/packages/node/src/resource/minio/minio.ts
+++ b/typescript/packages/node/src/resource/minio/minio.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   minioToS3Config,
   redactMinIOConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { MINIO_PROMPT } from './prompt.ts'
 
-export interface MinIOResourceState {
-  type: string
-  config: MinIOConfigRedacted
-}
+export type MinIOResourceState = S3AliasResourceState<MinIOConfigRedacted>
 
-export class MinIOResource extends S3Resource {
-  override readonly kind: string = ResourceName.MINIO
+export class MinIOResource extends S3AliasResource<MinIOConfig, MinIOConfigRedacted> {
   override readonly prompt: string = MINIO_PROMPT
-  readonly minioConfig: MinIOConfig
-  private readonly minioOps: readonly RegisteredOp[]
-  private readonly minioCommands: readonly RegisteredCommand[]
 
   constructor(config: MinIOConfig) {
-    super(minioToS3Config(config))
-    this.minioConfig = config
-    this.minioOps = remapOpsResource(super.ops(), ResourceName.MINIO)
-    this.minioCommands = remapCommandsResource(super.commands(), ResourceName.MINIO)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.minioOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.minioCommands
-  }
-
-  override getState(): Promise<MinIOResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactMinIOConfig(this.minioConfig),
-    })
-  }
-
-  override loadState(_state: MinIOResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.MINIO, config, minioToS3Config(config), redactMinIOConfig)
   }
 }

--- a/typescript/packages/node/src/resource/oci/oci.ts
+++ b/typescript/packages/node/src/resource/oci/oci.ts
@@ -12,49 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import { ociToS3Config, redactOciConfig, type OCIConfig, type OCIConfigRedacted } from './config.ts'
 import { OCI_PROMPT } from './prompt.ts'
 
-export interface OCIResourceState {
-  type: string
-  config: OCIConfigRedacted
-}
+export type OCIResourceState = S3AliasResourceState<OCIConfigRedacted>
 
-export class OCIResource extends S3Resource {
-  override readonly kind: string = ResourceName.OCI
+export class OCIResource extends S3AliasResource<OCIConfig, OCIConfigRedacted> {
   override readonly prompt: string = OCI_PROMPT
-  readonly ociConfig: OCIConfig
-  private readonly ociOps: readonly RegisteredOp[]
-  private readonly ociCommands: readonly RegisteredCommand[]
 
   constructor(config: OCIConfig) {
-    super(ociToS3Config(config))
-    this.ociConfig = config
-    this.ociOps = remapOpsResource(super.ops(), ResourceName.OCI)
-    this.ociCommands = remapCommandsResource(super.commands(), ResourceName.OCI)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.ociOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.ociCommands
-  }
-
-  override getState(): Promise<OCIResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactOciConfig(this.ociConfig),
-    })
-  }
-
-  override loadState(_state: OCIResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.OCI, config, ociToS3Config(config), redactOciConfig)
   }
 }

--- a/typescript/packages/node/src/resource/qingstor/qingstor.ts
+++ b/typescript/packages/node/src/resource/qingstor/qingstor.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   qingStorToS3Config,
   redactQingStorConfig,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { QINGSTOR_PROMPT } from './prompt.ts'
 
-export interface QingStorResourceState {
-  type: string
-  config: QingStorConfigRedacted
-}
+export type QingStorResourceState = S3AliasResourceState<QingStorConfigRedacted>
 
-export class QingStorResource extends S3Resource {
-  override readonly kind: string = ResourceName.QINGSTOR
+export class QingStorResource extends S3AliasResource<QingStorConfig, QingStorConfigRedacted> {
   override readonly prompt: string = QINGSTOR_PROMPT
-  readonly qingStorConfig: QingStorConfig
-  private readonly qingStorOps: readonly RegisteredOp[]
-  private readonly qingStorCommands: readonly RegisteredCommand[]
 
   constructor(config: QingStorConfig) {
-    super(qingStorToS3Config(config))
-    this.qingStorConfig = config
-    this.qingStorOps = remapOpsResource(super.ops(), ResourceName.QINGSTOR)
-    this.qingStorCommands = remapCommandsResource(super.commands(), ResourceName.QINGSTOR)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.qingStorOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.qingStorCommands
-  }
-
-  override getState(): Promise<QingStorResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactQingStorConfig(this.qingStorConfig),
-    })
-  }
-
-  override loadState(_state: QingStorResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.QINGSTOR, config, qingStorToS3Config(config), redactQingStorConfig)
   }
 }

--- a/typescript/packages/node/src/resource/r2/r2.ts
+++ b/typescript/packages/node/src/resource/r2/r2.ts
@@ -12,49 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import { r2ToS3Config, redactR2Config, type R2Config, type R2ConfigRedacted } from './config.ts'
 import { R2_PROMPT } from './prompt.ts'
 
-export interface R2ResourceState {
-  type: string
-  config: R2ConfigRedacted
-}
+export type R2ResourceState = S3AliasResourceState<R2ConfigRedacted>
 
-export class R2Resource extends S3Resource {
-  override readonly kind: string = ResourceName.R2
+export class R2Resource extends S3AliasResource<R2Config, R2ConfigRedacted> {
   override readonly prompt: string = R2_PROMPT
-  readonly r2Config: R2Config
-  private readonly r2Ops: readonly RegisteredOp[]
-  private readonly r2Commands: readonly RegisteredCommand[]
 
   constructor(config: R2Config) {
-    super(r2ToS3Config(config))
-    this.r2Config = config
-    this.r2Ops = remapOpsResource(super.ops(), ResourceName.R2)
-    this.r2Commands = remapCommandsResource(super.commands(), ResourceName.R2)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.r2Ops
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.r2Commands
-  }
-
-  override getState(): Promise<R2ResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactR2Config(this.r2Config),
-    })
-  }
-
-  override loadState(_state: R2ResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.R2, config, r2ToS3Config(config), redactR2Config)
   }
 }

--- a/typescript/packages/node/src/resource/s3_alias.ts
+++ b/typescript/packages/node/src/resource/s3_alias.ts
@@ -12,10 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { S3Resource } from './s3/s3.ts'
+import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
+import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
+import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core/resource/secrets'
 import type { ConfigOf, RedactedConfig } from '@struktoai/mirage-core/resource/secrets'
 import { normalizeFields } from '@struktoai/mirage-core/utils/normalize'
-import type { S3Config } from './s3/config.ts'
+import type { S3Config, S3ConfigRedacted } from './s3/config.ts'
 
 /**
  * Shared shape for the S3-compatible providers.
@@ -160,5 +164,72 @@ export function makeFixedAlias<C extends S3AliasConfig & { endpoint: string }, R
       }) as unknown as R,
     normalize: (input) =>
       normalizeFields(input, { rename: RENAME, transform: TRANSFORM }) as unknown as C,
+  }
+}
+
+/**
+ * The snapshot state of an S3-compatible alias: its own kind and its own
+ * redacted config, not the `s3` kind and S3 config it delegates to.
+ */
+export interface S3AliasResourceState<TRedacted> {
+  type: string
+  config: TRedacted
+}
+
+/**
+ * The shared body of every S3-compatible provider resource (MinIO, Ceph,
+ * R2, Wasabi, ...). Each is an {@link S3Resource} reached through a
+ * provider-shaped config, so all it owns is its `kind`, that config, and
+ * ops/commands retagged from `s3` onto the kind. A subclass supplies its
+ * prompt as a plain field and hands the varying pieces to `super`.
+ *
+ * `toS3Config` and `redact` arrive as functions rather than as an
+ * {@link Alias}: the four providers whose region or endpoint rule fits
+ * neither {@link makeRegionAlias} nor {@link makeFixedAlias} write their
+ * own pair, so the resource layer takes the two functions every provider
+ * has either way. Mirrors python `S3AliasResource` in
+ * `mirage/resource/s3_alias.py`.
+ */
+export abstract class S3AliasResource<
+  TConfig,
+  TRedacted extends S3ConfigRedacted,
+> extends S3Resource {
+  override readonly kind: string
+  readonly aliasConfig: TConfig
+  private readonly aliasOps: readonly RegisteredOp[]
+  private readonly aliasCommands: readonly RegisteredCommand[]
+  private readonly redactAlias: (config: TConfig) => TRedacted
+
+  protected constructor(
+    kind: string,
+    config: TConfig,
+    s3Config: S3Config,
+    redact: (config: TConfig) => TRedacted,
+  ) {
+    super(s3Config)
+    this.kind = kind
+    this.aliasConfig = config
+    this.redactAlias = redact
+    this.aliasOps = remapOpsResource(super.ops(), kind)
+    this.aliasCommands = remapCommandsResource(super.commands(), kind)
+  }
+
+  override ops(): readonly RegisteredOp[] {
+    return this.aliasOps
+  }
+
+  override commands(): readonly RegisteredCommand[] {
+    return this.aliasCommands
+  }
+
+  override getState(): Promise<S3AliasResourceState<TRedacted>> {
+    return Promise.resolve({
+      type: this.kind,
+      config: this.redactAlias(this.aliasConfig),
+    })
+  }
+
+  override loadState(_state: S3AliasResourceState<TRedacted>): Promise<void> {
+    return Promise.resolve()
   }
 }

--- a/typescript/packages/node/src/resource/scaleway/scaleway.ts
+++ b/typescript/packages/node/src/resource/scaleway/scaleway.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactScalewayConfig,
   scalewayToS3Config,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { SCALEWAY_PROMPT } from './prompt.ts'
 
-export interface ScalewayResourceState {
-  type: string
-  config: ScalewayConfigRedacted
-}
+export type ScalewayResourceState = S3AliasResourceState<ScalewayConfigRedacted>
 
-export class ScalewayResource extends S3Resource {
-  override readonly kind: string = ResourceName.SCALEWAY
+export class ScalewayResource extends S3AliasResource<ScalewayConfig, ScalewayConfigRedacted> {
   override readonly prompt: string = SCALEWAY_PROMPT
-  readonly scalewayConfig: ScalewayConfig
-  private readonly scalewayOps: readonly RegisteredOp[]
-  private readonly scalewayCommands: readonly RegisteredCommand[]
 
   constructor(config: ScalewayConfig) {
-    super(scalewayToS3Config(config))
-    this.scalewayConfig = config
-    this.scalewayOps = remapOpsResource(super.ops(), ResourceName.SCALEWAY)
-    this.scalewayCommands = remapCommandsResource(super.commands(), ResourceName.SCALEWAY)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.scalewayOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.scalewayCommands
-  }
-
-  override getState(): Promise<ScalewayResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactScalewayConfig(this.scalewayConfig),
-    })
-  }
-
-  override loadState(_state: ScalewayResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.SCALEWAY, config, scalewayToS3Config(config), redactScalewayConfig)
   }
 }

--- a/typescript/packages/node/src/resource/seaweedfs/seaweedfs.ts
+++ b/typescript/packages/node/src/resource/seaweedfs/seaweedfs.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactSeaweedFSConfig,
   seaweedfsToS3Config,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { SEAWEEDFS_PROMPT } from './prompt.ts'
 
-export interface SeaweedFSResourceState {
-  type: string
-  config: SeaweedFSConfigRedacted
-}
+export type SeaweedFSResourceState = S3AliasResourceState<SeaweedFSConfigRedacted>
 
-export class SeaweedFSResource extends S3Resource {
-  override readonly kind: string = ResourceName.SEAWEEDFS
+export class SeaweedFSResource extends S3AliasResource<SeaweedFSConfig, SeaweedFSConfigRedacted> {
   override readonly prompt: string = SEAWEEDFS_PROMPT
-  readonly seaweedfsConfig: SeaweedFSConfig
-  private readonly seaweedfsOps: readonly RegisteredOp[]
-  private readonly seaweedfsCommands: readonly RegisteredCommand[]
 
   constructor(config: SeaweedFSConfig) {
-    super(seaweedfsToS3Config(config))
-    this.seaweedfsConfig = config
-    this.seaweedfsOps = remapOpsResource(super.ops(), ResourceName.SEAWEEDFS)
-    this.seaweedfsCommands = remapCommandsResource(super.commands(), ResourceName.SEAWEEDFS)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.seaweedfsOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.seaweedfsCommands
-  }
-
-  override getState(): Promise<SeaweedFSResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactSeaweedFSConfig(this.seaweedfsConfig),
-    })
-  }
-
-  override loadState(_state: SeaweedFSResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.SEAWEEDFS, config, seaweedfsToS3Config(config), redactSeaweedFSConfig)
   }
 }

--- a/typescript/packages/node/src/resource/supabase/supabase.ts
+++ b/typescript/packages/node/src/resource/supabase/supabase.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactSupabaseConfig,
   supabaseToS3Config,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { SUPABASE_PROMPT } from './prompt.ts'
 
-export interface SupabaseResourceState {
-  type: string
-  config: SupabaseConfigRedacted
-}
+export type SupabaseResourceState = S3AliasResourceState<SupabaseConfigRedacted>
 
-export class SupabaseResource extends S3Resource {
-  override readonly kind: string = ResourceName.SUPABASE
+export class SupabaseResource extends S3AliasResource<SupabaseConfig, SupabaseConfigRedacted> {
   override readonly prompt: string = SUPABASE_PROMPT
-  readonly supabaseConfig: SupabaseConfig
-  private readonly supabaseOps: readonly RegisteredOp[]
-  private readonly supabaseCommands: readonly RegisteredCommand[]
 
   constructor(config: SupabaseConfig) {
-    super(supabaseToS3Config(config))
-    this.supabaseConfig = config
-    this.supabaseOps = remapOpsResource(super.ops(), ResourceName.SUPABASE)
-    this.supabaseCommands = remapCommandsResource(super.commands(), ResourceName.SUPABASE)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.supabaseOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.supabaseCommands
-  }
-
-  override getState(): Promise<SupabaseResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactSupabaseConfig(this.supabaseConfig),
-    })
-  }
-
-  override loadState(_state: SupabaseResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.SUPABASE, config, supabaseToS3Config(config), redactSupabaseConfig)
   }
 }

--- a/typescript/packages/node/src/resource/tencent/tencent.ts
+++ b/typescript/packages/node/src/resource/tencent/tencent.ts
@@ -12,11 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactTencentConfig,
   tencentToS3Config,
@@ -25,41 +22,12 @@ import {
 } from './config.ts'
 import { TENCENT_PROMPT } from './prompt.ts'
 
-export interface TencentResourceState {
-  type: string
-  config: TencentConfigRedacted
-}
+export type TencentResourceState = S3AliasResourceState<TencentConfigRedacted>
 
-export class TencentResource extends S3Resource {
-  override readonly kind: string = ResourceName.TENCENT
+export class TencentResource extends S3AliasResource<TencentConfig, TencentConfigRedacted> {
   override readonly prompt: string = TENCENT_PROMPT
-  readonly tencentConfig: TencentConfig
-  private readonly tencentOps: readonly RegisteredOp[]
-  private readonly tencentCommands: readonly RegisteredCommand[]
 
   constructor(config: TencentConfig) {
-    super(tencentToS3Config(config))
-    this.tencentConfig = config
-    this.tencentOps = remapOpsResource(super.ops(), ResourceName.TENCENT)
-    this.tencentCommands = remapCommandsResource(super.commands(), ResourceName.TENCENT)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.tencentOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.tencentCommands
-  }
-
-  override getState(): Promise<TencentResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactTencentConfig(this.tencentConfig),
-    })
-  }
-
-  override loadState(_state: TencentResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.TENCENT, config, tencentToS3Config(config), redactTencentConfig)
   }
 }

--- a/typescript/packages/node/src/resource/wasabi/wasabi.ts
+++ b/typescript/packages/node/src/resource/wasabi/wasabi.ts
@@ -12,54 +12,22 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { RegisteredCommand } from '@struktoai/mirage-core/commands/config'
-import type { RegisteredOp } from '@struktoai/mirage-core/ops/registry'
-import { remapCommandsResource, remapOpsResource } from '@struktoai/mirage-core/resource/s3/remap'
 import { ResourceName } from '@struktoai/mirage-core/types'
-import { S3Resource } from '../s3/s3.ts'
+import { S3AliasResource, type S3AliasResourceState } from '../s3_alias.ts'
 import {
   redactWasabiConfig,
-  wasabiToS3Config,
   type WasabiConfig,
   type WasabiConfigRedacted,
+  wasabiToS3Config,
 } from './config.ts'
 import { WASABI_PROMPT } from './prompt.ts'
 
-export interface WasabiResourceState {
-  type: string
-  config: WasabiConfigRedacted
-}
+export type WasabiResourceState = S3AliasResourceState<WasabiConfigRedacted>
 
-export class WasabiResource extends S3Resource {
-  override readonly kind: string = ResourceName.WASABI
+export class WasabiResource extends S3AliasResource<WasabiConfig, WasabiConfigRedacted> {
   override readonly prompt: string = WASABI_PROMPT
-  readonly wasabiConfig: WasabiConfig
-  private readonly wasabiOps: readonly RegisteredOp[]
-  private readonly wasabiCommands: readonly RegisteredCommand[]
 
   constructor(config: WasabiConfig) {
-    super(wasabiToS3Config(config))
-    this.wasabiConfig = config
-    this.wasabiOps = remapOpsResource(super.ops(), ResourceName.WASABI)
-    this.wasabiCommands = remapCommandsResource(super.commands(), ResourceName.WASABI)
-  }
-
-  override ops(): readonly RegisteredOp[] {
-    return this.wasabiOps
-  }
-
-  override commands(): readonly RegisteredCommand[] {
-    return this.wasabiCommands
-  }
-
-  override getState(): Promise<WasabiResourceState> {
-    return Promise.resolve({
-      type: this.kind,
-      config: redactWasabiConfig(this.wasabiConfig),
-    })
-  }
-
-  override loadState(_state: WasabiResourceState): Promise<void> {
-    return Promise.resolve()
+    super(ResourceName.WASABI, config, wasabiToS3Config(config), redactWasabiConfig)
   }
 }


### PR DESCRIPTION
## What

Every S3-compatible provider resource (MinIO, Ceph, R2, Wasabi, ...) is an `S3Resource` reached through a provider-shaped config, and each one hand-wrote the same class body: store the config, retag ops and commands from `s3` onto the alias kind, build redacted state, no-op `loadState`. That body was duplicated **28 times in TypeScript** (14 providers × browser + node, differing only in the prompt constant) and **14 times in Python**.

This collapses all 42 onto a shared `S3AliasResource`. **52 files, −843 lines net.**

## Where it lives

The *config* half was already shared — `resource/s3_alias.{ts,py}` holds `S3AliasConfig` plus the region/fixed endpoint rules — so the resource half joins it in the same module rather than a new file. That also keeps the layout-parity gate at baseline, which is what caught the first attempt at `resource/s3/alias.ts`.

`S3AliasResource` **cannot** live in `core`: `S3Resource` is defined once per runtime package and the two are different hierarchies (browser `implements Resource`, node `extends BaseResource`). So each runtime package gets one, which is 28 → 2.

Python's copy absorbs `__init__` and `get_state`. The 14 `load_state` overrides went with it — `S3Resource.load_state` was already a documented no-op, so those 14 never did anything.

## Three design calls

**A base class, not a factory.** `MinIOResource` stays a real class, so its name still works as a type, `instanceof` and subclassing still work, and the prompt stays a plain field. A factory (`export const MinIOResource = make(...)`) would have forced `export type MinIOResource = InstanceType<typeof MinIOResource>` and given worse hovers for no extra collapse. Python's own alias resources are short *because* they subclass, so this mirrors the side that already had it right.

**The prompt is untouched on both access paths.** `MINIO_PROMPT` lives in `prompt.ts` and is still re-exported from the package index, so importing it directly is unchanged; the runtime read (`resource.prompt` in `server/summary.ts`, `m.resource.PROMPT` in `workspace/file_prompt.py`) is still a plain field read.

**`toS3Config` and `redact` pass as functions, not as the existing `Alias<C, R>` object.** Four providers — gcs, oci, supabase, wasabi — have region/endpoint rules that fit neither `makeRegionAlias` nor `makeFixedAlias` and write their own pair. The two functions are what every provider has either way; the `Alias` object is not.

## The one deliberate break

The per-provider `minioConfig` / `minio_config` field is now `aliasConfig` / `alias_config`. Nothing outside each class read it except seven Python tests, updated here. No backward-compatibility shim, per `CLAUDE.md`.

## Verification

| | |
|---|---|
| node tests | 2399 passed, 0 failed |
| browser tests | 212 passed, 0 failed |
| python suite | exit 0, 0 failures (`--ignore=tests/fuse`, no macFUSE here) |
| mypy | clean, 1973 files |
| `pnpm -r typecheck` | 11/11 projects |
| eslint / knip / prettier | clean |
| layout parity | 259 = baseline |
| case targets | 2289 = baseline |
| spec parity | 93 commands match |
| barrel surface | 77 names |
| spec + width drift | none after regen |

The existing `s3_aliases.test.ts` battery (81 tests) already asserts exactly what moved — alias kind, retagged ops, retagged commands, redacted state — for all 14 providers across both endpoint families, so this refactor had a real regression net rather than a hopeful one.

One local caveat: the `Type check (mypy)` pre-commit hook reports Failed while mypy itself prints `Success` — the hook's `uv run` relocks `uv.lock`. `uv run --frozen mypy` passes with the lock untouched, and `uv.lock` is not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
