### PR TITLE
fix: measure the gmail excerpt and daemon description budgets in code points

### DIFF
--- a/python/tests/core/gmail/test_search.py
+++ b/python/tests/core/gmail/test_search.py
@@ -1,0 +1,79 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Any
+
+from mirage.core.gmail.scope import GmailScope
+from mirage.core.gmail.search import format_grep_results
+
+SCOPE = GmailScope(use_native=True,
+                   label_name="INBOX",
+                   date_str=None,
+                   resource_path="/")
+
+EMOJI = "\U0001F600"
+
+
+def _row(body_text: str) -> dict[str, Any]:
+    return {
+        "id": "m1",
+        "subject": "note",
+        "snippet": "fallback snippet",
+        "sender": "a@b.c",
+        "date": "2026-08-19",
+        "label": "INBOX",
+        "body_text": body_text,
+    }
+
+
+def _excerpt(lines: list[str]) -> str:
+    """Everything after the ``<path>:[<sender>] `` header."""
+    line = lines[0]
+    return line[line.index("] ") + 2:]
+
+
+def test_no_match_budget_counts_code_points():
+    # Gmail matched the message server-side on something the literal scan
+    # does not find, so the excerpt falls back to the head of the body. 200
+    # emoji are 200 code points and 400 UTF-16 units, which is the input the
+    # typescript twin cut to 117 -- splitting the 118th surrogate pair.
+    body = EMOJI * 200
+    excerpt = _excerpt(
+        format_grep_results([_row(body)], SCOPE, "/gmail", "zzz"))
+    assert excerpt == f"note {body}"
+    assert len(excerpt) == 205
+    assert "�" not in excerpt
+
+
+def test_match_window_cuts_on_code_point_boundaries():
+    pad = EMOJI * 200
+    excerpt = _excerpt(
+        format_grep_results([_row(f"{pad} needle {pad}")], SCOPE, "/gmail",
+                            "needle"))
+    assert excerpt == f"...{EMOJI * 119} needle {EMOJI * 119}..."
+    assert "�" not in excerpt
+
+
+def test_match_window_on_ascii():
+    body = "a" * 300 + " needle " + "b" * 300
+    excerpt = _excerpt(
+        format_grep_results([_row(body)], SCOPE, "/gmail", "needle"))
+    assert excerpt == f"...{'a' * 119} needle {'b' * 119}..."
+
+
+def test_empty_pattern_falls_back_to_the_snippet():
+    lines = format_grep_results([_row("body")], SCOPE, "/gmail")
+    assert lines == [
+        "/gmail/INBOX/2026-08-19/note__m1.gmail.json:[a@b.c] fallback snippet"
+    ]

--- a/python/tests/server/test_summary.py
+++ b/python/tests/server/test_summary.py
@@ -1,0 +1,50 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.resource.ram import RAMResource
+from mirage.server.summary import _mount_description
+
+ASTRAL = "\U00010400"
+
+
+class _PromptResource(RAMResource):
+
+    def __init__(self, prompt: str) -> None:
+        super().__init__()
+        self.PROMPT = prompt
+
+
+def test_short_prompt_is_returned_whole():
+    assert _mount_description(_PromptResource("hello")) == "hello"
+    assert _mount_description(_PromptResource("")) == ""
+
+
+def test_budget_counts_code_points():
+    # 40 ascii plus 45 Deseret letters is 85 code points and 130 UTF-16
+    # units, so the typescript twin ellipsized a prompt this side leaves
+    # whole -- and its cut landed inside the 40th surrogate pair.
+    prompt = "a" * 40 + ASTRAL * 45
+    assert _mount_description(_PromptResource(prompt)) == prompt
+
+
+def test_ellipsizes_on_a_code_point_boundary():
+    result = _mount_description(_PromptResource(ASTRAL * 130))
+    assert result == ASTRAL * 119 + "…"
+    assert len(result) == 120
+    assert "�" not in result
+
+
+def test_trailing_whitespace_is_dropped_before_the_ellipsis():
+    prompt = "x" * 118 + "  " + "y" * 10
+    assert _mount_description(_PromptResource(prompt)) == "x" * 118 + "…"

--- a/typescript/packages/core/src/core/gmail/search.test.ts
+++ b/typescript/packages/core/src/core/gmail/search.test.ts
@@ -1,0 +1,91 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { formatGrepResults, type GmailSearchRow } from './search.ts'
+import type { GmailScope } from './scope.ts'
+
+const SCOPE: GmailScope = {
+  useNative: true,
+  labelName: 'INBOX',
+  dateStr: null,
+  resourcePath: '/',
+}
+
+const EMOJI = '\u{1F600}'
+
+function row(bodyText: string): GmailSearchRow {
+  return {
+    id: 'm1',
+    subject: 'note',
+    snippet: 'fallback snippet',
+    sender: 'a@b.c',
+    date: '2026-08-19',
+    label: 'INBOX',
+    bodyText,
+  }
+}
+
+/** The excerpt is everything after the `<path>:[<sender>] ` header. */
+function excerptOf(lines: string[]): string {
+  const line = lines[0] ?? ''
+  return line.slice(line.indexOf('] ') + 2)
+}
+
+/**
+ * Re-encode through UTF-8, which is what a lone surrogate does not survive.
+ *
+ * A slice that lands inside a surrogate pair leaves a half that is still a
+ * legal `String` value, so `toContain('�')` on the raw excerpt sees
+ * nothing; the replacement character only appears once the bytes are written.
+ */
+function roundTrip(text: string): string {
+  return new TextDecoder('utf-8').decode(new TextEncoder().encode(text))
+}
+
+describe('formatGrepResults excerpts', () => {
+  it('measures the no-match budget in code points, matching python', () => {
+    // Gmail matched the message server-side on something the literal scan
+    // does not find, so the excerpt falls back to the head of the body.
+    // 200 emoji are 200 code points and 400 UTF-16 units: python returns all
+    // of them, and measuring in units returned 117 plus a split 118th pair.
+    const body = EMOJI.repeat(200)
+    const excerpt = excerptOf(formatGrepResults([row(body)], SCOPE, '/gmail', 'zzz'))
+    expect(excerpt).toBe(`note ${body}`)
+    expect(Array.from(excerpt)).toHaveLength(205)
+    expect(roundTrip(excerpt)).not.toContain('�')
+  })
+
+  it('windows around the match on code-point boundaries', () => {
+    const pad = EMOJI.repeat(200)
+    const excerpt = excerptOf(
+      formatGrepResults([row(`${pad} needle ${pad}`)], SCOPE, '/gmail', 'needle'),
+    )
+    // `note ` + 200 emoji + ` needle ` + 200 emoji, windowed 120 code points
+    // either side of the hit at index 206 and clipped to the body's end.
+    expect(excerpt).toBe(`...${EMOJI.repeat(119)} needle ${EMOJI.repeat(119)}...`)
+    expect(roundTrip(excerpt)).not.toContain('�')
+  })
+
+  it('leaves an ascii excerpt exactly where python leaves it', () => {
+    const body = `${'a'.repeat(300)} needle ${'b'.repeat(300)}`
+    const excerpt = excerptOf(formatGrepResults([row(body)], SCOPE, '/gmail', 'needle'))
+    expect(excerpt).toBe(`...${'a'.repeat(119)} needle ${'b'.repeat(119)}...`)
+  })
+
+  it('falls back to the snippet when the pattern is empty', () => {
+    const lines = formatGrepResults([row('body')], SCOPE, '/gmail')
+    expect(lines).toEqual(['/gmail/INBOX/2026-08-19/note__m1.gmail.json:[a@b.c] fallback snippet'])
+  })
+})

--- a/typescript/packages/core/src/core/gmail/search.ts
+++ b/typescript/packages/core/src/core/gmail/search.ts
@@ -30,17 +30,24 @@ export interface GmailSearchRow {
   bodyText: string
 }
 
+// Every offset below is a python string index, and python counts code points
+// where `String.length` and `String.indexOf` count UTF-16 units. Measuring in
+// units halves the budget for astral text -- a 200-emoji body excerpts to all
+// 200 in python and to 117 here -- and the cut lands inside the 118th
+// surrogate pair, whose lone half encodes as U+FFFD.
 function extractExcerpt(text: string, pattern: string): string {
   if (text === '' || pattern === '') return ''
   const flat = text.replace(/\s+/g, ' ').trim()
   const lower = flat.toLowerCase()
-  const idx = lower.indexOf(pattern.toLowerCase())
-  if (idx < 0) return flat.slice(0, EXCERPT_MAX)
+  const hit = lower.indexOf(pattern.toLowerCase())
+  const points = Array.from(flat)
+  if (hit < 0) return points.slice(0, EXCERPT_MAX).join('')
+  const idx = Array.from(lower.slice(0, hit)).length
   const start = Math.max(0, idx - EXCERPT_WINDOW)
-  const end = Math.min(flat.length, idx + pattern.length + EXCERPT_WINDOW)
+  const end = Math.min(points.length, idx + Array.from(pattern).length + EXCERPT_WINDOW)
   const prefix = start > 0 ? '...' : ''
-  const suffix = end < flat.length ? '...' : ''
-  return `${prefix}${flat.slice(start, end)}${suffix}`
+  const suffix = end < points.length ? '...' : ''
+  return `${prefix}${points.slice(start, end).join('')}${suffix}`
 }
 
 function buildQuery(pattern: string, labelName: string | null, dateStr: string | null): string {

--- a/typescript/packages/server/src/summary.test.ts
+++ b/typescript/packages/server/src/summary.test.ts
@@ -13,11 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import type { Resource } from '@struktoai/mirage-core/resource/base'
 import { RAMResource } from '@struktoai/mirage-core/resource/ram/ram'
 import { MountMode } from '@struktoai/mirage-core/types'
 import { Workspace } from '@struktoai/mirage-node'
 import { WorkspaceRegistry } from './registry.ts'
-import { makeBrief, makeDetail } from './summary.ts'
+import { describeResource, makeBrief, makeDetail } from './summary.ts'
 
 describe('summary', () => {
   it('makeBrief reports prefix count + workspace mode', () => {
@@ -41,5 +42,42 @@ describe('summary', () => {
     expect(detail.mounts.map((m) => m.prefix).sort()).toEqual(['/', '/data/'])
     const dataMount = detail.mounts.find((m) => m.prefix === '/data/')
     expect(dataMount?.resource).toBe('ram')
+  })
+})
+
+const ASTRAL = '\u{10400}'
+
+// `RAMResource.prompt` is inferred as its own string literal, so a subclass
+// cannot widen it; the description only ever reads the field.
+function promptResource(prompt: string): Resource {
+  return Object.assign(new RAMResource(), { prompt })
+}
+
+describe('describeResource', () => {
+  it('returns a short prompt whole', () => {
+    expect(describeResource(promptResource('hello'))).toBe('hello')
+    expect(describeResource(promptResource(''))).toBe('')
+  })
+
+  it('measures the budget in code points, matching python', () => {
+    // 40 ascii plus 45 Deseret letters is 85 code points and 130 UTF-16
+    // units, so measuring `String.length` ellipsized a prompt python leaves
+    // whole -- and the cut landed inside the 40th surrogate pair.
+    const prompt = 'a'.repeat(40) + ASTRAL.repeat(45)
+    expect(describeResource(promptResource(prompt))).toBe(prompt)
+  })
+
+  it('ellipsizes on a code-point boundary', () => {
+    const out = describeResource(promptResource(ASTRAL.repeat(130)))
+    expect(out).toBe(ASTRAL.repeat(119) + '\u2026')
+    expect(Array.from(out)).toHaveLength(120)
+    // A half pair is a legal `String` value and only becomes U+FFFD once the
+    // bytes are written, so the check has to go through UTF-8.
+    expect(new TextDecoder('utf-8').decode(new TextEncoder().encode(out))).not.toContain('\uFFFD')
+  })
+
+  it('drops trailing whitespace before the ellipsis', () => {
+    const prompt = 'x'.repeat(118) + '  ' + 'y'.repeat(10)
+    expect(describeResource(promptResource(prompt))).toBe('x'.repeat(118) + '\u2026')
   })
 })

--- a/typescript/packages/server/src/summary.ts
+++ b/typescript/packages/server/src/summary.ts
@@ -36,10 +36,20 @@ function userMounts(ws: Workspace) {
   return ws.mounts().filter((m) => !isAutoPrefix(m.prefix))
 }
 
-function describeResource(resource: Resource): string {
+/**
+ * Shorten a resource's prompt to the description budget.
+ *
+ * The budget counts characters, which python's `len` reads as code points and
+ * `String.length` reads as UTF-16 units. Measuring in units would ellipsize a
+ * prompt python leaves whole and could cut a surrogate pair in half, so this
+ * measures and slices `Array.from` -- the same fix `sanitizeLabel` carries.
+ */
+export function describeResource(resource: Resource): string {
   const raw = resource.prompt ?? ''
-  if (raw.length <= DESCRIPTION_MAX) return raw
-  return raw.slice(0, DESCRIPTION_MAX - 1).trimEnd() + '\u2026'
+  const points = Array.from(raw)
+  if (points.length <= DESCRIPTION_MAX) return raw
+  const cut = points.slice(0, DESCRIPTION_MAX - 1).join('')
+  return cut.trimEnd() + '\u2026'
 }
 
 async function buildInternals(ws: Workspace): Promise<WorkspaceInternals> {


### PR DESCRIPTION
Two more of the code-unit/code-point divergences [#869](https://github.com/strukto-ai/mirage/pull/869) fixed for `sanitizeLabel`/`sanitizeName`, found by sweeping from the python side. Both measure and slice `String.length`, which counts UTF-16 units, where the python twin measures `len` and slices, which count code points.

### `extractExcerpt` (gmail grep), live

`core/gmail/search.ts` builds a grep excerpt with four unit-counted offsets: the `EXCERPT_MAX` cut, `indexOf`, `pattern.length`, and `flat.length`. A 200-emoji body is 200 code points and 400 units, so python returns all 200 and typescript returned 117 — ~40% of the excerpt dropped on the same message. The windowed branch is worse than short: `slice(286, 532)` on an emoji run cuts *inside* a surrogate pair at both ends, and the lone halves encode as U+FFFD in the grep line.

Every offset now runs over `Array.from(flat)`. `indexOf` still finds the hit in units, so its result is converted once (`Array.from(lower.slice(0, hit)).length`) rather than the whole search being rewritten.

### `describeResource` (daemon workspace detail), latent

`server/summary.ts` ellipsizes a resource's prompt at 120. Every `PROMPT` mirage ships today is ASCII, so nothing diverges in practice; fixed for consistency rather than left as a known-divergent twin — a prompt of astral characters would have ellipsized at half the budget.

### Pins

Both sides get parity pins mirroring `sanitize.test.ts` / `test_sanitize.py`: an input python leaves whole must survive intact, and an over-budget astral input must cut on a code-point boundary with no U+FFFD. The excerpt pins go through the exported `formatGrepResults` / `format_grep_results`, so they run the real function rather than a copy of it, and every expected string was read off the python implementation before being written down. Reverting either fix fails exactly the two new astral cases per language.

`describeResource` is exported for its pin; the equivalent python name is already importable. Knip is clean.

Two new python suites (`tests/core/gmail/test_search.py`, `tests/server/test_summary.py`) close mirror gaps; neither moves `MIRROR_BASELINE`, which already counted both basenames.

### Verification

- `pnpm -r typecheck`, `pnpm exec knip`
- vitest: core 9251, browser 212, node 2399, server 182 — all pass
- `pytest --ignore=tests/fuse` — 15741 passed, 491 skipped, 1 xfail (no macFUSE on the dev host)
- `pre-commit run --all-files` — every hook passes; the mypy hook's "Failed" line is its `uv run` rewriting `uv.lock`, and it reports `Success: no issues found in 1974 source files`
