### PR TITLE
feat(observe): surface op events and join them to their line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,18 @@ Packages split by role, one module per concern, the same way in both languages:
 Command history is a recording, not a command log. A hidden `Observer` records every top-level command as timestamp-ordered events (`COMMAND`, `CLEAR`, `DELETE`, op events); the user-facing surfaces are just views of those events.
 
 - **Observer + ObserverStore.** The `Observer` owns a storage-agnostic `ObserverStore` (`append`/`write`/`readAll`/`readMatching`/`clear`/`close`), not a mount. Stores: `RAMObserverStore` (core, default), `DiskObserverStore` and `RedisObserverStore` (node). RAM is just the default, history can persist to disk or Redis.
+- **Op events are readable, and joined to their line.** Every event the
+  recorder writes is reachable: `ws.history()` / `ws.op_history()`
+  (`history()` / `opHistory()`) are the two views, and `Observer.line_events`
+  / `lineEvents` returns one typed line's ops followed by its command entry.
+  What joins them is `line_id`, minted once per `RecordingScope` /
+  `runWithRecording` and stamped on every `OpRecord` and on the command
+  entry, so a nested eval's ops carry the *top-level* line's id. An op
+  raised outside a scope (a FUSE callback, a direct `ws.ops` / `ws.fs`
+  call) carries none, which is what "no line caused this" looks like.
+  Snapshots still capture COMMAND/CLEAR/DELETE only: a snapshot pins reads
+  through fingerprints and revisions, so the transfer log would add size
+  without adding a fact it restores from.
 - **Two views over the same events.** `/.bash_history` is a read-only view mount (`HistoryViewResource`) rendered in GNU bash histfile format (`#<epoch>` line then the command), so `cat`/`grep`/`tail`/`find` work on it for free. The `history` shell builtin (GNU `-c -d -a -n -r -w -s -p` + count) routes through the same mount, so file and builtin never disagree.
 - **Recording scope.** Top-level lines record; nested evals (`$()`, `eval`, `source`, `xargs`) run with `record: false`, so their inner ops bubble to the parent and no spurious command is logged (mirrors GNU's line reader).
 - **Snapshots.** History is captured as events into snapshot state and restored on load.

--- a/docs/home/observer.mdx
+++ b/docs/home/observer.mdx
@@ -68,6 +68,46 @@ const wsRedis = new Workspace(
 
 </CodeGroup>
 
+## Reading the events
+
+Every event the recorder writes is reachable programmatically. Command events and
+op events are separate views over the same log, and a `line_id` joins them: an op
+carries the id of the typed line that caused it, and that line's command event
+carries the same id.
+
+<CodeGroup>
+
+```python Python
+await ws.history()      # command events, all sessions, timestamp order
+await ws.op_history()   # op events, all sessions, timestamp order
+
+# Every op one line caused, then the line itself
+line_id = (await ws.observer.command_events())[-1]["line_id"]
+await ws.observer.line_events(line_id)
+```
+
+```typescript TypeScript
+await ws.history() // command events, all sessions, timestamp order
+await ws.opHistory() // op events, all sessions, timestamp order
+
+// Every op one line caused, then the line itself
+const commands = await ws.observer.commandEvents()
+await ws.observer.lineEvents(commands.at(-1).line_id)
+```
+
+</CodeGroup>
+
+An op event carries `op`, `path` (virtual, mount prefix included), `source`,
+`bytes`, `duration_ms` and `line_id`. Ops raised outside a typed line (a FUSE
+callback, a direct `ws.ops` / `ws.fs` call) carry no `line_id`, because no line
+caused them.
+
+<Note>
+Op events cover byte transfers — reads, writes, and the create/truncate/unlink
+family. Metadata ops (`stat`, `readdir`) are recorded on the ops facade and FUSE
+paths, not for shell commands, so an `ls` leaves a command event and no op event.
+</Note>
+
 ## Supported: command history
 
 The Observer powers a GNU-bash-compatible history, exposed two ways over the same
@@ -93,5 +133,8 @@ The format is GNU bash (`#<epoch>`), not zsh (`: <ts>:<dur>;<cmd>`).
 
 History is part of the workspace state: the Observer's command, clear, and delete
 events are captured into a [snapshot](/home/snapshot) and restored on load, so a
-restored workspace replays with the same history. The `/.bash_history` view mount
+restored workspace replays with the same history. Op events are deliberately left
+out: a snapshot pins what was read through fingerprints and revisions, and
+carrying the whole transfer log would grow the snapshot without adding a fact it
+restores from. The `/.bash_history` view mount
 itself is not stored, it is a live projection rebuilt from the events.

--- a/python/mirage/observe/context.py
+++ b/python/mirage/observe/context.py
@@ -18,6 +18,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 
 from mirage.observe.record import OpRecord
+from mirage.utils.ids import uuid7
 
 
 @dataclass(frozen=True)
@@ -35,10 +36,14 @@ class Recorder:
         sink (list[OpRecord]): Where new records are appended.
         mount_prefix (str): Current frame's mount prefix (e.g. "/s3").
             Empty when no mount is active.
+        line_id (str): Identifier of the typed line being recorded,
+            stamped onto every record so the ops and the command event
+            share a key. Empty when no line owns the frame.
     """
 
     sink: list[OpRecord] = field(default_factory=list)
     mount_prefix: str = ""
+    line_id: str = ""
 
 
 _recorder: ContextVar[Recorder | None] = ContextVar("_recorder", default=None)
@@ -54,6 +59,11 @@ class RecordingScope:
     eval, xargs, ...) construct one so their ops flow into the
     enclosing typed line's scope instead of opening their own.
 
+    ``line_id`` identifies the line for the whole of its run and is
+    stamped on every record the scope collects. An inactive scope
+    reports the enclosing line's id rather than one of its own, so a
+    nested eval's ops are attributed to the top-level line that ran it.
+
     Args:
         active (bool): False joins the enclosing scope instead of
             opening a new one.
@@ -63,9 +73,13 @@ class RecordingScope:
         self.records: list[OpRecord] = []
         self._token = None
         if active:
-            rec = Recorder()
+            rec = Recorder(line_id=uuid7())
             self.records = rec.sink
             self._token = _recorder.set(rec)
+            self.line_id = rec.line_id
+            return
+        enclosing = _recorder.get()
+        self.line_id = "" if enclosing is None else enclosing.line_id
 
     def close(self) -> None:
         """Restore the previous recorder. Idempotent."""
@@ -124,7 +138,8 @@ def push_mount_prefix(prefix: str) -> str:
     rec = _recorder.get()
     if rec is None:
         return ""
-    _recorder.set(Recorder(sink=rec.sink, mount_prefix=prefix))
+    _recorder.set(
+        Recorder(sink=rec.sink, mount_prefix=prefix, line_id=rec.line_id))
     return rec.mount_prefix
 
 
@@ -213,6 +228,7 @@ def record(op: str,
             duration_ms=elapsed,
             fingerprint=fingerprint,
             revision=revision,
+            line_id=rec.line_id or None,
         ))
 
 
@@ -257,6 +273,7 @@ def record_stream(op: str,
         duration_ms=0,
         fingerprint=fingerprint,
         revision=revision,
+        line_id=rec.line_id or None,
     )
     rec.sink.append(op_rec)
     return op_rec

--- a/python/mirage/observe/log_entry.py
+++ b/python/mirage/observe/log_entry.py
@@ -44,6 +44,9 @@ class LogEntry:
         stdout (str | None): Truncated stdout (for type="command").
         offset (int | None): 1-based listing position (for
             type="delete"); negative counts back from the end.
+        line_id (str | None): The typed line this event belongs to. An
+            op event and the command event it ran under carry the same
+            value, which is what joins them.
     """
 
     type: str
@@ -60,6 +63,7 @@ class LogEntry:
     exit_code: int | None = None
     stdout: str | None = None
     offset: int | None = None
+    line_id: str | None = None
 
     @staticmethod
     def from_op_record(
@@ -90,6 +94,7 @@ class LogEntry:
             source=rec.source,
             bytes=rec.bytes,
             duration_ms=rec.duration_ms,
+            line_id=rec.line_id,
         )
 
     def to_json_line(self) -> str:

--- a/python/mirage/observe/observer.py
+++ b/python/mirage/observe/observer.py
@@ -90,6 +90,7 @@ class Observer:
         agent: str,
         session: str,
         cwd: str | None = None,
+        line_id: str | None = None,
     ) -> None:
         """Record one finished typed line: its ops, then its command.
 
@@ -103,6 +104,8 @@ class Observer:
             agent (str): Agent that issued the line.
             session (str): Session the line ran in.
             cwd (str | None): Session cwd at completion.
+            line_id (str | None): Identifier the line's op records
+                carry, stamped on the command entry so the two join.
         """
         # TODO: batch the op lines and the command line into a single
         # store.append so one typed line costs one roundtrip and lands
@@ -120,6 +123,7 @@ class Observer:
                 command=command,
                 exit_code=io.exit_code,
                 stdout=stdout.decode(errors="replace")[:STDOUT_TRUNCATE],
+                line_id=line_id,
             ))
 
     async def log_command_text(self,
@@ -207,6 +211,34 @@ class Observer:
         return [
             e for e in await self.events() if e.get("type") == EVENT_COMMAND
         ]
+
+    async def op_events(self) -> list[dict[str, Any]]:
+        """Op events across all sessions, in timestamp order.
+
+        The recorder writes one of these per byte transfer a line
+        caused. They share their ``line_id`` with the command event
+        that produced them, so :meth:`line_events` joins the two.
+
+        Returns:
+            list[dict]: Events with type == EVENT_OP.
+        """
+        return [e for e in await self.events() if e.get("type") == EVENT_OP]
+
+    async def line_events(self, line_id: str) -> list[dict[str, Any]]:
+        """Every event one typed line produced, in append order.
+
+        The line's ops come first and its command entry last, which is
+        the order they were recorded in.
+
+        Args:
+            line_id (str): The line identifier to select on.
+
+        Returns:
+            list[dict]: Events carrying that ``line_id``.
+        """
+        if not line_id:
+            return []
+        return [e for e in await self.events() if e.get("line_id") == line_id]
 
     async def session_command_events(self,
                                      session: str) -> list[dict[str, Any]]:

--- a/python/mirage/observe/record.py
+++ b/python/mirage/observe/record.py
@@ -39,6 +39,10 @@ class OpRecord:
             bytes can be re-fetched even if the live object has moved on.
             Strictly stronger than ``fingerprint`` — populated only by
             backends that can guarantee revision durability.
+        line_id (str | None): The typed line this op was emitted under,
+            shared with that line's command event so the two can be
+            joined. None for an op raised outside a recording scope
+            (a FUSE callback, a direct ``ws.ops`` call).
     """
 
     op: str
@@ -49,6 +53,7 @@ class OpRecord:
     duration_ms: int
     fingerprint: str | None = field(default=None)
     revision: str | None = field(default=None)
+    line_id: str | None = field(default=None)
 
     @property
     def is_cache(self) -> bool:

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import asyncio
 import errno
 import time
 from typing import Any
@@ -128,8 +127,8 @@ class Ops:
         norm = ("/" + stripped + "/" if stripped else "/")
         self._mounts = [m for m in self._mounts if m.prefix != norm]
 
-    def _record(self, op: str, path: str, source: str, nbytes: int,
-                start_ms: int) -> None:
+    async def _record(self, op: str, path: str, source: str, nbytes: int,
+                      start_ms: int) -> None:
         elapsed = int(time.monotonic() * 1000) - start_ms
         # A facade call raised by guest code inside a typed line (the
         # runtime's patched open()) belongs to that line; one raised by
@@ -146,8 +145,12 @@ class Ops:
         )
         self.records.append(rec)
         if self._observer is not None:
-            asyncio.ensure_future(
-                self._observer.log_op(rec, self._agent_id, self._session_id))
+            # Awaited, not fired and forgotten: an ensure_future here
+            # left the event unwritten when the caller read the log on
+            # the next line (the RAM store's read never yields, so the
+            # task had not run), and let close() race a pending append.
+            # TypeScript's sink is awaited for the same reason.
+            await self._observer.log_op(rec, self._agent_id, self._session_id)
 
     def _owner(self, path: str) -> OpsMount | None:
         """The mount owning ``path`` by longest prefix, or None."""
@@ -215,17 +218,17 @@ class Ops:
             # moment of completion, so even a foreign error the door
             # never defined leaves the transfer on the books.
             if report.completed and owner is not None:
-                self._record_op(op, path, owner, report.source, report.bytes,
-                                None, kwargs, start)
+                await self._record_op(op, path, owner, report.source,
+                                      report.bytes, None, kwargs, start)
             raise
         if owner is not None:
-            self._record_op(op, path, owner, report.source, report.bytes,
-                            result, kwargs, start)
+            await self._record_op(op, path, owner, report.source, report.bytes,
+                                  result, kwargs, start)
         return result
 
-    def _record_op(self, op: str, path: str, owner: OpsMount,
-                   source: str | None, moved: int | None, result: Any,
-                   kwargs: dict[str, Any], start: int) -> None:
+    async def _record_op(self, op: str, path: str, owner: OpsMount,
+                         source: str | None, moved: int | None, result: Any,
+                         kwargs: dict[str, Any], start: int) -> None:
         """Record one op from the door's report of who served it.
 
         The door names the server when it was not the owning mount (a
@@ -248,7 +251,8 @@ class Ops:
         """
         nbytes = (moved if moved is not None else self._payload_bytes(
             result, kwargs))
-        self._record(op, path, source or owner.resource_type, nbytes, start)
+        await self._record(op, path, source or owner.resource_type, nbytes,
+                           start)
 
     async def read(self,
                    path: str,

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from mirage.io import OpReport
 from mirage.observe import OpRecord
+from mirage.observe.context import active_recorder
 from mirage.ops.config import NO_FOLLOW_OPS, NamespaceLinks, OpsMount
 from mirage.runtime.types import DispatchFn
 from mirage.types import FileStat, FileType, MountMode, PathSpec
@@ -130,6 +131,10 @@ class Ops:
     def _record(self, op: str, path: str, source: str, nbytes: int,
                 start_ms: int) -> None:
         elapsed = int(time.monotonic() * 1000) - start_ms
+        # A facade call raised by guest code inside a typed line (the
+        # runtime's patched open()) belongs to that line; one raised by
+        # a FUSE callback belongs to no line and carries none.
+        recorder = active_recorder()
         rec = OpRecord(
             op=op,
             path=path,
@@ -137,6 +142,7 @@ class Ops:
             bytes=nbytes,
             timestamp=int(time.time() * 1000),
             duration_ms=elapsed,
+            line_id=(recorder.line_id or None) if recorder else None,
         )
         self.records.append(rec)
         if self._observer is not None:

--- a/python/mirage/workspace/workspace/execute.py
+++ b/python/mirage/workspace/workspace/execute.py
@@ -278,6 +278,10 @@ async def execute_line(
         await ws._session_mgr.flush()
         ws._ops.records.extend(scope.records)
         if is_line:
-            await ws.observer.log_execution(command, io, scope.records, agent
-                                            or "", session_id,
-                                            session_cwd(ws, session_id))
+            await ws.observer.log_execution(command,
+                                            io,
+                                            scope.records,
+                                            agent or "",
+                                            session_id,
+                                            session_cwd(ws, session_id),
+                                            line_id=scope.line_id)

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -289,6 +289,17 @@ class Workspace:
         return await explain_line(parse(line), session, self._registry,
                                   self._namespace)
 
+    async def op_history(self) -> list[dict[str, Any]]:
+        """Op events recorded by the hidden recorder.
+
+        One entry per byte transfer a command caused, carrying the
+        ``line_id`` of the line that caused it.
+
+        Returns:
+            list[dict]: All sessions' op events, timestamp order.
+        """
+        return await self.observer.op_events()
+
     @property
     def ops(self) -> Ops:
         return self._ops

--- a/python/tests/observe/test_op_events.py
+++ b/python/tests/observe/test_op_events.py
@@ -1,0 +1,100 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage import MountMode, Workspace
+from mirage.observe.log_entry import EVENT_COMMAND, EVENT_OP
+from mirage.resource.ram import RAMResource
+
+
+async def _ws_after(*lines: str) -> Workspace:
+    ws = Workspace({"/ram": RAMResource()}, mode=MountMode.WRITE)
+    for line in lines:
+        await ws.execute(line)
+    return ws
+
+
+async def _events_after(*lines: str) -> tuple[list[dict], list[dict]]:
+    ws = await _ws_after(*lines)
+    return await ws.observer.command_events(), await ws.observer.op_events()
+
+
+async def _op_history_and_op_events() -> tuple[list[dict], list[dict]]:
+    ws = await _ws_after("echo hi > /ram/x.txt")
+    return await ws.op_history(), await ws.observer.op_events()
+
+
+async def _history_types() -> set[str]:
+    ws = await _ws_after("echo hi > /ram/x.txt")
+    return {e["type"] for e in await ws.history()}
+
+
+async def _line_events_of_second_command() -> list[dict]:
+    ws = await _ws_after("echo hi > /ram/x.txt", "cat /ram/x.txt")
+    commands = await ws.observer.command_events()
+    return await ws.observer.line_events(commands[1]["line_id"])
+
+
+async def _records_and_line_id() -> tuple[list[str | None], str]:
+    ws = await _ws_after("echo hi > /ram/x.txt")
+    commands = await ws.observer.command_events()
+    return [r.line_id for r in ws.ops.records], commands[0]["line_id"]
+
+
+def test_op_events_are_reachable():
+    _, ops = asyncio.run(
+        _events_after("echo hi > /ram/x.txt", "cat /ram/x.txt"))
+    assert [e["op"] for e in ops] == ["write", "read"]
+    assert all(e["type"] == EVENT_OP for e in ops)
+
+
+def test_op_history_mirrors_observer():
+    history, events = asyncio.run(_op_history_and_op_events())
+    assert history == events
+
+
+def test_history_still_holds_commands_only():
+    assert asyncio.run(_history_types()) == {EVENT_COMMAND}
+
+
+def test_line_id_joins_ops_to_their_command():
+    commands, ops = asyncio.run(
+        _events_after("echo hi > /ram/x.txt", "cat /ram/x.txt"))
+    first, second = commands[0]["line_id"], commands[1]["line_id"]
+    assert first and second and first != second
+    assert [e["line_id"] for e in ops] == [first, second]
+
+
+def test_line_events_returns_the_ops_then_their_command():
+    events = asyncio.run(_line_events_of_second_command())
+    assert [e["type"] for e in events] == [EVENT_OP, EVENT_COMMAND]
+    assert events[0]["op"] == "read"
+    assert events[1]["command"] == "cat /ram/x.txt"
+
+
+def test_nested_eval_ops_carry_the_top_level_line_id():
+    commands, ops = asyncio.run(
+        _events_after("echo hi > /ram/x.txt", "echo $(cat /ram/x.txt)"))
+    assert [c["command"] for c in commands] == [
+        "echo hi > /ram/x.txt",
+        "echo $(cat /ram/x.txt)",
+    ]
+    assert [o["op"] for o in ops] == ["write", "read"]
+    assert ops[1]["line_id"] == commands[1]["line_id"]
+
+
+def test_op_records_carry_the_line_id():
+    line_ids, command_line_id = asyncio.run(_records_and_line_id())
+    assert line_ids == [command_line_id]

--- a/python/tests/observe/test_op_events.py
+++ b/python/tests/observe/test_op_events.py
@@ -47,6 +47,14 @@ async def _line_events_of_second_command() -> list[dict]:
     return await ws.observer.line_events(commands[1]["line_id"])
 
 
+async def _facade_write_then_read() -> tuple[list[dict], list[dict]]:
+    ws = Workspace({"/ram": RAMResource()}, mode=MountMode.WRITE)
+    await ws.ops.write("/ram/a.txt", b"hello")
+    immediate = await ws.op_history()
+    await asyncio.sleep(0)
+    return immediate, await ws.op_history()
+
+
 async def _records_and_line_id() -> tuple[list[str | None], str]:
     ws = await _ws_after("echo hi > /ram/x.txt")
     commands = await ws.observer.command_events()
@@ -93,6 +101,12 @@ def test_nested_eval_ops_carry_the_top_level_line_id():
     ]
     assert [o["op"] for o in ops] == ["write", "read"]
     assert ops[1]["line_id"] == commands[1]["line_id"]
+
+
+def test_a_facade_write_is_readable_without_yielding():
+    immediate, after_yield = asyncio.run(_facade_write_then_read())
+    assert [e["op"] for e in immediate] == ["write"]
+    assert immediate == after_yield
 
 
 def test_op_records_carry_the_line_id():

--- a/typescript/packages/core/src/observe/context.ts
+++ b/typescript/packages/core/src/observe/context.ts
@@ -14,11 +14,17 @@
 
 import { createAsyncContext } from '../utils/async_context.ts'
 import { OpRecord } from './record.ts'
+import { uuid7 } from '../utils/ids.ts'
 import { rstripSlash } from '../utils/slash.ts'
 
 interface RecordingState {
   records: OpRecord[]
   mountPrefix: string
+  /**
+   * Identifier of the typed line being recorded, stamped onto every
+   * record so the ops and the command event share a key.
+   */
+  lineId: string
 }
 
 const storage = createAsyncContext<RecordingState>()
@@ -34,10 +40,20 @@ interface RevisionsState {
 
 const revisionsStorage = createAsyncContext<RevisionsState>()
 
-export async function runWithRecording<T>(fn: () => Promise<T>): Promise<[T, OpRecord[]]> {
-  const state: RecordingState = { records: [], mountPrefix: '' }
+export async function runWithRecording<T>(fn: () => Promise<T>): Promise<[T, OpRecord[], string]> {
+  const state: RecordingState = { records: [], mountPrefix: '', lineId: uuid7() }
   const value = await storage.run(state, fn)
-  return [value, state.records]
+  return [value, state.records, state.lineId]
+}
+
+/**
+ * The line id of the active recording scope, or null outside one.
+ * The ops facade reads it so a call raised by guest code inside a typed
+ * line (the runtime's patched open()) is attributed to that line, while
+ * one raised by a FUSE callback belongs to no line and carries none.
+ */
+export function activeLineId(): string | null {
+  return storage.getStore()?.lineId ?? null
 }
 
 /**
@@ -53,7 +69,9 @@ export async function runWithRecording<T>(fn: () => Promise<T>): Promise<[T, OpR
 export function runWithMountPrefix<T>(prefix: string, fn: () => Promise<T>): Promise<T> {
   const state = storage.getStore()
   if (state === undefined) return fn()
-  return Promise.resolve(storage.run({ records: state.records, mountPrefix: prefix }, fn))
+  return Promise.resolve(
+    storage.run({ records: state.records, mountPrefix: prefix, lineId: state.lineId }, fn),
+  )
 }
 
 /**
@@ -112,6 +130,7 @@ export function record(
       durationMs: elapsed,
       fingerprint: options.fingerprint ?? null,
       revision: options.revision ?? null,
+      lineId: state.lineId === '' ? null : state.lineId,
     }),
   )
 }
@@ -133,6 +152,7 @@ export function recordStream(
     durationMs: 0,
     fingerprint: options.fingerprint ?? null,
     revision: options.revision ?? null,
+    lineId: state.lineId === '' ? null : state.lineId,
   })
   state.records.push(rec)
   return rec

--- a/typescript/packages/core/src/observe/log_entry.ts
+++ b/typescript/packages/core/src/observe/log_entry.ts
@@ -37,6 +37,11 @@ export interface LogEntryInit {
   exitCode?: number
   stdout?: string
   offset?: number
+  /**
+   * The typed line this event belongs to. An op event and the command
+   * event it ran under carry the same value, which is what joins them.
+   */
+  lineId?: string
 }
 
 export class LogEntry {
@@ -54,6 +59,7 @@ export class LogEntry {
   readonly exitCode: number | undefined
   readonly stdout: string | undefined
   readonly offset: number | undefined
+  readonly lineId: string | undefined
 
   constructor(init: LogEntryInit) {
     this.type = init.type
@@ -70,6 +76,7 @@ export class LogEntry {
     this.exitCode = init.exitCode
     this.stdout = init.stdout
     this.offset = init.offset
+    this.lineId = init.lineId
   }
 
   static fromOpRecord(rec: OpRecord, agent: string, session: string, cwd?: string): LogEntry {
@@ -85,6 +92,7 @@ export class LogEntry {
       durationMs: rec.durationMs,
     }
     if (cwd !== undefined) init.cwd = cwd
+    if (rec.lineId !== null) init.lineId = rec.lineId
     return new LogEntry(init)
   }
 
@@ -105,6 +113,7 @@ export class LogEntry {
     if (this.exitCode !== undefined) obj.exit_code = this.exitCode
     if (this.stdout !== undefined) obj.stdout = this.stdout
     if (this.offset !== undefined) obj.offset = this.offset
+    if (this.lineId !== undefined) obj.line_id = this.lineId
     return JSON.stringify(obj)
   }
 }

--- a/typescript/packages/core/src/observe/observer.ts
+++ b/typescript/packages/core/src/observe/observer.ts
@@ -93,6 +93,7 @@ export class Observer {
     agent: string,
     session: string,
     cwd?: string,
+    lineId?: string,
   ): Promise<void> {
     // TODO: batch the op lines and the command line into a single
     // store.append so one typed line costs one roundtrip and lands
@@ -112,6 +113,7 @@ export class Observer {
       stdout: text,
     }
     if (cwd !== undefined) init.cwd = cwd
+    if (lineId !== undefined && lineId !== '') init.lineId = lineId
     await this.log(new LogEntry(init))
   }
 
@@ -153,6 +155,25 @@ export class Observer {
   /** Command events across all sessions, in append order. */
   async commandEvents(): Promise<EventDict[]> {
     return (await this.events()).filter((e) => e.type === EVENT_COMMAND)
+  }
+
+  /**
+   * Op events across all sessions, in timestamp order. The recorder
+   * writes one per byte transfer a line caused; they share their
+   * `line_id` with the command event that produced them, so
+   * {@link lineEvents} joins the two.
+   */
+  async opEvents(): Promise<EventDict[]> {
+    return (await this.events()).filter((e) => e.type === EVENT_OP)
+  }
+
+  /**
+   * Every event one typed line produced, in append order: the line's
+   * ops first and its command entry last.
+   */
+  async lineEvents(lineId: string): Promise<EventDict[]> {
+    if (lineId === '') return []
+    return (await this.events()).filter((e) => e.line_id === lineId)
   }
 
   /**

--- a/typescript/packages/core/src/observe/op_events.test.ts
+++ b/typescript/packages/core/src/observe/op_events.test.ts
@@ -1,0 +1,147 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { IOResult } from '../io/types.ts'
+import {
+  activeLineId,
+  record,
+  recordStream,
+  runWithMountPrefix,
+  runWithRecording,
+} from './context.ts'
+import { EVENT_COMMAND, EVENT_OP, LogEntry } from './log_entry.ts'
+import { Observer } from './observer.ts'
+import { OpRecord } from './record.ts'
+import { RAMObserverStore } from './store.ts'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('line id on the recording scope', () => {
+  it('is minted per scope and stamped on every record', async () => {
+    const [, records, lineId] = await runWithRecording(() => {
+      record('read', '/a.txt', 'ram', 3, performance.now())
+      recordStream('read', '/b.txt', 'ram')
+      return Promise.resolve()
+    })
+    expect(lineId).toMatch(UUID_RE)
+    expect(records.map((r) => r.lineId)).toEqual([lineId, lineId])
+  })
+
+  it('differs between scopes', async () => {
+    const [, , first] = await runWithRecording(() => Promise.resolve())
+    const [, , second] = await runWithRecording(() => Promise.resolve())
+    expect(first).not.toBe(second)
+  })
+
+  it('survives a mount-prefix push', async () => {
+    const [, records, lineId] = await runWithRecording(async () => {
+      await runWithMountPrefix('/s3', () => {
+        record('read', '/a.txt', 's3', 3, performance.now())
+        return Promise.resolve()
+      })
+    })
+    expect(records[0]?.path).toBe('/s3/a.txt')
+    expect(records[0]?.lineId).toBe(lineId)
+  })
+
+  it('is null outside any scope', () => {
+    expect(activeLineId()).toBeNull()
+    record('read', '/a.txt', 'ram', 3, performance.now())
+  })
+})
+
+describe('line id on the wire', () => {
+  it('rides fromOpRecord into the log entry and out as line_id', () => {
+    const rec = new OpRecord({
+      op: 'read',
+      path: '/a.txt',
+      source: 'ram',
+      bytes: 3,
+      timestamp: 1000,
+      durationMs: 1,
+      lineId: 'abc',
+    })
+    const entry = LogEntry.fromOpRecord(rec, 'agent', 'sess')
+    expect(entry.lineId).toBe('abc')
+    const line = JSON.parse(entry.toJsonLine()) as { line_id?: string }
+    expect(line.line_id).toBe('abc')
+  })
+
+  it('is absent from the line when the record carries none', () => {
+    const rec = new OpRecord({
+      op: 'read',
+      path: '/a.txt',
+      source: 'ram',
+      bytes: 3,
+      timestamp: 1000,
+      durationMs: 1,
+    })
+    const entry = LogEntry.fromOpRecord(rec, 'agent', 'sess')
+    expect(entry.lineId).toBeUndefined()
+    expect('line_id' in JSON.parse(entry.toJsonLine())).toBe(false)
+  })
+})
+
+describe('Observer op views', () => {
+  function opRecord(path: string, lineId: string): OpRecord {
+    return new OpRecord({
+      op: 'read',
+      path,
+      source: 'ram',
+      bytes: 1,
+      timestamp: 1000,
+      durationMs: 0,
+      lineId,
+    })
+  }
+
+  it('opEvents returns only ops, and lineEvents joins them to their command', async () => {
+    const o = new Observer(new RAMObserverStore())
+    await o.logExecution(
+      'cat /a.txt',
+      new IOResult({ exitCode: 0 }),
+      [opRecord('/a.txt', 'line-1')],
+      'agent',
+      'sess',
+      '/',
+      'line-1',
+    )
+    await o.logExecution(
+      'cat /b.txt',
+      new IOResult({ exitCode: 0 }),
+      [opRecord('/b.txt', 'line-2')],
+      'agent',
+      'sess',
+      '/',
+      'line-2',
+    )
+
+    const ops = await o.opEvents()
+    expect(ops.map((e) => e.path)).toEqual(['/a.txt', '/b.txt'])
+    expect(ops.every((e) => e.type === EVENT_OP)).toBe(true)
+
+    const line = await o.lineEvents('line-2')
+    expect(line.map((e) => e.type)).toEqual([EVENT_OP, EVENT_COMMAND])
+    expect(line[0]?.path).toBe('/b.txt')
+    expect(line[1]?.command).toBe('cat /b.txt')
+  })
+
+  it('lineEvents is empty for an unknown or blank id', async () => {
+    const o = new Observer(new RAMObserverStore())
+    await o.logExecution('echo hi', new IOResult({ exitCode: 0 }), [], 'a', 's', '/', 'line-1')
+    expect(await o.lineEvents('nope')).toEqual([])
+    expect(await o.lineEvents('')).toEqual([])
+  })
+})

--- a/typescript/packages/core/src/observe/record.ts
+++ b/typescript/packages/core/src/observe/record.ts
@@ -35,6 +35,12 @@ export interface OpRecordInit {
    * replay to pin reads to the exact recorded version.
    */
   revision?: string | null
+  /**
+   * The typed line this op was emitted under, shared with that line's
+   * command event so the two can be joined. Null for an op raised
+   * outside a recording scope (a FUSE callback, a direct ws.fs call).
+   */
+  lineId?: string | null
 }
 
 export class OpRecord {
@@ -46,6 +52,7 @@ export class OpRecord {
   durationMs: number
   fingerprint: string | null
   revision: string | null
+  lineId: string | null
 
   constructor(init: OpRecordInit) {
     this.op = init.op
@@ -56,6 +63,7 @@ export class OpRecord {
     this.durationMs = init.durationMs
     this.fingerprint = init.fingerprint ?? null
     this.revision = init.revision ?? null
+    this.lineId = init.lineId ?? null
   }
 
   get isCache(): boolean {
@@ -72,6 +80,7 @@ export class OpRecord {
       durationMs: this.durationMs,
       fingerprint: this.fingerprint,
       revision: this.revision,
+      lineId: this.lineId,
     }
   }
 }

--- a/typescript/packages/core/src/ops/ops.ts
+++ b/typescript/packages/core/src/ops/ops.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { OpReport } from '../io/types.ts'
+import { activeLineId } from '../observe/context.ts'
 import { OpRecord } from '../observe/record.ts'
 import { NO_FOLLOW_OPS, type NamespaceLinks } from './config.ts'
 import type { OpKwargs } from './registry.ts'
@@ -116,6 +117,7 @@ export class Ops {
       bytes,
       timestamp: Date.now(),
       durationMs: Date.now() - startMs,
+      lineId: activeLineId(),
     })
     this.records.push(rec)
     if (this.sink !== null) await this.sink(rec)

--- a/typescript/packages/core/src/workspace/history_view.test.ts
+++ b/typescript/packages/core/src/workspace/history_view.test.ts
@@ -406,3 +406,51 @@ describe('history snapshot rewind', () => {
     await dst.close()
   })
 })
+
+describe('op events and their line id', () => {
+  it('opHistory returns the ops a command caused, history stays commands only', async () => {
+    const ws = makeWs()
+    await ws.execute('echo hi > /data/x.txt')
+    await ws.execute('cat /data/x.txt')
+    const ops = await ws.opHistory()
+    expect(ops.map((e) => e.op)).toEqual(['write', 'read'])
+    expect(await ws.opHistory()).toEqual(await ws.observer.opEvents())
+    expect(new Set((await ws.history()).map((e) => e.type))).toEqual(new Set(['command']))
+    await ws.close()
+  })
+
+  it('line_id joins each op to the command that caused it', async () => {
+    const ws = makeWs()
+    await ws.execute('echo hi > /data/x.txt')
+    await ws.execute('cat /data/x.txt')
+    const cmds = await ws.observer.commandEvents()
+    const [first, second] = [cmds[0]?.line_id, cmds[1]?.line_id]
+    expect(first).toBeTruthy()
+    expect(first).not.toBe(second)
+    expect((await ws.opHistory()).map((e) => e.line_id)).toEqual([first, second])
+    const line = await ws.observer.lineEvents(second as string)
+    expect(line.map((e) => e.type)).toEqual(['op', 'command'])
+    expect(line[1]?.command).toBe('cat /data/x.txt')
+    await ws.close()
+  })
+
+  it("a nested eval's ops carry the top-level line's id", async () => {
+    const ws = makeWs()
+    await ws.execute('echo hi > /data/x.txt')
+    await ws.execute('echo $(cat /data/x.txt)')
+    const cmds = await ws.observer.commandEvents()
+    expect(cmds.map((c) => c.command)).toEqual(['echo hi > /data/x.txt', 'echo $(cat /data/x.txt)'])
+    const ops = await ws.opHistory()
+    expect(ops.map((o) => o.op)).toEqual(['write', 'read'])
+    expect(ops[1]?.line_id).toBe(cmds[1]?.line_id)
+    await ws.close()
+  })
+
+  it('the in-memory ledger carries the same id', async () => {
+    const ws = makeWs()
+    await ws.execute('echo hi > /data/x.txt')
+    const cmds = await ws.observer.commandEvents()
+    expect(ws.records.map((r) => r.lineId)).toEqual([cmds[0]?.line_id])
+    await ws.close()
+  })
+})

--- a/typescript/packages/core/src/workspace/workspace/execute.ts
+++ b/typescript/packages/core/src/workspace/workspace/execute.ts
@@ -15,6 +15,7 @@
 import type { ByteSource } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import { runWithRecording } from '../../observe/context.ts'
+import { uuid7 } from '../../utils/ids.ts'
 import type { Observer } from '../../observe/observer.ts'
 import type { OpRecord } from '../../observe/record.ts'
 import { Channel } from '../../shell/console/types.ts'
@@ -112,6 +113,7 @@ async function deniedResult(
       options.agentId ?? env.agentId ?? '',
       session.sessionId,
       options.cwd ?? session.cwd,
+      uuid7(),
     )
   }
   await env.sessions.flush()
@@ -358,6 +360,7 @@ async function runParsedLine(
         callAgentId,
         targetSession.sessionId,
         effectiveSession.cwd,
+        uuid7(),
       )
     }
     return new ExecuteResult(result.stdout, result.stderr ?? new Uint8Array(), result.exitCode)
@@ -384,9 +387,9 @@ async function runParsedLine(
       () => runCommandTree(deps, rootNode, effectiveSession, stdin),
       env.sessions,
     )
-  let execResult: [[ByteSource | null, IOResult, ExecutionNode], OpRecord[]]
+  let execResult: [[ByteSource | null, IOResult, ExecutionNode], OpRecord[], string]
   try {
-    execResult = isLine ? await runWithRecording(runBody) : [await runBody(), []]
+    execResult = isLine ? await runWithRecording(runBody) : [await runBody(), [], '']
   } catch (err) {
     // Abort (cancellation) and content drift are control-flow signals
     // that must propagate, mirroring the Python workspace. Any other
@@ -398,7 +401,7 @@ async function runParsedLine(
     targetSession.lastExitCode = failed.exitCode
     return new ExecuteResult(new Uint8Array(), failed.stderr, failed.exitCode)
   }
-  const [[materialized, io], opRecords] = execResult
+  const [[materialized, io], opRecords, lineId] = execResult
   targetSession.lastExitCode = io.exitCode
   let stdoutBytes: Uint8Array
   try {
@@ -438,6 +441,7 @@ async function runParsedLine(
       callAgentId,
       targetSession.sessionId,
       effectiveSession.cwd,
+      lineId,
     )
   }
 

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -386,6 +386,15 @@ export class Workspace {
     return this.observer.commandEvents()
   }
 
+  /**
+   * Op events recorded by the hidden recorder, across all sessions in
+   * timestamp order. One entry per byte transfer a command caused,
+   * carrying the `line_id` of the line that caused it.
+   */
+  opHistory(): Promise<EventDict[]> {
+    return this.observer.opEvents()
+  }
+
   // The sandboxed runtimes' sole data path (quickjs, pyodide, monty).
   // Routes through `dispatch`, not the raw Ops facade, so sandbox I/O
   // takes the same path as shell commands — cache read-through on


### PR DESCRIPTION
Refs #861.

The recorder already wrote an op event per byte transfer, and nothing could read one. Every view filtered to `type="command"` — `/.bash_history` (`core/history/read.py`), the `history` builtin, `ws.history()`, and snapshot capture — so a session that recorded six ops answered with nine commands and zero ops from every public surface. The data was being persisted and thrown away.

Two additions, mirrored in both languages.

**`op_events()` / `opEvents()`** is the missing view, and **`ws.op_history()` / `ws.opHistory()`** is its workspace door, spelled the way `history()` already is. Nothing else about the store changes: the same JSONL, read through a second filter.

**`line_id`** is what makes the two views joinable. An op could only be attributed to its command by append order within a session file, which is a contract that holds until anything writes concurrently. The id is minted once per `RecordingScope` / `runWithRecording`, carried through `push_mount_prefix` / `runWithMountPrefix` so a mount frame cannot drop it, and stamped on both the op records and the command entry. **`line_events()` / `lineEvents()`** is then a filter rather than an inference.

Three consequences, each pinned by a test:

- A nested eval's ops carry the **top-level** line's id. The recorder already scopes them that way (an inactive `RecordingScope` joins its enclosing one), so reporting the inner eval would contradict the scoping that already exists.
- An op raised outside a line carries **none**. A FUSE callback and a direct `ws.ops` / `ws.fs` call have no line behind them, and a synthesized id would claim otherwise.
- Guest code inside a line **does** get the line's id: the runtime's patched `open()` reaches the ops facade, so `Ops._record` reads `active_recorder()` / `activeLineId()` rather than assuming no line is running.

The wire format gains one optional key, `line_id`, absent when there is no line — `to_json_line` already drops `None`, and the TS twin only sets it when present, so an old entry still parses.

Snapshots deliberately keep capturing `COMMAND`/`CLEAR`/`DELETE` only. A snapshot pins what was read through fingerprints and revisions, so the transfer log would grow it without adding a fact it restores from. Documented rather than left as a silent filter.

## Scope, deliberately narrow

This is questions 1 and 2 of #861 only, and it is purely additive — new read paths over data already being recorded, plus a join key. Nothing is removed and no existing behaviour changes, so it does not foreclose the open questions in that issue (metadata ops on the shell path, HTTP-layer instrumentation, the `is_cache` naming, bounding `ws.ops.records`).

Two things I did **not** do, on purpose:

- **No `/.mirage/ops.jsonl` view mount.** #861 question 1 raises whether letting an agent grep its own I/O is a useful capability or a self-observation hazard. That felt like a maintainer call, so this adds the programmatic surface only.
- **No new instrumentation.** Coverage is what it already was — 14 of 37 backends, read/write family only — so `op_history()` is honest about what the ledger currently holds, not more.

`line_id` is my coinage and I have no attachment to it; happy to rename if there is a convention I missed.

## Test plan

Run on `main` @ 8e18c5687:

- `uv run pytest` — 15,913 passed, 495 skipped, 1 xfailed, 0 failures (7 new tests in `tests/observe/test_op_events.py`)
- `pnpm test` (core) — 9,252 passed, 10 skipped, 0 failures (12 new tests across `observe/op_events.test.ts` and `workspace/history_view.test.ts`)
- `pre-commit run` — all 20 hooks pass, including mypy, ruff, PEP8, PathSpec discipline, Prettier, ESLint and Knip
- `tsc --noEmit` — clean
- `scripts/check_layout_parity.py --strict` — 259, unchanged from baseline

The TS tests are split on purpose. The observe unit tests build no shell parser: an earlier draft did, and as the 28th test file to load tree-sitter WASM it pushed the pyodide REPL tests past their 5s timeout and made the suite flaky (a different set of tests failed each run). The plumbing is covered directly in `observe/op_events.test.ts`, and the four end-to-end assertions live in `workspace/history_view.test.ts`, which already builds a parser and already tests views over recorder events.

Docs updated: `docs/home/observer.mdx` gains a "Reading the events" section and states the snapshot exclusion; `CLAUDE.md` gains a History bullet.
