### PR TITLE
feat(hierarchy): move lancedb and qdrant onto the kit with per-mount routes

### DIFF
--- a/python/mirage/core/hierarchy/bind.py
+++ b/python/mirage/core/hierarchy/bind.py
@@ -1,0 +1,50 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import Callable
+from typing import TypeVar
+from weakref import WeakKeyDictionary
+
+from mirage.accessor.base import Accessor
+from mirage.core.hierarchy.probe import A
+
+T = TypeVar("T")
+
+
+def per_accessor(build: Callable[[A], T]) -> Callable[[A], T]:
+    """Cache one built value per accessor, for config-shaped route tables.
+
+    Most backends have one tree shape, so their scope table and factories
+    bind at module import. A backend whose tree is a function of mount
+    config (lancedb's ``group_by`` depth and leaf set, qdrant's likewise)
+    builds them per mount instead: the accessor carries the config, so
+    the accessor is the cache key, and the cache is weak so a dropped
+    mount takes its routes with it. The build runs once per accessor;
+    listers, guards and readers stay module-level functions that read
+    ``accessor.config`` at call time, so tests keep patching client
+    functions the same way they do for import-bound backends.
+
+    Args:
+        build (Callable[[A], T]): constructs the per-mount value.
+    """
+    cache: "WeakKeyDictionary[Accessor, T]" = WeakKeyDictionary()
+
+    def cached(accessor: A) -> T:
+        got = cache.get(accessor)
+        if got is None:
+            got = build(accessor)
+            cache[accessor] = got
+        return got
+
+    return cached

--- a/python/mirage/core/hierarchy/readdir.py
+++ b/python/mirage/core/hierarchy/readdir.py
@@ -86,10 +86,12 @@ def make_readdir(
     async def readdir(accessor: A,
                       path_spec: PathSpec,
                       index: IndexCacheStore = NULL_INDEX) -> list[str]:
-        if index is NULL_INDEX:
+        if index is NULL_INDEX or index is None:
             # Entry resolution and the parent-listing warm both read what
             # readdir just wrote, so a caller with no cache still needs
-            # one for the duration of the call.
+            # one for the duration of the call. None arrives from bare
+            # commands built outside a workspace (the TS twin's ?? treats
+            # null and undefined alike).
             index = RAMIndexCacheStore()
         virtual = path_spec.virtual
         prefix = mount_prefix_of(path_spec.virtual, path_spec.resource_path)

--- a/python/mirage/core/hierarchy/stat.py
+++ b/python/mirage/core/hierarchy/stat.py
@@ -90,10 +90,12 @@ def make_stat(
     async def stat(accessor: A,
                    path: PathSpec,
                    index: IndexCacheStore = NULL_INDEX) -> FileStat:
-        if index is NULL_INDEX:
+        if index is NULL_INDEX or index is None:
             # Entry resolution and listed_size read what the probe's
             # parent listing just wrote, so a caller with no cache still
-            # needs one for the duration of the call.
+            # needs one for the duration of the call. None arrives from
+            # bare commands built outside a workspace (the TS twin's ??
+            # treats null and undefined alike).
             index = RAMIndexCacheStore()
         virtual = path.virtual
         match = detect(path)

--- a/python/mirage/core/lancedb/read.py
+++ b/python/mirage/core/lancedb/read.py
@@ -13,21 +13,26 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import base64
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from mirage.accessor.lancedb import LanceDBAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.hierarchy.bind import per_accessor
+from mirage.core.hierarchy.read import Reader, make_read
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.core.lancedb.query import row_record
 from mirage.core.lancedb.render import render_card
-from mirage.core.lancedb.scope import LanceDBRowScope, detect_scope
+from mirage.core.lancedb.scope import detect_for, table_of
 from mirage.types import JsonValue, PathSpec
 from mirage.utils.errors import enoent
 
 
-async def _resolve_row(accessor: LanceDBAccessor, scope, config,
-                       virtual: str) -> dict[str, Any]:
-    row = await row_record(accessor, scope.table, config.id_column,
-                           scope.row_id)
+async def _row_of(accessor: LanceDBAccessor, match: ScopeMatch,
+                  virtual: str) -> dict[str, Any]:
+    config = accessor.config
+    row = await row_record(accessor, table_of(config, match), config.id_column,
+                           match.slots["row_id"])
     if row is None:
         raise enoent(virtual)
     return row
@@ -41,18 +46,37 @@ def _blob_bytes(value: JsonValue) -> bytes:
     raise ValueError("blob column is not bytes or base64 str")
 
 
+async def _read_card(accessor: LanceDBAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    row = await _row_of(accessor, match, path.virtual)
+    return render_card(row, accessor.config)
+
+
+async def _read_blob(accessor: LanceDBAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    config = accessor.config
+    if not config.blob_column:
+        raise enoent(path)
+    row = await _row_of(accessor, match, path.virtual)
+    return _blob_bytes(row.get(config.blob_column))
+
+
+READERS: dict[str, Reader[LanceDBAccessor]] = {
+    "row_card": _read_card,
+    "row_blob": _read_blob,
+}
+
+
+def _build(accessor: LanceDBAccessor) -> Callable[..., Awaitable[bytes]]:
+    return make_read(detect_for(accessor), READERS)
+
+
+read_for = per_accessor(_build)
+
+
 async def read(
     accessor: LanceDBAccessor,
     path: PathSpec,
     index: IndexCacheStore = NULL_INDEX,
 ) -> bytes:
-    config = accessor.config
-    scope = detect_scope(path, config)
-    if not isinstance(scope, LanceDBRowScope):
-        raise enoent(path)
-    row = await _resolve_row(accessor, scope, config, path.virtual)
-    if scope.blob:
-        if not config.blob_column:
-            raise enoent(path)
-        return _blob_bytes(row.get(config.blob_column))
-    return render_card(row, config)
+    return await read_for(accessor)(accessor, path, index)

--- a/python/mirage/core/lancedb/readdir.py
+++ b/python/mirage/core/lancedb/readdir.py
@@ -16,26 +16,30 @@ from typing import Any
 
 from mirage.accessor.lancedb import LanceDBAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
+from mirage.core.hierarchy.bind import per_accessor
+from mirage.core.hierarchy.probe import ReaddirFn
+from mirage.core.hierarchy.readdir import Lister, make_readdir
+from mirage.core.hierarchy.scope import ROOT, ScopeMatch
 from mirage.core.lancedb.query import (distinct_values, list_tables,
-                                       rows_matching, table_columns)
+                                       rows_matching, table_columns,
+                                       table_exists)
 from mirage.core.lancedb.render import render_card
-from mirage.core.lancedb.scope import (LanceDBGroupScope, ScopeLevel,
-                                       detect_scope)
+from mirage.core.lancedb.scope import detect_for, filters_of, table_of
+from mirage.resource.lancedb.config import LanceDBConfig
 from mirage.types import PathSpec
 
+GROUP_TYPE = "lancedb/group"
 
-def _row_files(rows: list[dict[str, Any]], config) -> list[str]:
-    names: list[str] = []
-    for row in rows:
-        rid = row[config.id_column]
-        names.append(f"{rid}.md")
-        if config.blob_column:
-            names.append(f"{rid}.{config.blob_ext}")
-    return names
+
+def _dir_entry(name: str) -> IndexEntry:
+    return IndexEntry(id=name,
+                      name=name,
+                      resource_type=GROUP_TYPE,
+                      vfs_name=name)
 
 
 def _row_entries(rows: list[dict[str, Any]],
-                 config) -> list[tuple[str, IndexEntry]]:
+                 config: LanceDBConfig) -> list[tuple[str, IndexEntry]]:
     # The widened select carries every rendered column, so each card's exact
     # size is free here; blob values are deliberately not fetched at listing
     # time, so blob entries stay size-unknown and stat renders them itself.
@@ -62,41 +66,63 @@ def _row_entries(rows: list[dict[str, Any]],
     return entries
 
 
+async def _children(
+        accessor: LanceDBAccessor, table: str,
+        filters: dict[str, str]) -> list[tuple[str, IndexEntry]] | None:
+    config = accessor.config
+    if not await table_exists(accessor, table):
+        return None
+    depth = len(filters)
+    if depth < len(config.group_by):
+        names = await distinct_values(accessor, table, config.group_by[depth],
+                                      filters, config.max_rows)
+        return [(name, _dir_entry(name)) for name in names]
+    # Select every column except the vector and blob ones (schema order, so
+    # the projected rows render byte-identically to the full rows read()
+    # fetches). Still one data query; the schema lookup is local metadata on
+    # the already-opened table.
+    columns = [
+        c for c in await table_columns(accessor, table)
+        if c != config.vector_column and c != config.blob_column
+    ]
+    rows = await rows_matching(accessor, table, filters, columns,
+                               config.max_rows)
+    return _row_entries(rows, config)
+
+
+async def _list_root(accessor: LanceDBAccessor,
+                     match: ScopeMatch) -> list[tuple[str, IndexEntry]] | None:
+    config = accessor.config
+    if not config.table:
+        return [(name, _dir_entry(name))
+                for name in await list_tables(accessor)]
+    return await _children(accessor, config.table, {})
+
+
+async def _list_group(
+        accessor: LanceDBAccessor,
+        match: ScopeMatch) -> list[tuple[str, IndexEntry]] | None:
+    config = accessor.config
+    return await _children(accessor, table_of(config, match),
+                           filters_of(config, match))
+
+
+LISTERS: dict[str, Lister[LanceDBAccessor]] = {
+    ROOT: _list_root,
+    "group": _list_group,
+}
+
+
+def _build(accessor: LanceDBAccessor) -> ReaddirFn[LanceDBAccessor]:
+    return make_readdir(detect_for(accessor), listers=LISTERS)
+
+
+readdir_for = per_accessor(_build)
+
+
 async def readdir(
     accessor: LanceDBAccessor,
     path: PathSpec,
     index: IndexCacheStore = NULL_INDEX,
 ) -> list[str]:
-    config = accessor.config
-    scope = detect_scope(path, config)
-    base = path.virtual.rstrip("/")
-
-    if scope.level == ScopeLevel.ROOT:
-        names = await list_tables(accessor)
-        return [f"{base}/{name}" for name in names]
-
-    if isinstance(scope, LanceDBGroupScope):
-        depth = len(scope.filters)
-        total = len(config.group_by)
-        if depth < total:
-            names = await distinct_values(accessor, scope.table,
-                                          config.group_by[depth],
-                                          scope.filters, config.max_rows)
-        else:
-            # Select every column except the vector and blob ones (schema
-            # order, so the projected rows render byte-identically to the
-            # full rows read() fetches). Still one data query; the schema
-            # lookup is local metadata on the already-opened table.
-            columns = [
-                c for c in await table_columns(accessor, scope.table)
-                if c != config.vector_column and c != config.blob_column
-            ]
-            rows = await rows_matching(accessor, scope.table, scope.filters,
-                                       columns, config.max_rows)
-            names = _row_files(rows, config)
-            # find-style callers pass index=None; there is nothing to seed.
-            if index is not None:
-                await index.set_dir(base, _row_entries(rows, config))
-        return [f"{base}/{name}" for name in names]
-
-    raise FileNotFoundError(path.virtual)
+    return await readdir_for(accessor)(accessor, path, index)

--- a/python/mirage/core/lancedb/scope.py
+++ b/python/mirage/core/lancedb/scope.py
@@ -12,100 +12,86 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Literal, TypeAlias
-
+from mirage.accessor.lancedb import LanceDBAccessor
+from mirage.core.hierarchy.bind import per_accessor
+from mirage.core.hierarchy.codec import Codec
+from mirage.core.hierarchy.scope import (DetectFn, Scope, ScopeMatch, Segment,
+                                         Slot, make_detect_scope)
 from mirage.resource.lancedb.config import LanceDBConfig
-from mirage.types import PathSpec
+from mirage.types import FileType
+from mirage.utils.filetype import image_type_for_extension
+
+CARD = Codec(suffix=".md")
 
 
-class ScopeLevel(str, Enum):
-    ROOT = "root"
-    GROUP_DIR = "group_dir"
-    ROW = "row"
-    UNKNOWN = "unknown"
+def scopes_for(config: LanceDBConfig) -> tuple[Scope, ...]:
+    """The mount's scope table, shaped by its config.
 
+    The tree is a function of the mount config, not of the backend: a
+    pinned ``table`` removes the leading table segment, every
+    ``group_by`` column adds one directory level, and ``blob_column``
+    adds a second leaf suffix beside the ``.md`` card. Group slots are
+    named positionally (``g0``, ``g1``, ...) so a column named ``table``
+    cannot collide with the table slot; ``filters_of`` maps them back to
+    column names. Every partial depth shares the one ``group`` kind, and
+    its lister derives the depth from the slots, so the lister table
+    stays static while the scope table varies per mount.
 
-@dataclass(frozen=True)
-class LanceDBRootScope:
-    resource_path: str = "/"
-    level: Literal[ScopeLevel.ROOT] = field(default=ScopeLevel.ROOT,
-                                            init=False)
-
-
-@dataclass(frozen=True)
-class LanceDBGroupScope:
-    table: str
-    filters: dict[str, str] = field(default_factory=dict)
-    resource_path: str = "/"
-    level: Literal[ScopeLevel.GROUP_DIR] = field(default=ScopeLevel.GROUP_DIR,
-                                                 init=False)
-
-
-@dataclass(frozen=True)
-class LanceDBRowScope:
-    table: str
-    row_id: str
-    blob: bool
-    filters: dict[str, str] = field(default_factory=dict)
-    resource_path: str = "/"
-    level: Literal[ScopeLevel.ROW] = field(default=ScopeLevel.ROW, init=False)
-
-
-@dataclass(frozen=True)
-class LanceDBUnknownScope:
-    resource_path: str = "/"
-    level: Literal[ScopeLevel.UNKNOWN] = field(default=ScopeLevel.UNKNOWN,
-                                               init=False)
-
-
-LanceDBScope: TypeAlias = (LanceDBRootScope | LanceDBGroupScope
-                           | LanceDBRowScope | LanceDBUnknownScope)
-
-
-def _parse_row_file(name: str,
-                    config: LanceDBConfig) -> tuple[str, bool] | None:
-    if name.endswith(".md"):
-        return name[:-len(".md")], False
+    Args:
+        config (LanceDBConfig): the mount's config.
+    """
+    prefix: tuple[Segment, ...] = () if config.table else (Slot("table"), )
+    groups = tuple(Slot(f"g{i}") for i in range(len(config.group_by)))
+    scopes = [
+        Scope(kind="group", segments=prefix + groups[:depth])
+        for depth in range(len(groups) + 1) if depth or prefix
+    ]
+    full = prefix + groups
+    scopes.append(
+        Scope(kind="row_card",
+              segments=full + (Slot("row_id", CARD), ),
+              leaf=True,
+              filetype=FileType.TEXT))
     if config.blob_column:
-        suffix = "." + config.blob_ext
-        if name.endswith(suffix):
-            return name[:-len(suffix)], True
-    return None
+        blob = Codec(suffix="." + config.blob_ext)
+        scopes.append(
+            Scope(kind="row_blob",
+                  segments=full + (Slot("row_id", blob), ),
+                  leaf=True,
+                  filetype=image_type_for_extension(config.blob_ext)))
+    return tuple(scopes)
 
 
-def detect_scope(path: PathSpec, config: LanceDBConfig) -> LanceDBScope:
-    raw = path.mount_path
-    key = raw.strip("/")
-    segs = key.split("/") if key else []
+def _detect(accessor: LanceDBAccessor) -> DetectFn:
+    return make_detect_scope(scopes_for(accessor.config))
 
+
+detect_for = per_accessor(_detect)
+
+
+def table_of(config: LanceDBConfig, match: ScopeMatch) -> str:
+    """The table a match addresses: pinned, or the path's first slot.
+
+    Args:
+        config (LanceDBConfig): the mount's config.
+        match (ScopeMatch): a match from this mount's classifier.
+    """
     if config.table:
-        table = config.table
-        rest = segs
-    else:
-        if not segs:
-            return LanceDBRootScope(resource_path=raw)
-        table = segs[0]
-        rest = segs[1:]
+        return config.table
+    return match.slots["table"]
 
-    gb = config.group_by
-    n = len(gb)
 
-    if len(rest) <= n:
-        filters = {gb[i]: rest[i] for i in range(len(rest))}
-        return LanceDBGroupScope(table=table,
-                                 filters=filters,
-                                 resource_path=raw)
+def filters_of(config: LanceDBConfig, match: ScopeMatch) -> dict[str, str]:
+    """The match's group filters, keyed back to column names.
 
-    if len(rest) == n + 1:
-        filters = {gb[i]: rest[i] for i in range(n)}
-        parsed = _parse_row_file(rest[n], config)
-        if parsed is not None:
-            return LanceDBRowScope(table=table,
-                                   filters=filters,
-                                   row_id=parsed[0],
-                                   blob=parsed[1],
-                                   resource_path=raw)
-
-    return LanceDBUnknownScope(resource_path=raw)
+    Args:
+        config (LanceDBConfig): the mount's config.
+        match (ScopeMatch): a match from this mount's classifier.
+    """
+    filters: dict[str, str] = {}
+    for i, column in enumerate(config.group_by):
+        value = match.slots.get(f"g{i}")
+        if value is None:
+            break
+        filters[column] = value
+    return filters

--- a/python/mirage/core/lancedb/stat.py
+++ b/python/mirage/core/lancedb/stat.py
@@ -12,13 +12,20 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import Awaitable, Callable
+
 from mirage.accessor.lancedb import LanceDBAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.hierarchy.bind import per_accessor
+from mirage.core.hierarchy.readdir import Guard
+from mirage.core.hierarchy.scope import ScopeMatch
+from mirage.core.hierarchy.stat import StatHook, make_stat
 from mirage.core.lancedb.query import table_exists
 from mirage.core.lancedb.read import read
-from mirage.core.lancedb.scope import (LanceDBGroupScope, LanceDBRowScope,
-                                       ScopeLevel, detect_scope)
+from mirage.core.lancedb.readdir import readdir_for
+from mirage.core.lancedb.scope import detect_for, table_of
 from mirage.types import FileStat, FileType, PathSpec
+from mirage.utils.errors import enoent
 from mirage.utils.filetype import image_type_for_extension
 
 
@@ -27,37 +34,53 @@ def _name_of(path: PathSpec) -> str:
     return stripped.rsplit("/", 1)[-1] or "/"
 
 
-async def stat(
-    accessor: LanceDBAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> FileStat:
+async def _table_guard(accessor: LanceDBAccessor, match: ScopeMatch,
+                       virtual: str) -> None:
+    if not await table_exists(accessor, table_of(accessor.config, match)):
+        raise enoent(virtual)
+
+
+async def _stat_row(accessor: LanceDBAccessor, match: ScopeMatch,
+                    path: PathSpec, index: IndexCacheStore) -> FileStat:
     config = accessor.config
-    scope = detect_scope(path, config)
-
-    if scope.level == ScopeLevel.UNKNOWN:
-        raise FileNotFoundError(path.virtual)
-
-    if (isinstance(scope, (LanceDBGroupScope, LanceDBRowScope))
-            and not await table_exists(accessor, scope.table)):
-        raise FileNotFoundError(path.virtual)
-
-    if scope.level in (ScopeLevel.ROOT, ScopeLevel.GROUP_DIR):
-        return FileStat(name=_name_of(path), type=FileType.DIRECTORY)
-
-    if not isinstance(scope, LanceDBRowScope):
-        raise FileNotFoundError(path.virtual)
-    if scope.blob:
+    if not await table_exists(accessor, table_of(config, match)):
+        raise enoent(path.virtual)
+    if match.kind == "row_blob":
         file_type = image_type_for_extension(config.blob_ext)
     else:
         file_type = FileType.TEXT
     # The row-dir readdir seeds exact card sizes; blob entries and a cold
     # index fall back to rendering the row, so the size is exact either way.
-    if index is not None:
-        lookup = await index.get(path.virtual.rstrip("/"))
-        if lookup.entry is not None and lookup.entry.size is not None:
-            return FileStat(name=_name_of(path),
-                            size=lookup.entry.size,
-                            type=file_type)
+    lookup = await index.get(path.virtual.rstrip("/"))
+    if lookup.entry is not None and lookup.entry.size is not None:
+        return FileStat(name=_name_of(path),
+                        size=lookup.entry.size,
+                        type=file_type)
     data = await read(accessor, path, index)
     return FileStat(name=_name_of(path), size=len(data), type=file_type)
+
+
+GUARDS: dict[str, Guard[LanceDBAccessor]] = {"group": _table_guard}
+
+OVERRIDES: dict[str, StatHook[LanceDBAccessor]] = {
+    "row_card": _stat_row,
+    "row_blob": _stat_row,
+}
+
+
+def _build(accessor: LanceDBAccessor) -> Callable[..., Awaitable[FileStat]]:
+    return make_stat(detect_for(accessor),
+                     readdir_for(accessor),
+                     guards=GUARDS,
+                     overrides=OVERRIDES)
+
+
+stat_for = per_accessor(_build)
+
+
+async def stat(
+    accessor: LanceDBAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = NULL_INDEX,
+) -> FileStat:
+    return await stat_for(accessor)(accessor, path, index)

--- a/python/mirage/core/qdrant/read.py
+++ b/python/mirage/core/qdrant/read.py
@@ -12,24 +12,70 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from mirage.accessor.qdrant import QdrantAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.hierarchy.bind import per_accessor
+from mirage.core.hierarchy.read import Reader, make_read
+from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.core.qdrant.query import row_record
 from mirage.core.qdrant.render import blob_bytes, render_json, render_text
-from mirage.core.qdrant.scope import QdrantRowScope, detect_scope
+from mirage.core.qdrant.scope import detect_for, table_of
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
 
-async def _resolve_row(accessor: QdrantAccessor, scope, config,
-                       virtual: str) -> dict[str, Any]:
-    row = await row_record(accessor, scope.table, config.id_field,
-                           scope.row_id)
+async def _row_of(accessor: QdrantAccessor, match: ScopeMatch,
+                  virtual: str) -> dict[str, Any]:
+    config = accessor.config
+    row = await row_record(accessor, table_of(config, match), config.id_field,
+                           match.slots["row_id"])
     if row is None:
         raise enoent(virtual)
     return row
+
+
+async def _read_json(accessor: QdrantAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    row = await _row_of(accessor, match, path.virtual)
+    return render_json(row, accessor.config)
+
+
+async def _read_text(accessor: QdrantAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    config = accessor.config
+    row = await _row_of(accessor, match, path.virtual)
+    if not config.text_field or row.get(config.text_field) is None:
+        raise enoent(path)
+    return render_text(row, config)
+
+
+async def _read_blob(accessor: QdrantAccessor, match: ScopeMatch,
+                     path: PathSpec, index: IndexCacheStore) -> bytes:
+    config = accessor.config
+    if not config.blob_field:
+        raise enoent(path)
+    row = await _row_of(accessor, match, path.virtual)
+    value = row.get(config.blob_field)
+    if value is None:
+        raise enoent(path)
+    return blob_bytes(value)
+
+
+READERS: dict[str, Reader[QdrantAccessor]] = {
+    "row_json": _read_json,
+    "row_text": _read_text,
+    "row_blob": _read_blob,
+}
+
+
+def _build(accessor: QdrantAccessor) -> Callable[..., Awaitable[bytes]]:
+    return make_read(detect_for(accessor), READERS)
+
+
+read_for = per_accessor(_build)
 
 
 async def read(
@@ -37,20 +83,4 @@ async def read(
     path: PathSpec,
     index: IndexCacheStore = NULL_INDEX,
 ) -> bytes:
-    config = accessor.config
-    scope = detect_scope(path, config)
-    if not isinstance(scope, QdrantRowScope):
-        raise enoent(path)
-    row = await _resolve_row(accessor, scope, config, path.virtual)
-    if scope.kind == "blob":
-        if not config.blob_field:
-            raise enoent(path)
-        value = row.get(config.blob_field)
-        if value is None:
-            raise enoent(path)
-        return blob_bytes(value)
-    if scope.kind == "txt":
-        if not config.text_field or row.get(config.text_field) is None:
-            raise enoent(path)
-        return render_text(row, config)
-    return render_json(row, config)
+    return await read_for(accessor)(accessor, path, index)

--- a/python/mirage/core/qdrant/readdir.py
+++ b/python/mirage/core/qdrant/readdir.py
@@ -17,25 +17,27 @@ from typing import Any
 
 from mirage.accessor.qdrant import QdrantAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
+from mirage.core.hierarchy.bind import per_accessor
+from mirage.core.hierarchy.probe import ReaddirFn
+from mirage.core.hierarchy.readdir import Lister, make_readdir
+from mirage.core.hierarchy.scope import ROOT, ScopeMatch
 from mirage.core.qdrant.query import (distinct_values, list_tables,
-                                      rows_matching)
+                                      rows_matching, table_exists)
 from mirage.core.qdrant.render import blob_bytes, render_json, render_text
-from mirage.core.qdrant.scope import QdrantGroupScope, ScopeLevel, detect_scope
+from mirage.core.qdrant.scope import detect_for, filters_of, table_of
+from mirage.resource.qdrant.config import QdrantConfig
 from mirage.types import JsonValue, PathSpec
 
 logger = logging.getLogger(__name__)
 
+GROUP_TYPE = "qdrant/group"
 
-def _row_files(rows: list[dict[str, Any]], config) -> list[str]:
-    names: list[str] = []
-    for row in rows:
-        rid = row[config.id_field]
-        names.append(f"{rid}.json")
-        if config.text_field and row.get(config.text_field) is not None:
-            names.append(f"{rid}.txt")
-        if config.blob_field and row.get(config.blob_field) is not None:
-            names.append(f"{rid}.{config.blob_ext}")
-    return names
+
+def _dir_entry(name: str) -> IndexEntry:
+    return IndexEntry(id=name,
+                      name=name,
+                      resource_type=GROUP_TYPE,
+                      vfs_name=name)
 
 
 def _blob_size(value: JsonValue) -> int | None:
@@ -51,7 +53,7 @@ def _blob_size(value: JsonValue) -> int | None:
 
 
 def _row_entries(rows: list[dict[str, Any]],
-                 config) -> list[tuple[str, IndexEntry]]:
+                 config: QdrantConfig) -> list[tuple[str, IndexEntry]]:
     # The scroll already carries every payload, so each file's exact
     # rendered size is free here; stat serves it from the index instead of
     # refetching one row per file.
@@ -88,33 +90,54 @@ def _row_entries(rows: list[dict[str, Any]],
     return entries
 
 
+async def _children(
+        accessor: QdrantAccessor, table: str,
+        filters: dict[str, str]) -> list[tuple[str, IndexEntry]] | None:
+    config = accessor.config
+    if not await table_exists(accessor, table):
+        return None
+    depth = len(filters)
+    if depth < len(config.group_by):
+        names = await distinct_values(accessor, table, config.group_by[depth],
+                                      filters, config.max_rows)
+        return [(name, _dir_entry(name)) for name in names]
+    rows = await rows_matching(accessor, table, filters, config.max_rows)
+    return _row_entries(rows, config)
+
+
+async def _list_root(accessor: QdrantAccessor,
+                     match: ScopeMatch) -> list[tuple[str, IndexEntry]] | None:
+    config = accessor.config
+    if not config.collection:
+        return [(name, _dir_entry(name))
+                for name in await list_tables(accessor)]
+    return await _children(accessor, config.collection, {})
+
+
+async def _list_group(
+        accessor: QdrantAccessor,
+        match: ScopeMatch) -> list[tuple[str, IndexEntry]] | None:
+    config = accessor.config
+    return await _children(accessor, table_of(config, match),
+                           filters_of(config, match))
+
+
+LISTERS: dict[str, Lister[QdrantAccessor]] = {
+    ROOT: _list_root,
+    "group": _list_group,
+}
+
+
+def _build(accessor: QdrantAccessor) -> ReaddirFn[QdrantAccessor]:
+    return make_readdir(detect_for(accessor), listers=LISTERS)
+
+
+readdir_for = per_accessor(_build)
+
+
 async def readdir(
     accessor: QdrantAccessor,
     path: PathSpec,
     index: IndexCacheStore = NULL_INDEX,
 ) -> list[str]:
-    config = accessor.config
-    scope = detect_scope(path, config)
-    base = path.virtual.rstrip("/")
-
-    if scope.level == ScopeLevel.ROOT:
-        names = await list_tables(accessor)
-        return [f"{base}/{name}" for name in names]
-
-    if isinstance(scope, QdrantGroupScope):
-        depth = len(scope.filters)
-        total = len(config.group_by)
-        if depth < total:
-            names = await distinct_values(accessor, scope.table,
-                                          config.group_by[depth],
-                                          scope.filters, config.max_rows)
-        else:
-            rows = await rows_matching(accessor, scope.table, scope.filters,
-                                       config.max_rows)
-            names = _row_files(rows, config)
-            # find-style callers pass index=None; there is nothing to seed.
-            if index is not None:
-                await index.set_dir(base, _row_entries(rows, config))
-        return [f"{base}/{name}" for name in names]
-
-    raise FileNotFoundError(path.virtual)
+    return await readdir_for(accessor)(accessor, path, index)

--- a/python/mirage/core/qdrant/scope.py
+++ b/python/mirage/core/qdrant/scope.py
@@ -12,101 +12,94 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Literal, TypeAlias
-
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.core.hierarchy.bind import per_accessor
+from mirage.core.hierarchy.codec import JSON_NAME, Codec
+from mirage.core.hierarchy.scope import (DetectFn, Scope, ScopeMatch, Segment,
+                                         Slot, make_detect_scope)
 from mirage.resource.qdrant.config import QdrantConfig
-from mirage.types import PathSpec
+from mirage.types import FileType
+from mirage.utils.filetype import image_type_for_extension
+
+TXT = Codec(suffix=".txt")
 
 
-class ScopeLevel(str, Enum):
-    ROOT = "root"
-    GROUP_DIR = "group_dir"
-    ROW = "row"
-    UNKNOWN = "unknown"
+def scopes_for(config: QdrantConfig) -> tuple[Scope, ...]:
+    """The mount's scope table, shaped by its config.
 
+    The tree is a function of the mount config, not of the backend: a
+    pinned ``collection`` removes the leading collection segment, every
+    ``group_by`` column adds one directory level, and ``text_field`` /
+    ``blob_field`` each add a leaf suffix beside the ``.json`` row.
+    Group slots are named positionally (``g0``, ``g1``, ...) so a column
+    named ``table`` cannot collide with the collection slot;
+    ``filters_of`` maps them back to column names. Every partial depth
+    shares the one ``group`` kind, and its lister derives the depth from
+    the slots, so the lister table stays static while the scope table
+    varies per mount.
 
-@dataclass(frozen=True)
-class QdrantRootScope:
-    resource_path: str = "/"
-    level: Literal[ScopeLevel.ROOT] = field(default=ScopeLevel.ROOT,
-                                            init=False)
-
-
-@dataclass(frozen=True)
-class QdrantGroupScope:
-    table: str
-    filters: dict[str, str] = field(default_factory=dict)
-    resource_path: str = "/"
-    level: Literal[ScopeLevel.GROUP_DIR] = field(default=ScopeLevel.GROUP_DIR,
-                                                 init=False)
-
-
-@dataclass(frozen=True)
-class QdrantRowScope:
-    table: str
-    row_id: str
-    kind: str
-    filters: dict[str, str] = field(default_factory=dict)
-    resource_path: str = "/"
-    level: Literal[ScopeLevel.ROW] = field(default=ScopeLevel.ROW, init=False)
-
-
-@dataclass(frozen=True)
-class QdrantUnknownScope:
-    resource_path: str = "/"
-    level: Literal[ScopeLevel.UNKNOWN] = field(default=ScopeLevel.UNKNOWN,
-                                               init=False)
-
-
-QdrantScope: TypeAlias = (QdrantRootScope | QdrantGroupScope | QdrantRowScope
-                          | QdrantUnknownScope)
-
-
-def _parse_row_file(name: str, config: QdrantConfig) -> tuple[str, str] | None:
-    if name.endswith(".json"):
-        return name[:-len(".json")], "json"
-    if config.text_field and name.endswith(".txt"):
-        return name[:-len(".txt")], "txt"
+    Args:
+        config (QdrantConfig): the mount's config.
+    """
+    prefix: tuple[Segment,
+                  ...] = () if config.collection else (Slot("table"), )
+    groups = tuple(Slot(f"g{i}") for i in range(len(config.group_by)))
+    scopes = [
+        Scope(kind="group", segments=prefix + groups[:depth])
+        for depth in range(len(groups) + 1) if depth or prefix
+    ]
+    full = prefix + groups
+    scopes.append(
+        Scope(kind="row_json",
+              segments=full + (Slot("row_id", JSON_NAME), ),
+              leaf=True,
+              filetype=FileType.TEXT))
+    if config.text_field:
+        scopes.append(
+            Scope(kind="row_text",
+                  segments=full + (Slot("row_id", TXT), ),
+                  leaf=True,
+                  filetype=FileType.TEXT))
     if config.blob_field:
-        suffix = "." + config.blob_ext
-        if name.endswith(suffix):
-            return name[:-len(suffix)], "blob"
-    return None
+        blob = Codec(suffix="." + config.blob_ext)
+        scopes.append(
+            Scope(kind="row_blob",
+                  segments=full + (Slot("row_id", blob), ),
+                  leaf=True,
+                  filetype=image_type_for_extension(config.blob_ext)))
+    return tuple(scopes)
 
 
-def detect_scope(path: PathSpec, config: QdrantConfig) -> QdrantScope:
-    raw = path.mount_path
-    key = raw.strip("/")
-    segs = key.split("/") if key else []
+def _detect(accessor: QdrantAccessor) -> DetectFn:
+    return make_detect_scope(scopes_for(accessor.config))
 
+
+detect_for = per_accessor(_detect)
+
+
+def table_of(config: QdrantConfig, match: ScopeMatch) -> str:
+    """The collection a match addresses: pinned, or the path's first slot.
+
+    Args:
+        config (QdrantConfig): the mount's config.
+        match (ScopeMatch): a match from this mount's classifier.
+    """
     if config.collection:
-        table = config.collection
-        rest = segs
-    else:
-        if not segs:
-            return QdrantRootScope(resource_path=raw)
-        table = segs[0]
-        rest = segs[1:]
+        return config.collection
+    return match.slots["table"]
 
-    gb = config.group_by
-    n = len(gb)
 
-    if len(rest) <= n:
-        filters = {gb[i]: rest[i] for i in range(len(rest))}
-        return QdrantGroupScope(table=table,
-                                filters=filters,
-                                resource_path=raw)
+def filters_of(config: QdrantConfig, match: ScopeMatch) -> dict[str, str]:
+    """The match's group filters, keyed back to column names.
 
-    if len(rest) == n + 1:
-        filters = {gb[i]: rest[i] for i in range(n)}
-        parsed = _parse_row_file(rest[n], config)
-        if parsed is not None:
-            return QdrantRowScope(table=table,
-                                  filters=filters,
-                                  row_id=parsed[0],
-                                  kind=parsed[1],
-                                  resource_path=raw)
-
-    return QdrantUnknownScope(resource_path=raw)
+    Args:
+        config (QdrantConfig): the mount's config.
+        match (ScopeMatch): a match from this mount's classifier.
+    """
+    filters: dict[str, str] = {}
+    for i, column in enumerate(config.group_by):
+        value = match.slots.get(f"g{i}")
+        if value is None:
+            break
+        filters[column] = value
+    return filters

--- a/python/mirage/core/qdrant/stat.py
+++ b/python/mirage/core/qdrant/stat.py
@@ -12,13 +12,20 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import Awaitable, Callable
+
 from mirage.accessor.qdrant import QdrantAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.hierarchy.bind import per_accessor
+from mirage.core.hierarchy.readdir import Guard
+from mirage.core.hierarchy.scope import ScopeMatch
+from mirage.core.hierarchy.stat import StatHook, make_stat
 from mirage.core.qdrant.query import table_exists
 from mirage.core.qdrant.read import read
-from mirage.core.qdrant.scope import (QdrantGroupScope, QdrantRowScope,
-                                      ScopeLevel, detect_scope)
+from mirage.core.qdrant.readdir import readdir_for
+from mirage.core.qdrant.scope import detect_for, table_of
 from mirage.types import FileStat, FileType, PathSpec
+from mirage.utils.errors import enoent
 from mirage.utils.filetype import image_type_for_extension
 
 
@@ -27,37 +34,54 @@ def _name_of(path: PathSpec) -> str:
     return stripped.rsplit("/", 1)[-1] or "/"
 
 
-async def stat(
-    accessor: QdrantAccessor,
-    path: PathSpec,
-    index: IndexCacheStore = NULL_INDEX,
-) -> FileStat:
+async def _table_guard(accessor: QdrantAccessor, match: ScopeMatch,
+                       virtual: str) -> None:
+    if not await table_exists(accessor, table_of(accessor.config, match)):
+        raise enoent(virtual)
+
+
+async def _stat_row(accessor: QdrantAccessor, match: ScopeMatch,
+                    path: PathSpec, index: IndexCacheStore) -> FileStat:
     config = accessor.config
-    scope = detect_scope(path, config)
-
-    if scope.level == ScopeLevel.UNKNOWN:
-        raise FileNotFoundError(path.virtual)
-
-    if (isinstance(scope, (QdrantGroupScope, QdrantRowScope))
-            and not await table_exists(accessor, scope.table)):
-        raise FileNotFoundError(path.virtual)
-
-    if scope.level in (ScopeLevel.ROOT, ScopeLevel.GROUP_DIR):
-        return FileStat(name=_name_of(path), type=FileType.DIRECTORY)
-
-    if not isinstance(scope, QdrantRowScope):
-        raise FileNotFoundError(path.virtual)
-    if scope.kind == "blob":
+    if not await table_exists(accessor, table_of(config, match)):
+        raise enoent(path.virtual)
+    if match.kind == "row_blob":
         file_type = image_type_for_extension(config.blob_ext)
     else:
         file_type = FileType.TEXT
     # The row-dir readdir seeds exact rendered sizes; a cold index falls
     # back to rendering the row, so the size is exact either way.
-    if index is not None:
-        lookup = await index.get(path.virtual.rstrip("/"))
-        if lookup.entry is not None and lookup.entry.size is not None:
-            return FileStat(name=_name_of(path),
-                            size=lookup.entry.size,
-                            type=file_type)
+    lookup = await index.get(path.virtual.rstrip("/"))
+    if lookup.entry is not None and lookup.entry.size is not None:
+        return FileStat(name=_name_of(path),
+                        size=lookup.entry.size,
+                        type=file_type)
     data = await read(accessor, path, index)
     return FileStat(name=_name_of(path), size=len(data), type=file_type)
+
+
+GUARDS: dict[str, Guard[QdrantAccessor]] = {"group": _table_guard}
+
+OVERRIDES: dict[str, StatHook[QdrantAccessor]] = {
+    "row_json": _stat_row,
+    "row_text": _stat_row,
+    "row_blob": _stat_row,
+}
+
+
+def _build(accessor: QdrantAccessor) -> Callable[..., Awaitable[FileStat]]:
+    return make_stat(detect_for(accessor),
+                     readdir_for(accessor),
+                     guards=GUARDS,
+                     overrides=OVERRIDES)
+
+
+stat_for = per_accessor(_build)
+
+
+async def stat(
+    accessor: QdrantAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = NULL_INDEX,
+) -> FileStat:
+    return await stat_for(accessor)(accessor, path, index)

--- a/python/tests/core/hierarchy/test_bind.py
+++ b/python/tests/core/hierarchy/test_bind.py
@@ -1,0 +1,51 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import gc
+import weakref
+
+from mirage.core.hierarchy.bind import per_accessor
+
+from .conftest import FakeAccessor
+
+
+def test_builds_once_per_accessor():
+    built: list[FakeAccessor] = []
+
+    def build(accessor: FakeAccessor) -> list[str]:
+        built.append(accessor)
+        return [f"routes-{len(built)}"]
+
+    cached = per_accessor(build)
+    accessor = FakeAccessor()
+    first = cached(accessor)
+    assert cached(accessor) is first
+    assert built == [accessor]
+
+
+def test_distinct_accessors_get_distinct_builds():
+    cached = per_accessor(lambda accessor: object())
+    one = FakeAccessor()
+    two = FakeAccessor()
+    assert cached(one) is not cached(two)
+
+
+def test_cache_is_weak():
+    cached = per_accessor(lambda accessor: object())
+    accessor = FakeAccessor()
+    cached(accessor)
+    ref = weakref.ref(accessor)
+    del accessor
+    gc.collect()
+    assert ref() is None

--- a/python/tests/core/hierarchy/test_readdir.py
+++ b/python/tests/core/hierarchy/test_readdir.py
@@ -45,6 +45,13 @@ def test_dynamic_level_joins_names_under_the_virtual_key(accessor):
     assert out == ["/h/rooms/red", "/h/rooms/blue"]
 
 
+def test_a_none_index_gets_a_call_local_store(accessor):
+    # Bare commands built outside a workspace bind index=None; the kit
+    # substitutes a call-local store exactly as it does for NULL_INDEX.
+    out = asyncio.run(READDIR(accessor, spec("/rooms"), index=None))
+    assert out == ["/h/rooms/red", "/h/rooms/blue"]
+
+
 def test_guard_runs_before_the_index_probe(accessor):
     index = RAMIndexCacheStore()
     asyncio.run(READDIR(accessor, spec("/rooms/red"), index=index))

--- a/python/tests/core/hierarchy/test_stat.py
+++ b/python/tests/core/hierarchy/test_stat.py
@@ -73,6 +73,14 @@ def test_leaf_proves_existence_through_the_parent_listing(accessor):
         asyncio.run(STAT(accessor, spec("/rooms/red/nope.json"), index=index))
 
 
+def test_a_none_index_gets_a_call_local_store(accessor):
+    # Bare commands built outside a workspace bind index=None; the kit
+    # substitutes a call-local store exactly as it does for NULL_INDEX.
+    st = asyncio.run(STAT(accessor, spec("/rooms/red/a.json"), index=None))
+    assert st.type == FileType.JSON
+    assert st.size == 7
+
+
 def test_invalid_shapes_are_enoent(accessor):
     with pytest.raises(FileNotFoundError):
         asyncio.run(STAT(accessor, spec("/halls")))

--- a/python/tests/core/lancedb/test_scope.py
+++ b/python/tests/core/lancedb/test_scope.py
@@ -12,7 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.lancedb.scope import ScopeLevel, detect_scope
+from mirage.accessor.lancedb import LanceDBAccessor
+from mirage.core.hierarchy.scope import INVALID, ROOT, make_detect_scope
+from mirage.core.lancedb.scope import (detect_for, filters_of, scopes_for,
+                                       table_of)
 from mirage.resource.lancedb.config import LanceDBConfig
 from mirage.types import PathSpec
 
@@ -35,47 +38,81 @@ def _ps(path: str) -> PathSpec:
                     resource_path=path.strip("/"))
 
 
+def _detect(config: LanceDBConfig):
+    return make_detect_scope(scopes_for(config))
+
+
 def test_root_multi_table():
-    s = detect_scope(_ps("/"), _cfg())
-    assert s.level == ScopeLevel.ROOT
+    match = _detect(_cfg())(_ps("/"))
+    assert match.kind == ROOT
 
 
 def test_table_group_dir():
-    s = detect_scope(_ps("/animals"), _cfg())
-    assert s.level == ScopeLevel.GROUP_DIR
-    assert s.table == "animals"
-    assert s.filters == {}
+    config = _cfg()
+    match = _detect(config)(_ps("/animals"))
+    assert match.kind == "group"
+    assert table_of(config, match) == "animals"
+    assert filters_of(config, match) == {}
 
 
 def test_nested_group_dir():
-    s = detect_scope(_ps("/animals/cat"), _cfg())
-    assert s.level == ScopeLevel.GROUP_DIR
-    assert s.filters == {"label": "cat"}
+    config = _cfg()
+    match = _detect(config)(_ps("/animals/cat"))
+    assert match.kind == "group"
+    assert filters_of(config, match) == {"label": "cat"}
 
 
 def test_leaf_group_dir():
-    s = detect_scope(_ps("/animals/cat/big"), _cfg())
-    assert s.level == ScopeLevel.GROUP_DIR
-    assert s.filters == {"label": "cat", "kind": "big"}
+    config = _cfg()
+    match = _detect(config)(_ps("/animals/cat/big"))
+    assert match.kind == "group"
+    assert filters_of(config, match) == {"label": "cat", "kind": "big"}
 
 
 def test_row_card():
-    s = detect_scope(_ps("/animals/cat/big/3.md"), _cfg())
-    assert s.level == ScopeLevel.ROW
-    assert s.row_id == "3"
-    assert s.blob is False
-    assert s.filters == {"label": "cat", "kind": "big"}
+    config = _cfg()
+    match = _detect(config)(_ps("/animals/cat/big/3.md"))
+    assert match.kind == "row_card"
+    assert match.slots["row_id"] == "3"
+    assert filters_of(config, match) == {"label": "cat", "kind": "big"}
 
 
 def test_row_blob():
-    s = detect_scope(_ps("/animals/cat/big/3.png"), _cfg())
-    assert s.level == ScopeLevel.ROW
-    assert s.row_id == "3"
-    assert s.blob is True
+    match = _detect(_cfg())(_ps("/animals/cat/big/3.png"))
+    assert match.kind == "row_blob"
+    assert match.slots["row_id"] == "3"
+
+
+def test_blob_needs_blob_column():
+    match = _detect(_cfg(blob_column=None))(_ps("/animals/cat/big/3.png"))
+    assert match.kind == INVALID
+
+
+def test_too_deep_is_invalid():
+    match = _detect(_cfg())(_ps("/animals/cat/big/3.md/extra"))
+    assert match.kind == INVALID
 
 
 def test_single_table_pin_elides_table():
-    s = detect_scope(_ps("/cat/big"), _cfg(table="animals"))
-    assert s.level == ScopeLevel.GROUP_DIR
-    assert s.table == "animals"
-    assert s.filters == {"label": "cat", "kind": "big"}
+    config = _cfg(table="animals")
+    match = _detect(config)(_ps("/cat/big"))
+    assert match.kind == "group"
+    assert table_of(config, match) == "animals"
+    assert filters_of(config, match) == {"label": "cat", "kind": "big"}
+
+
+def test_pinned_flat_table_rows_at_root():
+    config = _cfg(table="animals", group_by=[])
+    detect = _detect(config)
+    assert detect(_ps("/")).kind == ROOT
+    match = detect(_ps("/3.md"))
+    assert match.kind == "row_card"
+    assert match.slots["row_id"] == "3"
+    assert detect(_ps("/whatever")).kind == INVALID
+
+
+def test_detect_for_caches_per_accessor():
+    accessor = LanceDBAccessor(_cfg())
+    assert detect_for(accessor) is detect_for(accessor)
+    other = LanceDBAccessor(_cfg(group_by=["label"]))
+    assert detect_for(other)(_ps("/animals/cat/3.md")).kind == "row_card"

--- a/python/tests/core/qdrant/test_scope.py
+++ b/python/tests/core/qdrant/test_scope.py
@@ -1,4 +1,7 @@
-from mirage.core.qdrant.scope import ScopeLevel, detect_scope
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.core.hierarchy.scope import INVALID, ROOT, make_detect_scope
+from mirage.core.qdrant.scope import (detect_for, filters_of, scopes_for,
+                                      table_of)
 from mirage.resource.qdrant.config import QdrantConfig
 from mirage.types import PathSpec
 
@@ -20,54 +23,82 @@ def _ps(path: str) -> PathSpec:
                     resource_path=path.strip("/"))
 
 
+def _detect(config: QdrantConfig):
+    return make_detect_scope(scopes_for(config))
+
+
 def test_root_multi_collection():
-    s = detect_scope(_ps("/"), _cfg())
-    assert s.level == ScopeLevel.ROOT
+    match = _detect(_cfg())(_ps("/"))
+    assert match.kind == ROOT
 
 
 def test_collection_group_dir():
-    s = detect_scope(_ps("/animals"), _cfg())
-    assert s.level == ScopeLevel.GROUP_DIR
-    assert s.table == "animals"
-    assert s.filters == {}
+    config = _cfg()
+    match = _detect(config)(_ps("/animals"))
+    assert match.kind == "group"
+    assert table_of(config, match) == "animals"
+    assert filters_of(config, match) == {}
 
 
 def test_nested_group_dir():
-    s = detect_scope(_ps("/animals/cat"), _cfg())
-    assert s.level == ScopeLevel.GROUP_DIR
-    assert s.filters == {"label": "cat"}
+    config = _cfg()
+    match = _detect(config)(_ps("/animals/cat"))
+    assert match.kind == "group"
+    assert filters_of(config, match) == {"label": "cat"}
 
 
 def test_leaf_group_dir():
-    s = detect_scope(_ps("/animals/cat/big"), _cfg())
-    assert s.level == ScopeLevel.GROUP_DIR
-    assert s.filters == {"label": "cat", "kind": "big"}
+    config = _cfg()
+    match = _detect(config)(_ps("/animals/cat/big"))
+    assert match.kind == "group"
+    assert filters_of(config, match) == {"label": "cat", "kind": "big"}
 
 
 def test_row_json():
-    s = detect_scope(_ps("/animals/cat/big/3.json"), _cfg())
-    assert s.level == ScopeLevel.ROW
-    assert s.row_id == "3"
-    assert s.kind == "json"
-    assert s.filters == {"label": "cat", "kind": "big"}
+    config = _cfg()
+    match = _detect(config)(_ps("/animals/cat/big/3.json"))
+    assert match.kind == "row_json"
+    assert match.slots["row_id"] == "3"
+    assert filters_of(config, match) == {"label": "cat", "kind": "big"}
 
 
 def test_row_text():
-    s = detect_scope(_ps("/animals/cat/big/3.txt"), _cfg())
-    assert s.level == ScopeLevel.ROW
-    assert s.row_id == "3"
-    assert s.kind == "txt"
+    match = _detect(_cfg())(_ps("/animals/cat/big/3.txt"))
+    assert match.kind == "row_text"
+    assert match.slots["row_id"] == "3"
 
 
 def test_row_blob():
-    s = detect_scope(_ps("/animals/cat/big/3.png"), _cfg())
-    assert s.level == ScopeLevel.ROW
-    assert s.row_id == "3"
-    assert s.kind == "blob"
+    match = _detect(_cfg())(_ps("/animals/cat/big/3.png"))
+    assert match.kind == "row_blob"
+    assert match.slots["row_id"] == "3"
+
+
+def test_text_needs_text_field():
+    match = _detect(_cfg(text_field=None))(_ps("/animals/cat/big/3.txt"))
+    assert match.kind == INVALID
+
+
+def test_blob_needs_blob_field():
+    match = _detect(_cfg(blob_field=None))(_ps("/animals/cat/big/3.png"))
+    assert match.kind == INVALID
+
+
+def test_too_deep_is_invalid():
+    match = _detect(_cfg())(_ps("/animals/cat/big/3.json/extra"))
+    assert match.kind == INVALID
 
 
 def test_single_collection_pin_elides_collection():
-    s = detect_scope(_ps("/cat/big"), _cfg(collection="animals"))
-    assert s.level == ScopeLevel.GROUP_DIR
-    assert s.table == "animals"
-    assert s.filters == {"label": "cat", "kind": "big"}
+    config = _cfg(collection="animals")
+    match = _detect(config)(_ps("/cat/big"))
+    assert match.kind == "group"
+    assert table_of(config, match) == "animals"
+    assert filters_of(config, match) == {"label": "cat", "kind": "big"}
+
+
+def test_detect_for_caches_per_accessor():
+    accessor = QdrantAccessor(_cfg())
+    assert detect_for(accessor) is detect_for(accessor)
+    other = QdrantAccessor(_cfg(collection="animals", group_by=["label"]))
+    assert detect_for(other)(_ps("/cat/3.json")).kind == "row_json"

--- a/typescript/packages/core/src/core/hierarchy/bind.test.ts
+++ b/typescript/packages/core/src/core/hierarchy/bind.test.ts
@@ -1,0 +1,38 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { Accessor } from '../../accessor/base.ts'
+import { perAccessor } from './bind.ts'
+
+class FakeAccessor extends Accessor {}
+
+describe('perAccessor', () => {
+  it('builds once per accessor', () => {
+    const built: FakeAccessor[] = []
+    const cached = perAccessor((accessor: FakeAccessor) => {
+      built.push(accessor)
+      return [`routes-${String(built.length)}`]
+    })
+    const accessor = new FakeAccessor()
+    const first = cached(accessor)
+    expect(cached(accessor)).toBe(first)
+    expect(built).toEqual([accessor])
+  })
+
+  it('distinct accessors get distinct builds', () => {
+    const cached = perAccessor((_accessor: FakeAccessor) => ({}))
+    expect(cached(new FakeAccessor())).not.toBe(cached(new FakeAccessor()))
+  })
+})

--- a/typescript/packages/core/src/core/hierarchy/bind.ts
+++ b/typescript/packages/core/src/core/hierarchy/bind.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { Accessor } from '../../accessor/base.ts'
+
+/**
+ * Cache one built value per accessor, for config-shaped route tables.
+ *
+ * Most backends have one tree shape, so their scope table and factories bind
+ * at module import. A backend whose tree is a function of mount config
+ * (lancedb's `groupBy` depth and leaf set, qdrant's likewise) builds them per
+ * mount instead: the accessor carries the config, so the accessor is the
+ * cache key, and the cache is weak so a dropped mount takes its routes with
+ * it. The build runs once per accessor; listers, guards and readers stay
+ * module-level functions that read `accessor.config` at call time, so tests
+ * keep patching client functions the same way they do for import-bound
+ * backends.
+ */
+export function perAccessor<A extends Accessor, T>(build: (accessor: A) => T): (accessor: A) => T {
+  const cache = new WeakMap<Accessor, T>()
+  return function cached(accessor: A): T {
+    const got = cache.get(accessor)
+    if (got !== undefined) return got
+    const made = build(accessor)
+    cache.set(accessor, made)
+    return made
+  }
+}

--- a/typescript/packages/core/src/core/lancedb/read.ts
+++ b/typescript/packages/core/src/core/lancedb/read.ts
@@ -17,20 +17,25 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import type { LanceRow } from './_driver.ts'
 import { PathSpec } from '../../types.ts'
 import { decodeBase64 } from '../../utils/base64.ts'
+import { enoent } from '../../utils/errors.ts'
+import { perAccessor } from '../hierarchy/bind.ts'
+import { makeRead, type Reader } from '../hierarchy/read.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { renderCard } from './render.ts'
-import { type LanceDBScope, ScopeLevel, detectScope } from './scope.ts'
+import { detectFor, tableOf } from './scope.ts'
 
-function notFound(p: string): Error {
-  const err = new Error(p) as Error & { code?: string }
-  err.code = 'ENOENT'
-  return err
-}
-
-async function resolveRow(accessor: LanceDBAccessor, scope: LanceDBScope): Promise<LanceRow> {
+async function rowOf(
+  accessor: LanceDBAccessor,
+  match: ScopeMatch,
+  virtual: string,
+): Promise<LanceRow> {
   const config = accessor.config
-  if (scope.table === null || scope.rowId === null) throw notFound(scope.resourcePath)
-  const row = await accessor.driver.rowRecord(scope.table, config.idColumn, scope.rowId)
-  if (row === null) throw notFound(scope.resourcePath)
+  const row = await accessor.driver.rowRecord(
+    tableOf(config, match),
+    config.idColumn,
+    match.slots.row_id ?? '',
+  )
+  if (row === null) throw enoent(virtual)
   return row
 }
 
@@ -40,19 +45,42 @@ function blobBytes(value: unknown): Uint8Array {
   throw new Error('blob column is not bytes or base64 string')
 }
 
+async function readCard(
+  accessor: LanceDBAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+): Promise<Uint8Array> {
+  const row = await rowOf(accessor, match, path.virtual)
+  return renderCard(row, accessor.config)
+}
+
+async function readBlob(
+  accessor: LanceDBAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+): Promise<Uint8Array> {
+  const config = accessor.config
+  if (config.blobColumn === null) throw enoent(path.virtual)
+  const row = await rowOf(accessor, match, path.virtual)
+  return blobBytes(row[config.blobColumn])
+}
+
+const READERS: Record<string, Reader<LanceDBAccessor>> = {
+  row_card: readCard,
+  row_blob: readBlob,
+}
+
+function buildRead(accessor: LanceDBAccessor) {
+  return makeRead(detectFor(accessor), READERS)
+}
+
+const readFor = perAccessor(buildRead)
+
 export async function read(
   accessor: LanceDBAccessor,
   path: PathSpec | string,
-  _index?: IndexCacheStore,
+  index?: IndexCacheStore,
 ): Promise<Uint8Array> {
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
-  const config = accessor.config
-  const scope = detectScope(spec, config)
-  if (scope.level !== ScopeLevel.ROW) throw notFound(spec.virtual)
-  const row = await resolveRow(accessor, scope)
-  if (scope.blob) {
-    if (config.blobColumn === null) throw notFound(spec.virtual)
-    return blobBytes(row[config.blobColumn])
-  }
-  return renderCard(row, config)
+  return readFor(accessor)(accessor, spec, index)
 }

--- a/typescript/packages/core/src/core/lancedb/readdir.ts
+++ b/typescript/packages/core/src/core/lancedb/readdir.ts
@@ -15,29 +15,23 @@
 import type { LanceDBAccessor } from '../../accessor/lancedb.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
+import type { LanceDBConfigResolved } from '../../resource/lancedb/config.ts'
 import type { LanceRow } from './_driver.ts'
 import { PathSpec } from '../../types.ts'
-import { rstripSlash } from '../../utils/slash.ts'
+import { perAccessor } from '../hierarchy/bind.ts'
+import type { ReaddirFn } from '../hierarchy/probe.ts'
+import { makeReaddir, type Lister } from '../hierarchy/readdir.ts'
+import { ROOT, type ScopeMatch } from '../hierarchy/scope.ts'
 import { renderCard } from './render.ts'
-import { ScopeLevel, detectScope } from './scope.ts'
+import { detectFor, filtersOf, tableOf } from './scope.ts'
 
-function notFound(p: string): Error {
-  const err = new Error(p) as Error & { code?: string }
-  err.code = 'ENOENT'
-  return err
+const GROUP_TYPE = 'lancedb/group'
+
+function dirEntry(name: string): IndexEntry {
+  return new IndexEntry({ id: name, name, resourceType: GROUP_TYPE, vfsName: name })
 }
 
-function rowFiles(rows: LanceRow[], config: LanceDBAccessor['config']): string[] {
-  const names: string[] = []
-  for (const row of rows) {
-    const id = String(row[config.idColumn])
-    names.push(`${id}.md`)
-    if (config.blobColumn !== null) names.push(`${id}.${config.blobExt}`)
-  }
-  return names
-}
-
-function rowEntries(rows: LanceRow[], config: LanceDBAccessor['config']): [string, IndexEntry][] {
+function rowEntries(rows: LanceRow[], config: LanceDBConfigResolved): [string, IndexEntry][] {
   // The widened select carries every rendered column, so each card's exact
   // size is free here; blob values are deliberately not fetched at listing
   // time, so blob entries stay size-unknown and stat renders them itself.
@@ -70,51 +64,71 @@ function rowEntries(rows: LanceRow[], config: LanceDBAccessor['config']): [strin
   return entries
 }
 
+async function children(
+  accessor: LanceDBAccessor,
+  table: string,
+  filters: Record<string, string>,
+): Promise<[string, IndexEntry][] | null> {
+  const config = accessor.config
+  const tables = await accessor.driver.listTables()
+  if (!tables.includes(table)) return null
+  const depth = Object.keys(filters).length
+  if (depth < config.groupBy.length) {
+    const names = await accessor.driver.distinct(
+      table,
+      config.groupBy[depth] ?? '',
+      filters,
+      config.maxRows,
+    )
+    return names.map((name): [string, IndexEntry] => [name, dirEntry(name)])
+  }
+  // Select every column except the vector and blob ones (schema order, so
+  // the projected rows render byte-identically to the full rows read()
+  // fetches). Still one data query; the schema lookup is local metadata on
+  // the already-opened table.
+  const columns = (await accessor.driver.tableColumns(table)).filter(
+    (c) => c !== config.vectorColumn && c !== config.blobColumn,
+  )
+  const rows = await accessor.driver.rowsMatching(table, filters, columns, config.maxRows)
+  return rowEntries(rows, config)
+}
+
+async function listRoot(
+  accessor: LanceDBAccessor,
+  _match: ScopeMatch,
+): Promise<[string, IndexEntry][] | null> {
+  const config = accessor.config
+  if (config.table === null) {
+    const tables = await accessor.driver.listTables()
+    return tables.map((name): [string, IndexEntry] => [name, dirEntry(name)])
+  }
+  return children(accessor, config.table, {})
+}
+
+async function listGroup(
+  accessor: LanceDBAccessor,
+  match: ScopeMatch,
+): Promise<[string, IndexEntry][] | null> {
+  const config = accessor.config
+  return children(accessor, tableOf(config, match), filtersOf(config, match))
+}
+
+const LISTERS: Record<string, Lister<LanceDBAccessor>> = {
+  [ROOT]: listRoot,
+  group: listGroup,
+}
+
+function buildReaddir(accessor: LanceDBAccessor): ReaddirFn<LanceDBAccessor> {
+  return makeReaddir(detectFor(accessor), { listers: LISTERS })
+}
+
+export const readdirFor = perAccessor(buildReaddir)
+
 export async function readdir(
   accessor: LanceDBAccessor,
   path: PathSpec | string,
   index?: IndexCacheStore,
 ): Promise<string[]> {
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
-  const config = accessor.config
-  const scope = detectScope(spec, config)
-  const base = rstripSlash(spec.virtual)
-
-  if (scope.level === ScopeLevel.ROOT) {
-    const tables = await accessor.driver.listTables()
-    return tables.map((name) => `${base}/${name}`)
-  }
-
-  if (scope.level === ScopeLevel.GROUP_DIR && scope.table !== null) {
-    const depth = Object.keys(scope.filters).length
-    const total = config.groupBy.length
-    let names: string[]
-    if (depth < total) {
-      names = await accessor.driver.distinct(
-        scope.table,
-        config.groupBy[depth] ?? '',
-        scope.filters,
-        config.maxRows,
-      )
-    } else {
-      // Select every column except the vector and blob ones (schema order,
-      // so the projected rows render byte-identically to the full rows
-      // read() fetches). Still one data query; the schema lookup is local
-      // metadata on the already-opened table.
-      const columns = (await accessor.driver.tableColumns(scope.table)).filter(
-        (c) => c !== config.vectorColumn && c !== config.blobColumn,
-      )
-      const rows = await accessor.driver.rowsMatching(
-        scope.table,
-        scope.filters,
-        columns,
-        config.maxRows,
-      )
-      names = rowFiles(rows, config)
-      if (index !== undefined) await index.setDir(base, rowEntries(rows, config))
-    }
-    return names.map((name) => `${base}/${name}`)
-  }
-
-  throw notFound(spec.virtual)
+  return readdirFor(accessor)(accessor, spec, index)
 }

--- a/typescript/packages/core/src/core/lancedb/scope.test.ts
+++ b/typescript/packages/core/src/core/lancedb/scope.test.ts
@@ -15,18 +15,34 @@
 import { stripSlash } from '../../utils/slash.ts'
 import { describe, expect, it } from 'vitest'
 
-import { resolveLanceDBConfig } from '../../resource/lancedb/config.ts'
+import { LanceDBAccessor } from '../../accessor/lancedb.ts'
+import {
+  resolveLanceDBConfig,
+  type LanceDBConfig,
+  type LanceDBConfigResolved,
+} from '../../resource/lancedb/config.ts'
 import { PathSpec } from '../../types.ts'
-import { ScopeLevel, detectScope } from './scope.ts'
+import { INVALID, ROOT, makeDetectScope, type DetectFn } from '../hierarchy/scope.ts'
+import type { LanceDriver } from './_driver.ts'
+import { detectFor, filtersOf, scopesFor, tableOf } from './scope.ts'
 
-const config = resolveLanceDBConfig({
-  uri: '/tmp/db',
-  groupBy: ['label', 'kind'],
-  idColumn: 'id',
-  blobColumn: 'image_bytes',
-  blobExt: 'png',
-  vectorColumn: 'vector',
-})
+function cfg(over: Partial<LanceDBConfig> = {}): LanceDBConfigResolved {
+  return resolveLanceDBConfig({
+    uri: '/tmp/db',
+    groupBy: ['label', 'kind'],
+    idColumn: 'id',
+    blobColumn: 'image_bytes',
+    blobExt: 'png',
+    vectorColumn: 'vector',
+    ...over,
+  })
+}
+
+const config = cfg()
+
+function detect(c: LanceDBConfigResolved): DetectFn {
+  return makeDetectScope(scopesFor(c))
+}
 
 function ps(p: string): PathSpec {
   return new PathSpec({ resourcePath: stripSlash(p), virtual: p, directory: p })
@@ -34,42 +50,65 @@ function ps(p: string): PathSpec {
 
 describe('lancedb scope', () => {
   it('root in multi-table mode', () => {
-    expect(detectScope(ps('/'), config).level).toBe(ScopeLevel.ROOT)
+    expect(detect(config)(ps('/')).kind).toBe(ROOT)
   })
 
   it('table is a group dir', () => {
-    const s = detectScope(ps('/animals'), config)
-    expect(s.level).toBe(ScopeLevel.GROUP_DIR)
-    expect(s.table).toBe('animals')
-    expect(s.filters).toEqual({})
+    const match = detect(config)(ps('/animals'))
+    expect(match.kind).toBe('group')
+    expect(tableOf(config, match)).toBe('animals')
+    expect(filtersOf(config, match)).toEqual({})
   })
 
   it('nested group dir binds a filter', () => {
-    expect(detectScope(ps('/animals/cat'), config).filters).toEqual({ label: 'cat' })
+    const match = detect(config)(ps('/animals/cat'))
+    expect(match.kind).toBe('group')
+    expect(filtersOf(config, match)).toEqual({ label: 'cat' })
   })
 
   it('row card', () => {
-    const s = detectScope(ps('/animals/cat/big/3.md'), config)
-    expect(s.level).toBe(ScopeLevel.ROW)
-    expect(s.rowId).toBe('3')
-    expect(s.blob).toBe(false)
-    expect(s.filters).toEqual({ label: 'cat', kind: 'big' })
+    const match = detect(config)(ps('/animals/cat/big/3.md'))
+    expect(match.kind).toBe('row_card')
+    expect(match.slots.row_id).toBe('3')
+    expect(filtersOf(config, match)).toEqual({ label: 'cat', kind: 'big' })
   })
 
   it('row blob', () => {
-    const s = detectScope(ps('/animals/cat/big/3.png'), config)
-    expect(s.blob).toBe(true)
+    const match = detect(config)(ps('/animals/cat/big/3.png'))
+    expect(match.kind).toBe('row_blob')
+    expect(match.slots.row_id).toBe('3')
   })
 
-  it('single-table pin elides the table level', () => {
-    const pinned = resolveLanceDBConfig({
-      uri: '/tmp/db',
-      table: 'animals',
-      groupBy: ['label', 'kind'],
-      idColumn: 'id',
-    })
-    const s = detectScope(ps('/cat/big'), pinned)
-    expect(s.level).toBe(ScopeLevel.GROUP_DIR)
-    expect(s.filters).toEqual({ label: 'cat', kind: 'big' })
+  it('blob leaf needs a blob column', () => {
+    const blobless = resolveLanceDBConfig({ uri: '/tmp/db', groupBy: ['label', 'kind'] })
+    const match = detect(blobless)(ps('/animals/cat/big/3.png'))
+    expect(match.kind).toBe(INVALID)
+  })
+
+  it('too-deep paths are invalid', () => {
+    expect(detect(config)(ps('/animals/cat/big/3.md/extra')).kind).toBe(INVALID)
+  })
+
+  it('pinned table elides the table segment', () => {
+    const pinned = cfg({ table: 'animals' })
+    const match = detect(pinned)(ps('/cat/big'))
+    expect(match.kind).toBe('group')
+    expect(tableOf(pinned, match)).toBe('animals')
+    expect(filtersOf(pinned, match)).toEqual({ label: 'cat', kind: 'big' })
+  })
+
+  it('pinned flat table serves rows at the root', () => {
+    const flat = detect(cfg({ table: 'animals', groupBy: [] }))
+    expect(flat(ps('/')).kind).toBe(ROOT)
+    expect(flat(ps('/3.md')).kind).toBe('row_card')
+    expect(flat(ps('/whatever')).kind).toBe(INVALID)
+  })
+
+  it('detectFor caches per accessor', () => {
+    const driver = {} as LanceDriver
+    const accessor = new LanceDBAccessor(driver, config)
+    expect(detectFor(accessor)).toBe(detectFor(accessor))
+    const other = new LanceDBAccessor(driver, cfg({ groupBy: ['label'] }))
+    expect(detectFor(other)(ps('/animals/cat/3.md')).kind).toBe('row_card')
   })
 })

--- a/typescript/packages/core/src/core/lancedb/scope.ts
+++ b/typescript/packages/core/src/core/lancedb/scope.ts
@@ -12,85 +12,82 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { LanceDBAccessor } from '../../accessor/lancedb.ts'
 import type { LanceDBConfigResolved } from '../../resource/lancedb/config.ts'
-import { PathSpec } from '../../types.ts'
-import { stripSlash } from '../../utils/slash.ts'
+import { FileType } from '../../types.ts'
+import { imageTypeForExtension } from '../../utils/filetype.ts'
+import { perAccessor } from '../hierarchy/bind.ts'
+import { Codec } from '../hierarchy/codec.ts'
+import { Scope, Slot, makeDetectScope, type DetectFn, type ScopeMatch } from '../hierarchy/scope.ts'
 
-export const ScopeLevel = Object.freeze({
-  ROOT: 'root',
-  GROUP_DIR: 'group_dir',
-  ROW: 'row',
-  UNKNOWN: 'unknown',
-} as const)
+const CARD = new Codec({ suffix: '.md' })
 
-export type ScopeLevel = (typeof ScopeLevel)[keyof typeof ScopeLevel]
-
-export interface LanceDBScope {
-  level: ScopeLevel
-  table: string | null
-  filters: Record<string, string>
-  rowId: string | null
-  blob: boolean
-  resourcePath: string
-}
-
-function parseRowFile(name: string, config: LanceDBConfigResolved): [string, boolean] | null {
-  if (name.endsWith('.md')) return [name.slice(0, -'.md'.length), false]
+/**
+ * The mount's scope table, shaped by its config.
+ *
+ * The tree is a function of the mount config, not of the backend: a pinned
+ * `table` removes the leading table segment, every `groupBy` column adds one
+ * directory level, and `blobColumn` adds a second leaf suffix beside the
+ * `.md` card. Group slots are named positionally (`g0`, `g1`, ...) so a
+ * column named `table` cannot collide with the table slot; `filtersOf` maps
+ * them back to column names. Every partial depth shares the one `group`
+ * kind, and its lister derives the depth from the slots, so the lister table
+ * stays static while the scope table varies per mount.
+ */
+export function scopesFor(config: LanceDBConfigResolved): Scope[] {
+  const prefix: Slot[] = config.table !== null ? [] : [new Slot('table')]
+  const groups = config.groupBy.map((_, i) => new Slot(`g${String(i)}`))
+  const scopes: Scope[] = []
+  for (let depth = 0; depth <= groups.length; depth++) {
+    if (depth === 0 && prefix.length === 0) continue
+    scopes.push(new Scope({ kind: 'group', segments: [...prefix, ...groups.slice(0, depth)] }))
+  }
+  const full = [...prefix, ...groups]
+  scopes.push(
+    new Scope({
+      kind: 'row_card',
+      segments: [...full, new Slot('row_id', CARD)],
+      leaf: true,
+      filetype: FileType.TEXT,
+    }),
+  )
   if (config.blobColumn !== null) {
-    const suffix = `.${config.blobExt}`
-    if (name.endsWith(suffix)) return [name.slice(0, -suffix.length), true]
+    const blob = new Codec({ suffix: `.${config.blobExt}` })
+    scopes.push(
+      new Scope({
+        kind: 'row_blob',
+        segments: [...full, new Slot('row_id', blob)],
+        leaf: true,
+        filetype: imageTypeForExtension(config.blobExt),
+      }),
+    )
   }
-  return null
+  return scopes
 }
 
-function make(
-  level: ScopeLevel,
-  resourcePath: string,
-  over: Partial<LanceDBScope> = {},
-): LanceDBScope {
-  return {
-    level,
-    table: over.table ?? null,
-    filters: over.filters ?? {},
-    rowId: over.rowId ?? null,
-    blob: over.blob ?? false,
-    resourcePath,
-  }
+function buildDetect(accessor: LanceDBAccessor): DetectFn {
+  return makeDetectScope(scopesFor(accessor.config))
 }
 
-export function detectScope(path: PathSpec | string, config: LanceDBConfigResolved): LanceDBScope {
-  const raw = path instanceof PathSpec ? path.mountPath : path
-  const key = stripSlash(raw)
-  const segs = key === '' ? [] : key.split('/')
+export const detectFor = perAccessor(buildDetect)
 
-  let table: string
-  let rest: string[]
-  if (config.table !== null) {
-    table = config.table
-    rest = segs
-  } else {
-    if (segs.length === 0) return make(ScopeLevel.ROOT, raw)
-    table = segs[0] ?? ''
-    rest = segs.slice(1)
+/** The table a match addresses: pinned, or the path's first slot. */
+export function tableOf(config: LanceDBConfigResolved, match: ScopeMatch): string {
+  if (config.table !== null) return config.table
+  return match.slots.table ?? ''
+}
+
+/** The match's group filters, keyed back to column names. */
+export function filtersOf(
+  config: LanceDBConfigResolved,
+  match: ScopeMatch,
+): Record<string, string> {
+  const filters: Record<string, string> = {}
+  for (let i = 0; i < config.groupBy.length; i++) {
+    const value = match.slots[`g${String(i)}`]
+    const column = config.groupBy[i]
+    if (value === undefined || column === undefined) break
+    filters[column] = value
   }
-
-  const gb = config.groupBy
-  const n = gb.length
-
-  if (rest.length <= n) {
-    const filters: Record<string, string> = {}
-    for (let i = 0; i < rest.length; i++) filters[gb[i] ?? ''] = rest[i] ?? ''
-    return make(ScopeLevel.GROUP_DIR, raw, { table, filters })
-  }
-
-  if (rest.length === n + 1) {
-    const filters: Record<string, string> = {}
-    for (let i = 0; i < n; i++) filters[gb[i] ?? ''] = rest[i] ?? ''
-    const parsed = parseRowFile(rest[n] ?? '', config)
-    if (parsed !== null) {
-      return make(ScopeLevel.ROW, raw, { table, filters, rowId: parsed[0], blob: parsed[1] })
-    }
-  }
-
-  return make(ScopeLevel.UNKNOWN, raw)
+  return filters
 }

--- a/typescript/packages/core/src/core/lancedb/stat.ts
+++ b/typescript/packages/core/src/core/lancedb/stat.ts
@@ -15,16 +15,16 @@
 import type { LanceDBAccessor } from '../../accessor/lancedb.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
+import { enoent } from '../../utils/errors.ts'
 import { imageTypeForExtension } from '../../utils/filetype.ts'
 import { rstripSlash } from '../../utils/slash.ts'
+import { perAccessor } from '../hierarchy/bind.ts'
+import type { Guard } from '../hierarchy/readdir.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
+import { makeStat, type StatHook } from '../hierarchy/stat.ts'
 import { read } from './read.ts'
-import { ScopeLevel, detectScope } from './scope.ts'
-
-function notFound(p: string): Error {
-  const err = new Error(p) as Error & { code?: string }
-  err.code = 'ENOENT'
-  return err
-}
+import { readdirFor } from './readdir.ts'
+import { detectFor, tableOf } from './scope.ts'
 
 function nameOf(spec: PathSpec): string {
   const stripped = rstripSlash(spec.virtual)
@@ -32,35 +32,58 @@ function nameOf(spec: PathSpec): string {
   return last === undefined || last === '' ? '/' : last
 }
 
+async function tableGuard(
+  accessor: LanceDBAccessor,
+  match: ScopeMatch,
+  virtual: string,
+): Promise<void> {
+  const tables = await accessor.driver.listTables()
+  if (!tables.includes(tableOf(accessor.config, match))) throw enoent(virtual)
+}
+
+async function statRow(
+  accessor: LanceDBAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<FileStat> {
+  const config = accessor.config
+  const tables = await accessor.driver.listTables()
+  if (!tables.includes(tableOf(config, match))) throw enoent(path.virtual)
+  const fileType = match.kind === 'row_blob' ? imageTypeForExtension(config.blobExt) : FileType.TEXT
+  // The row-dir readdir seeds exact card sizes; blob entries and a cold
+  // index fall back to rendering the row, so the size is exact either way.
+  if (index !== undefined) {
+    const lookup = await index.get(rstripSlash(path.virtual))
+    if (lookup.entry !== undefined && lookup.entry !== null && lookup.entry.size !== null) {
+      return new FileStat({ name: nameOf(path), size: lookup.entry.size, type: fileType })
+    }
+  }
+  const data = await read(accessor, path, index)
+  return new FileStat({ name: nameOf(path), size: data.length, type: fileType })
+}
+
+const GUARDS: Record<string, Guard<LanceDBAccessor>> = { group: tableGuard }
+
+const OVERRIDES: Record<string, StatHook<LanceDBAccessor>> = {
+  row_card: statRow,
+  row_blob: statRow,
+}
+
+function buildStat(accessor: LanceDBAccessor) {
+  return makeStat(detectFor(accessor), readdirFor(accessor), {
+    guards: GUARDS,
+    overrides: OVERRIDES,
+  })
+}
+
+const statFor = perAccessor(buildStat)
+
 export async function stat(
   accessor: LanceDBAccessor,
   path: PathSpec | string,
   index?: IndexCacheStore,
 ): Promise<FileStat> {
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
-  const config = accessor.config
-  const scope = detectScope(spec, config)
-
-  if (scope.level === ScopeLevel.UNKNOWN) throw notFound(spec.virtual)
-
-  if (scope.table !== null) {
-    const tables = await accessor.driver.listTables()
-    if (!tables.includes(scope.table)) throw notFound(spec.virtual)
-  }
-
-  if (scope.level === ScopeLevel.ROOT || scope.level === ScopeLevel.GROUP_DIR) {
-    return new FileStat({ name: nameOf(spec), type: FileType.DIRECTORY })
-  }
-
-  const fileType = scope.blob ? imageTypeForExtension(config.blobExt) : FileType.TEXT
-  // The row-dir readdir seeds exact card sizes; blob entries and a cold
-  // index fall back to rendering the row, so the size is exact either way.
-  if (index !== undefined) {
-    const lookup = await index.get(rstripSlash(spec.virtual))
-    if (lookup.entry !== undefined && lookup.entry !== null && lookup.entry.size !== null) {
-      return new FileStat({ name: nameOf(spec), size: lookup.entry.size, type: fileType })
-    }
-  }
-  const data = await read(accessor, spec, index)
-  return new FileStat({ name: nameOf(spec), size: data.length, type: fileType })
+  return statFor(accessor)(accessor, spec, index)
 }

--- a/typescript/packages/core/src/core/qdrant/read.ts
+++ b/typescript/packages/core/src/core/qdrant/read.ts
@@ -17,46 +17,83 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import type { QdrantRow } from './client.ts'
 import { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
+import { perAccessor } from '../hierarchy/bind.ts'
+import { makeRead, type Reader } from '../hierarchy/read.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { blobBytes, renderJson, renderText } from './render.ts'
-import { type QdrantScope, ScopeLevel, detectScope } from './scope.ts'
+import { detectFor, tableOf } from './scope.ts'
 
-async function resolveRow(
+async function rowOf(
   accessor: QdrantAccessor,
-  scope: QdrantScope,
-  notFoundPath: string,
+  match: ScopeMatch,
+  virtual: string,
 ): Promise<QdrantRow> {
   const config = accessor.config
-  if (scope.table === null || scope.rowId === null) throw enoent(notFoundPath)
-  const row = await accessor.rowRecord(scope.table, config.idField, scope.rowId)
-  if (row === null) throw enoent(notFoundPath)
+  const row = await accessor.rowRecord(
+    tableOf(config, match),
+    config.idField,
+    match.slots.row_id ?? '',
+  )
+  if (row === null) throw enoent(virtual)
   return row
 }
+
+async function readJson(
+  accessor: QdrantAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+): Promise<Uint8Array> {
+  const row = await rowOf(accessor, match, path.virtual)
+  return renderJson(row, accessor.config)
+}
+
+async function readText(
+  accessor: QdrantAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+): Promise<Uint8Array> {
+  const config = accessor.config
+  const row = await rowOf(accessor, match, path.virtual)
+  if (
+    config.textField === null ||
+    row[config.textField] === null ||
+    row[config.textField] === undefined
+  ) {
+    throw enoent(path.virtual)
+  }
+  return renderText(row, config)
+}
+
+async function readBlob(
+  accessor: QdrantAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+): Promise<Uint8Array> {
+  const config = accessor.config
+  if (config.blobField === null) throw enoent(path.virtual)
+  const row = await rowOf(accessor, match, path.virtual)
+  const value = row[config.blobField]
+  if (value === null || value === undefined) throw enoent(path.virtual)
+  return blobBytes(value)
+}
+
+const READERS: Record<string, Reader<QdrantAccessor>> = {
+  row_json: readJson,
+  row_text: readText,
+  row_blob: readBlob,
+}
+
+function buildRead(accessor: QdrantAccessor) {
+  return makeRead(detectFor(accessor), READERS)
+}
+
+const readFor = perAccessor(buildRead)
 
 export async function read(
   accessor: QdrantAccessor,
   path: PathSpec | string,
-  _index?: IndexCacheStore,
+  index?: IndexCacheStore,
 ): Promise<Uint8Array> {
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
-  const config = accessor.config
-  const scope = detectScope(spec, config)
-  if (scope.level !== ScopeLevel.ROW) throw enoent(spec.virtual)
-  const row = await resolveRow(accessor, scope, spec.virtual)
-  if (scope.kind === 'blob') {
-    if (config.blobField === null) throw enoent(spec.virtual)
-    const blobValue = row[config.blobField]
-    if (blobValue === null || blobValue === undefined) throw enoent(spec.virtual)
-    return blobBytes(blobValue)
-  }
-  if (scope.kind === 'txt') {
-    if (
-      config.textField === null ||
-      row[config.textField] === null ||
-      row[config.textField] === undefined
-    ) {
-      throw enoent(spec.virtual)
-    }
-    return renderText(row, config)
-  }
-  return renderJson(row, config)
+  return readFor(accessor)(accessor, spec, index)
 }

--- a/typescript/packages/core/src/core/qdrant/readdir.test.ts
+++ b/typescript/packages/core/src/core/qdrant/readdir.test.ts
@@ -43,6 +43,7 @@ function accessor(): QdrantAccessor {
   return {
     config,
     listTables: () => Promise.resolve(['animals']),
+    tableExists: (name: string) => Promise.resolve(name === 'animals'),
     distinct: () => Promise.resolve(['big']),
     rowsMatching: () => Promise.resolve([ROW]),
   } as unknown as QdrantAccessor
@@ -85,6 +86,7 @@ describe('qdrant readdir sizes', () => {
     const acc = {
       config,
       listTables: () => Promise.resolve(['animals']),
+      tableExists: (name: string) => Promise.resolve(name === 'animals'),
       distinct: () => Promise.resolve(['big']),
       rowsMatching: () => Promise.resolve([broken]),
     } as unknown as QdrantAccessor

--- a/typescript/packages/core/src/core/qdrant/readdir.ts
+++ b/typescript/packages/core/src/core/qdrant/readdir.ts
@@ -15,32 +15,20 @@
 import type { QdrantAccessor } from '../../accessor/qdrant.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
+import type { QdrantConfigResolved } from '../../resource/qdrant/config.ts'
 import type { QdrantRow } from './client.ts'
 import { PathSpec } from '../../types.ts'
-import { enoent } from '../../utils/errors.ts'
-import { rstripSlash } from '../../utils/slash.ts'
+import { perAccessor } from '../hierarchy/bind.ts'
+import type { ReaddirFn } from '../hierarchy/probe.ts'
+import { makeReaddir, type Lister } from '../hierarchy/readdir.ts'
+import { ROOT, type ScopeMatch } from '../hierarchy/scope.ts'
 import { blobBytes, renderJson, renderText } from './render.ts'
-import { ScopeLevel, detectScope } from './scope.ts'
+import { detectFor, filtersOf, tableOf } from './scope.ts'
 
-function rowFiles(rows: QdrantRow[], config: QdrantAccessor['config']): string[] {
-  const names: string[] = []
-  for (const row of rows) {
-    const id = String(row[config.idField])
-    names.push(`${id}.json`)
-    if (
-      config.textField !== null &&
-      row[config.textField] !== null &&
-      row[config.textField] !== undefined
-    )
-      names.push(`${id}.txt`)
-    if (
-      config.blobField !== null &&
-      row[config.blobField] !== null &&
-      row[config.blobField] !== undefined
-    )
-      names.push(`${id}.${config.blobExt}`)
-  }
-  return names
+const GROUP_TYPE = 'qdrant/group'
+
+function dirEntry(name: string): IndexEntry {
+  return new IndexEntry({ id: name, name, resourceType: GROUP_TYPE, vfsName: name })
 }
 
 function blobSize(value: unknown): number | null {
@@ -54,7 +42,7 @@ function blobSize(value: unknown): number | null {
   }
 }
 
-function rowEntries(rows: QdrantRow[], config: QdrantAccessor['config']): [string, IndexEntry][] {
+function rowEntries(rows: QdrantRow[], config: QdrantConfigResolved): [string, IndexEntry][] {
   // The scroll already carries every payload, so each file's exact rendered
   // size is free here; stat serves it from the index instead of refetching
   // one row per file.
@@ -108,44 +96,63 @@ function rowEntries(rows: QdrantRow[], config: QdrantAccessor['config']): [strin
   return entries
 }
 
+async function children(
+  accessor: QdrantAccessor,
+  table: string,
+  filters: Record<string, string>,
+): Promise<[string, IndexEntry][] | null> {
+  const config = accessor.config
+  if (!(await accessor.tableExists(table))) return null
+  const depth = Object.keys(filters).length
+  if (depth < config.groupBy.length) {
+    const names = await accessor.distinct(
+      table,
+      config.groupBy[depth] ?? '',
+      filters,
+      config.maxRows,
+    )
+    return names.map((name): [string, IndexEntry] => [name, dirEntry(name)])
+  }
+  const rows = await accessor.rowsMatching(table, filters, [config.idField], config.maxRows)
+  return rowEntries(rows, config)
+}
+
+async function listRoot(
+  accessor: QdrantAccessor,
+  _match: ScopeMatch,
+): Promise<[string, IndexEntry][] | null> {
+  const config = accessor.config
+  if (config.collection === null) {
+    const tables = await accessor.listTables()
+    return tables.map((name): [string, IndexEntry] => [name, dirEntry(name)])
+  }
+  return children(accessor, config.collection, {})
+}
+
+async function listGroup(
+  accessor: QdrantAccessor,
+  match: ScopeMatch,
+): Promise<[string, IndexEntry][] | null> {
+  const config = accessor.config
+  return children(accessor, tableOf(config, match), filtersOf(config, match))
+}
+
+const LISTERS: Record<string, Lister<QdrantAccessor>> = {
+  [ROOT]: listRoot,
+  group: listGroup,
+}
+
+function buildReaddir(accessor: QdrantAccessor): ReaddirFn<QdrantAccessor> {
+  return makeReaddir(detectFor(accessor), { listers: LISTERS })
+}
+
+export const readdirFor = perAccessor(buildReaddir)
+
 export async function readdir(
   accessor: QdrantAccessor,
   path: PathSpec | string,
   index?: IndexCacheStore,
 ): Promise<string[]> {
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
-  const config = accessor.config
-  const scope = detectScope(spec, config)
-  const base = rstripSlash(spec.virtual)
-
-  if (scope.level === ScopeLevel.ROOT) {
-    const tables = await accessor.listTables()
-    return tables.map((name) => `${base}/${name}`)
-  }
-
-  if (scope.level === ScopeLevel.GROUP_DIR && scope.table !== null) {
-    const depth = Object.keys(scope.filters).length
-    const total = config.groupBy.length
-    let names: string[]
-    if (depth < total) {
-      names = await accessor.distinct(
-        scope.table,
-        config.groupBy[depth] ?? '',
-        scope.filters,
-        config.maxRows,
-      )
-    } else {
-      const rows = await accessor.rowsMatching(
-        scope.table,
-        scope.filters,
-        [config.idField],
-        config.maxRows,
-      )
-      names = rowFiles(rows, config)
-      if (index !== undefined) await index.setDir(base, rowEntries(rows, config))
-    }
-    return names.map((name) => `${base}/${name}`)
-  }
-
-  throw enoent(spec.virtual)
+  return readdirFor(accessor)(accessor, spec, index)
 }

--- a/typescript/packages/core/src/core/qdrant/scope.test.ts
+++ b/typescript/packages/core/src/core/qdrant/scope.test.ts
@@ -15,18 +15,33 @@
 import { stripSlash } from '../../utils/slash.ts'
 import { describe, expect, it } from 'vitest'
 
-import { resolveQdrantConfig } from '../../resource/qdrant/config.ts'
+import { QdrantAccessor } from '../../accessor/qdrant.ts'
+import {
+  resolveQdrantConfig,
+  type QdrantConfig,
+  type QdrantConfigResolved,
+} from '../../resource/qdrant/config.ts'
 import { PathSpec } from '../../types.ts'
-import { ScopeLevel, detectScope } from './scope.ts'
+import { INVALID, ROOT, makeDetectScope, type DetectFn } from '../hierarchy/scope.ts'
+import { detectFor, filtersOf, scopesFor, tableOf } from './scope.ts'
 
-const config = resolveQdrantConfig({
-  groupBy: ['label', 'kind'],
-  idField: 'id',
-  textField: 'name',
-  blobField: 'image_bytes',
-  blobExt: 'png',
-  vectorField: 'vector',
-})
+function cfg(over: Partial<QdrantConfig> = {}): QdrantConfigResolved {
+  return resolveQdrantConfig({
+    groupBy: ['label', 'kind'],
+    idField: 'id',
+    textField: 'name',
+    blobField: 'image_bytes',
+    blobExt: 'png',
+    vectorField: 'vector',
+    ...over,
+  })
+}
+
+const config = cfg()
+
+function detect(c: QdrantConfigResolved): DetectFn {
+  return makeDetectScope(scopesFor(c))
+}
 
 function ps(p: string): PathSpec {
   return new PathSpec({ resourcePath: stripSlash(p), virtual: p, directory: p })
@@ -34,46 +49,64 @@ function ps(p: string): PathSpec {
 
 describe('qdrant scope', () => {
   it('root in multi-collection mode', () => {
-    expect(detectScope(ps('/'), config).level).toBe(ScopeLevel.ROOT)
+    expect(detect(config)(ps('/')).kind).toBe(ROOT)
   })
 
   it('collection is a group dir', () => {
-    const s = detectScope(ps('/animals'), config)
-    expect(s.level).toBe(ScopeLevel.GROUP_DIR)
-    expect(s.table).toBe('animals')
-    expect(s.filters).toEqual({})
+    const match = detect(config)(ps('/animals'))
+    expect(match.kind).toBe('group')
+    expect(tableOf(config, match)).toBe('animals')
+    expect(filtersOf(config, match)).toEqual({})
   })
 
   it('nested group dir binds a filter', () => {
-    expect(detectScope(ps('/animals/cat'), config).filters).toEqual({ label: 'cat' })
+    const match = detect(config)(ps('/animals/cat'))
+    expect(match.kind).toBe('group')
+    expect(filtersOf(config, match)).toEqual({ label: 'cat' })
   })
 
   it('row json', () => {
-    const s = detectScope(ps('/animals/cat/big/3.json'), config)
-    expect(s.level).toBe(ScopeLevel.ROW)
-    expect(s.rowId).toBe('3')
-    expect(s.kind).toBe('json')
-    expect(s.filters).toEqual({ label: 'cat', kind: 'big' })
+    const match = detect(config)(ps('/animals/cat/big/3.json'))
+    expect(match.kind).toBe('row_json')
+    expect(match.slots.row_id).toBe('3')
+    expect(filtersOf(config, match)).toEqual({ label: 'cat', kind: 'big' })
   })
 
   it('row text', () => {
-    const s = detectScope(ps('/animals/cat/big/3.txt'), config)
-    expect(s.kind).toBe('txt')
+    const match = detect(config)(ps('/animals/cat/big/3.txt'))
+    expect(match.kind).toBe('row_text')
+    expect(match.slots.row_id).toBe('3')
   })
 
   it('row blob', () => {
-    const s = detectScope(ps('/animals/cat/big/3.png'), config)
-    expect(s.kind).toBe('blob')
+    const match = detect(config)(ps('/animals/cat/big/3.png'))
+    expect(match.kind).toBe('row_blob')
+    expect(match.slots.row_id).toBe('3')
   })
 
-  it('single-collection pin elides the collection level', () => {
-    const pinned = resolveQdrantConfig({
-      collection: 'animals',
-      groupBy: ['label', 'kind'],
-      idField: 'id',
-    })
-    const s = detectScope(ps('/cat/big'), pinned)
-    expect(s.level).toBe(ScopeLevel.GROUP_DIR)
-    expect(s.filters).toEqual({ label: 'cat', kind: 'big' })
+  it('text and blob leaves need their config fields', () => {
+    const bare = resolveQdrantConfig({ groupBy: ['label', 'kind'] })
+    expect(detect(bare)(ps('/animals/cat/big/3.txt')).kind).toBe(INVALID)
+    expect(detect(bare)(ps('/animals/cat/big/3.png')).kind).toBe(INVALID)
+    expect(detect(bare)(ps('/animals/cat/big/3.json')).kind).toBe('row_json')
+  })
+
+  it('too-deep paths are invalid', () => {
+    expect(detect(config)(ps('/animals/cat/big/3.json/extra')).kind).toBe(INVALID)
+  })
+
+  it('pinned collection elides the collection segment', () => {
+    const pinned = cfg({ collection: 'animals' })
+    const match = detect(pinned)(ps('/cat/big'))
+    expect(match.kind).toBe('group')
+    expect(tableOf(pinned, match)).toBe('animals')
+    expect(filtersOf(pinned, match)).toEqual({ label: 'cat', kind: 'big' })
+  })
+
+  it('detectFor caches per accessor', () => {
+    const accessor = new QdrantAccessor(config)
+    expect(detectFor(accessor)).toBe(detectFor(accessor))
+    const other = new QdrantAccessor(cfg({ collection: 'animals', groupBy: ['label'] }))
+    expect(detectFor(other)(ps('/cat/3.json')).kind).toBe('row_json')
   })
 })

--- a/typescript/packages/core/src/core/qdrant/scope.ts
+++ b/typescript/packages/core/src/core/qdrant/scope.ts
@@ -12,88 +12,90 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
 import type { QdrantConfigResolved } from '../../resource/qdrant/config.ts'
-import { PathSpec } from '../../types.ts'
-import { stripSlash } from '../../utils/slash.ts'
+import { FileType } from '../../types.ts'
+import { imageTypeForExtension } from '../../utils/filetype.ts'
+import { perAccessor } from '../hierarchy/bind.ts'
+import { Codec, JSON_NAME } from '../hierarchy/codec.ts'
+import { Scope, Slot, makeDetectScope, type DetectFn, type ScopeMatch } from '../hierarchy/scope.ts'
 
-export const ScopeLevel = Object.freeze({
-  ROOT: 'root',
-  GROUP_DIR: 'group_dir',
-  ROW: 'row',
-  UNKNOWN: 'unknown',
-} as const)
+const TXT = new Codec({ suffix: '.txt' })
 
-export type ScopeLevel = (typeof ScopeLevel)[keyof typeof ScopeLevel]
-
-export interface QdrantScope {
-  level: ScopeLevel
-  table: string | null
-  filters: Record<string, string>
-  rowId: string | null
-  kind: string | null
-  resourcePath: string
-}
-
-function parseRowFile(name: string, config: QdrantConfigResolved): [string, string] | null {
-  if (name.endsWith('.json')) return [name.slice(0, -'.json'.length), 'json']
-  if (config.textField !== null && name.endsWith('.txt')) {
-    return [name.slice(0, -'.txt'.length), 'txt']
+/**
+ * The mount's scope table, shaped by its config.
+ *
+ * The tree is a function of the mount config, not of the backend: a pinned
+ * `collection` removes the leading collection segment, every `groupBy` column
+ * adds one directory level, and `textField` / `blobField` each add a leaf
+ * suffix beside the `.json` row. Group slots are named positionally (`g0`,
+ * `g1`, ...) so a column named `table` cannot collide with the collection
+ * slot; `filtersOf` maps them back to column names. Every partial depth
+ * shares the one `group` kind, and its lister derives the depth from the
+ * slots, so the lister table stays static while the scope table varies per
+ * mount.
+ */
+export function scopesFor(config: QdrantConfigResolved): Scope[] {
+  const prefix: Slot[] = config.collection !== null ? [] : [new Slot('table')]
+  const groups = config.groupBy.map((_, i) => new Slot(`g${String(i)}`))
+  const scopes: Scope[] = []
+  for (let depth = 0; depth <= groups.length; depth++) {
+    if (depth === 0 && prefix.length === 0) continue
+    scopes.push(new Scope({ kind: 'group', segments: [...prefix, ...groups.slice(0, depth)] }))
+  }
+  const full = [...prefix, ...groups]
+  scopes.push(
+    new Scope({
+      kind: 'row_json',
+      segments: [...full, new Slot('row_id', JSON_NAME)],
+      leaf: true,
+      filetype: FileType.TEXT,
+    }),
+  )
+  if (config.textField !== null) {
+    scopes.push(
+      new Scope({
+        kind: 'row_text',
+        segments: [...full, new Slot('row_id', TXT)],
+        leaf: true,
+        filetype: FileType.TEXT,
+      }),
+    )
   }
   if (config.blobField !== null) {
-    const suffix = `.${config.blobExt}`
-    if (name.endsWith(suffix)) return [name.slice(0, -suffix.length), 'blob']
+    const blob = new Codec({ suffix: `.${config.blobExt}` })
+    scopes.push(
+      new Scope({
+        kind: 'row_blob',
+        segments: [...full, new Slot('row_id', blob)],
+        leaf: true,
+        filetype: imageTypeForExtension(config.blobExt),
+      }),
+    )
   }
-  return null
+  return scopes
 }
 
-function make(
-  level: ScopeLevel,
-  resourcePath: string,
-  over: Partial<QdrantScope> = {},
-): QdrantScope {
-  return {
-    level,
-    table: over.table ?? null,
-    filters: over.filters ?? {},
-    rowId: over.rowId ?? null,
-    kind: over.kind ?? null,
-    resourcePath,
-  }
+function buildDetect(accessor: QdrantAccessor): DetectFn {
+  return makeDetectScope(scopesFor(accessor.config))
 }
 
-export function detectScope(path: PathSpec | string, config: QdrantConfigResolved): QdrantScope {
-  const raw = path instanceof PathSpec ? path.mountPath : path
-  const key = stripSlash(raw)
-  const segs = key === '' ? [] : key.split('/')
+export const detectFor = perAccessor(buildDetect)
 
-  let table: string
-  let rest: string[]
-  if (config.collection !== null) {
-    table = config.collection
-    rest = segs
-  } else {
-    if (segs.length === 0) return make(ScopeLevel.ROOT, raw)
-    table = segs[0] ?? ''
-    rest = segs.slice(1)
+/** The collection a match addresses: pinned, or the path's first slot. */
+export function tableOf(config: QdrantConfigResolved, match: ScopeMatch): string {
+  if (config.collection !== null) return config.collection
+  return match.slots.table ?? ''
+}
+
+/** The match's group filters, keyed back to column names. */
+export function filtersOf(config: QdrantConfigResolved, match: ScopeMatch): Record<string, string> {
+  const filters: Record<string, string> = {}
+  for (let i = 0; i < config.groupBy.length; i++) {
+    const value = match.slots[`g${String(i)}`]
+    const column = config.groupBy[i]
+    if (value === undefined || column === undefined) break
+    filters[column] = value
   }
-
-  const gb = config.groupBy
-  const n = gb.length
-
-  if (rest.length <= n) {
-    const filters: Record<string, string> = {}
-    for (let i = 0; i < rest.length; i++) filters[gb[i] ?? ''] = rest[i] ?? ''
-    return make(ScopeLevel.GROUP_DIR, raw, { table, filters })
-  }
-
-  if (rest.length === n + 1) {
-    const filters: Record<string, string> = {}
-    for (let i = 0; i < n; i++) filters[gb[i] ?? ''] = rest[i] ?? ''
-    const parsed = parseRowFile(rest[n] ?? '', config)
-    if (parsed !== null) {
-      return make(ScopeLevel.ROW, raw, { table, filters, rowId: parsed[0], kind: parsed[1] })
-    }
-  }
-
-  return make(ScopeLevel.UNKNOWN, raw)
+  return filters
 }

--- a/typescript/packages/core/src/core/qdrant/stat.ts
+++ b/typescript/packages/core/src/core/qdrant/stat.ts
@@ -18,8 +18,13 @@ import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
 import { imageTypeForExtension } from '../../utils/filetype.ts'
 import { rstripSlash } from '../../utils/slash.ts'
+import { perAccessor } from '../hierarchy/bind.ts'
+import type { Guard } from '../hierarchy/readdir.ts'
+import type { ScopeMatch } from '../hierarchy/scope.ts'
+import { makeStat, type StatHook } from '../hierarchy/stat.ts'
 import { read } from './read.ts'
-import { ScopeLevel, detectScope } from './scope.ts'
+import { readdirFor } from './readdir.ts'
+import { detectFor, tableOf } from './scope.ts'
 
 function nameOf(spec: PathSpec): string {
   const stripped = rstripSlash(spec.virtual)
@@ -27,34 +32,57 @@ function nameOf(spec: PathSpec): string {
   return last === undefined || last === '' ? '/' : last
 }
 
+async function tableGuard(
+  accessor: QdrantAccessor,
+  match: ScopeMatch,
+  virtual: string,
+): Promise<void> {
+  if (!(await accessor.tableExists(tableOf(accessor.config, match)))) throw enoent(virtual)
+}
+
+async function statRow(
+  accessor: QdrantAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<FileStat> {
+  const config = accessor.config
+  if (!(await accessor.tableExists(tableOf(config, match)))) throw enoent(path.virtual)
+  const fileType = match.kind === 'row_blob' ? imageTypeForExtension(config.blobExt) : FileType.TEXT
+  // The row-dir readdir seeds exact rendered sizes; a cold index falls back
+  // to rendering the row, so the size is exact either way.
+  if (index !== undefined) {
+    const lookup = await index.get(rstripSlash(path.virtual))
+    if (lookup.entry !== undefined && lookup.entry !== null && lookup.entry.size !== null) {
+      return new FileStat({ name: nameOf(path), size: lookup.entry.size, type: fileType })
+    }
+  }
+  const data = await read(accessor, path, index)
+  return new FileStat({ name: nameOf(path), size: data.length, type: fileType })
+}
+
+const GUARDS: Record<string, Guard<QdrantAccessor>> = { group: tableGuard }
+
+const OVERRIDES: Record<string, StatHook<QdrantAccessor>> = {
+  row_json: statRow,
+  row_text: statRow,
+  row_blob: statRow,
+}
+
+function buildStat(accessor: QdrantAccessor) {
+  return makeStat(detectFor(accessor), readdirFor(accessor), {
+    guards: GUARDS,
+    overrides: OVERRIDES,
+  })
+}
+
+const statFor = perAccessor(buildStat)
+
 export async function stat(
   accessor: QdrantAccessor,
   path: PathSpec | string,
   index?: IndexCacheStore,
 ): Promise<FileStat> {
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
-  const config = accessor.config
-  const scope = detectScope(spec, config)
-
-  if (scope.level === ScopeLevel.UNKNOWN) throw enoent(spec.virtual)
-
-  if (scope.table !== null) {
-    if (!(await accessor.tableExists(scope.table))) throw enoent(spec.virtual)
-  }
-
-  if (scope.level === ScopeLevel.ROOT || scope.level === ScopeLevel.GROUP_DIR) {
-    return new FileStat({ name: nameOf(spec), type: FileType.DIRECTORY })
-  }
-
-  const fileType = scope.kind === 'blob' ? imageTypeForExtension(config.blobExt) : FileType.TEXT
-  // The row-dir readdir seeds exact rendered sizes; a cold index falls back
-  // to rendering the row, so the size is exact either way.
-  if (index !== undefined) {
-    const lookup = await index.get(rstripSlash(spec.virtual))
-    if (lookup.entry !== undefined && lookup.entry !== null && lookup.entry.size !== null) {
-      return new FileStat({ name: nameOf(spec), size: lookup.entry.size, type: fileType })
-    }
-  }
-  const data = await read(accessor, spec, index)
-  return new FileStat({ name: nameOf(spec), size: data.length, type: fileType })
+  return statFor(accessor)(accessor, spec, index)
 }


### PR DESCRIPTION
Migrates lancedb and qdrant onto the core/hierarchy kit, in both languages. These are the two backends whose route table is a function of mount config (pinned table/collection, group_by depth, config-gated leaf set), so their scope tables cannot bind at module import like the other 17 consumers.

The per-mount mechanism is one new kit helper, hierarchy/bind per_accessor (perAccessor): a weak map keyed on the accessor that caches one build of make_detect_scope(scopes_for(config)) plus the three factories per mount. The kit factories themselves needed no change for this; they were already pure functions. Listers, guards and readers stay module-level functions that read accessor.config at call time, so the existing patch-the-client-fns test convention is unchanged and the module-level readdir/stat/read signatures (and all io.py/ops/resource wiring) are untouched.

Scope shape, identical for both backends: a pinned table/collection drops the leading table slot; group slots are named positionally (g0, g1, ...) so a column literally named "table" cannot collide with the table slot, with table_of/filters_of mapping back to column names; every partial depth shares one "group" kind whose lister derives the depth from the slots, so the lister table stays static while the scope table varies per mount. Leaf codecs are config-built (.md and blob for lancedb; .json, .txt and blob for qdrant).

One kit fix rode along: make_readdir and make_stat now normalize index=None the same as NULL_INDEX (a call-local RAM store). Bare commands built outside a workspace bind None; the old backends tolerated it and the kit crashed. The TS twin was already safe via ??. Pinned by new kit tests.

Behavior changes, pinned by unit tests; integ goldens needed zero changes (95/95 per host, both hosts):

- cat of the mount root is EISDIR (was ENOENT), matching the rest of the kit family
- ls of a nonexistent table/collection is a clean ENOENT instead of a leaked driver error
- dot-led segments are refused and dropped from listings
- every listing level now seeds the index (old code seeded only the rows level)
- qdrant .json leaves keep FileType.TEXT, the old behavior in both languages

Verified: full python suite + mypy clean, pnpm -r build/typecheck/test, layout parity at baseline (bind lands on both sides), pre-commit fixpoint.