### PR TITLE
feat(hierarchy): move discord, slack, gmail and email onto the kit

### DIFF
--- a/python/mirage/commands/builtin/discord/grep.py
+++ b/python/mirage/commands/builtin/discord/grep.py
@@ -31,7 +31,7 @@ from mirage.core.discord.entry import channel_dirname
 from mirage.core.discord.formatters import format_grep_results
 from mirage.core.discord.read import read as discord_read
 from mirage.core.discord.readdir import readdir as _readdir
-from mirage.core.discord.scope import detect_scope
+from mirage.core.discord.scope import NATIVE_KINDS, detect_scope
 from mirage.core.discord.search import search_guild
 from mirage.core.discord.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult, materialize
@@ -80,20 +80,22 @@ async def grep(accessor: DiscordAccessor, paths: list[PathSpec],
     # the generic scan; see SEARCH_HONORED above.
     operand = pushdown_operand(paths, opts.flags, pattern, SEARCH_HONORED)
     if pattern is not None and operand is not None and fl.as_bool("w"):
-        scope = detect_scope(operand)
-        if scope.use_native and scope.guild_id is not None:
+        match = detect_scope(operand)
+        if match.kind in NATIVE_KINDS:
+            guild_id = match.slots["guild_id"]
             try:
                 msgs = await search_guild(
                     accessor.config,
-                    scope.guild_id,
+                    guild_id,
                     pattern,
-                    channel_id=scope.channel_id,
+                    channel_id=match.slots.get("channel_id"),
                     limit=SEARCH_MAX_RESULTS,
                 )
                 file_prefix = mount_prefix_of(operand.virtual,
                                               operand.resource_path) or ""
-                resource_first = scope.resource_path.split("/", 1)[0]
-                channels = await list_channels(accessor.config, scope.guild_id)
+                resource_first = match.resource_path.strip("/").split("/",
+                                                                      1)[0]
+                channels = await list_channels(accessor.config, guild_id)
                 channel_map = {c["id"]: channel_dirname(c) for c in channels}
                 lines = format_grep_results(msgs, file_prefix, resource_first,
                                             channel_map)

--- a/python/mirage/commands/builtin/discord/head.py
+++ b/python/mirage/commands/builtin/discord/head.py
@@ -30,9 +30,29 @@ from mirage.core.discord.history import date_to_snowflake
 from mirage.core.discord.read import read as discord_read
 from mirage.core.discord.render import history_jsonl_bytes
 from mirage.core.discord.scope import detect_scope
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
+
+
+def _chat_match(path: PathSpec) -> ScopeMatch | None:
+    """The day chain a chat.jsonl operand names, or None.
+
+    A literal ``.../<day>/chat.jsonl`` names the day itself; a
+    ``.../<day>/*.jsonl`` glob names the day dir plus a pattern only
+    chat.jsonl can satisfy. Both address one day's messages.
+
+    Args:
+        path (PathSpec): the head operand, glob or literal.
+    """
+    match = detect_scope(path.dir if path.pattern else path)
+    if path.pattern is not None:
+        if not path.pattern.endswith(".jsonl") or match.kind != "day":
+            return None
+    elif match.kind != "messages":
+        return None
+    return match
 
 
 async def head_provision(accessor: DiscordAccessor, paths: list[PathSpec],
@@ -56,21 +76,21 @@ async def head(accessor: DiscordAccessor, paths: list[PathSpec],
         return None, IOResult(exit_code=1, stderr=str(exc).encode())
     lines = parsed.lines if parsed.lines is not None else 10
     if paths:
-        scope = detect_scope(paths[0])
+        match = _chat_match(paths[0]) if len(paths) == 1 else None
 
         # Smart head: fetch only first N messages for a single date. Only
         # counts one API page can honor (Discord caps limit at 100) take
         # the shortcut; zero, negative (all-but-last-N) and larger counts,
         # -v headers, byte counts and -z all keep the generic path.
-        if (len(paths) == 1 and scope.level == "messages" and scope.channel_id
-                and scope.date_str and parsed.bytes_ is None
+        if (match is not None and parsed.bytes_ is None
                 and not parsed.zero_terminated and not parsed.verbose
                 and 0 < lines <= 100):
-            after = date_to_snowflake(scope.date_str)
-            before_int = int(date_to_snowflake(scope.date_str, end=True))
+            day = match.slots["day"]
+            after = date_to_snowflake(day)
+            before_int = int(date_to_snowflake(day, end=True))
             msgs = await discord_get(
                 accessor.config,
-                f"/channels/{scope.channel_id}/messages",
+                f"/channels/{match.slots['channel_id']}/messages",
                 params={
                     "after": after,
                     "limit": lines

--- a/python/mirage/commands/builtin/discord/io.py
+++ b/python/mirage/commands/builtin/discord/io.py
@@ -17,6 +17,7 @@ from functools import partial
 from mirage.commands.builtin.generic_bind import CommandIO
 from mirage.commands.builtin.utils.wrap import stream_from_bytes
 from mirage.core.discord.read import read as _read
+from mirage.core.discord.read import read_range as _read_range
 from mirage.core.discord.readdir import readdir as _readdir
 from mirage.core.discord.stat import stat as _stat
 
@@ -27,7 +28,7 @@ from mirage.core.discord.stat import stat as _stat
 IO = CommandIO(
     readdir=_readdir,
     read_bytes=_read,
-    read_range=_read,
+    read_range=_read_range,
     read_stream=partial(stream_from_bytes, _read),
     stat=_stat,
     is_mounted=lambda a: True,

--- a/python/mirage/commands/builtin/discord/rg.py
+++ b/python/mirage/commands/builtin/discord/rg.py
@@ -32,7 +32,7 @@ from mirage.core.discord.entry import channel_dirname
 from mirage.core.discord.formatters import format_grep_results
 from mirage.core.discord.read import read as discord_read
 from mirage.core.discord.readdir import readdir as _readdir
-from mirage.core.discord.scope import detect_scope
+from mirage.core.discord.scope import NATIVE_KINDS, detect_scope
 from mirage.core.discord.search import search_guild
 from mirage.core.discord.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
@@ -56,20 +56,22 @@ async def rg(accessor: DiscordAccessor, paths: list[PathSpec],
     # the generic scan; see SEARCH_HONORED above.
     operand = pushdown_operand(paths, opts.flags, pattern_str, SEARCH_HONORED)
     if operand is not None and fl.as_bool("w"):
-        scope = detect_scope(operand)
-        if scope.use_native and scope.guild_id is not None:
+        match = detect_scope(operand)
+        if match.kind in NATIVE_KINDS:
+            guild_id = match.slots["guild_id"]
             try:
                 msgs = await search_guild(
                     accessor.config,
-                    scope.guild_id,
+                    guild_id,
                     pattern_str,
-                    channel_id=scope.channel_id,
+                    channel_id=match.slots.get("channel_id"),
                     limit=SEARCH_MAX_RESULTS,
                 )
                 file_prefix = mount_prefix_of(operand.virtual,
                                               operand.resource_path) or ""
-                resource_first = scope.resource_path.split("/", 1)[0]
-                channels = await list_channels(accessor.config, scope.guild_id)
+                resource_first = match.resource_path.strip("/").split("/",
+                                                                      1)[0]
+                channels = await list_channels(accessor.config, guild_id)
                 channel_map = {c["id"]: channel_dirname(c) for c in channels}
                 lines = format_grep_results(msgs, file_prefix, resource_first,
                                             channel_map)

--- a/python/mirage/commands/builtin/email/grep.py
+++ b/python/mirage/commands/builtin/email/grep.py
@@ -29,7 +29,7 @@ from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagView
 from mirage.core.email.read import read as email_read
 from mirage.core.email.readdir import readdir as _readdir
-from mirage.core.email.scope import EmailScope, detect_scope
+from mirage.core.email.scope import NATIVE_KINDS, detect_scope
 from mirage.core.email.search import search_and_format
 from mirage.core.email.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
@@ -77,10 +77,10 @@ async def grep(accessor: EmailAccessor, paths: list[PathSpec],
     operand = pushdown_operand(paths, opts.flags, pattern, SEARCH_HONORED)
     if (pattern is not None and operand is not None
             and (fl.as_bool("r") or fl.as_bool("R"))):
-        scope = detect_scope(operand)
-        if scope.use_native and scope.folder:
+        match = detect_scope(operand)
+        if match.kind in NATIVE_KINDS:
             return await _grep_server_side(accessor,
-                                           scope.folder,
+                                           match.slots["folder"],
                                            pattern,
                                            operand,
                                            i=fl.as_bool("i"),
@@ -120,7 +120,7 @@ async def _grep_server_side(
     file_prefix = mount_prefix_of(operand.virtual, operand.resource_path)
     pairs = await search_and_format(
         accessor,
-        EmailScope(use_native=True, folder=folder),
+        folder,
         pattern,
         file_prefix,
         max_results=accessor.config.max_messages,

--- a/python/mirage/commands/builtin/email/rg.py
+++ b/python/mirage/commands/builtin/email/rg.py
@@ -29,7 +29,7 @@ from mirage.core.email.client import fetch_message
 from mirage.core.email.read import read as email_read
 from mirage.core.email.readdir import readdir as _readdir
 from mirage.core.email.render import message_json_text
-from mirage.core.email.scope import detect_scope
+from mirage.core.email.scope import NATIVE_KINDS, detect_scope
 from mirage.core.email.search import _build_vfs_path, search_messages
 from mirage.core.email.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
@@ -60,10 +60,10 @@ async def rg(accessor: EmailAccessor, paths: list[PathSpec], texts: list[str],
     # It used to return exit 1 instead, reporting "nothing matched" for a
     # search it had not run.
     operand = pushdown_operand(paths, opts.flags, pattern_str, SEARCH_HONORED)
-    scope = detect_scope(operand) if operand is not None else None
-    if (operand is not None and scope is not None and scope.use_native
-            and scope.folder):
-        folder = scope.folder
+    match = detect_scope(operand) if operand is not None else None
+    if (operand is not None and match is not None
+            and match.kind in NATIVE_KINDS):
+        folder = match.slots["folder"]
         uids = await search_messages(accessor,
                                      folder,
                                      text=pattern_str,

--- a/python/mirage/commands/builtin/gmail/grep.py
+++ b/python/mirage/commands/builtin/gmail/grep.py
@@ -27,7 +27,7 @@ from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagView
 from mirage.core.gmail.read import read as gmail_read
 from mirage.core.gmail.readdir import readdir as _readdir
-from mirage.core.gmail.scope import detect_scope
+from mirage.core.gmail.scope import NATIVE_KINDS, detect_scope
 from mirage.core.gmail.search import format_grep_results, search_messages
 from mirage.core.gmail.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
@@ -65,18 +65,19 @@ async def grep(accessor: GmailAccessor, paths: list[PathSpec],
     # the generic grep over rendered files; see SEARCH_HONORED above.
     operand = pushdown_operand(paths, opts.flags, pattern, SEARCH_HONORED)
     if pattern is not None and operand is not None and fl.as_bool("w"):
-        scope = detect_scope(operand)
-        if scope.use_native:
+        match = detect_scope(operand)
+        if match.kind in NATIVE_KINDS:
             file_prefix = mount_prefix_of(operand.virtual,
                                           operand.resource_path) or ""
             rows = await search_messages(
                 accessor.token_manager,
                 pattern,
-                label_name=scope.label_name,
-                date_str=scope.date_str,
+                label_name=match.slots.get("label"),
+                date_str=match.slots.get("day"),
                 max_results=SEARCH_MAX_RESULTS,
             )
-            lines = format_grep_results(rows, scope, file_prefix, pattern)
+            lines = format_grep_results(rows, match.slots.get("label"),
+                                        file_prefix, pattern)
             if not lines:
                 return b"", IOResult(exit_code=1)
             return format_records(lines), IOResult()

--- a/python/mirage/commands/builtin/gmail/rg.py
+++ b/python/mirage/commands/builtin/gmail/rg.py
@@ -27,7 +27,7 @@ from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagView
 from mirage.core.gmail.read import read as gmail_read
 from mirage.core.gmail.readdir import readdir as _readdir
-from mirage.core.gmail.scope import detect_scope
+from mirage.core.gmail.scope import NATIVE_KINDS, detect_scope
 from mirage.core.gmail.search import format_grep_results, search_messages
 from mirage.core.gmail.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
@@ -46,18 +46,19 @@ async def rg(accessor: GmailAccessor, paths: list[PathSpec], texts: list[str],
     # operand with no reshaping flag may be answered by the search API.
     operand = pushdown_operand(paths, opts.flags, pattern_str, SEARCH_HONORED)
     if operand is not None and fl.as_bool("w"):
-        scope = detect_scope(operand)
-        if scope.use_native:
+        match = detect_scope(operand)
+        if match.kind in NATIVE_KINDS:
             file_prefix = mount_prefix_of(operand.virtual,
                                           operand.resource_path) or ""
             rows = await search_messages(
                 accessor.token_manager,
                 pattern_str,
-                label_name=scope.label_name,
-                date_str=scope.date_str,
+                label_name=match.slots.get("label"),
+                date_str=match.slots.get("day"),
                 max_results=SEARCH_MAX_RESULTS,
             )
-            lines = format_grep_results(rows, scope, file_prefix, pattern_str)
+            lines = format_grep_results(rows, match.slots.get("label"),
+                                        file_prefix, pattern_str)
             if not lines:
                 return b"", IOResult(exit_code=1)
             return format_records(lines), IOResult()

--- a/python/mirage/commands/builtin/slack/grep.py
+++ b/python/mirage/commands/builtin/slack/grep.py
@@ -31,7 +31,7 @@ from mirage.core.slack.formatters import (build_query,
                                           format_grep_results)
 from mirage.core.slack.read import read as slack_read
 from mirage.core.slack.readdir import readdir as _readdir
-from mirage.core.slack.scope import detect_scope
+from mirage.core.slack.scope import NATIVE_KINDS, detect_scope, search_target
 from mirage.core.slack.search import (search_available, search_files,
                                       search_messages)
 from mirage.core.slack.stat import stat as _stat
@@ -82,19 +82,15 @@ async def grep(accessor: SlackAccessor, paths: list[PathSpec],
     # the per-message scan; see SEARCH_HONORED above.
     operand = pushdown_operand(paths, opts.flags, pattern, SEARCH_HONORED)
     if pattern is not None and operand is not None and fl.as_bool("w"):
-        scope = detect_scope(operand)
-        if (scope.use_native and scope.target != "files"
-                and search_available(accessor.config)):
+        match = detect_scope(operand)
+        if match.kind in NATIVE_KINDS and search_available(accessor.config):
+            target = search_target(match)
             file_prefix = mount_prefix_of(operand.virtual,
                                           operand.resource_path) or ""
-            query = build_query(pattern, scope)
-            # Every scope that reaches here searches messages: the guard
-            # above ruled out the files leaf, and a "messages" target is a
-            # chat.jsonl leaf, which is not use_native. What is left is the
-            # channel, container and root scopes and the date directory --
-            # and those carry files too, so only the files half stays
-            # conditional.
-            do_files = scope.target in (None, "date")
+            query = build_query(pattern, target)
+            # Every kind that reaches here searches messages, and each of
+            # them (the root, the containers, a channel, a date dir)
+            # carries files too, so both halves run.
             native_lines: list[str] = []
             err: Exception | None = None
             try:
@@ -102,13 +98,12 @@ async def grep(accessor: SlackAccessor, paths: list[PathSpec],
                                             query,
                                             count=SEARCH_MAX_RESULTS)
                 native_lines.extend(
-                    format_grep_results(raw, scope, file_prefix))
-                if do_files:
-                    raw_f = await search_files(accessor.config,
-                                               query,
-                                               count=SEARCH_MAX_RESULTS)
-                    native_lines.extend(
-                        format_file_grep_results(raw_f, scope, file_prefix))
+                    format_grep_results(raw, target, file_prefix))
+                raw_f = await search_files(accessor.config,
+                                           query,
+                                           count=SEARCH_MAX_RESULTS)
+                native_lines.extend(
+                    format_file_grep_results(raw_f, target, file_prefix))
             except Exception as exc:
                 err = exc
             if err is None:

--- a/python/mirage/commands/builtin/slack/io.py
+++ b/python/mirage/commands/builtin/slack/io.py
@@ -18,6 +18,7 @@ from mirage.commands.builtin.generic_bind import CommandIO
 from mirage.commands.builtin.utils.wrap import stream_from_bytes
 from mirage.core.slack.constants import DU_MAX_ENTRIES
 from mirage.core.slack.read import read as _read
+from mirage.core.slack.read import read_range as _read_range
 from mirage.core.slack.readdir import readdir as _readdir
 from mirage.core.slack.stat import stat as _stat
 
@@ -28,7 +29,7 @@ from mirage.core.slack.stat import stat as _stat
 IO = CommandIO(
     readdir=_readdir,
     read_bytes=_read,
-    read_range=_read,
+    read_range=_read_range,
     read_stream=partial(stream_from_bytes, _read),
     stat=_stat,
     is_mounted=lambda a: True,

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -32,7 +32,7 @@ from mirage.core.slack.formatters import (build_query,
                                           format_grep_results)
 from mirage.core.slack.read import read as slack_read
 from mirage.core.slack.readdir import readdir as _readdir
-from mirage.core.slack.scope import detect_scope
+from mirage.core.slack.scope import NATIVE_KINDS, detect_scope, search_target
 from mirage.core.slack.search import (search_available, search_files,
                                       search_messages)
 from mirage.core.slack.stat import stat as _stat
@@ -55,19 +55,15 @@ async def rg(accessor: SlackAccessor, paths: list[PathSpec], texts: list[str],
     # operand with no reshaping flag may be answered by the search API.
     operand = pushdown_operand(paths, opts.flags, pattern_str, SEARCH_HONORED)
     if operand is not None and fl.as_bool("w"):
-        scope = detect_scope(operand)
-        if (scope.use_native and scope.target != "files"
-                and search_available(accessor.config)):
+        match = detect_scope(operand)
+        if match.kind in NATIVE_KINDS and search_available(accessor.config):
+            target = search_target(match)
             file_prefix = mount_prefix_of(operand.virtual,
                                           operand.resource_path) or ""
-            query = build_query(pattern_str, scope)
-            # Every scope that reaches here searches messages: the guard
-            # above ruled out the files leaf, and a "messages" target is a
-            # chat.jsonl leaf, which is not use_native. What is left is the
-            # channel, container and root scopes and the date directory --
-            # and those carry files too, so only the files half stays
-            # conditional.
-            do_files = scope.target in (None, "date")
+            query = build_query(pattern_str, target)
+            # Every kind that reaches here searches messages, and each of
+            # them (the root, the containers, a channel, a date dir)
+            # carries files too, so both halves run.
             native_lines: list[str] = []
             err: Exception | None = None
             try:
@@ -75,13 +71,12 @@ async def rg(accessor: SlackAccessor, paths: list[PathSpec], texts: list[str],
                                             query,
                                             count=SEARCH_MAX_RESULTS)
                 native_lines.extend(
-                    format_grep_results(raw, scope, file_prefix))
-                if do_files:
-                    raw_f = await search_files(accessor.config,
-                                               query,
-                                               count=SEARCH_MAX_RESULTS)
-                    native_lines.extend(
-                        format_file_grep_results(raw_f, scope, file_prefix))
+                    format_grep_results(raw, target, file_prefix))
+                raw_f = await search_files(accessor.config,
+                                           query,
+                                           count=SEARCH_MAX_RESULTS)
+                native_lines.extend(
+                    format_file_grep_results(raw_f, target, file_prefix))
             except Exception as exc:
                 err = exc
             if err is None:

--- a/python/mirage/core/discord/entry.py
+++ b/python/mirage/core/discord/entry.py
@@ -98,10 +98,13 @@ def member_entry(m: dict[str, Any]) -> IndexEntry:
     )
 
 
-def history_entry(channel_key: str, date: str) -> IndexEntry:
+def history_entry(channel_id: str, date: str) -> IndexEntry:
+    # channel_id rides extra so the day and files listers can query the
+    # history API without re-resolving the channel through its parent.
     return IndexEntry(
-        id=f"{channel_key}:{date}",
+        id=f"{channel_id}:{date}",
         name=date,
         resource_type=DiscordResourceType.HISTORY,
-        vfs_name=f"{date}.jsonl",
+        vfs_name=date,
+        extra={"channel_id": channel_id},
     )

--- a/python/mirage/core/discord/read.py
+++ b/python/mirage/core/discord/read.py
@@ -13,104 +13,113 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.discord import DiscordAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.discord.files import download_file
 from mirage.core.discord.history import get_history_jsonl
 from mirage.core.discord.members import list_members
-from mirage.core.discord.readdir import readdir as _readdir
+from mirage.core.discord.readdir import readdir
 from mirage.core.discord.render import member_json_bytes
+from mirage.core.discord.scope import detect_scope
+from mirage.core.hierarchy.probe import resolve_entry
+from mirage.core.hierarchy.read import make_read, make_read_range
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
-from mirage.utils.ranges import slice_window
 
 
-async def _ensure_channel(
-    index: IndexCacheStore,
-    prefix: str,
-    ch_key: str,
-    virtual: str,
-):
-    ch_virtual = prefix + "/" + ch_key
-    lookup = await index.get(ch_virtual)
-    if lookup.entry is None:
-        raise enoent(virtual)
-    return lookup
+async def _ancestor_entry(accessor: DiscordAccessor, path: PathSpec,
+                          index: IndexCacheStore,
+                          up: int) -> IndexEntry | None:
+    virtual = path.virtual.rstrip("/")
+    for _ in range(up):
+        virtual = virtual.rsplit("/", 1)[0]
+    prefix = mount_prefix_of(path.virtual, path.resource_path)
+    spec = PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=mount_key(virtual, prefix))
+    return await resolve_entry(readdir, accessor, spec, index)
 
 
-async def read(
-    accessor: DiscordAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-    offset: int = 0,
-    size: int | None = None,
-) -> bytes:
-    """Read a Discord path, optionally only a byte range of it.
+async def _read_chat(accessor: DiscordAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    """Render one day's history; the channel id comes from the listing.
 
-    Only an attachment has a remote range to ask for. A channel's
-    history and a member profile are rendered here into JSON, so their
-    bytes do not exist until we make them and the window can only be
-    taken afterwards.
+    The typed ``name__id`` dirname is only trusted once the listing
+    proves it, so a fabricated channel id is ENOENT rather than a raw
+    API error.
 
     Args:
-        accessor (DiscordAccessor): Discord accessor.
-        path (PathSpec): the path to read.
-        index (IndexCacheStore): listing cache, consulted for the entry.
-        offset (int): first byte to read.
-        size (int | None): how many bytes, or None for the rest.
+        accessor (DiscordAccessor): discord accessor.
+        match (ScopeMatch): a match holding the day chain.
+        path (PathSpec): the chat.jsonl path.
+        index (IndexCacheStore): index cache.
     """
-    virtual = path.virtual if isinstance(path, PathSpec) else path
-    prefix = mount_prefix_of(path.virtual, path.resource_path)
-    key = path.resource_path
-    parts = key.split("/")
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is not None:
+        channel_id = entry.id.split(":", 1)[0]
+    else:
+        # A sealed day lists nothing but the file still reads through
+        # the channel, reproducing the API's own answer for the fetch.
+        channel = await _ancestor_entry(accessor, path, index, up=2)
+        if channel is None:
+            raise enoent(path.virtual)
+        channel_id = channel.id
+    return await get_history_jsonl(accessor.config, channel_id,
+                                   match.slots["day"])
 
-    # <guild>/channels/<ch>/<date>/chat.jsonl
-    if (len(parts) == 5 and parts[1] == "channels"
-            and parts[4] == "chat.jsonl"):
-        ch_key = f"{parts[0]}/{parts[1]}/{parts[2]}"
-        ch_lookup = await _ensure_channel(index, prefix, ch_key, virtual)
-        history = await get_history_jsonl(accessor.config, ch_lookup.entry.id,
-                                          parts[3])
-        return slice_window(history, offset, size)
 
-    # <guild>/channels/<ch>/<date>/files/<blob>
-    if (len(parts) == 6 and parts[1] == "channels" and parts[4] == "files"):
-        virtual_key = prefix + "/" + key
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            # Hydrate via date dir readdir, which triggers _fetch_day
-            date_key = "/".join(parts[:4])
-            date_spec = PathSpec(
-                virtual=prefix + "/" + date_key,
-                directory=prefix + "/" + date_key,
-                resource_path=mount_key(prefix + "/" + date_key, prefix),
-            )
-            await _readdir(accessor, date_spec, index)
-            lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            raise enoent(virtual)
-        url = (lookup.entry.extra
-               or {}).get("url") or (lookup.entry.extra
-                                     or {}).get("proxy_url") or ""
-        if not url:
-            raise enoent(virtual)
-        return await download_file(url, offset, size)
+async def _read_member(accessor: DiscordAccessor, match: ScopeMatch,
+                       path: PathSpec, index: IndexCacheStore) -> bytes:
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is None:
+        raise enoent(path.virtual)
+    members = await list_members(accessor.config, match.slots["guild_id"])
+    for m in members:
+        user = m.get("user", {})
+        if user.get("id") == entry.id:
+            return member_json_bytes(m)
+    raise enoent(path.virtual)
 
-    # <guild>/members/<user>.json
-    if len(parts) == 3 and parts[1] == "members":
-        virtual_key = prefix + "/" + key
-        entry_lookup = await index.get(virtual_key)
-        if entry_lookup.entry is None:
-            raise enoent(virtual)
-        guild_virtual = prefix + "/" + parts[0]
-        guild_lookup = await index.get(guild_virtual)
-        if guild_lookup.entry is None:
-            raise enoent(virtual)
-        members = await list_members(accessor.config, guild_lookup.entry.id)
-        for m in members:
-            user = m.get("user", {})
-            if user.get("id") == entry_lookup.entry.id:
-                return slice_window(member_json_bytes(m), offset, size)
-        raise enoent(virtual)
 
-    raise enoent(virtual)
+async def _blob_url(accessor: DiscordAccessor, path: PathSpec,
+                    index: IndexCacheStore) -> str:
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is None:
+        raise enoent(path.virtual)
+    url = entry.extra.get("url") or entry.extra.get("proxy_url") or ""
+    if not url:
+        raise enoent(path.virtual)
+    return url
+
+
+async def _read_blob(accessor: DiscordAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    return await download_file(await _blob_url(accessor, path, index), 0, None)
+
+
+async def _read_blob_range(accessor: DiscordAccessor, match: ScopeMatch,
+                           path: PathSpec, index: IndexCacheStore, offset: int,
+                           size: int | None) -> bytes:
+    return await download_file(await _blob_url(accessor, path, index), offset,
+                               size)
+
+
+read = make_read(
+    detect_scope,
+    readers={
+        "messages": _read_chat,
+        "member": _read_member,
+        "file_blob": _read_blob,
+    },
+)
+
+# Only an attachment has a remote range to ask for. A channel's history
+# and a member profile are rendered here into JSON, so their bytes do
+# not exist until we make them and the window can only be taken
+# afterwards.
+read_range = make_read_range(
+    detect_scope,
+    read,
+    ranged={"file_blob": _read_blob_range},
+)

--- a/python/mirage/core/discord/readdir.py
+++ b/python/mirage/core/discord/readdir.py
@@ -18,23 +18,25 @@ from datetime import datetime, timedelta, timezone
 import aiohttp
 
 from mirage.accessor.discord import DiscordAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
+from mirage.cache.index import IndexEntry
 from mirage.core.discord.channels import list_channels
-from mirage.core.discord.entry import (DiscordResourceType, channel_entry,
-                                       guild_entry, history_entry,
-                                       member_entry, snowflake_to_date)
+from mirage.core.discord.entry import (channel_entry, guild_entry,
+                                       history_entry, member_entry,
+                                       snowflake_to_date)
 from mirage.core.discord.files import file_blob_name
 from mirage.core.discord.guilds import list_guilds
 from mirage.core.discord.history import list_messages_for_day
 from mirage.core.discord.members import list_members
 from mirage.core.discord.render import history_jsonl_bytes
-from mirage.types import PathSpec
-from mirage.utils.errors import enoent, enotdir
-from mirage.utils.key_prefix import mount_key, mount_prefix_of
+from mirage.core.discord.scope import detect_scope
+from mirage.core.hierarchy.readdir import DirListing, Listed, make_readdir
+from mirage.core.hierarchy.scope import ScopeMatch
 
 logger = logging.getLogger(__name__)
 
 SOFT_HTTP_STATUSES = frozenset((403, 404, 429))
+
+CONTAINER_TYPE = "discord/container"
 
 
 def _is_soft_error(exc: Exception) -> bool:
@@ -48,172 +50,64 @@ def _date_range(end_date: str, days: int = 30) -> list[str]:
             for i in range(days - 1, -1, -1)]
 
 
-def _normalize_path(path: PathSpec) -> tuple[str, str, str]:
-    """Reduce input to (prefix, key, virtual_key)."""
-    prefix = mount_prefix_of(path.virtual, path.resource_path)
-    raw = path.directory if path.pattern else path.virtual
-    if prefix and raw.startswith(prefix):
-        raw = raw[len(prefix):] or "/"
-    key = raw.strip("/")
-    virtual_key = prefix + "/" + key if key else prefix or "/"
-    return prefix, key, virtual_key
+def _container_entry(name: str, guild_id: str) -> IndexEntry:
+    return IndexEntry(
+        id=guild_id,
+        name=name,
+        resource_type=CONTAINER_TYPE,
+        vfs_name=name,
+    )
 
 
-async def _readdir_root(
-    accessor: DiscordAccessor,
-    prefix: str,
-    virtual_key: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    listing = await index.list_dir(virtual_key)
-    if listing.entries is not None:
-        return listing.entries
+async def _list_root(accessor: DiscordAccessor, match: ScopeMatch) -> Listed:
     guilds = await list_guilds(accessor.config)
-    entries = []
-    names = []
-    for g in guilds:
-        entry = guild_entry(g)
-        entries.append((entry.vfs_name, entry))
-        names.append(f"{prefix}/{entry.vfs_name}")
-    await index.set_dir(virtual_key, entries)
-    return names
+    entries = [guild_entry(g) for g in guilds]
+    return [(entry.vfs_name, entry) for entry in entries]
 
 
-async def _ensure_guild_id(
-    accessor: DiscordAccessor,
-    prefix: str,
-    guild_part: str,
-    index: IndexCacheStore,
-    raw_path: str,
-) -> str:
-    guild_virtual_key = prefix + "/" + guild_part
-    lookup = await index.get(guild_virtual_key)
-    if lookup.entry is None:
-        await _readdir_root(accessor, prefix, prefix or "/", index)
-        lookup = await index.get(guild_virtual_key)
-    if lookup.entry is None:
-        raise enoent(raw_path)
-    return lookup.entry.id
+async def _list_guild(accessor: DiscordAccessor, match: ScopeMatch,
+                      own: IndexEntry) -> Listed:
+    return [
+        ("channels", _container_entry("channels", own.id)),
+        ("members", _container_entry("members", own.id)),
+    ]
 
 
-async def _readdir_guild_top(
-    prefix: str,
-    key: str,
-) -> list[str]:
-    return [f"{prefix}/{key}/channels", f"{prefix}/{key}/members"]
+async def _list_channels_dir(accessor: DiscordAccessor, match: ScopeMatch,
+                             own: IndexEntry) -> Listed:
+    channels = await list_channels(accessor.config, own.id)
+    entries = [channel_entry(c) for c in channels]
+    return [(entry.vfs_name, entry) for entry in entries]
 
 
-async def _readdir_channels(
-    accessor: DiscordAccessor,
-    prefix: str,
-    key: str,
-    virtual_key: str,
-    parts: list[str],
-    index: IndexCacheStore,
-    raw_path: str,
-) -> list[str]:
-    listing = await index.list_dir(virtual_key)
-    if listing.entries is not None:
-        return listing.entries
-    guild_id = await _ensure_guild_id(accessor, prefix, parts[0], index,
-                                      raw_path)
-    channels = await list_channels(accessor.config, guild_id)
-    entries = []
-    names = []
-    for c in channels:
-        entry = channel_entry(c)
-        entries.append((entry.vfs_name, entry))
-        names.append(f"{prefix}/{key}/{entry.vfs_name}")
-    await index.set_dir(virtual_key, entries)
-    return names
+async def _list_members_dir(accessor: DiscordAccessor, match: ScopeMatch,
+                            own: IndexEntry) -> Listed:
+    members = await list_members(accessor.config, own.id)
+    entries = [member_entry(m) for m in members]
+    return [(entry.vfs_name, entry) for entry in entries]
 
 
-async def _readdir_members(
-    accessor: DiscordAccessor,
-    prefix: str,
-    key: str,
-    virtual_key: str,
-    parts: list[str],
-    index: IndexCacheStore,
-    raw_path: str,
-) -> list[str]:
-    listing = await index.list_dir(virtual_key)
-    if listing.entries is not None:
-        return listing.entries
-    guild_id = await _ensure_guild_id(accessor, prefix, parts[0], index,
-                                      raw_path)
-    members = await list_members(accessor.config, guild_id)
-    entries = []
-    names = []
-    for m in members:
-        entry = member_entry(m)
-        entries.append((entry.vfs_name, entry))
-        names.append(f"{prefix}/{key}/{entry.vfs_name}")
-    await index.set_dir(virtual_key, entries)
-    return names
-
-
-async def _ensure_channel_lookup(
-    accessor: DiscordAccessor,
-    prefix: str,
-    parts: list[str],
-    index: IndexCacheStore,
-    raw_path: str,
-):
-    channel_vk = f"{prefix}/{'/'.join(parts[:3])}"
-    lookup = await index.get(channel_vk)
-    if lookup.entry is None:
-        await _readdir_channels(accessor, prefix, "/".join(parts[:2]),
-                                f"{prefix}/{'/'.join(parts[:2])}", parts[:2],
-                                index, raw_path)
-        lookup = await index.get(channel_vk)
-    if lookup.entry is None:
-        raise enoent(raw_path)
-    return lookup
-
-
-async def _readdir_channel_dates(
-    accessor: DiscordAccessor,
-    prefix: str,
-    key: str,
-    virtual_key: str,
-    parts: list[str],
-    index: IndexCacheStore,
-    raw_path: str,
-) -> list[str]:
-    listing = await index.list_dir(virtual_key)
-    if listing.entries is not None:
-        return listing.entries
-    lookup = await _ensure_channel_lookup(accessor, prefix, parts, index,
-                                          raw_path)
-    last_msg_id = lookup.entry.remote_time
+async def _list_channel_days(accessor: DiscordAccessor, match: ScopeMatch,
+                             own: IndexEntry) -> Listed:
+    last_msg_id = own.remote_time
     if last_msg_id:
         end_date = snowflake_to_date(last_msg_id)
     else:
         end_date = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
-    dates = _date_range(end_date)
-    entries = []
-    names = []
-    for d in dates:
-        entry = history_entry(key, d)
-        entry.resource_type = DiscordResourceType.HISTORY
-        entry.vfs_name = d
-        entries.append((d, entry))
-        names.append(f"{prefix}/{key}/{d}")
-    await index.set_dir(virtual_key, entries)
-    return names
+    return [(d, history_entry(own.id, d)) for d in _date_range(end_date)]
 
 
-async def _fetch_day(
-    accessor: DiscordAccessor,
-    channel_id: str,
-    date_str: str,
-    date_vkey: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> None:
-    """Walk the day's history once, populate date dir and files dir
-    entries in the index. Tolerates soft HTTP errors (403/404/429) by
-    sealing an empty date dir.
+async def _day_listing(accessor: DiscordAccessor, channel_id: str,
+                       date_str: str) -> DirListing:
+    """One history fetch, answering the day dir and its files subdir.
+
+    A soft HTTP error (403/404/429) seals an empty day: the dir lists
+    nothing, and stat serves chat.jsonl with the size left unknown.
+
+    Args:
+        accessor (DiscordAccessor): discord accessor.
+        channel_id (str): the channel snowflake.
+        date_str (str): the day, ``YYYY-MM-DD``.
     """
     try:
         messages = await list_messages_for_day(accessor.config, channel_id,
@@ -222,8 +116,7 @@ async def _fetch_day(
         if _is_soft_error(e):
             logger.debug("discord: history denied for %s/%s (%d); empty day",
                          channel_id, date_str, e.status)
-            await index.set_dir(date_vkey, [])
-            return
+            return DirListing(entries=[])
         raise
     # The day's messages are already in hand, so chat.jsonl's exact rendered
     # size is free here; read() renders the same messages the same way.
@@ -239,11 +132,11 @@ async def _fetch_day(
         name="files",
         resource_type="discord/files_dir",
         vfs_name="files",
+        extra={
+            "channel_id": channel_id,
+            "date": date_str
+        },
     )
-    await index.set_dir(date_vkey, [
-        ("chat.jsonl", chat_entry),
-        ("files", files_entry),
-    ])
     file_entries: list[tuple[str, IndexEntry]] = []
     for msg in messages:
         for att in msg.get("attachments") or []:
@@ -280,120 +173,39 @@ async def _fetch_day(
                                          date_str,
                                      },
                                  )))
-    await index.set_dir(f"{date_vkey}/files", file_entries)
+    return DirListing(
+        entries=[("chat.jsonl", chat_entry), ("files", files_entry)],
+        seeds={"files": file_entries},
+    )
 
 
-async def _readdir_date_contents(
-    accessor: DiscordAccessor,
-    prefix: str,
-    key: str,
-    virtual_key: str,
-    parts: list[str],
-    index: IndexCacheStore,
-    raw_path: str,
-) -> list[str]:
-    cached = await index.list_dir(virtual_key)
-    if cached.entries is not None:
-        return cached.entries
-    lookup = await _ensure_channel_lookup(accessor, prefix, parts, index,
-                                          raw_path)
-    await _fetch_day(accessor, lookup.entry.id, parts[3], virtual_key, index)
-    cached = await index.list_dir(virtual_key)
-    if cached.entries is None:
-        raise enoent(raw_path)
-    return cached.entries
+async def _list_day(accessor: DiscordAccessor, match: ScopeMatch,
+                    channel: IndexEntry) -> Listed:
+    # The proof is the channel entry, not the day's own: any well-formed
+    # date under a real channel fetches, including dates outside the
+    # bounded window the channel listing mints.
+    return await _day_listing(accessor, channel.id, match.slots["day"])
 
 
-async def _readdir_files_dir(
-    accessor: DiscordAccessor,
-    prefix: str,
-    key: str,
-    virtual_key: str,
-    parts: list[str],
-    index: IndexCacheStore,
-    raw_path: str,
-) -> list[str]:
-    cached = await index.list_dir(virtual_key)
-    if cached.entries is not None:
-        return cached.entries
-    # Date dir lookup triggers _fetch_day which populates the files dir
-    date_key = "/".join(parts[:4])
-    date_vk = f"{prefix}/{date_key}"
-    date_spec = PathSpec(virtual=date_vk,
-                         directory=date_vk,
-                         resource_path=mount_key(date_vk, prefix))
-    await readdir(accessor, date_spec, index)
-    cached = await index.list_dir(virtual_key)
-    if cached.entries is None:
-        raise enoent(raw_path)
-    return cached.entries
+async def _list_files(accessor: DiscordAccessor, match: ScopeMatch,
+                      own: IndexEntry) -> Listed:
+    # Normally served from the day lister's seed; reached only when the
+    # index evicted the files listing while the day's entries survived.
+    channel_id = own.extra.get("channel_id") or own.id.split(":", 1)[0]
+    listing = await _day_listing(accessor, channel_id, match.slots["day"])
+    return listing.seeds.get("files", [])
 
 
-def _is_leaf(parts: list[str]) -> bool:
-    """Report whether the path names a file rather than a directory.
-
-    Args:
-        parts (list[str]): mount-relative path segments.
-    """
-    if len(parts) == 3 and parts[1] == "members":
-        return parts[2].endswith(".json")
-    if len(parts) == 5 and parts[1] == "channels":
-        return parts[4] == "chat.jsonl"
-    if len(parts) == 6 and parts[1] == "channels" and parts[4] == "files":
-        return True
-    return False
-
-
-async def readdir(
-    accessor: DiscordAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    """List directory contents.
-
-    Args:
-        accessor (DiscordAccessor): discord accessor.
-        path (PathSpec): resource-relative path.
-        index (IndexCacheStore): index cache.
-    """
-    prefix, key, virtual_key = _normalize_path(path)
-    raw_path = path.virtual
-
-    if not key:
-        return await _readdir_root(accessor, prefix, virtual_key, index)
-
-    parts = key.split("/")
-
-    if len(parts) == 1:
-        # Bootstrap from the root listing when the index is cold, the way
-        # every other branch does: listing a guild directly must not depend
-        # on having listed the mount root first.
-        await _ensure_guild_id(accessor, prefix, parts[0], index, raw_path)
-        return await _readdir_guild_top(prefix, key)
-
-    if len(parts) == 2 and parts[1] == "channels":
-        return await _readdir_channels(accessor, prefix, key, virtual_key,
-                                       parts, index, raw_path)
-
-    if len(parts) == 2 and parts[1] == "members":
-        return await _readdir_members(accessor, prefix, key, virtual_key,
-                                      parts, index, raw_path)
-
-    if len(parts) == 3 and parts[1] == "channels":
-        return await _readdir_channel_dates(accessor, prefix, key, virtual_key,
-                                            parts, index, raw_path)
-
-    if len(parts) == 4 and parts[1] == "channels":
-        return await _readdir_date_contents(accessor, prefix, key, virtual_key,
-                                            parts, index, raw_path)
-
-    if (len(parts) == 5 and parts[1] == "channels" and parts[4] == "files"):
-        return await _readdir_files_dir(accessor, prefix, key, virtual_key,
-                                        parts, index, raw_path)
-
-    # A leaf that exists is ENOTDIR, not ENOENT: callers tell "this is a
-    # file, read it" from "there is nothing here" by the errno. Anything
-    # else is a shape discord does not serve.
-    if _is_leaf(parts):
-        raise enotdir(raw_path)
-    raise enoent(raw_path)
+readdir = make_readdir(
+    detect_scope,
+    listers={"root": _list_root},
+    entry_listers={
+        "guild": _list_guild,
+        "channels_dir": _list_channels_dir,
+        "members_dir": _list_members_dir,
+        "channel": _list_channel_days,
+        "files": _list_files,
+    },
+    parent_entry_listers={"day": _list_day},
+    leaf_error="enotdir",
+)

--- a/python/mirage/core/discord/scope.py
+++ b/python/mirage/core/discord/scope.py
@@ -12,237 +12,44 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
-from dataclasses import dataclass
+from mirage.core.hierarchy.codec import DATE, JSON_NAME
+from mirage.core.hierarchy.scope import Scope, Slot, make_detect_scope
+from mirage.types import FileType
 
-from mirage.types import PathSpec
-from mirage.utils.key_prefix import mount_prefix_of
+_GUILD = (Slot("guild", id_key="guild_id"), )
+_CHANNEL = _GUILD + ("channels", Slot("channel", id_key="channel_id"))
+_DAY = _CHANNEL + (Slot("day", DATE), )
 
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+# One description of the tree: readdir, stat, read and the search
+# push-down all classify through it, so the file surface and the command
+# surface cannot disagree about what a path means. Every dynamic level
+# is a `name__id` dirname the tree itself mints, so the ids decode from
+# the path and detection needs no index or network round-trip.
+SCOPES = (
+    Scope(kind="guild", segments=_GUILD),
+    Scope(kind="channels_dir", segments=_GUILD + ("channels", )),
+    Scope(kind="members_dir", segments=_GUILD + ("members", )),
+    Scope(kind="channel", segments=_CHANNEL),
+    Scope(kind="member",
+          segments=_GUILD +
+          ("members", Slot("member", JSON_NAME, id_key="user_id")),
+          leaf=True,
+          filetype=FileType.JSON),
+    Scope(kind="day", segments=_DAY),
+    Scope(kind="messages",
+          segments=_DAY + ("chat.jsonl", ),
+          leaf=True,
+          filetype=FileType.TEXT),
+    Scope(kind="files", segments=_DAY + ("files", )),
+    Scope(kind="file_blob", segments=_DAY + ("files", Slot("blob")),
+          leaf=True),
+)
 
+detect_scope = make_detect_scope(SCOPES)
 
-@dataclass
-class DiscordScope:
-    """Resolved scope for a discord path.
-
-    Attributes:
-        level (str): one of ``root``, ``guild``, ``channel``, ``date``,
-            ``messages``, ``files``, ``file_blob``, ``member``.
-        use_native (bool): whether native guild search may serve this scope.
-        guild_name (str | None): display half of the guild dirname.
-        guild_id (str | None): guild snowflake parsed from the dirname.
-        channel_name (str | None): display half of the channel dirname.
-        channel_id (str | None): channel snowflake parsed from the dirname.
-        member_name (str | None): display half of the member filename.
-        member_id (str | None): user snowflake parsed from the filename.
-        container (str | None): ``channels`` or ``members``.
-        date_str (str | None): ``YYYY-MM-DD`` for date-level and below.
-        resource_path (str): resource-relative key (prefix stripped).
-    """
-
-    level: str
-    use_native: bool
-    guild_name: str | None = None
-    guild_id: str | None = None
-    channel_name: str | None = None
-    channel_id: str | None = None
-    member_name: str | None = None
-    member_id: str | None = None
-    container: str | None = None
-    date_str: str | None = None
-    resource_path: str = "/"
-
-
-def _split_dirname(dirname: str) -> tuple[str, str | None]:
-    if "__" in dirname:
-        name, _, cid = dirname.rpartition("__")
-        return name, cid or None
-    return dirname, None
-
-
-def detect_scope(path: PathSpec) -> DiscordScope:
-    """Determine scope from a path.
-
-    IDs come straight out of the ``name__id`` dirnames the tree mints, so
-    detection is pure and needs no index or network round-trip; a bare
-    name without ``__id`` yields ``None`` ids and the caller falls back
-    to the scan. Mirrors the TypeScript ``detectScope``.
-
-    Examples::
-
-        /                                              → root
-        /<guild>                                       → guild
-        /<guild>/channels                              → guild
-        /<guild>/members                               → guild
-        /<guild>/channels/<ch>                         → channel
-        /<guild>/members/<user>.json                   → member
-        /<guild>/channels/<ch>/<date>                  → date
-        /<guild>/channels/<ch>/<date>/chat.jsonl       → messages
-        /<guild>/channels/<ch>/<date>/files            → files
-        /<guild>/channels/<ch>/<date>/files/<blob>     → file_blob
-    """
-
-    prefix = mount_prefix_of(path.virtual, path.resource_path) or ""
-
-    if path.pattern and path.pattern.endswith(".jsonl"):
-        dir_key = path.directory.strip("/")
-        if prefix:
-            dir_key = dir_key.removeprefix(prefix.strip("/") + "/")
-        dp = dir_key.split("/") if dir_key else []
-        if len(dp) == 3 and dp[1] == "channels" and dp[0] and dp[2]:
-            guild_name, guild_id = _split_dirname(dp[0])
-            channel_name, channel_id = _split_dirname(dp[2])
-            return DiscordScope(
-                level="channel",
-                use_native=True,
-                guild_name=guild_name,
-                guild_id=guild_id,
-                channel_name=channel_name,
-                channel_id=channel_id,
-                container="channels",
-                resource_path=dir_key,
-            )
-        if (len(dp) == 4 and dp[1] == "channels" and dp[0] and dp[2]
-                and _DATE_RE.match(dp[3])):
-            guild_name, guild_id = _split_dirname(dp[0])
-            channel_name, channel_id = _split_dirname(dp[2])
-            return DiscordScope(
-                level="messages",
-                use_native=True,
-                guild_name=guild_name,
-                guild_id=guild_id,
-                channel_name=channel_name,
-                channel_id=channel_id,
-                container="channels",
-                date_str=dp[3],
-                resource_path=dir_key,
-            )
-
-    key = path.resource_path
-    if not key:
-        return DiscordScope(level="root", use_native=True, resource_path="/")
-
-    parts = key.split("/")
-
-    if len(parts) == 1:
-        guild_name, guild_id = _split_dirname(parts[0])
-        return DiscordScope(
-            level="guild",
-            use_native=True,
-            guild_name=guild_name,
-            guild_id=guild_id,
-            resource_path=key,
-        )
-
-    if len(parts) == 2:
-        guild_name, guild_id = _split_dirname(parts[0])
-        if parts[1] in ("channels", "members"):
-            return DiscordScope(
-                level="guild",
-                use_native=parts[1] == "channels",
-                guild_name=guild_name,
-                guild_id=guild_id,
-                container=parts[1],
-                resource_path=key,
-            )
-        return DiscordScope(
-            level="guild",
-            use_native=False,
-            guild_name=guild_name,
-            guild_id=guild_id,
-            resource_path=key,
-        )
-
-    if len(parts) == 3:
-        guild_name, guild_id = _split_dirname(parts[0])
-        if parts[1] == "channels":
-            channel_name, channel_id = _split_dirname(parts[2])
-            return DiscordScope(
-                level="channel",
-                use_native=True,
-                guild_name=guild_name,
-                guild_id=guild_id,
-                channel_name=channel_name,
-                channel_id=channel_id,
-                container="channels",
-                resource_path=key,
-            )
-        if parts[1] == "members":
-            member_name, member_id = _split_dirname(
-                parts[2].removesuffix(".json"))
-            return DiscordScope(
-                level="member",
-                use_native=False,
-                guild_name=guild_name,
-                guild_id=guild_id,
-                member_name=member_name,
-                member_id=member_id,
-                container="members",
-                resource_path=key,
-            )
-
-    # /<guild>/channels/<ch>/<date>
-    if (len(parts) == 4 and parts[1] == "channels"
-            and _DATE_RE.match(parts[3])):
-        guild_name, guild_id = _split_dirname(parts[0])
-        channel_name, channel_id = _split_dirname(parts[2])
-        return DiscordScope(
-            level="date",
-            use_native=True,
-            guild_name=guild_name,
-            guild_id=guild_id,
-            channel_name=channel_name,
-            channel_id=channel_id,
-            container="channels",
-            date_str=parts[3],
-            resource_path=key,
-        )
-
-    # /<guild>/channels/<ch>/<date>/chat.jsonl or .../files
-    if (len(parts) == 5 and parts[1] == "channels"
-            and _DATE_RE.match(parts[3])):
-        guild_name, guild_id = _split_dirname(parts[0])
-        channel_name, channel_id = _split_dirname(parts[2])
-        if parts[4] == "chat.jsonl":
-            return DiscordScope(
-                level="messages",
-                use_native=False,
-                guild_name=guild_name,
-                guild_id=guild_id,
-                channel_name=channel_name,
-                channel_id=channel_id,
-                container="channels",
-                date_str=parts[3],
-                resource_path=key,
-            )
-        if parts[4] == "files":
-            return DiscordScope(
-                level="files",
-                use_native=True,
-                guild_name=guild_name,
-                guild_id=guild_id,
-                channel_name=channel_name,
-                channel_id=channel_id,
-                container="channels",
-                date_str=parts[3],
-                resource_path=key,
-            )
-
-    # /<guild>/channels/<ch>/<date>/files/<blob>
-    if (len(parts) == 6 and parts[1] == "channels" and _DATE_RE.match(parts[3])
-            and parts[4] == "files"):
-        guild_name, guild_id = _split_dirname(parts[0])
-        channel_name, channel_id = _split_dirname(parts[2])
-        return DiscordScope(
-            level="file_blob",
-            use_native=False,
-            guild_name=guild_name,
-            guild_id=guild_id,
-            channel_name=channel_name,
-            channel_id=channel_id,
-            container="channels",
-            date_str=parts[3],
-            resource_path=key,
-        )
-
-    return DiscordScope(level="guild", use_native=False, resource_path=key)
+# Kinds the guild search push-down may answer for. A chat.jsonl operand
+# is deliberately absent: `search_guild` takes a channel but no date, so
+# serving a one-day file from a channel-wide search would report
+# messages the line did not ask for. Same doctrine for `file_blob` and
+# `member`, whose bytes the message search does not carry.
+NATIVE_KINDS = frozenset({"guild", "channels_dir", "channel", "day", "files"})

--- a/python/mirage/core/discord/stat.py
+++ b/python/mirage/core/discord/stat.py
@@ -12,145 +12,136 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import logging
-import re
-
 from mirage.accessor.discord import DiscordAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.discord.entry import snowflake_to_iso
-from mirage.core.discord.readdir import readdir as _readdir
+from mirage.core.discord.readdir import readdir
+from mirage.core.discord.scope import detect_scope
+from mirage.core.hierarchy.probe import resolve_entry
+from mirage.core.hierarchy.scope import ScopeMatch
+from mirage.core.hierarchy.stat import entry_stat, make_stat
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.filetype import filetype_from_mimetype
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
-logger = logging.getLogger(__name__)
 
-VIRTUAL_DIRS = {"", "channels", "members"}
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-
-
-async def _populate_via_parent(
-    accessor: DiscordAccessor,
-    virtual_key: str,
-    prefix: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> None:
-    parent_virtual = virtual_key.rsplit("/", 1)[0] or "/"
-    try:
-        await _readdir(
-            accessor,
-            PathSpec(virtual=parent_virtual,
-                     directory=parent_virtual,
-                     resource_path=mount_key(parent_virtual, prefix)),
-            index=index,
-        )
-    except FileNotFoundError as exc:
-        logger.debug("stat populate failed for %s: %s", virtual_key, exc)
+def _dir_stat(match: ScopeMatch, path: PathSpec,
+              entry: IndexEntry) -> FileStat:
+    return FileStat(name=entry.vfs_name, type=FileType.DIRECTORY)
 
 
-async def stat(
-    accessor: DiscordAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> FileStat:
-    virtual = path.virtual
+def _guild_stat(match: ScopeMatch, path: PathSpec,
+                entry: IndexEntry) -> FileStat:
+    return FileStat(
+        name=entry.vfs_name or entry.name,
+        type=FileType.DIRECTORY,
+        extra={"guild_id": entry.id},
+    )
+
+
+def _channel_stat(match: ScopeMatch, path: PathSpec,
+                  entry: IndexEntry) -> FileStat:
+    return FileStat(
+        name=entry.vfs_name or entry.name,
+        type=FileType.DIRECTORY,
+        modified=snowflake_to_iso(entry.remote_time),
+        extra={"channel_id": entry.id},
+    )
+
+
+def _file_blob_stat(match: ScopeMatch, path: PathSpec,
+                    entry: IndexEntry) -> FileStat:
+    mimetype = entry.extra.get("content_type", "")
+    return FileStat(
+        name=entry.vfs_name or entry.name,
+        size=entry.size,
+        type=filetype_from_mimetype(mimetype),
+        extra={
+            "content_type": mimetype,
+            "attachment_id": entry.id,
+        },
+    )
+
+
+async def _channel_proven(accessor: DiscordAccessor, path: PathSpec,
+                          index: IndexCacheStore, up: int) -> None:
+    """Raise ENOENT unless the path's channel ancestor exists.
+
+    Args:
+        accessor (DiscordAccessor): discord accessor.
+        path (PathSpec): the day or chat.jsonl path being stat'd.
+        index (IndexCacheStore): index cache.
+        up (int): how many trailing segments to drop to reach the
+            channel (1 for a day dir, 2 for its children).
+    """
+    virtual = path.virtual.rstrip("/")
+    for _ in range(up):
+        virtual = virtual.rsplit("/", 1)[0]
     prefix = mount_prefix_of(path.virtual, path.resource_path)
-    key = path.resource_path
+    spec = PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=mount_key(virtual, prefix))
+    if await resolve_entry(readdir, accessor, spec, index) is None:
+        raise enoent(path.virtual)
 
-    if not key:
-        return FileStat(name="/", type=FileType.DIRECTORY)
 
-    parts = key.split("/")
-    virtual_key = prefix + "/" + key
+async def _stat_day(accessor: DiscordAccessor, match: ScopeMatch,
+                    path: PathSpec, index: IndexCacheStore) -> FileStat:
+    """Stat a day directory, which resolves beyond the listed window.
 
-    if len(parts) == 1:
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            await _populate_via_parent(accessor, virtual_key, prefix, index)
-            lookup = await index.get(virtual_key)
-            if lookup.entry is None:
-                raise enoent(virtual)
-        return FileStat(
-            name=lookup.entry.vfs_name or lookup.entry.name,
-            type=FileType.DIRECTORY,
-            extra={"guild_id": lookup.entry.id},
-        )
+    The channel listing synthesizes a bounded window of recent days,
+    but the history API answers a range query for any date, so a
+    well-formed day under a channel that exists is a directory whether
+    or not the window lists it. A bogus channel chain is ENOENT.
 
-    if len(parts) == 2 and parts[1] in VIRTUAL_DIRS:
-        return FileStat(name=parts[1], type=FileType.DIRECTORY)
+    Args:
+        accessor (DiscordAccessor): discord accessor.
+        match (ScopeMatch): a match holding ``guild``/``channel``/``day``.
+        path (PathSpec): the path to stat.
+        index (IndexCacheStore): index cache.
+    """
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is not None:
+        return FileStat(name=entry.vfs_name, type=FileType.DIRECTORY)
+    await _channel_proven(accessor, path, index, up=1)
+    return FileStat(name=match.slots["day"], type=FileType.DIRECTORY)
 
-    if len(parts) == 3 and parts[1] == "channels":
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            await _populate_via_parent(accessor, virtual_key, prefix, index)
-            lookup = await index.get(virtual_key)
-            if lookup.entry is None:
-                raise enoent(virtual)
-        return FileStat(
-            name=lookup.entry.vfs_name or lookup.entry.name,
-            type=FileType.DIRECTORY,
-            modified=snowflake_to_iso(lookup.entry.remote_time),
-            extra={"channel_id": lookup.entry.id},
-        )
 
-    if len(parts) == 3 and parts[1] == "members":
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            await _populate_via_parent(accessor, virtual_key, prefix, index)
-            lookup = await index.get(virtual_key)
-            if lookup.entry is None:
-                raise enoent(virtual)
-        return FileStat(
-            name=lookup.entry.vfs_name or lookup.entry.name,
-            size=lookup.entry.size,
-            type=FileType.JSON,
-            extra={"user_id": lookup.entry.id},
-        )
+async def _stat_chat(accessor: DiscordAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> FileStat:
+    """Stat chat.jsonl, which survives a sealed day.
 
-    # <guild>/channels/<ch>/<date>
-    if (len(parts) == 4 and parts[1] == "channels"
-            and _DATE_RE.match(parts[3])):
-        return FileStat(name=parts[3], type=FileType.DIRECTORY)
+    A day whose history could not be listed (403/404/429) seals an
+    empty date dir; the file still stats, with the size left unknown.
 
-    # <guild>/channels/<ch>/<date>/chat.jsonl
-    if (len(parts) == 5 and parts[1] == "channels" and _DATE_RE.match(parts[3])
-            and parts[4] == "chat.jsonl"):
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            await _populate_via_parent(accessor, virtual_key, prefix, index)
-            lookup = await index.get(virtual_key)
-        # A day whose history could not be listed (403/404/429) seals an
-        # empty date dir; the file still stats, with the size left unknown.
-        return FileStat(
-            name="chat.jsonl",
-            size=lookup.entry.size if lookup.entry is not None else None,
-            type=FileType.TEXT,
-        )
+    Args:
+        accessor (DiscordAccessor): discord accessor.
+        match (ScopeMatch): a match holding the day chain.
+        path (PathSpec): the path to stat.
+        index (IndexCacheStore): index cache.
+    """
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is not None:
+        return FileStat(name="chat.jsonl", type=FileType.TEXT, size=entry.size)
+    await _channel_proven(accessor, path, index, up=2)
+    return FileStat(name="chat.jsonl", type=FileType.TEXT, size=None)
 
-    # <guild>/channels/<ch>/<date>/files
-    if (len(parts) == 5 and parts[1] == "channels" and _DATE_RE.match(parts[3])
-            and parts[4] == "files"):
-        return FileStat(name="files", type=FileType.DIRECTORY)
 
-    # <guild>/channels/<ch>/<date>/files/<blob>
-    if (len(parts) == 6 and parts[1] == "channels" and _DATE_RE.match(parts[3])
-            and parts[4] == "files"):
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            await _populate_via_parent(accessor, virtual_key, prefix, index)
-            lookup = await index.get(virtual_key)
-            if lookup.entry is None:
-                raise enoent(virtual)
-        mimetype = (lookup.entry.extra or {}).get("content_type", "")
-        return FileStat(
-            name=lookup.entry.vfs_name or lookup.entry.name,
-            size=lookup.entry.size,
-            type=filetype_from_mimetype(mimetype),
-            extra={
-                "content_type": mimetype,
-                "attachment_id": lookup.entry.id,
-            },
-        )
-
-    raise enoent(virtual)
+stat = make_stat(
+    detect_scope,
+    readdir,
+    entry_stats={
+        "guild": _guild_stat,
+        "channels_dir": _dir_stat,
+        "members_dir": _dir_stat,
+        "channel": _channel_stat,
+        "member": entry_stat("user_id", FileType.JSON),
+        "files": _dir_stat,
+        "file_blob": _file_blob_stat,
+    },
+    overrides={
+        "day": _stat_day,
+        "messages": _stat_chat,
+    },
+)

--- a/python/mirage/core/email/read.py
+++ b/python/mirage/core/email/read.py
@@ -12,47 +12,44 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import posixpath
-
 from mirage.accessor.email import EmailAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.cache.index import IndexCacheStore
 from mirage.core.email.client import fetch_attachment, fetch_message
+from mirage.core.email.readdir import readdir
 from mirage.core.email.render import message_json_bytes
+from mirage.core.email.scope import detect_scope
+from mirage.core.hierarchy.probe import resolve_entry
+from mirage.core.hierarchy.read import make_read
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-from mirage.utils.key_prefix import mount_prefix_of
 
 
-async def read(
-    accessor: EmailAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> bytes:
-    virtual = path.virtual
-    prefix = mount_prefix_of(path.virtual, path.resource_path)
-    key = path.resource_path
-    virtual_key = prefix + "/" + key if prefix else "/" + key
-    result = await index.get(virtual_key)
-    if result.entry is None:
-        raise enoent(virtual)
-    if result.entry.resource_type in ("email/folder", "email/date",
-                                      "email/attachment_dir"):
-        raise IsADirectoryError(virtual)
-    if result.entry.resource_type == "email/attachment":
-        parent_key = posixpath.dirname(virtual_key)
-        parent_result = await index.get(parent_key)
-        if parent_result.entry is None:
-            raise enoent(virtual)
-        uid = parent_result.entry.id
-        parts = virtual_key.strip("/").split("/")
-        folder = parts[1] if prefix else parts[0]
-        filename = result.entry.vfs_name
-        data = await fetch_attachment(accessor, folder, uid, filename)
-        if data is None:
-            raise enoent(virtual)
-        return data
-    parts = virtual_key.strip("/").split("/")
-    folder = parts[1] if prefix else parts[0]
-    uid = result.entry.id
-    msg = await fetch_message(accessor, folder, uid)
+async def _read_message(accessor: EmailAccessor, match: ScopeMatch,
+                        path: PathSpec, index: IndexCacheStore) -> bytes:
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is None:
+        raise enoent(path.virtual)
+    msg = await fetch_message(accessor, match.slots["folder"], entry.id)
     return message_json_bytes(msg)
+
+
+async def _read_attachment(accessor: EmailAccessor, match: ScopeMatch,
+                           path: PathSpec, index: IndexCacheStore) -> bytes:
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is None:
+        raise enoent(path.virtual)
+    data = await fetch_attachment(accessor, match.slots["folder"],
+                                  match.slots["uid"], entry.vfs_name)
+    if data is None:
+        raise enoent(path.virtual)
+    return data
+
+
+read = make_read(
+    detect_scope,
+    readers={
+        "message": _read_message,
+        "attachment": _read_attachment,
+    },
+)

--- a/python/mirage/core/email/readdir.py
+++ b/python/mirage/core/email/readdir.py
@@ -17,14 +17,14 @@ from functools import partial
 from typing import Any
 
 from mirage.accessor.email import EmailAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
+from mirage.cache.index import IndexEntry
 from mirage.core.email.client import (INTERNAL_DATE_KEY, fetch_headers,
                                       list_message_uids)
 from mirage.core.email.folders import list_folders
 from mirage.core.email.render import message_json_bytes
-from mirage.types import PathSpec
-from mirage.utils.errors import enoent
-from mirage.utils.key_prefix import mount_key, mount_prefix_of
+from mirage.core.email.scope import detect_scope
+from mirage.core.hierarchy.readdir import DirListing, Listed, make_readdir
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.utils.sanitize import NAME_MAX_BYTES, byte_len, sanitize_label
 
 TITLE_MAX = 80
@@ -85,132 +85,121 @@ def _date_bucket(message: dict[str, Any]) -> str:
     return internal if internal is not None else EPOCH_DATE
 
 
-async def readdir(
-    accessor: EmailAccessor,
-    path_spec: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    virtual = path_spec.virtual
-    prefix = mount_prefix_of(path_spec.virtual, path_spec.resource_path)
-    path = (path_spec.dir if path_spec.pattern else path_spec).mount_path
-    key = path.strip("/")
-    virtual_key = prefix + "/" + key if key else prefix or "/"
-    parts = key.split("/") if key else []
-    depth = len(parts)
+def _date_children(
+    headers: list[dict[str, Any]]
+) -> tuple[list[tuple[str, IndexEntry]], dict[str, list[tuple[str,
+                                                              IndexEntry]]]]:
+    """One date directory's children, plus its attachment-dir seeds.
 
-    if depth == 0:
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        folders = await list_folders(accessor)
-        entries = []
-        for folder_name in folders:
-            entry = IndexEntry(
-                id=folder_name,
-                name=folder_name,
-                resource_type="email/folder",
-                vfs_name=folder_name,
-            )
-            entries.append((folder_name, entry))
-        await index.set_dir(virtual_key, entries)
-        return [f"{prefix}/{name}" for name, _ in entries]
+    Args:
+        headers (list[dict]): the date's fetched message headers.
+    """
+    children: list[tuple[str, IndexEntry]] = []
+    seeds: dict[str, list[tuple[str, IndexEntry]]] = {}
+    for hdr in headers:
+        uid = hdr["uid"]
+        subject = hdr.get("subject", "") or "No Subject"
+        filename = _msg_filename(subject, uid)
+        children.append((filename,
+                         IndexEntry(
+                             id=uid,
+                             name=subject,
+                             resource_type="email/message",
+                             vfs_name=filename,
+                             size=len(message_json_bytes(hdr)),
+                         )))
+        attachments = hdr.get("attachments", [])
+        if attachments:
+            att_dir_name = filename.replace(".email.json", "")
+            children.append((att_dir_name,
+                             IndexEntry(
+                                 id=uid,
+                                 name=att_dir_name,
+                                 resource_type="email/attachment_dir",
+                                 vfs_name=att_dir_name,
+                             )))
+            seeds[att_dir_name] = [(att["filename"],
+                                    IndexEntry(
+                                        id=att["filename"],
+                                        name=att["filename"],
+                                        resource_type="email/attachment",
+                                        vfs_name=att["filename"],
+                                        size=att.get("size"),
+                                    )) for att in attachments]
+    return children, seeds
 
-    if depth == 1:
-        folder_name = parts[0]
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        # An unknown folder must be ENOENT: selecting it over IMAP fails with
-        # "command SEARCH illegal in state AUTH", which leaked to the caller.
-        if folder_name not in await list_folders(accessor):
-            raise enoent(virtual)
-        max_msgs = accessor.config.max_messages
-        uids = await list_message_uids(accessor,
-                                       folder_name,
-                                       max_results=max_msgs)
-        headers_list = await fetch_headers(accessor, folder_name, uids)
-        date_groups: dict[str, list[dict[str, Any]]] = {}
-        for hdr in headers_list:
-            date_str = _date_bucket(hdr)
-            date_groups.setdefault(date_str, []).append(hdr)
-        date_entries: list[tuple[str, IndexEntry]] = []
-        for date_str in sorted(date_groups.keys(), reverse=True):
-            date_entry = IndexEntry(
-                id=date_str,
-                name=date_str,
-                resource_type="email/date",
-                vfs_name=date_str,
-            )
-            date_entries.append((date_str, date_entry))
-            msg_entries: list[tuple[str, IndexEntry]] = []
-            for hdr in date_groups[date_str]:
-                uid = hdr["uid"]
-                subject = hdr.get("subject", "") or "No Subject"
-                filename = _msg_filename(subject, uid)
-                msg_entry = IndexEntry(
-                    id=uid,
-                    name=subject,
-                    resource_type="email/message",
-                    vfs_name=filename,
-                    size=len(message_json_bytes(hdr)),
-                )
-                msg_entries.append((filename, msg_entry))
-                attachments = hdr.get("attachments", [])
-                if attachments:
-                    att_dir_name = filename.replace(".email.json", "")
-                    att_dir_entry = IndexEntry(
-                        id=uid,
-                        name=att_dir_name,
-                        resource_type="email/attachment_dir",
-                        vfs_name=att_dir_name,
-                    )
-                    msg_entries.append((att_dir_name, att_dir_entry))
-                    att_entries: list[tuple[str, IndexEntry]] = []
-                    for att in attachments:
-                        att_entry = IndexEntry(
-                            id=att["filename"],
-                            name=att["filename"],
-                            resource_type="email/attachment",
-                            vfs_name=att["filename"],
-                            size=att.get("size"),
-                        )
-                        att_entries.append((att["filename"], att_entry))
-                    att_dir_vkey = (virtual_key + "/" + date_str + "/" +
-                                    att_dir_name)
-                    await index.set_dir(att_dir_vkey, att_entries)
-            date_vkey = virtual_key + "/" + date_str
-            await index.set_dir(date_vkey, msg_entries)
-        await index.set_dir(virtual_key, date_entries)
-        return [f"{prefix}/{key}/{name}" for name, _ in date_entries]
 
-    if depth == 2:
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        folder_vkey = PathSpec(
-            virtual=prefix + "/" + parts[0],
-            directory=prefix + "/" + parts[0],
-            resource_path=mount_key(prefix + "/" + parts[0], prefix),
-        )
-        await readdir(accessor, folder_vkey, index)
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        raise enoent(virtual)
+async def _folder_headers(accessor: EmailAccessor,
+                          folder_name: str) -> list[dict[str, Any]]:
+    uids = await list_message_uids(accessor,
+                                   folder_name,
+                                   max_results=accessor.config.max_messages)
+    return await fetch_headers(accessor, folder_name, uids)
 
-    if depth == 3:
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        folder_vkey = PathSpec(
-            virtual=prefix + "/" + parts[0],
-            directory=prefix + "/" + parts[0],
-            resource_path=mount_key(prefix + "/" + parts[0], prefix),
-        )
-        await readdir(accessor, folder_vkey, index)
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        raise enoent(virtual)
 
-    raise enoent(virtual)
+async def _list_root(accessor: EmailAccessor, match: ScopeMatch) -> Listed:
+    folders = await list_folders(accessor)
+    return [(name,
+             IndexEntry(
+                 id=name,
+                 name=name,
+                 resource_type="email/folder",
+                 vfs_name=name,
+             )) for name in folders]
+
+
+async def _list_folder(accessor: EmailAccessor, match: ScopeMatch,
+                       own: IndexEntry) -> Listed:
+    headers_list = await _folder_headers(accessor, own.id)
+    date_groups: dict[str, list[dict[str, Any]]] = {}
+    for hdr in headers_list:
+        date_groups.setdefault(_date_bucket(hdr), []).append(hdr)
+    entries: list[tuple[str, IndexEntry]] = []
+    seeds: dict[str, list[tuple[str, IndexEntry]]] = {}
+    for date_str in sorted(date_groups.keys(), reverse=True):
+        entries.append((date_str,
+                        IndexEntry(
+                            id=date_str,
+                            name=date_str,
+                            resource_type="email/date",
+                            vfs_name=date_str,
+                        )))
+        children, att_seeds = _date_children(date_groups[date_str])
+        seeds[date_str] = children
+        for att_dir, att_entries in att_seeds.items():
+            seeds[f"{date_str}/{att_dir}"] = att_entries
+    return DirListing(entries=entries, seeds=seeds)
+
+
+async def _list_day(accessor: EmailAccessor, match: ScopeMatch,
+                    own: IndexEntry) -> Listed:
+    # Normally served from the folder lister's seed; reached only when
+    # the index evicted the day listing while the date entry survived.
+    headers_list = await _folder_headers(accessor, match.slots["folder"])
+    day = match.slots["day"]
+    children, att_seeds = _date_children(
+        [hdr for hdr in headers_list if _date_bucket(hdr) == day])
+    return DirListing(entries=children, seeds=att_seeds)
+
+
+async def _list_attachment_dir(accessor: EmailAccessor, match: ScopeMatch,
+                               own: IndexEntry) -> Listed:
+    # Same eviction fallback: one header fetch rebuilds the listing.
+    headers_list = await fetch_headers(accessor, match.slots["folder"],
+                                       [own.id])
+    for hdr in headers_list:
+        _, seeds = _date_children([hdr])
+        for att_entries in seeds.values():
+            return att_entries
+    return []
+
+
+readdir = make_readdir(
+    detect_scope,
+    listers={"root": _list_root},
+    entry_listers={
+        "folder": _list_folder,
+        "day": _list_day,
+        "attachment_dir": _list_attachment_dir,
+    },
+)

--- a/python/mirage/core/email/scope.py
+++ b/python/mirage/core/email/scope.py
@@ -12,39 +12,38 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from dataclasses import dataclass
+from mirage.core.hierarchy.codec import DATE, Codec
+from mirage.core.hierarchy.scope import Scope, Slot, make_detect_scope
+from mirage.types import FileType
 
-from mirage.types import PathSpec
+EMAIL_JSON = Codec(suffix=".email.json")
 
+_FOLDER = (Slot("folder"), )
+_DAY = _FOLDER + (Slot("day", DATE), )
 
-@dataclass
-class EmailScope:
-    use_native: bool
-    folder: str | None = None
-    resource_path: str = "/"
+# One description of the tree: readdir, stat, read and the search
+# push-down all classify through it, so the file surface and the command
+# surface cannot disagree about what a path means. The message scope is
+# declared before the attachment dir because only the suffix separates
+# the two at that depth.
+SCOPES = (
+    Scope(kind="folder", segments=_FOLDER),
+    Scope(kind="day", segments=_DAY),
+    Scope(kind="message",
+          segments=_DAY + (Slot("message", EMAIL_JSON, id_key="uid"), ),
+          leaf=True,
+          filetype=FileType.JSON),
+    Scope(kind="attachment_dir",
+          segments=_DAY + (Slot("attachment_dir", id_key="uid"), )),
+    Scope(kind="attachment",
+          segments=_DAY +
+          (Slot("attachment_dir", id_key="uid"), Slot("filename")),
+          leaf=True),
+)
 
+detect_scope = make_detect_scope(SCOPES)
 
-def detect_scope(path: PathSpec) -> EmailScope:
-    key = path.mount_path.strip("/")
-    if not key:
-        return EmailScope(use_native=False, resource_path="/")
-    parts = [x for x in key.split("/") if x]
-    if not parts:
-        return EmailScope(use_native=False, resource_path="/")
-    if key.endswith(".email.json"):
-        return EmailScope(
-            use_native=False,
-            folder=parts[0],
-            resource_path=key,
-        )
-    if len(parts) <= 2:
-        return EmailScope(
-            use_native=True,
-            folder=parts[0],
-            resource_path=key,
-        )
-    return EmailScope(
-        use_native=False,
-        folder=parts[0],
-        resource_path=key,
-    )
+# Kinds the mailbox search push-down may answer for: one folder or one
+# of its days. IMAP search selects a folder, so the mount root cannot
+# push down, and a message or attachment names one node.
+NATIVE_KINDS = frozenset({"folder", "day"})

--- a/python/mirage/core/email/search.py
+++ b/python/mirage/core/email/search.py
@@ -18,7 +18,6 @@ from mirage.accessor.email import EmailAccessor
 from mirage.core.email.client import fetch_message, list_message_uids
 from mirage.core.email.readdir import _date_bucket, _msg_filename
 from mirage.core.email.render import message_json_text
-from mirage.core.email.scope import EmailScope
 
 
 def build_search_criteria(
@@ -89,13 +88,12 @@ def _build_vfs_path(prefix: str, folder: str, msg: dict[str, Any]) -> str:
 
 async def search_and_format(
     accessor: EmailAccessor,
-    scope: EmailScope,
+    folder: str,
     pattern: str,
     prefix: str,
     max_results: int | None = None,
 ) -> list[tuple[str, str]]:
     """Run native search and return (vfs_path, message_json) pairs."""
-    folder = scope.folder or ""
     if not folder:
         return []
     uids = await search_messages(accessor,

--- a/python/mirage/core/email/stat.py
+++ b/python/mirage/core/email/stat.py
@@ -12,86 +12,57 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import logging
-
-from mirage.accessor.email import EmailAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.email.client import list_folders
-from mirage.core.email.readdir import readdir as _readdir
+from mirage.cache.index import IndexEntry
+from mirage.core.email.readdir import readdir
+from mirage.core.email.scope import detect_scope
+from mirage.core.hierarchy.scope import ScopeMatch
+from mirage.core.hierarchy.stat import make_stat
 from mirage.types import FileStat, FileType, PathSpec
-from mirage.utils.errors import enoent
 from mirage.utils.filetype import guess_type
-from mirage.utils.key_prefix import mount_key, mount_prefix_of
-
-logger = logging.getLogger(__name__)
 
 
-async def stat(
-    accessor: EmailAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> FileStat:
-    virtual = path.virtual
-    prefix = mount_prefix_of(path.virtual, path.resource_path)
-    key = path.resource_path
-    if not key:
-        return FileStat(name="/", type=FileType.DIRECTORY)
-    virtual_key = prefix + "/" + key if prefix else "/" + key
-    result = await index.get(virtual_key)
-    if result.entry is None and "/" not in key:
-        folders = await list_folders(accessor)
-        if key in folders:
-            return FileStat(name=key, type=FileType.DIRECTORY)
-        raise enoent(virtual)
-    if result.entry is None:
-        parent_virtual = virtual_key.rsplit("/", 1)[0] or "/"
-        try:
-            await _readdir(
-                accessor,
-                PathSpec(virtual=parent_virtual,
-                         directory=parent_virtual,
-                         resource_path=mount_key(parent_virtual, prefix)),
-                index=index,
-            )
-        except FileNotFoundError as exc:
-            logger.debug("stat populate failed for %s: %s", virtual_key, exc)
-        result = await index.get(virtual_key)
-        if result.entry is None:
-            raise enoent(virtual)
-    rt = result.entry.resource_type
-    if rt == "email/folder":
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=FileType.DIRECTORY,
-        )
-    if rt == "email/date":
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=FileType.DIRECTORY,
-        )
-    if rt == "email/message":
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=FileType.JSON,
-            size=result.entry.size,
-            extra={"uid": result.entry.id},
-        )
-    if rt == "email/attachment_dir":
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=FileType.DIRECTORY,
-            extra={"uid": result.entry.id},
-        )
-    if rt == "email/attachment":
-        ft = guess_type(result.entry.vfs_name)
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=ft,
-            size=result.entry.size,
-            extra={"attachment_id": result.entry.id},
-        )
+def _dir_stat(match: ScopeMatch, path: PathSpec,
+              entry: IndexEntry) -> FileStat:
+    return FileStat(name=entry.vfs_name, type=FileType.DIRECTORY)
+
+
+def _message_stat(match: ScopeMatch, path: PathSpec,
+                  entry: IndexEntry) -> FileStat:
     return FileStat(
-        name=result.entry.vfs_name,
+        name=entry.vfs_name,
         type=FileType.JSON,
-        extra={"uid": result.entry.id},
+        size=entry.size,
+        extra={"uid": entry.id},
     )
+
+
+def _attachment_dir_stat(match: ScopeMatch, path: PathSpec,
+                         entry: IndexEntry) -> FileStat:
+    return FileStat(
+        name=entry.vfs_name,
+        type=FileType.DIRECTORY,
+        extra={"uid": entry.id},
+    )
+
+
+def _attachment_stat(match: ScopeMatch, path: PathSpec,
+                     entry: IndexEntry) -> FileStat:
+    return FileStat(
+        name=entry.vfs_name,
+        type=guess_type(entry.vfs_name),
+        size=entry.size,
+        extra={"attachment_id": entry.id},
+    )
+
+
+stat = make_stat(
+    detect_scope,
+    readdir,
+    entry_stats={
+        "folder": _dir_stat,
+        "day": _dir_stat,
+        "message": _message_stat,
+        "attachment_dir": _attachment_dir_stat,
+        "attachment": _attachment_stat,
+    },
+)

--- a/python/mirage/core/gmail/read.py
+++ b/python/mirage/core/gmail/read.py
@@ -12,47 +12,44 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import posixpath
-from functools import partial
-
 from mirage.accessor.gmail import GmailAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.cache.index.warm import entry_or_warm
+from mirage.cache.index import IndexCacheStore
 from mirage.core.gmail.messages import (get_attachment, get_message_raw,
                                         message_json_bytes)
 from mirage.core.gmail.readdir import readdir
+from mirage.core.gmail.scope import detect_scope
+from mirage.core.hierarchy.probe import resolve_entry
+from mirage.core.hierarchy.read import make_read
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
 
-async def read(
-    accessor: GmailAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> bytes:
-    virtual = path.virtual
-    prefix = mount_prefix_of(path.virtual, path.resource_path)
-    key = path.resource_path
-    virtual_key = prefix + "/" + key if prefix else "/" + key
-    parent_key = posixpath.dirname(virtual_key) or "/"
-    parent_path = PathSpec.from_str_path(parent_key,
-                                         mount_key(parent_key, prefix))
-    warm = (partial(readdir, accessor, parent_path, index)
-            if parent_key != virtual_key else None)
-    entry = await entry_or_warm(index, virtual_key, warm)
+async def _read_message(accessor: GmailAccessor, match: ScopeMatch,
+                        path: PathSpec, index: IndexCacheStore) -> bytes:
+    entry = await resolve_entry(readdir, accessor, path, index)
     if entry is None:
-        raise enoent(virtual)
-    if entry.resource_type in ("gmail/label", "gmail/date",
-                               "gmail/attachment_dir"):
-        raise IsADirectoryError(virtual)
-    if entry.resource_type == "gmail/attachment":
-        att_dir_result = await index.get(parent_key)
-        if att_dir_result.entry is None:
-            raise enoent(virtual)
-        message_id = att_dir_result.entry.id
-        attachment_id = entry.id
-        return await get_attachment(accessor.token_manager, message_id,
-                                    attachment_id)
+        raise enoent(path.virtual)
     raw = await get_message_raw(accessor.token_manager, entry.id)
     return message_json_bytes(raw)
+
+
+async def _read_attachment(accessor: GmailAccessor, match: ScopeMatch,
+                           path: PathSpec, index: IndexCacheStore) -> bytes:
+    # The message id decodes from the attachment dir's `subject__id`
+    # segment; the attachment id only exists in the listing, so the
+    # entry stays the proof of existence AND the id source.
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is None:
+        raise enoent(path.virtual)
+    return await get_attachment(accessor.token_manager,
+                                match.slots["message_id"], entry.id)
+
+
+read = make_read(
+    detect_scope,
+    readers={
+        "message": _read_message,
+        "attachment": _read_attachment,
+    },
+)

--- a/python/mirage/core/gmail/readdir.py
+++ b/python/mirage/core/gmail/readdir.py
@@ -12,27 +12,25 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import logging
 from datetime import datetime, timezone
 from functools import partial
 from typing import Any
 
 from mirage.accessor.gmail import GmailAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
+from mirage.cache.index import IndexEntry
 from mirage.core.gmail.date_query import date_dir_to_gmail_query
 from mirage.core.gmail.labels import list_labels
 from mirage.core.gmail.messages import (_extract_attachments, _extract_header,
                                         get_message_raw, list_messages,
                                         message_json_bytes)
-from mirage.types import PathSpec
-from mirage.utils.errors import enoent
-from mirage.utils.key_prefix import mount_key, mount_prefix_of
+from mirage.core.gmail.scope import detect_scope
+from mirage.core.hierarchy.readdir import DirListing, Listed, make_readdir
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.utils.sanitize import NAME_MAX_BYTES, byte_len, sanitize_label
-
-logger = logging.getLogger(__name__)
 
 TITLE_MAX = 80
 MSG_SUFFIX = ".gmail.json"
+MAX_MESSAGES = 50
 
 _sanitize = partial(sanitize_label, fallback="No_Subject", max_len=TITLE_MAX)
 
@@ -75,225 +73,152 @@ def _date_from_internal(internal_date: str) -> str:
     return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
 
 
-async def _build_date_groups(
-    accessor: GmailAccessor,
-    msg_ids: list[dict[str, Any]],
-    index: IndexCacheStore,
-    virtual_key: str,
-    write_dates: bool,
-) -> list[tuple[str, IndexEntry]]:
-    date_groups: dict[str, list[dict[str, Any]]] = {}
+def _attachment_entries(
+        payload: dict[str, Any]) -> list[tuple[str, IndexEntry]]:
+    entries: list[tuple[str, IndexEntry]] = []
+    for att in _extract_attachments(payload):
+        att_name = _attachment_filename(att["attachment_id"], att["filename"])
+        entries.append((att_name,
+                        IndexEntry(
+                            id=att["attachment_id"],
+                            name=att["filename"],
+                            resource_type="gmail/attachment",
+                            vfs_name=att_name,
+                            size=att["size"],
+                        )))
+    return entries
+
+
+def _date_children(
+    raws: list[dict[str, Any]]
+) -> tuple[list[tuple[str, IndexEntry]], dict[str, list[tuple[str,
+                                                              IndexEntry]]]]:
+    """One date directory's children, plus its attachment-dir seeds.
+
+    Args:
+        raws (list[dict]): the date's full message payloads.
+    """
+    children: list[tuple[str, IndexEntry]] = []
+    seeds: dict[str, list[tuple[str, IndexEntry]]] = {}
+    for raw in raws:
+        mid = raw["id"]
+        headers = raw.get("payload", {}).get("headers", [])
+        subject = _extract_header(headers, "Subject") or "No Subject"
+        filename = _msg_filename(subject, mid)
+        size_estimate = raw.get("sizeEstimate")
+        # The listing already fetched the full message, so the exact
+        # rendered .gmail.json length is free; sizeEstimate is the
+        # source message size and stays in extra.
+        children.append((filename,
+                         IndexEntry(
+                             id=mid,
+                             name=subject,
+                             resource_type="gmail/message",
+                             vfs_name=filename,
+                             size=len(message_json_bytes(raw)),
+                             extra={"size_estimate": size_estimate}
+                             if size_estimate is not None else {},
+                         )))
+        att_entries = _attachment_entries(raw.get("payload", {}))
+        if att_entries:
+            att_dir = _attach_dir_name(subject, mid)
+            children.append((att_dir,
+                             IndexEntry(
+                                 id=mid,
+                                 name=att_dir,
+                                 resource_type="gmail/attachment_dir",
+                                 vfs_name=att_dir,
+                             )))
+            seeds[att_dir] = att_entries
+    return children, seeds
+
+
+async def _group_by_date(
+        accessor: GmailAccessor,
+        msg_ids: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = {}
     for m in msg_ids:
-        mid = m["id"]
-        raw = await get_message_raw(accessor.token_manager, mid)
-        internal_date = raw.get("internalDate", "0")
-        date_str = _date_from_internal(internal_date)
-        date_groups.setdefault(date_str, []).append(raw)
-    date_entries: list[tuple[str, IndexEntry]] = []
-    for date_str in sorted(date_groups.keys(), reverse=True):
-        date_entry = IndexEntry(
-            id=date_str,
-            name=date_str,
-            resource_type="gmail/date",
-            vfs_name=date_str,
-        )
-        date_entries.append((date_str, date_entry))
-        date_children: list[tuple[str, IndexEntry]] = []
-        for raw in date_groups[date_str]:
-            mid = raw["id"]
-            headers = raw.get("payload", {}).get("headers", [])
-            subject = _extract_header(headers, "Subject") or "No Subject"
-            filename = _msg_filename(subject, mid)
-            size_estimate = raw.get("sizeEstimate")
-            # The listing already fetched the full message, so the exact
-            # rendered .gmail.json length is free; sizeEstimate is the
-            # source message size and stays in extra.
-            msg_entry = IndexEntry(
-                id=mid,
-                name=subject,
-                resource_type="gmail/message",
-                vfs_name=filename,
-                size=len(message_json_bytes(raw)),
-                extra={"size_estimate": size_estimate}
-                if size_estimate is not None else {},
-            )
-            date_children.append((filename, msg_entry))
-            attachments = _extract_attachments(raw.get("payload", {}))
-            if attachments:
-                att_dir = _attach_dir_name(subject, mid)
-                att_dir_entry = IndexEntry(
-                    id=mid,
-                    name=att_dir,
-                    resource_type="gmail/attachment_dir",
-                    vfs_name=att_dir,
-                )
-                date_children.append((att_dir, att_dir_entry))
-                att_entries: list[tuple[str, IndexEntry]] = []
-                for att in attachments:
-                    att_name = _attachment_filename(att["attachment_id"],
-                                                    att["filename"])
-                    att_entry = IndexEntry(
-                        id=att["attachment_id"],
-                        name=att["filename"],
-                        resource_type="gmail/attachment",
-                        vfs_name=att_name,
-                        size=att["size"],
-                    )
-                    att_entries.append((att_name, att_entry))
-                att_vkey = virtual_key + "/" + date_str + "/" + att_dir
-                if write_dates:
-                    await index.set_dir(att_vkey, att_entries)
-        if write_dates:
-            await index.set_dir(virtual_key + "/" + date_str, date_children)
-    return date_entries
+        raw = await get_message_raw(accessor.token_manager, m["id"])
+        date_str = _date_from_internal(raw.get("internalDate", "0"))
+        groups.setdefault(date_str, []).append(raw)
+    return groups
 
 
-async def readdir(
-    accessor: GmailAccessor,
-    path_spec: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    virtual = path_spec.virtual
-    prefix = mount_prefix_of(path_spec.virtual, path_spec.resource_path)
-    path = (path_spec.dir if path_spec.pattern else path_spec).mount_path
-    key = path.strip("/")
-    virtual_key = prefix + "/" + key if key else prefix or "/"
-    parts = key.split("/") if key else []
-    depth = len(parts)
+async def _list_root(accessor: GmailAccessor, match: ScopeMatch) -> Listed:
+    labels = await list_labels(accessor.token_manager)
+    entries: list[tuple[str, IndexEntry]] = []
+    for lb in labels:
+        if lb.get("type") == "system":
+            name = lb["id"]
+        else:
+            name = lb.get("name", lb["id"])
+        entries.append((name,
+                        IndexEntry(
+                            id=lb["id"],
+                            name=name,
+                            resource_type="gmail/label",
+                            vfs_name=name,
+                        )))
+    return entries
 
-    if depth == 0:
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        labels = await list_labels(accessor.token_manager)
-        entries = []
-        for lb in labels:
-            if lb.get("type") == "system":
-                name = lb["id"]
-            else:
-                name = lb.get("name", lb["id"])
-            entry = IndexEntry(
-                id=lb["id"],
-                name=name,
-                resource_type="gmail/label",
-                vfs_name=name,
-            )
-            entries.append((name, entry))
-        await index.set_dir(virtual_key, entries)
-        return [f"{prefix}/{name}" for name, _ in entries]
 
-    if depth == 1:
-        label_name = parts[0]
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        label_key = prefix + "/" + label_name if prefix else "/" + label_name
-        result = await index.get(label_key)
-        if result.entry is None:
-            # Auto-bootstrap: populate label index.
-            try:
-                root = PathSpec(
-                    virtual=prefix or "/",
-                    directory=prefix or "/",
-                    resource_path=mount_key(prefix or "/", prefix),
-                )
-                await readdir(accessor, root, index)
-                result = await index.get(label_key)
-            except Exception as e:
-                logger.debug(
-                    "gmail readdir: bootstrap failed for %s: %s",
-                    label_key,
-                    e,
-                )
-        if result.entry is None:
-            raise enoent(virtual)
-        label_id = result.entry.id
-        msg_ids = await list_messages(
-            accessor.token_manager,
-            label_id=label_id,
-            max_results=50,
-        )
-        date_entries = await _build_date_groups(
-            accessor,
-            msg_ids,
-            index,
-            virtual_key,
-            write_dates=True,
-        )
-        await index.set_dir(virtual_key, date_entries)
-        return [f"{prefix}/{key}/{name}" for name, _ in date_entries]
+async def _list_label(accessor: GmailAccessor, match: ScopeMatch,
+                      own: IndexEntry) -> Listed:
+    msg_ids = await list_messages(
+        accessor.token_manager,
+        label_id=own.id,
+        max_results=MAX_MESSAGES,
+    )
+    groups = await _group_by_date(accessor, msg_ids)
+    entries: list[tuple[str, IndexEntry]] = []
+    seeds: dict[str, list[tuple[str, IndexEntry]]] = {}
+    for date_str in sorted(groups.keys(), reverse=True):
+        entries.append((date_str,
+                        IndexEntry(
+                            id=date_str,
+                            name=date_str,
+                            resource_type="gmail/date",
+                            vfs_name=date_str,
+                            extra={"label_id": own.id},
+                        )))
+        children, att_seeds = _date_children(groups[date_str])
+        seeds[date_str] = children
+        for att_dir, att_entries in att_seeds.items():
+            seeds[f"{date_str}/{att_dir}"] = att_entries
+    return DirListing(entries=entries, seeds=seeds)
 
-    if depth == 2:
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        label_name = parts[0]
-        date_str = parts[1]
-        date_query = date_dir_to_gmail_query(date_str)
-        if date_query is not None:
-            label_key = (prefix + "/" + label_name if prefix else "/" +
-                         label_name)
-            label_result = await index.get(label_key)
-            if label_result.entry is None:
-                try:
-                    root = PathSpec(
-                        virtual=prefix or "/",
-                        directory=prefix or "/",
-                        resource_path=mount_key(prefix or "/", prefix),
-                    )
-                    await readdir(accessor, root, index)
-                    label_result = await index.get(label_key)
-                except Exception as e:
-                    logger.debug(
-                        "gmail readdir: date-dir bootstrap failed for %s: %s",
-                        label_key,
-                        e,
-                    )
-            if label_result.entry is not None:
-                label_id = label_result.entry.id
-                label_vkey = label_key
-                msg_ids = await list_messages(
-                    accessor.token_manager,
-                    label_id=label_id,
-                    query=date_query,
-                    max_results=50,
-                )
-                await _build_date_groups(
-                    accessor,
-                    msg_ids,
-                    index,
-                    label_vkey,
-                    write_dates=True,
-                )
-                if not msg_ids:
-                    await index.set_dir(virtual_key, [])
-                cached = await index.list_dir(virtual_key)
-                if cached.entries is not None:
-                    return cached.entries
-                raise enoent(virtual)
-        label_path = prefix + "/" + parts[0] if prefix else "/" + parts[0]
-        await readdir(
-            accessor,
-            PathSpec.from_str_path(label_path, mount_key(label_path, prefix)),
-            index)
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        raise enoent(virtual)
 
-    if depth == 3:
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        date_path = (prefix + "/" + parts[0] + "/" +
-                     parts[1] if prefix else "/" + parts[0] + "/" + parts[1])
-        await readdir(
-            accessor,
-            PathSpec.from_str_path(date_path, mount_key(date_path, prefix)),
-            index)
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        raise enoent(virtual)
+async def _list_day(accessor: GmailAccessor, match: ScopeMatch,
+                    label: IndexEntry) -> Listed:
+    # The proof is the label entry, not the day's own: a date query
+    # answers for any well-formed day, including days the label's
+    # bounded recent listing never minted.
+    date_query = date_dir_to_gmail_query(match.slots["day"])
+    if date_query is None:
+        return []
+    msg_ids = await list_messages(
+        accessor.token_manager,
+        label_id=label.id,
+        query=date_query,
+        max_results=MAX_MESSAGES,
+    )
+    groups = await _group_by_date(accessor, msg_ids)
+    children, att_seeds = _date_children(groups.get(match.slots["day"], []))
+    return DirListing(entries=children, seeds=att_seeds)
 
-    raise enoent(virtual)
+
+async def _list_attachment_dir(accessor: GmailAccessor, match: ScopeMatch,
+                               own: IndexEntry) -> Listed:
+    raw = await get_message_raw(accessor.token_manager, own.id)
+    return _attachment_entries(raw.get("payload", {}))
+
+
+readdir = make_readdir(
+    detect_scope,
+    listers={"root": _list_root},
+    entry_listers={
+        "label": _list_label,
+        "attachment_dir": _list_attachment_dir,
+    },
+    parent_entry_listers={"day": _list_day},
+)

--- a/python/mirage/core/gmail/scope.py
+++ b/python/mirage/core/gmail/scope.py
@@ -12,60 +12,38 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from dataclasses import dataclass
+from mirage.core.hierarchy.codec import DATE, Codec
+from mirage.core.hierarchy.scope import ROOT, Scope, Slot, make_detect_scope
+from mirage.types import FileType
 
-from mirage.types import PathSpec
-from mirage.utils.key_prefix import mount_prefix_of
+GMAIL_JSON = Codec(suffix=".gmail.json")
 
+_LABEL = (Slot("label"), )
+_DAY = _LABEL + (Slot("day", DATE), )
 
-@dataclass
-class GmailScope:
-    use_native: bool
-    label_name: str | None = None
-    date_str: str | None = None
-    resource_path: str = "/"
+# One description of the tree: readdir, stat, read and the search
+# push-down all classify through it, so the file surface and the command
+# surface cannot disagree about what a path means. The message scope is
+# declared before the attachment dir because only the suffix separates
+# the two at that depth.
+SCOPES = (
+    Scope(kind="label", segments=_LABEL),
+    Scope(kind="day", segments=_DAY),
+    Scope(kind="message",
+          segments=_DAY + (Slot("message", GMAIL_JSON, id_key="message_id"), ),
+          leaf=True,
+          filetype=FileType.JSON),
+    Scope(kind="attachment_dir",
+          segments=_DAY + (Slot("attachment_dir", id_key="message_id"), )),
+    Scope(kind="attachment",
+          segments=_DAY +
+          (Slot("attachment_dir", id_key="message_id"), Slot("filename")),
+          leaf=True),
+)
 
+detect_scope = make_detect_scope(SCOPES)
 
-def detect_scope(path: PathSpec) -> GmailScope:
-    prefix = mount_prefix_of(path.virtual, path.resource_path) or ""
-
-    if path.pattern and path.pattern.endswith(".gmail.json"):
-        dir_key = path.directory.strip("/")
-        if prefix:
-            dir_key = dir_key.removeprefix(prefix.strip("/") + "/")
-        parts = dir_key.split("/") if dir_key else []
-        if len(parts) == 2:
-            return GmailScope(
-                use_native=True,
-                label_name=parts[0],
-                date_str=parts[1],
-                resource_path=dir_key,
-            )
-
-    key = path.resource_path
-    if not key:
-        return GmailScope(use_native=True, resource_path="/")
-
-    parts = key.split("/")
-
-    if len(parts) == 1:
-        return GmailScope(
-            use_native=True,
-            label_name=parts[0],
-            resource_path=key,
-        )
-
-    if len(parts) == 2:
-        return GmailScope(
-            use_native=True,
-            label_name=parts[0],
-            date_str=parts[1],
-            resource_path=key,
-        )
-
-    return GmailScope(
-        use_native=False,
-        label_name=parts[0],
-        date_str=parts[1] if len(parts) >= 2 else None,
-        resource_path=key,
-    )
+# Kinds the Gmail search push-down may answer for: the whole account,
+# one label, or one label's day. A message file or an attachment names
+# one node, which a query over the account cannot stand in for.
+NATIVE_KINDS = frozenset({ROOT, "label", "day"})

--- a/python/mirage/core/gmail/search.py
+++ b/python/mirage/core/gmail/search.py
@@ -19,7 +19,6 @@ from mirage.core.gmail.messages import (_decode_body, _extract_header,
                                         get_message_processed, get_message_raw,
                                         list_messages)
 from mirage.core.gmail.readdir import _msg_filename
-from mirage.core.gmail.scope import GmailScope
 from mirage.core.google.client import TokenManager
 
 EXCERPT_WINDOW = 120
@@ -107,13 +106,13 @@ async def search_messages(
 
 def format_grep_results(
     rows: list[dict[str, Any]],
-    scope: GmailScope,
+    label_name: str | None,
     prefix: str,
     pattern: str = "",
 ) -> list[str]:
     lines: list[str] = []
     for row in rows:
-        label = row.get("label") or scope.label_name or "INBOX"
+        label = row.get("label") or label_name or "INBOX"
         date = row.get("date", "")
         mid = row.get("id", "")
         # The same builder readdir names the file with, not a second

--- a/python/mirage/core/gmail/stat.py
+++ b/python/mirage/core/gmail/stat.py
@@ -12,95 +12,96 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import logging
-
 from mirage.accessor.gmail import GmailAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.gmail.labels import list_labels
-from mirage.core.gmail.readdir import readdir as _readdir
+from mirage.cache.index import IndexCacheStore, IndexEntry
+from mirage.core.gmail.readdir import readdir
+from mirage.core.gmail.scope import detect_scope
+from mirage.core.hierarchy.probe import resolve_entry
+from mirage.core.hierarchy.scope import ScopeMatch
+from mirage.core.hierarchy.stat import make_stat
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.filetype import guess_type
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
-logger = logging.getLogger(__name__)
 
-
-async def stat(
-    accessor: GmailAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> FileStat:
-    virtual = path.virtual
-    prefix = mount_prefix_of(path.virtual, path.resource_path)
-    key = path.resource_path
-    if not key:
-        return FileStat(name="/", type=FileType.DIRECTORY)
-    virtual_key = prefix + "/" + key if prefix else "/" + key
-    result = await index.get(virtual_key)
-    if result.entry is None and "/" not in key:
-        labels = await list_labels(accessor.token_manager)
-        names = {
-            lb["id"] if lb.get("type") == "system" else lb.get(
-                "name", lb["id"])
-            for lb in labels
-        }
-        if key in names:
-            return FileStat(name=key, type=FileType.DIRECTORY)
-        raise enoent(virtual)
-    if result.entry is None:
-        parent_virtual = virtual_key.rsplit("/", 1)[0] or "/"
-        try:
-            await _readdir(
-                accessor,
-                PathSpec(virtual=parent_virtual,
-                         directory=parent_virtual,
-                         resource_path=mount_key(parent_virtual, prefix)),
-                index=index,
-            )
-        except FileNotFoundError as exc:
-            logger.debug("stat populate failed for %s: %s", virtual_key, exc)
-        result = await index.get(virtual_key)
-        if result.entry is None:
-            raise enoent(virtual)
-    rt = result.entry.resource_type
-    if rt == "gmail/label":
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=FileType.DIRECTORY,
-            extra={"label_id": result.entry.id},
-        )
-    if rt == "gmail/date":
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=FileType.DIRECTORY,
-        )
-    if rt == "gmail/message":
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=FileType.JSON,
-            size=result.entry.size,
-            extra={
-                "message_id": result.entry.id,
-                **result.entry.extra
-            },
-        )
-    if rt == "gmail/attachment_dir":
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=FileType.DIRECTORY,
-            extra={"message_id": result.entry.id},
-        )
-    if rt == "gmail/attachment":
-        ft = guess_type(result.entry.vfs_name)
-        return FileStat(
-            name=result.entry.vfs_name,
-            type=ft,
-            size=result.entry.size,
-            extra={"attachment_id": result.entry.id},
-        )
+def _label_stat(match: ScopeMatch, path: PathSpec,
+                entry: IndexEntry) -> FileStat:
     return FileStat(
-        name=result.entry.vfs_name,
-        type=FileType.JSON,
-        extra={"message_id": result.entry.id},
+        name=entry.vfs_name,
+        type=FileType.DIRECTORY,
+        extra={"label_id": entry.id},
     )
+
+
+def _message_stat(match: ScopeMatch, path: PathSpec,
+                  entry: IndexEntry) -> FileStat:
+    return FileStat(
+        name=entry.vfs_name,
+        type=FileType.JSON,
+        size=entry.size,
+        extra={
+            "message_id": entry.id,
+            **entry.extra
+        },
+    )
+
+
+def _attachment_dir_stat(match: ScopeMatch, path: PathSpec,
+                         entry: IndexEntry) -> FileStat:
+    return FileStat(
+        name=entry.vfs_name,
+        type=FileType.DIRECTORY,
+        extra={"message_id": entry.id},
+    )
+
+
+def _attachment_stat(match: ScopeMatch, path: PathSpec,
+                     entry: IndexEntry) -> FileStat:
+    return FileStat(
+        name=entry.vfs_name,
+        type=guess_type(entry.vfs_name),
+        size=entry.size,
+        extra={"attachment_id": entry.id},
+    )
+
+
+async def _stat_day(accessor: GmailAccessor, match: ScopeMatch, path: PathSpec,
+                    index: IndexCacheStore) -> FileStat:
+    """Stat a day directory, which resolves beyond the listed window.
+
+    The label listing groups a bounded number of recent messages into
+    day dirs, but the date query answers for any well-formed day, so a
+    day under a label that exists is a directory whether or not the
+    recent window lists it. A bogus label is ENOENT.
+
+    Args:
+        accessor (GmailAccessor): gmail accessor.
+        match (ScopeMatch): a match holding ``label`` and ``day``.
+        path (PathSpec): the path to stat.
+        index (IndexCacheStore): index cache.
+    """
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is not None:
+        return FileStat(name=entry.vfs_name, type=FileType.DIRECTORY)
+    label_virtual = path.virtual.rstrip("/").rsplit("/", 1)[0]
+    prefix = mount_prefix_of(path.virtual, path.resource_path)
+    label_spec = PathSpec(virtual=label_virtual,
+                          directory=label_virtual,
+                          resource_path=mount_key(label_virtual, prefix))
+    if await resolve_entry(readdir, accessor, label_spec, index) is None:
+        raise enoent(path.virtual)
+    return FileStat(name=match.slots["day"], type=FileType.DIRECTORY)
+
+
+stat = make_stat(
+    detect_scope,
+    readdir,
+    entry_stats={
+        "label": _label_stat,
+        "message": _message_stat,
+        "attachment_dir": _attachment_dir_stat,
+        "attachment": _attachment_stat,
+    },
+    overrides={"day": _stat_day},
+)

--- a/python/mirage/core/hierarchy/codec.py
+++ b/python/mirage/core/hierarchy/codec.py
@@ -17,6 +17,22 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 _ASCII_DIGITS = re.compile(r"^[0-9]+$")
+_ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def iso_date_shaped(text: str) -> bool:
+    """Whether the text is shaped like a YYYY-MM-DD date.
+
+    Shape only, not a calendar check: the dated-message backends mint
+    their date directories from real timestamps, so a shaped-but-absent
+    date resolves through the listing like any other name. A backend
+    that must refuse impossible dates (gcal, whose day dirs exist by
+    construction) validates with its own calendar-aware check instead.
+
+    Args:
+        text (str): decoded segment payload.
+    """
+    return _ISO_DATE.match(text) is not None
 
 
 def ascii_digits(text: str) -> bool:
@@ -75,3 +91,4 @@ RAW = Codec()
 JSON_NAME = Codec(suffix=".json")
 JSONL_NAME = Codec(suffix=".jsonl")
 INT_JSON = Codec(suffix=".json", validate=ascii_digits)
+DATE = Codec(validate=iso_date_shaped)

--- a/python/mirage/core/hierarchy/read.py
+++ b/python/mirage/core/hierarchy/read.py
@@ -19,12 +19,19 @@ from mirage.core.hierarchy.probe import A
 from mirage.core.hierarchy.scope import ROOT, DetectFn, ScopeMatch
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
+from mirage.utils.ranges import slice_window
 
 Reader = Callable[[A, ScopeMatch, PathSpec, IndexCacheStore], Awaitable[bytes]]
 
 WindowedReader = Callable[
     [A, ScopeMatch, PathSpec, IndexCacheStore, int | None, int | None],
     Awaitable[bytes]]
+
+RangedReader = Callable[
+    [A, ScopeMatch, PathSpec, IndexCacheStore, int, int | None],
+    Awaitable[bytes]]
+
+ReadFn = Callable[..., Awaitable[bytes]]
 
 
 def make_read(
@@ -75,3 +82,40 @@ def make_read(
         return await reader(accessor, match, path, index)
 
     return read
+
+
+def make_read_range(
+    detect: DetectFn,
+    read: ReadFn,
+    *,
+    ranged: Mapping[str, RangedReader[A]],
+) -> ReadFn:
+    """Build a byte-ranged read over a hierarchy read.
+
+    A rendered file has no remote range to ask for — its bytes do not
+    exist until the read renders them — so the window is sliced after
+    the fact. A stored blob does (discord and slack attachments serve
+    HTTP range requests), and downloading the whole file to keep a
+    slice would defeat the ranged read; those kinds name a ranged
+    reader here and push the window to the source.
+
+    Args:
+        detect (DetectFn): the backend's scope classifier.
+        read (ReadFn): the backend's full read, usually ``make_read``'s.
+        ranged (Mapping[str, RangedReader]): per-kind readers that push
+            the byte window to the source.
+    """
+
+    async def read_range(accessor: A,
+                         path: PathSpec,
+                         index: IndexCacheStore = NULL_INDEX,
+                         offset: int = 0,
+                         size: int | None = None) -> bytes:
+        match = detect(path)
+        fn = ranged.get(match.kind)
+        if fn is not None:
+            return await fn(accessor, match, path, index, offset, size)
+        data = await read(accessor, path, index)
+        return slice_window(data, offset, size)
+
+    return read_range

--- a/python/mirage/core/hierarchy/readdir.py
+++ b/python/mirage/core/hierarchy/readdir.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
 from typing import Literal
 
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
@@ -23,11 +24,41 @@ from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotdir
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
-Lister = Callable[[A, ScopeMatch],
-                  Awaitable[list[tuple[str, IndexEntry]] | None]]
-EntryLister = Callable[[A, ScopeMatch, IndexEntry],
-                       Awaitable[list[tuple[str, IndexEntry]]]]
+
+@dataclass(frozen=True, slots=True)
+class DirListing:
+    """A listing that also proves descendant listings.
+
+    For a backend whose one fetch answers more than one directory: a
+    dated-message day fetch yields the day's own children AND the
+    contents of its ``files/`` subdirectory, and a mail label listing
+    yields the date directories AND each date's messages AND each
+    message's attachment directory. Returning the extra listings as
+    seeds lets the kit cache them, so entering a seeded directory costs
+    no second identical fetch.
+
+    Args:
+        entries (list[tuple[str, IndexEntry]]): the listed directory's
+            own children.
+        seeds (Mapping[str, list[tuple[str, IndexEntry]]]): descendant
+            listings the same fetch proved, keyed by path relative to
+            the listed directory (``files``, ``2026-01-05/Report__17``).
+    """
+    entries: list[tuple[str, IndexEntry]]
+    seeds: Mapping[str, list[tuple[str,
+                                   IndexEntry]]] = field(default_factory=dict)
+
+
+Listed = list[tuple[str, IndexEntry]] | DirListing
+Lister = Callable[[A, ScopeMatch], Awaitable["Listed | None"]]
+EntryLister = Callable[[A, ScopeMatch, IndexEntry], Awaitable[Listed]]
 Guard = Callable[[A, ScopeMatch, str], Awaitable[None]]
+
+
+def _drop_hidden(
+        listed: list[tuple[str, IndexEntry]]) -> list[tuple[str, IndexEntry]]:
+    return [(name, entry) for name, entry in listed
+            if not name.startswith(".")]
 
 
 def make_readdir(
@@ -35,6 +66,7 @@ def make_readdir(
     *,
     listers: Mapping[str, Lister[A]],
     entry_listers: Mapping[str, EntryLister[A]] | None = None,
+    parent_entry_listers: Mapping[str, EntryLister[A]] | None = None,
     static_root: tuple[str, ...] | None = None,
     guards: Mapping[str, Guard[A]] | None = None,
     leaf_error: Literal["enoent", "enotdir"] = "enoent",
@@ -50,6 +82,11 @@ def make_readdir(
     path that stat, read and child readdir all report absent.
     A lister may answer None instead of a listing: the directory's
     container does not exist, reported as ENOENT on the virtual path.
+    A lister may answer a ``DirListing`` to seed descendant listings its
+    fetch already proved; entering a seeded directory then reads the
+    index instead of refetching (the entry-lister branch re-checks the
+    listing after resolving, because the resolve itself may have run the
+    seeding parent).
 
     An entry lister is for a directory whose existence and contents are
     already proven by its parent's listing: the kit resolves the
@@ -62,13 +99,22 @@ def make_readdir(
     parent listing's ``IndexEntry.extra`` (trello stashes each
     ``card.json`` size on the card's directory entry).
 
+    A parent-entry lister is for a directory whose existence is decided
+    by its PARENT's entry rather than its own: a dated-message day dir
+    is real for any well-formed date under a channel that exists,
+    including dates the channel's bounded listing window never minted,
+    so the proof is the channel entry and the fetch takes the date from
+    the match.
+
     Args:
         detect (DetectFn): the backend's scope classifier.
         listers (Mapping[str, Lister]): one lister per directory kind;
             include ``root`` for a dynamic mount root.
         entry_listers (Mapping[str, EntryLister]): listers for kinds
-            resolved through their parent's listing; a kind appears in
-            exactly one of the two tables.
+            resolved through their parent's listing.
+        parent_entry_listers (Mapping[str, EntryLister]): listers handed
+            the parent directory's entry instead of their own; a kind
+            appears in at most one of the three tables.
         static_root (tuple[str, ...] | None): fixed top-level names, for
             backends whose root never changes; bypasses the index.
         guards (Mapping[str, Guard]): existence checks that run before
@@ -79,9 +125,13 @@ def make_readdir(
     """
 
     resolved = entry_listers if entry_listers is not None else {}
-    overlap = set(listers) & set(resolved)
+    parented = (parent_entry_listers
+                if parent_entry_listers is not None else {})
+    tables = [set(listers), set(resolved), set(parented)]
+    overlap = ((tables[0] & tables[1]) | (tables[0] & tables[2])
+               | (tables[1] & tables[2]))
     if overlap:
-        raise ValueError(f"kinds in both lister tables: {sorted(overlap)}")
+        raise ValueError(f"kinds in several lister tables: {sorted(overlap)}")
 
     async def readdir(accessor: A,
                       path_spec: PathSpec,
@@ -103,7 +153,8 @@ def make_readdir(
             return [f"{prefix}/{d}" for d in static_root]
         lister = listers.get(match.kind)
         entry_lister = resolved.get(match.kind)
-        if lister is None and entry_lister is None:
+        parent_lister = parented.get(match.kind)
+        if lister is None and entry_lister is None and parent_lister is None:
             if (match.scope is not None and match.scope.leaf
                     and leaf_error == "enotdir"):
                 raise enotdir(virtual)
@@ -114,25 +165,44 @@ def make_readdir(
         listing = await index.list_dir(virtual_key)
         if listing.entries is not None:
             return listing.entries
-        if entry_lister is not None:
+        if entry_lister is not None or parent_lister is not None:
+            proof_key = virtual_key
+            if parent_lister is not None:
+                proof_key = virtual_key.rsplit("/", 1)[0] or "/"
             own = await resolve_entry(
                 readdir, accessor,
-                PathSpec(virtual=virtual_key,
-                         directory=virtual_key,
-                         resource_path=mount_key(virtual_key, prefix)), index)
+                PathSpec(virtual=proof_key,
+                         directory=proof_key,
+                         resource_path=mount_key(proof_key, prefix)), index)
             if own is None:
                 raise enoent(virtual)
-            listed = await entry_lister(accessor, match, own)
+            # The resolve may have warmed this very listing: a parent's
+            # lister can seed a child listing from the same fetch
+            # (DirListing.seeds), so ask the index again before fetching.
+            relisted = await index.list_dir(virtual_key)
+            if relisted.entries is not None:
+                return relisted.entries
+            if entry_lister is not None:
+                listed = await entry_lister(accessor, match, own)
+            else:
+                assert parent_lister is not None
+                listed = await parent_lister(accessor, match, own)
         else:
             assert lister is not None
             maybe = await lister(accessor, match)
             if maybe is None:
                 raise enoent(virtual)
             listed = maybe
-        entries = [(name, entry) for name, entry in listed
-                   if not name.startswith(".")]
+        seeds: Mapping[str, list[tuple[str, IndexEntry]]] = {}
+        if isinstance(listed, DirListing):
+            seeds = listed.seeds
+            listed = listed.entries
+        entries = _drop_hidden(listed)
         await index.set_dir(virtual_key, entries)
         stem = virtual_key.rstrip("/")
+        for rel, child_entries in seeds.items():
+            await index.set_dir(f"{stem}/{rel.strip('/')}",
+                                _drop_hidden(child_entries))
         return [f"{stem}/{name}" for name, _ in entries]
 
     return readdir

--- a/python/mirage/core/slack/formatters.py
+++ b/python/mirage/core/slack/formatters.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from mirage.core.slack.files import file_blob_name
-from mirage.core.slack.scope import SlackScope
+from mirage.core.slack.scope import SearchTarget
 from mirage.utils.naming import make_id_name
 from mirage.utils.sanitize import path_safe_name
 
@@ -52,12 +52,12 @@ def user_filename(u: dict[str, Any]) -> str:
     return f"{make_id_name(name, u['id'], path_safe=True)}.json"
 
 
-def build_query(pattern: str, scope: SlackScope) -> str:
+def build_query(pattern: str, scope: SearchTarget) -> str:
     """Compose a Slack search query string for a pushed-down grep/rg call.
 
     Args:
         pattern (str): user-supplied pattern.
-        scope (SlackScope): the Slack-side directory the grep is rooted at.
+        scope (SearchTarget): the Slack-side directory the grep is rooted at.
 
     Returns:
         str: query with optional in:#channel or in:@user prefix.
@@ -71,14 +71,14 @@ def build_query(pattern: str, scope: SlackScope) -> str:
 
 def format_grep_results(
     raw: bytes,
-    scope: SlackScope,
+    scope: SearchTarget,
     prefix: str,
 ) -> list[str]:
     """Format a Slack search.messages JSON response as grep-style lines.
 
     Args:
         raw (bytes): JSON-encoded search.messages response.
-        scope (SlackScope): the rooted scope used to compute relative paths.
+        scope (SearchTarget): the rooted scope used to compute relative paths.
         prefix (str): VFS mount prefix to prepend.
 
     Returns:
@@ -111,14 +111,14 @@ def format_grep_results(
 
 def format_file_grep_results(
     raw: bytes,
-    scope: SlackScope,
+    scope: SearchTarget,
     prefix: str,
 ) -> list[str]:
     """Format a Slack search.files JSON response as grep-style lines.
 
     Args:
         raw (bytes): JSON-encoded search.files response.
-        scope (SlackScope): the rooted scope (must have channel_id).
+        scope (SearchTarget): the rooted scope (must have channel_id).
         prefix (str): VFS mount prefix to prepend.
 
     Returns:

--- a/python/mirage/core/slack/read.py
+++ b/python/mirage/core/slack/read.py
@@ -13,77 +13,109 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.slack import SlackAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.cache.index import IndexCacheStore, IndexEntry
+from mirage.core.hierarchy.probe import resolve_entry
+from mirage.core.hierarchy.read import make_read, make_read_range
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.core.slack import files as slack_files
 from mirage.core.slack.history import get_history_jsonl
+from mirage.core.slack.readdir import readdir
+from mirage.core.slack.scope import detect_scope
 from mirage.core.slack.users import get_user_profile, user_json_bytes
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-from mirage.utils.key_prefix import mount_prefix_of
-from mirage.utils.ranges import slice_window
+from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
 
-async def read(
-    accessor: SlackAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-    offset: int = 0,
-    size: int | None = None,
-) -> bytes:
-    """Read a Slack path, optionally only a byte range of it.
+async def _ancestor_entry(accessor: SlackAccessor, path: PathSpec,
+                          index: IndexCacheStore,
+                          up: int) -> IndexEntry | None:
+    virtual = path.virtual.rstrip("/")
+    for _ in range(up):
+        virtual = virtual.rsplit("/", 1)[0]
+    prefix = mount_prefix_of(path.virtual, path.resource_path)
+    spec = PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=mount_key(virtual, prefix))
+    return await resolve_entry(readdir, accessor, spec, index)
 
-    Only an uploaded file has a remote range to ask for. A channel's
-    history and a user profile are rendered here into JSON, so their
-    bytes do not exist until we make them and the window can only be
-    taken afterwards.
+
+async def _read_chat(accessor: SlackAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    """Render one day's history; the channel id comes from the listing.
+
+    The typed ``name__id`` dirname is only trusted once the listing
+    proves it, so a fabricated channel id is ENOENT rather than a raw
+    API error.
 
     Args:
-        accessor (SlackAccessor): Slack accessor.
-        path (PathSpec): the path to read.
-        index (IndexCacheStore): listing cache, consulted for the entry.
-        offset (int): first byte to read.
-        size (int | None): how many bytes, or None for the rest.
+        accessor (SlackAccessor): slack accessor.
+        match (ScopeMatch): a match holding the day chain.
+        path (PathSpec): the chat.jsonl path.
+        index (IndexCacheStore): index cache.
     """
-    virtual = path.virtual
-    prefix = mount_prefix_of(path.virtual, path.resource_path) if isinstance(
-        path, PathSpec) else ""
-    raw = path.virtual if isinstance(path, PathSpec) else path
-    if prefix and raw.startswith(prefix):
-        raw = raw[len(prefix):] or "/"
-    key = raw.strip("/")
-    parts = key.split("/")
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is not None:
+        channel_id = entry.id.split(":", 1)[0]
+    else:
+        # A sealed day lists nothing but the file still reads through
+        # the channel, reproducing the API's own answer for the fetch.
+        channel = await _ancestor_entry(accessor, path, index, up=2)
+        if channel is None:
+            raise enoent(path.virtual)
+        channel_id = channel.id
+    return await get_history_jsonl(accessor.config, channel_id,
+                                   match.slots["day"])
 
-    if (len(parts) == 4 and parts[0] in ("channels", "dms")
-            and parts[3] == "chat.jsonl"):
-        parent_key = f"{parts[0]}/{parts[1]}"
-        virtual_key = prefix + "/" + parent_key
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            raise enoent(virtual)
-        channel_id = lookup.entry.id
-        date_str = parts[2]
-        history = await get_history_jsonl(accessor.config, channel_id,
-                                          date_str)
-        return slice_window(history, offset, size)
 
-    if (len(parts) == 5 and parts[0] in ("channels", "dms")
-            and parts[3] == "files"):
-        virtual_key = prefix + "/" + key
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None or not lookup.entry.extra:
-            raise enoent(virtual)
-        url = lookup.entry.extra.get("url_private_download")
-        if not url:
-            raise enoent(virtual)
-        return await slack_files.download_file(accessor.config, url, offset,
-                                               size)
+async def _read_user(accessor: SlackAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is None:
+        raise enoent(path.virtual)
+    user = await get_user_profile(accessor.config, entry.id)
+    return user_json_bytes(user)
 
-    if len(parts) == 2 and parts[0] == "users":
-        virtual_key = prefix + "/" + key
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            raise enoent(virtual)
-        user = await get_user_profile(accessor.config, lookup.entry.id)
-        return slice_window(user_json_bytes(user), offset, size)
 
-    raise enoent(virtual)
+async def _blob_url(accessor: SlackAccessor, path: PathSpec,
+                    index: IndexCacheStore) -> str:
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is None:
+        raise enoent(path.virtual)
+    url = entry.extra.get("url_private_download")
+    if not isinstance(url, str) or not url:
+        raise enoent(path.virtual)
+    return url
+
+
+async def _read_blob(accessor: SlackAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    url = await _blob_url(accessor, path, index)
+    return await slack_files.download_file(accessor.config, url, 0, None)
+
+
+async def _read_blob_range(accessor: SlackAccessor, match: ScopeMatch,
+                           path: PathSpec, index: IndexCacheStore, offset: int,
+                           size: int | None) -> bytes:
+    url = await _blob_url(accessor, path, index)
+    return await slack_files.download_file(accessor.config, url, offset, size)
+
+
+read = make_read(
+    detect_scope,
+    readers={
+        "messages": _read_chat,
+        "user": _read_user,
+        "file_blob": _read_blob,
+    },
+)
+
+# Only an uploaded file has a remote range to ask for. A channel's
+# history and a user profile are rendered here into JSON, so their bytes
+# do not exist until we make them and the window can only be taken
+# afterwards.
+read_range = make_read_range(
+    detect_scope,
+    read,
+    ranged={"file_blob": _read_blob_range},
+)

--- a/python/mirage/core/slack/readdir.py
+++ b/python/mirage/core/slack/readdir.py
@@ -16,18 +16,17 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 from mirage.accessor.slack import SlackAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
+from mirage.cache.index import IndexEntry
+from mirage.core.hierarchy.readdir import DirListing, Listed, make_readdir
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.core.slack.channels import list_channels, list_dms
 from mirage.core.slack.client import slack_get
 from mirage.core.slack.files import file_blob_name
 from mirage.core.slack.formatters import (channel_dirname, dm_dirname,
                                           user_filename)
 from mirage.core.slack.history import fetch_messages_for_day, messages_to_jsonl
-from mirage.core.slack.scope import SlackScope, detect_scope
+from mirage.core.slack.scope import detect_scope
 from mirage.core.slack.users import list_users, user_json_bytes
-from mirage.types import PathSpec
-from mirage.utils.errors import enoent
-from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
 logger = logging.getLogger(__name__)
 
@@ -78,251 +77,92 @@ async def _latest_message_ts(config, channel_id: str) -> float | None:
     return None
 
 
-def _normalize_path(path: PathSpec) -> tuple[PathSpec, str, str, str]:
-    prefix = mount_prefix_of(path.virtual, path.resource_path) or ""
-    raw = path.directory if path.pattern else path.virtual
-    if prefix and raw.startswith(prefix):
-        raw = raw[len(prefix):] or "/"
-    key = raw.strip("/")
-    virtual_key = prefix + "/" + key if key else prefix or "/"
-    return path, prefix, key, virtual_key
-
-
-async def _readdir_root(prefix: str) -> list[str]:
-    return [f"{prefix}/channels", f"{prefix}/dms", f"{prefix}/users"]
-
-
-async def _readdir_channels(
-    accessor: SlackAccessor,
-    prefix: str,
-    virtual_key: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    listing = await index.list_dir(virtual_key)
-    if listing.entries is not None:
-        return listing.entries
+async def _list_channels_root(accessor: SlackAccessor,
+                              match: ScopeMatch) -> Listed:
     channels = await list_channels(accessor.config)
     entries: list[tuple[str, IndexEntry]] = []
-    names: list[str] = []
     for ch in channels:
         dirname = channel_dirname(ch)
-        entry = IndexEntry(
-            id=ch["id"],
-            name=ch.get("name", ""),
-            resource_type="slack/channel",
-            vfs_name=dirname,
-            remote_time=str(ch.get("created", 0)),
-        )
-        entries.append((dirname, entry))
-        names.append(f"{prefix}/channels/{dirname}")
-    await index.set_dir(virtual_key, entries)
-    return names
+        entries.append((dirname,
+                        IndexEntry(
+                            id=ch["id"],
+                            name=ch.get("name", ""),
+                            resource_type="slack/channel",
+                            vfs_name=dirname,
+                            remote_time=str(ch.get("created", 0)),
+                        )))
+    return entries
 
 
-async def _readdir_dms(
-    accessor: SlackAccessor,
-    prefix: str,
-    virtual_key: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    listing = await index.list_dir(virtual_key)
-    if listing.entries is not None:
-        return listing.entries
+async def _list_dms_root(accessor: SlackAccessor, match: ScopeMatch) -> Listed:
     dms = await list_dms(accessor.config)
     users = await list_users(accessor.config)
     user_map = {u["id"]: u.get("name", u["id"]) for u in users}
     entries: list[tuple[str, IndexEntry]] = []
-    names: list[str] = []
     for dm in dms:
         dirname = dm_dirname(dm, user_map)
         uid = dm.get("user", "")
-        entry = IndexEntry(
-            id=dm["id"],
-            name=user_map.get(uid, uid),
-            resource_type="slack/dm",
-            vfs_name=dirname,
-            remote_time=str(dm.get("created", 0)),
-        )
-        entries.append((dirname, entry))
-        names.append(f"{prefix}/dms/{dirname}")
-    await index.set_dir(virtual_key, entries)
-    return names
+        entries.append((dirname,
+                        IndexEntry(
+                            id=dm["id"],
+                            name=user_map.get(uid, uid),
+                            resource_type="slack/dm",
+                            vfs_name=dirname,
+                            remote_time=str(dm.get("created", 0)),
+                        )))
+    return entries
 
 
-async def _readdir_users(
-    accessor: SlackAccessor,
-    prefix: str,
-    virtual_key: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    listing = await index.list_dir(virtual_key)
-    if listing.entries is not None:
-        return listing.entries
+async def _list_users_root(accessor: SlackAccessor,
+                           match: ScopeMatch) -> Listed:
     users = await list_users(accessor.config)
     entries: list[tuple[str, IndexEntry]] = []
-    names: list[str] = []
     for u in users:
         filename = user_filename(u)
-        entry = IndexEntry(
-            id=u["id"],
-            name=u.get("name", ""),
-            resource_type="slack/user",
-            vfs_name=filename,
-            size=len(user_json_bytes(u)),
-        )
-        entries.append((filename, entry))
-        names.append(f"{prefix}/users/{filename}")
-    await index.set_dir(virtual_key, entries)
-    return names
+        entries.append((filename,
+                        IndexEntry(
+                            id=u["id"],
+                            name=u.get("name", ""),
+                            resource_type="slack/user",
+                            vfs_name=filename,
+                            size=len(user_json_bytes(u)),
+                        )))
+    return entries
 
 
-async def _readdir_channel_dates(
-    accessor: SlackAccessor,
-    path: PathSpec,
-    prefix: str,
-    key: str,
-    virtual_key: str,
-    container: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    lookup = await index.get(virtual_key)
-    if lookup.entry is None:
-        parent_str = prefix + "/" + container
-        parent = PathSpec(virtual=parent_str,
-                          directory=parent_str,
-                          resource_path=mount_key(parent_str, prefix))
-        await readdir(accessor, parent, index)
-        lookup = await index.get(virtual_key)
-    if lookup.entry is None:
-        raise enoent(path)
-    listing = await index.list_dir(virtual_key)
-    if listing.entries is not None:
-        return listing.entries
-    created = int(lookup.entry.remote_time or 0)
-    latest_ts = await _latest_message_ts(accessor.config, lookup.entry.id)
+async def _list_channel_days(accessor: SlackAccessor, match: ScopeMatch,
+                             own: IndexEntry) -> Listed:
+    created = int(own.remote_time or 0)
+    latest_ts = await _latest_message_ts(accessor.config, own.id)
     if latest_ts and created:
         dates = _date_range(latest_ts, created)
     elif latest_ts:
         dates = _date_range(latest_ts, int(latest_ts))
     else:
         dates = []
-    entries: list[tuple[str, IndexEntry]] = []
-    names: list[str] = []
-    for d in dates:
-        entry = IndexEntry(
-            id=f"{lookup.entry.id}:{d}",
-            name=d,
-            resource_type="slack/date_dir",
-            vfs_name=d,
-        )
-        entries.append((d, entry))
-        names.append(f"{prefix}/{key}/{d}")
-    await index.set_dir(virtual_key, entries)
-    return names
+    return [(d,
+             IndexEntry(
+                 id=f"{own.id}:{d}",
+                 name=d,
+                 resource_type="slack/date_dir",
+                 vfs_name=d,
+                 extra={"channel_id": own.id},
+             )) for d in dates]
 
 
-async def _readdir_date_contents(
-    accessor: SlackAccessor,
-    path: PathSpec,
-    prefix: str,
-    key: str,
-    virtual_key: str,
-    container: str,
-    chan_seg: str,
-    date_str: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    cached = await index.list_dir(virtual_key)
-    if cached.entries is not None:
-        return cached.entries
-    parent_vk = f"{prefix}/{container}/{chan_seg}"
-    parent_lookup = await index.get(parent_vk)
-    if parent_lookup.entry is None:
-        parent_str = f"{prefix}/{container}/{chan_seg}"
-        parent = PathSpec(virtual=parent_str,
-                          directory=parent_str,
-                          resource_path=mount_key(parent_str, prefix))
-        await readdir(accessor, parent, index)
-        parent_lookup = await index.get(parent_vk)
-    if parent_lookup.entry is None:
-        raise enoent(path)
-    channel_id = parent_lookup.entry.id
-    await _fetch_day(accessor, channel_id, date_str, virtual_key, index)
-    cached = await index.list_dir(virtual_key)
-    if cached.entries is not None:
-        return cached.entries
-    raise enoent(path)
+async def _day_listing(accessor: SlackAccessor, channel_id: str,
+                       date_str: str) -> DirListing:
+    """One history fetch, answering the day dir and its files subdir.
 
+    A soft history error (not_in_channel, missing_scope, ...) seals an
+    empty day: the dir lists nothing, and stat serves chat.jsonl with
+    the size left unknown.
 
-async def _readdir_files_dir(
-    accessor: SlackAccessor,
-    path: PathSpec,
-    prefix: str,
-    key: str,
-    virtual_key: str,
-    container: str,
-    chan_seg: str,
-    date_str: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    cached = await index.list_dir(virtual_key)
-    if cached.entries is not None:
-        return cached.entries
-    date_str_path = f"{prefix}/{container}/{chan_seg}/{date_str}"
-    date_path = PathSpec(virtual=date_str_path,
-                         directory=date_str_path,
-                         resource_path=mount_key(date_str_path, prefix))
-    await readdir(accessor, date_path, index)
-    cached = await index.list_dir(virtual_key)
-    if cached.entries is not None:
-        return cached.entries
-    raise enoent(path)
-
-
-async def readdir(
-    accessor: SlackAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> list[str]:
-    path, prefix, key, virtual_key = _normalize_path(path)
-
-    if not key:
-        return await _readdir_root(prefix)
-
-    scope = detect_scope(path)
-    container = scope.container
-
-    if key == "channels":
-        return await _readdir_channels(accessor, prefix, virtual_key, index)
-    if key == "dms":
-        return await _readdir_dms(accessor, prefix, virtual_key, index)
-    if key == "users":
-        return await _readdir_users(accessor, prefix, virtual_key, index)
-
-    parts = key.split("/")
-    if container in ("channels", "dms") and len(parts) == 2:
-        return await _readdir_channel_dates(accessor, path, prefix, key,
-                                            virtual_key, container, index)
-    if container in ("channels", "dms") and scope.target == "date":
-        return await _readdir_date_contents(accessor, path, prefix, key,
-                                            virtual_key, container, parts[1],
-                                            parts[2], index)
-    if container in ("channels", "dms") and scope.target == "files":
-        return await _readdir_files_dir(accessor, path, prefix, key,
-                                        virtual_key, container, parts[1],
-                                        parts[2], index)
-    # An unrecognized path is not an empty directory: returning [] made
-    # `ls` and `tree` report a bogus path as a real-but-empty one.
-    raise enoent(path.virtual)
-
-
-async def _fetch_day(
-    accessor: SlackAccessor,
-    channel_id: str,
-    date_str: str,
-    date_vkey: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> None:
+    Args:
+        accessor (SlackAccessor): slack accessor.
+        channel_id (str): the channel or DM id.
+        date_str (str): the day, ``YYYY-MM-DD``.
+    """
     try:
         messages = await fetch_messages_for_day(accessor.config, channel_id,
                                                 date_str)
@@ -330,8 +170,7 @@ async def _fetch_day(
         if any(code in str(e) for code in _SOFT_HISTORY_ERRORS):
             logger.debug("slack: history denied for %s/%s (%s); empty day",
                          channel_id, date_str, e)
-            await index.set_dir(date_vkey, [])
-            return
+            return DirListing(entries=[])
         raise
     chat_entry = IndexEntry(
         id=f"{channel_id}:{date_str}:chat",
@@ -345,11 +184,11 @@ async def _fetch_day(
         name="files",
         resource_type="slack/files_dir",
         vfs_name="files",
+        extra={
+            "channel_id": channel_id,
+            "date": date_str
+        },
     )
-    await index.set_dir(date_vkey, [
-        ("chat.jsonl", chat_entry),
-        ("files", files_entry),
-    ])
     file_entries: list[tuple[str, IndexEntry]] = []
     for msg in messages:
         for fmeta in msg.get("files", []) or []:
@@ -385,7 +224,42 @@ async def _fetch_day(
                          date_str,
                      },
                  )))
-    await index.set_dir(date_vkey + "/files", file_entries)
+    return DirListing(
+        entries=[("chat.jsonl", chat_entry), ("files", files_entry)],
+        seeds={"files": file_entries},
+    )
 
 
-__all__ = ["readdir", "VIRTUAL_ROOTS", "SlackScope"]
+async def _list_day(accessor: SlackAccessor, match: ScopeMatch,
+                    channel: IndexEntry) -> Listed:
+    # The proof is the channel entry, not the day's own: any well-formed
+    # date under a real channel fetches, including dates outside the
+    # bounded window the channel listing mints.
+    return await _day_listing(accessor, channel.id, match.slots["day"])
+
+
+async def _list_files(accessor: SlackAccessor, match: ScopeMatch,
+                      own: IndexEntry) -> Listed:
+    # Normally served from the day lister's seed; reached only when the
+    # index evicted the files listing while the day's entries survived.
+    channel_id = own.extra.get("channel_id") or own.id.split(":", 1)[0]
+    listing = await _day_listing(accessor, channel_id, match.slots["day"])
+    return listing.seeds.get("files", [])
+
+
+readdir = make_readdir(
+    detect_scope,
+    listers={
+        "channels_root": _list_channels_root,
+        "dms_root": _list_dms_root,
+        "users_root": _list_users_root,
+    },
+    entry_listers={
+        "channel": _list_channel_days,
+        "files": _list_files,
+    },
+    parent_entry_listers={"day": _list_day},
+    static_root=VIRTUAL_ROOTS,
+)
+
+__all__ = ["readdir", "VIRTUAL_ROOTS"]

--- a/python/mirage/core/slack/scope.py
+++ b/python/mirage/core/slack/scope.py
@@ -12,137 +12,89 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
 from dataclasses import dataclass
 
-from mirage.types import PathSpec
-from mirage.utils.key_prefix import mount_prefix_of
+from mirage.core.hierarchy.codec import DATE, JSON_NAME, Codec
+from mirage.core.hierarchy.scope import (ROOT, Scope, ScopeMatch, Slot,
+                                         make_detect_scope)
+from mirage.types import FileType
 
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+def is_container(text: str) -> bool:
+    """Whether a segment names a message container.
+
+    Args:
+        text (str): decoded segment payload.
+    """
+    return text in ("channels", "dms")
 
 
-@dataclass
-class SlackScope:
-    use_native: bool
+# Channels and DMs share every level below the container, so the
+# container is a validated slot rather than two parallel scope families;
+# the decoded value rides the slots the way an id does.
+CONTAINER = Codec(validate=is_container)
+
+_CHANNEL = (Slot("container", CONTAINER), Slot("channel", id_key="channel_id"))
+_DAY = _CHANNEL + (Slot("day", DATE), )
+
+# One description of the tree: readdir, stat, read and the search
+# push-down all classify through it, so the file surface and the command
+# surface cannot disagree about what a path means.
+SCOPES = (
+    Scope(kind="channels_root", segments=("channels", ), probed=False),
+    Scope(kind="dms_root", segments=("dms", ), probed=False),
+    Scope(kind="users_root", segments=("users", ), probed=False),
+    Scope(kind="user",
+          segments=("users", Slot("user", JSON_NAME, id_key="user_id")),
+          leaf=True,
+          filetype=FileType.JSON),
+    Scope(kind="channel", segments=_CHANNEL),
+    Scope(kind="day", segments=_DAY),
+    Scope(kind="messages",
+          segments=_DAY + ("chat.jsonl", ),
+          leaf=True,
+          filetype=FileType.TEXT),
+    Scope(kind="files", segments=_DAY + ("files", )),
+    Scope(kind="file_blob", segments=_DAY + ("files", Slot("blob")),
+          leaf=True),
+)
+
+detect_scope = make_detect_scope(SCOPES)
+
+# Kinds the workspace search push-down may answer for. Slack search is
+# workspace-wide, so the root qualifies; a chat.jsonl or blob operand
+# names one day's file, which a channel-wide search cannot stand in for,
+# and the files directory is excluded because search.files has no
+# per-day filter either.
+NATIVE_KINDS = frozenset({ROOT, "channels_root", "dms_root", "channel", "day"})
+
+
+@dataclass(frozen=True, slots=True)
+class SearchTarget:
+    """The channel coordinates a search push-down carries.
+
+    Args:
+        container (str | None): ``channels`` or ``dms``; None at the root.
+        channel_name (str | None): display half of the channel dirname.
+        channel_id (str | None): channel id parsed from the dirname.
+    """
+    container: str | None = None
     channel_name: str | None = None
     channel_id: str | None = None
-    container: str | None = None
-    date_str: str | None = None
-    target: str | None = None
-    resource_path: str = "/"
 
 
-def _split_dirname(dirname: str) -> tuple[str, str | None]:
-    if "__" in dirname:
-        name, _, cid = dirname.rpartition("__")
-        return name, cid or None
-    return dirname, None
+def search_target(match: ScopeMatch) -> SearchTarget:
+    """The coordinates a native search should scope itself to.
 
-
-def detect_scope(path: PathSpec) -> SlackScope:
-    prefix = mount_prefix_of(path.virtual, path.resource_path) or ""
-
-    if path.pattern:
-        dir_key = path.directory.strip("/")
-        if prefix:
-            dir_key = dir_key.removeprefix(prefix.strip("/") + "/")
-        parts = dir_key.split("/") if dir_key else []
-        if len(parts) >= 2 and parts[0] in ("channels", "dms"):
-            name, cid = _split_dirname(parts[1])
-            target: str | None = None
-            date_str: str | None = None
-            if len(parts) == 2:
-                target = None
-            elif len(parts) == 3 and _DATE_RE.match(parts[2]):
-                target = "date"
-                date_str = parts[2]
-            elif (len(parts) == 4 and parts[3] == "files"
-                  and _DATE_RE.match(parts[2])):
-                target = "files"
-                date_str = parts[2]
-            return SlackScope(
-                use_native=True,
-                channel_name=name,
-                channel_id=cid,
-                container=parts[0],
-                date_str=date_str,
-                target=target,
-                resource_path=dir_key,
-            )
-
-    key = path.resource_path
-    if not key:
-        return SlackScope(use_native=True, resource_path="/")
-
-    parts = key.split("/")
-    root = parts[0]
-
-    if root == "users":
-        return SlackScope(use_native=False, resource_path=key)
-
-    if root not in ("channels", "dms"):
-        return SlackScope(use_native=False, resource_path=key)
-
-    if len(parts) == 1:
-        return SlackScope(use_native=True, container=root, resource_path=key)
-
-    if len(parts) == 2:
-        name, cid = _split_dirname(parts[1])
-        return SlackScope(
-            use_native=True,
-            channel_name=name,
-            channel_id=cid,
-            container=root,
-            resource_path=key,
-        )
-
-    if len(parts) == 3 and _DATE_RE.match(parts[2]):
-        name, cid = _split_dirname(parts[1])
-        return SlackScope(
-            use_native=True,
-            channel_name=name,
-            channel_id=cid,
-            container=root,
-            date_str=parts[2],
-            target="date",
-            resource_path=key,
-        )
-
-    if (len(parts) == 4 and parts[3] == "chat.jsonl"
-            and _DATE_RE.match(parts[2])):
-        name, cid = _split_dirname(parts[1])
-        return SlackScope(
-            use_native=False,
-            channel_name=name,
-            channel_id=cid,
-            container=root,
-            date_str=parts[2],
-            target="messages",
-            resource_path=key,
-        )
-
-    if (len(parts) == 4 and parts[3] == "files" and _DATE_RE.match(parts[2])):
-        name, cid = _split_dirname(parts[1])
-        return SlackScope(
-            use_native=True,
-            channel_name=name,
-            channel_id=cid,
-            container=root,
-            date_str=parts[2],
-            target="files",
-            resource_path=key,
-        )
-
-    if (len(parts) == 5 and parts[3] == "files" and _DATE_RE.match(parts[2])):
-        name, cid = _split_dirname(parts[1])
-        return SlackScope(
-            use_native=False,
-            channel_name=name,
-            channel_id=cid,
-            container=root,
-            date_str=parts[2],
-            target="files",
-            resource_path=key,
-        )
-
-    return SlackScope(use_native=False, resource_path=key)
+    Args:
+        match (ScopeMatch): the classified operand.
+    """
+    if match.kind == "channels_root":
+        return SearchTarget(container="channels")
+    if match.kind == "dms_root":
+        return SearchTarget(container="dms")
+    return SearchTarget(
+        container=match.slots.get("container"),
+        channel_name=match.slots.get("channel"),
+        channel_id=match.slots.get("channel_id"),
+    )

--- a/python/mirage/core/slack/stat.py
+++ b/python/mirage/core/slack/stat.py
@@ -12,22 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import logging
-import re
-
 from mirage.accessor.slack import SlackAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.slack.readdir import readdir as _readdir
+from mirage.cache.index import IndexCacheStore, IndexEntry
+from mirage.core.hierarchy.probe import resolve_entry
+from mirage.core.hierarchy.scope import ScopeMatch
+from mirage.core.hierarchy.stat import make_stat
+from mirage.core.slack.readdir import readdir
+from mirage.core.slack.scope import detect_scope
 from mirage.core.timeutil import epoch_to_iso
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.filetype import filetype_from_mimetype
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
-
-logger = logging.getLogger(__name__)
-
-VIRTUAL_DIRS = {"", "channels", "dms", "users"}
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _slack_modified(remote_time: str) -> str | None:
@@ -42,111 +38,105 @@ def _slack_modified(remote_time: str) -> str | None:
     return epoch_to_iso(ts)
 
 
-async def _populate_via_parent(
-    accessor: SlackAccessor,
-    virtual_key: str,
-    prefix: str,
-    index: IndexCacheStore = NULL_INDEX,
-) -> None:
-    parent_virtual = virtual_key.rsplit("/", 1)[0] or "/"
-    try:
-        await _readdir(
-            accessor,
-            PathSpec(virtual=parent_virtual,
-                     directory=parent_virtual,
-                     resource_path=mount_key(parent_virtual, prefix)),
-            index=index,
-        )
-    except FileNotFoundError as exc:
-        logger.debug("stat populate failed for %s: %s", virtual_key, exc)
+def _channel_stat(match: ScopeMatch, path: PathSpec,
+                  entry: IndexEntry) -> FileStat:
+    return FileStat(
+        name=entry.vfs_name or entry.name,
+        type=FileType.DIRECTORY,
+        modified=_slack_modified(entry.remote_time),
+        extra={"channel_id": entry.id},
+    )
 
 
-async def stat(
-    accessor: SlackAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> FileStat:
-    virtual = path.virtual
-    prefix = mount_prefix_of(path.virtual, path.resource_path) if isinstance(
-        path, PathSpec) else ""
-    raw = path.virtual if isinstance(path, PathSpec) else path
-    if prefix and raw.startswith(prefix):
-        raw = raw[len(prefix):] or "/"
-    key = raw.strip("/")
+def _user_stat(match: ScopeMatch, path: PathSpec,
+               entry: IndexEntry) -> FileStat:
+    return FileStat(
+        name=entry.vfs_name or entry.name,
+        type=FileType.JSON,
+        size=entry.size,
+        extra={"user_id": entry.id},
+    )
 
-    if key in VIRTUAL_DIRS:
-        name = key if key else "/"
-        return FileStat(name=name, type=FileType.DIRECTORY)
 
-    parts = key.split("/")
-    virtual_key = prefix + "/" + key
+def _dir_stat(match: ScopeMatch, path: PathSpec,
+              entry: IndexEntry) -> FileStat:
+    return FileStat(name=entry.vfs_name, type=FileType.DIRECTORY)
 
-    if len(parts) == 2 and parts[0] in ("channels", "dms"):
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            await _populate_via_parent(accessor, virtual_key, prefix, index)
-            lookup = await index.get(virtual_key)
-            if lookup.entry is None:
-                raise enoent(virtual)
-        return FileStat(
-            name=lookup.entry.vfs_name or lookup.entry.name,
-            type=FileType.DIRECTORY,
-            modified=_slack_modified(lookup.entry.remote_time),
-            extra={"channel_id": lookup.entry.id},
-        )
 
-    if len(parts) == 2 and parts[0] == "users":
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            await _populate_via_parent(accessor, virtual_key, prefix, index)
-            lookup = await index.get(virtual_key)
-            if lookup.entry is None:
-                raise enoent(virtual)
-        return FileStat(
-            name=lookup.entry.vfs_name or lookup.entry.name,
-            type=FileType.JSON,
-            size=lookup.entry.size,
-            extra={"user_id": lookup.entry.id},
-        )
+def _file_blob_stat(match: ScopeMatch, path: PathSpec,
+                    entry: IndexEntry) -> FileStat:
+    mimetype = entry.extra.get("mimetype", "")
+    return FileStat(
+        name=entry.vfs_name or entry.name,
+        type=filetype_from_mimetype(mimetype),
+        size=entry.size,
+        modified=_slack_modified(entry.remote_time),
+        extra={"file_id": entry.id},
+    )
 
-    if (len(parts) == 3 and parts[0] in ("channels", "dms")
-            and _DATE_RE.match(parts[2])):
-        return FileStat(name=parts[2], type=FileType.DIRECTORY)
 
-    if (len(parts) == 4 and parts[0] in ("channels", "dms")
-            and _DATE_RE.match(parts[2]) and parts[3] == "chat.jsonl"):
-        # The day's readdir renders the messages it fetched and stores the
-        # byte length, so stat serves it from the index instead of
-        # answering blind.
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            await _populate_via_parent(accessor, virtual_key, prefix, index)
-            lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            raise enoent(virtual)
-        return FileStat(name="chat.jsonl",
-                        type=FileType.TEXT,
-                        size=lookup.entry.size)
+async def _channel_proven(accessor: SlackAccessor, path: PathSpec,
+                          index: IndexCacheStore, up: int) -> None:
+    """Raise ENOENT unless the path's channel ancestor exists.
 
-    if (len(parts) == 4 and parts[0] in ("channels", "dms")
-            and _DATE_RE.match(parts[2]) and parts[3] == "files"):
-        return FileStat(name="files", type=FileType.DIRECTORY)
+    Args:
+        accessor (SlackAccessor): slack accessor.
+        path (PathSpec): the day or chat.jsonl path being stat'd.
+        index (IndexCacheStore): index cache.
+        up (int): how many trailing segments to drop to reach the
+            channel (1 for a day dir, 2 for its children).
+    """
+    virtual = path.virtual.rstrip("/")
+    for _ in range(up):
+        virtual = virtual.rsplit("/", 1)[0]
+    prefix = mount_prefix_of(path.virtual, path.resource_path)
+    spec = PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=mount_key(virtual, prefix))
+    if await resolve_entry(readdir, accessor, spec, index) is None:
+        raise enoent(path.virtual)
 
-    if (len(parts) == 5 and parts[0] in ("channels", "dms")
-            and _DATE_RE.match(parts[2]) and parts[3] == "files"):
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            await _populate_via_parent(accessor, virtual_key, prefix, index)
-            lookup = await index.get(virtual_key)
-            if lookup.entry is None:
-                raise enoent(virtual)
-        mimetype = lookup.entry.extra.get("mimetype", "")
-        return FileStat(
-            name=lookup.entry.vfs_name or lookup.entry.name,
-            type=filetype_from_mimetype(mimetype),
-            size=lookup.entry.size,
-            modified=_slack_modified(lookup.entry.remote_time),
-            extra={"file_id": lookup.entry.id},
-        )
 
-    raise enoent(virtual)
+async def _stat_day(accessor: SlackAccessor, match: ScopeMatch, path: PathSpec,
+                    index: IndexCacheStore) -> FileStat:
+    """Stat a day directory, which resolves beyond the listed window.
+
+    The channel listing synthesizes a bounded window of recent days,
+    but the history API answers a range query for any date, so a
+    well-formed day under a channel that exists is a directory whether
+    or not the window lists it. A bogus channel chain is ENOENT.
+
+    Args:
+        accessor (SlackAccessor): slack accessor.
+        match (ScopeMatch): a match holding ``container``/``channel``/
+            ``day``.
+        path (PathSpec): the path to stat.
+        index (IndexCacheStore): index cache.
+    """
+    entry = await resolve_entry(readdir, accessor, path, index)
+    if entry is not None:
+        return FileStat(name=entry.vfs_name, type=FileType.DIRECTORY)
+    await _channel_proven(accessor, path, index, up=1)
+    return FileStat(name=match.slots["day"], type=FileType.DIRECTORY)
+
+
+def _chat_stat(match: ScopeMatch, path: PathSpec,
+               entry: IndexEntry) -> FileStat:
+    # A denied or empty day lists no chat.jsonl, and the kit reports the
+    # absent entry as ENOENT: slack does not fabricate a sizeless file
+    # for a sealed day (discord deliberately does; see its override).
+    return FileStat(name="chat.jsonl", type=FileType.TEXT, size=entry.size)
+
+
+stat = make_stat(
+    detect_scope,
+    readdir,
+    entry_stats={
+        "channel": _channel_stat,
+        "user": _user_stat,
+        "messages": _chat_stat,
+        "files": _dir_stat,
+        "file_blob": _file_blob_stat,
+    },
+    overrides={"day": _stat_day},
+)

--- a/python/tests/commands/builtin/email/test_find.py
+++ b/python/tests/commands/builtin/email/test_find.py
@@ -87,9 +87,6 @@ async def test_type_f_lists_attachments():
     with patch("mirage.core.email.readdir.list_folders",
                new_callable=AsyncMock,
                return_value=["INBOX"]), \
-         patch("mirage.core.email.stat.list_folders",
-               new_callable=AsyncMock,
-               return_value=["INBOX"]), \
          patch("mirage.core.email.readdir.list_message_uids",
                new_callable=AsyncMock,
                return_value=["7"]), \
@@ -109,9 +106,6 @@ async def test_type_f_lists_attachments():
 @pytest.mark.asyncio
 async def test_type_d_lists_attachment_dir_not_attachment():
     with patch("mirage.core.email.readdir.list_folders",
-               new_callable=AsyncMock,
-               return_value=["INBOX"]), \
-         patch("mirage.core.email.stat.list_folders",
                new_callable=AsyncMock,
                return_value=["INBOX"]), \
          patch("mirage.core.email.readdir.list_message_uids",
@@ -150,9 +144,6 @@ async def test_name_with_size_falls_through_to_walk():
          patch("mirage.core.email.readdir.list_folders",
                new_callable=AsyncMock,
                return_value=["INBOX"]), \
-         patch("mirage.core.email.stat.list_folders",
-               new_callable=AsyncMock,
-               return_value=["INBOX"]), \
          patch("mirage.core.email.readdir.list_message_uids",
                new_callable=AsyncMock,
                return_value=[]):
@@ -177,9 +168,6 @@ async def test_second_folder_operand_falls_through_to_walk():
          patch("mirage.core.email.readdir.list_folders",
                new_callable=AsyncMock,
                return_value=["INBOX", "Sent"]), \
-         patch("mirage.core.email.stat.list_folders",
-               new_callable=AsyncMock,
-               return_value=["INBOX", "Sent"]), \
          patch("mirage.core.email.readdir.list_message_uids",
                new_callable=AsyncMock,
                return_value=[]):
@@ -198,9 +186,6 @@ async def test_mount_root_walks_instead_of_reporting_no_match():
     search = AsyncMock(return_value=[])
     with patch("mirage.commands.builtin.email.find.search_messages", search), \
          patch("mirage.core.email.readdir.list_folders",
-               new_callable=AsyncMock,
-               return_value=["INBOX", "Sent"]), \
-         patch("mirage.core.email.stat.list_folders",
                new_callable=AsyncMock,
                return_value=["INBOX", "Sent"]), \
          patch("mirage.core.email.readdir.list_message_uids",

--- a/python/tests/core/discord/conftest.py
+++ b/python/tests/core/discord/conftest.py
@@ -1,0 +1,155 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import aiohttp
+import pytest
+
+import mirage.core.discord.read as read_mod
+import mirage.core.discord.readdir as readdir_mod
+from mirage.accessor.discord import DiscordAccessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.core.discord.config import DiscordConfig
+from mirage.core.discord.history import date_to_snowflake
+from mirage.core.discord.render import history_jsonl_bytes
+
+GUILD = {"id": "G001", "name": "My Server"}
+CHANNELS = [
+    {
+        "id": "C001",
+        "name": "general",
+        "type": 0,
+        "last_message_id": date_to_snowflake("2024-01-15"),
+    },
+    {
+        "id": "C002",
+        "name": "random",
+        "type": 0
+    },
+]
+MEMBERS = [{"user": {"id": "U001", "username": "alice"}, "nick": "al"}]
+
+MESSAGES = [
+    {
+        "id": "1",
+        "content": "hello",
+        "author": {
+            "username": "alice"
+        }
+    },
+    {
+        "id":
+        "2",
+        "content":
+        "files",
+        "author": {
+            "username": "bob"
+        },
+        "attachments": [
+            {
+                "id": "A1",
+                "filename": "kept.txt",
+                "url": "https://cdn.example/kept.txt",
+                "size": 5,
+                "content_type": "text/plain",
+            },
+            {
+                "id": "A2",
+                "filename": "tombstoned.txt",
+            },
+            {
+                "id": "A3",
+                "filename": "sizeless.txt",
+                "url": "https://cdn.example/sizeless.txt",
+            },
+            {
+                "id": "A4",
+                "filename": "urlless.txt",
+                "size": 9,
+            },
+        ],
+    },
+]
+
+DAY = "2024-01-15"
+SEALED_DAY = "2024-01-13"
+BROKEN_DAY = "2024-01-12"
+
+
+def _http_error(status: int) -> aiohttp.ClientResponseError:
+    return aiohttp.ClientResponseError(
+        request_info=None,  # type: ignore[arg-type]
+        history=(),
+        status=status)
+
+
+class FakeDiscordApi:
+
+    def __init__(self) -> None:
+        self.day_fetches: list[tuple[str, str]] = []
+        self.downloads: list[tuple[str, int, int | None]] = []
+
+    async def list_guilds(self, config):
+        return [dict(GUILD)]
+
+    async def list_channels(self, config, guild_id):
+        assert guild_id == GUILD["id"]
+        return [dict(c) for c in CHANNELS]
+
+    async def list_members(self, config, guild_id):
+        assert guild_id == GUILD["id"]
+        return [dict(m) for m in MEMBERS]
+
+    async def list_messages_for_day(self, config, channel_id, date_str):
+        self.day_fetches.append((channel_id, date_str))
+        if date_str == SEALED_DAY:
+            raise _http_error(403)
+        if date_str == BROKEN_DAY:
+            raise _http_error(500)
+        if channel_id == "C001" and date_str == DAY:
+            return [dict(m) for m in MESSAGES]
+        return []
+
+    async def get_history_jsonl(self, config, channel_id, date_str):
+        return history_jsonl_bytes(await self.list_messages_for_day(
+            config, channel_id, date_str))
+
+    async def download_file(self, url, offset=0, size=None):
+        self.downloads.append((url, offset, size))
+        data = b"0123456789"
+        end = len(data) if size is None else offset + size
+        return data[offset:end]
+
+
+@pytest.fixture
+def api(monkeypatch):
+    fake = FakeDiscordApi()
+    monkeypatch.setattr(readdir_mod, "list_guilds", fake.list_guilds)
+    monkeypatch.setattr(readdir_mod, "list_channels", fake.list_channels)
+    monkeypatch.setattr(readdir_mod, "list_members", fake.list_members)
+    monkeypatch.setattr(readdir_mod, "list_messages_for_day",
+                        fake.list_messages_for_day)
+    monkeypatch.setattr(read_mod, "get_history_jsonl", fake.get_history_jsonl)
+    monkeypatch.setattr(read_mod, "list_members", fake.list_members)
+    monkeypatch.setattr(read_mod, "download_file", fake.download_file)
+    return fake
+
+
+@pytest.fixture
+def accessor():
+    return DiscordAccessor(config=DiscordConfig(token="test-bot-token"))
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()

--- a/python/tests/core/discord/test_read.py
+++ b/python/tests/core/discord/test_read.py
@@ -12,90 +12,91 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import asyncio
-from unittest.mock import AsyncMock, patch
+import json
 
 import pytest
 
-from mirage.accessor.discord import DiscordAccessor
-from mirage.cache.index import IndexEntry
-from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.core.discord.config import DiscordConfig
-from mirage.core.discord.read import read
+from mirage.core.discord.read import read, read_range
+from mirage.core.discord.render import history_jsonl_bytes
 from mirage.types import PathSpec
+from tests.core.discord.conftest import DAY, MESSAGES, SEALED_DAY
+
+pytestmark = pytest.mark.asyncio
+
+GUILD_DIR = "My Server__G001"
+CHANNEL = f"{GUILD_DIR}/channels/general__C001"
+CHAT = f"/{CHANNEL}/{DAY}/chat.jsonl"
 
 
-@pytest.fixture
-def index():
-    store = RAMIndexCacheStore()
-    asyncio.run(
-        store.put(
-            "/My Server/channels/general",
-            IndexEntry(
-                id="C001",
-                name="general",
-                resource_type="discord/channel",
-                vfs_name="general",
-            ),
-        ))
-    return store
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.lstrip("/"))
 
 
-@pytest.fixture
-def accessor():
-    config = DiscordConfig(token="test-bot-token")
-    return DiscordAccessor(config=config)
+async def test_read_jsonl(api, accessor, index):
+    # Cold: no prior listing is needed, the read resolves the channel
+    # through the index itself.
+    result = await read(accessor, spec(CHAT), index)
+    assert result == history_jsonl_bytes(MESSAGES)
 
 
-@pytest.mark.asyncio
-async def test_read_jsonl(accessor, index):
-    fake_data = b'{"id":"100","content":"hello"}\n'
-    with patch(
-            "mirage.core.discord.read.get_history_jsonl",
-            new_callable=AsyncMock,
-            return_value=fake_data,
-    ) as mock_hist:
-        path = "/My Server/channels/general/2024-01-15/chat.jsonl"
-        result = await read(
-            accessor,
-            PathSpec(virtual=path,
-                     directory=path,
-                     resource_path=path.strip("/")),
-            index,
-        )
-
-    assert result == fake_data
-    mock_hist.assert_called_once_with(accessor.config, "C001", "2024-01-15")
-
-
-@pytest.mark.asyncio
-async def test_read_not_found(accessor, index):
+async def test_read_jsonl_bogus_channel_is_enoent(api, accessor, index):
+    # The typed `name__id` is only trusted once the listing proves it, so
+    # a fabricated channel id is ENOENT rather than a raw API error.
     with pytest.raises(FileNotFoundError):
-        await read(
-            accessor,
-            PathSpec(resource_path="no/such/path",
-                     virtual="/no/such/path",
-                     directory="/no/such/path"), index)
+        await read(accessor,
+                   spec(f"/{GUILD_DIR}/channels/nope__C9/{DAY}/chat.jsonl"),
+                   index)
 
 
-@pytest.mark.asyncio
-async def test_read_jsonl_window_is_sliced_locally(accessor, index):
-    """A rendered branch has no remote range, so the window is taken after."""
-    fake_data = b'{"id":"100","content":"hello"}\n'
-    with patch(
-            "mirage.core.discord.read.get_history_jsonl",
-            new_callable=AsyncMock,
-            return_value=fake_data,
-    ):
-        path = "/My Server/channels/general/2024-01-15/chat.jsonl"
-        result = await read(
-            accessor,
-            PathSpec(virtual=path,
-                     directory=path,
-                     resource_path=path.strip("/")),
-            index,
-            offset=1,
-            size=4,
-        )
+async def test_read_not_found(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await read(accessor, spec("/no/such/path"), index)
 
-    assert result == b'"id"'
+
+async def test_read_jsonl_window_is_sliced_locally(api, accessor, index):
+    # A rendered branch has no remote range, so the window is taken after.
+    whole = history_jsonl_bytes(MESSAGES)
+    result = await read_range(accessor, spec(CHAT), index, offset=1, size=4)
+    assert result == whole[1:5]
+
+
+async def test_read_chat_on_a_sealed_day_reproduces_the_api_answer(
+        api, accessor, index):
+    # The sealed day lists nothing but the file still reads through the
+    # channel; the fetch then answers what the API answers.
+    import aiohttp
+    with pytest.raises(aiohttp.ClientResponseError):
+        await read(accessor, spec(f"/{CHANNEL}/{SEALED_DAY}/chat.jsonl"),
+                   index)
+
+
+async def test_read_member_json(api, accessor, index):
+    data = await read(accessor, spec(f"/{GUILD_DIR}/members/alice__U001.json"),
+                      index)
+    payload = json.loads(data)
+    assert payload["user"]["id"] == "U001"
+
+
+async def test_read_blob_pushes_the_range_to_the_source(api, accessor, index):
+    result = await read_range(accessor,
+                              spec(f"/{CHANNEL}/{DAY}/files/kept__A1.txt"),
+                              index,
+                              offset=2,
+                              size=3)
+    assert result == b"234"
+    assert api.downloads == [("https://cdn.example/kept.txt", 2, 3)]
+
+
+async def test_read_dir_is_enoent_when_unproven(api, accessor, index):
+    # A matched shape alone is no existence proof: reading a directory
+    # kind answers "No such file" unless the node exists by construction.
+    with pytest.raises(FileNotFoundError):
+        await read(accessor, spec("/Nope__G9"), index)
+
+
+async def test_read_tombstoned_attachment_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await read(accessor,
+                   spec(f"/{CHANNEL}/{DAY}/files/tombstoned__A2.txt"), index)

--- a/python/tests/core/discord/test_readdir.py
+++ b/python/tests/core/discord/test_readdir.py
@@ -12,362 +12,119 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from unittest.mock import AsyncMock, patch
+import re
 
 import pytest
 
-from mirage.accessor.discord import DiscordAccessor
-from mirage.cache.index import IndexEntry
-from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.core.discord.config import DiscordConfig
+import mirage.core.discord.readdir as readdir_mod
 from mirage.core.discord.readdir import readdir
 from mirage.core.discord.render import history_jsonl_bytes, member_json_bytes
 from mirage.types import PathSpec
+from tests.core.discord.conftest import DAY, MEMBERS, MESSAGES
+
+pytestmark = pytest.mark.asyncio
+
+GUILD_DIR = "My Server__G001"
+CHANNEL = f"{GUILD_DIR}/channels/general__C001"
 
 
-@pytest.fixture
-def index():
-    return RAMIndexCacheStore()
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.lstrip("/"))
 
 
-@pytest.fixture
-def accessor():
-    return DiscordAccessor(config=DiscordConfig(token="test-bot-token"), )
+async def test_readdir_root(api, accessor, index):
+    result = await readdir(accessor, spec("/"), index)
+    assert result == [f"/{GUILD_DIR}"]
 
 
-@pytest.mark.asyncio
-async def test_readdir_root(accessor, index):
-    guilds = [
-        {
-            "id": "G001",
-            "name": "My Server"
-        },
-    ]
-    with patch(
-            "mirage.core.discord.readdir.list_guilds",
-            new_callable=AsyncMock,
-            return_value=guilds,
-    ):
-        result = await readdir(
-            accessor, PathSpec(resource_path="", virtual="/", directory="/"),
-            index)
+async def test_readdir_root_with_slash_in_name(api, accessor, index,
+                                               monkeypatch):
 
-    assert "/My Server__G001" in result
+    async def guilds(config):
+        return [{"id": "G001", "name": "A/B Test Server"}]
 
-
-@pytest.mark.asyncio
-async def test_readdir_root_with_slash_in_name(accessor, index):
-    guilds = [
-        {
-            "id": "G001",
-            "name": "A/B Test Server"
-        },
-    ]
-    with patch(
-            "mirage.core.discord.readdir.list_guilds",
-            new_callable=AsyncMock,
-            return_value=guilds,
-    ):
-        result = await readdir(
-            accessor, PathSpec(resource_path="", virtual="/", directory="/"),
-            index)
-
+    monkeypatch.setattr(readdir_mod, "list_guilds", guilds)
+    result = await readdir(accessor, spec("/"), index)
     assert result == ["/A∕B Test Server__G001"]
 
 
-@pytest.mark.asyncio
-async def test_readdir_root_with_apostrophe(accessor, index):
-    guilds = [
-        {
-            "id": "G001",
-            "name": "Zecheng's Server"
-        },
-    ]
-    with patch(
-            "mirage.core.discord.readdir.list_guilds",
-            new_callable=AsyncMock,
-            return_value=guilds,
-    ):
-        result = await readdir(
-            accessor, PathSpec(resource_path="", virtual="/", directory="/"),
-            index)
+async def test_readdir_root_with_apostrophe(api, accessor, index, monkeypatch):
 
-    assert "/Zecheng's Server__G001" in result
+    async def guilds(config):
+        return [{"id": "G001", "name": "Zecheng's Server"}]
+
+    monkeypatch.setattr(readdir_mod, "list_guilds", guilds)
+    result = await readdir(accessor, spec("/"), index)
+    assert result == ["/Zecheng's Server__G001"]
 
 
-@pytest.mark.asyncio
-async def test_readdir_guild(accessor, index):
-    await index.put(
-        "/My Server",
-        IndexEntry(
-            id="G001",
-            name="My Server",
-            resource_type="discord/guild",
-            vfs_name="My Server",
-        ),
-    )
-
-    result = await readdir(
-        accessor,
-        PathSpec(resource_path="My Server",
-                 virtual="/My Server",
-                 directory="/My Server"), index)
-
+async def test_readdir_guild(api, accessor, index):
+    result = await readdir(accessor, spec(f"/{GUILD_DIR}"), index)
     assert result == [
-        "/My Server/channels",
-        "/My Server/members",
+        f"/{GUILD_DIR}/channels",
+        f"/{GUILD_DIR}/members",
     ]
 
 
-@pytest.mark.asyncio
-async def test_readdir_channels(accessor, index):
-    await index.put(
-        "/My Server",
-        IndexEntry(
-            id="G001",
-            name="My Server",
-            resource_type="discord/guild",
-            vfs_name="My Server",
-        ),
-    )
-    channels = [
-        {
-            "id": "C001",
-            "name": "general",
-            "type": 0
-        },
-        {
-            "id": "C002",
-            "name": "random",
-            "type": 0
-        },
-    ]
-    with patch(
-            "mirage.core.discord.readdir.list_channels",
-            new_callable=AsyncMock,
-            return_value=channels,
-    ):
-        result = await readdir(
-            accessor,
-            PathSpec(resource_path="My Server/channels",
-                     virtual="/My Server/channels",
-                     directory="/My Server/channels"), index)
-
-    assert "/My Server/channels/general__C001" in result
-    assert "/My Server/channels/random__C002" in result
-
-
-@pytest.mark.asyncio
-async def test_readdir_channel_dates(accessor, index):
-    await index.put(
-        "/My Server",
-        IndexEntry(
-            id="G001",
-            name="My Server",
-            resource_type="discord/guild",
-            vfs_name="My Server",
-        ),
-    )
-    await index.put(
-        "/My Server/channels/general",
-        IndexEntry(
-            id="C001",
-            name="general",
-            resource_type="discord/channel",
-            vfs_name="general",
-        ),
-    )
-
-    result = await readdir(
-        accessor,
-        PathSpec(resource_path="My Server/channels/general",
-                 virtual="/My Server/channels/general",
-                 directory="/My Server/channels/general"), index)
-
-    assert len(result) >= 1
-    # New layout: date directories (no extension)
-    import re
-    date_re = re.compile(r"^/My Server/channels/general/\d{4}-\d{2}-\d{2}$")
-    assert all(date_re.match(r) for r in result)
-
-
-@pytest.mark.asyncio
-async def test_readdir_date_sizes_chat_jsonl(accessor, index):
-    await index.put(
-        "/My Server",
-        IndexEntry(
-            id="G001",
-            name="My Server",
-            resource_type="discord/guild",
-            vfs_name="My Server",
-        ),
-    )
-    await index.put(
-        "/My Server/channels/general",
-        IndexEntry(
-            id="C001",
-            name="general",
-            resource_type="discord/channel",
-            vfs_name="general",
-        ),
-    )
-    messages = [
-        {
-            "id": "1",
-            "content": "hello",
-            "author": {
-                "username": "alice"
-            }
-        },
-        {
-            "id": "2",
-            "content": "world",
-            "author": {
-                "username": "bob"
-            }
-        },
-    ]
-    with patch(
-            "mirage.core.discord.readdir.list_messages_for_day",
-            new_callable=AsyncMock,
-            return_value=messages,
-    ):
-        await readdir(
-            accessor,
-            PathSpec(resource_path="My Server/channels/general/2024-01-15",
-                     virtual="/My Server/channels/general/2024-01-15",
-                     directory="/My Server/channels/general/2024-01-15"),
-            index)
-
-    lookup = await index.get(
-        "/My Server/channels/general/2024-01-15/chat.jsonl")
-    assert lookup.entry.size == len(history_jsonl_bytes(messages))
-
-
-@pytest.mark.asyncio
-async def test_readdir_members_sized(accessor, index):
-    await index.put(
-        "/My Server",
-        IndexEntry(
-            id="G001",
-            name="My Server",
-            resource_type="discord/guild",
-            vfs_name="My Server",
-        ),
-    )
-    members = [{"user": {"id": "U001", "username": "alice"}, "nick": "al"}]
-    with patch(
-            "mirage.core.discord.readdir.list_members",
-            new_callable=AsyncMock,
-            return_value=members,
-    ):
-        await readdir(
-            accessor,
-            PathSpec(resource_path="My Server/members",
-                     virtual="/My Server/members",
-                     directory="/My Server/members"), index)
-
-    lookup = await index.get("/My Server/members/alice__U001.json")
-    assert lookup.entry.size == len(member_json_bytes(members[0]))
-
-
-@pytest.mark.asyncio
-async def test_readdir_unknown_shape_raises_enoent(accessor, index):
-    await index.put(
-        "/My Server",
-        IndexEntry(
-            id="G001",
-            name="My Server",
-            resource_type="discord/guild",
-            vfs_name="My Server",
-        ),
-    )
+async def test_readdir_bogus_guild_is_enoent(api, accessor, index):
     with pytest.raises(FileNotFoundError):
-        await readdir(
-            accessor,
-            PathSpec(resource_path="My Server/nope",
-                     virtual="/My Server/nope",
-                     directory="/My Server/nope"), index)
+        await readdir(accessor, spec("/Nope__G9"), index)
 
 
-@pytest.mark.asyncio
-async def test_readdir_leaf_raises_enotdir(accessor, index):
+async def test_readdir_channels(api, accessor, index):
+    result = await readdir(accessor, spec(f"/{GUILD_DIR}/channels"), index)
+    assert f"/{GUILD_DIR}/channels/general__C001" in result
+    assert f"/{GUILD_DIR}/channels/random__C002" in result
+
+
+async def test_readdir_channel_dates(api, accessor, index):
+    result = await readdir(accessor, spec(f"/{CHANNEL}"), index)
+    assert len(result) >= 1
+    date_re = re.compile(rf"^/{re.escape(CHANNEL)}/\d{{4}}-\d{{2}}-\d{{2}}$")
+    assert all(date_re.match(r) for r in result)
+    assert f"/{CHANNEL}/{DAY}" in result
+
+
+async def test_readdir_date_sizes_chat_jsonl(api, accessor, index):
+    await readdir(accessor, spec(f"/{CHANNEL}/{DAY}"), index)
+    lookup = await index.get(f"/{CHANNEL}/{DAY}/chat.jsonl")
+    assert lookup.entry.size == len(history_jsonl_bytes(MESSAGES))
+
+
+async def test_readdir_members_sized(api, accessor, index):
+    await readdir(accessor, spec(f"/{GUILD_DIR}/members"), index)
+    lookup = await index.get(f"/{GUILD_DIR}/members/alice__U001.json")
+    assert lookup.entry.size == len(member_json_bytes(MEMBERS[0]))
+
+
+async def test_readdir_unknown_shape_raises_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await readdir(accessor, spec(f"/{GUILD_DIR}/nope"), index)
+
+
+async def test_readdir_leaf_raises_enotdir(api, accessor, index):
     # A file is ENOTDIR, not ENOENT: callers tell "read this" from "nothing
     # here" by the errno.
-    key = "My Server/channels/general/2026-06-01/chat.jsonl"
     with pytest.raises(NotADirectoryError):
-        await readdir(
-            accessor,
-            PathSpec(resource_path=key, virtual="/" + key,
-                     directory="/" + key), index)
+        await readdir(accessor, spec(f"/{CHANNEL}/{DAY}/chat.jsonl"), index)
 
 
-@pytest.mark.asyncio
-async def test_readdir_files_skips_tombstoned_attachments(accessor, index):
+async def test_readdir_files_skips_tombstoned_attachments(
+        api, accessor, index):
     # Tombstoned and access-restricted attachments carry an id but no
     # download URL and no byte size; listing them would surface phantom
     # files that ENOENT on read.
-    await index.put(
-        "/My Server",
-        IndexEntry(
-            id="G001",
-            name="My Server",
-            resource_type="discord/guild",
-            vfs_name="My Server",
-        ),
-    )
-    await index.put(
-        "/My Server/channels/general",
-        IndexEntry(
-            id="C001",
-            name="general",
-            resource_type="discord/channel",
-            vfs_name="general",
-        ),
-    )
-    messages = [{
-        "id":
-        "1",
-        "content":
-        "files",
-        "author": {
-            "username": "alice"
-        },
-        "attachments": [
-            {
-                "id": "A1",
-                "filename": "kept.txt",
-                "url": "https://cdn.example/kept.txt",
-                "size": 5,
-            },
-            {
-                "id": "A2",
-                "filename": "tombstoned.txt",
-            },
-            {
-                "id": "A3",
-                "filename": "sizeless.txt",
-                "url": "https://cdn.example/sizeless.txt",
-            },
-            {
-                "id": "A4",
-                "filename": "urlless.txt",
-                "size": 9,
-            },
-        ],
-    }]
-    with patch(
-            "mirage.core.discord.readdir.list_messages_for_day",
-            new_callable=AsyncMock,
-            return_value=messages,
-    ):
-        names = await readdir(
-            accessor,
-            PathSpec(
-                resource_path="My Server/channels/general/2024-01-15/files",
-                virtual="/My Server/channels/general/2024-01-15/files",
-                directory="/My Server/channels/general/2024-01-15/files"),
-            index)
-    assert names == [
-        "/My Server/channels/general/2024-01-15/files/kept__A1.txt"
-    ]
+    names = await readdir(accessor, spec(f"/{CHANNEL}/{DAY}/files"), index)
+    assert names == [f"/{CHANNEL}/{DAY}/files/kept__A1.txt"]
+
+
+async def test_files_dir_rides_the_day_fetch(api, accessor, index):
+    # One history fetch answers the day dir AND its files subdir: the day
+    # lister seeds the files listing, so entering it costs no second call.
+    await readdir(accessor, spec(f"/{CHANNEL}/{DAY}"), index)
+    fetches = len(api.day_fetches)
+    names = await readdir(accessor, spec(f"/{CHANNEL}/{DAY}/files"), index)
+    assert names == [f"/{CHANNEL}/{DAY}/files/kept__A1.txt"]
+    assert len(api.day_fetches) == fetches

--- a/python/tests/core/discord/test_readdir_date_layout.py
+++ b/python/tests/core/discord/test_readdir_date_layout.py
@@ -12,142 +12,49 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from unittest.mock import AsyncMock, patch
-
 import aiohttp
 import pytest
 
-from mirage.accessor.discord import DiscordAccessor
-from mirage.cache.index import IndexEntry
-from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.core.discord.config import DiscordConfig
 from mirage.core.discord.readdir import readdir
 from mirage.types import PathSpec
+from tests.core.discord.conftest import BROKEN_DAY, DAY, SEALED_DAY
+
+pytestmark = pytest.mark.asyncio
+
+CHANNEL = "My Server__G001/channels/general__C001"
 
 
-@pytest.fixture
-def index():
-    return RAMIndexCacheStore()
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.lstrip("/"))
 
 
-@pytest.fixture
-def accessor():
-    return DiscordAccessor(config=DiscordConfig(token="t"))
+async def test_date_dir_contents_lists_chat_and_files(api, accessor, index):
+    result = await readdir(accessor, spec(f"/{CHANNEL}/{DAY}"), index)
+    assert result == [
+        f"/{CHANNEL}/{DAY}/chat.jsonl",
+        f"/{CHANNEL}/{DAY}/files",
+    ]
 
 
-async def _seed_channel(idx):
-    await idx.put(
-        "/G",
-        IndexEntry(id="G1",
-                   name="G",
-                   resource_type="discord/guild",
-                   vfs_name="G"),
-    )
-    await idx.put(
-        "/G/channels/ch",
-        IndexEntry(id="C1",
-                   name="ch",
-                   resource_type="discord/channel",
-                   vfs_name="ch"),
-    )
+async def test_files_dir_lists_attachments(api, accessor, index):
+    result = await readdir(accessor, spec(f"/{CHANNEL}/{DAY}/files"), index)
+    assert result == [f"/{CHANNEL}/{DAY}/files/kept__A1.txt"]
 
 
-@pytest.mark.asyncio
-async def test_date_dir_contents_lists_chat_and_files(accessor, index):
-    fake_messages = [{
-        "id":
-        "100",
-        "content":
-        "hi",
-        "attachments": [{
-            "id": "A1",
-            "filename": "pic.png",
-            "url": "https://cdn.example/A1/pic.png",
-            "proxy_url": "https://media.example/A1/pic.png",
-            "content_type": "image/png",
-            "size": 1234,
-        }],
-    }]
-    await _seed_channel(index)
-    with patch("mirage.core.discord.readdir.list_messages_for_day",
-               new_callable=AsyncMock,
-               return_value=fake_messages):
-        result = await readdir(
-            accessor,
-            PathSpec(resource_path="G/channels/ch/2024-04-04",
-                     virtual="/G/channels/ch/2024-04-04",
-                     directory="/G/channels/ch/2024-04-04"),
-            index,
-        )
-    assert "/G/channels/ch/2024-04-04/chat.jsonl" in result
-    assert "/G/channels/ch/2024-04-04/files" in result
-
-
-@pytest.mark.asyncio
-async def test_files_dir_lists_attachments(accessor, index):
-    fake_messages = [{
-        "id":
-        "100",
-        "attachments": [{
-            "id": "A1",
-            "filename": "pic.png",
-            "url": "https://cdn.example/A1/pic.png",
-            "content_type": "image/png",
-            "size": 1234,
-        }],
-    }]
-    await _seed_channel(index)
-    with patch("mirage.core.discord.readdir.list_messages_for_day",
-               new_callable=AsyncMock,
-               return_value=fake_messages):
-        result = await readdir(
-            accessor,
-            PathSpec(resource_path="G/channels/ch/2024-04-04/files",
-                     virtual="/G/channels/ch/2024-04-04/files",
-                     directory="/G/channels/ch/2024-04-04/files"),
-            index,
-        )
-    assert any(r.endswith("pic__A1.png") for r in result)
-
-
-@pytest.mark.asyncio
-async def test_fetch_day_swallows_soft_errors(accessor, index):
-    await _seed_channel(index)
-    err = aiohttp.ClientResponseError(
-        request_info=None,  # type: ignore[arg-type]
-        history=(),
-        status=403,
-    )
-    with patch("mirage.core.discord.readdir.list_messages_for_day",
-               new_callable=AsyncMock,
-               side_effect=err):
-        result = await readdir(
-            accessor,
-            PathSpec(resource_path="G/channels/ch/2024-04-04",
-                     virtual="/G/channels/ch/2024-04-04",
-                     directory="/G/channels/ch/2024-04-04"),
-            index,
-        )
-    # empty day on soft error → sealed listing (no chat.jsonl/files entries)
+async def test_fetch_day_swallows_soft_errors(api, accessor, index):
+    # A 403/404/429 seals an empty day rather than failing the listing.
+    result = await readdir(accessor, spec(f"/{CHANNEL}/{SEALED_DAY}"), index)
     assert result == []
 
 
-@pytest.mark.asyncio
-async def test_fetch_day_propagates_hard_errors(accessor, index):
-    await _seed_channel(index)
-    err = aiohttp.ClientResponseError(
-        request_info=None,  # type: ignore[arg-type]
-        history=(),
-        status=500,
-    )
-    with patch("mirage.core.discord.readdir.list_messages_for_day",
-               new_callable=AsyncMock,
-               side_effect=err):
-        with pytest.raises(aiohttp.ClientResponseError):
-            await readdir(
-                accessor,
-                PathSpec(resource_path="G/channels/ch/2024-04-04",
-                         virtual="/G/channels/ch/2024-04-04",
-                         directory="/G/channels/ch/2024-04-04"),
-                index,
-            )
+async def test_fetch_day_propagates_hard_errors(api, accessor, index):
+    with pytest.raises(aiohttp.ClientResponseError):
+        await readdir(accessor, spec(f"/{CHANNEL}/{BROKEN_DAY}"), index)
+
+
+async def test_files_under_a_sealed_day_is_enoent(api, accessor, index):
+    # The sealed day lists nothing, so its files subdir does not exist.
+    with pytest.raises(FileNotFoundError):
+        await readdir(accessor, spec(f"/{CHANNEL}/{SEALED_DAY}/files"), index)

--- a/python/tests/core/discord/test_scope.py
+++ b/python/tests/core/discord/test_scope.py
@@ -12,196 +12,95 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.discord.scope import detect_scope
-from mirage.types import PathSpec
-from mirage.utils.key_prefix import mount_key
+from mirage.core.discord.scope import NATIVE_KINDS, detect_scope
+from mirage.core.hierarchy.scope import INVALID, ROOT
+
+CHAT = "/My Server__G1/channels/general__C1/2024-01-15/chat.jsonl"
 
 
-def _gs(path: str, prefix: str = "", pattern: str | None = None) -> PathSpec:
-    return PathSpec(
-        resource_path=mount_key(path, prefix),
-        virtual=path,
-        directory=path.rsplit("/", 1)[0] + "/" if pattern else path,
-        pattern=pattern,
-        resolved=pattern is None,
-    )
-
-
-# ── root ──────────────────────────────────────
-
-
-def test_root_empty():
-    scope = detect_scope(PathSpec.from_str_path("/"))
-    assert scope.level == "root"
-    assert scope.use_native is True
-    assert scope.resource_path == "/"
-
-
-def test_root_prefix():
-    scope = detect_scope(_gs("/discord/", prefix="/discord"))
-    assert scope.level == "root"
-
-
-# ── guild ─────────────────────────────────────
+def test_root():
+    assert detect_scope("/").kind == ROOT
 
 
 def test_guild():
-    scope = detect_scope(_gs("/discord/myserver__G1", prefix="/discord"))
-    assert scope.level == "guild"
-    assert scope.use_native is True
-    assert scope.guild_name == "myserver"
-    assert scope.guild_id == "G1"
+    match = detect_scope("/My Server__G1")
+    assert match.kind == "guild"
+    assert match.slots == {"guild": "My Server", "guild_id": "G1"}
 
 
-def test_guild_channels():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/channels", prefix="/discord"))
-    assert scope.level == "guild"
-    assert scope.use_native is True
-    assert scope.container == "channels"
-    assert scope.guild_id == "G1"
+def test_guild_bare_name_is_invalid():
+    # The tree mints every dirname as `name__id`, so a bare name can
+    # never be a listed guild and classifies as invalid outright.
+    assert detect_scope("/My Server").kind == INVALID
 
 
-def test_guild_members_not_native():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/members", prefix="/discord"))
-    assert scope.level == "guild"
-    assert scope.use_native is False
-    assert scope.container == "members"
-    assert scope.guild_id == "G1"
-
-
-def test_guild_bare_name_has_no_id():
-    scope = detect_scope(_gs("/discord/myserver", prefix="/discord"))
-    assert scope.level == "guild"
-    assert scope.guild_name == "myserver"
-    assert scope.guild_id is None
-
-
-# ── channel ───────────────────────────────────
+def test_containers():
+    assert detect_scope("/My Server__G1/channels").kind == "channels_dir"
+    assert detect_scope("/My Server__G1/members").kind == "members_dir"
+    assert detect_scope("/My Server__G1/nope").kind == INVALID
 
 
 def test_channel():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/channels/general__C1", prefix="/discord"))
-    assert scope.level == "channel"
-    assert scope.use_native is True
-    assert scope.guild_name == "myserver"
-    assert scope.guild_id == "G1"
-    assert scope.channel_name == "general"
-    assert scope.channel_id == "C1"
-    assert scope.container == "channels"
-
-
-def test_channel_bare_name_has_no_id():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/channels/general", prefix="/discord"))
-    assert scope.level == "channel"
-    assert scope.channel_name == "general"
-    assert scope.channel_id is None
-
-
-# ── member ────────────────────────────────────
+    match = detect_scope("/My Server__G1/channels/general__C1")
+    assert match.kind == "channel"
+    assert match.slots["channel"] == "general"
+    assert match.slots["channel_id"] == "C1"
 
 
 def test_member_json():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/members/alice__U1.json", prefix="/discord"))
-    assert scope.level == "member"
-    assert scope.use_native is False
-    assert scope.container == "members"
-    assert scope.guild_id == "G1"
-    assert scope.member_name == "alice"
-    assert scope.member_id == "U1"
-    assert scope.channel_id is None
+    match = detect_scope("/My Server__G1/members/alice__U1.json")
+    assert match.kind == "member"
+    assert match.slots["member"] == "alice"
+    assert match.slots["user_id"] == "U1"
 
 
-# ── date / messages / files ────────────────────
+def test_member_without_suffix_is_invalid():
+    assert detect_scope("/My Server__G1/members/alice__U1").kind == INVALID
 
 
-def test_date_dir():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/channels/general__C1/2026-04-10",
-            prefix="/discord"))
-    assert scope.level == "date"
-    assert scope.use_native is True
-    assert scope.guild_id == "G1"
-    assert scope.channel_id == "C1"
-    assert scope.date_str == "2026-04-10"
+def test_day_dir():
+    match = detect_scope("/My Server__G1/channels/general__C1/2024-01-15")
+    assert match.kind == "day"
+    assert match.slots["day"] == "2024-01-15"
+
+
+def test_non_date_under_channel_is_invalid():
+    assert detect_scope(
+        "/My Server__G1/channels/general__C1/notadate").kind == INVALID
 
 
 def test_messages_file():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/channels/general__C1/2026-04-10/chat.jsonl",
-            prefix="/discord"))
-    assert scope.level == "messages"
-    assert scope.use_native is False
-    assert scope.guild_id == "G1"
-    assert scope.channel_id == "C1"
-    assert scope.date_str == "2026-04-10"
+    match = detect_scope(CHAT)
+    assert match.kind == "messages"
+    assert match.scope is not None and match.scope.leaf
 
 
 def test_files_dir():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/channels/general__C1/2026-04-10/files",
-            prefix="/discord"))
-    assert scope.level == "files"
-    assert scope.use_native is True
-    assert scope.date_str == "2026-04-10"
+    assert detect_scope(
+        "/My Server__G1/channels/general__C1/2024-01-15/files").kind == "files"
 
 
 def test_file_blob():
-    scope = detect_scope(
-        _gs(
-            "/discord/myserver__G1/channels/general__C1/2026-04-10/files/"
-            "img__A1.png",
-            prefix="/discord"))
-    assert scope.level == "file_blob"
-    assert scope.use_native is False
-    assert scope.channel_id == "C1"
-    assert scope.date_str == "2026-04-10"
+    match = detect_scope(
+        "/My Server__G1/channels/general__C1/2024-01-15/files/kept__A1.txt")
+    assert match.kind == "file_blob"
+    assert match.slots["blob"] == "kept__A1.txt"
 
 
-def test_deep_unknown_path_falls_back():
-    scope = detect_scope(_gs("/discord/a/b/c/d/e/f/g", prefix="/discord"))
-    assert scope.level == "guild"
-    assert scope.use_native is False
+def test_deep_unknown_path_is_invalid():
+    assert detect_scope(
+        "/My Server__G1/channels/general__C1/2024-01-15/files/a/b").kind \
+        == INVALID
 
 
-# ── glob patterns ─────────────────────────────
+def test_dot_segment_is_invalid():
+    assert detect_scope("/My Server__G1/channels/.hidden__C1").kind == INVALID
 
 
-def test_glob_jsonl_in_channel():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/channels/general__C1/*.jsonl",
-            prefix="/discord",
-            pattern="*.jsonl"))
-    assert scope.level == "channel"
-    assert scope.use_native is True
-    assert scope.guild_id == "G1"
-    assert scope.channel_id == "C1"
-
-
-def test_glob_jsonl_in_date_dir():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/channels/general__C1/2026-04-10/*.jsonl",
-            prefix="/discord",
-            pattern="*.jsonl"))
-    assert scope.level == "messages"
-    assert scope.use_native is True
-    assert scope.date_str == "2026-04-10"
-    assert scope.channel_id == "C1"
-
-
-def test_glob_non_jsonl():
-    scope = detect_scope(
-        _gs("/discord/myserver__G1/members/*.json",
-            prefix="/discord",
-            pattern="*.json"))
-    assert scope.level != "channel"
-
-
-def _spec(path: str, prefix: str = "/discord") -> PathSpec:
-    return PathSpec(resource_path=mount_key(path, prefix),
-                    virtual=path,
-                    directory=path)
+def test_native_kinds_exclude_the_rendered_leaves():
+    # chat.jsonl, member profiles and stored blobs are not answerable by
+    # the guild message search; the containers above them are.
+    assert "messages" not in NATIVE_KINDS
+    assert "member" not in NATIVE_KINDS
+    assert "file_blob" not in NATIVE_KINDS
+    assert {"guild", "channel", "day", "files"} <= NATIVE_KINDS

--- a/python/tests/core/discord/test_stat.py
+++ b/python/tests/core/discord/test_stat.py
@@ -12,176 +12,136 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import asyncio
-
 import pytest
 
-from mirage.accessor.discord import DiscordAccessor
-from mirage.cache.index import IndexEntry
-from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.core.discord.entry import snowflake_to_iso
+from mirage.core.discord.render import history_jsonl_bytes
 from mirage.core.discord.stat import stat
 from mirage.types import FileType, PathSpec
+from tests.core.discord.conftest import CHANNELS, DAY, MESSAGES, SEALED_DAY
+
+pytestmark = pytest.mark.asyncio
+
+GUILD_DIR = "My Server__G001"
+CHANNEL = f"{GUILD_DIR}/channels/general__C001"
 
 
-@pytest.fixture
-def index():
-    store = RAMIndexCacheStore()
-    asyncio.run(
-        store.put(
-            "/My Server",
-            IndexEntry(
-                id="G001",
-                name="My Server",
-                resource_type="discord/guild",
-                vfs_name="My Server",
-            ),
-        ))
-    asyncio.run(
-        store.put(
-            "/My Server/channels/general",
-            IndexEntry(
-                id="C001",
-                name="general",
-                resource_type="discord/channel",
-                remote_time="794354201395200000",
-                vfs_name="general",
-            ),
-        ))
-    asyncio.run(
-        store.put(
-            "/My Server/members/alice.json",
-            IndexEntry(
-                id="U001",
-                name="alice",
-                resource_type="discord/member",
-                vfs_name="alice.json",
-                size=42,
-            ),
-        ))
-    asyncio.run(
-        store.put(
-            "/My Server/channels/general/2024-01-15/chat.jsonl",
-            IndexEntry(
-                id="C001:2024-01-15:chat",
-                name="chat.jsonl",
-                resource_type="discord/chat_jsonl",
-                vfs_name="chat.jsonl",
-                size=17,
-            ),
-        ))
-    return store
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.lstrip("/"))
 
 
-@pytest.fixture
-def accessor():
-    return DiscordAccessor(config=object())
+async def test_stat_root(api, accessor, index):
+    row = await stat(accessor, spec("/"), index)
+    assert row.type is FileType.DIRECTORY
 
 
-@pytest.mark.asyncio
-async def test_stat_root(accessor, index):
-    result = await stat(accessor,
-                        PathSpec(resource_path="", virtual="/", directory="/"),
-                        index)
-    assert result.type == FileType.DIRECTORY
-    assert result.name == "/"
+async def test_stat_guild(api, accessor, index):
+    row = await stat(accessor, spec(f"/{GUILD_DIR}"), index)
+    assert row.type is FileType.DIRECTORY
+    assert row.name == GUILD_DIR
+    assert row.extra["guild_id"] == "G001"
 
 
-@pytest.mark.asyncio
-async def test_stat_guild(accessor, index):
-    result = await stat(
-        accessor,
-        PathSpec(resource_path="My Server",
-                 virtual="/My Server",
-                 directory="/My Server"), index)
-    assert result.type == FileType.DIRECTORY
-    assert result.extra["guild_id"] == "G001"
-
-
-@pytest.mark.asyncio
-async def test_stat_channel(accessor, index):
-    result = await stat(
-        accessor,
-        PathSpec(resource_path="My Server/channels/general",
-                 virtual="/My Server/channels/general",
-                 directory="/My Server/channels/general"), index)
-    assert result.type == FileType.DIRECTORY
-    assert result.extra["channel_id"] == "C001"
-    assert result.modified == "2021-01-01T00:00:00Z"
-
-
-@pytest.mark.asyncio
-async def test_stat_member(accessor, index):
-    result = await stat(
-        accessor,
-        PathSpec(resource_path="My Server/members/alice.json",
-                 virtual="/My Server/members/alice.json",
-                 directory="/My Server/members/alice.json"), index)
-    assert result.type == FileType.JSON
-    assert result.extra["user_id"] == "U001"
-    assert result.size == 42
-
-
-@pytest.mark.asyncio
-async def test_stat_date_dir(accessor, index):
-    path = "/My Server/channels/general/2024-01-15"
-    result = await stat(
-        accessor,
-        PathSpec(virtual=path, directory=path, resource_path=path.strip("/")),
-        index)
-    assert result.type == FileType.DIRECTORY
-    assert result.name == "2024-01-15"
-
-
-@pytest.mark.asyncio
-async def test_stat_chat_jsonl(accessor, index):
-    path = "/My Server/channels/general/2024-01-15/chat.jsonl"
-    result = await stat(
-        accessor,
-        PathSpec(virtual=path, directory=path, resource_path=path.strip("/")),
-        index)
-    assert result.type == FileType.TEXT
-    assert result.name == "chat.jsonl"
-    assert result.size == 17
-
-
-@pytest.mark.asyncio
-async def test_stat_files_dir(accessor, index):
-    path = "/My Server/channels/general/2024-01-15/files"
-    result = await stat(
-        accessor,
-        PathSpec(virtual=path, directory=path, resource_path=path.strip("/")),
-        index)
-    assert result.type == FileType.DIRECTORY
-    assert result.name == "files"
-
-
-@pytest.mark.asyncio
-async def test_stat_non_date_chat_jsonl_not_found(accessor, index):
-    path = "/My Server/channels/general/notadate/chat.jsonl"
+async def test_stat_bogus_guild_is_enoent(api, accessor, index):
     with pytest.raises(FileNotFoundError):
-        await stat(
-            accessor,
-            PathSpec(virtual=path,
-                     directory=path,
-                     resource_path=path.strip("/")), index)
+        await stat(accessor, spec("/Nope__G9"), index)
 
 
-@pytest.mark.asyncio
-async def test_stat_non_date_files_dir_not_found(accessor, index):
-    path = "/My Server/channels/general/notadate/files"
+async def test_stat_containers(api, accessor, index):
+    for name in ("channels", "members"):
+        row = await stat(accessor, spec(f"/{GUILD_DIR}/{name}"), index)
+        assert row.type is FileType.DIRECTORY
+        assert row.name == name
+
+
+async def test_stat_container_under_bogus_guild_is_enoent(
+        api, accessor, index):
+    # The containers exist per guild, so a guild the listing does not
+    # prove takes its children with it.
     with pytest.raises(FileNotFoundError):
-        await stat(
-            accessor,
-            PathSpec(virtual=path,
-                     directory=path,
-                     resource_path=path.strip("/")), index)
+        await stat(accessor, spec("/Nope__G9/channels"), index)
 
 
-@pytest.mark.asyncio
-async def test_stat_not_found(accessor, index):
+async def test_stat_channel(api, accessor, index):
+    row = await stat(accessor, spec(f"/{CHANNEL}"), index)
+    assert row.type is FileType.DIRECTORY
+    assert row.extra["channel_id"] == "C001"
+    assert row.modified == snowflake_to_iso(CHANNELS[0]["last_message_id"])
+
+
+async def test_stat_member(api, accessor, index):
+    row = await stat(accessor, spec(f"/{GUILD_DIR}/members/alice__U001.json"),
+                     index)
+    assert row.type is FileType.JSON
+    assert row.extra["user_id"] == "U001"
+    assert row.size is not None and row.size > 0
+
+
+async def test_stat_day_dir(api, accessor, index):
+    row = await stat(accessor, spec(f"/{CHANNEL}/{DAY}"), index)
+    assert row.type is FileType.DIRECTORY
+    assert row.name == DAY
+
+
+async def test_stat_day_outside_the_window_is_a_directory(
+        api, accessor, index):
+    # The channel listing synthesizes a bounded window of recent days, but
+    # the history API answers a range query for any date.
+    row = await stat(accessor, spec(f"/{CHANNEL}/1999-01-01"), index)
+    assert row.type is FileType.DIRECTORY
+    assert row.name == "1999-01-01"
+
+
+async def test_stat_day_under_bogus_channel_is_enoent(api, accessor, index):
     with pytest.raises(FileNotFoundError):
-        await stat(
-            accessor,
-            PathSpec(resource_path="nonexistent/path",
-                     virtual="/nonexistent/path",
-                     directory="/nonexistent/path"), index)
+        await stat(accessor, spec(f"/{GUILD_DIR}/channels/nope__C9/{DAY}"),
+                   index)
+
+
+async def test_stat_chat_jsonl(api, accessor, index):
+    row = await stat(accessor, spec(f"/{CHANNEL}/{DAY}/chat.jsonl"), index)
+    assert row.type is FileType.TEXT
+    assert row.size == len(history_jsonl_bytes(MESSAGES))
+
+
+async def test_stat_chat_jsonl_sealed_day_has_unknown_size(
+        api, accessor, index):
+    # A day whose history could not be listed (403/404/429) seals an empty
+    # date dir; the file still stats, with the size left unknown.
+    row = await stat(accessor, spec(f"/{CHANNEL}/{SEALED_DAY}/chat.jsonl"),
+                     index)
+    assert row.type is FileType.TEXT
+    assert row.size is None
+
+
+async def test_stat_chat_jsonl_under_bogus_channel_is_enoent(
+        api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor,
+                   spec(f"/{GUILD_DIR}/channels/nope__C9/{DAY}/chat.jsonl"),
+                   index)
+
+
+async def test_stat_files_dir(api, accessor, index):
+    row = await stat(accessor, spec(f"/{CHANNEL}/{DAY}/files"), index)
+    assert row.type is FileType.DIRECTORY
+
+
+async def test_stat_files_under_a_sealed_day_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, spec(f"/{CHANNEL}/{SEALED_DAY}/files"), index)
+
+
+async def test_stat_file_blob(api, accessor, index):
+    row = await stat(accessor, spec(f"/{CHANNEL}/{DAY}/files/kept__A1.txt"),
+                     index)
+    assert row.size == 5
+    assert row.extra["attachment_id"] == "A1"
+    assert row.extra["content_type"] == "text/plain"
+
+
+async def test_stat_unknown_shape_is_enoent(api, accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, spec(f"/{GUILD_DIR}/nope"), index)

--- a/python/tests/core/gmail/test_read.py
+++ b/python/tests/core/gmail/test_read.py
@@ -103,7 +103,10 @@ async def test_read_is_directory(accessor, index):
              vfs_name="INBOX",
          )),
     ])
-    with pytest.raises(IsADirectoryError):
+    # A directory kind has no reader, and a matched shape alone is no
+    # existence proof, so the kit answers "No such file" (the same rule
+    # gcal, notion and the database mounts pin).
+    with pytest.raises(FileNotFoundError):
         await read(
             accessor,
             PathSpec(resource_path=mount_key("/gmail/INBOX", "/gmail"),

--- a/python/tests/core/gmail/test_readdir.py
+++ b/python/tests/core/gmail/test_readdir.py
@@ -121,12 +121,21 @@ async def test_readdir_label(accessor, index):
 
 @pytest.mark.asyncio
 async def test_readdir_not_found(accessor, index):
-    with pytest.raises(FileNotFoundError):
-        await readdir(
-            accessor,
-            PathSpec(resource_path=mount_key("/gmail/NONEXISTENT", "/gmail"),
-                     virtual="/gmail/NONEXISTENT",
-                     directory="/gmail/NONEXISTENT"), index)
+    with patch(
+            "mirage.core.gmail.readdir.list_labels",
+            new_callable=AsyncMock,
+            return_value=[{
+                "type": "system",
+                "id": "INBOX"
+            }],
+    ):
+        with pytest.raises(FileNotFoundError):
+            await readdir(
+                accessor,
+                PathSpec(resource_path=mount_key("/gmail/NONEXISTENT",
+                                                 "/gmail"),
+                         virtual="/gmail/NONEXISTENT",
+                         directory="/gmail/NONEXISTENT"), index)
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/gmail/test_scope.py
+++ b/python/tests/core/gmail/test_scope.py
@@ -12,73 +12,61 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.gmail.scope import detect_scope
-from mirage.types import PathSpec
-from mirage.utils.key_prefix import mount_key
+from mirage.core.gmail.scope import NATIVE_KINDS, detect_scope
+from mirage.core.hierarchy.scope import INVALID, ROOT
 
 
-def _gs(path: str,
-        prefix: str = "",
-        pattern: str | None = None,
-        directory: str | None = None) -> PathSpec:
-    return PathSpec(
-        resource_path=mount_key(path, prefix),
-        virtual=path,
-        directory=directory
-        or (path.rsplit("/", 1)[0] + "/" if "/" in path else "/"),
-        pattern=pattern,
-    )
-
-
-def test_root_empty():
-    scope = detect_scope(PathSpec.from_str_path("/"))
-    assert scope.use_native is True
-    assert scope.label_name is None
-
-
-def test_root_with_prefix():
-    scope = detect_scope(_gs("/gmail/", prefix="/gmail"))
-    assert scope.use_native is True
+def test_root():
+    match = detect_scope("/")
+    assert match.kind == ROOT
+    assert ROOT in NATIVE_KINDS
 
 
 def test_label_dir():
-    scope = detect_scope(_gs("/gmail/INBOX", prefix="/gmail"))
-    assert scope.use_native is True
-    assert scope.label_name == "INBOX"
-    assert scope.date_str is None
+    match = detect_scope("/INBOX")
+    assert match.kind == "label"
+    assert match.slots == {"label": "INBOX"}
+    assert "label" in NATIVE_KINDS
 
 
-def test_label_date_dir():
-    scope = detect_scope(_gs("/gmail/INBOX/2026-04-10", prefix="/gmail"))
-    assert scope.use_native is True
-    assert scope.label_name == "INBOX"
-    assert scope.date_str == "2026-04-10"
+def test_day_dir():
+    match = detect_scope("/INBOX/2026-04-12")
+    assert match.kind == "day"
+    assert match.slots == {"label": "INBOX", "day": "2026-04-12"}
+    assert "day" in NATIVE_KINDS
 
 
-def test_specific_message_file():
-    scope = detect_scope(
-        _gs("/gmail/INBOX/2026-04-10/Hello__abc123.gmail.json",
-            prefix="/gmail"))
-    assert scope.use_native is False
-    assert scope.label_name == "INBOX"
+def test_non_date_under_label_is_invalid():
+    assert detect_scope("/INBOX/notadate").kind == INVALID
 
 
-def test_attachment_path():
-    scope = detect_scope(
-        _gs("/gmail/INBOX/2026-04-10/Hello__abc123/file.pdf", prefix="/gmail"))
-    assert scope.use_native is False
+def test_message_file():
+    match = detect_scope("/INBOX/2026-04-12/Test_Email__msg1.gmail.json")
+    assert match.kind == "message"
+    assert match.slots["message"] == "Test_Email"
+    assert match.slots["message_id"] == "msg1"
+    assert "message" not in NATIVE_KINDS
 
 
-def test_glob_in_date_dir():
-    spec = PathSpec(
-        resource_path=mount_key("/gmail/INBOX/2026-04-10/*.gmail.json",
-                                "/gmail"),
-        virtual="/gmail/INBOX/2026-04-10/*.gmail.json",
-        directory="/gmail/INBOX/2026-04-10/",
-        pattern="*.gmail.json",
-        resolved=False,
-    )
-    scope = detect_scope(spec)
-    assert scope.use_native is True
-    assert scope.label_name == "INBOX"
-    assert scope.date_str == "2026-04-10"
+def test_attachment_dir():
+    match = detect_scope("/INBOX/2026-04-12/Test_Email__msg1")
+    assert match.kind == "attachment_dir"
+    assert match.slots["message_id"] == "msg1"
+
+
+def test_attachment_file():
+    match = detect_scope("/INBOX/2026-04-12/Test_Email__msg1/report.pdf")
+    assert match.kind == "attachment"
+    assert match.slots["message_id"] == "msg1"
+    assert match.slots["filename"] == "report.pdf"
+    assert "attachment" not in NATIVE_KINDS
+
+
+def test_bare_name_at_message_depth_is_invalid():
+    # Without the `__id` half the segment can be neither a message file
+    # nor an attachment dir.
+    assert detect_scope("/INBOX/2026-04-12/loose-file").kind == INVALID
+
+
+def test_deep_unknown_path_is_invalid():
+    assert detect_scope("/INBOX/2026-04-12/A__m1/b/c").kind == INVALID

--- a/python/tests/core/gmail/test_search.py
+++ b/python/tests/core/gmail/test_search.py
@@ -14,13 +14,9 @@
 
 from typing import Any
 
-from mirage.core.gmail.scope import GmailScope
 from mirage.core.gmail.search import format_grep_results
 
-SCOPE = GmailScope(use_native=True,
-                   label_name="INBOX",
-                   date_str=None,
-                   resource_path="/")
+LABEL = "INBOX"
 
 EMOJI = "\U0001F600"
 
@@ -50,7 +46,7 @@ def test_no_match_budget_counts_code_points():
     # typescript twin cut to 117 -- splitting the 118th surrogate pair.
     body = EMOJI * 200
     excerpt = _excerpt(
-        format_grep_results([_row(body)], SCOPE, "/gmail", "zzz"))
+        format_grep_results([_row(body)], LABEL, "/gmail", "zzz"))
     assert excerpt == f"note {body}"
     assert len(excerpt) == 205
     assert "�" not in excerpt
@@ -59,7 +55,7 @@ def test_no_match_budget_counts_code_points():
 def test_match_window_cuts_on_code_point_boundaries():
     pad = EMOJI * 200
     excerpt = _excerpt(
-        format_grep_results([_row(f"{pad} needle {pad}")], SCOPE, "/gmail",
+        format_grep_results([_row(f"{pad} needle {pad}")], LABEL, "/gmail",
                             "needle"))
     assert excerpt == f"...{EMOJI * 119} needle {EMOJI * 119}..."
     assert "�" not in excerpt
@@ -68,12 +64,12 @@ def test_match_window_cuts_on_code_point_boundaries():
 def test_match_window_on_ascii():
     body = "a" * 300 + " needle " + "b" * 300
     excerpt = _excerpt(
-        format_grep_results([_row(body)], SCOPE, "/gmail", "needle"))
+        format_grep_results([_row(body)], LABEL, "/gmail", "needle"))
     assert excerpt == f"...{'a' * 119} needle {'b' * 119}..."
 
 
 def test_empty_pattern_falls_back_to_the_snippet():
-    lines = format_grep_results([_row("body")], SCOPE, "/gmail")
+    lines = format_grep_results([_row("body")], LABEL, "/gmail")
     assert lines == [
         "/gmail/INBOX/2026-08-19/note__m1.gmail.json:[a@b.c] fallback snippet"
     ]

--- a/python/tests/core/gmail/test_stat.py
+++ b/python/tests/core/gmail/test_stat.py
@@ -184,7 +184,7 @@ async def test_stat_not_found(accessor, index):
 @pytest.mark.asyncio
 async def test_stat_unknown_top_level_raises(accessor, index):
     with patch(
-            "mirage.core.gmail.stat.list_labels",
+            "mirage.core.gmail.readdir.list_labels",
             new_callable=AsyncMock,
             return_value=[{
                 "type": "system",
@@ -203,7 +203,7 @@ async def test_stat_unknown_top_level_raises(accessor, index):
 @pytest.mark.asyncio
 async def test_stat_real_label_via_api(accessor, index):
     with patch(
-            "mirage.core.gmail.stat.list_labels",
+            "mirage.core.gmail.readdir.list_labels",
             new_callable=AsyncMock,
             return_value=[{
                 "type": "system",
@@ -222,12 +222,13 @@ async def test_stat_real_label_via_api(accessor, index):
 @pytest.mark.asyncio
 async def test_stat_propagates_parent_refresh_failure(accessor, index):
     failure = RuntimeError("gmail unavailable")
-    with patch("mirage.core.gmail.stat._readdir",
+    with patch("mirage.core.gmail.readdir.list_labels",
                new_callable=AsyncMock,
                side_effect=failure):
         with pytest.raises(RuntimeError, match="gmail unavailable"):
             await stat(
                 accessor,
-                PathSpec.from_str_path("/INBOX/missing.gmail.json"),
+                PathSpec.from_str_path(
+                    "/INBOX/2026-04-12/missing__x1.gmail.json"),
                 index,
             )

--- a/python/tests/core/hierarchy/conftest.py
+++ b/python/tests/core/hierarchy/conftest.py
@@ -16,7 +16,7 @@ import pytest
 
 from mirage.accessor.base import Accessor
 from mirage.cache.index import IndexEntry
-from mirage.core.hierarchy.codec import INT_JSON, JSON_NAME, Codec
+from mirage.core.hierarchy.codec import DATE, INT_JSON, JSON_NAME, Codec
 from mirage.core.hierarchy.scope import (Scope, ScopeMatch, Slot,
                                          make_detect_scope)
 from mirage.types import FileType, PathSpec
@@ -28,6 +28,9 @@ SCOPES = (
           segments=("rooms", Slot("room"), Slot("note", JSON_NAME)),
           leaf=True,
           filetype=FileType.JSON),
+    Scope(kind="room_atts", segments=("rooms", Slot("room"), "atts")),
+    Scope(kind="room_day", segments=("rooms", Slot("room"), Slot("day",
+                                                                 DATE))),
     Scope(kind="revision",
           segments=("rooms", Slot("room"), "revisions", Slot("rev", INT_JSON)),
           leaf=True,

--- a/python/tests/core/hierarchy/test_codec.py
+++ b/python/tests/core/hierarchy/test_codec.py
@@ -12,8 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.hierarchy.codec import (INT_JSON, JSON_NAME, JSONL_NAME, RAW,
-                                         ascii_digits)
+from mirage.core.hierarchy.codec import (DATE, INT_JSON, JSON_NAME, JSONL_NAME,
+                                         RAW, ascii_digits)
 
 
 def test_raw_takes_any_nonempty_segment():
@@ -48,3 +48,14 @@ def test_ascii_digits_guard():
     assert ascii_digits("42")
     assert not ascii_digits("4x2")
     assert not ascii_digits("")
+
+
+def test_date_is_shape_only():
+    # Shape only, not a calendar check: the dated-message backends mint
+    # their date directories from real timestamps, so a shaped-but-absent
+    # date resolves through the listing like any other name.
+    assert DATE.decode("2024-01-15") == "2024-01-15"
+    assert DATE.decode("2026-02-30") == "2026-02-30"
+    assert DATE.decode("2024-1-15") is None
+    assert DATE.decode("notadate") is None
+    assert DATE.decode("2024-01-15x") is None

--- a/python/tests/core/hierarchy/test_read.py
+++ b/python/tests/core/hierarchy/test_read.py
@@ -17,7 +17,7 @@ import asyncio
 import pytest
 
 from mirage.cache.index import IndexCacheStore
-from mirage.core.hierarchy.read import make_read
+from mirage.core.hierarchy.read import make_read, make_read_range
 from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.types import PathSpec
 from tests.core.hierarchy.conftest import FakeAccessor, detect_scope, spec
@@ -69,4 +69,37 @@ def test_windowed_reader_receives_the_window(accessor):
 
 def test_plain_reader_ignores_the_window(accessor):
     out = asyncio.run(READ(accessor, spec("/rooms/red/a.json"), limit=3))
+    assert out == b"red:a"
+
+
+async def _read_note_range(accessor: FakeAccessor, match: ScopeMatch,
+                           path: PathSpec, index: IndexCacheStore, offset: int,
+                           size: int | None) -> bytes:
+    return f"ranged:{match.slots['note']}:{offset}:{size}".encode()
+
+
+READ_RANGE = make_read_range(detect_scope,
+                             READ,
+                             ranged={"tagged": _read_note_range})
+
+
+def test_ranged_reader_pushes_the_window_to_the_source(accessor):
+    # "tagged" names a ranged reader, so the window reaches it verbatim.
+    ranged = make_read_range(detect_scope,
+                             READ,
+                             ranged={"note": _read_note_range})
+    out = asyncio.run(
+        ranged(accessor, spec("/rooms/red/a.json"), offset=2, size=5))
+    assert out == b"ranged:a:2:5"
+
+
+def test_unranged_kind_slices_the_full_read(accessor):
+    out = asyncio.run(
+        READ_RANGE(accessor, spec("/rooms/red/a.json"), offset=1, size=3))
+    # The full read rendered "red:a"; the window is taken after the fact.
+    assert out == b"ed:"
+
+
+def test_ranged_read_defaults_to_the_whole_file(accessor):
+    out = asyncio.run(READ_RANGE(accessor, spec("/rooms/red/a.json")))
     assert out == b"red:a"

--- a/python/tests/core/hierarchy/test_readdir.py
+++ b/python/tests/core/hierarchy/test_readdir.py
@@ -18,7 +18,7 @@ import pytest
 
 from mirage.cache.index import IndexEntry
 from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.core.hierarchy.readdir import make_readdir
+from mirage.core.hierarchy.readdir import DirListing, make_readdir
 from mirage.core.hierarchy.scope import ScopeMatch
 from tests.core.hierarchy.conftest import (FakeAccessor, detect_scope,
                                            list_notes, list_rooms, room_guard,
@@ -142,4 +142,103 @@ def test_a_kind_in_both_lister_tables_fails_at_build():
         make_readdir(detect_scope,
                      listers={"room": list_notes},
                      entry_listers={"room": _entry_notes},
+                     static_root=("rooms", ))
+
+
+def _room_entry(room: str) -> IndexEntry:
+    return IndexEntry(id=room,
+                      name=room,
+                      resource_type="fake/room",
+                      vfs_name=room)
+
+
+async def _seeding_notes(accessor, match, own):
+    accessor.calls.append(f"seed-notes:{match.slots['room']}")
+    atts = IndexEntry(id=f"{own.id}:atts",
+                      name="atts",
+                      resource_type="fake/atts",
+                      vfs_name="atts")
+    blob = IndexEntry(id="x",
+                      name="x.bin",
+                      resource_type="fake/blob",
+                      vfs_name="x.bin",
+                      size=3)
+    return DirListing(entries=[("atts", atts)],
+                      seeds={"atts": [("x.bin", blob)]})
+
+
+async def _atts_fallback(accessor, match, own):
+    accessor.calls.append(f"atts-fallback:{match.slots['room']}")
+    return []
+
+
+SEEDED_READDIR = make_readdir(
+    detect_scope,
+    listers={"rooms": list_rooms},
+    entry_listers={
+        "room": _seeding_notes,
+        "room_atts": _atts_fallback,
+    },
+    static_root=("rooms", ),
+)
+
+
+def test_seeds_serve_the_child_listing_without_a_second_fetch(accessor):
+    index = RAMIndexCacheStore()
+    asyncio.run(SEEDED_READDIR(accessor, spec("/rooms/red"), index=index))
+    out = asyncio.run(
+        SEEDED_READDIR(accessor, spec("/rooms/red/atts"), index=index))
+    assert out == ["/h/rooms/red/atts/x.bin"]
+    # One fetch answered both directories; the atts lister never ran.
+    assert accessor.calls == ["rooms", "seed-notes:red"]
+
+
+def test_entry_branch_rechecks_the_listing_after_resolving(accessor):
+    # A cold readdir of the seeded child resolves its own entry, which
+    # warms the seeding parent; the re-check then serves the listing the
+    # warm just wrote instead of running the fallback lister.
+    out = asyncio.run(SEEDED_READDIR(accessor, spec("/rooms/red/atts")))
+    assert out == ["/h/rooms/red/atts/x.bin"]
+    assert accessor.calls == ["rooms", "seed-notes:red"]
+
+
+async def _days_by_room(accessor, match, room_entry):
+    accessor.calls.append(f"days:{room_entry.id}:{match.slots['day']}")
+    day = match.slots["day"]
+    return [(f"{day}.txt",
+             IndexEntry(id=f"{room_entry.id}:{day}",
+                        name=f"{day}.txt",
+                        resource_type="fake/day_note",
+                        vfs_name=f"{day}.txt"))]
+
+
+PARENT_READDIR = make_readdir(
+    detect_scope,
+    listers={"rooms": list_rooms},
+    entry_listers={"room": _entry_notes},
+    parent_entry_listers={"room_day": _days_by_room},
+    static_root=("rooms", ),
+)
+
+
+def test_parent_entry_lister_is_proven_by_the_parent(accessor):
+    # The day dir has no entry of its own (the room listing never minted
+    # one); the proof is the room entry, handed to the lister.
+    out = asyncio.run(PARENT_READDIR(accessor, spec("/rooms/red/2024-01-15")))
+    assert out == ["/h/rooms/red/2024-01-15/2024-01-15.txt"]
+    assert accessor.calls == ["rooms", "days:red:2024-01-15"]
+
+
+def test_parent_entry_lister_bogus_parent_is_enoent(accessor):
+    with pytest.raises(FileNotFoundError):
+        asyncio.run(PARENT_READDIR(accessor, spec("/rooms/ghost/2024-01-15")))
+    assert accessor.calls == ["rooms"]
+
+
+def test_a_kind_in_several_lister_tables_fails_at_build():
+    with pytest.raises(ValueError):
+        make_readdir(detect_scope,
+                     listers={"rooms": list_rooms},
+                     entry_listers={"room_day": _atts_fallback},
+                     parent_entry_listers={"room_day": _days_by_room},
                      static_root=("rooms", ))

--- a/python/tests/core/slack/test_read.py
+++ b/python/tests/core/slack/test_read.py
@@ -22,8 +22,20 @@ from yarl import URL
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import IndexEntry, RAMIndexCacheStore
 from mirage.core.slack.config import SlackConfig
-from mirage.core.slack.read import read
+from mirage.core.slack.read import read, read_range
 from mirage.types import PathSpec
+
+pytestmark = pytest.mark.asyncio
+
+CHANNEL = "channels/general__C001"
+CHAT = f"/{CHANNEL}/2023-11-14/chat.jsonl"
+BLOB = f"/{CHANNEL}/2026-04-10/files/report__F1.pdf"
+
+
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual,
+                    resource_path=virtual.lstrip("/"))
 
 
 @pytest.fixture
@@ -53,21 +65,51 @@ async def _populate_index(index: RAMIndexCacheStore) -> RAMIndexCacheStore:
             ),
         ),
     ])
+    await index.set_dir(f"/{CHANNEL}/2023-11-14", [
+        (
+            "chat.jsonl",
+            IndexEntry(
+                id="C001:2023-11-14:chat",
+                name="chat.jsonl",
+                resource_type="slack/chat_jsonl",
+                vfs_name="chat.jsonl",
+                size=35,
+            ),
+        ),
+    ])
     await index.set_dir("/users", [
         (
-            "alice.json",
+            "alice__U001.json",
             IndexEntry(
                 id="U001",
                 name="alice",
                 resource_type="slack/user",
-                vfs_name="alice.json",
+                vfs_name="alice__U001.json",
+            ),
+        ),
+    ])
+    await index.set_dir(f"/{CHANNEL}/2026-04-10/files", [
+        (
+            "report__F1.pdf",
+            IndexEntry(
+                id="F1",
+                name="report.pdf",
+                resource_type="slack/file",
+                vfs_name="report__F1.pdf",
+                size=4096,
+                extra={
+                    "mimetype": "application/pdf",
+                    "url_private_download":
+                    "https://files.slack.com/x/report.pdf",
+                    "channel_id": "C001",
+                    "date": "2026-04-10",
+                },
             ),
         ),
     ])
     return index
 
 
-@pytest.mark.asyncio
 async def test_read_jsonl(accessor, index):
     await _populate_index(index)
     history_bytes = b'{"text":"hello","ts":"1700000001"}\n'
@@ -76,71 +118,21 @@ async def test_read_jsonl(accessor, index):
             new_callable=AsyncMock,
             return_value=history_bytes,
     ) as mock_hist:
-        result = await read(
-            accessor,
-            PathSpec(
-                resource_path=("/channels/general__C001/2023-11-14/chat.jsonl"
-                               ).strip("/"),
-                virtual="/channels/general__C001/2023-11-14/chat.jsonl",
-                directory="/channels/general__C001/2023-11-14/chat.jsonl"),
-            index=index)
+        result = await read(accessor, spec(CHAT), index)
 
     assert result == history_bytes
     mock_hist.assert_called_once_with(accessor.config, "C001", "2023-11-14")
 
 
-@pytest.mark.asyncio
 async def test_read_file_blob(accessor, index):
-    await index.set_dir("/channels", [
-        (
-            "general__C001",
-            IndexEntry(
-                id="C001",
-                name="general",
-                resource_type="slack/channel",
-                vfs_name="general__C001",
-            ),
-        ),
-    ])
-    await index.set_dir(
-        "/channels/general__C001/2026-04-10/files",
-        [
-            (
-                "report__F1.pdf",
-                IndexEntry(
-                    id="F1",
-                    name="report.pdf",
-                    resource_type="slack/file",
-                    vfs_name="report__F1.pdf",
-                    size=4096,
-                    extra={
-                        "mimetype": "application/pdf",
-                        "url_private_download":
-                        "https://files.slack.com/x/report.pdf",
-                        "channel_id": "C001",
-                        "date": "2026-04-10",
-                    },
-                ),
-            ),
-        ],
-    )
+    await _populate_index(index)
     with patch("mirage.core.slack.files.download_file",
                new_callable=AsyncMock,
                return_value=b"%PDF-1.4 fake bytes"):
-        data = await read(
-            accessor,
-            PathSpec(resource_path=("channels/general__C001/2026-04-10"
-                                    "/files/report__F1.pdf"),
-                     virtual=("/channels/general__C001/2026-04-10"
-                              "/files/report__F1.pdf"),
-                     directory=("/channels/general__C001/2026-04-10"
-                                "/files/report__F1.pdf")),
-            index=index,
-        )
+        data = await read(accessor, spec(BLOB), index)
     assert data == b"%PDF-1.4 fake bytes"
 
 
-@pytest.mark.asyncio
 async def test_read_user_json(accessor, index):
     await _populate_index(index)
     user_data = {
@@ -153,28 +145,18 @@ async def test_read_user_json(accessor, index):
             new_callable=AsyncMock,
             return_value=user_data,
     ):
-        result = await read(accessor,
-                            PathSpec(resource_path="users/alice.json",
-                                     virtual="/users/alice.json",
-                                     directory="/users/alice.json"),
-                            index=index)
+        result = await read(accessor, spec("/users/alice__U001.json"), index)
 
     parsed = json.loads(result)
     assert parsed["id"] == "U001"
     assert parsed["name"] == "alice"
 
 
-@pytest.mark.asyncio
 async def test_read_not_found(accessor, index):
     with pytest.raises(FileNotFoundError):
-        await read(accessor,
-                   PathSpec(resource_path="nonexistent/path",
-                            virtual="/nonexistent/path",
-                            directory="/nonexistent/path"),
-                   index=index)
+        await read(accessor, spec("/nonexistent/path"), index)
 
 
-@pytest.mark.asyncio
 async def test_download_file_uses_bot_token():
     from mirage.core.slack.files import download_file
     with aioresponses() as m:
@@ -189,79 +171,29 @@ async def test_download_file_uses_bot_token():
     assert sent[1].kwargs["headers"] == {"Authorization": "Bearer xoxb-bot"}
 
 
-@pytest.mark.asyncio
 async def test_read_file_blob_pushes_the_window_down(accessor, index):
-    """An upload is stored bytes, so the window becomes a Range header."""
-    await index.set_dir("/channels", [
-        (
-            "general__C001",
-            IndexEntry(
-                id="C001",
-                name="general",
-                resource_type="slack/channel",
-                vfs_name="general__C001",
-            ),
-        ),
-    ])
-    await index.set_dir(
-        "/channels/general__C001/2026-04-10/files",
-        [
-            (
-                "report__F1.pdf",
-                IndexEntry(
-                    id="F1",
-                    name="report.pdf",
-                    resource_type="slack/file",
-                    vfs_name="report__F1.pdf",
-                    size=4096,
-                    extra={
-                        "url_private_download":
-                        "https://files.slack.com/x/report.pdf",
-                    },
-                ),
-            ),
-        ],
-    )
+    await _populate_index(index)
     with patch("mirage.core.slack.files.download_file",
                new_callable=AsyncMock,
                return_value=b"1.4 f") as mock_dl:
-        data = await read(
-            accessor,
-            PathSpec(resource_path=("channels/general__C001/2026-04-10"
-                                    "/files/report__F1.pdf"),
-                     virtual=("/channels/general__C001/2026-04-10"
-                              "/files/report__F1.pdf"),
-                     directory=("/channels/general__C001/2026-04-10"
-                                "/files/report__F1.pdf")),
-            index=index,
-            offset=5,
-            size=5,
-        )
+        data = await read_range(accessor, spec(BLOB), index, offset=5, size=5)
     assert data == b"1.4 f"
     mock_dl.assert_called_once_with(accessor.config,
                                     "https://files.slack.com/x/report.pdf", 5,
                                     5)
 
 
-@pytest.mark.asyncio
 async def test_read_jsonl_window_is_sliced_locally(accessor, index):
-    """Rendered history has no remote range, so the window is taken after."""
+    # Rendered history has no remote range, so the window is taken after.
     await _populate_index(index)
     with patch(
             "mirage.core.slack.read.get_history_jsonl",
             new_callable=AsyncMock,
             return_value=b'{"text":"hello"}\n',
     ):
-        result = await read(
-            accessor,
-            PathSpec(
-                resource_path=(
-                    "/channels/general__C001/2023-11-14/chat.jsonl"),
-                virtual="/channels/general__C001/2023-11-14/chat.jsonl",
-                directory="/channels/general__C001/2023-11-14/chat.jsonl",
-            ),
-            index=index,
-            offset=1,
-            size=6,
-        )
+        result = await read_range(accessor,
+                                  spec(CHAT),
+                                  index,
+                                  offset=1,
+                                  size=6)
     assert result == b'"text"'

--- a/python/tests/core/slack/test_readdir_soft_errors.py
+++ b/python/tests/core/slack/test_readdir_soft_errors.py
@@ -19,7 +19,7 @@ import pytest
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import RAMIndexCacheStore
 from mirage.core.slack.config import SlackConfig
-from mirage.core.slack.readdir import _fetch_day, _latest_message_ts, readdir
+from mirage.core.slack.readdir import _latest_message_ts, readdir
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -65,21 +65,42 @@ async def test_latest_message_ts_reraises_unrelated_errors(config):
 
 
 @pytest.mark.asyncio
-async def test_fetch_day_seals_empty_dir_on_not_in_channel(config, index):
+async def test_day_listing_seals_empty_dir_on_not_in_channel(config, index):
     err = RuntimeError(
         "Slack API error (conversations.history): not_in_channel")
     accessor = SlackAccessor(config=config)
+    channels_page = {
+        "channels": [{
+            "id": "C_INACCESSIBLE",
+            "name": "foo",
+            "created": 1
+        }],
+        "response_metadata": {
+            "next_cursor": ""
+        },
+    }
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        if method == "conversations.list":
+            return channels_page
+        raise AssertionError(f"unexpected {method}")
 
     async def fake_history(_cfg, channel_id, date_str):
         raise err
 
-    with patch("mirage.core.slack.readdir.fetch_messages_for_day",
+    day = "/slack/channels/foo__C_INACCESSIBLE/2026-05-10"
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get), \
+         patch("mirage.core.slack.readdir.fetch_messages_for_day",
                new=fake_history):
-        await _fetch_day(accessor, "C_INACCESSIBLE", "2026-05-10",
-                         "/slack/channels/foo__C_INACCESSIBLE/2026-05-10",
-                         index)
-    listing = await index.list_dir(
-        "/slack/channels/foo__C_INACCESSIBLE/2026-05-10")
+        names = await readdir(
+            accessor,
+            PathSpec(resource_path=mount_key(day, "/slack"),
+                     virtual=day,
+                     directory=day),
+            index,
+        )
+    assert names == []
+    listing = await index.list_dir(day)
     assert listing.entries == []
 
 

--- a/python/tests/core/slack/test_scope.py
+++ b/python/tests/core/slack/test_scope.py
@@ -12,171 +12,99 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.slack.scope import detect_scope
-from mirage.types import PathSpec
-from mirage.utils.key_prefix import mount_key
+from mirage.core.hierarchy.scope import INVALID, ROOT
+from mirage.core.slack.scope import (NATIVE_KINDS, SearchTarget, detect_scope,
+                                     search_target)
 
 
-def _gs(path: str,
-        prefix: str = "",
-        pattern: str | None = None,
-        directory: str | None = None) -> PathSpec:
-    return PathSpec(
-        resource_path=mount_key(path, prefix),
-        virtual=path,
-        directory=directory
-        or (path.rsplit("/", 1)[0] + "/" if "/" in path else "/"),
-        pattern=pattern,
-    )
+def test_root():
+    match = detect_scope("/")
+    assert match.kind == ROOT
+    assert ROOT in NATIVE_KINDS
 
 
-def test_root_empty():
-    scope = detect_scope(PathSpec.from_str_path("/"))
-    assert scope.use_native is True
-    assert scope.channel_name is None
-
-
-def test_root_with_prefix():
-    scope = detect_scope(_gs("/slack/", prefix="/slack"))
-    assert scope.use_native is True
-
-
-def test_channels_root():
-    scope = detect_scope(_gs("/slack/channels", prefix="/slack"))
-    assert scope.use_native is True
-    assert scope.container == "channels"
-    assert scope.channel_name is None
+def test_containers():
+    assert detect_scope("/channels").kind == "channels_root"
+    assert detect_scope("/dms").kind == "dms_root"
+    assert detect_scope("/users").kind == "users_root"
 
 
 def test_channel_dir():
-    scope = detect_scope(_gs("/slack/channels/general__C1", prefix="/slack"))
-    assert scope.use_native is True
-    assert scope.container == "channels"
-    assert scope.channel_name == "general"
-    assert scope.channel_id == "C1"
+    match = detect_scope("/channels/general__C001")
+    assert match.kind == "channel"
+    assert match.slots == {
+        "container": "channels",
+        "channel": "general",
+        "channel_id": "C001",
+    }
 
 
-def test_channel_dm_dir():
-    scope = detect_scope(_gs("/slack/dms/alice__D1", prefix="/slack"))
-    assert scope.use_native is True
-    assert scope.container == "dms"
-    assert scope.channel_name == "alice"
-    assert scope.channel_id == "D1"
+def test_dm_dir():
+    match = detect_scope("/dms/alice__D001")
+    assert match.kind == "channel"
+    assert match.slots["container"] == "dms"
+    assert match.slots["channel_id"] == "D001"
 
 
-def test_channel_glob_jsonl():
-    spec = PathSpec(
-        resource_path=mount_key("/slack/channels/general__C1/*/chat.jsonl",
-                                "/slack"),
-        virtual="/slack/channels/general__C1/*/chat.jsonl",
-        directory="/slack/channels/general__C1/",
-        pattern="*/chat.jsonl",
-        resolved=False,
-    )
-    scope = detect_scope(spec)
-    assert scope.use_native is True
-    assert scope.channel_name == "general"
-    assert scope.channel_id == "C1"
+def test_channel_bare_name_is_invalid():
+    # The tree mints every dirname as `name__id`, so a bare name can
+    # never be a listed channel and classifies as invalid outright.
+    assert detect_scope("/channels/general").kind == INVALID
 
 
-def test_specific_chat_jsonl():
-    scope = detect_scope(
-        _gs("/slack/channels/general__C1/2026-04-10/chat.jsonl",
-            prefix="/slack"))
-    assert scope.use_native is False
-    assert scope.date_str == "2026-04-10"
-    assert scope.channel_name == "general"
-    assert scope.channel_id == "C1"
+def test_user_file():
+    match = detect_scope("/users/alice__U001.json")
+    assert match.kind == "user"
+    assert match.slots == {"user": "alice", "user_id": "U001"}
+    assert "user" not in NATIVE_KINDS
 
 
-def test_users_dir_not_native():
-    scope = detect_scope(_gs("/slack/users", prefix="/slack"))
-    assert scope.use_native is False
+def test_day_dir():
+    match = detect_scope("/channels/general__C001/2024-04-10")
+    assert match.kind == "day"
+    assert match.slots["day"] == "2024-04-10"
+    assert "day" in NATIVE_KINDS
 
 
-def test_users_file_not_native():
-    scope = detect_scope(_gs("/slack/users/alice__U1.json", prefix="/slack"))
-    assert scope.use_native is False
+def test_non_date_under_channel_is_invalid():
+    assert detect_scope("/channels/general__C001/notadate").kind == INVALID
 
 
-def test_unknown_root_not_native():
-    scope = detect_scope(_gs("/slack/whatever", prefix="/slack"))
-    assert scope.use_native is False
+def test_chat_jsonl():
+    match = detect_scope("/channels/general__C001/2024-04-10/chat.jsonl")
+    assert match.kind == "messages"
+    assert "messages" not in NATIVE_KINDS
 
 
-def test_dirname_without_id():
-    scope = detect_scope(_gs("/slack/channels/general", prefix="/slack"))
-    assert scope.use_native is True
-    assert scope.channel_name == "general"
-    assert scope.channel_id is None
+def test_files_dir_is_not_native():
+    match = detect_scope("/channels/general__C001/2024-04-10/files")
+    assert match.kind == "files"
+    # search.files has no per-day filter, so the files dir takes the scan.
+    assert "files" not in NATIVE_KINDS
 
 
-def _spec(path: str, prefix: str = "/slack") -> PathSpec:
-    return PathSpec(resource_path=mount_key(path, prefix),
-                    virtual=path,
-                    directory=path)
+def test_file_blob():
+    match = detect_scope("/dms/bob__D001/2024-04-10/files/report__F1.pdf")
+    assert match.kind == "file_blob"
+    assert match.slots["blob"] == "report__F1.pdf"
+    assert "file_blob" not in NATIVE_KINDS
 
 
-def test_date_dir():
-    scope = detect_scope(
-        _gs("/slack/channels/general__C1/2026-04-10", prefix="/slack"))
-    assert scope.use_native is True
-    assert scope.date_str == "2026-04-10"
-    assert scope.channel_name == "general"
-    assert scope.channel_id == "C1"
-    assert scope.target == "date"
+def test_unknown_root_is_invalid():
+    assert detect_scope("/nope").kind == INVALID
+    assert detect_scope("/nope/deeper").kind == INVALID
 
 
-def test_files_dir():
-    scope = detect_scope(
-        _gs("/slack/channels/general__C1/2026-04-10/files", prefix="/slack"))
-    assert scope.use_native is True
-    assert scope.date_str == "2026-04-10"
-    assert scope.target == "files"
+def test_search_target_from_channel():
+    match = detect_scope("/channels/general__C001/2024-04-10")
+    assert search_target(match) == SearchTarget(container="channels",
+                                                channel_name="general",
+                                                channel_id="C001")
 
 
-def test_specific_file_blob():
-    scope = detect_scope(
-        _gs("/slack/channels/general__C1/2026-04-10/files/report__F1.pdf",
-            prefix="/slack"))
-    assert scope.use_native is False
-    assert scope.date_str == "2026-04-10"
-    assert scope.target == "files"
-    assert scope.channel_name == "general"
-    assert scope.channel_id == "C1"
+def test_search_target_from_container_root():
+    assert search_target(detect_scope("/dms")) == SearchTarget(container="dms")
 
 
-def test_glob_files_in_day():
-    spec = PathSpec(
-        resource_path=mount_key(
-            "/slack/channels/general__C1/2026-04-10/files/*.pdf", "/slack"),
-        virtual="/slack/channels/general__C1/2026-04-10/files/*.pdf",
-        directory="/slack/channels/general__C1/2026-04-10/files/",
-        pattern="*.pdf",
-        resolved=False,
-    )
-    scope = detect_scope(spec)
-    assert scope.use_native is True
-    assert scope.target == "files"
-
-
-def test_chat_jsonl_target():
-    scope = detect_scope(
-        _gs("/slack/channels/general__C1/2026-04-10/chat.jsonl",
-            prefix="/slack"))
-    assert scope.target == "messages"
-
-
-def test_depth3_non_date_falls_through():
-    scope = detect_scope(
-        _gs("/slack/channels/general__C1/notadate", prefix="/slack"))
-    assert scope.use_native is False
-    assert scope.target is None
-
-
-def test_depth4_unknown_leaf_under_date_not_native():
-    scope = detect_scope(
-        _gs("/slack/channels/general__C1/2026-04-10/random.txt",
-            prefix="/slack"))
-    assert scope.use_native is False
-    assert scope.target is None
+def test_search_target_from_root_is_workspace_wide():
+    assert search_target(detect_scope("/")) == SearchTarget()

--- a/python/tests/core/slack/test_search.py
+++ b/python/tests/core/slack/test_search.py
@@ -19,7 +19,7 @@ import pytest
 
 from mirage.core.slack.config import SlackConfig
 from mirage.core.slack.formatters import format_grep_results
-from mirage.core.slack.scope import SlackScope
+from mirage.core.slack.scope import SearchTarget
 from mirage.core.slack.search import search_messages
 
 
@@ -68,12 +68,10 @@ def test_format_grep_results_path_uses_chat_jsonl():
         },
     }
     raw = json.dumps(raw_payload).encode()
-    scope = SlackScope(
-        use_native=True,
+    scope = SearchTarget(
         container="channels",
         channel_name="general",
         channel_id="C001",
-        target="messages",
     )
     lines = format_grep_results(raw, scope, "/slack")
     assert len(lines) == 1

--- a/python/tests/core/slack/test_search_files.py
+++ b/python/tests/core/slack/test_search_files.py
@@ -19,7 +19,7 @@ import pytest
 
 from mirage.core.slack.config import SlackConfig
 from mirage.core.slack.formatters import build_query, format_file_grep_results
-from mirage.core.slack.scope import SlackScope
+from mirage.core.slack.scope import SearchTarget
 from mirage.core.slack.search import search_files
 
 
@@ -58,11 +58,9 @@ def test_format_file_grep_results_renders_paths():
         },
     }
     raw = json.dumps(raw_payload).encode()
-    scope = SlackScope(use_native=True,
-                       container="channels",
-                       channel_name="general",
-                       channel_id="C001",
-                       target="files")
+    scope = SearchTarget(container="channels",
+                         channel_name="general",
+                         channel_id="C001")
     lines = format_file_grep_results(raw, scope, "/slack")
     assert len(lines) == 1
     line = lines[0]
@@ -73,11 +71,9 @@ def test_format_file_grep_results_renders_paths():
 
 
 def test_build_query_unchanged_for_files():
-    scope = SlackScope(use_native=True,
-                       container="channels",
-                       channel_name="eng",
-                       channel_id="C1",
-                       target="files")
+    scope = SearchTarget(container="channels",
+                         channel_name="eng",
+                         channel_id="C1")
     assert build_query("foo", scope) == "in:#eng foo"
 
 
@@ -95,11 +91,9 @@ def test_format_file_grep_results_emits_exact_path():
         },
     }
     raw = json.dumps(raw_payload).encode()
-    scope = SlackScope(use_native=True,
-                       container="channels",
-                       channel_name="general",
-                       channel_id="C001",
-                       target="files")
+    scope = SearchTarget(container="channels",
+                         channel_name="general",
+                         channel_id="C001")
     lines = format_file_grep_results(raw, scope, "/slack")
     assert len(lines) == 1
     expected_path = ("/slack/channels/general__C001/2024-04-10/files/"
@@ -120,11 +114,9 @@ def test_format_file_grep_results_skips_when_no_scope_channel():
         },
     }
     raw = json.dumps(raw_payload).encode()
-    scope = SlackScope(use_native=True,
-                       container="channels",
-                       channel_name=None,
-                       channel_id=None,
-                       target="files")
+    scope = SearchTarget(container="channels",
+                         channel_name=None,
+                         channel_id=None)
     lines = format_file_grep_results(raw, scope, "/slack")
     assert lines == []
 
@@ -142,12 +134,10 @@ def test_format_file_grep_results_preserves_special_chars():
         },
     }
     raw = json.dumps(raw_payload).encode()
-    scope = SlackScope(
-        use_native=True,
+    scope = SearchTarget(
         container="channels",
         channel_name="general",
         channel_id="C001",
-        target="files",
     )
     lines = format_file_grep_results(raw, scope, "/slack")
     assert len(lines) == 1

--- a/python/tests/core/slack/test_stat.py
+++ b/python/tests/core/slack/test_stat.py
@@ -53,12 +53,12 @@ async def _populate_index(index: RAMIndexCacheStore) -> None:
     ])
     await index.set_dir("/users", [
         (
-            "alice.json",
+            "alice__U001.json",
             IndexEntry(
                 id="U001",
                 name="alice",
                 resource_type="slack/user",
-                vfs_name="alice.json",
+                vfs_name="alice__U001.json",
             ),
         ),
     ])
@@ -90,9 +90,9 @@ async def test_stat_channel(accessor, index):
 async def test_stat_user(accessor, index):
     await _populate_index(index)
     result = await stat(accessor,
-                        PathSpec(resource_path="users/alice.json",
-                                 virtual="/users/alice.json",
-                                 directory="/users/alice.json"),
+                        PathSpec(resource_path="users/alice__U001.json",
+                                 virtual="/users/alice__U001.json",
+                                 directory="/users/alice__U001.json"),
                         index=index)
     assert result.type == FileType.JSON
     assert result.extra["user_id"] == "U001"
@@ -176,6 +176,17 @@ async def test_stat_chat_jsonl_absent_from_day_is_enoent(accessor, index):
 
 @pytest.mark.asyncio
 async def test_stat_files_dir(accessor, index):
+    await index.set_dir("/channels/general__C001/2026-04-10", [
+        ("files",
+         IndexEntry(id="C001:2026-04-10:files",
+                    name="files",
+                    resource_type="slack/files_dir",
+                    vfs_name="files",
+                    extra={
+                        "channel_id": "C001",
+                        "date": "2026-04-10"
+                    })),
+    ])
     s = await stat(accessor,
                    PathSpec(
                        resource_path="channels/general__C001/2026-04-10/files",
@@ -183,6 +194,19 @@ async def test_stat_files_dir(accessor, index):
                        directory="/channels/general__C001/2026-04-10/files"),
                    index=index)
     assert s.type == FileType.DIRECTORY
+
+
+@pytest.mark.asyncio
+async def test_stat_files_absent_from_day_is_enoent(accessor, index):
+    # A sealed day lists nothing, so its files subdir does not exist.
+    await index.set_dir("/channels/general__C001/2026-04-10", [])
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor,
+                   PathSpec(
+                       resource_path="channels/general__C001/2026-04-10/files",
+                       virtual="/channels/general__C001/2026-04-10/files",
+                       directory="/channels/general__C001/2026-04-10/files"),
+                   index=index)
 
 
 @pytest.mark.asyncio
@@ -276,7 +300,7 @@ async def test_stat_file_blob_unknown_mimetype_is_binary(accessor, index):
 @pytest.mark.asyncio
 async def test_stat_propagates_parent_refresh_failure(accessor, index):
     failure = RuntimeError("slack unavailable")
-    with patch("mirage.core.slack.stat._readdir",
+    with patch("mirage.core.slack.readdir.list_channels",
                new_callable=AsyncMock,
                side_effect=failure):
         with pytest.raises(RuntimeError, match="slack unavailable"):

--- a/python/tests/fuse/test_discord_fuse.py
+++ b/python/tests/fuse/test_discord_fuse.py
@@ -19,27 +19,43 @@ import pytest
 
 from mirage import Workspace
 from mirage.cache.index import IndexEntry
+from mirage.core.discord.entry import (channel_dirname, channel_entry,
+                                       guild_dirname, guild_entry,
+                                       history_entry, member_entry,
+                                       member_filename)
 from mirage.fuse.fs import MirageFS
 from mirage.ops import Ops
 from mirage.resource.discord import DiscordConfig, DiscordResource
 from mirage.types import FileType, MountMode
 
-GUILD = "TestGuild"
-CHANNEL = "general"
+GUILD_PAYLOAD = {"id": "G1", "name": "TestGuild"}
+CHANNEL_PAYLOAD = {"id": "C1", "name": "general", "type": 0}
+MEMBER_PAYLOAD = {"user": {"id": "U1", "username": "alice"}, "roles": []}
+
+# Every dynamic level is a `name__id` dirname the tree itself mints, so
+# the fixture mints them the same way; a bare name is not a path the
+# classifier recognizes.
+GUILD = guild_dirname(GUILD_PAYLOAD)
+CHANNEL = channel_dirname(CHANNEL_PAYLOAD)
+MEMBER = member_filename(MEMBER_PAYLOAD)
 DATE = "2024-01-15"
 FILE = "chat.jsonl"
-GUILD_PATH = f"{GUILD}"
 CHANNEL_PATH = f"{GUILD}/channels/{CHANNEL}"
-DATE_DIR_PATH = f"{GUILD}/channels/{CHANNEL}/{DATE}"
-FILE_PATH = f"{GUILD}/channels/{CHANNEL}/{DATE}/{FILE}"
-MEMBER_PATH = f"{GUILD}/members/alice.json"
+DATE_DIR_PATH = f"{CHANNEL_PATH}/{DATE}"
+FILE_PATH = f"{DATE_DIR_PATH}/{FILE}"
+MEMBER_PATH = f"{GUILD}/members/{MEMBER}"
 
 PREFIX = "/discord"
 
 FAKE_JSONL = (b'{"id":"1","content":"hello","author":{"username":"alice"}}\n'
               b'{"id":"2","content":"world","author":{"username":"bob"}}\n')
 
-FAKE_MEMBER = b'{"user":{"id":"U1","username":"alice"},"roles":[]}'
+# The day lister records chat.jsonl's exact rendered size, so a sizeless
+# entry is the sealed-day case, which is what getattr reports 0 for.
+CHAT_ENTRY = IndexEntry(id=f"{CHANNEL_PAYLOAD['id']}:{DATE}:chat",
+                        name=FILE,
+                        resource_type="discord/chat_jsonl",
+                        vfs_name=FILE)
 
 
 def _run(coro):
@@ -55,79 +71,25 @@ def _make_world() -> tuple[DiscordResource, Workspace]:
     resource = DiscordResource(config=config)
     ws = Workspace({f"{PREFIX}/": resource}, mode=MountMode.READ)
     index = resource.index
+    _run(index.put(f"{PREFIX}/{GUILD}", guild_entry(GUILD_PAYLOAD)))
+    _run(index.put(f"{PREFIX}/{CHANNEL_PATH}", channel_entry(CHANNEL_PAYLOAD)))
     _run(
-        index.put(
-            f"{PREFIX}/{GUILD}",
-            IndexEntry(id="G1",
-                       name=GUILD,
-                       resource_type="discord/guild",
-                       vfs_name=GUILD)))
+        index.put(f"{PREFIX}/{DATE_DIR_PATH}",
+                  history_entry(CHANNEL_PAYLOAD["id"], DATE)))
+    _run(index.put(f"{PREFIX}/{FILE_PATH}", CHAT_ENTRY))
+    _run(index.put(f"{PREFIX}/{MEMBER_PATH}", member_entry(MEMBER_PAYLOAD)))
+    # A seeded listing answers readdir without a lister, so the mount
+    # serves these directories without reaching the API.
     _run(
-        index.put(
-            f"{PREFIX}/{CHANNEL_PATH}",
-            IndexEntry(id="C1",
-                       name=CHANNEL,
-                       resource_type="discord/channel",
-                       vfs_name=CHANNEL)))
+        index.set_dir(f"{PREFIX}/{GUILD}/channels",
+                      [(CHANNEL, channel_entry(CHANNEL_PAYLOAD))]))
     _run(
-        index.put(
-            f"{PREFIX}/{DATE_DIR_PATH}",
-            IndexEntry(id="C1:2024-01-15",
-                       name="2024-01-15",
-                       resource_type="discord/history",
-                       vfs_name=DATE)))
+        index.set_dir(f"{PREFIX}/{CHANNEL_PATH}",
+                      [(DATE, history_entry(CHANNEL_PAYLOAD["id"], DATE))]))
+    _run(index.set_dir(f"{PREFIX}/{DATE_DIR_PATH}", [(FILE, CHAT_ENTRY)]))
     _run(
-        index.put(
-            f"{PREFIX}/{FILE_PATH}",
-            IndexEntry(id="C1:2024-01-15:chat",
-                       name="chat.jsonl",
-                       resource_type="discord/chat_jsonl",
-                       vfs_name=FILE)))
-    _run(
-        index.put(
-            f"{PREFIX}/{MEMBER_PATH}",
-            IndexEntry(id="U1",
-                       name="alice",
-                       resource_type="discord/member",
-                       vfs_name="alice.json")))
-    _run(
-        index.put(
-            f"{PREFIX}/{GUILD}/members",
-            IndexEntry(id="G1:members",
-                       name="members",
-                       resource_type="discord/virtual_dir")))
-    _run(
-        index.set_dir(f"{PREFIX}/{GUILD}/channels", [
-            (CHANNEL,
-             IndexEntry(id="C1",
-                        name=CHANNEL,
-                        resource_type="discord/channel",
-                        vfs_name=CHANNEL)),
-        ]))
-    _run(
-        index.set_dir(f"{PREFIX}/{CHANNEL_PATH}", [
-            (DATE,
-             IndexEntry(id="C1:2024-01-15",
-                        name="2024-01-15",
-                        resource_type="discord/history",
-                        vfs_name=DATE)),
-        ]))
-    _run(
-        index.set_dir(f"{PREFIX}/{DATE_DIR_PATH}", [
-            (FILE,
-             IndexEntry(id="C1:2024-01-15:chat",
-                        name="chat.jsonl",
-                        resource_type="discord/chat_jsonl",
-                        vfs_name=FILE)),
-        ]))
-    _run(
-        index.set_dir(f"{PREFIX}/{GUILD}/members", [
-            ("alice.json",
-             IndexEntry(id="U1",
-                        name="alice",
-                        resource_type="discord/member",
-                        vfs_name="alice.json")),
-        ]))
+        index.set_dir(f"{PREFIX}/{GUILD}/members",
+                      [(MEMBER, member_entry(MEMBER_PAYLOAD))]))
     return resource, ws
 
 
@@ -171,7 +133,7 @@ def test_ops_readdir_dates(ops):
 def test_ops_readdir_members(ops):
     entries = _run(ops.readdir(f"{PREFIX}/{GUILD}/members/"))
     names = [e.rsplit("/", 1)[-1] for e in entries]
-    assert "alice.json" in names
+    assert MEMBER in names
 
 
 # ── ops.stat ─────────────────────────────────────

--- a/typescript/packages/core/src/commands/builtin/discord/_test_util.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/_test_util.ts
@@ -115,9 +115,9 @@ export async function seedChannel(
     const entries: [string, IndexEntry][] = dates.map((d) => [
       d,
       new IndexEntry({
-        id: `${channelDirname}:${d}`,
+        id: `${channelId}:${d}`,
         name: d,
-        resourceType: 'discord/date_dir',
+        resourceType: 'discord/history',
         vfsName: d,
       }),
     ])
@@ -129,7 +129,7 @@ export async function seedChannel(
         [
           'chat.jsonl',
           new IndexEntry({
-            id: `${channelDirname}:${d}:chat`,
+            id: `${channelId}:${d}:chat`,
             name: 'chat.jsonl',
             resourceType: 'discord/chat_jsonl',
             vfsName: 'chat.jsonl',
@@ -138,13 +138,17 @@ export async function seedChannel(
         [
           'files',
           new IndexEntry({
-            id: `${channelDirname}:${d}:files`,
+            id: `${channelId}:${d}:files`,
             name: 'files',
             resourceType: 'discord/files_dir',
             vfsName: 'files',
+            extra: { channel_id: channelId, date: d },
           }),
         ],
       ])
+      // The real day fetch seeds the files listing in the same write, so
+      // the fixture does too; without it a walk would refetch the day.
+      await index.setDir(`${dateKey}/files`, [])
     }
   }
 }

--- a/typescript/packages/core/src/commands/builtin/discord/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.ts
@@ -21,7 +21,7 @@ import { resolveGlobOf } from '../generic_bind/index.ts'
 import { DISCORD_IO } from './io.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
-import { detectScope } from '../../../core/discord/scope.ts'
+import { detectScope, NATIVE_KINDS } from '../../../core/discord/scope.ts'
 import { formatGrepResults, searchGuild } from '../../../core/discord/search.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
 import { IOResult } from '../../../io/types.ts'
@@ -75,20 +75,27 @@ async function grepCommand(
   // the generic scan; see SEARCH_HONORED above.
   const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
   if (pattern !== null && operand !== null && fl.asBool('w')) {
-    const scope = detectScope(operand)
-    if (scope.useNative && scope.guildId !== undefined) {
+    const match = detectScope(operand)
+    if (NATIVE_KINDS.has(match.kind)) {
+      const guildId = match.slots.guild_id ?? ''
+      const channelId = match.slots.channel_id
       try {
         const count = SEARCH_MAX_RESULTS
-        const raw = await searchGuild(accessor, scope.guildId, pattern, scope.channelId, count)
+        const raw = await searchGuild(accessor, guildId, pattern, channelId, count)
         const channelMap = new Map<string, string>()
-        if (scope.channelId === undefined) {
-          for (const ch of await listChannels(accessor, scope.guildId)) {
+        if (channelId === undefined) {
+          for (const ch of await listChannels(accessor, guildId)) {
             if (ch.name !== undefined) channelMap.set(ch.id, ch.name)
           }
         }
+        const target = {
+          guildId,
+          ...(match.slots.guild !== undefined ? { guildName: match.slots.guild } : {}),
+          ...(match.slots.channel !== undefined ? { channelName: match.slots.channel } : {}),
+        }
         const lines = formatGrepResults(
           raw,
-          scope,
+          target,
           mountPrefixOf(operand.virtual, operand.resourcePath),
           channelMap,
         )

--- a/typescript/packages/core/src/commands/builtin/discord/io.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/io.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { DiscordAccessor } from '../../../accessor/discord.ts'
-import { read as discordRead } from '../../../core/discord/read.ts'
+import { read as discordRead, readRange as discordReadRange } from '../../../core/discord/read.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
 import { type CommandIO, rangeOf } from '../generic_bind/index.ts'
@@ -22,7 +22,7 @@ import { streamFromBytes } from '../utils/wrap.ts'
 export const DISCORD_IO: CommandIO<DiscordAccessor> = {
   readdir: discordReaddir,
   readBytes: discordRead,
-  readRange: rangeOf(discordRead),
+  readRange: rangeOf(discordReadRange),
   readStream: (a, p, i) => streamFromBytes(discordRead, a, p, i),
   stat: discordStat,
   isMounted: () => true,

--- a/typescript/packages/core/src/commands/builtin/discord/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/rg.ts
@@ -21,7 +21,7 @@ import { DISCORD_IO } from './io.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
-import { detectScope } from '../../../core/discord/scope.ts'
+import { detectScope, NATIVE_KINDS } from '../../../core/discord/scope.ts'
 import { listChannels } from '../../../core/discord/channels.ts'
 import { formatGrepResults, searchGuild } from '../../../core/discord/search.ts'
 import { IOResult } from '../../../io/types.ts'
@@ -65,20 +65,27 @@ async function rgCommand(
   // operand with no reshaping flag may be answered by the search API.
   const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
   if (operand !== null && fl.asBool('w')) {
-    const scope = detectScope(operand)
-    if (scope.useNative && scope.guildId !== undefined) {
+    const match = detectScope(operand)
+    if (NATIVE_KINDS.has(match.kind)) {
+      const guildId = match.slots.guild_id ?? ''
+      const channelId = match.slots.channel_id
       try {
         const count = SEARCH_MAX_RESULTS
-        const raw = await searchGuild(accessor, scope.guildId, pattern, scope.channelId, count)
+        const raw = await searchGuild(accessor, guildId, pattern, channelId, count)
         const channelMap = new Map<string, string>()
-        if (scope.channelId === undefined) {
-          for (const ch of await listChannels(accessor, scope.guildId)) {
+        if (channelId === undefined) {
+          for (const ch of await listChannels(accessor, guildId)) {
             if (ch.name !== undefined) channelMap.set(ch.id, ch.name)
           }
         }
+        const target = {
+          guildId,
+          ...(match.slots.guild !== undefined ? { guildName: match.slots.guild } : {}),
+          ...(match.slots.channel !== undefined ? { channelName: match.slots.channel } : {}),
+        }
         const lines = formatGrepResults(
           raw,
-          scope,
+          target,
           mountPrefixOf(operand.virtual, operand.resourcePath),
           channelMap,
         )

--- a/typescript/packages/core/src/commands/builtin/gmail/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/grep.ts
@@ -19,7 +19,7 @@ import { resolveGlobOf } from '../generic_bind/index.ts'
 import { GMAIL_IO } from './io.ts'
 import { read as gmailRead } from '../../../core/gmail/read.ts'
 import { readdir as gmailReaddir } from '../../../core/gmail/readdir.ts'
-import { detectScope } from '../../../core/gmail/scope.ts'
+import { detectScope, NATIVE_KINDS } from '../../../core/gmail/scope.ts'
 import { formatGrepResults, searchMessages } from '../../../core/gmail/search.ts'
 import { stat as gmailStat } from '../../../core/gmail/stat.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
@@ -63,17 +63,18 @@ async function grepCommand(
   // the generic grep over rendered files; see SEARCH_HONORED above.
   const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
   if (pattern !== null && operand !== null && fl.asBool('w')) {
-    const scope = detectScope(operand)
-    if (scope.useNative) {
+    const match = detectScope(operand)
+    if (NATIVE_KINDS.has(match.kind)) {
+      const labelName = match.slots.label ?? null
       const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
       const rows = await searchMessages(
         accessor.tokenManager,
         pattern,
-        scope.labelName,
-        scope.dateStr,
+        labelName,
+        match.slots.day ?? null,
         SEARCH_MAX_RESULTS,
       )
-      const lines = formatGrepResults(rows, scope, filePrefix, pattern)
+      const lines = formatGrepResults(rows, labelName, filePrefix, pattern)
       if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
       return [out, new IOResult()]

--- a/typescript/packages/core/src/commands/builtin/gmail/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/rg.ts
@@ -20,7 +20,7 @@ import { GMAIL_IO } from './io.ts'
 import { read as gmailRead } from '../../../core/gmail/read.ts'
 import { readdir as gmailReaddir } from '../../../core/gmail/readdir.ts'
 import { stat as gmailStat } from '../../../core/gmail/stat.ts'
-import { detectScope } from '../../../core/gmail/scope.ts'
+import { detectScope, NATIVE_KINDS } from '../../../core/gmail/scope.ts'
 import { formatGrepResults, searchMessages } from '../../../core/gmail/search.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
@@ -61,17 +61,18 @@ async function rgCommand(
   // operand with no reshaping flag may be answered by the search API.
   const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
   if (operand !== null && fl.asBool('w')) {
-    const scope = detectScope(operand)
-    if (scope.useNative) {
+    const match = detectScope(operand)
+    if (NATIVE_KINDS.has(match.kind)) {
+      const labelName = match.slots.label ?? null
       const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
       const rows = await searchMessages(
         accessor.tokenManager,
         pattern,
-        scope.labelName,
-        scope.dateStr,
+        labelName,
+        match.slots.day ?? null,
         SEARCH_MAX_RESULTS,
       )
-      const lines = formatGrepResults(rows, scope, filePrefix, pattern)
+      const lines = formatGrepResults(rows, labelName, filePrefix, pattern)
       if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
       return [out, new IOResult()]

--- a/typescript/packages/core/src/commands/builtin/slack/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/grep.ts
@@ -24,7 +24,7 @@ import { resolveGlobOf } from '../generic_bind/index.ts'
 import { SLACK_IO } from './io.ts'
 import { read as slackRead } from '../../../core/slack/read.ts'
 import { readdir as slackReaddir } from '../../../core/slack/readdir.ts'
-import { detectScope } from '../../../core/slack/scope.ts'
+import { detectScope, NATIVE_KINDS, searchTarget } from '../../../core/slack/scope.ts'
 import { searchFiles, searchMessages } from '../../../core/slack/search.ts'
 import { stat as slackStat } from '../../../core/slack/stat.ts'
 import { IOResult } from '../../../io/types.ts'
@@ -78,27 +78,21 @@ async function grepCommand(
   // the per-message scan; see SEARCH_HONORED above.
   const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
   if (pattern !== null && operand !== null && fl.asBool('w')) {
-    const scope = detectScope(operand)
-    if (
-      scope.useNative &&
-      scope.target !== 'files' &&
-      (accessor.transport.searchAvailable?.() ?? true)
-    ) {
+    const match = detectScope(operand)
+    if (NATIVE_KINDS.has(match.kind) && (accessor.transport.searchAvailable?.() ?? true)) {
+      const target = searchTarget(match)
       const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
-      const query = buildQuery(pattern, scope)
+      const query = buildQuery(pattern, target)
       const count = SEARCH_MAX_RESULTS
-      // Every scope that reaches here searches messages: the guard above
-      // ruled out the files leaf, and a 'messages' target is a chat.jsonl
-      // leaf, which is not useNative. What is left is the channel, container
-      // and root scopes and the date directory — and those carry files too,
-      // so only the files half stays conditional.
-      const doFiles = scope.target === undefined || scope.target === 'date'
+      // Every kind that reaches here searches messages, and each of them
+      // (the root, the containers, a channel, a date dir) carries files
+      // too, so both halves run.
       try {
         const raw = await searchMessages(accessor, query, count)
-        const nativeLines: string[] = [...formatGrepResults(raw, scope, filePrefix)]
-        if (doFiles) {
+        const nativeLines: string[] = [...formatGrepResults(raw, target, filePrefix)]
+        {
           const rawF = await searchFiles(accessor, query, count)
-          nativeLines.push(...formatFileGrepResults(rawF, scope, filePrefix))
+          nativeLines.push(...formatFileGrepResults(rawF, target, filePrefix))
         }
         if (nativeLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
         return [ENC.encode(nativeLines.join('\n') + '\n'), new IOResult()]

--- a/typescript/packages/core/src/commands/builtin/slack/io.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/io.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { SlackAccessor } from '../../../accessor/slack.ts'
-import { read as slackRead } from '../../../core/slack/read.ts'
+import { read as slackRead, readRange as slackReadRange } from '../../../core/slack/read.ts'
 import { DU_MAX_ENTRIES } from '../../../core/slack/constants.ts'
 import { readdir as slackReaddir } from '../../../core/slack/readdir.ts'
 import { stat as slackStat } from '../../../core/slack/stat.ts'
@@ -23,7 +23,7 @@ import { streamFromBytes } from '../utils/wrap.ts'
 export const SLACK_IO: CommandIO<SlackAccessor> = {
   readdir: slackReaddir,
   readBytes: slackRead,
-  readRange: rangeOf(slackRead),
+  readRange: rangeOf(slackReadRange),
   readStream: (a, p, i) => streamFromBytes(slackRead, a, p, i),
   stat: slackStat,
   isMounted: () => true,

--- a/typescript/packages/core/src/commands/builtin/slack/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/rg.ts
@@ -25,7 +25,7 @@ import {
   formatFileGrepResults,
   formatGrepResults,
 } from '../../../core/slack/formatters.ts'
-import { detectScope } from '../../../core/slack/scope.ts'
+import { detectScope, NATIVE_KINDS, searchTarget } from '../../../core/slack/scope.ts'
 import { searchFiles, searchMessages } from '../../../core/slack/search.ts'
 import { IOResult } from '../../../io/types.ts'
 import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
@@ -68,27 +68,21 @@ async function rgCommand(
   // operand with no reshaping flag may be answered by the search API.
   const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
   if (operand !== null && fl.asBool('w')) {
-    const scope = detectScope(operand)
-    if (
-      scope.useNative &&
-      scope.target !== 'files' &&
-      (accessor.transport.searchAvailable?.() ?? true)
-    ) {
+    const match = detectScope(operand)
+    if (NATIVE_KINDS.has(match.kind) && (accessor.transport.searchAvailable?.() ?? true)) {
+      const target = searchTarget(match)
       const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
-      const query = buildQuery(pattern, scope)
+      const query = buildQuery(pattern, target)
       const count = SEARCH_MAX_RESULTS
-      // Every scope that reaches here searches messages: the guard above
-      // ruled out the files leaf, and a 'messages' target is a chat.jsonl
-      // leaf, which is not useNative. What is left is the channel, container
-      // and root scopes and the date directory — and those carry files too,
-      // so only the files half stays conditional.
-      const doFiles = scope.target === undefined || scope.target === 'date'
+      // Every kind that reaches here searches messages, and each of them
+      // (the root, the containers, a channel, a date dir) carries files
+      // too, so both halves run.
       try {
         const raw = await searchMessages(accessor, query, count)
-        const nativeLines: string[] = [...formatGrepResults(raw, scope, filePrefix)]
-        if (doFiles) {
+        const nativeLines: string[] = [...formatGrepResults(raw, target, filePrefix)]
+        {
           const rawF = await searchFiles(accessor, query, count)
-          nativeLines.push(...formatFileGrepResults(rawF, scope, filePrefix))
+          nativeLines.push(...formatFileGrepResults(rawF, target, filePrefix))
         }
         if (nativeLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
         return [ENC.encode(nativeLines.join('\n') + '\n'), new IOResult()]

--- a/typescript/packages/core/src/core/discord/entry.test.ts
+++ b/typescript/packages/core/src/core/discord/entry.test.ts
@@ -117,7 +117,8 @@ describe('DiscordIndexEntry', () => {
     expect(entry.name).toBe('2026-04-25')
     expect(entry.resourceType).toBe(DiscordResourceType.HISTORY)
     expect(entry.resourceType).toBe('discord/history')
-    expect(entry.vfsName).toBe('2026-04-25.jsonl')
+    expect(entry.vfsName).toBe('2026-04-25')
+    expect(entry.extra).toEqual({ channel_id: 'C1' })
   })
 })
 

--- a/typescript/packages/core/src/core/discord/entry.ts
+++ b/typescript/packages/core/src/core/discord/entry.ts
@@ -66,12 +66,15 @@ export const DiscordIndexEntry = {
       ...(size !== undefined ? { size } : {}),
     })
   },
+  // channel_id rides extra so the day and files listers can query the
+  // history API without re-resolving the channel through its parent.
   history(channelId: string, date: string): IndexEntry {
     return new IndexEntry({
       id: `${channelId}:${date}`,
       name: date,
       resourceType: DiscordResourceType.HISTORY,
-      vfsName: `${date}.jsonl`,
+      vfsName: date,
+      extra: { channel_id: channelId },
     })
   },
 }

--- a/typescript/packages/core/src/core/discord/read.test.ts
+++ b/typescript/packages/core/src/core/discord/read.test.ts
@@ -71,11 +71,8 @@ describe('read history jsonl branch', () => {
         }),
       ],
     ])
-    let returned = false
     const t = new FakeDiscordTransport((_m, endpoint) => {
       if (endpoint === '/channels/C1/messages') {
-        if (returned) return []
-        returned = true
         return [
           { id: '1196300000000000000', content: 'hello' },
           { id: '1196400000000000000', content: 'world' },
@@ -267,10 +264,12 @@ describe('read unknown', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('throws ENOENT for root', async () => {
+  it('throws EISDIR for root', async () => {
+    // The root exists by construction, so reading it as a file is the one
+    // shape the kit reports as a directory rather than absent.
     const t = new FakeDiscordTransport(() => null)
     await expect(
       read(new DiscordAccessor(t), spec('/mnt/discord', '/mnt/discord')),
-    ).rejects.toMatchObject({ code: 'ENOENT' })
+    ).rejects.toMatchObject({ code: 'EISDIR' })
   })
 })

--- a/typescript/packages/core/src/core/discord/read.ts
+++ b/typescript/packages/core/src/core/discord/read.ts
@@ -12,122 +12,124 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { DiscordAccessor } from '../../accessor/discord.ts'
+import type { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
+import { enoent } from '../../utils/errors.ts'
+import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
+import { resolveEntry } from '../hierarchy/probe.ts'
+import { makeRead, makeReadRange } from '../hierarchy/read.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { downloadFile } from './files.ts'
 import { getHistoryJsonl } from './history.ts'
 import { listMembers } from './members.ts'
-import { readdir as discordReaddir } from './readdir.ts'
+import { readdir } from './readdir.ts'
 import { memberJsonBytes } from './render.ts'
-import { stripSlash } from '../../utils/slash.ts'
-import { sliceWindow } from '../../utils/ranges.ts'
+import { detectScope } from './scope.ts'
 
-function fileNotFound(key: string): Error {
-  const e = new Error(`ENOENT: ${key}`) as Error & { code: string }
-  e.code = 'ENOENT'
-  return e
+async function ancestorEntry(
+  accessor: DiscordAccessor,
+  path: PathSpec,
+  index: IndexCacheStore | undefined,
+  up: number,
+): Promise<IndexEntry | null> {
+  let virtual = path.virtual.replace(/\/+$/, '')
+  for (let i = 0; i < up; i++) virtual = virtual.split('/').slice(0, -1).join('/')
+  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
+  const spec = new PathSpec({
+    virtual,
+    directory: virtual,
+    resourcePath: mountKey(virtual, prefix),
+  })
+  return resolveEntry(readdir, accessor, spec, index)
 }
 
 /**
- * Read a Discord path, optionally only a byte range of it.
+ * Render one day's history; the channel id comes from the listing.
  *
- * Only an attachment has a remote range to ask for. A channel's history and
- * a member profile are rendered here into JSON, so their bytes do not exist
- * until we make them and the window can only be taken afterwards.
- *
- * Args:
- *   accessor: Discord accessor.
- *   path: the path to read.
- *   index: listing cache, consulted for the entry.
- *   options: `{offset, size}`, the byte window, or absent for the whole file.
+ * The typed `name__id` dirname is only trusted once the listing proves it,
+ * so a fabricated channel id is ENOENT rather than a raw API error.
  */
-export async function read(
+async function readChat(
   accessor: DiscordAccessor,
+  match: ScopeMatch,
   path: PathSpec,
   index?: IndexCacheStore,
-  options?: { offset?: number; size?: number },
 ): Promise<Uint8Array> {
-  const offset = options?.offset ?? 0
-  const size = options?.size ?? null
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  let raw = path.virtual
-  if (prefix !== '' && raw.startsWith(prefix)) {
-    raw = raw.slice(prefix.length) || '/'
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  let channelId: string
+  if (entry !== null) {
+    channelId = entry.id.split(':', 1)[0] ?? ''
+  } else {
+    // A sealed day lists nothing but the file still reads through the
+    // channel, reproducing the API's own answer for the fetch.
+    const channel = await ancestorEntry(accessor, path, index, 2)
+    if (channel === null) throw enoent(path)
+    channelId = channel.id
   }
-  const key = stripSlash(raw)
-  const parts = key.split('/')
-
-  // <guild>/channels/<ch>/<date>/chat.jsonl
-  if (
-    parts.length === 5 &&
-    parts[1] === 'channels' &&
-    parts[4] === 'chat.jsonl' &&
-    parts[0] !== undefined &&
-    parts[2] !== undefined &&
-    parts[3] !== undefined
-  ) {
-    if (index === undefined) throw fileNotFound(key)
-    const chKey = `${parts[0]}/${parts[1]}/${parts[2]}`
-    const chLookup = await index.get(`${prefix}/${chKey}`)
-    if (chLookup.entry === undefined || chLookup.entry === null) throw fileNotFound(key)
-    return sliceWindow(await getHistoryJsonl(accessor, chLookup.entry.id, parts[3]), offset, size)
-  }
-
-  // <guild>/channels/<ch>/<date>/files/<blob>
-  if (parts.length === 6 && parts[1] === 'channels' && parts[4] === 'files') {
-    if (index === undefined) throw fileNotFound(key)
-    const virtualKey = `${prefix}/${key}`
-    let lookup = await index.get(virtualKey)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      // Hydrate via date dir readdir (triggers fetchDay)
-      const dateKey = parts.slice(0, 4).join('/')
-      const dateVk = `${prefix}/${dateKey}`
-      await discordReaddir(
-        accessor,
-        new PathSpec({
-          virtual: dateVk,
-          directory: dateVk,
-          resourcePath: mountKey(dateVk, prefix),
-        }),
-        index,
-      )
-      lookup = await index.get(virtualKey)
-    }
-    if (lookup.entry === undefined || lookup.entry === null) throw fileNotFound(key)
-    const extra = lookup.entry.extra
-    const url =
-      typeof extra.url === 'string' && extra.url !== ''
-        ? extra.url
-        : typeof extra.proxy_url === 'string'
-          ? extra.proxy_url
-          : ''
-    if (url === '') throw fileNotFound(key)
-    return await downloadFile(url, offset, size)
-  }
-
-  // <guild>/members/<user>.json
-  if (
-    parts.length === 3 &&
-    parts[1] === 'members' &&
-    parts[2]?.endsWith('.json') === true &&
-    parts[0] !== undefined
-  ) {
-    if (index === undefined) throw fileNotFound(key)
-    const virtualKey = `${prefix}/${key}`
-    const lookup = await index.get(virtualKey)
-    if (lookup.entry === undefined || lookup.entry === null) throw fileNotFound(key)
-    const guildLookup = await index.get(`${prefix}/${parts[0]}`)
-    if (guildLookup.entry === undefined || guildLookup.entry === null) throw fileNotFound(key)
-    const members = await listMembers(accessor, guildLookup.entry.id)
-    for (const m of members) {
-      if (m.user?.id === lookup.entry.id) {
-        return sliceWindow(memberJsonBytes(m), offset, size)
-      }
-    }
-    throw fileNotFound(key)
-  }
-
-  throw fileNotFound(key)
+  return getHistoryJsonl(accessor, channelId, match.slots.day ?? '')
 }
+
+async function readMember(
+  accessor: DiscordAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<Uint8Array> {
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry === null) throw enoent(path)
+  const members = await listMembers(accessor, match.slots.guild_id ?? '')
+  for (const m of members) {
+    if (m.user?.id === entry.id) return memberJsonBytes(m)
+  }
+  throw enoent(path)
+}
+
+async function blobUrl(
+  accessor: DiscordAccessor,
+  path: PathSpec,
+  index: IndexCacheStore | undefined,
+): Promise<string> {
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry === null) throw enoent(path)
+  const extra = entry.extra
+  const direct = typeof extra.url === 'string' ? extra.url : ''
+  const proxy = typeof extra.proxy_url === 'string' ? extra.proxy_url : ''
+  const url = direct !== '' ? direct : proxy
+  if (url === '') throw enoent(path)
+  return url
+}
+
+async function readBlob(
+  accessor: DiscordAccessor,
+  _match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<Uint8Array> {
+  return downloadFile(await blobUrl(accessor, path, index), 0, null)
+}
+
+async function readBlobRange(
+  accessor: DiscordAccessor,
+  _match: ScopeMatch,
+  path: PathSpec,
+  index: IndexCacheStore | undefined,
+  offset: number,
+  size: number | null,
+): Promise<Uint8Array> {
+  return downloadFile(await blobUrl(accessor, path, index), offset, size)
+}
+
+export const read = makeRead<DiscordAccessor>(detectScope, {
+  messages: readChat,
+  member: readMember,
+  file_blob: readBlob,
+})
+
+// Only an attachment has a remote range to ask for. A channel's history and
+// a member profile are rendered here into JSON, so their bytes do not exist
+// until we make them and the window can only be taken afterwards.
+export const readRange = makeReadRange<DiscordAccessor>(detectScope, read, {
+  file_blob: readBlobRange,
+})

--- a/typescript/packages/core/src/core/discord/readdir.test.ts
+++ b/typescript/packages/core/src/core/discord/readdir.test.ts
@@ -161,14 +161,24 @@ describe('readdir /<guild>', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('returns the channels/members pair without index (no auto-bootstrap)', async () => {
-    const t = new FakeDiscordTransport(() => null)
+  it('returns the channels/members pair once the guild is proven', async () => {
+    const t = new FakeDiscordTransport((_m, endpoint) =>
+      endpoint === '/users/@me/guilds' ? [{ id: 'G1', name: 'Whatever' }] : null,
+    )
     const out = await readdir(
       new DiscordAccessor(t),
       spec('/mnt/discord/Whatever__G1', '/mnt/discord'),
     )
     expect(out).toEqual(['/mnt/discord/Whatever__G1/channels', '/mnt/discord/Whatever__G1/members'])
-    expect(t.calls).toHaveLength(0)
+  })
+
+  it('throws ENOENT for a bogus guild', async () => {
+    const t = new FakeDiscordTransport((_m, endpoint) =>
+      endpoint === '/users/@me/guilds' ? [{ id: 'G1', name: 'Whatever' }] : null,
+    )
+    await expect(
+      readdir(new DiscordAccessor(t), spec('/mnt/discord/Nope__G9', '/mnt/discord')),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })
 
@@ -409,8 +419,8 @@ describe('readdir /<guild>/channels/<ch>', () => {
     expect(out[1]).toBe('/mnt/discord/My Server__G1/channels/general__C1/2016-04-29')
     expect(out[29]).toBe('/mnt/discord/My Server__G1/channels/general__C1/2016-04-01')
     const lookup = await idx.get('/mnt/discord/My Server__G1/channels/general__C1/2016-04-30')
-    expect(lookup.entry?.id).toBe('general__C1:2016-04-30')
-    expect(lookup.entry?.resourceType).toBe('discord/date_dir')
+    expect(lookup.entry?.id).toBe('C1:2016-04-30')
+    expect(lookup.entry?.resourceType).toBe('discord/history')
     expect(t.calls).toHaveLength(0)
   })
 

--- a/typescript/packages/core/src/core/discord/readdir.ts
+++ b/typescript/packages/core/src/core/discord/readdir.ts
@@ -12,24 +12,24 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { DiscordAccessor } from '../../accessor/discord.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
-import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { PathSpec } from '../../types.ts'
+import { epochToIso } from '../../utils/dates.ts'
+import { makeReaddir, type DirListing, type Listed } from '../hierarchy/readdir.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { listChannels } from './channels.ts'
+import { DiscordApiError } from './client.ts'
 import { DiscordIndexEntry, DiscordResourceType } from './entry.ts'
 import { fileBlobName } from './files.ts'
 import { listGuilds } from './guilds.ts'
 import { DISCORD_EPOCH, listMessagesForDay } from './history.ts'
 import { listMembers } from './members.ts'
 import { historyJsonlBytes, memberJsonBytes } from './render.ts'
-import { DiscordApiError } from './client.ts'
-import { epochToIso } from '../../utils/dates.ts'
-import { stripSlash } from '../../utils/slash.ts'
-import { enoent, enotdir } from '../../utils/errors.ts'
+import { detectScope } from './scope.ts'
 
 const SOFT_STATUSES = new Set([403, 404, 429])
+
+const CONTAINER_TYPE = 'discord/container'
 
 export function snowflakeToDate(snowflake: string): string {
   if (snowflake === '') return ''
@@ -79,185 +79,99 @@ function isSoftError(err: unknown): boolean {
   return err instanceof DiscordApiError && SOFT_STATUSES.has(err.status)
 }
 
-interface Normalized {
-  prefix: string
-  key: string
-  virtualKey: string
-  rawPath: string
+function containerEntry(name: string, guildId: string): IndexEntry {
+  return new IndexEntry({
+    id: guildId,
+    name,
+    resourceType: CONTAINER_TYPE,
+    vfsName: name,
+  })
 }
 
-function normalize(path: PathSpec): Normalized {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  let raw = path.pattern !== null ? path.directory : path.virtual
-  if (prefix !== '' && raw.startsWith(prefix)) {
-    raw = raw.slice(prefix.length) || '/'
-  }
-  const key = stripSlash(raw)
-  const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
-  return { prefix, key, virtualKey, rawPath: path.virtual }
-}
-
-async function ensureGuildId(
-  accessor: DiscordAccessor,
-  prefix: string,
-  guildPart: string,
-  index: IndexCacheStore,
-  rawPath: string,
-): Promise<string> {
-  const vk = `${prefix}/${guildPart}`
-  let lookup = await index.get(vk)
-  if (lookup.entry === undefined || lookup.entry === null) {
-    const root = new PathSpec({
-      virtual: prefix !== '' ? prefix : '/',
-      directory: prefix !== '' ? prefix : '/',
-      resourcePath: mountKey(prefix !== '' ? prefix : '/', prefix),
-    })
-    await readdir(accessor, root, index)
-    lookup = await index.get(vk)
-  }
-  if (lookup.entry === undefined || lookup.entry === null) throw enoent(rawPath)
-  return lookup.entry.id
-}
-
-async function ensureChannelLookup(
-  accessor: DiscordAccessor,
-  prefix: string,
-  parts: string[],
-  index: IndexCacheStore,
-  rawPath: string,
-): Promise<IndexEntry> {
-  const channelVk = `${prefix}/${parts.slice(0, 3).join('/')}`
-  let lookup = await index.get(channelVk)
-  if (lookup.entry === undefined || lookup.entry === null) {
-    const parentPath = `${prefix}/${parts.slice(0, 2).join('/')}`
-    await readdir(
-      accessor,
-      new PathSpec({
-        virtual: parentPath,
-        directory: parentPath,
-        resourcePath: mountKey(parentPath, prefix),
-      }),
-      index,
-    )
-    lookup = await index.get(channelVk)
-  }
-  if (lookup.entry === undefined || lookup.entry === null) throw enoent(rawPath)
-  return lookup.entry
-}
-
-async function readdirRoot(
-  accessor: DiscordAccessor,
-  prefix: string,
-  virtualKey: string,
-  index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  if (index !== undefined) {
-    const listing = await index.listDir(virtualKey)
-    if (listing.entries !== undefined && listing.entries !== null) return listing.entries
-  }
+async function listRoot(accessor: DiscordAccessor, _match: ScopeMatch): Promise<Listed | null> {
   const guilds = await listGuilds(accessor)
-  const entries: [string, IndexEntry][] = []
-  const names: string[] = []
-  for (const g of guilds) {
+  return guilds.map((g) => {
     const entry = DiscordIndexEntry.guild(g)
+    return [entry.vfsName, entry] as [string, IndexEntry]
+  })
+}
+
+function listGuildContainers(
+  _accessor: DiscordAccessor,
+  _match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  return Promise.resolve<[string, IndexEntry][]>([
+    ['channels', containerEntry('channels', own.id)],
+    ['members', containerEntry('members', own.id)],
+  ])
+}
+
+async function listChannelsDir(
+  accessor: DiscordAccessor,
+  _match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  const channels = await listChannels(accessor, own.id)
+  return channels.map((c) => {
+    const base = DiscordIndexEntry.channel(c)
+    const lastMsgId = typeof c.last_message_id === 'string' ? c.last_message_id : ''
+    const entry = lastMsgId !== '' ? base.copyWith({ remoteTime: lastMsgId }) : base
+    return [entry.vfsName, entry] as [string, IndexEntry]
+  })
+}
+
+async function listMembersDir(
+  accessor: DiscordAccessor,
+  _match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  const members = await listMembers(accessor, own.id)
+  const entries: [string, IndexEntry][] = []
+  for (const m of members) {
+    const user = m.user
+    if (user === undefined || user.id === '') continue
+    // The listing already carries the whole member payload read() renders,
+    // so the exact size is free here.
+    const entry = DiscordIndexEntry.member(
+      { id: user.id, name: user.username ?? '' },
+      memberJsonBytes(m).byteLength,
+    )
     entries.push([entry.vfsName, entry])
-    names.push(`${prefix}/${entry.vfsName}`)
   }
-  if (index !== undefined) await index.setDir(virtualKey, entries)
-  return names
+  return entries
 }
 
-async function readdirGuildContainer(
-  accessor: DiscordAccessor,
-  prefix: string,
-  key: string,
-  virtualKey: string,
-  parts: string[],
-  index: IndexCacheStore,
-  rawPath: string,
-): Promise<string[]> {
-  const listing = await index.listDir(virtualKey)
-  if (listing.entries !== undefined && listing.entries !== null) return listing.entries
-  const guildPart = parts[0]
-  if (guildPart === undefined) throw enoent(rawPath)
-  const guildId = await ensureGuildId(accessor, prefix, guildPart, index, rawPath)
-  const entries: [string, IndexEntry][] = []
-  const names: string[] = []
-  if (parts[1] === 'channels') {
-    const channels = await listChannels(accessor, guildId)
-    for (const c of channels) {
-      const base = DiscordIndexEntry.channel(c)
-      const lastMsgId = typeof c.last_message_id === 'string' ? c.last_message_id : ''
-      const entry = lastMsgId !== '' ? base.copyWith({ remoteTime: lastMsgId }) : base
-      entries.push([entry.vfsName, entry])
-      names.push(`${prefix}/${key}/${entry.vfsName}`)
-    }
-  } else {
-    const members = await listMembers(accessor, guildId)
-    for (const m of members) {
-      const user = m.user
-      if (user === undefined || user.id === '') continue
-      // The listing already carries the whole member payload read() renders,
-      // so the exact size is free here.
-      const entry = DiscordIndexEntry.member(
-        { id: user.id, name: user.username ?? '' },
-        memberJsonBytes(m).byteLength,
-      )
-      entries.push([entry.vfsName, entry])
-      names.push(`${prefix}/${key}/${entry.vfsName}`)
-    }
-  }
-  await index.setDir(virtualKey, entries)
-  return names
-}
-
-async function readdirChannelDates(
-  accessor: DiscordAccessor,
-  prefix: string,
-  key: string,
-  virtualKey: string,
-  parts: string[],
-  index: IndexCacheStore,
-  rawPath: string,
-): Promise<string[]> {
-  const listing = await index.listDir(virtualKey)
-  if (listing.entries !== undefined && listing.entries !== null) return listing.entries
-  const lookup = await ensureChannelLookup(accessor, prefix, parts, index, rawPath)
-  const lastMsgId = lookup.remoteTime
+function listChannelDays(
+  _accessor: DiscordAccessor,
+  _match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  const lastMsgId = own.remoteTime
   const endDate = lastMsgId !== '' ? snowflakeToDate(lastMsgId) : todayUtc()
-  const dates = dateRangeDescending(endDate, 30)
-  const channelDir = parts[2] ?? ''
-  const entries: [string, IndexEntry][] = []
-  const names: string[] = []
-  for (const d of dates) {
-    const entry = new IndexEntry({
-      id: `${channelDir}:${d}`,
-      name: d,
-      resourceType: DiscordResourceType.DATE_DIR,
-      vfsName: d,
-    })
-    entries.push([d, entry])
-    names.push(`${prefix}/${key}/${d}`)
-  }
-  await index.setDir(virtualKey, entries)
-  return names
+  return Promise.resolve(
+    dateRangeDescending(endDate, 30).map(
+      (d) => [d, DiscordIndexEntry.history(own.id, d)] as [string, IndexEntry],
+    ),
+  )
 }
 
-async function fetchDay(
+/**
+ * One history fetch, answering the day dir and its files subdir.
+ *
+ * A soft HTTP error (403/404/429) seals an empty day: the dir lists nothing,
+ * and stat serves chat.jsonl with the size left unknown.
+ */
+async function dayListing(
   accessor: DiscordAccessor,
   channelId: string,
   dateStr: string,
-  dateVk: string,
-  index: IndexCacheStore,
-): Promise<void> {
+): Promise<DirListing> {
   let messages
   try {
     messages = await listMessagesForDay(accessor, channelId, dateStr)
   } catch (e) {
-    if (isSoftError(e)) {
-      await index.setDir(dateVk, [])
-      return
-    }
+    if (isSoftError(e)) return { entries: [], seeds: {} }
     throw e
   }
   // The day's messages are already in hand, so chat.jsonl's exact rendered
@@ -274,11 +188,8 @@ async function fetchDay(
     name: 'files',
     resourceType: DiscordResourceType.FILES_DIR,
     vfsName: 'files',
+    extra: { channel_id: channelId, date: dateStr },
   })
-  await index.setDir(dateVk, [
-    ['chat.jsonl', chatEntry],
-    ['files', filesEntry],
-  ])
   const fileEntries: [string, IndexEntry][] = []
   for (const msg of messages) {
     const atts = (msg.attachments ?? []) as {
@@ -296,140 +207,69 @@ async function fetchDay(
       // sizes. Mirrors the slack guard.
       if (!att.id || !att.url || att.size === undefined) continue
       const blobName = fileBlobName(att)
-      const entry = new IndexEntry({
-        id: att.id,
-        name: att.filename ?? '',
-        resourceType: DiscordResourceType.FILE,
-        vfsName: blobName,
-        size: att.size,
-        extra: {
-          url: att.url,
-          proxy_url: att.proxy_url ?? '',
-          content_type: att.content_type ?? '',
-          message_id: msg.id,
-          author: (msg.author as { username?: string } | undefined)?.username ?? '',
-          channel_id: channelId,
-          date: dateStr,
-        },
-      })
-      fileEntries.push([blobName, entry])
+      fileEntries.push([
+        blobName,
+        new IndexEntry({
+          id: att.id,
+          name: att.filename ?? '',
+          resourceType: DiscordResourceType.FILE,
+          vfsName: blobName,
+          size: att.size,
+          extra: {
+            url: att.url,
+            proxy_url: att.proxy_url ?? '',
+            content_type: att.content_type ?? '',
+            message_id: msg.id,
+            author: (msg.author as { username?: string } | undefined)?.username ?? '',
+            channel_id: channelId,
+            date: dateStr,
+          },
+        }),
+      ])
     }
   }
-  await index.setDir(`${dateVk}/files`, fileEntries)
+  return {
+    entries: [
+      ['chat.jsonl', chatEntry],
+      ['files', filesEntry],
+    ],
+    seeds: { files: fileEntries },
+  }
 }
 
-async function readdirDateContents(
+function listDay(
   accessor: DiscordAccessor,
-  prefix: string,
-  virtualKey: string,
-  parts: string[],
-  index: IndexCacheStore,
-  rawPath: string,
-): Promise<string[]> {
-  const cached = await index.listDir(virtualKey)
-  if (cached.entries !== undefined && cached.entries !== null) return cached.entries
-  const lookup = await ensureChannelLookup(accessor, prefix, parts, index, rawPath)
-  const dateStr = parts[3]
-  if (dateStr === undefined) throw enoent(rawPath)
-  await fetchDay(accessor, lookup.id, dateStr, virtualKey, index)
-  const after = await index.listDir(virtualKey)
-  if (after.entries === undefined || after.entries === null) throw enoent(rawPath)
-  return after.entries
+  match: ScopeMatch,
+  channel: IndexEntry,
+): Promise<Listed> {
+  // The proof is the channel entry, not the day's own: any well-formed date
+  // under a real channel fetches, including dates outside the bounded window
+  // the channel listing mints.
+  return dayListing(accessor, channel.id, match.slots.day ?? '')
 }
 
-async function readdirFilesDir(
+async function listFiles(
   accessor: DiscordAccessor,
-  prefix: string,
-  virtualKey: string,
-  parts: string[],
-  index: IndexCacheStore,
-  rawPath: string,
-): Promise<string[]> {
-  const cached = await index.listDir(virtualKey)
-  if (cached.entries !== undefined && cached.entries !== null) return cached.entries
-  const dateKey = parts.slice(0, 4).join('/')
-  const dateVk = `${prefix}/${dateKey}`
-  await readdir(
-    accessor,
-    new PathSpec({ virtual: dateVk, directory: dateVk, resourcePath: mountKey(dateVk, prefix) }),
-    index,
-  )
-  const after = await index.listDir(virtualKey)
-  if (after.entries === undefined || after.entries === null) throw enoent(rawPath)
-  return after.entries
+  match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  // Normally served from the day lister's seed; reached only when the index
+  // evicted the files listing while the day's entries survived.
+  const fromExtra = typeof own.extra.channel_id === 'string' ? own.extra.channel_id : ''
+  const channelId = fromExtra !== '' ? fromExtra : (own.id.split(':', 1)[0] ?? '')
+  const listing = await dayListing(accessor, channelId, match.slots.day ?? '')
+  return listing.seeds.files ?? []
 }
 
-function isLeaf(parts: string[]): boolean {
-  if (parts.length === 3 && parts[1] === 'members') return parts[2]?.endsWith('.json') === true
-  if (parts.length === 5 && parts[1] === 'channels') return parts[4] === 'chat.jsonl'
-  if (parts.length === 6 && parts[1] === 'channels' && parts[4] === 'files') return true
-  return false
-}
-
-export async function readdir(
-  accessor: DiscordAccessor,
-  path: PathSpec,
-  index?: IndexCacheStore,
-): Promise<string[]> {
-  const { prefix, key, virtualKey, rawPath } = normalize(path)
-
-  if (key === '') return readdirRoot(accessor, prefix, virtualKey, index)
-
-  const parts = key.split('/')
-
-  if (parts.length === 1) {
-    if (index !== undefined) {
-      const lookup = await index.get(virtualKey)
-      if (lookup.entry === undefined || lookup.entry === null) {
-        const root = new PathSpec({
-          virtual: prefix !== '' ? prefix : '/',
-          directory: prefix !== '' ? prefix : '/',
-          resourcePath: mountKey(prefix !== '' ? prefix : '/', prefix),
-        })
-        await readdir(accessor, root, index)
-        const retry = await index.get(virtualKey)
-        if (retry.entry === undefined || retry.entry === null) throw enoent(rawPath)
-      }
-    }
-    return [`${prefix}/${key}/channels`, `${prefix}/${key}/members`]
-  }
-
-  if (parts.length === 2 && (parts[1] === 'channels' || parts[1] === 'members')) {
-    if (index === undefined) throw enoent(rawPath)
-    return readdirGuildContainer(accessor, prefix, key, virtualKey, parts, index, rawPath)
-  }
-
-  if (parts.length === 3 && parts[1] === 'channels') {
-    if (index === undefined) throw enoent(rawPath)
-    return readdirChannelDates(accessor, prefix, key, virtualKey, parts, index, rawPath)
-  }
-
-  const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
-
-  if (
-    parts.length === 4 &&
-    parts[1] === 'channels' &&
-    parts[3] !== undefined &&
-    DATE_RE.test(parts[3])
-  ) {
-    if (index === undefined) throw enoent(rawPath)
-    return readdirDateContents(accessor, prefix, virtualKey, parts, index, rawPath)
-  }
-
-  if (
-    parts.length === 5 &&
-    parts[1] === 'channels' &&
-    parts[3] !== undefined &&
-    DATE_RE.test(parts[3]) &&
-    parts[4] === 'files'
-  ) {
-    if (index === undefined) throw enoent(rawPath)
-    return readdirFilesDir(accessor, prefix, virtualKey, parts, index, rawPath)
-  }
-
-  // A leaf that exists is ENOTDIR, not ENOENT: callers tell "this is a file,
-  // read it" from "there is nothing here" by the errno. Anything else is a
-  // shape discord does not serve.
-  if (isLeaf(parts)) throw enotdir(rawPath)
-  throw enoent(rawPath)
-}
+export const readdir = makeReaddir<DiscordAccessor>(detectScope, {
+  listers: { root: listRoot },
+  entryListers: {
+    guild: listGuildContainers,
+    channels_dir: listChannelsDir,
+    members_dir: listMembersDir,
+    channel: listChannelDays,
+    files: listFiles,
+  },
+  parentEntryListers: { day: listDay },
+  leafError: 'enotdir',
+})

--- a/typescript/packages/core/src/core/discord/scope.test.ts
+++ b/typescript/packages/core/src/core/discord/scope.test.ts
@@ -12,209 +12,94 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { stripSlash } from '../../utils/slash.ts'
-import { mountKey } from '../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
-import { detectScope } from './scope.ts'
-import { PathSpec } from '../../types.ts'
+
+import { INVALID, ROOT } from '../hierarchy/scope.ts'
+import { detectScope, NATIVE_KINDS } from './scope.ts'
+
+const CHAT = '/My Server__G1/channels/general__C1/2024-01-15/chat.jsonl'
 
 describe('detectScope', () => {
-  it('root → level=root, useNative=true, resourcePath /', () => {
-    const s = detectScope(new PathSpec({ resourcePath: '', virtual: '/', directory: '/' }))
-    expect(s.level).toBe('root')
-    expect(s.useNative).toBe(true)
-    expect(s.resourcePath).toBe('/')
+  it('classifies the root', () => {
+    expect(detectScope('/').kind).toBe(ROOT)
   })
 
-  it('/myserver__G1 → level=guild, guildName=myserver, guildId=G1, useNative=true', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver__G1',
-        virtual: '/myserver__G1',
-        directory: '/myserver__G1',
-      }),
-    )
-    expect(s.level).toBe('guild')
-    expect(s.guildName).toBe('myserver')
-    expect(s.guildId).toBe('G1')
-    expect(s.useNative).toBe(true)
+  it('classifies a guild and decodes both dirname halves', () => {
+    const match = detectScope('/My Server__G1')
+    expect(match.kind).toBe('guild')
+    expect(match.slots).toEqual({ guild: 'My Server', guild_id: 'G1' })
   })
 
-  it('/myserver__G1/channels → level=guild, container=channels, guildId=G1, useNative=true', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver__G1/channels',
-        virtual: '/myserver__G1/channels',
-        directory: '/myserver__G1/channels',
-      }),
-    )
-    expect(s.level).toBe('guild')
-    expect(s.container).toBe('channels')
-    expect(s.guildId).toBe('G1')
-    expect(s.useNative).toBe(true)
+  it('refuses a bare guild name', () => {
+    // The tree mints every dirname as `name__id`, so a bare name can never
+    // be a listed guild and classifies as invalid outright.
+    expect(detectScope('/My Server').kind).toBe(INVALID)
   })
 
-  it('/myserver__G1/members → level=guild, container=members, guildId=G1, useNative=false', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver__G1/members',
-        virtual: '/myserver__G1/members',
-        directory: '/myserver__G1/members',
-      }),
-    )
-    expect(s.level).toBe('guild')
-    expect(s.container).toBe('members')
-    expect(s.guildId).toBe('G1')
-    expect(s.useNative).toBe(false)
+  it('classifies the containers', () => {
+    expect(detectScope('/My Server__G1/channels').kind).toBe('channels_dir')
+    expect(detectScope('/My Server__G1/members').kind).toBe('members_dir')
+    expect(detectScope('/My Server__G1/nope').kind).toBe(INVALID)
   })
 
-  it('/myserver__G1/channels/general__C1 → level=channel, useNative=true', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver__G1/channels/general__C1',
-        virtual: '/myserver__G1/channels/general__C1',
-        directory: '/myserver__G1/channels/general__C1',
-      }),
-    )
-    expect(s.level).toBe('channel')
-    expect(s.guildName).toBe('myserver')
-    expect(s.guildId).toBe('G1')
-    expect(s.channelName).toBe('general')
-    expect(s.channelId).toBe('C1')
-    expect(s.container).toBe('channels')
-    expect(s.useNative).toBe(true)
+  it('classifies a channel', () => {
+    const match = detectScope('/My Server__G1/channels/general__C1')
+    expect(match.kind).toBe('channel')
+    expect(match.slots.channel).toBe('general')
+    expect(match.slots.channel_id).toBe('C1')
   })
 
-  it('/myserver__G1/channels/general__C1/2026-04-24/chat.jsonl → level=messages', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver__G1/channels/general__C1/2026-04-24/chat.jsonl',
-        virtual: '/myserver__G1/channels/general__C1/2026-04-24/chat.jsonl',
-        directory: '/myserver__G1/channels/general__C1/2026-04-24/chat.jsonl',
-      }),
-    )
-    expect(s.level).toBe('messages')
-    expect(s.dateStr).toBe('2026-04-24')
-    expect(s.useNative).toBe(false)
-    expect(s.guildId).toBe('G1')
-    expect(s.channelId).toBe('C1')
-    expect(s.container).toBe('channels')
+  it('classifies a member profile', () => {
+    const match = detectScope('/My Server__G1/members/alice__U1.json')
+    expect(match.kind).toBe('member')
+    expect(match.slots.member).toBe('alice')
+    expect(match.slots.user_id).toBe('U1')
   })
 
-  it('/myserver__G1/channels/general__C1/2026-04-24 → level=date', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver__G1/channels/general__C1/2026-04-24',
-        virtual: '/myserver__G1/channels/general__C1/2026-04-24',
-        directory: '/myserver__G1/channels/general__C1/2026-04-24',
-      }),
-    )
-    expect(s.level).toBe('date')
-    expect(s.dateStr).toBe('2026-04-24')
-    expect(s.useNative).toBe(true)
+  it('refuses a member without the .json suffix', () => {
+    expect(detectScope('/My Server__G1/members/alice__U1').kind).toBe(INVALID)
   })
 
-  it('/myserver__G1/channels/general__C1/2026-04-24/files/blob.png → level=file_blob', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: stripSlash(
-          '/myserver__G1/channels/general__C1/2026-04-24/files/blob__A1.png',
-        ),
-        virtual: '/myserver__G1/channels/general__C1/2026-04-24/files/blob__A1.png',
-        directory: '/myserver__G1/channels/general__C1/2026-04-24/files/blob__A1.png',
-      }),
-    )
-    expect(s.level).toBe('file_blob')
-    expect(s.dateStr).toBe('2026-04-24')
+  it('classifies a day directory', () => {
+    const match = detectScope('/My Server__G1/channels/general__C1/2024-01-15')
+    expect(match.kind).toBe('day')
+    expect(match.slots.day).toBe('2024-01-15')
   })
 
-  it('*.jsonl glob in channel dir → level=channel, useNative=true', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver__G1/channels/general__C1/*.jsonl',
-        virtual: '/myserver__G1/channels/general__C1/*.jsonl',
-        directory: '/myserver__G1/channels/general__C1',
-        pattern: '*.jsonl',
-      }),
-    )
-    expect(s.level).toBe('channel')
-    expect(s.useNative).toBe(true)
-    expect(s.guildId).toBe('G1')
-    expect(s.channelId).toBe('C1')
-    expect(s.container).toBe('channels')
+  it('refuses a non-date under a channel', () => {
+    expect(detectScope('/My Server__G1/channels/general__C1/notadate').kind).toBe(INVALID)
   })
 
-  it('handles dirname without __id (just name) gracefully', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver__G1/channels/general',
-        virtual: '/myserver__G1/channels/general',
-        directory: '/myserver__G1/channels/general',
-      }),
-    )
-    expect(s.level).toBe('channel')
-    expect(s.channelName).toBe('general')
-    expect(s.channelId).toBeUndefined()
+  it('classifies chat.jsonl as a leaf', () => {
+    const match = detectScope(CHAT)
+    expect(match.kind).toBe('messages')
+    expect(match.scope?.leaf).toBe(true)
   })
 
-  it('respects PathSpec.prefix', () => {
-    const s = detectScope(
-      new PathSpec({
-        virtual: '/discord/myserver__G1/channels/general__C1',
-        directory: '/discord/myserver__G1/channels/general__C1',
-        resourcePath: mountKey('/discord/myserver__G1/channels/general__C1', '/discord'),
-      }),
-    )
-    expect(s.level).toBe('channel')
-    expect(s.guildName).toBe('myserver')
-    expect(s.guildId).toBe('G1')
-    expect(s.channelName).toBe('general')
-    expect(s.channelId).toBe('C1')
+  it('classifies the files dir and its blobs', () => {
+    expect(detectScope('/My Server__G1/channels/general__C1/2024-01-15/files').kind).toBe('files')
+    const blob = detectScope('/My Server__G1/channels/general__C1/2024-01-15/files/kept__A1.txt')
+    expect(blob.kind).toBe('file_blob')
+    expect(blob.slots.blob).toBe('kept__A1.txt')
   })
 
-  it('respects PathSpec.prefix on glob inside channel dir', () => {
-    const s = detectScope(
-      new PathSpec({
-        virtual: '/discord/myserver__G1/channels/general__C1/*.jsonl',
-        directory: '/discord/myserver__G1/channels/general__C1',
-        pattern: '*.jsonl',
-        resourcePath: mountKey('/discord/myserver__G1/channels/general__C1/*.jsonl', '/discord'),
-      }),
+  it('refuses deep unknown paths and dot segments', () => {
+    expect(detectScope('/My Server__G1/channels/general__C1/2024-01-15/files/a/b').kind).toBe(
+      INVALID,
     )
-    expect(s.level).toBe('channel')
-    expect(s.useNative).toBe(true)
-    expect(s.guildId).toBe('G1')
-    expect(s.channelId).toBe('C1')
+    expect(detectScope('/My Server__G1/channels/.hidden__C1').kind).toBe(INVALID)
   })
+})
 
-  it('member json file → level=member, container=members, useNative=false', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver__G1/members/alice__U1.json',
-        virtual: '/myserver__G1/members/alice__U1.json',
-        directory: '/myserver__G1/members/alice__U1.json',
-      }),
-    )
-    expect(s.level).toBe('member')
-    expect(s.container).toBe('members')
-    expect(s.useNative).toBe(false)
-    expect(s.guildId).toBe('G1')
-    expect(s.memberName).toBe('alice')
-    expect(s.memberId).toBe('U1')
-    expect(s.channelName).toBeUndefined()
-    expect(s.channelId).toBeUndefined()
-  })
-
-  it('guild dirname without __id parsed gracefully', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'myserver',
-        virtual: '/myserver',
-        directory: '/myserver',
-      }),
-    )
-    expect(s.level).toBe('guild')
-    expect(s.guildName).toBe('myserver')
-    expect(s.guildId).toBeUndefined()
+describe('NATIVE_KINDS', () => {
+  it('excludes the rendered leaves', () => {
+    // chat.jsonl, member profiles and stored blobs are not answerable by
+    // the guild message search; the containers above them are.
+    expect(NATIVE_KINDS.has('messages')).toBe(false)
+    expect(NATIVE_KINDS.has('member')).toBe(false)
+    expect(NATIVE_KINDS.has('file_blob')).toBe(false)
+    for (const kind of ['guild', 'channel', 'day', 'files']) {
+      expect(NATIVE_KINDS.has(kind)).toBe(true)
+    }
   })
 })

--- a/typescript/packages/core/src/core/discord/scope.ts
+++ b/typescript/packages/core/src/core/discord/scope.ts
@@ -12,254 +12,56 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountPrefixOf } from '../../utils/key_prefix.ts'
-import type { PathSpec } from '../../types.ts'
-import { stripSlash } from '../../utils/slash.ts'
+import { DATE, JSON_NAME } from '../hierarchy/codec.ts'
+import { makeDetectScope, Scope, Slot } from '../hierarchy/scope.ts'
+import { FileType } from '../../types.ts'
 
-type DiscordLevel =
-  | 'root'
-  | 'guild'
-  | 'channel'
-  | 'date'
-  | 'messages'
-  | 'files'
-  | 'file_blob'
-  | 'member'
+const GUILD = [new Slot('guild', undefined, 'guild_id')] as const
+const CHANNEL = [...GUILD, 'channels', new Slot('channel', undefined, 'channel_id')] as const
+const DAY = [...CHANNEL, new Slot('day', DATE)] as const
 
-export interface DiscordScope {
-  level: DiscordLevel
-  useNative: boolean
-  guildName?: string
-  guildId?: string
-  channelName?: string
-  channelId?: string
-  memberName?: string
-  memberId?: string
-  container?: 'channels' | 'members'
-  dateStr?: string
-  resourcePath: string
-}
+// One description of the tree: readdir, stat, read and the search push-down
+// all classify through it, so the file surface and the command surface cannot
+// disagree about what a path means. Every dynamic level is a `name__id`
+// dirname the tree itself mints, so the ids decode from the path and
+// detection needs no index or network round-trip.
+export const SCOPES: readonly Scope[] = [
+  new Scope({ kind: 'guild', segments: GUILD }),
+  new Scope({ kind: 'channels_dir', segments: [...GUILD, 'channels'] }),
+  new Scope({ kind: 'members_dir', segments: [...GUILD, 'members'] }),
+  new Scope({ kind: 'channel', segments: CHANNEL }),
+  new Scope({
+    kind: 'member',
+    segments: [...GUILD, 'members', new Slot('member', JSON_NAME, 'user_id')],
+    leaf: true,
+    filetype: FileType.JSON,
+  }),
+  new Scope({ kind: 'day', segments: DAY }),
+  new Scope({
+    kind: 'messages',
+    segments: [...DAY, 'chat.jsonl'],
+    leaf: true,
+    filetype: FileType.TEXT,
+  }),
+  new Scope({ kind: 'files', segments: [...DAY, 'files'] }),
+  new Scope({
+    kind: 'file_blob',
+    segments: [...DAY, 'files', new Slot('blob')],
+    leaf: true,
+  }),
+]
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+export const detectScope = makeDetectScope(SCOPES)
 
-function stripSlashes(s: string): string {
-  return stripSlash(s)
-}
-
-function splitDirname(dirname: string): [string, string | undefined] {
-  const idx = dirname.lastIndexOf('__')
-  if (idx === -1) return [dirname, undefined]
-  const name = dirname.slice(0, idx)
-  const cid = dirname.slice(idx + 2)
-  return [name, cid.length > 0 ? cid : undefined]
-}
-
-export function detectScope(path: PathSpec): DiscordScope {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-
-  if (path.pattern?.endsWith('.jsonl')) {
-    let dirKey = stripSlashes(path.directory)
-    if (prefix) {
-      const stripped = stripSlashes(prefix) + '/'
-      if (dirKey.startsWith(stripped)) dirKey = dirKey.slice(stripped.length)
-    }
-    const dp = dirKey ? dirKey.split('/') : []
-    if (dp.length === 3 && dp[1] === 'channels' && dp[0] && dp[2]) {
-      const [guildName, guildId] = splitDirname(dp[0])
-      const [channelName, channelId] = splitDirname(dp[2])
-      return {
-        level: 'channel',
-        useNative: true,
-        guildName,
-        ...(guildId !== undefined ? { guildId } : {}),
-        channelName,
-        ...(channelId !== undefined ? { channelId } : {}),
-        container: 'channels',
-        resourcePath: dirKey,
-      }
-    }
-    if (
-      dp.length === 4 &&
-      dp[1] === 'channels' &&
-      dp[0] !== undefined &&
-      dp[2] !== undefined &&
-      dp[3] !== undefined &&
-      DATE_RE.test(dp[3])
-    ) {
-      const [guildName, guildId] = splitDirname(dp[0])
-      const [channelName, channelId] = splitDirname(dp[2])
-      return {
-        level: 'messages',
-        useNative: true,
-        guildName,
-        ...(guildId !== undefined ? { guildId } : {}),
-        channelName,
-        ...(channelId !== undefined ? { channelId } : {}),
-        container: 'channels',
-        dateStr: dp[3],
-        resourcePath: dirKey,
-      }
-    }
-  }
-
-  const key = path.resourcePath
-  if (!key) return { level: 'root', useNative: true, resourcePath: '/' }
-
-  const parts = key.split('/')
-  const [first, second, third, fourth, fifth, sixth] = parts
-
-  if (first === undefined) {
-    return { level: 'guild', useNative: false, resourcePath: key }
-  }
-
-  if (parts.length === 1) {
-    const [guildName, guildId] = splitDirname(first)
-    return {
-      level: 'guild',
-      useNative: true,
-      guildName,
-      ...(guildId !== undefined ? { guildId } : {}),
-      resourcePath: key,
-    }
-  }
-
-  if (parts.length === 2 && second !== undefined) {
-    const [guildName, guildId] = splitDirname(first)
-    if (second === 'channels' || second === 'members') {
-      return {
-        level: 'guild',
-        useNative: second === 'channels',
-        guildName,
-        ...(guildId !== undefined ? { guildId } : {}),
-        container: second,
-        resourcePath: key,
-      }
-    }
-    return {
-      level: 'guild',
-      useNative: false,
-      guildName,
-      ...(guildId !== undefined ? { guildId } : {}),
-      resourcePath: key,
-    }
-  }
-
-  if (parts.length === 3 && second !== undefined && third !== undefined) {
-    const [guildName, guildId] = splitDirname(first)
-    if (second === 'channels') {
-      const [channelName, channelId] = splitDirname(third)
-      return {
-        level: 'channel',
-        useNative: true,
-        guildName,
-        ...(guildId !== undefined ? { guildId } : {}),
-        channelName,
-        ...(channelId !== undefined ? { channelId } : {}),
-        container: 'channels',
-        resourcePath: key,
-      }
-    }
-    if (second === 'members') {
-      const stem = third.endsWith('.json') ? third.slice(0, -5) : third
-      const [memberName, memberId] = splitDirname(stem)
-      return {
-        level: 'member',
-        useNative: false,
-        guildName,
-        ...(guildId !== undefined ? { guildId } : {}),
-        memberName,
-        ...(memberId !== undefined ? { memberId } : {}),
-        container: 'members',
-        resourcePath: key,
-      }
-    }
-  }
-
-  // /<guild>/channels/<ch>/<date>
-  if (
-    parts.length === 4 &&
-    second === 'channels' &&
-    third !== undefined &&
-    fourth !== undefined &&
-    DATE_RE.test(fourth)
-  ) {
-    const [guildName, guildId] = splitDirname(first)
-    const [channelName, channelId] = splitDirname(third)
-    return {
-      level: 'date',
-      useNative: true,
-      guildName,
-      ...(guildId !== undefined ? { guildId } : {}),
-      channelName,
-      ...(channelId !== undefined ? { channelId } : {}),
-      container: 'channels',
-      dateStr: fourth,
-      resourcePath: key,
-    }
-  }
-
-  // /<guild>/channels/<ch>/<date>/chat.jsonl or /<date>/files
-  if (
-    parts.length === 5 &&
-    second === 'channels' &&
-    third !== undefined &&
-    fourth !== undefined &&
-    DATE_RE.test(fourth)
-  ) {
-    const [guildName, guildId] = splitDirname(first)
-    const [channelName, channelId] = splitDirname(third)
-    if (fifth === 'chat.jsonl') {
-      return {
-        level: 'messages',
-        useNative: false,
-        guildName,
-        ...(guildId !== undefined ? { guildId } : {}),
-        channelName,
-        ...(channelId !== undefined ? { channelId } : {}),
-        container: 'channels',
-        dateStr: fourth,
-        resourcePath: key,
-      }
-    }
-    if (fifth === 'files') {
-      return {
-        level: 'files',
-        useNative: true,
-        guildName,
-        ...(guildId !== undefined ? { guildId } : {}),
-        channelName,
-        ...(channelId !== undefined ? { channelId } : {}),
-        container: 'channels',
-        dateStr: fourth,
-        resourcePath: key,
-      }
-    }
-  }
-
-  // /<guild>/channels/<ch>/<date>/files/<blob>
-  if (
-    parts.length === 6 &&
-    second === 'channels' &&
-    third !== undefined &&
-    fourth !== undefined &&
-    DATE_RE.test(fourth) &&
-    fifth === 'files' &&
-    sixth !== undefined
-  ) {
-    const [guildName, guildId] = splitDirname(first)
-    const [channelName, channelId] = splitDirname(third)
-    return {
-      level: 'file_blob',
-      useNative: false,
-      guildName,
-      ...(guildId !== undefined ? { guildId } : {}),
-      channelName,
-      ...(channelId !== undefined ? { channelId } : {}),
-      container: 'channels',
-      dateStr: fourth,
-      resourcePath: key,
-    }
-  }
-
-  return { level: 'guild', useNative: false, resourcePath: key }
-}
+// Kinds the guild search push-down may answer for. A chat.jsonl operand is
+// deliberately absent: `searchGuild` takes a channel but no date, so serving
+// a one-day file from a channel-wide search would report messages the line
+// did not ask for. Same doctrine for `file_blob` and `member`, whose bytes
+// the message search does not carry.
+export const NATIVE_KINDS: ReadonlySet<string> = new Set([
+  'guild',
+  'channels_dir',
+  'channel',
+  'day',
+  'files',
+])

--- a/typescript/packages/core/src/core/discord/search.test.ts
+++ b/typescript/packages/core/src/core/discord/search.test.ts
@@ -115,11 +115,8 @@ describe('searchGuild', () => {
 
 describe('formatGrepResults', () => {
   const scope = {
-    level: 'guild' as const,
-    useNative: true,
     guildId: 'G1',
     guildName: 'My Server',
-    resourcePath: 'My Server__G1',
   }
 
   it('builds full VFS path with prefix, sanitized guild and channel dirs', () => {
@@ -172,7 +169,7 @@ describe('formatGrepResults', () => {
           content: 'msg',
         },
       ],
-      { ...scope, level: 'channel', channelId: 'C3', channelName: 'eng' },
+      { ...scope, channelName: 'eng' },
       '/discord',
     )
     expect(lines).toEqual([

--- a/typescript/packages/core/src/core/discord/search.ts
+++ b/typescript/packages/core/src/core/discord/search.ts
@@ -16,7 +16,6 @@ import type { DiscordAccessor } from '../../accessor/discord.ts'
 import { channelDirname, guildDirname } from './entry.ts'
 import { offsetPages } from './paginate.ts'
 import { snowflakeToIso } from './readdir.ts'
-import type { DiscordScope } from './scope.ts'
 
 const PAGE_SIZE = 25
 
@@ -79,13 +78,19 @@ function asString(value: unknown): string {
   return typeof value === 'string' ? value : ''
 }
 
+export interface SearchScope {
+  guildId: string
+  guildName?: string
+  channelName?: string
+}
+
 export function formatGrepResults(
   messages: readonly DiscordSearchMessage[],
-  scope: DiscordScope,
+  scope: SearchScope,
   prefix: string,
   channelNames: ReadonlyMap<string, string> = new Map(),
 ): string[] {
-  const guildId = scope.guildId ?? ''
+  const guildId = scope.guildId
   const guildVfs = guildDirname({
     id: guildId,
     ...(scope.guildName !== undefined ? { name: scope.guildName } : {}),

--- a/typescript/packages/core/src/core/discord/stat.test.ts
+++ b/typescript/packages/core/src/core/discord/stat.test.ts
@@ -23,10 +23,13 @@ import { stat } from './stat.ts'
 
 class FakeDiscordTransport implements DiscordTransport {
   public readonly calls: { method: DiscordMethod; endpoint: string }[] = []
-  constructor(private readonly responder: () => DiscordResponse = () => null) {}
+  constructor(
+    private readonly responder: (method: DiscordMethod, endpoint: string) => DiscordResponse = () =>
+      null,
+  ) {}
   call(method: DiscordMethod, endpoint: string): Promise<DiscordResponse> {
     this.calls.push({ method, endpoint })
-    return Promise.resolve(this.responder())
+    return Promise.resolve(this.responder(method, endpoint))
   }
 }
 
@@ -85,26 +88,35 @@ describe('stat guild dir', () => {
   })
 })
 
-describe('stat virtual containers under guild', () => {
-  it('returns DIRECTORY for /<g>/channels (no index lookup)', async () => {
-    const t = new FakeDiscordTransport()
+describe('stat containers under guild', () => {
+  const guilds = new FakeDiscordTransport((_m, endpoint) =>
+    endpoint === '/users/@me/guilds' ? [{ id: 'G1', name: 'My Server' }] : null,
+  )
+
+  it('returns DIRECTORY for /<g>/channels once the guild is proven', async () => {
     const out = await stat(
-      new DiscordAccessor(t),
+      new DiscordAccessor(guilds),
       spec('/mnt/discord/My Server__G1/channels', '/mnt/discord'),
     )
     expect(out.type).toBe(FileType.DIRECTORY)
     expect(out.name).toBe('channels')
-    expect(t.calls).toHaveLength(0)
   })
 
-  it('returns DIRECTORY for /<g>/members (no index lookup)', async () => {
-    const t = new FakeDiscordTransport()
+  it('returns DIRECTORY for /<g>/members once the guild is proven', async () => {
     const out = await stat(
-      new DiscordAccessor(t),
+      new DiscordAccessor(guilds),
       spec('/mnt/discord/My Server__G1/members', '/mnt/discord'),
     )
     expect(out.type).toBe(FileType.DIRECTORY)
     expect(out.name).toBe('members')
+  })
+
+  it('throws ENOENT for a container under a bogus guild', async () => {
+    // The containers exist per guild, so a guild the listing does not
+    // prove takes its children with it.
+    await expect(
+      stat(new DiscordAccessor(guilds), spec('/mnt/discord/Nope__G9/channels', '/mnt/discord')),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })
 
@@ -207,19 +219,47 @@ describe('stat member file', () => {
 })
 
 describe('stat history chat.jsonl', () => {
-  it('returns TEXT with chat.jsonl name (no index lookup)', async () => {
-    const t = new FakeDiscordTransport()
+  it('returns TEXT with the rendered size once the day is fetched', async () => {
+    const t = new FakeDiscordTransport((_m, endpoint) => {
+      if (endpoint === '/users/@me/guilds') return [{ id: 'G1', name: 'My Server' }]
+      if (endpoint === '/guilds/G1/channels') return [{ id: 'C1', name: 'general', type: 0 }]
+      if (endpoint === '/channels/C1/messages')
+        return [{ id: '1196300000000000000', content: 'hello' }]
+      return null
+    })
     const out = await stat(
       new DiscordAccessor(t),
       spec('/mnt/discord/My Server__G1/channels/general__C1/2024-01-15/chat.jsonl', '/mnt/discord'),
     )
     expect(out.type).toBe(FileType.TEXT)
     expect(out.name).toBe('chat.jsonl')
-    expect(t.calls).toHaveLength(0)
+    expect(out.size).not.toBeNull()
   })
 
-  it('returns DIRECTORY for date dir', async () => {
-    const t = new FakeDiscordTransport()
+  it('throws ENOENT for chat.jsonl under a bogus channel', async () => {
+    const t = new FakeDiscordTransport((_m, endpoint) => {
+      if (endpoint === '/users/@me/guilds') return [{ id: 'G1', name: 'My Server' }]
+      if (endpoint === '/guilds/G1/channels') return []
+      return null
+    })
+    await expect(
+      stat(
+        new DiscordAccessor(t),
+        spec(
+          '/mnt/discord/My Server__G1/channels/general__C1/2024-01-15/chat.jsonl',
+          '/mnt/discord',
+        ),
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('returns DIRECTORY for a date dir under a real channel', async () => {
+    const t = new FakeDiscordTransport((_m, endpoint) => {
+      if (endpoint === '/users/@me/guilds') return [{ id: 'G1', name: 'My Server' }]
+      if (endpoint === '/guilds/G1/channels') return [{ id: 'C1', name: 'general', type: 0 }]
+      if (endpoint === '/channels/C1/messages') return []
+      return null
+    })
     const out = await stat(
       new DiscordAccessor(t),
       spec('/mnt/discord/My Server__G1/channels/general__C1/2024-01-15', '/mnt/discord'),
@@ -268,7 +308,7 @@ describe('discord stat parent-listing failures', () => {
     await expect(
       stat(
         new DiscordAccessor(new FailingTransport(boom)),
-        spec('/mnt/discord/guild-a', '/mnt/discord'),
+        spec('/mnt/discord/guild-a__G7', '/mnt/discord'),
         new RAMIndexCacheStore(),
       ),
     ).rejects.toThrow('401 Unauthorized')
@@ -279,7 +319,7 @@ describe('discord stat parent-listing failures', () => {
     await expect(
       stat(
         new DiscordAccessor(new FailingTransport(gone)),
-        spec('/mnt/discord/guild-a', '/mnt/discord'),
+        spec('/mnt/discord/guild-a__G7', '/mnt/discord'),
         new RAMIndexCacheStore(),
       ),
     ).rejects.toMatchObject({ code: 'ENOENT' })

--- a/typescript/packages/core/src/core/discord/stat.ts
+++ b/typescript/packages/core/src/core/discord/stat.ts
@@ -12,164 +12,133 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { DiscordAccessor } from '../../accessor/discord.ts'
+import type { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
-import { readdir as coreReaddir, snowflakeToIso } from './readdir.ts'
-import { isMissingPath } from '../../utils/errors.ts'
+import { enoent } from '../../utils/errors.ts'
 import { filetypeFromMimetype } from '../../utils/filetype.ts'
-import { stripSlash } from '../../utils/slash.ts'
+import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
+import { resolveEntry } from '../hierarchy/probe.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
+import { entryStat, makeStat } from '../hierarchy/stat.ts'
+import { readdir, snowflakeToIso } from './readdir.ts'
+import { detectScope } from './scope.ts'
 
-const VIRTUAL_DIRS: ReadonlySet<string> = new Set(['channels', 'members'])
-
-function fileNotFound(key: string): Error {
-  const e = new Error(`ENOENT: ${key}`) as Error & { code: string }
-  e.code = 'ENOENT'
-  return e
+function dirStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({ name: entry.vfsName, type: FileType.DIRECTORY })
 }
 
-async function lookupWithFallback(
+function guildStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({
+    name: entry.vfsName !== '' ? entry.vfsName : entry.name,
+    type: FileType.DIRECTORY,
+    extra: { guild_id: entry.id },
+  })
+}
+
+function channelStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  const modified = snowflakeToIso(entry.remoteTime)
+  return new FileStat({
+    name: entry.vfsName !== '' ? entry.vfsName : entry.name,
+    type: FileType.DIRECTORY,
+    ...(modified !== null ? { modified } : {}),
+    extra: { channel_id: entry.id },
+  })
+}
+
+function fileBlobStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  const mimetype = typeof entry.extra.content_type === 'string' ? entry.extra.content_type : ''
+  return new FileStat({
+    name: entry.vfsName !== '' ? entry.vfsName : entry.name,
+    ...(entry.size !== null ? { size: entry.size } : {}),
+    type: filetypeFromMimetype(mimetype),
+    extra: { content_type: mimetype, attachment_id: entry.id },
+  })
+}
+
+/**
+ * Raise ENOENT unless the path's channel ancestor exists. `up` is how many
+ * trailing segments to drop to reach the channel (1 for a day dir, 2 for its
+ * children).
+ */
+async function channelProven(
   accessor: DiscordAccessor,
-  virtualKey: string,
-  prefix: string,
-  index: IndexCacheStore,
-) {
-  const result = await index.get(virtualKey)
-  if (result.entry !== undefined && result.entry !== null) return result
-  const parentVirtual = virtualKey.includes('/')
-    ? virtualKey.slice(0, virtualKey.lastIndexOf('/')) || '/'
-    : '/'
-  try {
-    await coreReaddir(
-      accessor,
-      new PathSpec({
-        virtual: parentVirtual,
-        directory: parentVirtual,
-        resolved: false,
-        resourcePath: mountKey(parentVirtual, prefix),
-      }),
-      index,
-    )
-  } catch (err) {
-    // Only a genuinely absent parent falls through to not-found. Auth,
-    // rate-limit and transport failures must propagate instead of reading
-    // back as ENOENT, which is what the Python side catches too.
-    if (!isMissingPath(err)) throw err
+  path: PathSpec,
+  index: IndexCacheStore | undefined,
+  up: number,
+): Promise<void> {
+  let virtual = path.virtual.replace(/\/+$/, '')
+  for (let i = 0; i < up; i++) virtual = virtual.split('/').slice(0, -1).join('/')
+  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
+  const spec = new PathSpec({
+    virtual,
+    directory: virtual,
+    resourcePath: mountKey(virtual, prefix),
+  })
+  if ((await resolveEntry(readdir, accessor, spec, index)) === null) {
+    throw enoent(path)
   }
-  return await index.get(virtualKey)
 }
 
-export async function stat(
+/**
+ * Stat a day directory, which resolves beyond the listed window.
+ *
+ * The channel listing synthesizes a bounded window of recent days, but the
+ * history API answers a range query for any date, so a well-formed day under
+ * a channel that exists is a directory whether or not the window lists it. A
+ * bogus channel chain is ENOENT.
+ */
+async function statDay(
   accessor: DiscordAccessor,
+  match: ScopeMatch,
   path: PathSpec,
   index?: IndexCacheStore,
 ): Promise<FileStat> {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  let raw = path.virtual
-  if (prefix !== '' && raw.startsWith(prefix)) {
-    raw = raw.slice(prefix.length) || '/'
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry !== null) {
+    return new FileStat({ name: entry.vfsName, type: FileType.DIRECTORY })
   }
-  const key = stripSlash(raw)
+  await channelProven(accessor, path, index, 1)
+  return new FileStat({ name: match.slots.day ?? '', type: FileType.DIRECTORY })
+}
 
-  if (key === '') {
-    return new FileStat({ name: '/', type: FileType.DIRECTORY })
-  }
-
-  const parts = key.split('/')
-  const part1 = parts[1] ?? ''
-  const part3 = parts[3] ?? ''
-  const virtualKey = `${prefix}/${key}`
-
-  if (parts.length === 1) {
-    if (index === undefined) throw fileNotFound(raw)
-    const lookup = await lookupWithFallback(accessor, virtualKey, prefix, index)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw fileNotFound(raw)
-    }
-    return new FileStat({
-      name: lookup.entry.vfsName !== '' ? lookup.entry.vfsName : lookup.entry.name,
-      type: FileType.DIRECTORY,
-      extra: { guild_id: lookup.entry.id },
-    })
-  }
-
-  if (parts.length === 2 && VIRTUAL_DIRS.has(part1)) {
-    return new FileStat({ name: part1, type: FileType.DIRECTORY })
-  }
-
-  if (parts.length === 3 && part1 === 'channels') {
-    if (index === undefined) throw fileNotFound(raw)
-    const lookup = await lookupWithFallback(accessor, virtualKey, prefix, index)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw fileNotFound(raw)
-    }
-    return new FileStat({
-      name: lookup.entry.vfsName !== '' ? lookup.entry.vfsName : lookup.entry.name,
-      type: FileType.DIRECTORY,
-      modified: snowflakeToIso(lookup.entry.remoteTime),
-      extra: { channel_id: lookup.entry.id },
-    })
-  }
-
-  if (parts.length === 3 && part1 === 'members') {
-    if (index === undefined) throw fileNotFound(raw)
-    const lookup = await lookupWithFallback(accessor, virtualKey, prefix, index)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw fileNotFound(raw)
-    }
-    return new FileStat({
-      name: lookup.entry.vfsName !== '' ? lookup.entry.vfsName : lookup.entry.name,
-      ...(lookup.entry.size !== null ? { size: lookup.entry.size } : {}),
-      type: FileType.JSON,
-      extra: { user_id: lookup.entry.id },
-    })
-  }
-
-  // <guild>/channels/<ch>/<date>
-  const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
-  if (parts.length === 4 && part1 === 'channels' && DATE_RE.test(part3)) {
-    return new FileStat({ name: part3, type: FileType.DIRECTORY })
-  }
-
-  // <guild>/channels/<ch>/<date>/chat.jsonl
-  if (
-    parts.length === 5 &&
-    part1 === 'channels' &&
-    DATE_RE.test(part3) &&
-    parts[4] === 'chat.jsonl'
-  ) {
-    if (index === undefined) return new FileStat({ name: 'chat.jsonl', type: FileType.TEXT })
-    const lookup = await lookupWithFallback(accessor, virtualKey, prefix, index)
-    // A day whose history could not be listed (403/404/429) seals an empty
-    // date dir; the file still stats, with the size left unknown.
-    const size = lookup.entry?.size
+/**
+ * Stat chat.jsonl, which survives a sealed day.
+ *
+ * A day whose history could not be listed (403/404/429) seals an empty date
+ * dir; the file still stats, with the size left unknown.
+ */
+async function statChat(
+  accessor: DiscordAccessor,
+  _match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<FileStat> {
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry !== null) {
     return new FileStat({
       name: 'chat.jsonl',
-      ...(size !== undefined && size !== null ? { size } : {}),
       type: FileType.TEXT,
+      ...(entry.size !== null ? { size: entry.size } : {}),
     })
   }
-
-  // <guild>/channels/<ch>/<date>/files
-  if (parts.length === 5 && part1 === 'channels' && DATE_RE.test(part3) && parts[4] === 'files') {
-    return new FileStat({ name: 'files', type: FileType.DIRECTORY })
-  }
-
-  // <guild>/channels/<ch>/<date>/files/<blob>
-  if (parts.length === 6 && part1 === 'channels' && DATE_RE.test(part3) && parts[4] === 'files') {
-    if (index === undefined) throw fileNotFound(raw)
-    const lookup = await lookupWithFallback(accessor, virtualKey, prefix, index)
-    if (lookup.entry === undefined || lookup.entry === null) throw fileNotFound(raw)
-    const extra = lookup.entry.extra
-    const mime = typeof extra.content_type === 'string' ? extra.content_type : ''
-    return new FileStat({
-      name: lookup.entry.vfsName !== '' ? lookup.entry.vfsName : lookup.entry.name,
-      ...(lookup.entry.size !== null ? { size: lookup.entry.size } : {}),
-      type: filetypeFromMimetype(mime),
-      extra: { content_type: mime, attachment_id: lookup.entry.id },
-    })
-  }
-
-  throw fileNotFound(raw)
+  await channelProven(accessor, path, index, 2)
+  return new FileStat({ name: 'chat.jsonl', type: FileType.TEXT })
 }
+
+export const stat = makeStat<DiscordAccessor>(detectScope, readdir, {
+  entryStats: {
+    guild: guildStat,
+    channels_dir: dirStat,
+    members_dir: dirStat,
+    channel: channelStat,
+    member: entryStat('user_id', FileType.JSON),
+    files: dirStat,
+    file_blob: fileBlobStat,
+  },
+  overrides: {
+    day: statDay,
+    messages: statChat,
+  },
+})

--- a/typescript/packages/core/src/core/gmail/read.ts
+++ b/typescript/packages/core/src/core/gmail/read.ts
@@ -12,45 +12,44 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { GmailAccessor } from '../../accessor/gmail.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { entryOrWarm } from '../../cache/index/warm.ts'
-import { PathSpec } from '../../types.ts'
+import type { PathSpec } from '../../types.ts'
+import { enoent } from '../../utils/errors.ts'
+import { resolveEntry } from '../hierarchy/probe.ts'
+import { makeRead } from '../hierarchy/read.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { getAttachment, getMessageRaw, messageJsonBytes } from './messages.ts'
 import { readdir } from './readdir.ts'
-import { gnuDirname } from '../../utils/path.ts'
-import { eisdir, enoent } from '../../utils/errors.ts'
+import { detectScope } from './scope.ts'
 
-export async function read(
+async function readMessage(
   accessor: GmailAccessor,
+  _match: ScopeMatch,
   path: PathSpec,
   index?: IndexCacheStore,
 ): Promise<Uint8Array> {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  const key = path.resourcePath
-  if (index === undefined) throw enoent(path.virtual)
-  const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
-  const parentKey = gnuDirname(virtualKey)
-  const entry = await entryOrWarm(
-    index,
-    virtualKey,
-    parentKey !== virtualKey
-      ? () => readdir(accessor, PathSpec.fromStrPath(parentKey, mountKey(parentKey, prefix)), index)
-      : null,
-  )
-  if (entry === null) throw enoent(path.virtual)
-  const rt = entry.resourceType
-  if (rt === 'gmail/label' || rt === 'gmail/date' || rt === 'gmail/attachment_dir') {
-    throw eisdir(path.virtual)
-  }
-  if (rt === 'gmail/attachment') {
-    const parentResult = await index.get(parentKey)
-    if (parentResult.entry === undefined || parentResult.entry === null) {
-      throw enoent(path.virtual)
-    }
-    return getAttachment(accessor.tokenManager, parentResult.entry.id, entry.id)
-  }
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry === null) throw enoent(path)
   const raw = await getMessageRaw(accessor.tokenManager, entry.id)
   return messageJsonBytes(raw)
 }
+
+async function readAttachment(
+  accessor: GmailAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<Uint8Array> {
+  // The message id decodes from the attachment dir's `subject__id`
+  // segment; the attachment id only exists in the listing, so the entry
+  // stays the proof of existence AND the id source.
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry === null) throw enoent(path)
+  return getAttachment(accessor.tokenManager, match.slots.message_id ?? '', entry.id)
+}
+
+export const read = makeRead<GmailAccessor>(detectScope, {
+  message: readMessage,
+  attachment: readAttachment,
+})

--- a/typescript/packages/core/src/core/gmail/readdir.ts
+++ b/typescript/packages/core/src/core/gmail/readdir.ts
@@ -12,11 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { GmailAccessor } from '../../accessor/gmail.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
-import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { PathSpec } from '../../types.ts'
+import { NAME_MAX_BYTES, byteLength, sanitizeLabel } from '../../utils/sanitize.ts'
+import { compareCodePoints } from '../../utils/sort.ts'
+import { makeReaddir, type DirListing, type Listed } from '../hierarchy/readdir.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { listLabels } from './labels.ts'
 import type { GmailMessageRaw } from './messages.ts'
 import {
@@ -26,12 +27,11 @@ import {
   listMessages,
   messageJsonBytes,
 } from './messages.ts'
-import { enoent } from '../../utils/errors.ts'
-import { NAME_MAX_BYTES, byteLength, sanitizeLabel } from '../../utils/sanitize.ts'
-import { compareCodePoints } from '../../utils/sort.ts'
+import { detectScope } from './scope.ts'
 
 const TITLE_MAX = 80
 const MSG_SUFFIX = '.gmail.json'
+const MAX_MESSAGES = 50
 
 export const sanitize = (text: string, maxBytes?: number): string =>
   sanitizeLabel(text, {
@@ -61,150 +61,168 @@ function dateFromInternal(internalDate: string | undefined): string {
   return `${yyyy}-${mm}-${dd}`
 }
 
-export async function readdir(
-  accessor: GmailAccessor,
-  path: PathSpec,
-  index?: IndexCacheStore,
-): Promise<string[]> {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  const key = (path.pattern !== null ? path.dir : path).resourcePath
-  const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
-  const parts = key === '' ? [] : key.split('/')
-  const depth = parts.length
+function attachmentEntries(raw: GmailMessageRaw): [string, IndexEntry][] {
+  return extractAttachments(raw.payload).map(
+    (att) =>
+      [
+        att.filename,
+        new IndexEntry({
+          id: att.attachmentId,
+          name: att.filename,
+          resourceType: 'gmail/attachment',
+          vfsName: att.filename,
+          size: att.size,
+        }),
+      ] as [string, IndexEntry],
+  )
+}
 
-  if (depth === 0) {
-    if (index !== undefined) {
-      const cached = await index.listDir(virtualKey)
-      if (cached.entries !== undefined && cached.entries !== null) return cached.entries
+/** One date directory's children, plus its attachment-dir seeds. */
+function dateChildren(raws: readonly GmailMessageRaw[]): {
+  children: [string, IndexEntry][]
+  seeds: Record<string, [string, IndexEntry][]>
+} {
+  const children: [string, IndexEntry][] = []
+  const seeds: Record<string, [string, IndexEntry][]> = {}
+  for (const raw of raws) {
+    const mid = raw.id ?? ''
+    const headers = raw.payload?.headers ?? []
+    const subject = extractHeader(headers, 'Subject') || 'No Subject'
+    const filename = msgFilename(subject, mid)
+    // The listing already fetched the full message, so the exact rendered
+    // .gmail.json length is free; sizeEstimate is the source message size
+    // and stays in extra.
+    children.push([
+      filename,
+      new IndexEntry({
+        id: mid,
+        name: subject,
+        resourceType: 'gmail/message',
+        vfsName: filename,
+        size: messageJsonBytes(raw).byteLength,
+        extra: raw.sizeEstimate != null ? { size_estimate: raw.sizeEstimate } : {},
+      }),
+    ])
+    const attEntries = attachmentEntries(raw)
+    if (attEntries.length > 0) {
+      const attDirName = filename.replace('.gmail.json', '')
+      children.push([
+        attDirName,
+        new IndexEntry({
+          id: mid,
+          name: attDirName,
+          resourceType: 'gmail/attachment_dir',
+          vfsName: attDirName,
+        }),
+      ])
+      seeds[attDirName] = attEntries
     }
-    const labels = await listLabels(accessor.tokenManager)
-    const entries: [string, IndexEntry][] = []
-    for (const lb of labels) {
-      const name = lb.type === 'system' ? lb.id : (lb.name ?? lb.id)
-      const entry = new IndexEntry({
+  }
+  return { children, seeds }
+}
+
+async function groupByDate(
+  accessor: GmailAccessor,
+  msgIds: readonly { id: string }[],
+): Promise<Map<string, GmailMessageRaw[]>> {
+  const groups = new Map<string, GmailMessageRaw[]>()
+  for (const m of msgIds) {
+    const raw = await getMessageRaw(accessor.tokenManager, m.id)
+    const dateStr = dateFromInternal(raw.internalDate)
+    let bucket = groups.get(dateStr)
+    if (bucket === undefined) {
+      bucket = []
+      groups.set(dateStr, bucket)
+    }
+    bucket.push(raw)
+  }
+  return groups
+}
+
+async function listRoot(accessor: GmailAccessor, _match: ScopeMatch): Promise<Listed | null> {
+  const labels = await listLabels(accessor.tokenManager)
+  return labels.map((lb) => {
+    const name = lb.type === 'system' ? lb.id : (lb.name ?? lb.id)
+    return [
+      name,
+      new IndexEntry({
         id: lb.id,
         name,
         resourceType: 'gmail/label',
         vfsName: name,
-      })
-      entries.push([name, entry])
-    }
-    if (index !== undefined) await index.setDir(virtualKey, entries)
-    return entries.map(([name]) => `${prefix}/${name}`)
-  }
+      }),
+    ] as [string, IndexEntry]
+  })
+}
 
-  if (depth === 1) {
-    const labelName = parts[0] ?? ''
-    if (index !== undefined) {
-      const cached = await index.listDir(virtualKey)
-      if (cached.entries !== undefined && cached.entries !== null) return cached.entries
-    }
-    if (index === undefined) throw enoent(path.virtual)
-    const labelKey = prefix !== '' ? `${prefix}/${labelName}` : `/${labelName}`
-    let result = await index.get(labelKey)
-    if (result.entry === undefined || result.entry === null) {
-      try {
-        const root = new PathSpec({
-          virtual: prefix !== '' ? prefix : '/',
-          directory: prefix !== '' ? prefix : '/',
-          resourcePath: mountKey(prefix !== '' ? prefix : '/', prefix),
-        })
-        await readdir(accessor, root, index)
-        result = await index.get(labelKey)
-      } catch {
-        // ignore — falls through to ENOENT below
-      }
-    }
-    if (result.entry === undefined || result.entry === null) throw enoent(path.virtual)
-    const labelId = result.entry.id
-    const msgIds = await listMessages(accessor.tokenManager, { labelId, maxResults: 50 })
-    const dateGroups = new Map<string, GmailMessageRaw[]>()
-    for (const m of msgIds) {
-      const mid = m.id
-      const rawMsg = await getMessageRaw(accessor.tokenManager, mid)
-      const dateStr = dateFromInternal(rawMsg.internalDate)
-      let bucket = dateGroups.get(dateStr)
-      if (bucket === undefined) {
-        bucket = []
-        dateGroups.set(dateStr, bucket)
-      }
-      bucket.push(rawMsg)
-    }
-    const sortedDates = [...dateGroups.keys()].sort(compareCodePoints).reverse()
-    const dateEntries: [string, IndexEntry][] = []
-    for (const dateStr of sortedDates) {
-      const dateEntry = new IndexEntry({
+async function listLabel(
+  accessor: GmailAccessor,
+  _match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  const msgIds = await listMessages(accessor.tokenManager, {
+    labelId: own.id,
+    maxResults: MAX_MESSAGES,
+  })
+  const groups = await groupByDate(accessor, msgIds)
+  const sortedDates = [...groups.keys()].sort(compareCodePoints).reverse()
+  const entries: [string, IndexEntry][] = []
+  const seeds: Record<string, [string, IndexEntry][]> = {}
+  for (const dateStr of sortedDates) {
+    entries.push([
+      dateStr,
+      new IndexEntry({
         id: dateStr,
         name: dateStr,
         resourceType: 'gmail/date',
         vfsName: dateStr,
-      })
-      dateEntries.push([dateStr, dateEntry])
-      const msgEntries: [string, IndexEntry][] = []
-      for (const rawMsg of dateGroups.get(dateStr) ?? []) {
-        const mid = rawMsg.id ?? ''
-        const headers = rawMsg.payload?.headers ?? []
-        const subject = extractHeader(headers, 'Subject') || 'No Subject'
-        const filename = msgFilename(subject, mid)
-        // The listing already fetched the full message, so the exact
-        // rendered .gmail.json length is free; sizeEstimate is the source
-        // message size and stays in extra.
-        const msgEntry = new IndexEntry({
-          id: mid,
-          name: subject,
-          resourceType: 'gmail/message',
-          vfsName: filename,
-          size: messageJsonBytes(rawMsg).byteLength,
-          extra: rawMsg.sizeEstimate != null ? { size_estimate: rawMsg.sizeEstimate } : {},
-        })
-        msgEntries.push([filename, msgEntry])
-        const attachments = extractAttachments(rawMsg.payload)
-        if (attachments.length > 0) {
-          const attDirName = filename.replace('.gmail.json', '')
-          const attDirEntry = new IndexEntry({
-            id: mid,
-            name: attDirName,
-            resourceType: 'gmail/attachment_dir',
-            vfsName: attDirName,
-          })
-          msgEntries.push([attDirName, attDirEntry])
-          const attEntries: [string, IndexEntry][] = []
-          for (const att of attachments) {
-            const attEntry = new IndexEntry({
-              id: att.attachmentId,
-              name: att.filename,
-              resourceType: 'gmail/attachment',
-              vfsName: att.filename,
-              size: att.size,
-            })
-            attEntries.push([att.filename, attEntry])
-          }
-          const attDirVKey = `${virtualKey}/${dateStr}/${attDirName}`
-          await index.setDir(attDirVKey, attEntries)
-        }
-      }
-      const dateVKey = `${virtualKey}/${dateStr}`
-      await index.setDir(dateVKey, msgEntries)
+        extra: { label_id: own.id },
+      }),
+    ])
+    const { children, seeds: attSeeds } = dateChildren(groups.get(dateStr) ?? [])
+    seeds[dateStr] = children
+    for (const [attDir, attEntries] of Object.entries(attSeeds)) {
+      seeds[`${dateStr}/${attDir}`] = attEntries
     }
-    await index.setDir(virtualKey, dateEntries)
-    return dateEntries.map(([name]) => `${prefix}/${key}/${name}`)
   }
-
-  if (depth === 2 || depth === 3) {
-    if (index === undefined) throw enoent(path.virtual)
-    let cached = await index.listDir(virtualKey)
-    if (cached.entries !== undefined && cached.entries !== null) return cached.entries
-    const labelPath = prefix !== '' ? `${prefix}/${parts[0] ?? ''}` : `/${parts[0] ?? ''}`
-    const labelSpec = new PathSpec({
-      virtual: labelPath,
-      directory: labelPath,
-      resourcePath: mountKey(labelPath, prefix),
-    })
-    await readdir(accessor, labelSpec, index)
-    cached = await index.listDir(virtualKey)
-    if (cached.entries !== undefined && cached.entries !== null) return cached.entries
-    throw enoent(path.virtual)
-  }
-
-  throw enoent(path.virtual)
+  return { entries, seeds }
 }
+
+async function listDay(
+  accessor: GmailAccessor,
+  match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  // Normally served from the label lister's seed; reached only when the
+  // index evicted the day listing while the date entry survived. The TS
+  // client has no date-scoped query (python pushes one down), so the
+  // fallback replays the label's recent window and keeps the day's bucket.
+  const labelId = typeof own.extra.label_id === 'string' ? own.extra.label_id : ''
+  if (labelId === '') return []
+  const msgIds = await listMessages(accessor.tokenManager, {
+    labelId,
+    maxResults: MAX_MESSAGES,
+  })
+  const groups = await groupByDate(accessor, msgIds)
+  const { children, seeds } = dateChildren(groups.get(match.slots.day ?? '') ?? [])
+  const listing: DirListing = { entries: children, seeds }
+  return listing
+}
+
+async function listAttachmentDir(
+  accessor: GmailAccessor,
+  _match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  const raw = await getMessageRaw(accessor.tokenManager, own.id)
+  return attachmentEntries(raw)
+}
+
+export const readdir = makeReaddir<GmailAccessor>(detectScope, {
+  listers: { root: listRoot },
+  entryListers: {
+    label: listLabel,
+    day: listDay,
+    attachment_dir: listAttachmentDir,
+  },
+})

--- a/typescript/packages/core/src/core/gmail/scope.ts
+++ b/typescript/packages/core/src/core/gmail/scope.ts
@@ -12,63 +12,43 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountPrefixOf } from '../../utils/key_prefix.ts'
-import type { PathSpec } from '../../types.ts'
-import { stripSlash } from '../../utils/slash.ts'
+import { Codec, DATE } from '../hierarchy/codec.ts'
+import { makeDetectScope, ROOT, Scope, Slot } from '../hierarchy/scope.ts'
+import { FileType } from '../../types.ts'
 
-export interface GmailScope {
-  useNative: boolean
-  labelName: string | null
-  dateStr: string | null
-  resourcePath: string
-}
+export const GMAIL_JSON = new Codec({ suffix: '.gmail.json' })
 
-export function detectScope(path: PathSpec): GmailScope {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath) || ''
+const LABEL = [new Slot('label')] as const
+const DAY = [...LABEL, new Slot('day', DATE)] as const
 
-  if (path.pattern?.endsWith('.gmail.json')) {
-    let dirKey = stripSlash(path.directory)
-    const trimmedPrefix = stripSlash(prefix)
-    if (trimmedPrefix !== '' && dirKey.startsWith(`${trimmedPrefix}/`)) {
-      dirKey = dirKey.slice(trimmedPrefix.length + 1)
-    }
-    const parts = dirKey === '' ? [] : dirKey.split('/')
-    if (parts.length === 2) {
-      return {
-        useNative: true,
-        labelName: parts[0] ?? null,
-        dateStr: parts[1] ?? null,
-        resourcePath: dirKey,
-      }
-    }
-  }
+// One description of the tree: readdir, stat, read and the search push-down
+// all classify through it, so the file surface and the command surface
+// cannot disagree about what a path means. The message scope is declared
+// before the attachment dir because only the suffix separates the two at
+// that depth.
+export const SCOPES: readonly Scope[] = [
+  new Scope({ kind: 'label', segments: LABEL }),
+  new Scope({ kind: 'day', segments: DAY }),
+  new Scope({
+    kind: 'message',
+    segments: [...DAY, new Slot('message', GMAIL_JSON, 'message_id')],
+    leaf: true,
+    filetype: FileType.JSON,
+  }),
+  new Scope({
+    kind: 'attachment_dir',
+    segments: [...DAY, new Slot('attachment_dir', undefined, 'message_id')],
+  }),
+  new Scope({
+    kind: 'attachment',
+    segments: [...DAY, new Slot('attachment_dir', undefined, 'message_id'), new Slot('filename')],
+    leaf: true,
+  }),
+]
 
-  const key = path.resourcePath
-  if (key === '') {
-    return { useNative: true, labelName: null, dateStr: null, resourcePath: '/' }
-  }
+export const detectScope = makeDetectScope(SCOPES)
 
-  const parts = key.split('/')
-  if (parts.length === 1) {
-    return {
-      useNative: true,
-      labelName: parts[0] ?? null,
-      dateStr: null,
-      resourcePath: key,
-    }
-  }
-  if (parts.length === 2) {
-    return {
-      useNative: true,
-      labelName: parts[0] ?? null,
-      dateStr: parts[1] ?? null,
-      resourcePath: key,
-    }
-  }
-  return {
-    useNative: false,
-    labelName: parts[0] ?? null,
-    dateStr: parts.length >= 2 ? (parts[1] ?? null) : null,
-    resourcePath: key,
-  }
-}
+// Kinds the Gmail search push-down may answer for: the whole account, one
+// label, or one label's day. A message file or an attachment names one
+// node, which a query over the account cannot stand in for.
+export const NATIVE_KINDS: ReadonlySet<string> = new Set([ROOT, 'label', 'day'])

--- a/typescript/packages/core/src/core/gmail/search.test.ts
+++ b/typescript/packages/core/src/core/gmail/search.test.ts
@@ -14,14 +14,8 @@
 
 import { describe, expect, it } from 'vitest'
 import { formatGrepResults, type GmailSearchRow } from './search.ts'
-import type { GmailScope } from './scope.ts'
 
-const SCOPE: GmailScope = {
-  useNative: true,
-  labelName: 'INBOX',
-  dateStr: null,
-  resourcePath: '/',
-}
+const LABEL = 'INBOX'
 
 const EMOJI = '\u{1F600}'
 
@@ -61,7 +55,7 @@ describe('formatGrepResults excerpts', () => {
     // 200 emoji are 200 code points and 400 UTF-16 units: python returns all
     // of them, and measuring in units returned 117 plus a split 118th pair.
     const body = EMOJI.repeat(200)
-    const excerpt = excerptOf(formatGrepResults([row(body)], SCOPE, '/gmail', 'zzz'))
+    const excerpt = excerptOf(formatGrepResults([row(body)], LABEL, '/gmail', 'zzz'))
     expect(excerpt).toBe(`note ${body}`)
     expect(Array.from(excerpt)).toHaveLength(205)
     expect(roundTrip(excerpt)).not.toContain('�')
@@ -70,7 +64,7 @@ describe('formatGrepResults excerpts', () => {
   it('windows around the match on code-point boundaries', () => {
     const pad = EMOJI.repeat(200)
     const excerpt = excerptOf(
-      formatGrepResults([row(`${pad} needle ${pad}`)], SCOPE, '/gmail', 'needle'),
+      formatGrepResults([row(`${pad} needle ${pad}`)], LABEL, '/gmail', 'needle'),
     )
     // `note ` + 200 emoji + ` needle ` + 200 emoji, windowed 120 code points
     // either side of the hit at index 206 and clipped to the body's end.
@@ -80,12 +74,12 @@ describe('formatGrepResults excerpts', () => {
 
   it('leaves an ascii excerpt exactly where python leaves it', () => {
     const body = `${'a'.repeat(300)} needle ${'b'.repeat(300)}`
-    const excerpt = excerptOf(formatGrepResults([row(body)], SCOPE, '/gmail', 'needle'))
+    const excerpt = excerptOf(formatGrepResults([row(body)], LABEL, '/gmail', 'needle'))
     expect(excerpt).toBe(`...${'a'.repeat(119)} needle ${'b'.repeat(119)}...`)
   })
 
   it('falls back to the snippet when the pattern is empty', () => {
-    const lines = formatGrepResults([row('body')], SCOPE, '/gmail')
+    const lines = formatGrepResults([row('body')], LABEL, '/gmail')
     expect(lines).toEqual(['/gmail/INBOX/2026-08-19/note__m1.gmail.json:[a@b.c] fallback snippet'])
   })
 })

--- a/typescript/packages/core/src/core/gmail/search.ts
+++ b/typescript/packages/core/src/core/gmail/search.ts
@@ -15,7 +15,6 @@
 import type { TokenManager } from '../google/client.ts'
 import { decodeBody, extractHeader, getMessageRaw, listMessages } from './messages.ts'
 import { msgFilename } from './readdir.ts'
-import type { GmailScope } from './scope.ts'
 
 const EXCERPT_WINDOW = 120
 const EXCERPT_MAX = 240
@@ -106,13 +105,13 @@ export async function searchMessages(
 
 export function formatGrepResults(
   rows: GmailSearchRow[],
-  scope: GmailScope,
+  labelName: string | null,
   prefix: string,
   pattern = '',
 ): string[] {
   const lines: string[] = []
   for (const row of rows) {
-    const label = row.label !== '' ? row.label : (scope.labelName ?? 'INBOX')
+    const label = row.label !== '' ? row.label : (labelName ?? 'INBOX')
     const date = row.date
     const mid = row.id
     // The same builder readdir names the file with, not a second spelling of

--- a/typescript/packages/core/src/core/gmail/stat.ts
+++ b/typescript/packages/core/src/core/gmail/stat.ts
@@ -12,92 +12,60 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { GmailAccessor } from '../../accessor/gmail.ts'
-import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { FileStat, FileType, PathSpec } from '../../types.ts'
-import { readdir as coreReaddir } from './readdir.ts'
-import { listLabels } from './labels.ts'
-import { enoent } from '../../utils/errors.ts'
+import type { IndexEntry } from '../../cache/index/config.ts'
+import type { PathSpec } from '../../types.ts'
+import { FileStat, FileType } from '../../types.ts'
 import { guessType } from '../../utils/filetype.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
+import { makeStat } from '../hierarchy/stat.ts'
+import { readdir } from './readdir.ts'
+import { detectScope } from './scope.ts'
 
-export async function stat(
-  accessor: GmailAccessor,
-  path: PathSpec,
-  index?: IndexCacheStore,
-): Promise<FileStat> {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  const key = path.resourcePath
-  if (key === '') return new FileStat({ name: '/', type: FileType.DIRECTORY })
-
-  if (index === undefined) throw enoent(path.virtual)
-  const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
-  let result = await index.get(virtualKey)
-  if (result.entry === undefined || result.entry === null) {
-    if (!key.includes('/')) {
-      const labels = await listLabels(accessor.tokenManager)
-      const names = new Set(labels.map((lb) => (lb.type === 'system' ? lb.id : (lb.name ?? lb.id))))
-      if (names.has(key)) return new FileStat({ name: key, type: FileType.DIRECTORY })
-      throw enoent(path.virtual)
-    }
-    const parentVirtual = virtualKey.slice(0, virtualKey.lastIndexOf('/')) || '/'
-    try {
-      await coreReaddir(
-        accessor,
-        new PathSpec({
-          virtual: parentVirtual,
-          directory: parentVirtual,
-          resolved: false,
-          resourcePath: mountKey(parentVirtual, prefix),
-        }),
-        index,
-      )
-    } catch {
-      // parent listing failed — fall through
-    }
-    result = await index.get(virtualKey)
-    if (result.entry === undefined || result.entry === null) {
-      throw enoent(path.virtual)
-    }
-  }
-  const rt = result.entry.resourceType
-  const vfsName = result.entry.vfsName !== '' ? result.entry.vfsName : result.entry.name
-  if (rt === 'gmail/label') {
-    return new FileStat({
-      name: vfsName,
-      type: FileType.DIRECTORY,
-      extra: { label_id: result.entry.id },
-    })
-  }
-  if (rt === 'gmail/date') {
-    return new FileStat({ name: vfsName, type: FileType.DIRECTORY })
-  }
-  if (rt === 'gmail/message') {
-    return new FileStat({
-      name: vfsName,
-      type: FileType.JSON,
-      size: result.entry.size,
-      extra: { message_id: result.entry.id, ...result.entry.extra },
-    })
-  }
-  if (rt === 'gmail/attachment_dir') {
-    return new FileStat({
-      name: vfsName,
-      type: FileType.DIRECTORY,
-      extra: { message_id: result.entry.id },
-    })
-  }
-  if (rt === 'gmail/attachment') {
-    return new FileStat({
-      name: vfsName,
-      type: guessType(vfsName),
-      size: result.entry.size,
-      extra: { attachment_id: result.entry.id },
-    })
-  }
+function labelStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
   return new FileStat({
-    name: vfsName,
-    type: FileType.JSON,
-    extra: { message_id: result.entry.id },
+    name: entry.vfsName,
+    type: FileType.DIRECTORY,
+    extra: { label_id: entry.id },
   })
 }
+
+function dayStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({ name: entry.vfsName, type: FileType.DIRECTORY })
+}
+
+function messageStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({
+    name: entry.vfsName,
+    type: FileType.JSON,
+    size: entry.size,
+    extra: { message_id: entry.id, ...entry.extra },
+  })
+}
+
+function attachmentDirStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({
+    name: entry.vfsName,
+    type: FileType.DIRECTORY,
+    extra: { message_id: entry.id },
+  })
+}
+
+function attachmentStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({
+    name: entry.vfsName,
+    type: guessType(entry.vfsName),
+    size: entry.size,
+    extra: { attachment_id: entry.id },
+  })
+}
+
+export const stat = makeStat<GmailAccessor>(detectScope, readdir, {
+  entryStats: {
+    label: labelStat,
+    day: dayStat,
+    message: messageStat,
+    attachment_dir: attachmentDirStat,
+    attachment: attachmentStat,
+  },
+})

--- a/typescript/packages/core/src/core/hierarchy/codec.test.ts
+++ b/typescript/packages/core/src/core/hierarchy/codec.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { INT_JSON, JSON_NAME, JSONL_NAME, RAW, asciiDigits } from './codec.ts'
+import { DATE, INT_JSON, JSON_NAME, JSONL_NAME, RAW, asciiDigits } from './codec.ts'
 
 describe('hierarchy codec', () => {
   it('RAW takes any nonempty segment', () => {
@@ -48,5 +48,18 @@ describe('hierarchy codec', () => {
     expect(asciiDigits('42')).toBe(true)
     expect(asciiDigits('4x2')).toBe(false)
     expect(asciiDigits('')).toBe(false)
+  })
+})
+
+describe('DATE', () => {
+  it('is shape only, not a calendar check', () => {
+    // The dated-message backends mint their date directories from real
+    // timestamps, so a shaped-but-absent date resolves through the
+    // listing like any other name.
+    expect(DATE.decode('2024-01-15')).toBe('2024-01-15')
+    expect(DATE.decode('2026-02-30')).toBe('2026-02-30')
+    expect(DATE.decode('2024-1-15')).toBeNull()
+    expect(DATE.decode('notadate')).toBeNull()
+    expect(DATE.decode('2024-01-15x')).toBeNull()
   })
 })

--- a/typescript/packages/core/src/core/hierarchy/codec.ts
+++ b/typescript/packages/core/src/core/hierarchy/codec.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 const ASCII_DIGITS = /^[0-9]+$/
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
 
 /**
  * Whether the text is a plain ASCII integer.
@@ -23,6 +24,19 @@ const ASCII_DIGITS = /^[0-9]+$/
  */
 export function asciiDigits(text: string): boolean {
   return ASCII_DIGITS.test(text)
+}
+
+/**
+ * Whether the text is shaped like a YYYY-MM-DD date.
+ *
+ * Shape only, not a calendar check: the dated-message backends mint their
+ * date directories from real timestamps, so a shaped-but-absent date
+ * resolves through the listing like any other name. A backend that must
+ * refuse impossible dates (gcal, whose day dirs exist by construction)
+ * validates with its own calendar-aware check instead.
+ */
+export function isoDateShaped(text: string): boolean {
+  return ISO_DATE.test(text)
 }
 
 /**
@@ -63,3 +77,4 @@ export const RAW = new Codec()
 export const JSON_NAME = new Codec({ suffix: '.json' })
 export const JSONL_NAME = new Codec({ suffix: '.jsonl' })
 export const INT_JSON = new Codec({ suffix: '.json', validate: asciiDigits })
+export const DATE = new Codec({ validate: isoDateShaped })

--- a/typescript/packages/core/src/core/hierarchy/read.test.ts
+++ b/typescript/packages/core/src/core/hierarchy/read.test.ts
@@ -17,7 +17,13 @@ import { Accessor } from '../../accessor/base.ts'
 import { FileType, PathSpec } from '../../types.ts'
 import { stripSlash } from '../../utils/slash.ts'
 import { JSON_NAME } from './codec.ts'
-import { makeRead, type Reader, type WindowedReader } from './read.ts'
+import {
+  makeRead,
+  makeReadRange,
+  type RangedReader,
+  type Reader,
+  type WindowedReader,
+} from './read.ts'
 import { Slot, Scope, makeDetectScope } from './scope.ts'
 
 const SCOPES: readonly Scope[] = [
@@ -96,6 +102,38 @@ describe('hierarchy makeRead', () => {
 
   it('lets a plain reader ignore the window', async () => {
     const out = await READ(new FakeAccessor(), spec('/rooms/red/a.json'), undefined, { limit: 3 })
+    expect(new TextDecoder().decode(out)).toBe('red:a')
+  })
+})
+
+const readNoteRange: RangedReader<FakeAccessor> = (_accessor, match, _path, _index, offset, size) =>
+  Promise.resolve(
+    new TextEncoder().encode(`ranged:${match.slots.note ?? ''}:${String(offset)}:${String(size)}`),
+  )
+
+describe('hierarchy makeReadRange', () => {
+  it('pushes the window to a ranged reader', async () => {
+    const readRange = makeReadRange<FakeAccessor>(detectScope, READ, { note: readNoteRange })
+    const out = await readRange(new FakeAccessor(), spec('/rooms/red/a.json'), undefined, {
+      offset: 2,
+      size: 5,
+    })
+    expect(new TextDecoder().decode(out)).toBe('ranged:a:2:5')
+  })
+
+  it('slices the full read for an unranged kind', async () => {
+    const readRange = makeReadRange<FakeAccessor>(detectScope, READ, {})
+    const out = await readRange(new FakeAccessor(), spec('/rooms/red/a.json'), undefined, {
+      offset: 1,
+      size: 3,
+    })
+    // The full read rendered "red:a"; the window is taken after the fact.
+    expect(new TextDecoder().decode(out)).toBe('ed:')
+  })
+
+  it('defaults to the whole file', async () => {
+    const readRange = makeReadRange<FakeAccessor>(detectScope, READ, {})
+    const out = await readRange(new FakeAccessor(), spec('/rooms/red/a.json'))
     expect(new TextDecoder().decode(out)).toBe('red:a')
   })
 })

--- a/typescript/packages/core/src/core/hierarchy/read.ts
+++ b/typescript/packages/core/src/core/hierarchy/read.ts
@@ -16,6 +16,7 @@ import type { Accessor } from '../../accessor/base.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import type { PathSpec } from '../../types.ts'
 import { eisdir, enoent } from '../../utils/errors.ts'
+import { sliceWindow } from '../../utils/ranges.ts'
 import { ROOT, type DetectFn, type ScopeMatch } from './scope.ts'
 
 export type Reader<A extends Accessor> = (
@@ -84,5 +85,49 @@ export function makeRead<A extends Accessor>(
       throw enoent(path)
     }
     return reader(accessor, match, path, index)
+  }
+}
+
+export type RangedReader<A extends Accessor> = (
+  accessor: A,
+  match: ScopeMatch,
+  path: PathSpec,
+  index: IndexCacheStore | undefined,
+  offset: number,
+  size: number | null,
+) => Promise<Uint8Array>
+
+/**
+ * Build a byte-ranged read over a hierarchy read.
+ *
+ * A rendered file has no remote range to ask for — its bytes do not exist
+ * until the read renders them — so the window is sliced after the fact. A
+ * stored blob does (discord and slack attachments serve HTTP range
+ * requests), and downloading the whole file to keep a slice would defeat the
+ * ranged read; those kinds name a ranged reader in `ranged` and push the
+ * byte window to the source.
+ */
+export function makeReadRange<A extends Accessor>(
+  detect: DetectFn,
+  read: (accessor: A, path: PathSpec, index?: IndexCacheStore) => Promise<Uint8Array>,
+  ranged: Readonly<Record<string, RangedReader<A>>>,
+): (
+  accessor: A,
+  path: PathSpec,
+  index?: IndexCacheStore,
+  options?: { offset?: number; size?: number },
+) => Promise<Uint8Array> {
+  return async function readRange(
+    accessor: A,
+    path: PathSpec,
+    index?: IndexCacheStore,
+    options?: { offset?: number; size?: number },
+  ): Promise<Uint8Array> {
+    const offset = options?.offset ?? 0
+    const size = options?.size ?? null
+    const match = detect(path)
+    const fn = ranged[match.kind]
+    if (fn !== undefined) return fn(accessor, match, path, index, offset, size)
+    return sliceWindow(await read(accessor, path, index), offset, size)
   }
 }

--- a/typescript/packages/core/src/core/hierarchy/readdir.test.ts
+++ b/typescript/packages/core/src/core/hierarchy/readdir.test.ts
@@ -19,7 +19,7 @@ import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
 import { FileType, PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
 import { stripSlash } from '../../utils/slash.ts'
-import { JSON_NAME } from './codec.ts'
+import { DATE, JSON_NAME } from './codec.ts'
 import { makeReaddir, type EntryLister, type Guard, type Lister } from './readdir.ts'
 import { Slot, Scope, makeDetectScope } from './scope.ts'
 
@@ -32,6 +32,8 @@ const SCOPES: readonly Scope[] = [
     leaf: true,
     filetype: FileType.JSON,
   }),
+  new Scope({ kind: 'room_atts', segments: ['rooms', new Slot('room'), 'atts'] }),
+  new Scope({ kind: 'room_day', segments: ['rooms', new Slot('room'), new Slot('day', DATE)] }),
 ]
 
 const detectScope = makeDetectScope(SCOPES)
@@ -133,7 +135,8 @@ describe('hierarchy makeReaddir', () => {
     // The classifier refuses every dot-leading segment, so a listing must
     // not advertise one (a quoted postgres schema can be named ".foo").
     const hiddenRooms: Lister<FakeAccessor> = async (accessor, match) => {
-      const rooms = (await listRooms(accessor, match)) ?? []
+      const listed = (await listRooms(accessor, match)) ?? []
+      const rooms = Array.isArray(listed) ? listed : listed.entries
       const entry = rooms[0]?.[1]
       if (entry === undefined) throw new Error('fixture rooms empty')
       return [['.secret', entry], ...rooms]
@@ -218,6 +221,116 @@ describe('hierarchy makeReaddir entry listers', () => {
         entryListers: { room: entryNotes },
         staticRoot: ['rooms'],
       }),
-    ).toThrow('kinds in both lister tables')
+    ).toThrow('kinds in several lister tables')
+  })
+})
+
+const seedingNotes: EntryLister<FakeAccessor> = (accessor, match, own) => {
+  accessor.calls.push(`seed-notes:${match.slots.room ?? ''}`)
+  const atts = new IndexEntry({
+    id: `${own.id}:atts`,
+    name: 'atts',
+    resourceType: 'fake/atts',
+    vfsName: 'atts',
+  })
+  const blob = new IndexEntry({
+    id: 'x',
+    name: 'x.bin',
+    resourceType: 'fake/blob',
+    vfsName: 'x.bin',
+    size: 3,
+  })
+  return Promise.resolve({
+    entries: [['atts', atts]] as [string, IndexEntry][],
+    seeds: { atts: [['x.bin', blob]] as [string, IndexEntry][] },
+  })
+}
+
+const attsFallback: EntryLister<FakeAccessor> = (accessor, match) => {
+  accessor.calls.push(`atts-fallback:${match.slots.room ?? ''}`)
+  return Promise.resolve<[string, IndexEntry][]>([])
+}
+
+const SEEDED_READDIR = makeReaddir<FakeAccessor>(detectScope, {
+  listers: { rooms: listRooms },
+  entryListers: {
+    room: seedingNotes,
+    room_atts: attsFallback,
+  },
+  staticRoot: ['rooms'],
+})
+
+describe('hierarchy makeReaddir seeded listings', () => {
+  it('serves the seeded child listing without a second fetch', async () => {
+    const accessor = new FakeAccessor()
+    const index = new RAMIndexCacheStore()
+    await SEEDED_READDIR(accessor, spec('/rooms/red'), index)
+    const out = await SEEDED_READDIR(accessor, spec('/rooms/red/atts'), index)
+    expect(out).toEqual(['/h/rooms/red/atts/x.bin'])
+    // One fetch answered both directories; the atts lister never ran.
+    expect(accessor.calls).toEqual(['rooms', 'seed-notes:red'])
+  })
+
+  it('re-checks the listing after resolving the entry', async () => {
+    // A cold readdir of the seeded child resolves its own entry, which
+    // warms the seeding parent; the re-check then serves the listing the
+    // warm just wrote instead of running the fallback lister.
+    const accessor = new FakeAccessor()
+    const out = await SEEDED_READDIR(accessor, spec('/rooms/red/atts'), new RAMIndexCacheStore())
+    expect(out).toEqual(['/h/rooms/red/atts/x.bin'])
+    expect(accessor.calls).toEqual(['rooms', 'seed-notes:red'])
+  })
+})
+
+const daysByRoom: EntryLister<FakeAccessor> = (accessor, match, roomEntry) => {
+  const day = match.slots.day ?? ''
+  accessor.calls.push(`days:${roomEntry.id}:${day}`)
+  return Promise.resolve<[string, IndexEntry][]>([
+    [
+      `${day}.txt`,
+      new IndexEntry({
+        id: `${roomEntry.id}:${day}`,
+        name: `${day}.txt`,
+        resourceType: 'fake/day_note',
+        vfsName: `${day}.txt`,
+      }),
+    ],
+  ])
+}
+
+const PARENT_READDIR = makeReaddir<FakeAccessor>(detectScope, {
+  listers: { rooms: listRooms },
+  entryListers: { room: entryNotes },
+  parentEntryListers: { room_day: daysByRoom },
+  staticRoot: ['rooms'],
+})
+
+describe('hierarchy makeReaddir parent-entry listers', () => {
+  it('is proven by the parent entry, not its own', async () => {
+    // The day dir has no entry of its own (the room listing never minted
+    // one); the proof is the room entry, handed to the lister.
+    const accessor = new FakeAccessor()
+    const out = await PARENT_READDIR(accessor, spec('/rooms/red/2024-01-15'))
+    expect(out).toEqual(['/h/rooms/red/2024-01-15/2024-01-15.txt'])
+    expect(accessor.calls).toEqual(['rooms', 'days:red:2024-01-15'])
+  })
+
+  it('throws ENOENT for a bogus parent', async () => {
+    const accessor = new FakeAccessor()
+    await expect(PARENT_READDIR(accessor, spec('/rooms/ghost/2024-01-15'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+    expect(accessor.calls).toEqual(['rooms'])
+  })
+
+  it('refuses a kind named in several lister tables at build', () => {
+    expect(() =>
+      makeReaddir<FakeAccessor>(detectScope, {
+        listers: { rooms: listRooms },
+        entryListers: { room_day: attsFallback },
+        parentEntryListers: { room_day: daysByRoom },
+        staticRoot: ['rooms'],
+      }),
+    ).toThrow('kinds in several lister tables')
   })
 })

--- a/typescript/packages/core/src/core/hierarchy/readdir.ts
+++ b/typescript/packages/core/src/core/hierarchy/readdir.ts
@@ -24,22 +24,42 @@ import { compareCodePoints } from '../../utils/sort.ts'
 import { resolveEntry, type ReaddirFn } from './probe.ts'
 import { INVALID, ROOT, type DetectFn, type ScopeMatch } from './scope.ts'
 
-export type Lister<A extends Accessor> = (
-  accessor: A,
-  match: ScopeMatch,
-) => Promise<[string, IndexEntry][] | null>
+/**
+ * A listing that also proves descendant listings.
+ *
+ * For a backend whose one fetch answers more than one directory: a
+ * dated-message day fetch yields the day's own children AND the contents of
+ * its `files/` subdirectory, and a mail label listing yields the date
+ * directories AND each date's messages AND each message's attachment
+ * directory. Returning the extra listings as seeds lets the kit cache them,
+ * so entering a seeded directory costs no second identical fetch. `seeds`
+ * keys are paths relative to the listed directory (`files`,
+ * `2026-01-05/Report__17`).
+ */
+export interface DirListing {
+  entries: [string, IndexEntry][]
+  seeds: Readonly<Record<string, [string, IndexEntry][]>>
+}
+
+export type Listed = [string, IndexEntry][] | DirListing
+
+export type Lister<A extends Accessor> = (accessor: A, match: ScopeMatch) => Promise<Listed | null>
 
 export type EntryLister<A extends Accessor> = (
   accessor: A,
   match: ScopeMatch,
   entry: IndexEntry,
-) => Promise<[string, IndexEntry][]>
+) => Promise<Listed>
 
 export type Guard<A extends Accessor> = (
   accessor: A,
   match: ScopeMatch,
   virtual: string,
 ) => Promise<void>
+
+function dropHidden(listed: [string, IndexEntry][]): [string, IndexEntry][] {
+  return listed.filter(([name]) => !name.startsWith('.'))
+}
 
 /**
  * Build a hierarchy readdir: dispatch, guards, index, name joins.
@@ -63,6 +83,18 @@ export type Guard<A extends Accessor> = (
  * ride the parent listing's `IndexEntry.extra` (trello stashes each
  * `card.json` size on the card's directory entry).
  *
+ * A lister may answer a `DirListing` to seed descendant listings its fetch
+ * already proved; entering a seeded directory then reads the index instead of
+ * refetching (the entry-lister branch re-checks the listing after resolving,
+ * because the resolve itself may have run the seeding parent).
+ *
+ * A parent-entry lister (`parentEntryListers`) is for a directory whose
+ * existence is decided by its PARENT's entry rather than its own: a
+ * dated-message day dir is real for any well-formed date under a channel that
+ * exists, including dates the channel's bounded listing window never minted,
+ * so the proof is the channel entry and the fetch takes the date from the
+ * match. A kind appears in at most one of the three tables.
+ *
  * `listers` holds one lister per directory kind; include `root` for a
  * dynamic mount root. `entryListers` holds listers for kinds resolved
  * through their parent's listing; a kind appears in exactly one of the two
@@ -77,6 +109,7 @@ export function makeReaddir<A extends Accessor>(
   options: {
     listers: Readonly<Record<string, Lister<A>>>
     entryListers?: Readonly<Record<string, EntryLister<A>>>
+    parentEntryListers?: Readonly<Record<string, EntryLister<A>>>
     staticRoot?: readonly string[]
     guards?: Readonly<Record<string, Guard<A>>>
     leafError?: 'enoent' | 'enotdir'
@@ -84,10 +117,16 @@ export function makeReaddir<A extends Accessor>(
 ): ReaddirFn<A> {
   const { listers, staticRoot, guards } = options
   const entryListers = options.entryListers ?? {}
+  const parentEntryListers = options.parentEntryListers ?? {}
   const leafError = options.leafError ?? 'enoent'
-  const overlap = Object.keys(listers).filter((kind) => entryListers[kind] !== undefined)
+  const overlap = [
+    ...Object.keys(listers).filter(
+      (kind) => entryListers[kind] !== undefined || parentEntryListers[kind] !== undefined,
+    ),
+    ...Object.keys(entryListers).filter((kind) => parentEntryListers[kind] !== undefined),
+  ]
   if (overlap.length > 0) {
-    throw new Error(`kinds in both lister tables: ${overlap.sort(compareCodePoints).join(', ')}`)
+    throw new Error(`kinds in several lister tables: ${overlap.sort(compareCodePoints).join(', ')}`)
   }
   return async function readdir(
     accessor: A,
@@ -110,7 +149,8 @@ export function makeReaddir<A extends Accessor>(
     }
     const lister = listers[match.kind]
     const entryLister = entryListers[match.kind]
-    if (lister === undefined && entryLister === undefined) {
+    const parentLister = parentEntryListers[match.kind]
+    if (lister === undefined && entryLister === undefined && parentLister === undefined) {
       if (match.scope !== null && match.scope.leaf && leafError === 'enotdir') {
         throw enotdir(pathSpec)
       }
@@ -120,21 +160,32 @@ export function makeReaddir<A extends Accessor>(
     if (guard !== undefined) await guard(accessor, match, virtual)
     const listing = await store.listDir(virtualKey)
     if (listing.entries !== undefined && listing.entries !== null) return listing.entries
-    let listed: [string, IndexEntry][]
-    if (entryLister !== undefined) {
+    let listed: Listed
+    if (entryLister !== undefined || parentLister !== undefined) {
+      const proofKey =
+        parentLister !== undefined
+          ? virtualKey.split('/').slice(0, -1).join('/') || '/'
+          : virtualKey
       const own = await resolveEntry(
         readdir,
         accessor,
         new PathSpec({
-          virtual: virtualKey,
-          directory: virtualKey,
+          virtual: proofKey,
+          directory: proofKey,
           resolved: false,
-          resourcePath: mountKey(virtualKey, prefix),
+          resourcePath: mountKey(proofKey, prefix),
         }),
         store,
       )
       if (own === null) throw enoent(pathSpec)
-      listed = await entryLister(accessor, match, own)
+      // The resolve may have warmed this very listing: a parent's lister
+      // can seed a child listing from the same fetch (DirListing.seeds),
+      // so ask the index again before fetching.
+      const relisted = await store.listDir(virtualKey)
+      if (relisted.entries !== undefined && relisted.entries !== null) return relisted.entries
+      const fetch = entryLister ?? parentLister
+      if (fetch === undefined) throw enoent(pathSpec)
+      listed = await fetch(accessor, match, own)
     } else if (lister !== undefined) {
       const maybe = await lister(accessor, match)
       if (maybe === null) throw enoent(pathSpec)
@@ -142,9 +193,17 @@ export function makeReaddir<A extends Accessor>(
     } else {
       throw enoent(pathSpec)
     }
-    const entries = listed.filter(([name]) => !name.startsWith('.'))
+    let seeds: Readonly<Record<string, [string, IndexEntry][]>> = {}
+    if (!Array.isArray(listed)) {
+      seeds = listed.seeds
+      listed = listed.entries
+    }
+    const entries = dropHidden(listed)
     await store.setDir(virtualKey, entries)
     const stem = rstripSlash(virtualKey)
+    for (const [rel, childEntries] of Object.entries(seeds)) {
+      await store.setDir(`${stem}/${stripSlash(rel)}`, dropHidden(childEntries))
+    }
     return entries.map(([name]) => `${stem}/${name}`)
   }
 }

--- a/typescript/packages/core/src/core/slack/formatters.test.ts
+++ b/typescript/packages/core/src/core/slack/formatters.test.ts
@@ -22,32 +22,28 @@ import {
   formatGrepResults,
   userFilename,
 } from './formatters.ts'
-import type { SlackScope } from './scope.ts'
+import type { SearchTarget } from './scope.ts'
 
 const ENC = new TextEncoder()
 
 describe('buildQuery', () => {
   it('returns pattern unchanged when no container', () => {
-    const scope: SlackScope = { useNative: true, resourcePath: '/' }
+    const scope: SearchTarget = {}
     expect(buildQuery('hi', scope)).toBe('hi')
   })
 
   it('prefixes channels with in:#name', () => {
-    const scope: SlackScope = {
-      useNative: true,
+    const scope: SearchTarget = {
       container: 'channels',
       channelName: 'general',
-      resourcePath: 'channels/general__C1',
     }
     expect(buildQuery('hi', scope)).toBe('in:#general hi')
   })
 
   it('prefixes dms with in:@name', () => {
-    const scope: SlackScope = {
-      useNative: true,
+    const scope: SearchTarget = {
       container: 'dms',
       channelName: 'alice',
-      resourcePath: 'dms/alice__D1',
     }
     expect(buildQuery('hi', scope)).toBe('in:@alice hi')
   })
@@ -69,12 +65,10 @@ describe('formatGrepResults', () => {
         },
       }),
     )
-    const scope: SlackScope = {
-      useNative: true,
+    const scope: SearchTarget = {
       container: 'channels',
       channelName: 'general',
       channelId: 'C1',
-      resourcePath: 'channels/general__C1',
     }
     const lines = formatGrepResults(raw, scope, '/mnt/slack')
     expect(lines).toHaveLength(1)
@@ -89,12 +83,10 @@ describe('formatGrepResults', () => {
         messages: { matches: [{ ts: '1700000000.0', text: 'hi', username: 'alice' }] },
       }),
     )
-    const scope: SlackScope = {
-      useNative: true,
+    const scope: SearchTarget = {
       container: 'channels',
       channelName: 'general',
       channelId: 'C1',
-      resourcePath: 'channels/general__C1',
     }
     const lines = formatGrepResults(raw, scope, '/mnt/slack')
     expect(lines[0]).toContain('/channels/general__C1/')
@@ -103,7 +95,7 @@ describe('formatGrepResults', () => {
 
   it('returns empty when no matches', () => {
     const raw = ENC.encode(JSON.stringify({ messages: { matches: [] } }))
-    const scope: SlackScope = { useNative: true, resourcePath: '/' }
+    const scope: SearchTarget = {}
     expect(formatGrepResults(raw, scope, '/mnt/slack')).toEqual([])
   })
 
@@ -115,12 +107,10 @@ describe('formatGrepResults', () => {
         },
       }),
     )
-    const scope: SlackScope = {
-      useNative: true,
+    const scope: SearchTarget = {
       container: 'channels',
       channelName: 'general',
       channelId: 'C1',
-      resourcePath: 'channels/general__C1',
     }
     const lines = formatGrepResults(raw, scope, '/mnt/slack')
     expect(lines[0]).toContain('[U1] a b c')
@@ -157,12 +147,10 @@ describe('formatFileGrepResults', () => {
         },
       }),
     )
-    const scope: SlackScope = {
-      useNative: true,
+    const scope: SearchTarget = {
       container: 'channels',
       channelName: 'general',
       channelId: 'C1',
-      resourcePath: 'channels/general__C1',
     }
     const lines = formatFileGrepResults(raw, scope, '/mnt/slack')
     expect(lines).toHaveLength(2)
@@ -178,7 +166,7 @@ describe('formatFileGrepResults', () => {
         files: { matches: [{ id: 'F1', name: 'x.txt', timestamp: 1 }] },
       }),
     )
-    const scope: SlackScope = { useNative: true, resourcePath: '/' }
+    const scope: SearchTarget = {}
     expect(formatFileGrepResults(raw, scope, '/mnt/slack')).toEqual([])
   })
 })

--- a/typescript/packages/core/src/core/slack/formatters.ts
+++ b/typescript/packages/core/src/core/slack/formatters.ts
@@ -14,7 +14,7 @@
 
 import { pathSafeName, sanitizeName } from '../../utils/sanitize.ts'
 import { makeIdName } from '../../utils/naming.ts'
-import type { SlackScope } from './scope.ts'
+import type { SearchTarget } from './scope.ts'
 
 const DEC = new TextDecoder('utf-8', { fatal: false })
 
@@ -78,7 +78,7 @@ interface SearchFilesPayload {
   files?: { matches?: SearchFileMatch[] }
 }
 
-export function buildQuery(pattern: string, scope: SlackScope): string {
+export function buildQuery(pattern: string, scope: SearchTarget): string {
   if (
     scope.container === 'channels' &&
     scope.channelName !== undefined &&
@@ -99,7 +99,7 @@ function tsToDate(ts: string | number | undefined): string {
   return new Date(tsFloat * 1000).toISOString().slice(0, 10)
 }
 
-export function formatGrepResults(raw: Uint8Array, scope: SlackScope, prefix: string): string[] {
+export function formatGrepResults(raw: Uint8Array, scope: SearchTarget, prefix: string): string[] {
   const payload = JSON.parse(DEC.decode(raw)) as SearchMessagePayload
   const matches = payload.messages?.matches ?? []
   const lines: string[] = []
@@ -123,7 +123,7 @@ export function formatGrepResults(raw: Uint8Array, scope: SlackScope, prefix: st
 
 export function formatFileGrepResults(
   raw: Uint8Array,
-  scope: SlackScope,
+  scope: SearchTarget,
   prefix: string,
 ): string[] {
   const payload = JSON.parse(DEC.decode(raw)) as SearchFilesPayload

--- a/typescript/packages/core/src/core/slack/read.test.ts
+++ b/typescript/packages/core/src/core/slack/read.test.ts
@@ -204,10 +204,12 @@ describe('read unknown', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('throws ENOENT for root', async () => {
+  it('throws EISDIR for root', async () => {
+    // The root exists by construction, so reading it as a file is the one
+    // shape the kit reports as a directory rather than absent.
     const t = new FakeTransport(() => ({ ok: true }))
     await expect(
       read(new SlackAccessor(t), spec('/mnt/slack', '/mnt/slack')),
-    ).rejects.toMatchObject({ code: 'ENOENT' })
+    ).rejects.toMatchObject({ code: 'EISDIR' })
   })
 })

--- a/typescript/packages/core/src/core/slack/read.ts
+++ b/typescript/packages/core/src/core/slack/read.ts
@@ -12,86 +12,127 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { enoent } from '../../utils/errors.ts'
-import { mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { SlackAccessor } from '../../accessor/slack.ts'
+import type { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import type { PathSpec } from '../../types.ts'
+import { PathSpec } from '../../types.ts'
+import { enoent } from '../../utils/errors.ts'
+import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
+import { resolveEntry } from '../hierarchy/probe.ts'
+import { makeRead, makeReadRange } from '../hierarchy/read.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { getHistoryJsonl } from './history.ts'
+import { readdir } from './readdir.ts'
 import { getUserProfile, userJsonBytes } from './users.ts'
-import { stripSlash } from '../../utils/slash.ts'
-import { sliceWindow } from '../../utils/ranges.ts'
+import { detectScope } from './scope.ts'
 
-/**
- * Read a Slack path, optionally only a byte range of it.
- *
- * Only an uploaded file has a remote range to ask for. A channel's history
- * and a user profile are rendered here into JSON, so their bytes do not
- * exist until we make them and the window can only be taken afterwards.
- *
- * Args:
- *   accessor: Slack accessor.
- *   path: the path to read.
- *   index: listing cache, consulted for the entry.
- *   options: `{offset, size}`, the byte window, or absent for the whole file.
- */
-export async function read(
+async function channelEntry(
   accessor: SlackAccessor,
   path: PathSpec,
-  index?: IndexCacheStore,
-  options?: { offset?: number; size?: number },
-): Promise<Uint8Array> {
-  const offset = options?.offset ?? 0
-  const size = options?.size ?? null
+  index: IndexCacheStore | undefined,
+): Promise<IndexEntry | null> {
+  const virtual = path.virtual.replace(/\/+$/, '').split('/').slice(0, -2).join('/')
   const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  let raw = path.virtual
-  if (prefix !== '' && raw.startsWith(prefix)) {
-    raw = raw.slice(prefix.length) || '/'
-  }
-  const key = stripSlash(raw)
-  const parts = key.split('/')
-  const part0 = parts[0] ?? ''
-  const part1 = parts[1] ?? ''
-  const part2 = parts[2] ?? ''
-  const part3 = parts[3] ?? ''
-
-  if (parts.length === 4 && (part0 === 'channels' || part0 === 'dms') && part3 === 'chat.jsonl') {
-    if (index === undefined) throw enoent(path)
-    const parentKey = `${prefix}/${part0}/${part1}`
-    const lookup = await index.get(parentKey)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw enoent(path)
-    }
-    return sliceWindow(await getHistoryJsonl(accessor, lookup.entry.id, part2), offset, size)
-  }
-
-  if (parts.length === 5 && (part0 === 'channels' || part0 === 'dms') && part3 === 'files') {
-    if (index === undefined) throw enoent(path)
-    const virtualKey = `${prefix}/${key}`
-    const lookup = await index.get(virtualKey)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw enoent(path)
-    }
-    const url = lookup.entry.extra.url_private_download
-    if (typeof url !== 'string' || url === '') {
-      throw enoent(path)
-    }
-    if (accessor.transport.downloadFile === undefined) {
-      throw new Error('slack: transport does not support file download')
-    }
-    return await accessor.transport.downloadFile(url, offset, size)
-  }
-
-  if (parts.length === 2 && part0 === 'users') {
-    if (index === undefined) throw enoent(path)
-    const virtualKey = `${prefix}/${key}`
-    const lookup = await index.get(virtualKey)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw enoent(path)
-    }
-    const user = await getUserProfile(accessor, lookup.entry.id)
-    return sliceWindow(userJsonBytes(user), offset, size)
-  }
-
-  throw enoent(path)
+  const spec = new PathSpec({
+    virtual,
+    directory: virtual,
+    resourcePath: mountKey(virtual, prefix),
+  })
+  return resolveEntry(readdir, accessor, spec, index)
 }
+
+/**
+ * Render one day's history; the channel id comes from the listing.
+ *
+ * The typed `name__id` dirname is only trusted once the listing proves it,
+ * so a fabricated channel id is ENOENT rather than a raw API error.
+ */
+async function readChat(
+  accessor: SlackAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<Uint8Array> {
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  let channelId: string
+  if (entry !== null) {
+    channelId = entry.id.split(':', 1)[0] ?? ''
+  } else {
+    // A sealed day lists nothing but the file still reads through the
+    // channel, reproducing the API's own answer for the fetch.
+    const channel = await channelEntry(accessor, path, index)
+    if (channel === null) throw enoent(path)
+    channelId = channel.id
+  }
+  return getHistoryJsonl(accessor, channelId, match.slots.day ?? '')
+}
+
+async function readUser(
+  accessor: SlackAccessor,
+  _match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<Uint8Array> {
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry === null) throw enoent(path)
+  const user = await getUserProfile(accessor, entry.id)
+  return userJsonBytes(user)
+}
+
+async function blobUrl(
+  accessor: SlackAccessor,
+  path: PathSpec,
+  index: IndexCacheStore | undefined,
+): Promise<string> {
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry === null) throw enoent(path)
+  const url =
+    typeof entry.extra.url_private_download === 'string' ? entry.extra.url_private_download : ''
+  if (url === '') throw enoent(path)
+  return url
+}
+
+async function downloadBlob(
+  accessor: SlackAccessor,
+  url: string,
+  offset: number,
+  size: number | null,
+): Promise<Uint8Array> {
+  if (accessor.transport.downloadFile === undefined) {
+    throw new Error('slack transport does not support file downloads')
+  }
+  return accessor.transport.downloadFile(url, offset, size)
+}
+
+async function readBlob(
+  accessor: SlackAccessor,
+  _match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<Uint8Array> {
+  return downloadBlob(accessor, await blobUrl(accessor, path, index), 0, null)
+}
+
+async function readBlobRange(
+  accessor: SlackAccessor,
+  _match: ScopeMatch,
+  path: PathSpec,
+  index: IndexCacheStore | undefined,
+  offset: number,
+  size: number | null,
+): Promise<Uint8Array> {
+  return downloadBlob(accessor, await blobUrl(accessor, path, index), offset, size)
+}
+
+export const read = makeRead<SlackAccessor>(detectScope, {
+  messages: readChat,
+  user: readUser,
+  file_blob: readBlob,
+})
+
+// Only an uploaded file has a remote range to ask for. A channel's history
+// and a user profile are rendered here into JSON, so their bytes do not
+// exist until we make them and the window can only be taken afterwards.
+export const readRange = makeReadRange<SlackAccessor>(detectScope, read, {
+  file_blob: readBlobRange,
+})

--- a/typescript/packages/core/src/core/slack/readdir.ts
+++ b/typescript/packages/core/src/core/slack/readdir.ts
@@ -12,18 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { SlackAccessor } from '../../accessor/slack.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
-import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { PathSpec } from '../../types.ts'
+import { makeReaddir, type DirListing, type Listed } from '../hierarchy/readdir.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { listChannels, listDms } from './channels.ts'
 import { channelDirname, dmDirname, fileBlobName, userFilename } from './formatters.ts'
 import { fetchMessagesForDay, messagesToJsonl, type SlackMessage } from './history.ts'
 import { detectScope } from './scope.ts'
 import { listUsers, userJsonBytes } from './users.ts'
-import { stripSlash } from '../../utils/slash.ts'
-import { enoent } from '../../utils/errors.ts'
+
+export const VIRTUAL_ROOTS = ['channels', 'dms', 'users'] as const
 
 const SOFT_HISTORY_ERRORS = [
   'not_in_channel',
@@ -69,217 +68,124 @@ export function dateRange(latestTs: number, created: number, maxDays = 90): stri
     startDate.getUTCDate(),
   )
   const dayMs = 86_400_000
-  const diffDays = Math.floor((endUtc - startUtc) / dayMs)
-  if (diffDays > maxDays) {
+  if ((endUtc - startUtc) / dayMs > maxDays) {
     startUtc = endUtc - (maxDays - 1) * dayMs
   }
   const dates: string[] = []
-  let cursor = endUtc
-  while (cursor >= startUtc) {
+  for (let cursor = endUtc; cursor >= startUtc; cursor -= dayMs) {
     const d = new Date(cursor)
     const yyyy = d.getUTCFullYear().toString().padStart(4, '0')
     const mm = (d.getUTCMonth() + 1).toString().padStart(2, '0')
     const dd = d.getUTCDate().toString().padStart(2, '0')
     dates.push(`${yyyy}-${mm}-${dd}`)
-    cursor -= dayMs
   }
   return dates
 }
 
-interface PathParts {
-  path: PathSpec
-  prefix: string
-  raw: string
-  key: string
-  virtualKey: string
-}
-
-function normalizePath(path: PathSpec): PathParts {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  let raw = path.pattern !== null ? path.directory : path.virtual
-  if (prefix !== '' && raw.startsWith(prefix)) {
-    raw = raw.slice(prefix.length) || '/'
-  }
-  const key = stripSlash(raw)
-  const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
-  return { path, prefix, raw, key, virtualKey }
-}
-
-function readdirRoot(prefix: string): string[] {
-  return [`${prefix}/channels`, `${prefix}/dms`, `${prefix}/users`]
-}
-
-async function readdirChannels(
+async function listChannelsRoot(
   accessor: SlackAccessor,
-  prefix: string,
-  virtualKey: string,
-  index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  if (index !== undefined) {
-    const listing = await index.listDir(virtualKey)
-    if (listing.entries !== undefined && listing.entries !== null) {
-      return listing.entries
-    }
-  }
+  _match: ScopeMatch,
+): Promise<Listed | null> {
   const channels = await listChannels(accessor)
-  const entries: [string, IndexEntry][] = []
-  const names: string[] = []
-  for (const ch of channels) {
+  return channels.map((ch) => {
     const dirname = channelDirname(ch)
-    const entry = new IndexEntry({
-      id: ch.id,
-      name: ch.name ?? '',
-      resourceType: 'slack/channel',
-      vfsName: dirname,
-      remoteTime: String(ch.created ?? 0),
-    })
-    entries.push([dirname, entry])
-    names.push(`${prefix}/channels/${dirname}`)
-  }
-  if (index !== undefined) {
-    await index.setDir(virtualKey, entries)
-  }
-  return names
+    return [
+      dirname,
+      new IndexEntry({
+        id: ch.id,
+        name: ch.name ?? '',
+        resourceType: 'slack/channel',
+        vfsName: dirname,
+        remoteTime: String(ch.created ?? 0),
+      }),
+    ] as [string, IndexEntry]
+  })
 }
 
-async function readdirDms(
-  accessor: SlackAccessor,
-  prefix: string,
-  virtualKey: string,
-  index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  if (index !== undefined) {
-    const listing = await index.listDir(virtualKey)
-    if (listing.entries !== undefined && listing.entries !== null) {
-      return listing.entries
-    }
-  }
+async function listDmsRoot(accessor: SlackAccessor, _match: ScopeMatch): Promise<Listed | null> {
   const dms = await listDms(accessor)
   const users = await listUsers(accessor)
   const userMap: Record<string, string> = {}
   for (const u of users) userMap[u.id] = u.name ?? u.id
-  const entries: [string, IndexEntry][] = []
-  const names: string[] = []
-  for (const dm of dms) {
+  return dms.map((dm) => {
     const dirname = dmDirname(dm, userMap)
     const uid = dm.user ?? ''
-    const entry = new IndexEntry({
-      id: dm.id,
-      name: userMap[uid] ?? uid,
-      resourceType: 'slack/dm',
-      vfsName: dirname,
-      remoteTime: String(dm.created ?? 0),
-    })
-    entries.push([dirname, entry])
-    names.push(`${prefix}/dms/${dirname}`)
-  }
-  if (index !== undefined) {
-    await index.setDir(virtualKey, entries)
-  }
-  return names
+    return [
+      dirname,
+      new IndexEntry({
+        id: dm.id,
+        name: userMap[uid] ?? uid,
+        resourceType: 'slack/dm',
+        vfsName: dirname,
+        remoteTime: String(dm.created ?? 0),
+      }),
+    ] as [string, IndexEntry]
+  })
 }
 
-async function readdirUsers(
-  accessor: SlackAccessor,
-  prefix: string,
-  virtualKey: string,
-  index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  if (index !== undefined) {
-    const listing = await index.listDir(virtualKey)
-    if (listing.entries !== undefined && listing.entries !== null) {
-      return listing.entries
-    }
-  }
+async function listUsersRoot(accessor: SlackAccessor, _match: ScopeMatch): Promise<Listed | null> {
   const users = await listUsers(accessor)
-  const entries: [string, IndexEntry][] = []
-  const names: string[] = []
-  for (const u of users) {
+  return users.map((u) => {
     const filename = userFilename(u)
-    const entry = new IndexEntry({
-      id: u.id,
-      name: u.name ?? '',
-      resourceType: 'slack/user',
-      vfsName: filename,
-      size: userJsonBytes(u).byteLength,
-    })
-    entries.push([filename, entry])
-    names.push(`${prefix}/users/${filename}`)
-  }
-  if (index !== undefined) {
-    await index.setDir(virtualKey, entries)
-  }
-  return names
+    return [
+      filename,
+      new IndexEntry({
+        id: u.id,
+        name: u.name ?? '',
+        resourceType: 'slack/user',
+        vfsName: filename,
+        size: userJsonBytes(u).byteLength,
+      }),
+    ] as [string, IndexEntry]
+  })
 }
 
-async function readdirChannelDates(
+async function listChannelDays(
   accessor: SlackAccessor,
-  parts: PathParts,
-  container: 'channels' | 'dms',
-  index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  if (index === undefined) {
-    throw enoent(parts.path)
-  }
-  let lookup = await index.get(parts.virtualKey)
-  if (lookup.entry === undefined || lookup.entry === null) {
-    const parentPath = `${parts.prefix}/${container}`
-    const parent = new PathSpec({
-      virtual: parentPath,
-      directory: parentPath,
-      resourcePath: mountKey(parentPath, parts.prefix),
-    })
-    await readdir(accessor, parent, index)
-    lookup = await index.get(parts.virtualKey)
-  }
-  if (lookup.entry === undefined || lookup.entry === null) {
-    throw enoent(parts.path)
-  }
-  const listing = await index.listDir(parts.virtualKey)
-  if (listing.entries !== undefined && listing.entries !== null) {
-    return listing.entries
-  }
-  const created = Number.parseInt(lookup.entry.remoteTime || '0', 10) || 0
-  const latestTs = await latestMessageTs(accessor, lookup.entry.id)
+  _match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  const created = Number.parseInt(own.remoteTime !== '' ? own.remoteTime : '0', 10)
+  const latestTs = await latestMessageTs(accessor, own.id)
   let dates: string[]
-  if (latestTs !== null && latestTs !== 0 && created !== 0) {
+  if (latestTs !== null && created > 0) {
     dates = dateRange(latestTs, created)
-  } else if (latestTs !== null && latestTs !== 0) {
+  } else if (latestTs !== null) {
     dates = dateRange(latestTs, Math.floor(latestTs))
   } else {
     dates = []
   }
-  const entries: [string, IndexEntry][] = []
-  const names: string[] = []
-  for (const d of dates) {
-    const entry = new IndexEntry({
-      id: `${lookup.entry.id}:${d}`,
-      name: d,
-      resourceType: 'slack/date_dir',
-      vfsName: d,
-    })
-    entries.push([d, entry])
-    names.push(`${parts.prefix}/${parts.key}/${d}`)
-  }
-  await index.setDir(parts.virtualKey, entries)
-  return names
+  return dates.map(
+    (d) =>
+      [
+        d,
+        new IndexEntry({
+          id: `${own.id}:${d}`,
+          name: d,
+          resourceType: 'slack/date_dir',
+          vfsName: d,
+          extra: { channel_id: own.id },
+        }),
+      ] as [string, IndexEntry],
+  )
 }
 
-async function fetchDay(
+/**
+ * One history fetch, answering the day dir and its files subdir.
+ *
+ * A soft history error (not_in_channel, missing_scope, ...) seals an empty
+ * day: the dir lists nothing, and read reproduces the API's own answer.
+ */
+async function dayListing(
   accessor: SlackAccessor,
   channelId: string,
   dateStr: string,
-  dateVirtualKey: string,
-  index: IndexCacheStore,
-): Promise<void> {
+): Promise<DirListing> {
   let messages: SlackMessage[]
   try {
     messages = await fetchMessagesForDay(accessor, channelId, dateStr)
   } catch (err) {
-    if (isSoftHistoryError(err)) {
-      await index.setDir(dateVirtualKey, [])
-      return
-    }
+    if (isSoftHistoryError(err)) return { entries: [], seeds: {} }
     throw err
   }
   const chatEntry = new IndexEntry({
@@ -294,11 +200,8 @@ async function fetchDay(
     name: 'files',
     resourceType: 'slack/files_dir',
     vfsName: 'files',
+    extra: { channel_id: channelId, date: dateStr },
   })
-  await index.setDir(dateVirtualKey, [
-    ['chat.jsonl', chatEntry],
-    ['files', filesEntry],
-  ])
   const fileEntries: [string, IndexEntry][] = []
   for (const msg of messages) {
     const files = (msg.files as { id?: string }[] | undefined) ?? []
@@ -320,124 +223,66 @@ async function fetchDay(
       if (meta.id === undefined || meta.id === '') continue
       if (meta.size === undefined || !meta.url_private_download) continue
       const blob = fileBlobName(meta)
-      const entry = new IndexEntry({
-        id: meta.id,
-        name: meta.title ?? meta.name ?? '',
-        resourceType: 'slack/file',
-        vfsName: blob,
-        size: meta.size,
-        remoteTime: String(meta.timestamp ?? ''),
-        extra: {
-          mimetype: meta.mimetype ?? '',
-          url_private_download: meta.url_private_download ?? '',
-          filetype: meta.filetype ?? '',
-          ts: typeof msg.ts === 'string' ? msg.ts : '',
-          channel_id: channelId,
-          date: dateStr,
-        },
-      })
-      fileEntries.push([blob, entry])
+      fileEntries.push([
+        blob,
+        new IndexEntry({
+          id: meta.id,
+          name: meta.title ?? meta.name ?? '',
+          resourceType: 'slack/file',
+          vfsName: blob,
+          size: meta.size,
+          remoteTime: String(meta.timestamp ?? ''),
+          extra: {
+            mimetype: meta.mimetype ?? '',
+            url_private_download: meta.url_private_download ?? '',
+            filetype: meta.filetype ?? '',
+            ts: typeof msg.ts === 'string' ? msg.ts : '',
+            channel_id: channelId,
+            date: dateStr,
+          },
+        }),
+      ])
     }
   }
-  await index.setDir(`${dateVirtualKey}/files`, fileEntries)
+  return {
+    entries: [
+      ['chat.jsonl', chatEntry],
+      ['files', filesEntry],
+    ],
+    seeds: { files: fileEntries },
+  }
 }
 
-async function readdirDateContents(
+function listDay(accessor: SlackAccessor, match: ScopeMatch, channel: IndexEntry): Promise<Listed> {
+  // The proof is the channel entry, not the day's own: any well-formed date
+  // under a real channel fetches, including dates outside the bounded window
+  // the channel listing mints.
+  return dayListing(accessor, channel.id, match.slots.day ?? '')
+}
+
+async function listFiles(
   accessor: SlackAccessor,
-  parts: PathParts,
-  container: 'channels' | 'dms',
-  segments: string[],
-  index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  if (index === undefined) throw enoent(parts.path)
-  const cached = await index.listDir(parts.virtualKey)
-  if (cached.entries !== undefined && cached.entries !== null) {
-    return cached.entries
-  }
-  const chanSeg = segments[1]
-  const dateStr = segments[2]
-  if (chanSeg === undefined || dateStr === undefined) throw enoent(parts.path)
-  const parentVirtual = `${parts.prefix}/${container}/${chanSeg}`
-  let parentLookup = await index.get(parentVirtual)
-  if (parentLookup.entry === undefined || parentLookup.entry === null) {
-    const parent = new PathSpec({
-      virtual: parentVirtual,
-      directory: parentVirtual,
-      resourcePath: mountKey(parentVirtual, parts.prefix),
-    })
-    await readdir(accessor, parent, index)
-    parentLookup = await index.get(parentVirtual)
-  }
-  if (parentLookup.entry === undefined || parentLookup.entry === null) {
-    throw enoent(parts.path)
-  }
-  await fetchDay(accessor, parentLookup.entry.id, dateStr, parts.virtualKey, index)
-  const refreshed = await index.listDir(parts.virtualKey)
-  if (refreshed.entries !== undefined && refreshed.entries !== null) {
-    return refreshed.entries
-  }
-  throw enoent(parts.path)
+  match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  // Normally served from the day lister's seed; reached only when the index
+  // evicted the files listing while the day's entries survived.
+  const fromExtra = typeof own.extra.channel_id === 'string' ? own.extra.channel_id : ''
+  const channelId = fromExtra !== '' ? fromExtra : (own.id.split(':', 1)[0] ?? '')
+  const listing = await dayListing(accessor, channelId, match.slots.day ?? '')
+  return listing.seeds.files ?? []
 }
 
-async function readdirFilesDir(
-  accessor: SlackAccessor,
-  parts: PathParts,
-  container: 'channels' | 'dms',
-  segments: string[],
-  index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  if (index === undefined) throw enoent(parts.path)
-  const cached = await index.listDir(parts.virtualKey)
-  if (cached.entries !== undefined && cached.entries !== null) {
-    return cached.entries
-  }
-  const chanSeg = segments[1]
-  const dateStr = segments[2]
-  if (chanSeg === undefined || dateStr === undefined) throw enoent(parts.path)
-  const datePath = `${parts.prefix}/${container}/${chanSeg}/${dateStr}`
-  const dateSpec = new PathSpec({
-    virtual: datePath,
-    directory: datePath,
-    resourcePath: mountKey(datePath, parts.prefix),
-  })
-  await readdir(accessor, dateSpec, index)
-  const refreshed = await index.listDir(parts.virtualKey)
-  if (refreshed.entries !== undefined && refreshed.entries !== null) {
-    return refreshed.entries
-  }
-  throw enoent(parts.path)
-}
-
-export async function readdir(
-  accessor: SlackAccessor,
-  path: PathSpec,
-  index?: IndexCacheStore,
-): Promise<string[]> {
-  const parts = normalizePath(path)
-  const { prefix, key, virtualKey } = parts
-
-  if (key === '') return readdirRoot(prefix)
-  if (key === 'channels') return readdirChannels(accessor, prefix, virtualKey, index)
-  if (key === 'dms') return readdirDms(accessor, prefix, virtualKey, index)
-  if (key === 'users') return readdirUsers(accessor, prefix, virtualKey, index)
-
-  const scope = detectScope(path)
-  const container = scope.container
-  const segments = key.split('/')
-  // Same reason as the fallback below: an unknown container is not an empty
-  // directory. Python raises here too.
-  if (container !== 'channels' && container !== 'dms') throw enoent(parts.path)
-
-  if (segments.length === 2) {
-    return readdirChannelDates(accessor, parts, container, index)
-  }
-  if (scope.target === 'date') {
-    return readdirDateContents(accessor, parts, container, segments, index)
-  }
-  if (scope.target === 'files' && segments.length === 4) {
-    return readdirFilesDir(accessor, parts, container, segments, index)
-  }
-  // An unrecognized path is not an empty directory: returning [] made `ls`
-  // and `tree` report a bogus path as a real-but-empty one.
-  throw enoent(parts.path)
-}
+export const readdir = makeReaddir<SlackAccessor>(detectScope, {
+  listers: {
+    channels_root: listChannelsRoot,
+    dms_root: listDmsRoot,
+    users_root: listUsersRoot,
+  },
+  entryListers: {
+    channel: listChannelDays,
+    files: listFiles,
+  },
+  parentEntryListers: { day: listDay },
+  staticRoot: VIRTUAL_ROOTS,
+})

--- a/typescript/packages/core/src/core/slack/scope.test.ts
+++ b/typescript/packages/core/src/core/slack/scope.test.ts
@@ -12,123 +12,103 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountKey } from '../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
-import { detectScope } from './scope.ts'
-import { PathSpec } from '../../types.ts'
+
+import { INVALID, ROOT } from '../hierarchy/scope.ts'
+import { detectScope, NATIVE_KINDS, searchTarget } from './scope.ts'
 
 describe('detectScope', () => {
-  it('root → useNative=true, resourcePath /', () => {
-    const s = detectScope(new PathSpec({ resourcePath: '', virtual: '/', directory: '/' }))
-    expect(s.useNative).toBe(true)
-    expect(s.resourcePath).toBe('/')
+  it('classifies the root, which slack search answers workspace-wide', () => {
+    expect(detectScope('/').kind).toBe(ROOT)
+    expect(NATIVE_KINDS.has(ROOT)).toBe(true)
   })
 
-  it('/channels → container=channels, useNative=true', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'channels',
-        virtual: '/channels',
-        directory: '/channels',
-      }),
-    )
-    expect(s.useNative).toBe(true)
-    expect(s.container).toBe('channels')
+  it('classifies the containers', () => {
+    expect(detectScope('/channels').kind).toBe('channels_root')
+    expect(detectScope('/dms').kind).toBe('dms_root')
+    expect(detectScope('/users').kind).toBe('users_root')
   })
 
-  it('/channels/general__C123 → channelName=general, channelId=C123', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'channels/general__C123',
-        virtual: '/channels/general__C123',
-        directory: '/channels/general__C123',
-      }),
-    )
-    expect(s.channelName).toBe('general')
-    expect(s.channelId).toBe('C123')
-    expect(s.container).toBe('channels')
-    expect(s.useNative).toBe(true)
+  it('classifies a channel dir and decodes both dirname halves', () => {
+    const match = detectScope('/channels/general__C001')
+    expect(match.kind).toBe('channel')
+    expect(match.slots).toEqual({
+      container: 'channels',
+      channel: 'general',
+      channel_id: 'C001',
+    })
   })
 
-  it('/channels/general__C123/2026-04-24 → date scope, useNative=true', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'channels/general__C123/2026-04-24',
-        virtual: '/channels/general__C123/2026-04-24',
-        directory: '/channels/general__C123/2026-04-24',
-      }),
-    )
-    expect(s.dateStr).toBe('2026-04-24')
-    expect(s.target).toBe('date')
-    expect(s.useNative).toBe(true)
+  it('classifies a dm dir under the same kind', () => {
+    const match = detectScope('/dms/alice__D001')
+    expect(match.kind).toBe('channel')
+    expect(match.slots.container).toBe('dms')
+    expect(match.slots.channel_id).toBe('D001')
   })
 
-  it('/channels/<chan>/<date>/chat.jsonl → messages target, useNative=false', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'channels/general__C123/2026-04-24/chat.jsonl',
-        virtual: '/channels/general__C123/2026-04-24/chat.jsonl',
-        directory: '/channels/general__C123/2026-04-24/chat.jsonl',
-      }),
-    )
-    expect(s.dateStr).toBe('2026-04-24')
-    expect(s.target).toBe('messages')
-    expect(s.useNative).toBe(false)
+  it('refuses a bare channel name', () => {
+    // The tree mints every dirname as `name__id`, so a bare name can never
+    // be a listed channel and classifies as invalid outright.
+    expect(detectScope('/channels/general').kind).toBe(INVALID)
   })
 
-  it('/channels/<chan>/<date>/files → files target, useNative=true', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'channels/general__C123/2026-04-24/files',
-        virtual: '/channels/general__C123/2026-04-24/files',
-        directory: '/channels/general__C123/2026-04-24/files',
-      }),
-    )
-    expect(s.target).toBe('files')
-    expect(s.useNative).toBe(true)
+  it('classifies a user file', () => {
+    const match = detectScope('/users/alice__U001.json')
+    expect(match.kind).toBe('user')
+    expect(match.slots).toEqual({ user: 'alice', user_id: 'U001' })
+    expect(NATIVE_KINDS.has('user')).toBe(false)
   })
 
-  it('/channels/<chan>/<date>/files/<blob> → files target, useNative=false', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'channels/general__C123/2026-04-24/files/foo__F1.pdf',
-        virtual: '/channels/general__C123/2026-04-24/files/foo__F1.pdf',
-        directory: '/channels/general__C123/2026-04-24/files/foo__F1.pdf',
-      }),
-    )
-    expect(s.target).toBe('files')
-    expect(s.useNative).toBe(false)
+  it('classifies a day directory', () => {
+    const match = detectScope('/channels/general__C001/2024-04-10')
+    expect(match.kind).toBe('day')
+    expect(match.slots.day).toBe('2024-04-10')
+    expect(NATIVE_KINDS.has('day')).toBe(true)
   })
 
-  it('/users → useNative=false, resourcePath=users', () => {
-    const s = detectScope(
-      new PathSpec({ resourcePath: 'users', virtual: '/users', directory: '/users' }),
-    )
-    expect(s.useNative).toBe(false)
-    expect(s.resourcePath).toBe('users')
+  it('refuses a non-date under a channel', () => {
+    expect(detectScope('/channels/general__C001/notadate').kind).toBe(INVALID)
   })
 
-  it('handles dirname without __id (just name)', () => {
-    const s = detectScope(
-      new PathSpec({
-        resourcePath: 'channels/general',
-        virtual: '/channels/general',
-        directory: '/channels/general',
-      }),
-    )
-    expect(s.channelName).toBe('general')
-    expect(s.channelId).toBeUndefined()
+  it('classifies chat.jsonl, which the push-down never answers', () => {
+    const match = detectScope('/channels/general__C001/2024-04-10/chat.jsonl')
+    expect(match.kind).toBe('messages')
+    expect(NATIVE_KINDS.has('messages')).toBe(false)
   })
 
-  it('respects PathSpec.prefix', () => {
-    const s = detectScope(
-      new PathSpec({
-        virtual: '/slack/channels/general__C1',
-        directory: '/slack/channels/general__C1',
-        resourcePath: mountKey('/slack/channels/general__C1', '/slack'),
-      }),
-    )
-    expect(s.channelName).toBe('general')
-    expect(s.channelId).toBe('C1')
+  it('classifies the files dir, which search.files cannot day-filter', () => {
+    expect(detectScope('/channels/general__C001/2024-04-10/files').kind).toBe('files')
+    expect(NATIVE_KINDS.has('files')).toBe(false)
+  })
+
+  it('classifies a file blob', () => {
+    const match = detectScope('/dms/bob__D001/2024-04-10/files/report__F1.pdf')
+    expect(match.kind).toBe('file_blob')
+    expect(match.slots.blob).toBe('report__F1.pdf')
+    expect(NATIVE_KINDS.has('file_blob')).toBe(false)
+  })
+
+  it('refuses unknown roots', () => {
+    expect(detectScope('/nope').kind).toBe(INVALID)
+    expect(detectScope('/nope/deeper').kind).toBe(INVALID)
+  })
+})
+
+describe('searchTarget', () => {
+  it('carries the channel coordinates', () => {
+    const target = searchTarget(detectScope('/channels/general__C001/2024-04-10'))
+    expect(target).toEqual({
+      container: 'channels',
+      channelName: 'general',
+      channelId: 'C001',
+    })
+  })
+
+  it('carries only the container at a container root', () => {
+    expect(searchTarget(detectScope('/dms'))).toEqual({ container: 'dms' })
+  })
+
+  it('is workspace-wide at the root', () => {
+    expect(searchTarget(detectScope('/'))).toEqual({})
   })
 })

--- a/typescript/packages/core/src/core/slack/scope.ts
+++ b/typescript/packages/core/src/core/slack/scope.ts
@@ -12,156 +12,84 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mountPrefixOf } from '../../utils/key_prefix.ts'
-import type { PathSpec } from '../../types.ts'
-import { stripSlash } from '../../utils/slash.ts'
+import { Codec, DATE, JSON_NAME } from '../hierarchy/codec.ts'
+import { makeDetectScope, ROOT, Scope, type ScopeMatch, Slot } from '../hierarchy/scope.ts'
+import { FileType } from '../../types.ts'
 
-type SlackTarget = 'date' | 'messages' | 'files'
+/** Whether a segment names a message container. */
+export function isContainer(text: string): boolean {
+  return text === 'channels' || text === 'dms'
+}
 
-export interface SlackScope {
-  useNative: boolean
+// Channels and DMs share every level below the container, so the container
+// is a validated slot rather than two parallel scope families; the decoded
+// value rides the slots the way an id does.
+const CONTAINER = new Codec({ validate: isContainer })
+
+const CHANNEL = [
+  new Slot('container', CONTAINER),
+  new Slot('channel', undefined, 'channel_id'),
+] as const
+const DAY = [...CHANNEL, new Slot('day', DATE)] as const
+
+// One description of the tree: readdir, stat, read and the search push-down
+// all classify through it, so the file surface and the command surface
+// cannot disagree about what a path means.
+export const SCOPES: readonly Scope[] = [
+  new Scope({ kind: 'channels_root', segments: ['channels'], probed: false }),
+  new Scope({ kind: 'dms_root', segments: ['dms'], probed: false }),
+  new Scope({ kind: 'users_root', segments: ['users'], probed: false }),
+  new Scope({
+    kind: 'user',
+    segments: ['users', new Slot('user', JSON_NAME, 'user_id')],
+    leaf: true,
+    filetype: FileType.JSON,
+  }),
+  new Scope({ kind: 'channel', segments: CHANNEL }),
+  new Scope({ kind: 'day', segments: DAY }),
+  new Scope({
+    kind: 'messages',
+    segments: [...DAY, 'chat.jsonl'],
+    leaf: true,
+    filetype: FileType.TEXT,
+  }),
+  new Scope({ kind: 'files', segments: [...DAY, 'files'] }),
+  new Scope({
+    kind: 'file_blob',
+    segments: [...DAY, 'files', new Slot('blob')],
+    leaf: true,
+  }),
+]
+
+export const detectScope = makeDetectScope(SCOPES)
+
+// Kinds the workspace search push-down may answer for. Slack search is
+// workspace-wide, so the root qualifies; a chat.jsonl or blob operand names
+// one day's file, which a channel-wide search cannot stand in for, and the
+// files directory is excluded because search.files has no per-day filter
+// either.
+export const NATIVE_KINDS: ReadonlySet<string> = new Set([
+  ROOT,
+  'channels_root',
+  'dms_root',
+  'channel',
+  'day',
+])
+
+/** The channel coordinates a search push-down carries. */
+export interface SearchTarget {
+  container?: string
   channelName?: string
   channelId?: string
-  container?: string
-  dateStr?: string
-  target?: SlackTarget
-  resourcePath: string
 }
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
-
-function stripSlashes(s: string): string {
-  return stripSlash(s)
-}
-
-function splitDirname(dirname: string): [string, string | undefined] {
-  const idx = dirname.lastIndexOf('__')
-  if (idx === -1) {
-    return [dirname, undefined]
+/** The coordinates a native search should scope itself to. */
+export function searchTarget(match: ScopeMatch): SearchTarget {
+  if (match.kind === 'channels_root') return { container: 'channels' }
+  if (match.kind === 'dms_root') return { container: 'dms' }
+  return {
+    ...(match.slots.container !== undefined ? { container: match.slots.container } : {}),
+    ...(match.slots.channel !== undefined ? { channelName: match.slots.channel } : {}),
+    ...(match.slots.channel_id !== undefined ? { channelId: match.slots.channel_id } : {}),
   }
-  const name = dirname.slice(0, idx)
-  const cid = dirname.slice(idx + 2)
-  return [name, cid.length > 0 ? cid : undefined]
-}
-
-function deepenedScope(
-  parts: string[],
-  prefix: string,
-  channelName: string,
-  cid: string | undefined,
-  container: string,
-  key: string,
-  base: 'native' | 'non-native',
-): SlackScope {
-  const dateStr = parts[2] ?? ''
-  const useNativeBase = base === 'native'
-  if (parts.length === 2) {
-    return {
-      useNative: true,
-      channelName,
-      ...(cid !== undefined ? { channelId: cid } : {}),
-      container,
-      resourcePath: key,
-    }
-  }
-  if (parts.length === 3 && DATE_RE.test(dateStr)) {
-    return {
-      useNative: useNativeBase,
-      channelName,
-      ...(cid !== undefined ? { channelId: cid } : {}),
-      container,
-      dateStr,
-      target: 'date',
-      resourcePath: key,
-    }
-  }
-  if (parts.length === 4 && DATE_RE.test(dateStr) && parts[3] === 'chat.jsonl') {
-    return {
-      useNative: false,
-      channelName,
-      ...(cid !== undefined ? { channelId: cid } : {}),
-      container,
-      dateStr,
-      target: 'messages',
-      resourcePath: key,
-    }
-  }
-  if (parts.length === 4 && DATE_RE.test(dateStr) && parts[3] === 'files') {
-    return {
-      useNative: true,
-      channelName,
-      ...(cid !== undefined ? { channelId: cid } : {}),
-      container,
-      dateStr,
-      target: 'files',
-      resourcePath: key,
-    }
-  }
-  if (parts.length === 5 && DATE_RE.test(dateStr) && parts[3] === 'files') {
-    return {
-      useNative: false,
-      channelName,
-      ...(cid !== undefined ? { channelId: cid } : {}),
-      container,
-      dateStr,
-      target: 'files',
-      resourcePath: key,
-    }
-  }
-  void prefix
-  return { useNative: false, resourcePath: key }
-}
-
-export function detectScope(path: PathSpec): SlackScope {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-
-  if (path.pattern !== null && path.pattern !== '') {
-    let dirKey = stripSlashes(path.directory)
-    if (prefix !== '') {
-      const stripped = stripSlashes(prefix) + '/'
-      if (dirKey.startsWith(stripped)) {
-        dirKey = dirKey.slice(stripped.length)
-      }
-    }
-    const dirParts = dirKey !== '' ? dirKey.split('/') : []
-    const [dirRoot, dirEntry] = dirParts
-    if (
-      dirParts.length >= 2 &&
-      dirEntry !== undefined &&
-      (dirRoot === 'channels' || dirRoot === 'dms')
-    ) {
-      const [name, cid] = splitDirname(dirEntry)
-      return deepenedScope(dirParts, prefix, name, cid, dirRoot, dirKey, 'native')
-    }
-  }
-
-  const key = path.resourcePath
-  if (key === '') {
-    return { useNative: true, resourcePath: '/' }
-  }
-
-  const parts = key.split('/')
-  const [root, second] = parts
-  if (root === undefined) {
-    return { useNative: false, resourcePath: key }
-  }
-
-  if (root === 'users') {
-    return { useNative: false, resourcePath: key }
-  }
-
-  if (root !== 'channels' && root !== 'dms') {
-    return { useNative: false, resourcePath: key }
-  }
-
-  if (parts.length === 1) {
-    return { useNative: true, container: root, resourcePath: key }
-  }
-
-  if (second === undefined) {
-    return { useNative: false, resourcePath: key }
-  }
-
-  const [name, cid] = splitDirname(second)
-  return deepenedScope(parts, prefix, name, cid, root, key, 'native')
 }

--- a/typescript/packages/core/src/core/slack/stat.test.ts
+++ b/typescript/packages/core/src/core/slack/stat.test.ts
@@ -23,11 +23,24 @@ import { stat } from './stat.ts'
 
 class FakeTransport implements SlackTransport {
   public readonly calls: { endpoint: string; params?: Record<string, string> }[] = []
-  constructor(private readonly responder: () => SlackResponse) {}
+  constructor(private readonly responder: (endpoint: string) => SlackResponse) {}
   call(endpoint: string, params?: Record<string, string>): Promise<SlackResponse> {
     this.calls.push({ endpoint, ...(params !== undefined ? { params } : {}) })
-    return Promise.resolve(this.responder())
+    return Promise.resolve(this.responder(endpoint))
   }
+}
+
+function channelWorld(endpoint: string): SlackResponse {
+  if (endpoint === 'conversations.list') {
+    return { ok: true, channels: [{ id: 'C1', name: 'general', created: 1 }] }
+  }
+  if (endpoint === 'conversations.open' || endpoint === 'users.conversations') {
+    return { ok: true, channels: [] }
+  }
+  if (endpoint === 'users.list') {
+    return { ok: true, members: [{ id: 'U1', name: 'alice' }] }
+  }
+  return { ok: true, channels: [], members: [], ims: [] }
 }
 
 function spec(virtual: string, prefix = ''): PathSpec {
@@ -167,25 +180,44 @@ describe('stat user file', () => {
 })
 
 describe('stat date directory', () => {
-  it('returns DIRECTORY with date name for channel/<chan>/<date>', async () => {
-    const t = new FakeTransport(() => ({ ok: true }))
+  it('returns DIRECTORY with date name for a listed channel', async () => {
+    const t = new FakeTransport(channelWorld)
     const out = await stat(
       new SlackAccessor(t),
       spec('/mnt/slack/channels/general__C1/2026-04-24', '/mnt/slack'),
     )
     expect(out.type).toBe(FileType.DIRECTORY)
     expect(out.name).toBe('2026-04-24')
-    expect(t.calls).toHaveLength(0)
   })
 
-  it('returns DIRECTORY with date name for dm/<dm>/<date>', async () => {
+  it('returns DIRECTORY with date name for a seeded dm', async () => {
+    const idx = new RAMIndexCacheStore()
+    await idx.setDir('/mnt/slack/dms', [
+      [
+        'alice__D1',
+        new IndexEntry({
+          id: 'D1',
+          name: 'alice',
+          resourceType: 'slack/dm',
+          vfsName: 'alice__D1',
+        }),
+      ],
+    ])
     const t = new FakeTransport(() => ({ ok: true }))
     const out = await stat(
       new SlackAccessor(t),
       spec('/mnt/slack/dms/alice__D1/2026-04-24', '/mnt/slack'),
+      idx,
     )
     expect(out.type).toBe(FileType.DIRECTORY)
     expect(out.name).toBe('2026-04-24')
+  })
+
+  it('throws ENOENT for a date under a bogus channel', async () => {
+    const t = new FakeTransport(channelWorld)
+    await expect(
+      stat(new SlackAccessor(t), spec('/mnt/slack/channels/nope__C9/2026-04-24', '/mnt/slack')),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })
 
@@ -230,14 +262,42 @@ describe('stat chat.jsonl and files dir', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('returns DIRECTORY files for <chan>/<date>/files', async () => {
+  it('returns DIRECTORY files for a listed day', async () => {
+    const idx = new RAMIndexCacheStore()
+    await idx.setDir('/mnt/slack/channels/general__C1/2026-04-24', [
+      [
+        'files',
+        new IndexEntry({
+          id: 'C1:2026-04-24:files',
+          name: 'files',
+          resourceType: 'slack/files_dir',
+          vfsName: 'files',
+          extra: { channel_id: 'C1', date: '2026-04-24' },
+        }),
+      ],
+    ])
     const t = new FakeTransport(() => ({ ok: true }))
     const out = await stat(
       new SlackAccessor(t),
       spec('/mnt/slack/channels/general__C1/2026-04-24/files', '/mnt/slack'),
+      idx,
     )
     expect(out.type).toBe(FileType.DIRECTORY)
     expect(out.name).toBe('files')
+  })
+
+  it('throws ENOENT for files under a sealed day', async () => {
+    // A sealed day lists nothing, so its files subdir does not exist.
+    const idx = new RAMIndexCacheStore()
+    await idx.setDir('/mnt/slack/channels/general__C1/2026-04-24', [])
+    const t = new FakeTransport(() => ({ ok: true }))
+    await expect(
+      stat(
+        new SlackAccessor(t),
+        spec('/mnt/slack/channels/general__C1/2026-04-24/files', '/mnt/slack'),
+        idx,
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })
 

--- a/typescript/packages/core/src/core/slack/stat.ts
+++ b/typescript/packages/core/src/core/slack/stat.ts
@@ -12,18 +12,19 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { enoent } from '../../utils/errors.ts'
-import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { SlackAccessor } from '../../accessor/slack.ts'
+import type { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
-import { readdir as coreReaddir } from './readdir.ts'
 import { epochToIso } from '../../utils/dates.ts'
+import { enoent } from '../../utils/errors.ts'
 import { filetypeFromMimetype } from '../../utils/filetype.ts'
-import { stripSlash } from '../../utils/slash.ts'
-
-const VIRTUAL_DIRS: ReadonlySet<string> = new Set(['', 'channels', 'dms', 'users'])
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
+import { resolveEntry } from '../hierarchy/probe.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
+import { makeStat } from '../hierarchy/stat.ts'
+import { readdir } from './readdir.ts'
+import { detectScope } from './scope.ts'
 
 function slackModified(remoteTime: string): string | null {
   if (remoteTime === '') return null
@@ -32,136 +33,90 @@ function slackModified(remoteTime: string): string | null {
   return epochToIso(ts)
 }
 
-async function lookupWithFallback(
-  accessor: SlackAccessor,
-  virtualKey: string,
-  prefix: string,
-  index: IndexCacheStore,
-) {
-  const result = await index.get(virtualKey)
-  if (result.entry !== undefined && result.entry !== null) return result
-  const parentVirtual = virtualKey.includes('/')
-    ? virtualKey.slice(0, virtualKey.lastIndexOf('/')) || '/'
-    : '/'
-  try {
-    await coreReaddir(
-      accessor,
-      new PathSpec({
-        virtual: parentVirtual,
-        directory: parentVirtual,
-        resolved: false,
-        resourcePath: mountKey(parentVirtual, prefix),
-      }),
-      index,
-    )
-  } catch {
-    // parent listing failed — fall through
-  }
-  return await index.get(virtualKey)
+function channelStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  const modified = slackModified(entry.remoteTime)
+  return new FileStat({
+    name: entry.vfsName !== '' ? entry.vfsName : entry.name,
+    type: FileType.DIRECTORY,
+    ...(modified !== null ? { modified } : {}),
+    extra: { channel_id: entry.id },
+  })
 }
 
-export async function stat(
+function userStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({
+    name: entry.vfsName !== '' ? entry.vfsName : entry.name,
+    type: FileType.JSON,
+    ...(entry.size !== null ? { size: entry.size } : {}),
+    extra: { user_id: entry.id },
+  })
+}
+
+function dirStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({ name: entry.vfsName, type: FileType.DIRECTORY })
+}
+
+function chatStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  // A denied or empty day lists no chat.jsonl, and the kit reports the
+  // absent entry as ENOENT: slack does not fabricate a sizeless file for a
+  // sealed day (discord deliberately does; see its override).
+  return new FileStat({
+    name: 'chat.jsonl',
+    type: FileType.TEXT,
+    ...(entry.size !== null ? { size: entry.size } : {}),
+  })
+}
+
+function fileBlobStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  const mimetype = typeof entry.extra.mimetype === 'string' ? entry.extra.mimetype : ''
+  const modified = slackModified(entry.remoteTime)
+  return new FileStat({
+    name: entry.vfsName !== '' ? entry.vfsName : entry.name,
+    type: filetypeFromMimetype(mimetype),
+    size: entry.size ?? null,
+    ...(modified !== null ? { modified } : {}),
+    extra: { file_id: entry.id },
+  })
+}
+
+/**
+ * Stat a day directory, which resolves beyond the listed window.
+ *
+ * The channel listing synthesizes a bounded window of recent days, but the
+ * history API answers a range query for any date, so a well-formed day under
+ * a channel that exists is a directory whether or not the window lists it. A
+ * bogus channel chain is ENOENT.
+ */
+async function statDay(
   accessor: SlackAccessor,
+  match: ScopeMatch,
   path: PathSpec,
   index?: IndexCacheStore,
 ): Promise<FileStat> {
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry !== null) {
+    return new FileStat({ name: entry.vfsName, type: FileType.DIRECTORY })
+  }
+  const virtual = path.virtual.replace(/\/+$/, '').split('/').slice(0, -1).join('/')
   const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  let raw = path.virtual
-  if (prefix !== '' && raw.startsWith(prefix)) {
-    raw = raw.slice(prefix.length) || '/'
+  const channelSpec = new PathSpec({
+    virtual,
+    directory: virtual,
+    resourcePath: mountKey(virtual, prefix),
+  })
+  if ((await resolveEntry(readdir, accessor, channelSpec, index)) === null) {
+    throw enoent(path)
   }
-  const key = stripSlash(raw)
-
-  if (VIRTUAL_DIRS.has(key)) {
-    const name = key !== '' ? key : '/'
-    return new FileStat({ name, type: FileType.DIRECTORY })
-  }
-
-  const parts = key.split('/')
-  const part0 = parts[0] ?? ''
-  const part2 = parts[2] ?? ''
-  const part3 = parts[3] ?? ''
-  const virtualKey = `${prefix}/${key}`
-
-  if (parts.length === 2 && (part0 === 'channels' || part0 === 'dms')) {
-    if (index === undefined) throw enoent(path)
-    const lookup = await lookupWithFallback(accessor, virtualKey, prefix, index)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw enoent(path)
-    }
-    return new FileStat({
-      name: lookup.entry.vfsName !== '' ? lookup.entry.vfsName : lookup.entry.name,
-      type: FileType.DIRECTORY,
-      modified: slackModified(lookup.entry.remoteTime),
-      extra: { channel_id: lookup.entry.id },
-    })
-  }
-
-  if (parts.length === 2 && part0 === 'users') {
-    if (index === undefined) throw enoent(path)
-    const lookup = await lookupWithFallback(accessor, virtualKey, prefix, index)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw enoent(path)
-    }
-    return new FileStat({
-      name: lookup.entry.vfsName !== '' ? lookup.entry.vfsName : lookup.entry.name,
-      type: FileType.JSON,
-      size: lookup.entry.size,
-      extra: { user_id: lookup.entry.id },
-    })
-  }
-
-  if (parts.length === 3 && (part0 === 'channels' || part0 === 'dms') && DATE_RE.test(part2)) {
-    return new FileStat({ name: part2, type: FileType.DIRECTORY })
-  }
-
-  if (
-    parts.length === 4 &&
-    (part0 === 'channels' || part0 === 'dms') &&
-    DATE_RE.test(part2) &&
-    part3 === 'chat.jsonl'
-  ) {
-    // The day's readdir renders the messages it fetched and stores the
-    // byte length, so stat serves it from the index instead of answering
-    // blind.
-    if (index === undefined) throw enoent(path)
-    const lookup = await lookupWithFallback(accessor, virtualKey, prefix, index)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw enoent(path)
-    }
-    return new FileStat({ name: 'chat.jsonl', type: FileType.TEXT, size: lookup.entry.size })
-  }
-
-  if (
-    parts.length === 4 &&
-    (part0 === 'channels' || part0 === 'dms') &&
-    DATE_RE.test(part2) &&
-    part3 === 'files'
-  ) {
-    return new FileStat({ name: 'files', type: FileType.DIRECTORY })
-  }
-
-  if (
-    parts.length === 5 &&
-    (part0 === 'channels' || part0 === 'dms') &&
-    DATE_RE.test(part2) &&
-    part3 === 'files'
-  ) {
-    if (index === undefined) throw enoent(path)
-    const lookup = await lookupWithFallback(accessor, virtualKey, prefix, index)
-    if (lookup.entry === undefined || lookup.entry === null) {
-      throw enoent(path)
-    }
-    const mimetype =
-      typeof lookup.entry.extra.mimetype === 'string' ? lookup.entry.extra.mimetype : ''
-    return new FileStat({
-      name: lookup.entry.vfsName !== '' ? lookup.entry.vfsName : lookup.entry.name,
-      type: filetypeFromMimetype(mimetype),
-      size: lookup.entry.size ?? null,
-      modified: slackModified(lookup.entry.remoteTime),
-      extra: { file_id: lookup.entry.id },
-    })
-  }
-
-  throw enoent(path)
+  return new FileStat({ name: match.slots.day ?? '', type: FileType.DIRECTORY })
 }
+
+export const stat = makeStat<SlackAccessor>(detectScope, readdir, {
+  entryStats: {
+    channel: channelStat,
+    user: userStat,
+    messages: chatStat,
+    files: dirStat,
+    file_blob: fileBlobStat,
+  },
+  overrides: { day: statDay },
+})

--- a/typescript/packages/node/src/commands/builtin/email/grep.ts
+++ b/typescript/packages/node/src/commands/builtin/email/grep.ts
@@ -35,7 +35,7 @@ import type { EmailAccessor } from '../../../accessor/email.ts'
 import { read as emailRead } from '../../../core/email/read.ts'
 import { readdir as emailReaddir } from '../../../core/email/readdir.ts'
 import { stat as emailStat } from '../../../core/email/stat.ts'
-import { detectScope } from '../../../core/email/scope.ts'
+import { detectScope, NATIVE_KINDS } from '../../../core/email/scope.ts'
 import { searchAndFormat } from '../../../core/email/search.ts'
 import { EMAIL_IO } from './io.ts'
 import { fileReadProvision } from './_provision.ts'
@@ -87,12 +87,12 @@ async function grepCommand(
   // answering, which is what the mount root does.
   const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
   if (pattern !== null && operand !== null && (fl.asBool('r') || fl.asBool('R'))) {
-    const scope = detectScope(operand)
-    if (scope.useNative && scope.folder !== null && scope.folder !== '') {
+    const match = detectScope(operand)
+    if (NATIVE_KINDS.has(match.kind)) {
       const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
       const pairs = await searchAndFormat(
         accessor,
-        scope,
+        match.slots.folder ?? '',
         pattern,
         filePrefix,
         accessor.config.maxMessages,

--- a/typescript/packages/node/src/commands/builtin/email/rg.ts
+++ b/typescript/packages/node/src/commands/builtin/email/rg.ts
@@ -34,7 +34,7 @@ import type { EmailAccessor } from '../../../accessor/email.ts'
 import { read as emailRead } from '../../../core/email/read.ts'
 import { readdir as emailReaddir } from '../../../core/email/readdir.ts'
 import { stat as emailStat } from '../../../core/email/stat.ts'
-import { detectScope } from '../../../core/email/scope.ts'
+import { detectScope, NATIVE_KINDS } from '../../../core/email/scope.ts'
 import { searchAndFormat } from '../../../core/email/search.ts'
 import { EMAIL_IO } from './io.ts'
 import { SEARCH_HONORED, messageLines } from './grep.ts'
@@ -80,12 +80,12 @@ async function rgCommand(
   // same way: a line the push-down cannot answer takes the generic scan.
   const operand = pushdownOperand(paths, opts.flags, pattern, SEARCH_HONORED)
   if (operand !== null) {
-    const scope = detectScope(operand)
-    if (scope.useNative && scope.folder !== null && scope.folder !== '') {
+    const match = detectScope(operand)
+    if (NATIVE_KINDS.has(match.kind)) {
       const filePrefix = mountPrefixOf(operand.virtual, operand.resourcePath)
       const pairs = await searchAndFormat(
         accessor,
-        scope,
+        match.slots.folder ?? '',
         pattern,
         filePrefix,
         accessor.config.maxMessages,

--- a/typescript/packages/node/src/core/email/_parse.ts
+++ b/typescript/packages/node/src/core/email/_parse.ts
@@ -25,13 +25,13 @@ interface EmailAddress {
   email: string
 }
 
-export interface ParsedAttachment {
+interface ParsedAttachment {
   filename: string
   content_type: string
   size: number
 }
 
-export interface ParsedAttachmentWithPayload extends ParsedAttachment {
+interface ParsedAttachmentWithPayload extends ParsedAttachment {
   payload: Uint8Array
 }
 

--- a/typescript/packages/node/src/core/email/read.ts
+++ b/typescript/packages/node/src/core/email/read.ts
@@ -13,47 +13,48 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
+import { resolveEntry } from '@struktoai/mirage-core/core/hierarchy/probe'
+import { makeRead } from '@struktoai/mirage-core/core/hierarchy/read'
+import type { ScopeMatch } from '@struktoai/mirage-core/core/hierarchy/scope'
 import type { PathSpec } from '@struktoai/mirage-core/types'
-import { eisdir, enoent } from '@struktoai/mirage-core/utils/errors'
-import { mountPrefixOf } from '@struktoai/mirage-core/utils/key_prefix'
-import { gnuDirname } from '@struktoai/mirage-core/utils/path'
-import { stripSlash } from '@struktoai/mirage-core/utils/slash'
+import { enoent } from '@struktoai/mirage-core/utils/errors'
 import type { EmailAccessor } from '../../accessor/email.ts'
 import { fetchAttachment, fetchMessage } from './client.ts'
+import { readdir } from './readdir.ts'
 import { messageJsonBytes } from './render.ts'
+import { detectScope } from './scope.ts'
 
-export async function read(
+async function readMessage(
   accessor: EmailAccessor,
+  match: ScopeMatch,
   path: PathSpec,
   index?: IndexCacheStore,
 ): Promise<Uint8Array> {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  const key = path.resourcePath
-  if (index === undefined) throw enoent(path.virtual)
-  const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
-  const result = await index.get(virtualKey)
-  if (result.entry === undefined || result.entry === null) throw enoent(path.virtual)
-  const rt = result.entry.resourceType
-  if (rt === 'email/folder' || rt === 'email/date' || rt === 'email/attachment_dir') {
-    throw eisdir(path.virtual)
-  }
-  if (rt === 'email/attachment') {
-    const parentKey = gnuDirname(virtualKey)
-    const parentResult = await index.get(parentKey)
-    if (parentResult.entry === undefined || parentResult.entry === null) {
-      throw enoent(path.virtual)
-    }
-    const uid = parentResult.entry.id
-    const parts = stripSlash(virtualKey).split('/')
-    const folder = prefix !== '' ? (parts[1] ?? '') : (parts[0] ?? '')
-    const filename = result.entry.vfsName !== '' ? result.entry.vfsName : result.entry.name
-    const data = await fetchAttachment(accessor, folder, uid, filename)
-    if (data === null) throw enoent(path.virtual)
-    return data
-  }
-  const parts = stripSlash(virtualKey).split('/')
-  const folder = prefix !== '' ? (parts[1] ?? '') : (parts[0] ?? '')
-  const uid = result.entry.id
-  const msg = await fetchMessage(accessor, folder, uid)
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry === null) throw enoent(path)
+  const msg = await fetchMessage(accessor, match.slots.folder ?? '', entry.id)
   return messageJsonBytes(msg)
 }
+
+async function readAttachment(
+  accessor: EmailAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<Uint8Array> {
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry === null) throw enoent(path)
+  const data = await fetchAttachment(
+    accessor,
+    match.slots.folder ?? '',
+    match.slots.uid ?? '',
+    entry.vfsName,
+  )
+  if (data === null) throw enoent(path)
+  return data
+}
+
+export const read = makeRead<EmailAccessor>(detectScope, {
+  message: readMessage,
+  attachment: readAttachment,
+})

--- a/typescript/packages/node/src/core/email/readdir.ts
+++ b/typescript/packages/node/src/core/email/readdir.ts
@@ -13,18 +13,19 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { IndexEntry } from '@struktoai/mirage-core/cache/index/config'
-import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
-import { PathSpec as PathSpecCtor } from '@struktoai/mirage-core/types'
-import type { PathSpec } from '@struktoai/mirage-core/types'
-import { enoent } from '@struktoai/mirage-core/utils/errors'
-import { mountKey, mountPrefixOf } from '@struktoai/mirage-core/utils/key_prefix'
+import {
+  makeReaddir,
+  type DirListing,
+  type Listed,
+} from '@struktoai/mirage-core/core/hierarchy/readdir'
+import type { ScopeMatch } from '@struktoai/mirage-core/core/hierarchy/scope'
 import { NAME_MAX_BYTES, byteLength, sanitizeLabel } from '@struktoai/mirage-core/utils/sanitize'
 import { compareCodePoints } from '@struktoai/mirage-core/utils/sort'
 import type { EmailAccessor } from '../../accessor/email.ts'
 import { fetchHeaders, listMessageUids, type FetchedMessage } from './client.ts'
 import { listFolders } from './folders.ts'
 import { messageJsonBytes } from './render.ts'
-import type { ParsedAttachment } from './_parse.ts'
+import { detectScope } from './scope.ts'
 
 const TITLE_MAX = 80
 const EPOCH_DATE = '1970-01-01'
@@ -112,130 +113,152 @@ export function dateBucket(message: FetchedMessage): string {
   return parseDate(message.date) ?? parseDate(message.internalDate) ?? EPOCH_DATE
 }
 
-export async function readdir(
-  accessor: EmailAccessor,
-  path: PathSpec,
-  index?: IndexCacheStore,
-): Promise<string[]> {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  const key = (path.pattern !== null ? path.dir : path).resourcePath
-  const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
-  const parts = key === '' ? [] : key.split('/')
-  const depth = parts.length
-
-  if (depth === 0) {
-    if (index !== undefined) {
-      const cached = await index.listDir(virtualKey)
-      if (cached.entries !== undefined && cached.entries !== null) return cached.entries
-    }
-    const folders = await listFolders(accessor)
-    const entries: [string, IndexEntry][] = []
-    for (const folderName of folders) {
-      const entry = new IndexEntry({
-        id: folderName,
-        name: folderName,
-        resourceType: 'email/folder',
-        vfsName: folderName,
-      })
-      entries.push([folderName, entry])
-    }
-    if (index !== undefined) await index.setDir(virtualKey, entries)
-    return entries.map(([name]) => `${prefix}/${name}`)
-  }
-
-  if (depth === 1) {
-    const folderName = parts[0] ?? ''
-    if (index !== undefined) {
-      const cached = await index.listDir(virtualKey)
-      if (cached.entries !== undefined && cached.entries !== null) return cached.entries
-    }
-    if (index === undefined) throw enoent(path.virtual)
-    // An unknown folder must be ENOENT: selecting it over IMAP fails with
-    // "command SEARCH illegal in state AUTH", which leaked to the caller.
-    if (!(await listFolders(accessor)).includes(folderName)) throw enoent(path.virtual)
-    const maxMessages = accessor.config.maxMessages
-    const uids = await listMessageUids(accessor, folderName, 'ALL', maxMessages)
-    const headersList = await fetchHeaders(accessor, folderName, uids)
-    const dateGroups = new Map<string, typeof headersList>()
-    for (const hdr of headersList) {
-      const dateStr = dateBucket(hdr)
-      let bucket = dateGroups.get(dateStr)
-      if (bucket === undefined) {
-        bucket = []
-        dateGroups.set(dateStr, bucket)
-      }
-      bucket.push(hdr)
-    }
-    const sortedDates = [...dateGroups.keys()].sort(compareCodePoints).reverse()
-    const dateEntries: [string, IndexEntry][] = []
-    for (const dateStr of sortedDates) {
-      const dateEntry = new IndexEntry({
-        id: dateStr,
-        name: dateStr,
-        resourceType: 'email/date',
-        vfsName: dateStr,
-      })
-      dateEntries.push([dateStr, dateEntry])
-      const msgEntries: [string, IndexEntry][] = []
-      for (const hdr of dateGroups.get(dateStr) ?? []) {
-        const uid = hdr.uid
-        const subject = hdr.subject || 'No Subject'
-        const filename = msgFilename(subject, uid)
-        const msgEntry = new IndexEntry({
+/** One date directory's children, plus its attachment-dir seeds. */
+function dateChildren(headers: readonly FetchedMessage[]): {
+  children: [string, IndexEntry][]
+  seeds: Record<string, [string, IndexEntry][]>
+} {
+  const children: [string, IndexEntry][] = []
+  const seeds: Record<string, [string, IndexEntry][]> = {}
+  for (const hdr of headers) {
+    const uid = hdr.uid
+    const subject = hdr.subject || 'No Subject'
+    const filename = msgFilename(subject, uid)
+    children.push([
+      filename,
+      new IndexEntry({
+        id: uid,
+        name: subject,
+        resourceType: 'email/message',
+        vfsName: filename,
+        size: messageJsonBytes(hdr).byteLength,
+      }),
+    ])
+    const attachments = hdr.attachments
+    if (attachments.length > 0) {
+      const attDirName = filename.replace('.email.json', '')
+      children.push([
+        attDirName,
+        new IndexEntry({
           id: uid,
-          name: subject,
-          resourceType: 'email/message',
-          vfsName: filename,
-          size: messageJsonBytes(hdr).byteLength,
-        })
-        msgEntries.push([filename, msgEntry])
-        const attachments: ParsedAttachment[] = hdr.attachments
-        if (attachments.length > 0) {
-          const attDirName = filename.replace('.email.json', '')
-          const attDirEntry = new IndexEntry({
-            id: uid,
-            name: attDirName,
-            resourceType: 'email/attachment_dir',
-            vfsName: attDirName,
-          })
-          msgEntries.push([attDirName, attDirEntry])
-          const attEntries: [string, IndexEntry][] = []
-          for (const att of attachments) {
-            const attEntry = new IndexEntry({
+          name: attDirName,
+          resourceType: 'email/attachment_dir',
+          vfsName: attDirName,
+        }),
+      ])
+      seeds[attDirName] = attachments.map(
+        (att) =>
+          [
+            att.filename,
+            new IndexEntry({
               id: att.filename,
               name: att.filename,
               resourceType: 'email/attachment',
               vfsName: att.filename,
               size: att.size,
-            })
-            attEntries.push([att.filename, attEntry])
-          }
-          const attDirVKey = `${virtualKey}/${dateStr}/${attDirName}`
-          await index.setDir(attDirVKey, attEntries)
-        }
-      }
-      const dateVKey = `${virtualKey}/${dateStr}`
-      await index.setDir(dateVKey, msgEntries)
+            }),
+          ] as [string, IndexEntry],
+      )
     }
-    await index.setDir(virtualKey, dateEntries)
-    return dateEntries.map(([name]) => `${prefix}/${key}/${name}`)
   }
-
-  if (depth === 2 || depth === 3) {
-    if (index === undefined) throw enoent(path.virtual)
-    let cached = await index.listDir(virtualKey)
-    if (cached.entries !== undefined && cached.entries !== null) return cached.entries
-    const folderPath = prefix !== '' ? `${prefix}/${parts[0] ?? ''}` : `/${parts[0] ?? ''}`
-    const folderSpec = new PathSpecCtor({
-      virtual: folderPath,
-      directory: folderPath,
-      resourcePath: mountKey(folderPath, prefix),
-    })
-    await readdir(accessor, folderSpec, index)
-    cached = await index.listDir(virtualKey)
-    if (cached.entries !== undefined && cached.entries !== null) return cached.entries
-    throw enoent(path.virtual)
-  }
-
-  throw enoent(path.virtual)
+  return { children, seeds }
 }
+
+async function folderHeaders(
+  accessor: EmailAccessor,
+  folderName: string,
+): Promise<FetchedMessage[]> {
+  const uids = await listMessageUids(accessor, folderName, 'ALL', accessor.config.maxMessages)
+  return fetchHeaders(accessor, folderName, uids)
+}
+
+async function listRoot(accessor: EmailAccessor, _match: ScopeMatch): Promise<Listed | null> {
+  const folders = await listFolders(accessor)
+  return folders.map(
+    (name) =>
+      [
+        name,
+        new IndexEntry({
+          id: name,
+          name,
+          resourceType: 'email/folder',
+          vfsName: name,
+        }),
+      ] as [string, IndexEntry],
+  )
+}
+
+async function listFolder(
+  accessor: EmailAccessor,
+  _match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  const headersList = await folderHeaders(accessor, own.id)
+  const dateGroups = new Map<string, FetchedMessage[]>()
+  for (const hdr of headersList) {
+    const dateStr = dateBucket(hdr)
+    let bucket = dateGroups.get(dateStr)
+    if (bucket === undefined) {
+      bucket = []
+      dateGroups.set(dateStr, bucket)
+    }
+    bucket.push(hdr)
+  }
+  const sortedDates = [...dateGroups.keys()].sort(compareCodePoints).reverse()
+  const entries: [string, IndexEntry][] = []
+  const seeds: Record<string, [string, IndexEntry][]> = {}
+  for (const dateStr of sortedDates) {
+    entries.push([
+      dateStr,
+      new IndexEntry({
+        id: dateStr,
+        name: dateStr,
+        resourceType: 'email/date',
+        vfsName: dateStr,
+      }),
+    ])
+    const { children, seeds: attSeeds } = dateChildren(dateGroups.get(dateStr) ?? [])
+    seeds[dateStr] = children
+    for (const [attDir, attEntries] of Object.entries(attSeeds)) {
+      seeds[`${dateStr}/${attDir}`] = attEntries
+    }
+  }
+  return { entries, seeds }
+}
+
+async function listDay(
+  accessor: EmailAccessor,
+  match: ScopeMatch,
+  _own: IndexEntry,
+): Promise<Listed> {
+  // Normally served from the folder lister's seed; reached only when the
+  // index evicted the day listing while the date entry survived.
+  const headersList = await folderHeaders(accessor, match.slots.folder ?? '')
+  const day = match.slots.day ?? ''
+  const { children, seeds } = dateChildren(headersList.filter((hdr) => dateBucket(hdr) === day))
+  const listing: DirListing = { entries: children, seeds }
+  return listing
+}
+
+async function listAttachmentDir(
+  accessor: EmailAccessor,
+  match: ScopeMatch,
+  own: IndexEntry,
+): Promise<Listed> {
+  // Same eviction fallback: one header fetch rebuilds the listing.
+  const headersList = await fetchHeaders(accessor, match.slots.folder ?? '', [own.id])
+  for (const hdr of headersList) {
+    const { seeds } = dateChildren([hdr])
+    for (const attEntries of Object.values(seeds)) return attEntries
+  }
+  return []
+}
+
+export const readdir = makeReaddir<EmailAccessor>(detectScope, {
+  listers: { root: listRoot },
+  entryListers: {
+    folder: listFolder,
+    day: listDay,
+    attachment_dir: listAttachmentDir,
+  },
+})

--- a/typescript/packages/node/src/core/email/scope.ts
+++ b/typescript/packages/node/src/core/email/scope.ts
@@ -12,29 +12,43 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { PathSpec } from '@struktoai/mirage-core/types'
-import { stripSlash } from '@struktoai/mirage-core/utils/slash'
+import { Codec, DATE } from '@struktoai/mirage-core/core/hierarchy/codec'
+import { makeDetectScope, Scope, Slot } from '@struktoai/mirage-core/core/hierarchy/scope'
+import { FileType } from '@struktoai/mirage-core/types'
 
-export interface EmailScope {
-  useNative: boolean
-  folder: string | null
-  resourcePath: string
-}
+const EMAIL_JSON = new Codec({ suffix: '.email.json' })
 
-export function detectScope(path: PathSpec): EmailScope {
-  const key = stripSlash(path.mountPath)
-  if (key === '') {
-    return { useNative: false, folder: null, resourcePath: '/' }
-  }
-  const parts = key.split('/').filter((s) => s !== '')
-  if (parts.length === 0) {
-    return { useNative: false, folder: null, resourcePath: '/' }
-  }
-  if (key.endsWith('.email.json')) {
-    return { useNative: false, folder: parts[0] ?? null, resourcePath: key }
-  }
-  if (parts.length <= 2) {
-    return { useNative: true, folder: parts[0] ?? null, resourcePath: key }
-  }
-  return { useNative: false, folder: parts[0] ?? null, resourcePath: key }
-}
+const FOLDER = [new Slot('folder')] as const
+const DAY = [...FOLDER, new Slot('day', DATE)] as const
+
+// One description of the tree: readdir, stat, read and the search push-down
+// all classify through it, so the file surface and the command surface
+// cannot disagree about what a path means. The message scope is declared
+// before the attachment dir because only the suffix separates the two at
+// that depth.
+const SCOPES: readonly Scope[] = [
+  new Scope({ kind: 'folder', segments: FOLDER }),
+  new Scope({ kind: 'day', segments: DAY }),
+  new Scope({
+    kind: 'message',
+    segments: [...DAY, new Slot('message', EMAIL_JSON, 'uid')],
+    leaf: true,
+    filetype: FileType.JSON,
+  }),
+  new Scope({
+    kind: 'attachment_dir',
+    segments: [...DAY, new Slot('attachment_dir', undefined, 'uid')],
+  }),
+  new Scope({
+    kind: 'attachment',
+    segments: [...DAY, new Slot('attachment_dir', undefined, 'uid'), new Slot('filename')],
+    leaf: true,
+  }),
+]
+
+export const detectScope = makeDetectScope(SCOPES)
+
+// Kinds the mailbox search push-down may answer for: one folder or one of
+// its days. IMAP search selects a folder, so the mount root cannot push
+// down, and a message or attachment names one node.
+export const NATIVE_KINDS: ReadonlySet<string> = new Set(['folder', 'day'])

--- a/typescript/packages/node/src/core/email/search.ts
+++ b/typescript/packages/node/src/core/email/search.ts
@@ -16,7 +16,6 @@ import type { EmailAccessor } from '../../accessor/email.ts'
 import { fetchMessage, listMessageUids, type FetchedMessage } from './client.ts'
 import { dateBucket, msgFilename } from './readdir.ts'
 import { messageJsonText } from './render.ts'
-import type { EmailScope } from './scope.ts'
 
 interface SearchOptions {
   text?: string | null
@@ -74,12 +73,11 @@ export function buildVfsPath(prefix: string, folder: string, msg: FetchedMessage
 
 export async function searchAndFormat(
   accessor: EmailAccessor,
-  scope: EmailScope,
+  folder: string,
   pattern: string,
   prefix: string,
   maxResults: number | null = null,
 ): Promise<[string, string][]> {
-  const folder = scope.folder ?? ''
   if (folder === '') return []
   const uids = await searchMessages(accessor, folder, { text: pattern }, maxResults)
   const pairs: [string, string][] = []

--- a/typescript/packages/node/src/core/email/stat.ts
+++ b/typescript/packages/node/src/core/email/stat.ts
@@ -12,79 +12,52 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
-import { FileStat, FileType, PathSpec } from '@struktoai/mirage-core/types'
-import { enoent } from '@struktoai/mirage-core/utils/errors'
+import type { IndexEntry } from '@struktoai/mirage-core/cache/index/config'
+import { makeStat } from '@struktoai/mirage-core/core/hierarchy/stat'
+import type { ScopeMatch } from '@struktoai/mirage-core/core/hierarchy/scope'
+import type { PathSpec } from '@struktoai/mirage-core/types'
+import { FileStat, FileType } from '@struktoai/mirage-core/types'
 import { guessType } from '@struktoai/mirage-core/utils/filetype'
-import { mountKey, mountPrefixOf } from '@struktoai/mirage-core/utils/key_prefix'
 import type { EmailAccessor } from '../../accessor/email.ts'
-import { listFolders } from './folders.ts'
 import { readdir } from './readdir.ts'
+import { detectScope } from './scope.ts'
 
-export async function stat(
-  accessor: EmailAccessor,
-  path: PathSpec,
-  index?: IndexCacheStore,
-): Promise<FileStat> {
-  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
-  const key = path.resourcePath
-  if (key === '') return new FileStat({ name: '/', type: FileType.DIRECTORY })
-
-  if (index === undefined) throw enoent(path.virtual)
-  const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
-  let result = await index.get(virtualKey)
-  if (result.entry === undefined || result.entry === null) {
-    if (!key.includes('/')) {
-      const folders = await listFolders(accessor)
-      if (folders.includes(key)) return new FileStat({ name: key, type: FileType.DIRECTORY })
-      throw enoent(path.virtual)
-    }
-    // Cold index: populate by listing the parent, mirroring the python
-    // backend's stat fallback.
-    const parentVirtual = virtualKey.slice(0, virtualKey.lastIndexOf('/')) || '/'
-    try {
-      await readdir(
-        accessor,
-        new PathSpec({
-          virtual: parentVirtual,
-          directory: parentVirtual,
-          resolved: false,
-          resourcePath: mountKey(parentVirtual, prefix),
-        }),
-        index,
-      )
-    } catch {
-      throw enoent(path.virtual)
-    }
-    result = await index.get(virtualKey)
-    if (result.entry === undefined || result.entry === null) throw enoent(path.virtual)
-  }
-  const rt = result.entry.resourceType
-  const vfsName = result.entry.vfsName !== '' ? result.entry.vfsName : result.entry.name
-  if (rt === 'email/folder') return new FileStat({ name: vfsName, type: FileType.DIRECTORY })
-  if (rt === 'email/date') return new FileStat({ name: vfsName, type: FileType.DIRECTORY })
-  if (rt === 'email/message') {
-    return new FileStat({
-      name: vfsName,
-      type: FileType.JSON,
-      size: result.entry.size,
-      extra: { uid: result.entry.id },
-    })
-  }
-  if (rt === 'email/attachment_dir') {
-    return new FileStat({
-      name: vfsName,
-      type: FileType.DIRECTORY,
-      extra: { uid: result.entry.id },
-    })
-  }
-  if (rt === 'email/attachment') {
-    return new FileStat({
-      name: vfsName,
-      type: guessType(vfsName),
-      size: result.entry.size,
-      extra: { attachment_id: result.entry.id },
-    })
-  }
-  return new FileStat({ name: vfsName, type: FileType.JSON, extra: { uid: result.entry.id } })
+function dirStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({ name: entry.vfsName, type: FileType.DIRECTORY })
 }
+
+function messageStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({
+    name: entry.vfsName,
+    type: FileType.JSON,
+    size: entry.size,
+    extra: { uid: entry.id },
+  })
+}
+
+function attachmentDirStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({
+    name: entry.vfsName,
+    type: FileType.DIRECTORY,
+    extra: { uid: entry.id },
+  })
+}
+
+function attachmentStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
+  return new FileStat({
+    name: entry.vfsName,
+    type: guessType(entry.vfsName),
+    size: entry.size,
+    extra: { attachment_id: entry.id },
+  })
+}
+
+export const stat = makeStat<EmailAccessor>(detectScope, readdir, {
+  entryStats: {
+    folder: dirStat,
+    day: dirStat,
+    message: messageStat,
+    attachment_dir: attachmentDirStat,
+    attachment: attachmentStat,
+  },
+})


### PR DESCRIPTION
Migrates the four wave-2d backends (discord, slack, gmail, email) onto the core/hierarchy kit, in both languages. The hand-rolled dataclass scope classifiers, readdir ladders and stat/read plumbing are replaced by kit scope tables, listers, guards and readers; grep/rg/head wrappers gate on a per-backend NATIVE_KINDS set plus match slots instead of scope.use_native.

Kit extensions (tested in tests/core/hierarchy and the .test.ts twins):

- DirListing(entries, seeds): a lister can return descendant listings the same fetch proved (discord/slack day fetch seeds the files dir; gmail label listing seeds date and attachment dirs), with a post-resolve re-check so a resolve that ran the seeding parent is not refetched.
- parent_entry_listers: a third lister table whose existence proof is the parent dir entry, for day directories that must list beyond the synthesized window.
- make_read_range: byte windows; ranged kinds (discord/slack file blobs) push offset/size to the source, everything else slices the full read.
- DATE codec: shape-only ISO date segment validation.

Behavior changes, pinned by unit tests; integ goldens needed zero changes (374/374 per host, both hosts, targets discord/slack/gmail/email/argerr-*/cli-discord/cli-slack):

- bare name segments without __id are now ENOENT everywhere (the tree always mints name__id)
- static container dirs under a nonexistent guild are ENOENT (was an unconditional dir)
- discord/slack files dir under a sealed day is ENOENT (was a dir)
- cat of an existing gmail label/date/attachment dir is ENOENT, not EISDIR (matched shape is not existence; the mount root stays EISDIR)
- gmail readdir bootstrap failures propagate instead of collapsing to ENOENT
- discord/slack cold reads work (old read required a warm index)
- deliberate divergence kept: discord stats a sealed day's chat.jsonl as size-unknown, slack answers ENOENT (pinned in both)

Verified: full python suite + mypy clean, pnpm -r build/typecheck/test, layout parity at baseline, pre-commit fixpoint.