### PR TITLE
Serve symlink, readlink and setattr to guests

### DIFF
--- a/docs/python/runtime/javascript.mdx
+++ b/docs/python/runtime/javascript.mdx
@@ -58,7 +58,7 @@ The engine runs under WebAssembly capability isolation: it sees only what
 the run passes it. Host files and the network are invisible. Workspace
 mounts are visible with no setup: mirage intercepts the sandbox's
 filesystem calls and bridges them through the workspace dispatch, so
-`std.open('/data/f.txt', 'r')` reads the mount live, and `os.stat`/`os.mkdir`/`os.rename`/`os.remove` stat and mutate it (0 or -errno in WASI numbering, like the real engine) — RAM, Redis, S3, or
+`std.open('/data/f.txt', 'r')` reads the mount live, and `os.stat`/`os.mkdir`/`os.rename`/`os.remove`/`os.utimes` stat and mutate it (0 or -errno in WASI numbering, like the real engine) — RAM, Redis, S3, or
 a virtual backend — and writes are immediately visible to every command,
 with the same cache, write modes, and per-session mount narrowing as
 `cat`. A read-only mount (or a session narrowed to read) fails the open,

--- a/docs/typescript/python-fs.mdx
+++ b/docs/typescript/python-fs.mdx
@@ -66,6 +66,23 @@ open('/ram/notes.txt', 'w').write('hello')              # writes flush back to R
     ```
     Anything that goes through Python's `open()` works (PIL, numpy, pandas, json, pickle).
   </Tab>
+  <Tab title="Symlinks & metadata">
+    ```python
+    import os
+
+    os.symlink('report.json', '/ram/latest.json')
+    print(os.readlink('/ram/latest.json'), os.path.islink('/ram/latest.json'))
+
+    os.utime('/ram/report.json', (1767225600, 1767225600))
+    os.chmod('/ram/report.json', 0o600)
+    ```
+    A link is namespace state, so no backend has to be able to store one:
+    the op reaches the name plane and a link lands on an S3 or Notion mount
+    the same way it lands on a RAM one. Links the shell made are collected
+    with the prefix, as links rather than as copies of their targets, so a
+    cyclic one is safe to walk past. A `chmod` or `utime` a backend cannot
+    keep is stored in the namespace overlay and reported back by `stat`.
+  </Tab>
   <Tab title="Cross-mount">
     ```python
     # Read from one mount, write to another, same Python code:
@@ -87,7 +104,6 @@ open('/ram/notes.txt', 'w').write('hello')              # writes flush back to R
 |---|---|---|
 | **External edits show up mid-run**, someone else edits the GDoc while your script runs | The tree is collected before the run and served synchronously after that | Each run re-collects, so the next one sees the edit |
 | **Huge mounts**, collecting a 100GB S3 bucket | Every byte is held in memory for the run | Mount a narrower prefix |
-| **Symlinks**, `os.symlink` inside the guest | Links are namespace state in Mirage, so no mount op can carry one | Refused with `EPERM` rather than silently lost at the end of the run |
 | **Concurrent writers**, two Python processes write the same path | Last `close()` wins, no conflict detection | Out of scope for v1 |
 | **Browser-only resources from Node**, OPFS | OPFS isn't a thing in Node | Run in a browser-side Mirage |
 

--- a/docs/typescript/python-fs.mdx
+++ b/docs/typescript/python-fs.mdx
@@ -81,7 +81,12 @@ open('/ram/notes.txt', 'w').write('hello')              # writes flush back to R
     the same way it lands on a RAM one. Links the shell made are collected
     with the prefix, as links rather than as copies of their targets, so a
     cyclic one is safe to walk past. A `chmod` or `utime` a backend cannot
-    keep is stored in the namespace overlay and reported back by `stat`.
+    keep is stored in the namespace overlay and reported back by `stat`, and
+    an `lstat` reads the link's own row rather than its target's, so a
+    `follow_symlinks=False` stamp is visible right after it is written.
+    `os.rename` moves a link by its own name instead of following it, and
+    `os.symlink` onto a name that is taken raises `FileExistsError`, both as
+    POSIX has them.
   </Tab>
   <Tab title="Cross-mount">
     ```python

--- a/docs/typescript/python.mdx
+++ b/docs/typescript/python.mdx
@@ -150,7 +150,7 @@ None. No V8 flag, no [JSPI](https://github.com/WebAssembly/js-promise-integratio
 
 - Live external edits: a change made to the resource from outside mid-run is not seen until the next run re-collects the prefix.
 - Concurrent writers: last write wins; no conflict detection.
-- Symlinks: links are namespace state in Mirage, so `os.symlink` is refused with `EPERM` rather than accepted and lost at the end of the run.
+- Directory links are not walked into: `os.symlink` and `os.readlink` are served, and a link the shell made is collected as a link rather than as a copy of its target, so nothing under a directory link is in the tree the run reads.
 
 ## What you cannot do
 

--- a/docs/typescript/runtime/javascript.mdx
+++ b/docs/typescript/runtime/javascript.mdx
@@ -58,7 +58,7 @@ The engine runs under WebAssembly capability isolation: it sees only what
 the run passes it. Host files and the network are invisible.
 
 Workspace mounts are visible with no setup: `std.open('/data/f.txt', 'r')`
-reads the mount, `os.readdir('/data')` lists it, and `os.stat`/`os.mkdir`/`os.rename`/`os.remove` stat and mutate it (0 or -errno in WASI numbering, like the real engine), bridged through the
+reads the mount, `os.readdir('/data')` lists it, and `os.stat`/`os.mkdir`/`os.rename`/`os.remove`/`os.utimes` stat and mutate it (0 or -errno in WASI numbering, like the real engine), bridged through the
 workspace dispatch so the code sees exactly what `cat` sees, with the same
 cache and write modes. Writes are visible to every command once the file is
 closed, and a read-only mount (or a session narrowed to read) fails the

--- a/integ/runtime/monty.json
+++ b/integ/runtime/monty.json
@@ -481,6 +481,38 @@
           }
         }
       ]
+    },
+    {
+      "id": "is_symlink_reads_the_name_plane",
+      "world": {
+        "runtimes": [
+          "monty",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "ln -s t.txt /ram/l",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "python3 -c \"from pathlib import Path; print(Path('/ram/l').is_symlink(), Path('/ram/t.txt').is_symlink())\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "True False\n"
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/pyodide.json
+++ b/integ/runtime/pyodide.json
@@ -343,6 +343,131 @@
           }
         }
       ]
+    },
+    {
+      "id": "symlink_roundtrip",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import os; os.symlink('t.txt', '/data/made')\"",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "readlink /data/made",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\n"
+          }
+        },
+        {
+          "command": "cat /data/made",
+          "expect": {
+            "exit": 0,
+            "stdout": "hello\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "readlink_a_shell_link",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "ln -s t.txt /data/l",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "python3 -c \"import os\nprint(os.readlink('/data/l'))\nprint(os.path.islink('/data/l'), os.path.islink('/data/t.txt'))\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\nTrue False\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "metadata_reaches_the_mount",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import os; os.utime('/data/t.txt', (100.0, 200.0))\"",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "stat -c %Y /data/t.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "200\n"
+          }
+        },
+        {
+          "command": "python3 -c \"import os; os.chmod('/data/t.txt', 0o600)\"",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "stat -c %a /data/t.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "600\n"
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/pyodide.json
+++ b/integ/runtime/pyodide.json
@@ -468,6 +468,90 @@
           }
         }
       ]
+    },
+    {
+      "id": "rename_a_link_moves_the_name",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import os\nos.symlink('t.txt', '/data/made')\nos.rename('/data/made', '/data/moved')\nprint(os.readlink('/data/moved'))\nprint(os.path.islink('/data/made'))\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\nFalse\n"
+          }
+        },
+        {
+          "command": "readlink /data/moved",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\n"
+          }
+        },
+        {
+          "command": "readlink /data/made",
+          "expect": {
+            "exit": 1
+          }
+        }
+      ]
+    },
+    {
+      "id": "rename_a_shell_link",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/data": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "ln -s t.txt /data/lk",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "python3 -c \"import os\nos.rename('/data/lk', '/data/lk2')\nprint(os.readlink('/data/lk2'))\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\n"
+          }
+        },
+        {
+          "command": "readlink /data/lk2",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\n"
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/quickjs.json
+++ b/integ/runtime/quickjs.json
@@ -347,6 +347,39 @@
           }
         }
       ]
+    },
+    {
+      "id": "utimes_reaches_the_mount",
+      "world": {
+        "runtimes": [
+          "quickjs",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "node -e \"console.log(os.utimes('/ram/t.txt', 100000, 200000), os.utimes('/ram/nope.txt', 1, 2))\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "0 -44\n"
+          }
+        },
+        {
+          "command": "stat -c %Y /ram/t.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "200\n"
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/wasi.json
+++ b/integ/runtime/wasi.json
@@ -381,6 +381,138 @@
           }
         }
       ]
+    },
+    {
+      "id": "rename_a_link_moves_the_name",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "ln -s t.txt /ram/lk",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "python3 -c \"import os\nos.rename('/ram/lk', '/ram/moved')\nprint(os.readlink('/ram/moved'))\nprint(os.path.islink('/ram/lk'))\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\nFalse\n"
+          }
+        },
+        {
+          "command": "readlink /ram/moved",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "symlink_refuses_an_occupied_name",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "mkdir /ram/d",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "ln -s t.txt /ram/lk",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "python3 -c \"import errno, os\nfor p in ('/ram/t.txt', '/ram/d', '/ram/lk', '/ram'):\n    try:\n        os.symlink('elsewhere', p)\n        print(p, 'created')\n    except OSError as exc:\n        print(p, errno.errorcode[exc.errno])\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "/ram/t.txt EEXIST\n/ram/d EEXIST\n/ram/lk EEXIST\n/ram EEXIST\n"
+          }
+        },
+        {
+          "command": "cat /ram/t.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "hello\n"
+          }
+        },
+        {
+          "command": "readlink /ram/lk",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a_links_own_time_reaches_the_guest",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "ln -s t.txt /ram/lk",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "python3 -c \"import os\nos.utime('/ram/lk', (1000000000, 1000000000), follow_symlinks=False)\nst = os.lstat('/ram/lk')\nprint(int(st.st_mtime))\nprint(os.path.islink('/ram/lk'))\nprint(int(os.stat('/ram/t.txt').st_mtime) != 1000000000)\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "1000000000\nTrue\nTrue\n"
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/wasi.json
+++ b/integ/runtime/wasi.json
@@ -191,6 +191,196 @@
           }
         }
       ]
+    },
+    {
+      "id": "symlink_roundtrip",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import os; os.symlink('t.txt', '/ram/made')\"",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "readlink /ram/made",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\n"
+          }
+        },
+        {
+          "command": "cat /ram/made",
+          "expect": {
+            "exit": 0,
+            "stdout": "hello\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "readlink_and_lstat_a_shell_link",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "ln -s t.txt /ram/l",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "python3 -c \"import os, stat\nprint(os.readlink('/ram/l'))\nst = os.lstat('/ram/l')\nprint(stat.S_ISLNK(st.st_mode), st.st_size)\nprint(os.path.islink('/ram/t.txt'))\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\nTrue 5\nFalse\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "readlink_splits_its_two_misses",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "mkdir /ram/d",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "python3 -c \"import errno, os\nfor p in ('/ram/t.txt', '/ram/d', '/ram/missing', '/ram/d/deep/missing'):\n    try:\n        os.readlink(p)\n    except OSError as exc:\n        print(p, errno.errorcode[exc.errno])\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "/ram/t.txt EINVAL\n/ram/d EINVAL\n/ram/missing ENOENT\n/ram/d/deep/missing ENOENT\n"
+          }
+        },
+        {
+          "command": "python3 -c \"import os\ntry:\n    os.readlink('/ram/missing')\nexcept FileNotFoundError:\n    print('caught as FileNotFoundError')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "caught as FileNotFoundError\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "utime_reaches_the_mount",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import os; os.utime('/ram/t.txt', (100.0, 200.0))\"",
+          "expect": {
+            "exit": 0
+          }
+        },
+        {
+          "command": "stat -c %Y /ram/t.txt",
+          "expect": {
+            "exit": 0,
+            "stdout": "200\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "hard_link_is_refused_with_eperm",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import errno, os\ntry:\n    os.link('/ram/t.txt', '/ram/hard')\nexcept OSError as exc:\n    print(exc.errno == errno.EPERM)\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "True\n"
+          }
+        },
+        {
+          "command": "ls /ram",
+          "expect": {
+            "exit": 0,
+            "stdout": "t.txt\n"
+          }
+        }
+      ]
     }
   ]
 }

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -68,18 +68,19 @@ async def restore_entry(dispatch: DispatchFn,
     A 120000 entry is a symlink whose blob is the target string, so it
     is restored through the namespace rather than written as content:
     writing the blob would leave a regular file spelling the target.
-    The namespace overwrites a link of the same name, which is what a
-    checkout that changes where a link points needs.
 
-    Whatever is already there goes first when it is the other kind,
-    because the two live on different planes and neither replaces the
-    other. Writing a regular blob at a path the namespace holds a link
-    for follows the link and lands the content in the file it points
-    at, corrupting a path no branch touched while the link stays; and
-    linking over a regular file leaves that file behind the link, ready
-    to reappear when the link goes. git replaces the entry in both
-    directions. The check is a namespace lookup, so the ordinary
-    file-for-file case costs nothing.
+    Whatever is already there goes first, whichever kind it is, because
+    git replaces a tree entry rather than merging with it. Two of the
+    four combinations are the ones that corrupt state: writing a regular
+    blob at a path the namespace holds a link for follows the link and
+    lands the content in the file it points at, damaging a path no
+    branch touched while the link stays; and linking over a regular file
+    leaves that file behind the link, ready to reappear when the link
+    goes. The fourth, a link over a link, is the retarget a checkout
+    does when a branch moves where a link points: symlink(2) does not
+    overwrite, so the old name is removed rather than replaced in place.
+    The check is a namespace lookup, so the ordinary file-for-file case
+    costs nothing.
 
     Args:
         dispatch (DispatchFn): workspace op dispatcher.
@@ -91,8 +92,7 @@ async def restore_entry(dispatch: DispatchFn,
     """
     linked = links is not None and links.stat_at(path) is not None
     if mode == SYMLINK:
-        if not linked:
-            await remove_file(dispatch, path)
+        await remove_file(dispatch, path)
         await dispatch("symlink",
                        PathSpec.from_str_path(path),
                        target=blob.decode("utf-8", errors="replace"))

--- a/python/mirage/fuse/core.py
+++ b/python/mirage/fuse/core.py
@@ -239,8 +239,26 @@ class MountCore:
         parent = path.rsplit("/", 1)[0] or "/"
         return posixpath.relpath(virtual_target, parent)
 
-    def link_stat(self, target: str) -> dict[str, Any]:
+    def link_stat(self, target: str, virtual: str) -> dict[str, Any]:
+        """The attrs a namespace link reports, from its own node row.
+
+        Built from the target string alone, every link over a mount
+        answered the mount's construction time and the mounting user, so
+        what ``chown -h`` and ``touch -h`` wrote was invisible through
+        the kernel. The row is the same one the door answers a no-follow
+        stat with. Size stays the displayable target's length (what this
+        mount's readlink returns), and the mode is always lrwxrwxrwx: a
+        symlink's permission bits are not consulted by any POSIX system.
+
+        Args:
+            target (str): the target as this mount presents it.
+            virtual (str): the link's virtual path, for the node row.
+        """
         entry = self.file_stat(len(target.encode()))
+        links = self._ops.links
+        row = None if links is None else links.link_stat_at(virtual)
+        if row is not None:
+            entry = self._apply_stat_attrs(entry, row)
         entry["st_mode"] = LINK_MODE
         return entry
 
@@ -338,7 +356,7 @@ class MountCore:
         # namespace links, so stat on a link path reports the target.
         target = self.link_target(path)
         if target is not None:
-            return self.link_stat(target)
+            return self.link_stat(target, self.resolve(path))
         s = self._run(self._ops.stat(self.resolve(path)))
         if s.type == FileType.DIRECTORY:
             return self._apply_stat_attrs(self.dir_stat(), s)

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -404,7 +404,7 @@ class Ops:
         await self._call("create", path)
 
     async def symlink(self, path: str, target: str) -> None:
-        """Create or overwrite a namespace symlink at ``path``.
+        """Create a namespace symlink at ``path``.
 
         Routed through the door like every write: session grants and
         admission policies fire on the link's turf, and the write lands
@@ -413,6 +413,12 @@ class Ops:
         Args:
             path (str): Virtual path of the link.
             target (str): What the link points to, as typed.
+
+        Raises:
+            FileExistsError: something is already at ``path`` (a file, a
+                directory, another link, a mount root). symlink(2) never
+                overwrites, and the door is the layer that can see both
+                planes to tell.
         """
         await self._call("symlink", path, target=target)
 

--- a/python/mirage/ops/os_patch.py
+++ b/python/mirage/ops/os_patch.py
@@ -364,9 +364,10 @@ class _OsRouter:
         try:
             return str(self._run(self._ops.readlink(virtual)))
         except OSError as exc:
-            # EINVAL is the node table's "not a link", which is the
-            # answer for an ordinary file and for a missing path alike;
-            # the caller's own stat reports the absence.
+            # EINVAL is the door's "there, but not a link". A missing
+            # path raises ENOENT instead, exactly as readlink(2) does,
+            # and that is the answer lstat owes its caller, so it is not
+            # swallowed here.
             if exc.errno == errno.EINVAL:
                 return None
             raise

--- a/python/mirage/runtime/python/monty/osaccess.py
+++ b/python/mirage/runtime/python/monty/osaccess.py
@@ -151,6 +151,21 @@ class MirageOSAccess(OSAccess):
         self._ensure_dir(path)
         return super().path_is_dir(path)
 
+    def path_is_symlink(self, path: PurePosixPath) -> bool:
+        """Whether `path` is a symlink, asking the mount's name plane.
+
+        Monty's own tree holds no links, so the base answer is always
+        False for a mounted path: a link the shell made was invisible
+        to `Path.is_symlink()` before this. Creation stays out of reach,
+        because monty 0.0.19's OSAccess has no symlink verb to override.
+
+        Args:
+            path (PurePosixPath): the guest path to test.
+        """
+        if self._vfs.is_link(str(path)):
+            return True
+        return bool(super().path_is_symlink(path))
+
     def path_stat(self, path: PurePosixPath):
         self._ensure_file(path)
         self._ensure_dir(path)

--- a/python/mirage/runtime/python/monty/vfs.py
+++ b/python/mirage/runtime/python/monty/vfs.py
@@ -60,6 +60,28 @@ class MontyVFS:
                 ValueError):
             return None
 
+    def is_link(self, virtual: str) -> bool:
+        """Whether the mount's name plane holds a symlink at `virtual`.
+
+        Answered through the readlink op rather than a listing, because
+        a python readdir row carries no link mark: the door resolves
+        entries by stat, and stat follows. One dispatch per question,
+        which is what every other predicate here costs too.
+
+        Args:
+            virtual (str): the path to test.
+        """
+        if self._core is None:
+            return False
+        try:
+            self._core.readlink(virtual)
+        except OSError:
+            # EINVAL for a path that is not a link, ENOENT for one that
+            # is not there: `is_symlink` is False either way, which is
+            # what pathlib answers for both.
+            return False
+        return True
+
     def write(self, virtual: str, data: bytes) -> None:
         if self._core is None:
             return

--- a/python/mirage/runtime/vfs.py
+++ b/python/mirage/runtime/vfs.py
@@ -34,8 +34,11 @@ class RuntimeVFS:
     """The mount-facing op vocabulary a sandboxed runtime encodes into.
 
     One instruction set (read/write/append/stat/readdir/create/truncate/
-    unlink/mkdir/rmdir/rename), one routing table, one place that knows
-    an append may have to become a whole-file write. Encoders hold one
+    unlink/mkdir/rmdir/rename/symlink/readlink/setattr), one routing
+    table, one place that knows an append may have to become a
+    whole-file write. The last three reach the name plane rather than a
+    backend, which is what lets a guest create a link or chmod a file on
+    a mount whose store has neither. Encoders hold one
     of these; they never inherit it, because a monty encoder must
     inherit the binding's own OSAccess and a wasm encoder is a table of
     preview1 host functions.
@@ -216,6 +219,73 @@ class RuntimeVFS:
         if self.mount_of(src) != self.mount_of(dst):
             raise CrossMountError(src, dst)
         self.call("rename", src, dst=PathSpec.from_str_path(dst))
+
+    def symlink(self, path: str, target: str) -> None:
+        """Create a namespace symlink at `path` pointing at `target`.
+
+        A link is namespace state, so no backend stores one and the
+        target is kept verbatim as the guest typed it. The dispatcher
+        answers this op from the node table itself, which is why a
+        runtime can serve `os.symlink` at all: the door a surface
+        already holds reaches the name plane, not just a mount.
+
+        Args:
+            path (str): guest-absolute path of the link to create.
+            target (str): link target, stored as typed.
+        """
+        self.call("symlink", path, target=target)
+
+    def readlink(self, path: str) -> str:
+        """The target of the symlink at `path`.
+
+        Args:
+            path (str): guest-absolute path of the link.
+
+        Returns:
+            str: the stored target.
+
+        Raises:
+            OSError: EINVAL when `path` is not a link, which is what the
+                node table answers and what POSIX readlink says.
+        """
+        return str(self.call("readlink", path))
+
+    def setattr(self,
+                path: str,
+                *,
+                mode: int | None = None,
+                uid: int | str | None = None,
+                gid: int | str | None = None,
+                atime: str | None = None,
+                mtime: str | None = None,
+                nofollow: bool = False) -> None:
+        """Write metadata fields, natively where the backend can hold them.
+
+        Every field is passed, unset ones as None, because the door
+        reads the whole set and stores in the namespace overlay whatever
+        the backend cannot keep. A mount with no setattr op therefore
+        still answers: chmod on an s3 or dropbox mount lands in the name
+        plane and stat reports it back. Stored, not enforced; mount mode
+        is the access control.
+
+        Args:
+            path (str): guest-absolute virtual path.
+            mode (int | None): permission bits (e.g. 0o644).
+            uid (int | str | None): owner id or name.
+            gid (int | str | None): group id or name.
+            atime (str | None): ISO access time.
+            mtime (str | None): ISO modification time.
+            nofollow (bool): write the link entry's own attrs rather
+                than its target's (a guest's AT_SYMLINK_NOFOLLOW).
+        """
+        self.call("setattr",
+                  path,
+                  mode=mode,
+                  uid=uid,
+                  gid=gid,
+                  atime=atime,
+                  mtime=mtime,
+                  nofollow=nofollow)
 
     def append(self, path: str, data: bytes, whole: bytes) -> None:
         """Extend `path` by `data`, falling back to writing `whole`.

--- a/python/mirage/runtime/wasm/abi.py
+++ b/python/mirage/runtime/wasm/abi.py
@@ -15,6 +15,7 @@
 import struct
 
 from mirage.errors import FsCondition, classify
+from mirage.runtime.verbs import refusal_of
 
 # WASI preview1 wire numbers, from wasi-libc's errno.h (alphabetical
 # numbering). These are NOT the host's POSIX values and must never be
@@ -87,11 +88,30 @@ ENOENT = wasi_errno(FsCondition.ENOENT)
 ENOTDIR = wasi_errno(FsCondition.ENOTDIR)
 ENOTSUP = wasi_errno(FsCondition.ENOTSUP)
 
+# Which refusal a hard link gets is the verb table's decision, not this
+# surface's; rendering it in preview1 numbers is. preview1 spells the
+# verb `path_link` and the table keys it `link`, so mapping the name is
+# all the host does with this. A verb absent from every table is
+# refused there too, so the fallback is unreachable.
+LINK_REFUSAL = wasi_errno(refusal_of("link") or FsCondition.EPERM)
+
 # filetypes
 FT_UNKNOWN = 0
 FT_CHR = 2
 FT_DIR = 3
 FT_REG = 4
+FT_SYMLINK = 7
+
+# lookupflags: whether a path's trailing symlink is resolved. Unset is
+# how a guest spells lstat, so a verb that reads it cannot dereference.
+LOOKUP_SYMLINK_FOLLOW = 1
+
+# fstflags for path_filestat_set_times: which stamp the call writes and
+# whether the value comes from the argument or from the host clock.
+FST_ATIM = 1
+FST_ATIM_NOW = 2
+FST_MTIM = 4
+FST_MTIM_NOW = 8
 
 # path_open oflags
 OFLAG_CREAT = 1

--- a/python/mirage/runtime/wasm/host.py
+++ b/python/mirage/runtime/wasm/host.py
@@ -14,6 +14,7 @@
 
 import functools
 import posixpath
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
@@ -21,16 +22,19 @@ from typing import Any, Callable, Literal
 from mirage.runtime.errors import CrossMountError
 from mirage.runtime.handles import FileHandle, FileTable
 from mirage.runtime.wasm.abi import (EBADF, EEXIST, EINVAL, EISDIR, ENOENT,
-                                     ENOTDIR, ENOTSUP, FDFLAG_APPEND, FT_CHR,
-                                     FT_DIR, FT_REG, OFLAG_CREAT,
-                                     OFLAG_DIRECTORY, OFLAG_EXCL, OFLAG_TRUNC,
-                                     OK, RIGHT_FD_WRITE, errno_for,
-                                     pack_dirent, pack_fdstat, pack_filestat,
-                                     pack_prestat, pack_u32, pack_u64,
-                                     unpack_iovs)
+                                     ENOTDIR, FDFLAG_APPEND, FST_ATIM,
+                                     FST_ATIM_NOW, FST_MTIM, FST_MTIM_NOW,
+                                     FT_CHR, FT_DIR, FT_REG, FT_SYMLINK,
+                                     LINK_REFUSAL, LOOKUP_SYMLINK_FOLLOW,
+                                     OFLAG_CREAT, OFLAG_DIRECTORY, OFLAG_EXCL,
+                                     OFLAG_TRUNC, OK, RIGHT_FD_WRITE,
+                                     errno_for, pack_dirent, pack_fdstat,
+                                     pack_filestat, pack_prestat, pack_u32,
+                                     pack_u64, unpack_iovs)
 # yapf: enable
 from mirage.runtime.wasm.types import GuestStat
 from mirage.runtime.wasm.vfs import WasmVFS
+from mirage.utils.dates import timestamp_iso
 
 FdKind = Literal["stdin", "stdout", "stderr", "dir", "file"]
 
@@ -53,6 +57,39 @@ else:
     Func = _Func
     FuncType = _FuncType
     ValType = _ValType
+
+
+def _filetype(st: GuestStat) -> int:
+    """The preview1 filetype for one guest stat.
+
+    Args:
+        st (GuestStat): the stat to classify.
+    """
+    if st.is_link:
+        return FT_SYMLINK
+    return FT_DIR if st.is_dir else FT_REG
+
+
+def _stamp(fst_flags: int, set_bit: int, now_bit: int, value: int,
+           now: float) -> str | None:
+    """One utimensat stamp as ISO text, None when the call omits it.
+
+    preview1 splits each of the two stamps into "write the argument" and
+    "write the host clock" bits, and neither set is UTIME_OMIT: leave
+    that field alone.
+
+    Args:
+        fst_flags (int): the call's fstflags bag.
+        set_bit (int): the FST_*TIM bit for this stamp.
+        now_bit (int): the FST_*TIM_NOW bit for this stamp.
+        value (int): the argument's epoch nanoseconds.
+        now (float): the host clock, read once for both stamps.
+    """
+    if fst_flags & now_bit:
+        return timestamp_iso(now)
+    if fst_flags & set_bit:
+        return timestamp_iso(value / 1_000_000_000)
+    return None
 
 
 def _call_guarded(fn: Callable[..., Any], caller: "wasmtime.Caller", *args:
@@ -384,9 +421,12 @@ class WasiFs:
         path = self._path_arg(caller, dirfd, ptr, length)
         if path is None:
             return EBADF
-        st = self._fs.stat(path)
-        packed = pack_filestat(st.size,
-                               st.mtime_ns, FT_DIR if st.is_dir else FT_REG,
+        # The follow bit is how a guest spells stat versus lstat, so it
+        # is read rather than ignored: without it every link answered as
+        # its target and os.path.islink was always False.
+        follow = bool(flags & LOOKUP_SYMLINK_FOLLOW)
+        st = self._fs.stat(path) if follow else self._fs.lstat(path)
+        packed = pack_filestat(st.size, st.mtime_ns, _filetype(st),
                                self._ino(path))
         self._store(caller, buf, packed)
         return OK
@@ -478,23 +518,55 @@ class WasiFs:
     def path_filestat_set_times(self, caller: "wasmtime.Caller", dirfd: int,
                                 flags: int, ptr: int, length: int, atim: int,
                                 mtim: int, fst_flags: int) -> int:
+        path = self._path_arg(caller, dirfd, ptr, length)
+        if path is None:
+            return EBADF
+        now = time.time()
+        atime = _stamp(fst_flags, FST_ATIM, FST_ATIM_NOW, atim, now)
+        mtime = _stamp(fst_flags, FST_MTIM, FST_MTIM_NOW, mtim, now)
+        if atime is None and mtime is None:
+            # No stamp selected is a no-op, not an error: utimensat(2)
+            # with two UTIME_OMIT values does nothing and succeeds.
+            return OK
+        self._fs.setattr(path,
+                         atime=atime,
+                         mtime=mtime,
+                         nofollow=not (flags & LOOKUP_SYMLINK_FOLLOW))
         return OK
 
     def path_readlink(self, caller: "wasmtime.Caller", dirfd: int, ptr: int,
                       length: int, buf: int, buf_len: int, used: int) -> int:
-        # Workspace links resolve inside dispatch; the guest never sees
-        # a symlink, so readlink on any path answers "not a symlink".
-        return EINVAL
+        path = self._path_arg(caller, dirfd, ptr, length)
+        if path is None:
+            return EBADF
+        raw = self._fs.readlink(path).encode()[:buf_len]
+        self._store(caller, buf, raw)
+        # preview1 truncates rather than refusing a short buffer, and
+        # reports what it wrote; a guest that wants the whole target
+        # retries with a bigger one, which is what wasi-libc does.
+        self._store(caller, used, pack_u32(len(raw)))
+        return OK
 
     def path_link(self, caller: "wasmtime.Caller", old_dirfd: int,
                   old_flags: int, old_ptr: int, old_length: int,
                   new_dirfd: int, new_ptr: int, new_length: int) -> int:
-        return ENOTSUP
+        # A hard link is a second name for one inode, and nothing above
+        # a mount holds that. Which refusal that is comes from the verb
+        # table, not from this surface; see abi.LINK_REFUSAL.
+        return LINK_REFUSAL
 
     def path_symlink(self, caller: "wasmtime.Caller", old_ptr: int,
                      old_length: int, dirfd: int, new_ptr: int,
                      new_length: int) -> int:
-        return ENOTSUP
+        # The old_* pair is the target string, not a path to resolve:
+        # a link stores what was typed, so it is read straight out of
+        # guest memory and never joined against a preopen.
+        target = self._load(caller, old_ptr, old_length).decode()
+        path = self._path_arg(caller, dirfd, new_ptr, new_length)
+        if path is None:
+            return EBADF
+        self._fs.symlink(path, target)
+        return OK
 
 
 def _spec() -> dict[str, tuple[list[Any], list[Any]]]:

--- a/python/mirage/runtime/wasm/types.py
+++ b/python/mirage/runtime/wasm/types.py
@@ -24,8 +24,12 @@ class GuestStat:
         size (int): size in bytes.
         mtime_ns (int): modification time in epoch nanoseconds, 0 when
             the source reports none.
+        is_link (bool): whether the path is a symlink. Only ever true
+            for a stat the guest asked not to follow, since every other
+            answer is the target's.
     """
 
     is_dir: bool
     size: int
     mtime_ns: int
+    is_link: bool = False

--- a/python/mirage/runtime/wasm/vfs.py
+++ b/python/mirage/runtime/wasm/vfs.py
@@ -146,6 +146,46 @@ class WasmVFS:
                          size=content_size(fs),
                          mtime_ns=0 if ns is None else ns)
 
+    def lstat(self, path: str) -> GuestStat:
+        """Stat a guest path without following a trailing symlink.
+
+        The link's own row is the node table's, not a backend's, so it
+        is reached through the readlink op and nothing else: a link
+        sizes as its target string and every other path answers exactly
+        as `stat` does. A build path can never be a link, so it takes
+        the ordinary path.
+
+        Args:
+            path (str): guest-absolute path.
+
+        Raises:
+            FileNotFoundError: the path exists on neither side.
+        """
+        if self._serving_build(path) is not None:
+            return self.stat(path)
+        target = self._readlink_or_none(path)
+        if target is None:
+            return self.stat(path)
+        return GuestStat(is_dir=False,
+                         size=len(target.encode()),
+                         mtime_ns=0,
+                         is_link=True)
+
+    def _readlink_or_none(self, path: str) -> str | None:
+        """The link target at `path`, or None when it is not a link.
+
+        Args:
+            path (str): guest-absolute path.
+        """
+        try:
+            return str(self._core_call("readlink", path))
+        except OSError as exc:
+            # EINVAL is the node table's "not a link"; a miss answers it
+            # too, and the stat that follows is the one that reports it.
+            if exc.errno not in (host_errno.EINVAL, host_errno.ENOENT):
+                raise
+            return None
+
     def stat_or_none(self, path: str) -> GuestStat | None:
         try:
             return self.stat(path)
@@ -203,6 +243,54 @@ class WasmVFS:
                 raise OSError(host_errno.EXDEV, "cross-device rename", src)
             raise PermissionError(READONLY_HINT)
         self._require_core().rename(src, dst)
+
+    def symlink(self, path: str, target: str) -> None:
+        """Create a symlink at `path` pointing at `target`.
+
+        Args:
+            path (str): guest-absolute path of the link.
+            target (str): what the link points to, stored as typed.
+        """
+        self._deny_build(path)
+        self._core_call("symlink", path, target=target)
+
+    def readlink(self, path: str) -> str:
+        """The target of the symlink at `path`.
+
+        Args:
+            path (str): guest-absolute path of the link.
+
+        Raises:
+            OSError: EINVAL when the path is not a link, which is what
+                readlink(2) answers and what the node table reports. A
+                build path answers that too rather than the read-only
+                refusal: reading is not the mutation `_deny_build`
+                guards, and the build holds no links.
+        """
+        if self._serving_build(path) is not None:
+            raise OSError(host_errno.EINVAL, "not a symbolic link", path)
+        return str(self._core_call("readlink", path))
+
+    def setattr(self, path: str, *, atime: str | None, mtime: str | None,
+                nofollow: bool) -> None:
+        """Write timestamps, in the namespace overlay where needed.
+
+        Times are the only attributes preview1 can express: it has no
+        chmod or chown call at all. A mount whose backend cannot hold a
+        stamp still answers, because the door overlays what the backend
+        declines.
+
+        Args:
+            path (str): guest-absolute path.
+            atime (str | None): ISO access time, None to leave it.
+            mtime (str | None): ISO modification time, None to leave it.
+            nofollow (bool): stamp the link itself, not its target.
+        """
+        self._deny_build(path)
+        self._require_core().setattr(path,
+                                     atime=atime,
+                                     mtime=mtime,
+                                     nofollow=nofollow)
 
     def flush(self, path: str, base_len: int, low_write: int,
               buf: bytes | bytearray) -> None:

--- a/python/mirage/runtime/wasm/vfs.py
+++ b/python/mirage/runtime/wasm/vfs.py
@@ -22,8 +22,9 @@ from mirage.runtime.wasm.build import BuildDir
 from mirage.runtime.wasm.config import WasmFsConfig
 from mirage.runtime.wasm.constants import READONLY_HINT
 from mirage.runtime.wasm.types import GuestStat
+from mirage.types import FileStat
 from mirage.utils.path import owner_prefix
-from mirage.utils.stat_view import content_size, is_dir, mtime_ns
+from mirage.utils.stat_view import content_size, is_dir, is_link, mtime_ns
 
 
 class WasmVFS:
@@ -138,22 +139,18 @@ class WasmVFS:
         build = self._serving_build(path)
         if build is not None:
             return build.stat(path)
-        fs = self._core_call("stat", path)
-        ns = mtime_ns(fs)
-        # The filestat record has no validity channel, so an unknown
-        # mtime and epoch zero both encode as 0 on this wire.
-        return GuestStat(is_dir=is_dir(fs),
-                         size=content_size(fs),
-                         mtime_ns=0 if ns is None else ns)
+        return self._guest_stat(self._core_call("stat", path))
 
     def lstat(self, path: str) -> GuestStat:
         """Stat a guest path without following a trailing symlink.
 
-        The link's own row is the node table's, not a backend's, so it
-        is reached through the readlink op and nothing else: a link
-        sizes as its target string and every other path answers exactly
-        as `stat` does. A build path can never be a link, so it takes
-        the ordinary path.
+        A link's own row is the node table's, not a backend's, and the
+        door serves it under `nofollow`: the row carries the target's
+        byte length as the size, the link's own mtime, and whatever a
+        `chown -h` or a no-follow `utime` wrote, none of which a row
+        rebuilt here from the target string could report. Every other
+        path answers exactly as `stat` does. A build path can never be
+        a link, so it takes the ordinary path.
 
         Args:
             path (str): guest-absolute path.
@@ -163,28 +160,22 @@ class WasmVFS:
         """
         if self._serving_build(path) is not None:
             return self.stat(path)
-        target = self._readlink_or_none(path)
-        if target is None:
-            return self.stat(path)
-        return GuestStat(is_dir=False,
-                         size=len(target.encode()),
-                         mtime_ns=0,
-                         is_link=True)
+        return self._guest_stat(self._core_call("stat", path, nofollow=True))
 
-    def _readlink_or_none(self, path: str) -> str | None:
-        """The link target at `path`, or None when it is not a link.
+    @staticmethod
+    def _guest_stat(fs: FileStat) -> GuestStat:
+        """Translate one mirage stat row into a preview1 filestat.
 
         Args:
-            path (str): guest-absolute path.
+            fs (FileStat): the row the door answered with.
         """
-        try:
-            return str(self._core_call("readlink", path))
-        except OSError as exc:
-            # EINVAL is the node table's "not a link"; a miss answers it
-            # too, and the stat that follows is the one that reports it.
-            if exc.errno not in (host_errno.EINVAL, host_errno.ENOENT):
-                raise
-            return None
+        ns = mtime_ns(fs)
+        # The filestat record has no validity channel, so an unknown
+        # mtime and epoch zero both encode as 0 on this wire.
+        return GuestStat(is_dir=is_dir(fs),
+                         size=content_size(fs),
+                         mtime_ns=0 if ns is None else ns,
+                         is_link=is_link(fs))
 
     def stat_or_none(self, path: str) -> GuestStat | None:
         try:

--- a/python/mirage/workspace/dispatcher/constants.py
+++ b/python/mirage/workspace/dispatcher/constants.py
@@ -38,6 +38,14 @@ POLICY_WRITE_OPS = DISPATCH_WRITE_OPS | frozenset({"setattr", "symlink"})
 # directions (create and readlink) rather than a router to a mount.
 NAMESPACE_TABLE_OPS = frozenset({"symlink", "readlink"})
 
+# Ops the node table answers when the path itself is a link, and only
+# then. The name is the whole of what exists there, so forwarding one
+# reaches a backend that has never heard of it: an unlink answered
+# ENOENT with the link still in the table, and a rename moved nothing.
+# ``stat`` joins them only under ``nofollow``, which is how a caller
+# spells lstat; a following stat arrives already resolved to its target.
+LINK_ENTRY_OPS = frozenset({"unlink", "rename", "stat"})
+
 # Ops that create the path they name. A hidden target refuses these as
 # EACCES rather than ENOENT, because "does not exist" is nonsense as
 # the answer to a create the caller is spelling out; every other op on

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -42,7 +42,7 @@ from mirage.workspace.reconcile import Reconciler
 from mirage.workspace.snapshot.drift import DriftQueue
 
 from mirage.workspace.dispatcher.constants import (  # isort: skip
-    DISPATCH_READ_OPS, DISPATCH_WRITE_OPS, HIDDEN_CREATE_OPS,
+    DISPATCH_READ_OPS, DISPATCH_WRITE_OPS, HIDDEN_CREATE_OPS, LINK_ENTRY_OPS,
     NAMESPACE_TABLE_OPS, POLICY_WRITE_OPS, SETATTR_KEYS)
 
 
@@ -222,13 +222,7 @@ class Dispatcher:
                 and not path_allowed(dst.virtual)):
             raise PermissionError(errno.EACCES, os.strerror(errno.EACCES),
                                   dst.virtual)
-        # An unlink of a link is the removal half of `symlink`, and the
-        # door owns both: a link has no backend entry, so forwarding it
-        # reaches a backend that has never heard of the name and answers
-        # ENOENT with the link still there. An unlink of anything else
-        # is an ordinary backend write.
-        if op in NAMESPACE_TABLE_OPS or (
-                op == "unlink" and self._namespace.is_link(path.virtual)):
+        if self._table_answers(op, path.virtual, kwargs):
             return (await self._namespace_table_op(op, path, kwargs,
                                                    report), IOResult())
         # `nofollow` is the caller's AT_SYMLINK_NOFOLLOW: an op that acts
@@ -353,6 +347,13 @@ class Dispatcher:
             await self.invalidate_after_write(mount, path, observed=observed)
             if op == "rename" and isinstance(kwargs.get("dst"), PathSpec):
                 await self.invalidate_after_write(mount, kwargs["dst"])
+                # rename(2) replaces the destination, so a node the
+                # table holds at that name does not survive the move.
+                # A link left there shadowed the file that had just
+                # landed: the listing showed the new file, every read
+                # followed the old link, and the moved content was
+                # reachable under no name at all.
+                await self._namespace.unlink(kwargs["dst"].virtual)
         bound = await post_ops_gate(policies, op, path, write, mount.prefix,
                                     result)
         if bound is not None:
@@ -362,26 +363,54 @@ class Dispatcher:
             result = await apply_op_limit(result, bound)
         return result, IOResult()
 
+    def _table_answers(self, op: str, virtual: str, kwargs: dict[str,
+                                                                 Any]) -> bool:
+        """Whether the node table answers this op instead of a backend.
+
+        ``symlink`` and ``readlink`` always, because a link exists
+        nowhere else. The rest only when the path itself is a link, and
+        then for the same reason the create and the read are the door's:
+        forwarding reaches a backend that has never heard of the name.
+        A no-follow stat is the read half of that fact (lstat asks for
+        the link's own row, which only the table holds); a following
+        stat never arrives here, since the follow above rewrote it to
+        the target.
+
+        Args:
+            op (str): the dispatched op name.
+            virtual (str): the op's virtual path.
+            kwargs (dict[str, Any]): the op's arguments, read for the
+                caller's ``nofollow``.
+        """
+        if op in NAMESPACE_TABLE_OPS:
+            return True
+        if op not in LINK_ENTRY_OPS:
+            return False
+        if op == "stat" and not kwargs.get("nofollow"):
+            return False
+        return self._namespace.is_link(virtual)
+
     async def _namespace_table_op(self, op: str, path: PathSpec,
                                   kwargs: dict[str, Any],
                                   report: OpReport | None) -> Any:
         """Answer a node-table op at the door itself, gated like a backend.
 
         A symlink is namespace state with no backend behind it, so the
-        door owns both directions. Admission still fires exactly as for
-        a backend write: the link's turf is the longest mount prefix
-        above it (the same ownership rule ``_link_allowed`` reads for),
-        session grants and both gates run, and the write leaves an
-        OpRecord — a scoped kernel mount refuses exactly like a scoped
-        shell. A link above every mount is bare namespace structure and
-        clears the gates with an empty prefix.
+        door owns every verb that names one. Admission still fires
+        exactly as for a backend write: the link's turf is the longest
+        mount prefix above it (the same ownership rule ``_link_allowed``
+        reads for), session grants and both gates run, and the write
+        leaves an OpRecord — a scoped kernel mount refuses exactly like
+        a scoped shell. A link above every mount is bare namespace
+        structure and clears the gates with an empty prefix.
 
         Args:
-            op (str): ``symlink``, ``readlink``, or the ``unlink`` of a
-                path the node table holds a link for.
+            op (str): ``symlink`` or ``readlink``, or the ``unlink``,
+                ``rename`` or no-follow ``stat`` of a path the node
+                table holds a link for.
             path (PathSpec): the link's own path, never followed.
             kwargs (dict[str, Any]): op arguments (``target`` for
-                symlink).
+                symlink, ``dst`` for rename).
             report (OpReport | None): the caller's report, stamped when
                 the answer is in hand.
         """
@@ -393,14 +422,41 @@ class Dispatcher:
         write = op in POLICY_WRITE_OPS
         await pre_ops_gate(policies, op, path, write, owner or "",
                            _session_id())
+        result: str | FileStat | None = None
         if op == "unlink":
             target = self._namespace.readlink(path.virtual) or ""
             await self._namespace.unlink(path.virtual)
-            result: str | None = None
+        elif op == "rename":
+            target = self._namespace.readlink(path.virtual) or ""
+            dst = kwargs["dst"]
+            # The destination is a create there, gated like the source,
+            # the way the backend path gates both ends of a rename. It
+            # is then replaced as rename(2) replaces it: any node the
+            # table holds at that name (a link, an attr overlay) goes.
+            await pre_ops_gate(policies, op, dst, True, owner or "",
+                               _session_id())
+            await self._namespace.unlink(dst.virtual)
+            await self._namespace.rename(path.virtual, dst.virtual)
         elif op == "symlink":
             target = str(kwargs["target"])
+            # symlink(2) refuses an occupied name, and the door is the
+            # only place that can tell: the node table sees a link, and
+            # a probe sees the file or directory a backend holds. Left
+            # unchecked, the new node shadowed live data (the bytes
+            # stayed, the name read as a link) and could bury a mount
+            # root, which is the one name a deployment configured.
+            if await self._path_present(path):
+                raise FileExistsError(errno.EEXIST, os.strerror(errno.EEXIST),
+                                      path.virtual)
             await self._namespace.symlink(path.virtual, target, time.time())
-            result = None
+        elif op == "stat":
+            row = self._namespace.link_stat_at(path.virtual)
+            if row is None:
+                raise FileNotFoundError(errno.ENOENT,
+                                        os.strerror(errno.ENOENT),
+                                        path.virtual)
+            target = self._namespace.readlink(path.virtual) or ""
+            result = row
         else:
             found = self._namespace.readlink(path.virtual)
             if found is None:
@@ -443,15 +499,17 @@ class Dispatcher:
         store a directory is not an object but the set of keys under it,
         so ``stat`` misses what ``readdir`` would list, and a listing
         has to be non-empty to count because those stores answer a
-        missing prefix with ``[]``. The namespace is asked first, since
-        a directory that exists only because a mount or a link sits
-        below it is structure no backend can see. Mirrors
+        missing prefix with ``[]``. The namespace is asked first, since a
+        link, and a directory that exists only because a mount or a link
+        sits below it, are structure no backend can see. Mirrors
         ``resolve_path_stat``, which cannot be reused here: it dispatches,
         and the door is what dispatch is inside of.
 
         Args:
             path (PathSpec): the path to probe.
         """
+        if self._namespace.is_link(path.virtual):
+            return True
         prefixes = [m.prefix for m in self._namespace.registry.mounts()]
         if namespace_stat(prefixes, self._namespace, path.virtual) is not None:
             return True

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -29,8 +29,9 @@ from mirage.ops.config import NO_FOLLOW_OPS, STAMP_WRITE_OPS
 from mirage.ops.namespace_view import (merge_readdir, namespace_listing,
                                        namespace_stat)
 from mirage.policy import post_ops_gate, pre_ops_gate
+from mirage.policy.errors import PolicyDenied, PolicyError
 from mirage.types import ConsistencyPolicy, FileStat, PathSpec, ResourceName
-from mirage.utils.errors import no_mount
+from mirage.utils.errors import MISS_ERRORS, no_mount
 from mirage.utils.key_prefix import mount_key
 from mirage.utils.path import owner_prefix
 from mirage.utils.ranges import slice_window
@@ -403,8 +404,7 @@ class Dispatcher:
         else:
             found = self._namespace.readlink(path.virtual)
             if found is None:
-                raise OSError(errno.EINVAL, os.strerror(errno.EINVAL),
-                              path.virtual)
+                raise await self._readlink_miss(path)
             target = found
             result = found
         record(op, path.virtual, ResourceName.RAM.value,
@@ -415,6 +415,86 @@ class Dispatcher:
         if bound is not None:
             return await apply_op_limit(result, bound)
         return result
+
+    async def _readlink_miss(self, path: PathSpec) -> OSError:
+        """The error a readlink of something that is not a link answers.
+
+        readlink(2) splits the two misses and callers read them
+        differently: a path that is there but is not a link is EINVAL,
+        and one that is not there at all is ENOENT, which is the code a
+        guest's ``except FileNotFoundError`` catches. The node table
+        only knows the first half, so absence is probed here and only
+        here, on the failure path, where one extra round trip buys the
+        right errno.
+
+        Args:
+            path (PathSpec): the path the readlink named.
+        """
+        if await self._path_present(path):
+            return OSError(errno.EINVAL, os.strerror(errno.EINVAL),
+                           path.virtual)
+        return FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
+                                 path.virtual)
+
+    async def _path_present(self, path: PathSpec) -> bool:
+        """Whether anything at all is at `path`, on every channel.
+
+        Absence takes both channels a backend can answer on: on a prefix
+        store a directory is not an object but the set of keys under it,
+        so ``stat`` misses what ``readdir`` would list, and a listing
+        has to be non-empty to count because those stores answer a
+        missing prefix with ``[]``. The namespace is asked first, since
+        a directory that exists only because a mount or a link sits
+        below it is structure no backend can see. Mirrors
+        ``resolve_path_stat``, which cannot be reused here: it dispatches,
+        and the door is what dispatch is inside of.
+
+        Args:
+            path (PathSpec): the path to probe.
+        """
+        prefixes = [m.prefix for m in self._namespace.registry.mounts()]
+        if namespace_stat(prefixes, self._namespace, path.virtual) is not None:
+            return True
+        mount = self._namespace.try_mount_for(path.virtual)
+        if mount is None:
+            return False
+        try:
+            if await self._probe_op("stat", mount, path) is not None:
+                return True
+            return bool(await self._probe_op("readdir", mount, path))
+        except (PolicyError, PolicyDenied):
+            # A channel that refuses to answer is not evidence of
+            # absence. Reporting "present" keeps the answer at the EINVAL
+            # every miss gave before the split, which asserts nothing the
+            # policy is withholding; reporting absence would assert a
+            # fact this door was not allowed to check.
+            return True
+
+    async def _probe_op(self, op: str, mount: MountEntry,
+                        path: PathSpec) -> Any:
+        """Run one read op for a probe, or None when it found nothing.
+
+        The probe reads on the caller's behalf but not at its request, so
+        it passes the same admission gate the op would at the door: a
+        policy that denies ``stat`` must not be reachable through a
+        readlink. That refusal is raised, not swallowed, because only the
+        caller knows what to answer when a channel goes dark.
+
+        Args:
+            op (str): ``stat`` or ``readdir``.
+            mount (MountEntry): the mount owning the path.
+            path (PathSpec): the path to probe.
+        """
+        if not mount.supports_op(op, path.virtual):
+            return None
+        await pre_ops_gate(self._namespace.registry.policies, op, path, False,
+                           mount.prefix, _session_id())
+        try:
+            return await mount.execute_op(op, path.virtual)
+        except MISS_ERRORS:
+            # The "nothing here" set exactly: a miss on one channel is
+            # not absence on its own, so the caller tries the other.
+            return None
 
     async def _apply_setattr(self, mount: MountEntry, path: PathSpec,
                              kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -30,10 +30,11 @@ from mirage.ops.namespace_view import (merge_readdir, namespace_listing,
                                        namespace_stat)
 from mirage.policy import post_ops_gate, pre_ops_gate
 from mirage.policy.errors import PolicyDenied, PolicyError
-from mirage.types import ConsistencyPolicy, FileStat, PathSpec, ResourceName
+from mirage.types import (ConsistencyPolicy, FileStat, FileType, PathSpec,
+                          ResourceName)
 from mirage.utils.errors import MISS_ERRORS, no_mount
 from mirage.utils.key_prefix import mount_key
-from mirage.utils.path import owner_prefix
+from mirage.utils.path import norm_dir, owner_prefix
 from mirage.utils.ranges import slice_window
 from mirage.workspace.mount import MountEntry
 from mirage.workspace.mount.namespace import Namespace
@@ -493,17 +494,23 @@ class Dispatcher:
                                  path.virtual)
 
     async def _path_present(self, path: PathSpec) -> bool:
-        """Whether anything at all is at `path`, on every channel.
+        """Whether anything at all is at `path`.
 
-        Absence takes both channels a backend can answer on: on a prefix
-        store a directory is not an object but the set of keys under it,
-        so ``stat`` misses what ``readdir`` would list, and a listing
-        has to be non-empty to count because those stores answer a
-        missing prefix with ``[]``. The namespace is asked first, since a
-        link, and a directory that exists only because a mount or a link
-        sits below it, are structure no backend can see. Mirrors
-        ``resolve_path_stat``, which cannot be reused here: it dispatches,
-        and the door is what dispatch is inside of.
+        Four channels, asked in the order of what they prove. The
+        namespace goes first: a link, and a directory that exists only
+        because a mount or a link sits below it, are structure no
+        backend can see, and a mount root is the deployment's own
+        configuration. Then the backend's row, which settles a file. A
+        directory row settles nothing, because an API tree synthesizes
+        its directories: a postgres schema lists ``tables/`` and
+        ``views/`` before anything has asked whether that schema is
+        there, and a grouping mount stats every path under a live
+        collection as a directory. So a directory is proven the way the
+        hierarchy kit itself proves one, by appearing in its parent's
+        listing, which is also the only way a prefix store can answer
+        for a directory that is nothing but a set of keys. Cannot reuse
+        ``resolve_path_stat``: that dispatches, and the door is what
+        dispatch is inside of.
 
         Args:
             path (PathSpec): the path to probe.
@@ -516,10 +523,13 @@ class Dispatcher:
         mount = self._namespace.try_mount_for(path.virtual)
         if mount is None:
             return False
+        if norm_dir(mount.prefix) == norm_dir(path.virtual):
+            return True
         try:
-            if await self._probe_op("stat", mount, path) is not None:
+            row = await self._probe_op("stat", mount, path)
+            if row is not None and row.type is not FileType.DIRECTORY:
                 return True
-            return bool(await self._probe_op("readdir", mount, path))
+            return await self._listed_by_parent(path)
         except (PolicyError, PolicyDenied):
             # A channel that refuses to answer is not evidence of
             # absence. Reporting "present" keeps the answer at the EINVAL
@@ -527,6 +537,27 @@ class Dispatcher:
             # policy is withholding; reporting absence would assert a
             # fact this door was not allowed to check.
             return True
+
+    async def _listed_by_parent(self, path: PathSpec) -> bool:
+        """Whether the path's own name is in its parent's listing.
+
+        Compared on the final segment, because backends disagree on
+        entry shape: bare names, a trailing slash to mark a directory,
+        or full paths. The same normalization ``merge_readdir`` dedupes
+        on.
+
+        Args:
+            path (PathSpec): the path to look for.
+        """
+        parent, _, name = path.virtual.rstrip("/").rpartition("/")
+        mount = self._namespace.try_mount_for(parent or "/")
+        if not name or mount is None:
+            return False
+        listing = await self._probe_op("readdir", mount,
+                                       PathSpec.from_str_path(parent or "/"))
+        return any(
+            str(entry).rstrip("/").rsplit("/", 1)[-1] == name
+            for entry in listing or ())
 
     async def _probe_op(self, op: str, mount: MountEntry,
                         path: PathSpec) -> Any:

--- a/python/mirage/workspace/executor/builtins/links/links.py
+++ b/python/mirage/workspace/executor/builtins/links/links.py
@@ -269,8 +269,18 @@ async def prepare_mv(
         if src.raw_path.endswith("/"):
             return items, None, None, await _slashed_link_refusal(
                 namespace, dispatch, src, dst, stat)
-        await namespace.unlink(target_dst)
-        await namespace.rename(src.virtual, target_dst)
+        # The move is a node-table rename, which the door answers: a
+        # link has no backend entry for the generic mv to move. Reaching
+        # the table directly from here would skip the admission gates
+        # every other mv passes, so the dispatch is the point.
+        try:
+            await dispatch("rename",
+                           src,
+                           dst=PathSpec.from_str_path(target_dst))
+        except PermissionError:
+            return items, None, None, fail(
+                "mv", f"mv: cannot move '{src.raw_path}' to "
+                f"'{dst.raw_path}': Permission denied\n")
         return items, None, None, ok("mv")
 
     post_rename: tuple[str, str] | None = None

--- a/python/mirage/workspace/executor/builtins/links/ln.py
+++ b/python/mirage/workspace/executor/builtins/links/ln.py
@@ -31,11 +31,18 @@ async def handle_ln(
 ) -> Result:
     """ln -s TARGET LINK: create a namespace symbolic link.
 
-    Flags: -f overwrite an existing link, -v report the link, -r store
-    the target relative to the link's directory (GNU --relative). -n
+    Flags: -f remove the destination first (GNU's own algorithm, so it
+    replaces a regular file too), -v report the link, -r store the
+    target relative to the link's directory (GNU --relative). -n
     (--no-dereference) and -T (--no-target-directory) are accepted no-ops:
     a namespace link name is never dereferenced nor treated as a directory
     to descend into, so both are already the effective behavior.
+
+    Divergence: GNU reads a directory destination as "link inside it"
+    (``ln -s f.txt d`` creates ``d/f.txt``), and mirage refuses the name
+    instead. Refusing is the safe half of that gap: the version before
+    the door owned the existence rule buried the directory under a link
+    node.
 
     The write itself is a dispatch op, so session grants and admission
     policies fire at the door; this handler keeps only the GNU operand
@@ -73,15 +80,35 @@ async def handle_ln(
         except CycleError:
             pass
         target_typed = posixpath.relpath(target_abs, link_dir)
-    exists = namespace.is_link(link_abs) and "f" not in flags
-    if namespace.is_mount_root(link_abs) or exists:
+    if namespace.is_mount_root(link_abs):
         return fail(
             "ln", f"ln: failed to create symbolic link "
             f"'{word_text(operands[1])}': File exists\n")
+    link_spec = PathSpec.from_str_path(link_abs)
+    if "f" in flags:
+        # GNU -f is "remove the destination, then link", which is why it
+        # replaces a regular file and not only a link. The door refuses
+        # an occupied name (symlink(2)'s EEXIST), so the removal is what
+        # makes the flag work rather than a formality; a destination
+        # that is not there is what -f is for, so its miss is the
+        # expected case and not an error.
+        try:
+            await dispatch("unlink", link_spec)
+        except FileNotFoundError:
+            pass
+        except IsADirectoryError:
+            return fail(
+                "ln", f"ln: {word_text(operands[1])}: "
+                f"cannot overwrite directory\n")
     try:
-        await dispatch("symlink",
-                       PathSpec.from_str_path(link_abs),
-                       target=target_typed)
+        await dispatch("symlink", link_spec, target=target_typed)
+    except FileExistsError:
+        # The door owns the existence rule (it is the only layer that
+        # can see both the node table and the backend); ln owns the
+        # wording.
+        return fail(
+            "ln", f"ln: failed to create symbolic link "
+            f"'{word_text(operands[1])}': File exists\n")
     except PermissionError:
         return fail(
             "ln", f"ln: failed to create symbolic link "

--- a/python/mirage/workspace/mount/namespace/namespace.py
+++ b/python/mirage/workspace/mount/namespace/namespace.py
@@ -96,9 +96,11 @@ def link_stat(name: str, meta: NodeMeta) -> FileStat:
 
     Size is the target string's byte length and mode is left unset so
     the formatter supplies 0777, which is what a real symlink inode
-    reports (a link carries no permission bits of its own). Ownership is
-    not in that category: a link has a real uid/gid that ``chown -h``
-    writes and ``ls -l`` shows, so both ride through from the node. The
+    reports (a link carries no permission bits of its own). Ownership
+    and the stamps are not in that category: a link has a real uid/gid
+    that ``chown -h`` writes and ``ls -l`` shows, and real times that
+    ``touch -h`` and a guest's no-follow ``utime`` write, so all four
+    ride through from the node. The
     target rides along in ``extra`` so every surface that has to name it
     (ls -l's ``name -> target``, file's "symbolic link to") reads one
     fact rather than querying the link table a second time.
@@ -115,6 +117,7 @@ def link_stat(name: str, meta: NodeMeta) -> FileStat:
         type=FileType.SYMLINK,
         uid=meta.uid,
         gid=meta.gid,
+        atime=meta.atime,
         extra={LINK_TARGET_KEY: target},
     )
 

--- a/python/tests/commands/cli/builtin/git/test_checkout.py
+++ b/python/tests/commands/cli/builtin/git/test_checkout.py
@@ -380,3 +380,25 @@ async def test_checking_out_a_link_over_a_regular_file_replaces_it(git_rw):
     await git_rw.execute("rm /repo/thing")
     listing = await git_rw.execute("ls /repo/thing")
     assert b"No such file or directory" in (listing.stderr or b"")
+
+
+@pytest.mark.asyncio
+async def test_checking_out_a_link_that_moved_retargets_it(git_rw):
+    # A branch that points the same link somewhere else: symlink(2) does
+    # not overwrite, so the checkout removes the old name before writing
+    # the new one. Relying on the node table to replace the entry in
+    # place left the checkout refused with EEXIST and the link pointing
+    # at the other branch's target.
+    assert (await run(git_rw, "checkout -b first"))[0] == 0
+    await git_rw.execute("ln -s a.txt /repo/lk")
+    assert (await run(git_rw, "add lk"))[0] == 0
+    assert (await run(git_rw, "commit -m first"))[0] == 0
+    assert (await run(git_rw, "checkout -b second"))[0] == 0
+    await git_rw.execute("printf 'other\\n' > /repo/b.txt")
+    await git_rw.execute("ln -sf b.txt /repo/lk")
+    assert (await run(git_rw, "add -A"))[0] == 0
+    assert (await run(git_rw, "commit -m second"))[0] == 0
+    assert (await run(git_rw, "checkout first"))[0] == 0
+    assert (await git_rw.execute("readlink /repo/lk")).stdout == b"a.txt\n"
+    assert (await run(git_rw, "checkout second"))[0] == 0
+    assert (await git_rw.execute("readlink /repo/lk")).stdout == b"b.txt\n"

--- a/python/tests/fuse/test_core.py
+++ b/python/tests/fuse/test_core.py
@@ -113,6 +113,31 @@ async def test_readlink_on_non_link_raises_einval(seeded):
 
 
 @pytest.mark.asyncio
+async def test_getattr_of_a_link_reports_the_nodes_own_row():
+    # A link has no backend inode, so the node table is the only place
+    # its stamps live. Built from the target string alone, getattr
+    # answered the mount's construction time for every link, so a
+    # `touch -h` through the mount was invisible right after it landed.
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+    await ws.execute("tee /a.txt", stdin=b"hello")
+    await ws.execute("ln -s a.txt /link")
+    core = MountCore(ws.ops)
+    await ws.dispatch("setattr",
+                      PathSpec.from_str_path("/link"),
+                      mode=None,
+                      uid=None,
+                      gid=None,
+                      atime=None,
+                      mtime="2020-01-02T03:04:05Z",
+                      nofollow=True)
+    attrs = core.getattr("/link")
+    assert attrs["st_mode"] == stat.S_IFLNK | 0o777
+    assert attrs["st_size"] == len("a.txt")
+    assert attrs["st_mtime"] == mtime_ns(
+        FileStat(name="link", modified="2020-01-02T03:04:05Z"))
+
+
+@pytest.mark.asyncio
 async def test_xattrs_round_trip(seeded):
     seeded.setxattr("/a.txt", "user.tag", b"v1")
     assert seeded.getxattr("/a.txt", "user.tag") == b"v1"

--- a/python/tests/ops/test_os_patch.py
+++ b/python/tests/ops/test_os_patch.py
@@ -367,6 +367,24 @@ class TestLinks:
             patched.readlink("/data/dir/a.txt")
         assert caught.value.errno == errno.EINVAL
 
+    def test_readlink_of_a_missing_path_is_enoent(self):
+        # The other half of readlink(2)'s split, and the half a caller's
+        # `except FileNotFoundError` is written against: EINVAL for both
+        # meant that clause never fired.
+        _, patched = seeded()
+        with pytest.raises(FileNotFoundError) as caught:
+            patched.readlink("/data/dir/gone.txt")
+        assert caught.value.errno == errno.ENOENT
+
+    def test_lstat_of_a_missing_path_stays_enoent(self):
+        # lstat probes readlink first, so the ENOENT above has to reach
+        # the caller rather than being read as "not a link".
+        _, patched = seeded()
+        with pytest.raises(FileNotFoundError):
+            patched.lstat("/data/dir/gone.txt")
+        assert patched.path.islink("/data/dir/gone.txt") is False
+        assert patched.path.lexists("/data/dir/gone.txt") is False
+
     def test_readlink_off_the_mount_answers_as_the_caller_spelled_it(
             self, tmp_path):
         _, patched = seeded()

--- a/python/tests/runtime/python/monty/test_osaccess.py
+++ b/python/tests/runtime/python/monty/test_osaccess.py
@@ -27,9 +27,11 @@ class FakeDispatch:
 
     def __init__(self,
                  files: dict[str, bytes],
-                 supports_append: bool = True) -> None:
+                 supports_append: bool = True,
+                 links: dict[str, str] | None = None) -> None:
         self.files = files
         self.supports_append = supports_append
+        self.links = dict(links or {})
         self.writes: list[tuple[str, bytes]] = []
         self.appends: list[tuple[str, bytes]] = []
         self.created: list[str] = []
@@ -101,6 +103,11 @@ class FakeDispatch:
                 self.files[dst] = self.files.pop(virtual)
             self.renamed.append((virtual, dst))
             return None, None
+        if op == "readlink":
+            found = self.links.get(virtual)
+            if found is None:
+                raise OSError(errno.EINVAL, "not a symbolic link", virtual)
+            return found, None
         raise ValueError(f"unexpected op {op}")
 
 
@@ -409,3 +416,17 @@ def test_monty_rename_within_one_mount_still_dispatches():
                     "Path('/a/f.txt').rename('/a/g.txt')")))
     assert result.exit_code == 0, result.stderr
     assert dispatch.renamed == [("/a/f.txt", "/a/g.txt")]
+
+
+def test_monty_is_symlink_reads_the_name_plane():
+    # Monty's own tree holds no links, so this answered False for every
+    # link the shell made before the verb was served.
+    dispatch = FakeDispatch({"/s3/t.txt": b"x"}, links={"/s3/l": "t.txt"})
+    runtime = MontyRuntime()
+    runtime.attach(dispatch, PrefixResolver(lambda: []))
+    code = (
+        "from pathlib import Path\n"
+        "print(Path('/s3/l').is_symlink(), Path('/s3/t.txt').is_symlink())")
+    result = asyncio.run(runtime.run(RunArgs(code=code)))
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout == b"True False\n"

--- a/python/tests/runtime/python/monty/test_vfs.py
+++ b/python/tests/runtime/python/monty/test_vfs.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
+
 from mirage.runtime.python.monty.vfs import MontyVFS
 from mirage.runtime.resolver import PrefixResolver
 from mirage.runtime.vfs import RuntimeVFS
@@ -25,11 +27,14 @@ class CountingCore(RuntimeVFS):
         files (dict[str, bytes]): the paths the mount holds.
     """
 
-    def __init__(self, files: dict[str, bytes]) -> None:
+    def __init__(self,
+                 files: dict[str, bytes],
+                 links: dict[str, str] | None = None) -> None:
         super().__init__(dispatch=None,
                          loop=None,
                          resolver=PrefixResolver(lambda: []))
         self.files = files
+        self.links = dict(links or {})
         self.calls: list[tuple[str, str]] = []
 
     def _raw(self, op, path, **kwargs):
@@ -54,6 +59,11 @@ class CountingCore(RuntimeVFS):
             if not names:
                 raise FileNotFoundError(path)
             return sorted(names)
+        if op == "readlink":
+            found = self.links.get(path)
+            if found is None:
+                raise OSError(errno.EINVAL, "not a symbolic link", path)
+            return found
         return None
 
     def ops(self, name: str) -> list[str]:
@@ -134,3 +144,16 @@ def test_an_unwired_view_answers_none_and_swallows_no_mutation():
     assert vfs.readdir("/s3") is None
     vfs.write("/s3/a.txt", b"x")
     vfs.unlink("/s3/a.txt")
+
+
+def test_is_link_reads_the_name_plane():
+    # Monty's own tree holds no links, so the readlink op is the only
+    # place the fact lives; a python readdir row carries no mark.
+    core = CountingCore({"/ram/t.txt": b"x"}, links={"/ram/l": "t.txt"})
+    vfs = MontyVFS(core)
+    assert vfs.is_link("/ram/l") is True
+    assert vfs.is_link("/ram/t.txt") is False
+
+
+def test_is_link_is_false_without_a_workspace():
+    assert MontyVFS(None).is_link("/ram/l") is False

--- a/python/tests/runtime/test_conformance.py
+++ b/python/tests/runtime/test_conformance.py
@@ -238,6 +238,12 @@ MONTY_ROWS = (
         "f.write('Z'); f.close()\"",
         setup=("echo -n a > /data/keep.txt", ),
         checks=(("cat /data/keep.txt", "aZ"), )),
+    Row("lstat",
+        "Path.is_symlink", "python3 -c \"from pathlib import Path; "
+        "print(Path('/data/l').is_symlink(), "
+        "Path('/data/t.txt').is_symlink())\"",
+        setup=("echo -n x > /data/t.txt", "ln -s t.txt /data/l"),
+        line_out="True False"),
 )
 
 WASI_ROWS = (
@@ -338,6 +344,42 @@ WASI_ROWS = (
         "f.write('Z'); f.close()\"",
         setup=("echo -n a > /data/keep.txt", ),
         checks=(("cat /data/keep.txt", "aZ"), )),
+    Row("symlink",
+        "os.symlink",
+        "python3 -c \"import os; os.symlink('t.txt', '/data/made')\"",
+        setup=("echo -n hi > /data/t.txt", ),
+        checks=(("readlink /data/made", "t.txt"), ("cat /data/made", "hi"))),
+    Row("readlink",
+        "os.readlink",
+        "python3 -c \"import os; print(os.readlink('/data/l'))\"",
+        setup=("echo -n x > /data/t.txt", "ln -s t.txt /data/l"),
+        line_out="t.txt"),
+    Row("lstat",
+        "os.path.islink", "python3 -c \"import os; "
+        "print(os.path.islink('/data/l'), os.path.islink('/data/t.txt'))\"",
+        setup=("echo -n x > /data/t.txt", "ln -s t.txt /data/l"),
+        line_out="True False"),
+    Row("lstat",
+        "os.lstat", "python3 -c \"import os, stat; st = os.lstat('/data/l'); "
+        "print(stat.S_ISLNK(st.st_mode), st.st_size)\"",
+        setup=("echo -n longer-than-target > /data/t.txt",
+               "ln -s t.txt /data/l"),
+        line_out="True 5"),
+    Row("utime",
+        "os.utime",
+        "python3 -c \"import os; os.utime('/data/t.txt', (100.0, 200.0))\"",
+        setup=("echo -n x > /data/t.txt", ),
+        checks=(("stat -c %Y /data/t.txt", "200"), )),
+    # A hard link is a second name for one inode and nothing above a
+    # mount holds that, so it is refused rather than faked. EPERM is
+    # what link(2) documents for a filesystem that cannot make one.
+    Row("link-refused",
+        "os.link", "python3 -c \"import errno, os\ntry:\n"
+        "    os.link('/data/t.txt', '/data/hard')\n"
+        "except OSError as exc:\n    print(exc.errno == errno.EPERM)\"",
+        setup=("echo -n x > /data/t.txt", ),
+        line_out="True",
+        checks=(("ls /data", "!hard"), )),
 )
 
 QUICKJS_ROWS = (
@@ -398,6 +440,16 @@ QUICKJS_ROWS = (
         "w.puts('Z'); w.close()\"",
         setup=("echo -n a > /data/keep.txt", ),
         checks=(("cat /data/keep.txt", "aZ"), )),
+    # The only metadata verb this engine has: qjs-wasi's `os` module
+    # ships no symlink, readlink or lstat at all (probed live), so a
+    # link is not addressable from a quickjs guest and utimes is the
+    # whole setattr surface. Stamps are milliseconds both ways.
+    Row("utime",
+        "os.utimes", "node -e \"const rc = "
+        "os.utimes('/data/t.txt', 100000, 200000); "
+        "if (rc !== 0) throw new Error('rc ' + rc)\"",
+        setup=("echo -n x > /data/t.txt", ),
+        checks=(("stat -c %Y /data/t.txt", "200"), )),
 )
 
 

--- a/python/tests/runtime/test_vfs.py
+++ b/python/tests/runtime/test_vfs.py
@@ -180,6 +180,42 @@ def test_flush_falls_back_to_a_whole_write_and_remembers_the_mount():
     assert ops == ["append", "write", "write"]
 
 
+def test_symlink_sends_the_target_verbatim():
+    vfs = RecordingVFS(prefixes=["/data/"])
+    vfs.symlink("/data/l", "../up/t.txt")
+    assert vfs.calls == [("symlink", "/data/l", {"target": "../up/t.txt"})]
+
+
+def test_readlink_returns_the_stored_target():
+
+    class LinkVFS(RecordingVFS):
+
+        def _raw(self, op, path, **kwargs):
+            super()._raw(op, path, **kwargs)
+            return "../up/t.txt"
+
+    assert LinkVFS(prefixes=["/data/"]).readlink("/data/l") == "../up/t.txt"
+
+
+def test_setattr_passes_every_field_so_the_door_reads_the_whole_set():
+    vfs = RecordingVFS(prefixes=["/data/"])
+    vfs.setattr("/data/f.txt", mode=0o600, mtime="1970-01-01T00:03:20+00:00")
+    assert vfs.calls == [("setattr", "/data/f.txt", {
+        "mode": 0o600,
+        "uid": None,
+        "gid": None,
+        "atime": None,
+        "mtime": "1970-01-01T00:03:20+00:00",
+        "nofollow": False,
+    })]
+
+
+def test_setattr_forwards_nofollow_for_the_dash_h_family():
+    vfs = RecordingVFS(prefixes=["/data/"])
+    vfs.setattr("/data/l", uid=4242, nofollow=True)
+    assert vfs.calls[0][2]["nofollow"] is True
+
+
 @pytest.mark.asyncio
 async def test_call_hops_from_a_worker_thread_to_the_workspace_loop():
     dispatch = RecordingDispatch()

--- a/python/tests/runtime/wasm/test_abi.py
+++ b/python/tests/runtime/wasm/test_abi.py
@@ -16,11 +16,16 @@ import errno as host_errno
 import struct
 
 from mirage.errors import FsCondition
+from mirage.runtime.verbs import refusal_of
+# yapf: disable
 from mirage.runtime.wasm.abi import (EACCES, EEXIST, EINVAL, EIO, EISDIR,
-                                     ENOENT, ENOTDIR, ENOTSUP, EXDEV, FT_DIR,
-                                     FT_REG, WASI, errno_for, pack_dirent,
-                                     pack_fdstat, pack_filestat, pack_prestat,
-                                     unpack_iovs, wasi_errno)
+                                     ENOENT, ENOTDIR, ENOTSUP, EXDEV, FST_ATIM,
+                                     FST_ATIM_NOW, FST_MTIM, FST_MTIM_NOW,
+                                     FT_DIR, FT_REG, FT_SYMLINK, LINK_REFUSAL,
+                                     LOOKUP_SYMLINK_FOLLOW, WASI, errno_for,
+                                     pack_dirent, pack_fdstat, pack_filestat,
+                                     pack_prestat, unpack_iovs, wasi_errno)
+# yapf: enable
 from mirage.utils.errors import no_mount
 from mirage.utils.path import CycleError
 
@@ -121,3 +126,20 @@ def test_dirent_carries_cookie_name_and_type():
 def test_unpack_iovs_decodes_pointer_length_pairs():
     raw = struct.pack("<IIII", 16, 128, 4096, 64)
     assert unpack_iovs(raw, 2) == [(16, 128), (4096, 64)]
+
+
+def test_link_refusal_comes_from_the_verb_table():
+    # The surface renders the refusal, the table decides it: pinning the
+    # translation rather than the number is what keeps a change to the
+    # table from silently leaving preview1 behind.
+    assert LINK_REFUSAL == wasi_errno(refusal_of("link"))
+    assert LINK_REFUSAL == WASI[FsCondition.EPERM]
+
+
+def test_symlink_filetype_is_the_preview1_number():
+    assert FT_SYMLINK == 7
+
+
+def test_lookup_and_fst_flag_bits_are_the_preview1_numbers():
+    assert LOOKUP_SYMLINK_FOLLOW == 1
+    assert (FST_ATIM, FST_ATIM_NOW, FST_MTIM, FST_MTIM_NOW) == (1, 2, 4, 8)

--- a/python/tests/runtime/wasm/test_host.py
+++ b/python/tests/runtime/wasm/test_host.py
@@ -18,7 +18,11 @@ import pytest
 
 pytest.importorskip("wasmtime")
 
-from mirage.runtime.wasm.host import WasiFs, _spec  # noqa: E402
+from mirage.runtime.wasm.abi import (  # noqa: E402  # isort: skip
+    FST_ATIM, FST_ATIM_NOW, FST_MTIM, FST_MTIM_NOW, FT_DIR, FT_REG, FT_SYMLINK)
+from mirage.runtime.wasm.host import (  # noqa: E402  # isort: skip
+    WasiFs, _filetype, _spec, _stamp)
+from mirage.runtime.wasm.types import GuestStat  # noqa: E402
 
 # End-to-end host-function behavior (path_open buffering, fd table,
 # errno answers inside a real guest) is covered by the live wasi and
@@ -38,3 +42,32 @@ def test_spec_covers_every_fs_import_of_the_shipped_guests():
     # python.wasm imports 28 preview1 fs functions; qjs-wasi.wasm a
     # 16-function subset. fd_renumber is shadowed too (dup2 support).
     assert len(_spec()) == 29
+
+
+def test_filetype_reads_the_kind_link_first():
+    link = GuestStat(is_dir=False, size=3, mtime_ns=0, is_link=True)
+    assert _filetype(link) == FT_SYMLINK
+    assert _filetype(GuestStat(is_dir=True, size=0, mtime_ns=0)) == FT_DIR
+    assert _filetype(GuestStat(is_dir=False, size=1, mtime_ns=0)) == FT_REG
+
+
+def test_stamp_omits_a_field_no_flag_selected():
+    # Neither bit set is utimensat's UTIME_OMIT: leave that stamp alone.
+    assert _stamp(0, FST_MTIM, FST_MTIM_NOW, 5_000_000_000, 1.0) is None
+
+
+def test_stamp_reads_the_argument_as_nanoseconds():
+    assert _stamp(FST_MTIM, FST_MTIM, FST_MTIM_NOW, 200_000_000_000,
+                  1.0) == "1970-01-01T00:03:20+00:00"
+
+
+def test_stamp_now_wins_over_the_argument():
+    # preview1 has both bits, and *_NOW means ignore the value entirely.
+    both = FST_ATIM | FST_ATIM_NOW
+    assert _stamp(both, FST_ATIM, FST_ATIM_NOW, 200_000_000_000,
+                  100.0) == "1970-01-01T00:01:40+00:00"
+
+
+def test_stamp_reads_only_its_own_half_of_the_flags():
+    assert _stamp(FST_ATIM, FST_MTIM, FST_MTIM_NOW, 1, 1.0) is None
+    assert _stamp(FST_MTIM, FST_ATIM, FST_ATIM_NOW, 1, 1.0) is None

--- a/python/tests/runtime/wasm/test_vfs.py
+++ b/python/tests/runtime/wasm/test_vfs.py
@@ -28,6 +28,10 @@ from mirage.runtime.wasm.vfs import WasmVFS
 from mirage.types import FileStat, FileType
 from mirage.utils.stat_view import mtime_ns
 
+# The stamp a link's own row carries, deliberately not the stamp the
+# double gives a file, so a test can tell which row it was answered.
+LINK_MTIME = "2026-07-16T00:00:00Z"
+
 
 class FakeVFS(RuntimeVFS):
     """Core double: real routing and flush logic, fake dispatch.
@@ -55,6 +59,15 @@ class FakeVFS(RuntimeVFS):
     def _raw(self, op, path, **kwargs):
         self.calls.append((op, path, kwargs))
         if op == "stat":
+            # The door answers a no-follow stat of a link from the node
+            # table, with the link's own row: its stamp, and its size in
+            # target bytes.
+            if kwargs.get("nofollow") and path in self.links:
+                target = self.links[path]
+                return FileStat(name=path,
+                                size=len(target.encode()),
+                                modified=LINK_MTIME,
+                                type=FileType.SYMLINK)
             if path in self.files:
                 return FileStat(name=path,
                                 size=len(self.files[path]),
@@ -273,6 +286,12 @@ def test_lstat_reports_a_link_as_a_link_sized_by_its_target():
     assert st.is_link is True
     assert st.is_dir is False
     assert st.size == len("t.txt")
+    # The row the node table holds, asked for as an lstat: a version
+    # that rebuilt it here from the target string reported epoch zero
+    # for every link, so a no-follow utime persisted and stayed
+    # invisible to the guest that wrote it.
+    assert st.mtime_ns == mtime_ns(FileStat(name="l", modified=LINK_MTIME))
+    assert ("stat", "/data/l", {"nofollow": True}) in bridge.calls
 
 
 def test_lstat_of_a_plain_path_answers_exactly_as_stat():

--- a/python/tests/runtime/wasm/test_vfs.py
+++ b/python/tests/runtime/wasm/test_vfs.py
@@ -40,13 +40,16 @@ class FakeVFS(RuntimeVFS):
                  files=None,
                  dirs=None,
                  prefixes=(),
+                 links=None,
                  modified="2026-07-15T00:00:00Z"):
         super().__init__(dispatch=None,
                          loop=None,
                          resolver=PrefixResolver(lambda: list(prefixes)))
         self.files = dict(files or {})
         self.dirs = set(dirs or ())
+        self.links = dict(links or {})
         self.modified = modified
+        self.attrs = []
         self.calls = []
 
     def _raw(self, op, path, **kwargs):
@@ -98,6 +101,19 @@ class FakeVFS(RuntimeVFS):
             # The real door merges child-mount names into readdir; the
             # double rides the same helper so it cannot drift from it.
             return sorted(merge_readdir(out, self.prefixes(), None, path))
+        if op == "symlink":
+            self.links[path] = kwargs["target"]
+            return None
+        if op == "readlink":
+            found = self.links.get(path)
+            if found is None:
+                # The door's own answer for a path the node table holds
+                # no link for, whether or not anything else is there.
+                raise OSError(host_errno.EINVAL, "not a symbolic link", path)
+            return found
+        if op == "setattr":
+            self.attrs.append((path, kwargs))
+            return {}
         raise NotImplementedError(op)
 
 
@@ -246,3 +262,86 @@ def test_stat_reads_offsetless_stamps_as_utc():
         else:
             os.environ["TZ"] = previous
         time.tzset()
+
+
+def test_lstat_reports_a_link_as_a_link_sized_by_its_target():
+    bridge = FakeVFS(files={"/data/t.txt": b"x" * 40},
+                     links={"/data/l": "t.txt"},
+                     prefixes=["/data/"])
+    fs = WasmVFS(None, bridge)
+    st = fs.lstat("/data/l")
+    assert st.is_link is True
+    assert st.is_dir is False
+    assert st.size == len("t.txt")
+
+
+def test_lstat_of_a_plain_path_answers_exactly_as_stat():
+    bridge = FakeVFS(files={"/data/f.txt": b"1234"}, prefixes=["/data/"])
+    fs = WasmVFS(None, bridge)
+    assert fs.lstat("/data/f.txt") == fs.stat("/data/f.txt")
+
+
+def test_stat_follows_a_link_because_the_door_resolves_it():
+    # The dispatcher resolves link prefixes for a following op, so the
+    # core never sees the link path: `stat` is the target's row.
+    bridge = FakeVFS(files={"/data/l": b"target-bytes"}, prefixes=["/data/"])
+    fs = WasmVFS(None, bridge)
+    st = fs.stat("/data/l")
+    assert st.is_link is False
+    assert st.size == len(b"target-bytes")
+
+
+def test_symlink_and_readlink_round_trip_the_target_verbatim():
+    bridge = FakeVFS(prefixes=["/data/"])
+    fs = WasmVFS(None, bridge)
+    fs.symlink("/data/l", "../up/t.txt")
+    assert bridge.links == {"/data/l": "../up/t.txt"}
+    assert fs.readlink("/data/l") == "../up/t.txt"
+
+
+def test_readlink_of_a_plain_path_is_einval():
+    bridge = FakeVFS(files={"/data/f.txt": b"x"}, prefixes=["/data/"])
+    fs = WasmVFS(None, bridge)
+    with pytest.raises(OSError) as caught:
+        fs.readlink("/data/f.txt")
+    assert caught.value.errno == host_errno.EINVAL
+
+
+def test_readlink_on_a_build_path_is_einval_not_read_only(tmp_path):
+    # Reading is not the mutation `_deny_build` guards, and the build
+    # holds no links, so the refusal is readlink's own.
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "lib" / "os.py").write_text("stdlib")
+    fs = WasmVFS(WasmFsConfig(host_root=str(tmp_path)), FakeVFS())
+    with pytest.raises(OSError) as caught:
+        fs.readlink("/lib/os.py")
+    assert caught.value.errno == host_errno.EINVAL
+
+
+def test_setattr_passes_every_field_including_nofollow():
+    bridge = FakeVFS(files={"/data/f.txt": b"x"}, prefixes=["/data/"])
+    fs = WasmVFS(None, bridge)
+    fs.setattr("/data/f.txt",
+               atime="1970-01-01T00:01:40+00:00",
+               mtime=None,
+               nofollow=True)
+    assert bridge.attrs == [("/data/f.txt", {
+        "mode": None,
+        "uid": None,
+        "gid": None,
+        "atime": "1970-01-01T00:01:40+00:00",
+        "mtime": None,
+        "nofollow": True,
+    })]
+
+
+def test_a_mutation_of_a_build_file_stays_refused(tmp_path):
+    # Only a path the build actually holds is refused; a new name under
+    # the build tree routes to the bridge, exactly as a new file does.
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "lib" / "os.py").write_text("stdlib")
+    fs = WasmVFS(WasmFsConfig(host_root=str(tmp_path)), FakeVFS())
+    with pytest.raises(PermissionError):
+        fs.symlink("/lib/os.py", "elsewhere.py")
+    with pytest.raises(PermissionError):
+        fs.setattr("/lib/os.py", atime=None, mtime="x", nofollow=False)

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -21,7 +21,8 @@ from mirage.policy import (Action, CommandRule, Deny, OpsContext, Policies,
                            Policy, PolicyDenied)
 from mirage.policy.rule import RulePolicy
 from mirage.resource.ram import RAMResource
-from mirage.types import ConsistencyPolicy, HiddenPaths, MountMode, PathSpec
+from mirage.types import (ConsistencyPolicy, FileType, HiddenPaths, MountMode,
+                          PathSpec)
 from mirage.workspace import Workspace
 from mirage.workspace.dispatcher import Dispatcher
 from mirage.workspace.session import Session
@@ -252,3 +253,82 @@ async def test_unlink_of_an_ordinary_file_still_reaches_the_backend():
         await ws.dispatch("unlink", PathSpec.from_str_path("/ram/a.txt"))
         listing = await ws.execute("ls /ram")
         assert (listing.stdout or b"").strip() == b""
+
+
+@pytest.mark.asyncio
+async def test_rename_moves_a_namespace_link():
+    # Same fact as the unlink above, one verb along: a guest's os.rename
+    # of a link forwarded to a backend that had never heard of the name,
+    # so it answered ENOENT with the link still under the old one.
+    with Workspace({"/ram/": RAMResource()}, mode=MountMode.WRITE) as ws:
+        await ws.execute("echo hi > /ram/a.txt")
+        await ws.execute("ln -s a.txt /ram/link")
+        await ws.dispatch("rename",
+                          PathSpec.from_str_path("/ram/link"),
+                          dst=PathSpec.from_str_path("/ram/moved"))
+        assert not ws._namespace.is_link("/ram/link")
+        assert ws._namespace.readlink("/ram/moved") == "a.txt"
+
+
+@pytest.mark.asyncio
+async def test_a_no_follow_stat_answers_a_links_own_row():
+    # lstat asks for the row only the node table holds. Without it every
+    # surface rebuilt the row from the target string and reported epoch
+    # zero, so a no-follow utime persisted and stayed invisible.
+    with Workspace({"/ram/": RAMResource()}, mode=MountMode.WRITE) as ws:
+        await ws.execute("echo hi > /ram/a.txt")
+        await ws.execute("ln -s a.txt /ram/link")
+        link = PathSpec.from_str_path("/ram/link")
+        row, _ = await ws.dispatch("stat", link, nofollow=True)
+        assert row.type == FileType.SYMLINK
+        assert row.size == len("a.txt")
+        await ws.dispatch("setattr",
+                          link,
+                          mode=None,
+                          uid=None,
+                          gid=None,
+                          atime=None,
+                          mtime="2020-01-02T03:04:05Z",
+                          nofollow=True)
+        row, _ = await ws.dispatch("stat", link, nofollow=True)
+        assert row.modified == "2020-01-02T03:04:05Z"
+        # Following is the other answer: the target's row, not the link's.
+        followed, _ = await ws.dispatch("stat", link)
+        assert followed.type != FileType.SYMLINK
+
+
+@pytest.mark.asyncio
+async def test_a_rename_replaces_a_link_at_the_destination():
+    # rename(2) replaces the destination. A link left in the table there
+    # shadowed the file that had just landed: the listing showed the new
+    # file, every read followed the old link, and the moved content was
+    # reachable under no name at all. mv did this right at the command
+    # tier, so only the surfaces below it (a guest, a kernel mount) saw
+    # the broken state.
+    with Workspace({"/ram/": RAMResource()}, mode=MountMode.WRITE) as ws:
+        await ws.execute("echo hi > /ram/a.txt")
+        await ws.execute("echo tgt > /ram/t.txt")
+        await ws.execute("ln -s t.txt /ram/link")
+        await ws.dispatch("rename",
+                          PathSpec.from_str_path("/ram/a.txt"),
+                          dst=PathSpec.from_str_path("/ram/link"))
+        assert not ws._namespace.is_link("/ram/link")
+        assert (await ws.execute("cat /ram/link")).stdout == b"hi\n"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("occupied",
+                         ["/ram/a.txt", "/ram/d", "/ram/link", "/ram"])
+async def test_symlink_refuses_an_occupied_name(occupied):
+    # symlink(2) is EEXIST on a name that is taken, and only the door can
+    # tell: a file and a directory are the backend's, a link is the node
+    # table's, and a mount root is the registry's. Unchecked, the node
+    # went on top and buried whatever was there.
+    with Workspace({"/ram/": RAMResource()}, mode=MountMode.WRITE) as ws:
+        await ws.execute("echo hi > /ram/a.txt; mkdir /ram/d")
+        await ws.execute("ln -s a.txt /ram/link")
+        with pytest.raises(FileExistsError):
+            await ws.dispatch("symlink",
+                              PathSpec.from_str_path(occupied),
+                              target="elsewhere")
+        assert (await ws.execute("cat /ram/a.txt")).stdout == b"hi\n"

--- a/python/tests/workspace/test_symlinks.py
+++ b/python/tests/workspace/test_symlinks.py
@@ -1274,3 +1274,61 @@ async def test_readlink_does_not_probe_past_a_policy_that_denies_stat():
     with pytest.raises(OSError) as caught:
         await ws.ops.readlink("/data/missing")
     assert caught.value.errno == errno.EINVAL
+
+
+@pytest.mark.asyncio
+async def test_ln_refuses_a_name_a_file_already_holds():
+    """GNU refuses an occupied destination; the node table alone cannot.
+
+    ``ln`` checked only its own table, so the link node landed on top of
+    a live file: the bytes stayed in the backend, unreachable, and the
+    name read as a dangling link. The door owns the rule now, because it
+    is the only layer that sees both planes.
+    """
+    ws = _ws()
+    await ws.execute("echo hi > /data/a.txt")
+    r = await ws.execute("ln -s /data/other /data/a.txt")
+    assert r.exit_code == 1
+    assert r.stderr.decode() == ("ln: failed to create symbolic link "
+                                 "'/data/a.txt': File exists\n")
+    assert (await ws.execute("cat /data/a.txt")).stdout == b"hi\n"
+
+
+@pytest.mark.asyncio
+async def test_ln_sf_replaces_a_regular_file():
+    # GNU -f removes the destination and then links, so it replaces a
+    # regular file and not only a link (pinned against coreutils 9.7).
+    ws = _ws()
+    await ws.execute("echo hi > /data/a.txt; echo t > /data/t.txt")
+    r = await ws.execute("ln -sf /data/t.txt /data/a.txt")
+    assert r.exit_code == 0
+    assert (await
+            ws.execute("readlink /data/a.txt")).stdout == b"/data/t.txt\n"
+    assert (await ws.execute("cat /data/a.txt")).stdout == b"t\n"
+
+
+@pytest.mark.asyncio
+async def test_mv_of_a_link_passes_the_admission_gate():
+    """The link rename is the door's, so a policy that denies it wins.
+
+    mv used to move the node itself, which meant the one write in the
+    shell that no admission policy could see.
+    """
+
+    class NoRename(Policy):
+
+        async def pre_ops(self, ctx):
+            if ctx.op == "rename":
+                return Deny(reason="frozen")
+            return None
+
+    ws = Workspace({"/data": (RAMResource(), MountMode.WRITE)},
+                   mode=MountMode.WRITE,
+                   policies=[NoRename()])
+    await ws.execute("echo hi > /data/a.txt")
+    await ws.execute("ln -s /data/a.txt /data/lk")
+    r = await ws.execute("mv /data/lk /data/lk2")
+    assert r.exit_code == 1
+    assert r.stderr.decode() == ("mv: cannot move '/data/lk' to "
+                                 "'/data/lk2': Permission denied\n")
+    assert (await ws.execute("readlink /data/lk")).stdout == b"/data/a.txt\n"

--- a/python/tests/workspace/test_symlinks.py
+++ b/python/tests/workspace/test_symlinks.py
@@ -12,8 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
+
 import pytest
 
+from mirage.policy import Deny
+from mirage.policy.base import Policy
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode
 from mirage.workspace import Workspace
@@ -1178,3 +1182,95 @@ async def test_mv_resolves_a_link_prefix_before_refusing_the_last():
     assert r.stderr.decode() == ("mv: cannot move '/data/alias/dlink/' to "
                                  "'/data/out': Not a directory\n")
     assert (await ws.execute("readlink /data/base/dlink")).exit_code == 0
+
+
+# readlink(2) splits its two misses and callers read them differently:
+# EINVAL means "there, but not a link", ENOENT means "not there". Pinned
+# against real Linux (python:3.13-slim): a file, a directory and a mount
+# root all answer EINVAL, and a missing path answers ENOENT whether or
+# not its parent exists.
+@pytest.mark.asyncio
+async def test_readlink_answers_the_target_for_a_link():
+    ws = _ws()
+    await ws.execute("echo hi > /data/a.txt")
+    await ws.execute("ln -s a.txt /data/l")
+    assert await ws.ops.readlink("/data/l") == "a.txt"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/data/a.txt", "/data/d", "/data"])
+async def test_readlink_of_something_that_is_there_is_einval(path: str):
+    ws = _ws()
+    await ws.execute("echo hi > /data/a.txt")
+    await ws.execute("mkdir /data/d")
+    with pytest.raises(OSError) as caught:
+        await ws.ops.readlink(path)
+    assert caught.value.errno == errno.EINVAL
+    assert not isinstance(caught.value, FileNotFoundError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path",
+                         ["/data/missing", "/data/d/deep/missing", "/nomount"])
+async def test_readlink_of_something_absent_is_enoent(path: str):
+    # FileNotFoundError, not a bare OSError: a guest's `except
+    # FileNotFoundError` is what has to catch this.
+    ws = _ws()
+    await ws.execute("mkdir /data/d")
+    with pytest.raises(FileNotFoundError) as caught:
+        await ws.ops.readlink(path)
+    assert caught.value.errno == errno.ENOENT
+
+
+@pytest.mark.asyncio
+async def test_readlink_reads_the_listing_channel_for_a_marker_less_dir():
+    # A prefix store keeps no directory object, so stat misses what
+    # readdir lists: reading only the first channel would report an
+    # implicit directory as absent.
+    ws = _ws()
+    await ws.execute("mkdir /data/d")
+    await ws.execute("echo x > /data/d/under.txt")
+    mount = ws._registry.try_mount_for("/data/d")
+    original = mount.execute_op
+
+    async def only_readdir(op_name, path, *args, **kwargs):
+        if op_name == "stat":
+            raise FileNotFoundError(path)
+        return await original(op_name, path, *args, **kwargs)
+
+    mount.execute_op = only_readdir
+    with pytest.raises(OSError) as caught:
+        await ws.ops.readlink("/data/d")
+    assert caught.value.errno == errno.EINVAL
+    # And the listing has to be non-empty to count: those stores answer
+    # a missing prefix with [] rather than raising, so an empty one is
+    # the absence case. Two different answers with stat silenced is what
+    # proves the listing is the channel being read.
+    await ws.execute("mkdir /data/hollow")
+    with pytest.raises(FileNotFoundError):
+        await ws.ops.readlink("/data/hollow")
+
+
+@pytest.mark.asyncio
+async def test_readlink_does_not_probe_past_a_policy_that_denies_stat():
+    """The probe reads on the caller's behalf, never past a refusal.
+
+    A policy that denies ``stat`` must not be reachable through a
+    readlink. A channel that refuses is not evidence of absence either,
+    so the errno collapses to the EINVAL every miss answered before the
+    split rather than claiming a path is gone.
+    """
+
+    class NoStat(Policy):
+
+        async def pre_ops(self, ctx):
+            if ctx.op in ("stat", "readdir"):
+                return Deny(reason="no probing")
+            return None
+
+    ws = Workspace({"/data": (RAMResource(), MountMode.WRITE)},
+                   mode=MountMode.WRITE,
+                   policies=[NoStat()])
+    with pytest.raises(OSError) as caught:
+        await ws.ops.readlink("/data/missing")
+    assert caught.value.errno == errno.EINVAL

--- a/python/tests/workspace/test_symlinks.py
+++ b/python/tests/workspace/test_symlinks.py
@@ -19,7 +19,7 @@ import pytest
 from mirage.policy import Deny
 from mirage.policy.base import Policy
 from mirage.resource.ram import RAMResource
-from mirage.types import MountMode
+from mirage.types import FileStat, FileType, MountMode
 from mirage.workspace import Workspace
 
 
@@ -1224,28 +1224,34 @@ async def test_readlink_of_something_absent_is_enoent(path: str):
 
 @pytest.mark.asyncio
 async def test_readlink_reads_the_listing_channel_for_a_marker_less_dir():
-    # A prefix store keeps no directory object, so stat misses what
-    # readdir lists: reading only the first channel would report an
-    # implicit directory as absent.
+    # A prefix store keeps no directory object, so stat misses what the
+    # parent's listing reports: reading only the first channel would
+    # report an implicit directory as absent.
     ws = _ws()
     await ws.execute("mkdir /data/d")
     await ws.execute("echo x > /data/d/under.txt")
     mount = ws._registry.try_mount_for("/data/d")
     original = mount.execute_op
 
-    async def only_readdir(op_name, path, *args, **kwargs):
+    async def prefix_store(op_name, path, *args, **kwargs):
         if op_name == "stat":
             raise FileNotFoundError(path)
-        return await original(op_name, path, *args, **kwargs)
+        entries = await original(op_name, path, *args, **kwargs)
+        if op_name != "readdir":
+            return entries
+        # A name with no keys under it is in no listing either, which is
+        # how such a store says a directory is not there. Two different
+        # answers with stat silenced is what proves the listing is the
+        # channel being read.
+        return [
+            e for e in entries
+            if str(e).rstrip("/").rsplit("/", 1)[-1] != "hollow"
+        ]
 
-    mount.execute_op = only_readdir
+    mount.execute_op = prefix_store
     with pytest.raises(OSError) as caught:
         await ws.ops.readlink("/data/d")
     assert caught.value.errno == errno.EINVAL
-    # And the listing has to be non-empty to count: those stores answer
-    # a missing prefix with [] rather than raising, so an empty one is
-    # the absence case. Two different answers with stat silenced is what
-    # proves the listing is the channel being read.
     await ws.execute("mkdir /data/hollow")
     with pytest.raises(FileNotFoundError):
         await ws.ops.readlink("/data/hollow")
@@ -1292,6 +1298,37 @@ async def test_ln_refuses_a_name_a_file_already_holds():
     assert r.stderr.decode() == ("ln: failed to create symbolic link "
                                  "'/data/a.txt': File exists\n")
     assert (await ws.execute("cat /data/a.txt")).stdout == b"hi\n"
+
+
+@pytest.mark.asyncio
+async def test_ln_into_a_synthesized_tree_is_not_an_occupied_name():
+    """A directory an API tree invents is not evidence the name is taken.
+
+    Those trees answer for a path nobody has created: a postgres schema
+    directory lists ``tables/`` and ``views/`` before anything asks
+    whether the schema is there, and a grouping mount stats every path
+    under a live collection as a directory. Refusing on either reading
+    denied the ordinary case of adding a link inside a mounted tree.
+    """
+    ws = _ws()
+    mount = ws._registry.try_mount_for("/data")
+    original = mount.execute_op
+
+    async def synthesized(op_name, path, *args, **kwargs):
+        if op_name == "stat":
+            return FileStat(name=path.rsplit("/", 1)[-1],
+                            type=FileType.DIRECTORY)
+        if op_name == "readdir":
+            return ["tables", "views"]
+        return await original(op_name, path, *args, **kwargs)
+
+    mount.execute_op = synthesized
+    r = await ws.execute("ln -s /data/x /data/meta_link")
+    assert r.exit_code == 0
+    assert not r.stderr
+    mount.execute_op = original
+    assert (await
+            ws.execute("readlink /data/meta_link")).stdout == b"/data/x\n"
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -51,18 +51,19 @@ export async function entryBytes(
  *
  * A 120000 entry is a symlink whose blob is the target string, so it is
  * restored through the namespace rather than written as content: writing the
- * blob would leave a regular file spelling the target. The namespace overwrites
- * a link of the same name, which is what a checkout that changes where a link
- * points needs.
+ * blob would leave a regular file spelling the target.
  *
- * Whatever is already there goes first when it is the other kind, because the
- * two live on different planes and neither replaces the other. Writing a
- * regular blob at a path the namespace holds a link for follows the link and
- * lands the content in the file it points at, corrupting a path no branch
- * touched while the link stays; and linking over a regular file leaves that
- * file behind the link, ready to reappear when the link goes. git replaces the
- * entry in both directions. The check is a namespace lookup, so the ordinary
- * file-for-file case costs nothing.
+ * Whatever is already there goes first, whichever kind it is, because git
+ * replaces a tree entry rather than merging with it. Two of the four
+ * combinations are the ones that corrupt state: writing a regular blob at a
+ * path the namespace holds a link for follows the link and lands the content in
+ * the file it points at, damaging a path no branch touched while the link
+ * stays; and linking over a regular file leaves that file behind the link,
+ * ready to reappear when the link goes. The fourth, a link over a link, is the
+ * retarget a checkout does when a branch moves where a link points: symlink(2)
+ * does not overwrite, so the old name is removed rather than replaced in place.
+ * The check is a namespace lookup, so the ordinary file-for-file case costs
+ * nothing.
  */
 export async function restoreEntry(
   dispatch: Dispatch,
@@ -73,7 +74,7 @@ export async function restoreEntry(
 ): Promise<void> {
   const linked = links !== null && links.statAt(path) !== null
   if (mode === SYMLINK_MODE) {
-    if (!linked) await removeFile(dispatch, path)
+    await removeFile(dispatch, path)
     await dispatch('symlink', PathSpec.fromStrPath(path), [], {
       target: new TextDecoder().decode(blob),
     })

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -701,6 +701,27 @@ describe('symlinks', () => {
     expect(DEC.decode(listing.stdout)).toContain('link -> numbers.txt')
   })
 
+  it('retargets a link the other branch points elsewhere', async () => {
+    // symlink(2) does not overwrite, so the checkout removes the old name
+    // before writing the new one. Relying on the node table to replace the
+    // entry in place left the checkout refused with EEXIST and the link
+    // pointing at the other branch's target.
+    const h = await harness()
+    expect((await h.run('checkout -b first'))[0]).toBe(0)
+    await h.ws.execute('ln -s numbers.txt /repo/lk')
+    expect((await h.run('add lk'))[0]).toBe(0)
+    expect((await h.run('commit -m first'))[0]).toBe(0)
+    expect((await h.run('checkout -b second'))[0]).toBe(0)
+    await write(h, 'other.txt', 'other\n')
+    await h.ws.execute('ln -sf other.txt /repo/lk')
+    expect((await h.run('add -A'))[0]).toBe(0)
+    expect((await h.run('commit -m second'))[0]).toBe(0)
+    expect((await h.run('checkout first'))[0]).toBe(0)
+    expect(DEC.decode((await h.ws.execute('readlink /repo/lk')).stdout)).toBe('numbers.txt\n')
+    expect((await h.run('checkout second'))[0]).toBe(0)
+    expect(DEC.decode((await h.ws.execute('readlink /repo/lk')).stdout)).toBe('other.txt\n')
+  })
+
   it('replaces a link with the regular file the other branch records', async () => {
     // git 2.47: a path that is a symlink on one branch and a regular file on
     // the other comes back as a regular file, and the file the link pointed at

--- a/typescript/packages/core/src/ops/config.ts
+++ b/typescript/packages/core/src/ops/config.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { FileStat } from '../types.ts'
+
 // Ops with lstat semantics: they act on the entry named by the path, so
 // no stat surface (dispatch, the fs facade, FUSE) may rewrite their
 // operand through the symlink table.
@@ -45,6 +47,9 @@ export interface NamespaceLinks {
   isLink(path: string): boolean
   // The stored target for a link path, null when not a link.
   readlink(path: string): string | null
+  // The link's own stat row (lstat), null when not a link. A link has no
+  // backend inode, so this table is the only authority for one.
+  linkStatAt(path: string): FileStat | null
   // Every link path to its stored target, the whole table.
   symlinkTargets(): Map<string, string>
   // Create or overwrite a symlink entry; target is kept verbatim.

--- a/typescript/packages/core/src/ops/ops.test.ts
+++ b/typescript/packages/core/src/ops/ops.test.ts
@@ -21,7 +21,7 @@ import { PolicyDenied, PolicyError } from '../policy/errors.ts'
 import type { Action, OpsContext, OpsResultContext } from '../policy/types.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { FileType, Limit, MountMode, OnExceed } from '../types.ts'
-import { enotdir } from '../utils/errors.ts'
+import { enoent, enotdir } from '../utils/errors.ts'
 import { Workspace } from '../workspace/workspace/workspace.ts'
 
 const DEC = new TextDecoder()
@@ -669,5 +669,97 @@ describe('Ops.setattr', () => {
     await ws.fs.symlink('/data/dir/link', 'f.txt')
     await ws.fs.setattr('/data/dir/link', { uid: 9 })
     expect((await ws.fs.stat('/data/dir/f.txt')).uid).toBe(9)
+  })
+})
+
+// readlink(2) splits its two misses and callers read them differently:
+// EINVAL means "there, but not a link", ENOENT means "not there". Pinned
+// against real Linux (python:3.13-slim): a file, a directory and a mount
+// root all answer EINVAL, and a missing path answers ENOENT whether or
+// not its parent exists.
+describe('Ops.readlink', () => {
+  const codeOf = async (ws: Workspace, path: string): Promise<string> => {
+    try {
+      await ws.fs.readlink(path)
+      return 'ok'
+    } catch (err) {
+      return String((err as { code?: string }).code)
+    }
+  }
+
+  it('answers the target for a link', async () => {
+    const ws = mkWorkspace()
+    await ws.fs.writeFile('/data/f.txt', 'x')
+    await ws.fs.symlink('/data/l', 'f.txt')
+    expect(await ws.fs.readlink('/data/l')).toBe('f.txt')
+  })
+
+  it('answers EINVAL for a path that is there but is not a link', async () => {
+    const ws = mkWorkspace()
+    await ws.fs.writeFile('/data/f.txt', 'x')
+    await ws.fs.mkdir('/data/d')
+    expect(await codeOf(ws, '/data/f.txt')).toBe('EINVAL')
+    expect(await codeOf(ws, '/data/d')).toBe('EINVAL')
+    expect(await codeOf(ws, '/data')).toBe('EINVAL')
+  })
+
+  it('answers ENOENT for a path that is not there', async () => {
+    const ws = mkWorkspace()
+    await ws.fs.mkdir('/data/d')
+    expect(await codeOf(ws, '/data/missing')).toBe('ENOENT')
+    expect(await codeOf(ws, '/data/d/deep/missing')).toBe('ENOENT')
+  })
+
+  // A store that keeps no directory object answers stat with a miss and
+  // readdir with keys, so absence takes both channels: reading only the
+  // first would report an implicit directory as ENOENT.
+  it('reads the listing channel when a backend has no directory object', async () => {
+    const resource = new RAMResource()
+    const ops = new OpsRegistry()
+    for (const op of resource.ops()) ops.register(op)
+    const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE, ops })
+    await ws.fs.mkdir('/data/d')
+    await ws.fs.writeFile('/data/d/under.txt', 'x')
+    // Registered after the writes, so only the probe sees the miss: a
+    // prefix store answers stat with nothing for a directory and
+    // readdir with the keys under it.
+    ops.register({
+      name: 'stat',
+      resource: resource.kind,
+      filetype: null,
+      fn: () => {
+        throw enoent('/data/d')
+      },
+      write: false,
+    })
+    expect(await codeOf(ws, '/data/d')).toBe('EINVAL')
+    // And the listing has to be non-empty to count: those stores answer
+    // a missing prefix with [] rather than raising, so an empty one is
+    // the absence case. Two different answers with stat silenced is what
+    // proves the listing is the channel being read.
+    await ws.fs.mkdir('/data/hollow')
+    expect(await codeOf(ws, '/data/hollow')).toBe('ENOENT')
+  })
+
+  // The probe reads on the caller's behalf, never past a refusal: a
+  // channel that will not answer is not evidence of absence, so the
+  // errno collapses to the EINVAL every miss gave before the split.
+  it('does not probe past a policy that denies stat', async () => {
+    const resource = new RAMResource()
+    const ops = new OpsRegistry()
+    for (const op of resource.ops()) ops.register(op)
+    const noProbe: Policy = {
+      preOps: (ctx: OpsContext) =>
+        Promise.resolve(
+          ctx.op === 'stat' || ctx.op === 'readdir'
+            ? { kind: 'deny' as const, reason: 'no probing' }
+            : null,
+        ),
+    }
+    const ws = new Workspace(
+      { '/data': resource },
+      { mode: MountMode.WRITE, ops, policies: [noProbe] },
+    )
+    expect(await codeOf(ws, '/data/missing')).toBe('EINVAL')
   })
 })

--- a/typescript/packages/core/src/ops/ops.test.ts
+++ b/typescript/packages/core/src/ops/ops.test.ts
@@ -710,19 +710,23 @@ describe('Ops.readlink', () => {
     expect(await codeOf(ws, '/data/d/deep/missing')).toBe('ENOENT')
   })
 
-  // A store that keeps no directory object answers stat with a miss and
-  // readdir with keys, so absence takes both channels: reading only the
-  // first would report an implicit directory as ENOENT.
+  // A store that keeps no directory object answers stat with a miss, so
+  // absence takes the parent's listing too: reading only the first
+  // channel would report an implicit directory as ENOENT.
   it('reads the listing channel when a backend has no directory object', async () => {
     const resource = new RAMResource()
     const ops = new OpsRegistry()
+    const realReaddir = resource.ops().find((op) => op.name === 'readdir')?.fn
+    if (realReaddir === undefined) throw new Error('RAMResource has no readdir op')
     for (const op of resource.ops()) ops.register(op)
     const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE, ops })
     await ws.fs.mkdir('/data/d')
     await ws.fs.writeFile('/data/d/under.txt', 'x')
-    // Registered after the writes, so only the probe sees the miss: a
-    // prefix store answers stat with nothing for a directory and
-    // readdir with the keys under it.
+    // Registered after the writes, so only the probe sees them: a prefix
+    // store answers stat with nothing for a directory, and a name with
+    // no keys under it is in no listing either, which is how such a
+    // store says a directory is not there. Two different answers with
+    // stat silenced is what proves the listing is the channel read.
     ops.register({
       name: 'stat',
       resource: resource.kind,
@@ -732,11 +736,17 @@ describe('Ops.readlink', () => {
       },
       write: false,
     })
+    ops.register({
+      name: 'readdir',
+      resource: resource.kind,
+      filetype: null,
+      fn: async (accessor, path, args, kwargs) => {
+        const entries = (await realReaddir(accessor, path, args, kwargs)) as string[]
+        return entries.filter((entry) => !entry.replace(/\/+$/, '').endsWith('hollow'))
+      },
+      write: false,
+    })
     expect(await codeOf(ws, '/data/d')).toBe('EINVAL')
-    // And the listing has to be non-empty to count: those stores answer
-    // a missing prefix with [] rather than raising, so an empty one is
-    // the absence case. Two different answers with stat silenced is what
-    // proves the listing is the channel being read.
     await ws.fs.mkdir('/data/hollow')
     expect(await codeOf(ws, '/data/hollow')).toBe('ENOENT')
   })

--- a/typescript/packages/core/src/ops/ops.ts
+++ b/typescript/packages/core/src/ops/ops.ts
@@ -279,12 +279,15 @@ export class Ops {
   }
 
   /**
-   * Create or overwrite a namespace symlink at `path`.
+   * Create a namespace symlink at `path`.
    *
    * Routed through the door like every write: session grants and
    * admission policies fire on the link's turf, and the write lands on
-   * the ledger. The target is stored verbatim as typed. Mirrors
-   * Python's Ops.symlink.
+   * the ledger. The target is stored verbatim as typed. Throws EEXIST
+   * when something is already at `path` (a file, a directory, another
+   * link, a mount root): symlink(2) never overwrites, and the door is
+   * the layer that can see both planes to tell. Mirrors Python's
+   * Ops.symlink.
    */
   async symlink(path: string, target: string): Promise<void> {
     await this.through('symlink', path, [], { target })

--- a/typescript/packages/core/src/ops/ops.ts
+++ b/typescript/packages/core/src/ops/ops.ts
@@ -16,29 +16,12 @@ import { OpReport } from '../io/types.ts'
 import { OpRecord } from '../observe/record.ts'
 import { NO_FOLLOW_OPS, type NamespaceLinks } from './config.ts'
 import type { OpKwargs } from './registry.ts'
-import type { FileStat } from '../types.ts'
+import type { FileStat, SetAttrFields } from '../types.ts'
 import { FileType, PathSpec } from '../types.ts'
 import { exdev, isMissingPath } from '../utils/errors.ts'
 import type { DispatchFn } from '../runtime/types.ts'
 
 export type OpSink = (rec: OpRecord) => Promise<void>
-
-/**
- * The metadata fields `setattr` takes, all optional.
- *
- * Spelled the way the op and the CommandOpts bag spell them, so one
- * fact keeps one name from a shell line down to a guest's chmod.
- * `nofollow` is not a field but the AT_SYMLINK_NOFOLLOW bit: it writes
- * the link entry's own attrs rather than its target's.
- */
-export interface SetAttrFields {
-  mode?: number
-  uid?: number | string
-  gid?: number | string
-  atime?: string
-  mtime?: string
-  nofollow?: boolean
-}
 
 interface MountOwner {
   readonly prefix: string

--- a/typescript/packages/core/src/runtime/conformance.test.ts
+++ b/typescript/packages/core/src/runtime/conformance.test.ts
@@ -23,6 +23,7 @@ import { PyodideRuntime } from './python/pyodide.ts'
 import { QuickJsRuntime } from './js/quickjs.ts'
 import type { BridgeDispatchFn, RunArgs } from './types.ts'
 import { PrefixResolver } from './resolver.ts'
+import { DIR_MODE, FILE_MODE } from '../utils/stat_view.ts'
 
 // The runtime conformance suite: one capability table, executed against
 // every runtime in that runtime's own idiom, with the outcome verified
@@ -156,6 +157,16 @@ const MONTY_ROWS: Row[] = [
     setup: ['echo -n a > /data/keep.txt'],
     checks: [['cat /data/keep.txt', 'aZ']],
     broken: MONTY_OPEN_UNSUPPORTED,
+  },
+  {
+    // Monty's own tree holds no links, so this reads the mount's name
+    // plane or answers False for a link the shell made. Creation is out
+    // of reach: the binding emits no symlink verb.
+    capability: 'lstat',
+    spelling: 'Path.is_symlink',
+    line: `python3 -c "from pathlib import Path; print(Path('/data/l').is_symlink(), Path('/data/t.txt').is_symlink())"`,
+    setup: ['echo -n x > /data/t.txt', 'ln -s t.txt /data/l'],
+    lineOut: 'True False',
   },
 ]
 
@@ -292,6 +303,40 @@ const PYODIDE_ROWS: Row[] = [
     setup: ['echo -n a > /data/keep.txt'],
     checks: [['cat /data/keep.txt', 'aZ']],
   },
+  {
+    // A link is namespace state, so the mount need not be able to store
+    // one: the op reaches the node table. The callback used to refuse
+    // with EPERM because no mount op could express a link at all.
+    capability: 'symlink',
+    spelling: 'os.symlink',
+    line: `python3 -c "import os; os.symlink('t.txt', '/data/made')"`,
+    setup: ['echo -n hi > /data/t.txt'],
+    checks: [
+      ['readlink /data/made', 't.txt'],
+      ['cat /data/made', 'hi'],
+    ],
+  },
+  {
+    capability: 'readlink',
+    spelling: 'os.readlink',
+    line: `python3 -c "import os; print(os.readlink('/data/lr'))"`,
+    setup: ['echo -n x > /data/t.txt', 'ln -s t.txt /data/lr'],
+    lineOut: 't.txt',
+  },
+  {
+    capability: 'lstat',
+    spelling: 'os.path.islink',
+    line: `python3 -c "import os; print(os.path.islink('/data/li'), os.path.islink('/data/t.txt'))"`,
+    setup: ['echo -n x > /data/t.txt', 'ln -s t.txt /data/li'],
+    lineOut: 'True False',
+  },
+  {
+    capability: 'utime',
+    spelling: 'os.utime',
+    line: `python3 -c "import os; os.utime('/data/t.txt', (100.0, 200.0))"`,
+    setup: ['echo -n x > /data/t.txt'],
+    checks: [['stat -c %Y /data/t.txt', '200']],
+  },
 ]
 
 const QUICKJS_ROWS: Row[] = [
@@ -379,6 +424,17 @@ const QUICKJS_ROWS: Row[] = [
     line: `node -e "const w = std.open('/data/keep.txt', 'a'); w.puts('Z'); w.close()"`,
     setup: ['echo -n a > /data/keep.txt'],
     checks: [['cat /data/keep.txt', 'aZ']],
+  },
+  {
+    // The only metadata verb this engine has: qjs-wasi's `os` module
+    // ships no symlink, readlink or lstat at all (probed live against
+    // the real binary), so the shim does not invent them and utimes is
+    // the whole setattr surface. Stamps are milliseconds both ways.
+    capability: 'utime',
+    spelling: 'os.utimes',
+    line: `node -e "const rc = os.utimes('/data/t.txt', 100000, 200000); if (rc !== 0) throw new Error('rc ' + rc)"`,
+    setup: ['echo -n x > /data/t.txt'],
+    checks: [['stat -c %Y /data/t.txt', '200']],
   },
 ]
 
@@ -539,10 +595,11 @@ function makeCountingBridge(seed: Record<string, string>): CountingBridge {
     }
     if (op === 'stat') {
       const hit = files.get(path)
-      if (hit !== undefined) return Promise.resolve({ size: hit.length, isDir: false, mtimeMs: 0 })
+      if (hit !== undefined)
+        return Promise.resolve({ size: hit.length, isDir: false, mtimeMs: 0, mode: FILE_MODE })
       const dir = path.replace(/\/$/, '')
       const isDir = dirs.has(dir) || [...files.keys()].some((p) => p.startsWith(dir + '/'))
-      if (isDir) return Promise.resolve({ size: 0, isDir: true, mtimeMs: 0 })
+      if (isDir) return Promise.resolve({ size: 0, isDir: true, mtimeMs: 0, mode: DIR_MODE })
       return Promise.reject(new Error(`ENOENT ${path}`))
     }
     if (op === 'readdir') {

--- a/typescript/packages/core/src/runtime/js/vfs.ts
+++ b/typescript/packages/core/src/runtime/js/vfs.ts
@@ -15,7 +15,7 @@
 import { classify } from '../../errors/index.ts'
 import { isMissingPath } from '../../utils/errors.ts'
 import { WASI } from './wasi.ts'
-import { DIR_MODE, FILE_MODE } from '../../utils/stat_view.ts'
+import { epochToIso } from '../../utils/dates.ts'
 import { FileHandle, FileTable, parseMode, type OpenMode } from '../handles/index.ts'
 import type { RuntimeVFS, VFSStat } from '../vfs.ts'
 import type { QuickJSAsyncContext, QuickJSHandle } from 'quickjs-emscripten'
@@ -76,9 +76,11 @@ os.stat = (path) => __mirage_stat(String(path));
 os.remove = (path) => __mirage_remove(String(path));
 os.mkdir = (path) => __mirage_mkdir(String(path));
 os.rename = (a, b) => __mirage_rename(String(a), String(b));
+os.utimes = (path, atime, mtime) => __mirage_utimes(String(path), atime, mtime);
 os.S_IFMT = 61440;
 os.S_IFDIR = 16384;
 os.S_IFREG = 32768;
+os.S_IFLNK = 40960;
 `
 
 /**
@@ -284,6 +286,21 @@ export function installMirageFs(ctx: QuickJSAsyncContext, vfs: RuntimeVFS | null
     }
   })
 
+  defineAsync('__mirage_utimes', async (pathH, atimeH, mtimeH) => {
+    const path = ctx.getString(pathH)
+    if (vfs === null || !underMount(path)) return ctx.newNumber(-ENOENT)
+    // The engine's stamps are milliseconds (qjs-libc splits them into
+    // tv_sec/tv_nsec at 1000), and the op takes ISO text.
+    const atime = epochToIso(ctx.getNumber(atimeH) / 1000)
+    const mtime = epochToIso(ctx.getNumber(mtimeH) / 1000)
+    try {
+      await vfs.setattr(path, { atime, mtime })
+      return ctx.newNumber(0)
+    } catch (err) {
+      return ctx.newNumber(-wasiErrno(err))
+    }
+  })
+
   defineAsync('__mirage_rename', async (srcH, dstH) => {
     const src = ctx.getString(srcH)
     const dst = ctx.getString(dstH)
@@ -326,7 +343,7 @@ export function installMirageFs(ctx: QuickJSAsyncContext, vfs: RuntimeVFS | null
       }
       setNum('dev', 0)
       setNum('ino', 0)
-      setNum('mode', st.isDir ? DIR_MODE : FILE_MODE)
+      setNum('mode', st.mode)
       setNum('nlink', 1)
       setNum('uid', 0)
       setNum('gid', 0)

--- a/typescript/packages/core/src/runtime/python/monty/osaccess.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/osaccess.test.ts
@@ -119,4 +119,28 @@ describe('MirageOSAccess path operations', () => {
     expect(await access.handle('Path.is_file', ['/ram/d/nope'])).toBe(false)
     expect(await access.handle('Path.exists', ['/ram/nope/deep'])).toBe(false)
   })
+
+  // Monty's own tree holds no links, so declining this verb answered
+  // False for a link the shell made.
+  it('answers is_symlink from the parent listing mark', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
+      if (op === 'readdir' && path === '/ram/d/') {
+        return Promise.resolve([
+          { path: '/ram/d/l', size: 0, isDir: false, isLink: true },
+          { path: '/ram/d/f', size: 1, isDir: false },
+        ])
+      }
+      return Promise.reject(new Error(`unexpected ${op} ${path}`))
+    })
+    const access = accessOn(dispatch)
+    expect(await access.handle('Path.is_symlink', ['/ram/d/l'])).toBe(true)
+    expect(await access.handle('Path.is_symlink', ['/ram/d/f'])).toBe(false)
+  })
+
+  // A path under no mount reaches monty's own tree, links included.
+  it('declines is_symlink outside every mount', () => {
+    const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve(undefined))
+    const access = accessOn(dispatch)
+    expect(access.handle('Path.is_symlink', ['/tmp/l'])).toBe(NOT_HANDLED)
+  })
 })

--- a/typescript/packages/core/src/runtime/python/monty/osaccess.ts
+++ b/typescript/packages/core/src/runtime/python/monty/osaccess.ts
@@ -106,6 +106,12 @@ export class MirageOSAccess {
           () => true,
           () => false,
         )
+      // Monty's own tree holds no links, so declining would answer
+      // False for one the shell made; the mount's name plane is the
+      // only place the fact lives. Creation stays out of reach: the
+      // binding emits no symlink verb to serve.
+      case 'Path.is_symlink':
+        return vfs.isLink(path)
       case 'Path.is_file':
         return vfs.entryFor(path).then(
           (e) => e !== null && !e.isDir,

--- a/typescript/packages/core/src/runtime/python/monty/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/vfs.test.ts
@@ -178,3 +178,29 @@ describe('MontyVFS negative cache', () => {
     expect(await vfs.read('/ram/x')).toEqual(new TextEncoder().encode('back'))
   })
 })
+
+// The link mark rides the parent's listing, which the door already
+// resolved, so a predicate the guest asks per path adds no dispatch of
+// its own. Monty's own tree holds no links, so declining would answer
+// False for one the shell made.
+describe('MontyVFS.isLink', () => {
+  const listing = (entries: unknown[]): BridgeDispatchFn =>
+    vi.fn<BridgeDispatchFn>((op) =>
+      op === 'readdir' ? Promise.resolve(entries) : Promise.resolve(undefined),
+    )
+
+  it('reads the mark off the parent listing', async () => {
+    const vfs = viewOn(listing([{ path: '/ram/link', size: 0, isDir: false, isLink: true }]))
+    expect(await vfs.isLink('/ram/link')).toBe(true)
+  })
+
+  it('answers false for an entry with no mark', async () => {
+    const vfs = viewOn(listing([{ path: '/ram/f', size: 1, isDir: false }]))
+    expect(await vfs.isLink('/ram/f')).toBe(false)
+  })
+
+  it('answers false when the parent will not list', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.reject(new Error('no such dir')))
+    expect(await viewOn(dispatch).isLink('/ram/gone/l')).toBe(false)
+  })
+})

--- a/typescript/packages/core/src/runtime/python/monty/vfs.ts
+++ b/typescript/packages/core/src/runtime/python/monty/vfs.ts
@@ -150,6 +150,25 @@ export class MontyVFS {
     }
   }
 
+  /**
+   * Whether the mount's name plane holds a symlink at `path`.
+   *
+   * Read off the parent's listing, which the door already marks, so a
+   * predicate the guest asks per path costs no dispatch of its own
+   * beyond the one `entryFor` was going to make. A parent that will
+   * not list answers False, the same as pathlib does for a path it
+   * cannot reach.
+   *
+   * Args:
+   *   path: the path to test.
+   */
+  isLink(path: string): Promise<boolean> {
+    return this.entryFor(path).then(
+      (e) => e?.isLink === true,
+      () => false,
+    )
+  }
+
   /** The parent's entry for `path`, or null when the parent lacks one. */
   async entryFor(path: string): Promise<VFSEntry | null> {
     if (this.missing.has(path)) return null

--- a/typescript/packages/core/src/runtime/python/vfs/constants.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/constants.ts
@@ -17,6 +17,10 @@ const S_IFREG = 0o100000
 
 export const DIR_MODE = S_IFDIR | 0o777
 export const FILE_MODE = S_IFREG | 0o666
+// A link is not this filesystem's choice the way the two above are: no
+// POSIX system consults the bits on a symlink, so every translator
+// reports the same mode and this one is shared rather than restated.
+export { LINK_MODE } from '../../../utils/stat_view.ts'
 
 export const BLKSIZE = 4096
 

--- a/typescript/packages/core/src/runtime/python/vfs/journal.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/journal.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { concatBytes, type RuntimeVFS } from '../../vfs.ts'
+import type { SetAttrFields } from '../../../types.ts'
 
 /**
  * One guest mutation, recorded in the order the script performed it.
@@ -28,6 +29,8 @@ export type MirageMutation =
   | { readonly kind: 'unlink'; readonly path: string }
   | { readonly kind: 'rmdir'; readonly path: string }
   | { readonly kind: 'rename'; readonly path: string; readonly dst: string }
+  | { readonly kind: 'symlink'; readonly path: string; readonly target: string }
+  | { readonly kind: 'setattr'; readonly path: string; readonly attrs: SetAttrFields }
 
 /**
  * The write-ahead log a pyodide guest records into.
@@ -52,6 +55,20 @@ export interface MutationJournal {
   markUnlink(path: string): void
   markRmdir(path: string): void
   markRename(src: string, dst: string): void
+  /**
+   * Args:
+   *   path: guest-absolute path of the link.
+   *   target: what it points at, stored verbatim.
+   */
+  markSymlink(path: string, target: string): void
+  /**
+   * Args:
+   *   path: guest-absolute path whose metadata changed.
+   *   attrs: only the fields the guest wrote, already in the op's own
+   *     terms (ISO stamps), because the unit Emscripten passes is the
+   *     caller's fact and not the journal's.
+   */
+  markSetattr(path: string, attrs: SetAttrFields): void
   /** Drain the journal: every mutation in guest order, cleared. */
   takeMutations(): MirageMutation[]
 }
@@ -96,6 +113,12 @@ export function createJournal(): MutationJournal {
     markRename(src, dst) {
       journal.push({ kind: 'rename', path: src, dst })
     },
+    markSymlink(path, target) {
+      journal.push({ kind: 'symlink', path, target })
+    },
+    markSetattr(path, attrs) {
+      journal.push({ kind: 'setattr', path, attrs })
+    },
     takeMutations() {
       return journal.splice(0, journal.length)
     },
@@ -126,5 +149,9 @@ export async function applyMutation(vfs: RuntimeVFS, mutation: MirageMutation): 
       return vfs.rmdir(mutation.path)
     case 'rename':
       return vfs.rename(mutation.path, mutation.dst)
+    case 'symlink':
+      return vfs.symlink(mutation.path, mutation.target)
+    case 'setattr':
+      return vfs.setattr(mutation.path, mutation.attrs)
   }
 }

--- a/typescript/packages/core/src/runtime/python/vfs/preload.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/preload.test.ts
@@ -21,22 +21,33 @@ import { PrefixResolver } from '../../resolver.ts'
 interface FakeFS {
   mkdirTree(path: string): void
   writeFile(path: string, bytes: Uint8Array): void
+  symlink?(path: string, target: string): void
   _dirs: Set<string>
   _files: Map<string, Uint8Array>
+  _links: Map<string, string>
 }
 
-function makeFakeFS(): FakeFS {
+function makeFakeFS(withLinks = true): FakeFS {
   const dirs = new Set<string>()
   const files = new Map<string, Uint8Array>()
+  const links = new Map<string, string>()
   return {
     _dirs: dirs,
     _files: files,
+    _links: links,
     mkdirTree(path) {
       dirs.add(path)
     },
     writeFile(path, bytes) {
       files.set(path, bytes)
     },
+    ...(withLinks
+      ? {
+          symlink(path: string, target: string) {
+            links.set(path, target)
+          },
+        }
+      : {}),
   }
 }
 
@@ -192,5 +203,53 @@ describe('preloadInto', () => {
     const fs = makeFakeFS()
     const vfs = new RuntimeVFS(dispatch, new PrefixResolver(() => ['/ram/', '/ram/inner/']))
     await expect(preloadInto(fs, vfs, '/ram/')).rejects.toThrow(/inner boom/)
+  })
+
+  // A link is copied as a link, never followed: stat reports the target,
+  // so a directory link would copy its whole subtree and a cyclic one
+  // would never terminate.
+  it('copies a link as a link and does not walk it', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
+      if (op === 'readdir' && path === '/ram/') {
+        return Promise.resolve([{ path: '/ram/loop', size: 0, isDir: true, isLink: true }])
+      }
+      if (op === 'readlink' && path === '/ram/loop') return Promise.resolve('/ram')
+      return Promise.reject(new Error(`unexpected ${op} ${path}`))
+    })
+    const fs = makeFakeFS()
+    await preloadInto(fs, new RuntimeVFS(dispatch), '/ram/')
+    expect(fs._links.get('/ram/loop')).toBe('/ram')
+    expect(fs._dirs.has('/ram/loop')).toBe(false)
+  })
+
+  it('skips a link the namespace listed but will not resolve', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
+      if (op === 'readdir' && path === '/ram/') {
+        return Promise.resolve([{ path: '/ram/l', size: 0, isDir: false, isLink: true }])
+      }
+      if (op === 'readlink') return Promise.reject(new Error('link vanished'))
+      return Promise.reject(new Error(`unexpected ${op} ${path}`))
+    })
+    const fs = makeFakeFS()
+    await preloadInto(fs, new RuntimeVFS(dispatch), '/ram/')
+    expect(fs._links.size).toBe(0)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  // A target that cannot hold links omits them without paying for the
+  // readlink, which is what every seed did before links were reachable.
+  it('does not read a link target when the target cannot hold one', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
+      if (op === 'readdir' && path === '/ram/') {
+        return Promise.resolve([{ path: '/ram/l', size: 0, isDir: false, isLink: true }])
+      }
+      return Promise.reject(new Error(`unexpected ${op} ${path}`))
+    })
+    const fs = makeFakeFS(false)
+    await preloadInto(fs, new RuntimeVFS(dispatch), '/ram/')
+    expect(fs._links.size).toBe(0)
+    expect(dispatch).not.toHaveBeenCalledWith('readlink', '/ram/l')
   })
 })

--- a/typescript/packages/core/src/runtime/python/vfs/preload.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/preload.ts
@@ -23,14 +23,34 @@ export interface FSLike {
    * when nothing will write to it.
    */
   markUnreadable?(path: string): void
+  /**
+   * Note a namespace symlink and its target. A target that cannot hold
+   * links omits them, which is what every seed did before links were
+   * reachable at all.
+   */
+  symlink?(path: string, target: string): void
 }
 
 async function preloadEntry(fs: FSLike, vfs: RuntimeVFS, entry: VFSEntry): Promise<void> {
-  // A namespace symlink is skipped, not followed: stat reports the
-  // target, so a directory link would copy its whole subtree here and a
-  // cyclic one would never terminate. The guest sees exactly what a
-  // seed can hold, which has never included links.
-  if (entry.isLink === true) return
+  // A namespace symlink is copied as a link, never followed: stat
+  // reports the target, so a directory link would copy its whole
+  // subtree here and a cyclic one would never terminate. The target is
+  // one readlink, which the walk pays only for the entries the
+  // namespace already marked.
+  if (entry.isLink === true) {
+    if (fs.symlink === undefined) return
+    try {
+      fs.symlink(entry.path, await vfs.readlink(entry.path))
+    } catch (err) {
+      // A link the namespace listed and then would not resolve: leaving
+      // it out is the honest seed, since inventing a target would make
+      // the guest read some other file's bytes.
+      console.warn(
+        `mirage preload: cannot read link ${entry.path}: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+    return
+  }
   if (entry.isDir) {
     fs.mkdirTree(entry.path)
     const next = entry.path.endsWith('/') ? entry.path : entry.path + '/'

--- a/typescript/packages/core/src/runtime/python/vfs/seed.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/seed.ts
@@ -25,6 +25,7 @@ export class MirageFsSeed implements FSLike {
   readonly dirs: string[] = []
   readonly files = new Map<string, Uint8Array>()
   readonly unreadable = new Set<string>()
+  readonly links = new Map<string, string>()
 
   mkdirTree(path: string): void {
     this.dirs.push(path)
@@ -32,6 +33,17 @@ export class MirageFsSeed implements FSLike {
 
   writeFile(path: string, bytes: Uint8Array): void {
     this.files.set(path, bytes)
+  }
+
+  /**
+   * Note a namespace symlink and what it points at.
+   *
+   * Args:
+   *   path: guest-absolute path of the link.
+   *   target: the stored target, verbatim as it was typed.
+   */
+  symlink(path: string, target: string): void {
+    this.links.set(path, target)
   }
 
   /**

--- a/typescript/packages/core/src/runtime/python/vfs/tree.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/tree.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { DIR_MODE, FILE_MODE } from './constants.ts'
+import { DIR_MODE, FILE_MODE, LINK_MODE } from './constants.ts'
 import { fsError } from './errors.ts'
 import type { MirageFsSeed } from './seed.ts'
 import type { FSNode, NodeHost, NodeOps, StreamOps } from './types.ts'
@@ -81,6 +81,10 @@ export class NodeTree {
       node.contents = bytes
       node.usedBytes = bytes.length
     }
+    for (const [path, target] of seed.links) {
+      const node = this.placeFile(path, LINK_MODE)
+      if (node !== null) node.link = target
+    }
   }
 
   /**
@@ -96,6 +100,7 @@ export class NodeTree {
     node.node_ops = this.nodeOps
     node.stream_ops = this.streamOps
     if (this.host.isDir(mode)) node.children = new Map()
+    else if (this.host.isLink(mode)) node.link = ''
     else {
       node.contents = new Uint8Array(0)
       node.usedBytes = 0
@@ -171,13 +176,20 @@ export class NodeTree {
     return cur
   }
 
-  private placeFile(path: string): FSNode | null {
+  /**
+   * Create a leaf node at `path`, building the directories above it.
+   *
+   * Args:
+   *   path: guest-absolute path of the leaf.
+   *   mode: type and permission bits, a regular file by default.
+   */
+  private placeFile(path: string, mode: number = FILE_MODE): FSNode | null {
     const rel = this.relative(path)
     if (rel === null) return null
     const cut = rel.lastIndexOf('/')
     const name = cut < 0 ? rel : rel.slice(cut + 1)
     if (name === '') return null
     const parent = cut <= 0 ? this.rootNode() : this.ensureDir(rel.slice(0, cut))
-    return this.makeNode(parent, name, FILE_MODE)
+    return this.makeNode(parent, name, mode)
   }
 }

--- a/typescript/packages/core/src/runtime/python/vfs/types.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/types.ts
@@ -60,6 +60,12 @@ export interface FSNode {
   contents?: Uint8Array
   usedBytes?: number
   unreadable?: boolean
+  /**
+   * A symlink's target, verbatim as it was typed. Emscripten's own
+   * MEMFS keeps it under this name and `FS.readlink` reads it, so the
+   * spelling is the interpreter's, not ours.
+   */
+  link?: string
 }
 
 export interface FSStream {
@@ -103,6 +109,7 @@ export interface NodeOps {
   rmdir(parent: FSNode, name: string): void
   readdir(node: FSNode): string[]
   symlink(parent: FSNode, name: string, target: string): FSNode
+  readlink(node: FSNode): string
 }
 
 export interface StreamOps {
@@ -130,6 +137,7 @@ export interface NodeHost {
   createNode(parent: FSNode | null, name: string, mode: number, rdev: number): FSNode
   isDir(mode: number): boolean
   isFile(mode: number): boolean
+  isLink(mode: number): boolean
 }
 
 /**

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
@@ -18,9 +18,11 @@ import { PrefixResolver } from '../../resolver.ts'
 import { RuntimeVFS } from '../../vfs.ts'
 import { applyMutation, createJournal, type MutationJournal } from './journal.ts'
 import { preloadInto } from './preload.ts'
-import { MirageFs } from './vfs.ts'
+import { changedAttrs, MirageFs } from './vfs.ts'
 import { MirageFsSeed } from './seed.ts'
 import type { BridgeDispatchFn } from '../../types.ts'
+import type { FSNode } from './types.ts'
+import type { SetAttrFields } from '../../../types.ts'
 
 const enc = new TextEncoder()
 const dec = new TextDecoder()
@@ -39,6 +41,8 @@ describe('MirageFs', () => {
   const mounts: string[] = []
   const store = new Map<string, Uint8Array>()
   const unreadable = new Set<string>()
+  const links = new Map<string, string>()
+  const attrs: [string, SetAttrFields][] = []
   let counter = 0
 
   // Mirrors what PyodideRuntime.syncMounts does, including collecting the
@@ -65,7 +69,7 @@ describe('MirageFs', () => {
 
   beforeAll(async () => {
     py = await loadPyodideRuntime()
-    const dispatch: BridgeDispatchFn = (op, path, bytes, dst) => {
+    const dispatch: BridgeDispatchFn = (op, path, bytes, dst, fields) => {
       calls.push(bytes ? { op, path, bytes: new Uint8Array(bytes) } : { op, path })
       if (op === 'read') {
         if (unreadable.has(path)) return Promise.reject(new Error('backend unavailable'))
@@ -89,12 +93,21 @@ describe('MirageFs', () => {
         store.set(dst, moved)
       }
       if (op === 'readdir') {
-        return Promise.resolve(
-          [...store.keys()]
-            .filter((k) => k.startsWith(path))
-            .map((k) => ({ path: k, size: store.get(k)?.length ?? 0, isDir: false })),
-        )
+        const files = [...store.keys()]
+          .filter((k) => k.startsWith(path))
+          .map((k) => ({ path: k, size: store.get(k)?.length ?? 0, isDir: false }))
+        const linked = [...links.keys()]
+          .filter((k) => k.startsWith(path))
+          .map((k) => ({ path: k, size: 0, isDir: false, isLink: true }))
+        return Promise.resolve([...files, ...linked])
       }
+      if (op === 'symlink' && dst !== undefined) links.set(path, dst)
+      if (op === 'readlink') {
+        const target = links.get(path)
+        if (target === undefined) return Promise.reject(new Error(`not a link: ${path}`))
+        return Promise.resolve(target)
+      }
+      if (op === 'setattr' && fields !== undefined) attrs.push([path, fields])
       return Promise.resolve(undefined)
     }
     vfs = new RuntimeVFS(dispatch, new PrefixResolver(() => mounts))
@@ -106,6 +119,8 @@ describe('MirageFs', () => {
     mounts.length = 0
     store.clear()
     unreadable.clear()
+    links.clear()
+    attrs.length = 0
     journal.takeMutations()
     counter += 1
   })
@@ -348,5 +363,179 @@ import os
 _size = os.stat('${p}sized.txt').st_size
 `)
     expect(py.globals.get('_size')).toBe(9)
+  })
+
+  // A link is namespace state, so the mount that gets it need not be
+  // able to store one: the op reaches the node table. Before this the
+  // callback refused with EPERM, which is what MEMFS-backed pyodide
+  // guests had to work around.
+  it('creates a symlink the guest asked for', async () => {
+    const p = prefix()
+    store.set(`${p}t.txt`, enc.encode('TARGET'))
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+import os
+os.symlink('t.txt', '${p}link')
+_is = os.path.islink('${p}link')
+_target = os.readlink('${p}link')
+`)
+    expect(py.globals.get('_is')).toBe(true)
+    expect(py.globals.get('_target')).toBe('t.txt')
+    await drain()
+    expect(links.get(`${p}link`)).toBe('t.txt')
+  })
+
+  // lstat sizes a link at its target string, which is what every POSIX
+  // system reports and what the mount's own row says.
+  it('lstats a created link as a link', async () => {
+    const p = prefix()
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+import os, stat
+os.symlink('some/where', '${p}l')
+_st = os.lstat('${p}l')
+_islnk = stat.S_ISLNK(_st.st_mode)
+_size = _st.st_size
+`)
+    expect(py.globals.get('_islnk')).toBe(true)
+    expect(py.globals.get('_size')).toBe('some/where'.length)
+  })
+
+  // The seed carries links now, so one the shell made is visible to the
+  // guest instead of missing: preload used to skip every link entry.
+  it('serves a seeded link to the guest', async () => {
+    const p = prefix()
+    store.set(`${p}real.txt`, enc.encode('CONTENT'))
+    links.set(`${p}seeded`, 'real.txt')
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+import os
+_is = os.path.islink('${p}seeded')
+_target = os.readlink('${p}seeded')
+`)
+    expect(py.globals.get('_is')).toBe(true)
+    expect(py.globals.get('_target')).toBe('real.txt')
+  })
+
+  it('refuses readlink on a path that is not a link', async () => {
+    const p = prefix()
+    store.set(`${p}plain.txt`, enc.encode('x'))
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+import errno, os
+try:
+    os.readlink('${p}plain.txt')
+    _errno = 0
+except OSError as exc:
+    _errno = exc.errno
+_einval = errno.EINVAL
+`)
+    expect(py.globals.get('_errno')).toBe(py.globals.get('_einval'))
+  })
+
+  // A guest utime reached only the private node table before this, so a
+  // stamp the script wrote vanished with the run.
+  it('sends a guest utime to the mount', async () => {
+    const p = prefix()
+    store.set(`${p}stamped.txt`, enc.encode('x'))
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+import os
+os.utime('${p}stamped.txt', (100.0, 200.0))
+`)
+    await drain()
+    expect(attrs).toEqual([
+      [`${p}stamped.txt`, { atime: '1970-01-01T00:01:40Z', mtime: '1970-01-01T00:03:20Z' }],
+    ])
+  })
+
+  // A truncating open reaches setattr too (Emscripten routes the resize
+  // through it), and that must not turn into a metadata write the guest
+  // never asked for: the bytes are the mutation, the stamp is not.
+  it('does not journal a metadata write for a truncating open', async () => {
+    const p = prefix()
+    store.set(`${p}w.txt`, enc.encode('OLD'))
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+f = open('${p}w.txt', 'w')
+f.write('NEW')
+f.close()
+`)
+    await drain()
+    expect(attrs.map(([path]) => path)).toEqual([])
+  })
+
+  // Emscripten finalizes a new file with a chmod of its own, on the same
+  // callback a guest's chmod arrives on. Journaling it would send a
+  // metadata write nobody asked for, store the filesystem's default mode
+  // over the mount's, and split the two coalesced writes a create makes.
+  it('does not journal a metadata write for a created file', async () => {
+    const p = prefix()
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+f = open('${p}fresh.txt', 'wb')
+f.write(b'hi')
+f.close()
+`)
+    await drain()
+    expect(attrs).toEqual([])
+    expect(dec.decode(store.get(`${p}fresh.txt`))).toBe('hi')
+  })
+
+  // The marker that suppresses the create's own chmod must not swallow
+  // the guest's next one.
+  it('still sends a chmod made right after a create', async () => {
+    const p = prefix()
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+import os
+open('${p}made.txt', 'wb').close()
+os.chmod('${p}made.txt', 0o640)
+`)
+    await drain()
+    expect(attrs).toEqual([[`${p}made.txt`, { mode: 0o640 }]])
+  })
+
+  it('sends a guest chmod to the mount as permission bits', async () => {
+    const p = prefix()
+    store.set(`${p}moded.txt`, enc.encode('x'))
+    await mountPrefix(p)
+    await py.runPythonAsync(`
+import os
+os.chmod('${p}moded.txt', 0o600)
+`)
+    await drain()
+    expect(attrs).toEqual([[`${p}moded.txt`, { mode: 0o600 }]])
+  })
+})
+
+// The comparison half of the same decision: Emscripten bumps a stamp on
+// writes that change nothing, and a mount should not hear about those.
+describe('changedAttrs', () => {
+  const nodeAt = (mode: number, atime: number, mtime: number): FSNode =>
+    ({ mode, atime, mtime }) as FSNode
+
+  it('answers null when nothing moved', () => {
+    const node = nodeAt(0o100644, 1000, 2000)
+    expect(changedAttrs(node, { mode: 0o100644, atime: 1000, mtime: 2000 })).toBeNull()
+  })
+
+  it('reports permission bits only, without the type bits', () => {
+    const node = nodeAt(0o100644, 0, 0)
+    expect(changedAttrs(node, { mode: 0o100600 })).toEqual({ mode: 0o600 })
+  })
+
+  it('renders each stamp as ISO from epoch milliseconds', () => {
+    const node = nodeAt(0o100644, 0, 0)
+    expect(changedAttrs(node, { atime: 100_000, mtime: 200_000 })).toEqual({
+      atime: '1970-01-01T00:01:40Z',
+      mtime: '1970-01-01T00:03:20Z',
+    })
+  })
+
+  // No POSIX call sets ctime, so a mount has nothing to write it to.
+  it('never reports ctime, and never reports size as metadata', () => {
+    const node = nodeAt(0o100644, 0, 0)
+    expect(changedAttrs(node, { ctime: 5, size: 9 })).toBeNull()
   })
 })

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.ts
@@ -13,7 +13,9 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { NO_WRITE, planFlush } from '../../handles/index.ts'
-import { BLKSIZE, SEEK_CUR, SEEK_END } from './constants.ts'
+import { epochToIso } from '../../../utils/dates.ts'
+import type { SetAttrFields } from '../../../types.ts'
+import { BLKSIZE, LINK_MODE, SEEK_CUR, SEEK_END } from './constants.ts'
 import { errnoError } from './errors.ts'
 import type { MutationJournal } from './journal.ts'
 import type { MirageFsSeed } from './seed.ts'
@@ -29,6 +31,44 @@ import type {
   SetAttr,
   StreamOps,
 } from './types.ts'
+
+const ENC = new TextEncoder()
+
+/**
+ * The metadata a `setattr` actually changes, or null when it changes
+ * none of it.
+ *
+ * Emscripten hands this callback more than a guest's chmod and utime:
+ * a stamp arrives beside a resize and beside a mode, and a write that
+ * moved no field would still journal an op. Sending one costs a
+ * dispatch and, worse, splits two writes the journal would otherwise
+ * coalesce. Comparing against the node costs one read.
+ *
+ * The one case comparing cannot catch is a create, whose finalizing
+ * chmod does lower a real mode; `MirageFs.fresh` is what suppresses
+ * that one.
+ *
+ * `ctime` is never included: no POSIX call sets it directly, so a mount
+ * has nothing to write it to. `size` is not metadata here either, it is
+ * the resize branch's bytes.
+ *
+ * Args:
+ *   node: the node as it stands before the write.
+ *   attr: the fields Emscripten passed, times as epoch ms.
+ */
+export function changedAttrs(node: FSNode, attr: SetAttr): SetAttrFields | null {
+  const fields: SetAttrFields = {}
+  if (attr.mode !== undefined && (attr.mode & 0o7777) !== (node.mode & 0o7777)) {
+    fields.mode = attr.mode & 0o7777
+  }
+  if (attr.atime !== undefined && attr.atime !== node.atime) {
+    fields.atime = epochToIso(attr.atime / 1000)
+  }
+  if (attr.mtime !== undefined && attr.mtime !== node.mtime) {
+    fields.mtime = epochToIso(attr.mtime / 1000)
+  }
+  return Object.keys(fields).length === 0 ? null : fields
+}
 
 /**
  * An Emscripten filesystem backed by a mirage mount.
@@ -56,6 +96,10 @@ export class MirageFs {
   private readonly journal: MutationJournal
   private readonly tree: NodeTree
   private readonly mountOf: (path: string) => string | null
+  // The file node FS.open just created, whose finalizing chmod is the
+  // filesystem's own and not a guest metadata write. Cleared by the
+  // first setattr, so it can never outlive the create it belongs to.
+  private fresh: FSNode | null = null
 
   /**
    * Args:
@@ -89,6 +133,7 @@ export class MirageFs {
       rmdir: this.rmdir.bind(this),
       readdir: this.readdir.bind(this),
       symlink: this.symlink.bind(this),
+      readlink: this.readlink.bind(this),
     }
     const streamOps: StreamOps = {
       open: this.streamOpen.bind(this),
@@ -112,7 +157,13 @@ export class MirageFs {
   }
 
   private getattr(node: FSNode): FSAttr {
-    const size = this.host.isDir(node.mode) ? BLKSIZE : (node.usedBytes ?? 0)
+    // A link sizes as its target string, which is what lstat reports on
+    // every POSIX system and what MEMFS answers for its own links.
+    const size = this.host.isLink(node.mode)
+      ? ENC.encode(node.link ?? '').length
+      : this.host.isDir(node.mode)
+        ? BLKSIZE
+        : (node.usedBytes ?? 0)
     return {
       dev: 1,
       ino: node.id,
@@ -131,10 +182,24 @@ export class MirageFs {
   }
 
   private setattr(node: FSNode, attr: SetAttr): void {
+    // Read the changes before applying them, and only outside a create:
+    // the same callback carries a guest's chmod and the chmod Emscripten
+    // itself performs to finalize a new file, and the two are the same
+    // shape. `fresh` is what tells them apart; the comparison then drops
+    // a stamp write that changes nothing.
+    const finalizing = this.fresh === node
+    this.fresh = null
+    const fields = finalizing ? null : changedAttrs(node, attr)
     if (attr.mode !== undefined) node.mode = attr.mode
     if (attr.atime !== undefined) node.atime = attr.atime
     if (attr.mtime !== undefined) node.mtime = attr.mtime
     if (attr.ctime !== undefined) node.ctime = attr.ctime
+    if (fields !== null) {
+      // A link's own attrs go to the link, since the tree resolved to
+      // the link node itself and the target's row is not what changed.
+      if (this.host.isLink(node.mode)) fields.nofollow = true
+      this.journal.markSetattr(this.tree.pathOf(node), fields)
+    }
     if (attr.size === undefined) return
     const old = node.contents ?? new Uint8Array(0)
     const next = new Uint8Array(attr.size)
@@ -161,10 +226,17 @@ export class MirageFs {
     node.rdev = rdev
     const path = this.tree.pathOf(node)
     if (this.host.isDir(mode)) this.journal.markMkdir(path)
-    // An empty write is what carries a file that is created and never
-    // written (`Path.touch()`, `open(p,'w').close()`) through to the
-    // mount. A later close for the same path coalesces over it.
-    else this.journal.markWrite(path, new Uint8Array(0))
+    else {
+      // An empty write is what carries a file that is created and never
+      // written (`Path.touch()`, `open(p,'w').close()`) through to the
+      // mount. A later close for the same path coalesces over it.
+      this.journal.markWrite(path, new Uint8Array(0))
+      // FS.open finalizes a new file with a chmod of its own, right
+      // here and on this node. Only a file is marked: a directory gets
+      // no such call, so a marker left on one would swallow the guest's
+      // next chmod instead.
+      this.fresh = node
+    }
     return node
   }
 
@@ -198,11 +270,35 @@ export class MirageFs {
     return ['.', '..', ...this.tree.childNames(node)]
   }
 
-  private symlink(): FSNode {
-    // Links are namespace state in mirage, not backend state, so no mount
-    // op can express one. Refusing is honest; MEMFS would accept it and
-    // the link would vanish at the end of the run.
-    throw errnoError(this.host, this.errno, 'EPERM')
+  /**
+   * Create a symlink node and record it for the mounts.
+   *
+   * A link is namespace state, which is exactly why this can be served:
+   * the op reaches the node table rather than a backend, so a link lands
+   * on an s3 or notion mount whose store has no such thing. The target
+   * is stored as typed and never resolved here.
+   *
+   * Args:
+   *   parent: directory the link is created in.
+   *   name: the link's own name.
+   *   target: what it points at, verbatim.
+   */
+  private symlink(parent: FSNode, name: string, target: string): FSNode {
+    const node = this.tree.makeNode(parent, name, LINK_MODE)
+    node.link = target
+    this.journal.markSymlink(this.tree.pathOf(node), target)
+    return node
+  }
+
+  /**
+   * The target of a symlink node.
+   *
+   * Args:
+   *   node: the node to read.
+   */
+  private readlink(node: FSNode): string {
+    if (!this.host.isLink(node.mode)) throw errnoError(this.host, this.errno, 'EINVAL')
+    return node.link ?? ''
   }
 
   private streamOpen(stream: FSStream): void {

--- a/typescript/packages/core/src/runtime/types.ts
+++ b/typescript/packages/core/src/runtime/types.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { IOResult, OpReport } from '../io/types.ts'
-import type { PathSpec } from '../types.ts'
+import type { PathSpec, SetAttrFields } from '../types.ts'
 import type { RuntimeConfig } from './config.ts'
 import type { PolicyScript } from './policy/types.ts'
 
@@ -68,6 +68,10 @@ export type DispatchFn = (
 /**
  * The narrow bridge a sandboxed guest's file I/O rides: fixed op names,
  * string paths, positional payloads (the guest cannot build PathSpecs).
+ *
+ * `dst` carries a rename's destination and a symlink's target: both are
+ * the op's second string, and a link target is stored verbatim rather
+ * than resolved, so there is nothing a second slot would say.
  */
 export type BridgeDispatchFn = (
   op:
@@ -81,10 +85,14 @@ export type BridgeDispatchFn = (
     | 'unlink'
     | 'mkdir'
     | 'rmdir'
-    | 'rename',
+    | 'rename'
+    | 'symlink'
+    | 'readlink'
+    | 'setattr',
   path: string,
   bytes?: Uint8Array,
   dst?: string,
+  attrs?: SetAttrFields,
 ) => Promise<unknown>
 
 /**

--- a/typescript/packages/core/src/runtime/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/vfs.test.ts
@@ -53,6 +53,36 @@ describe('RuntimeVFS transport', () => {
     expect(entries[0]).toEqual({ path: '/ram/a.txt', size: 4, isDir: false })
   })
 
+  // The target rides the `dst` slot: it is the op's second string and a
+  // link stores it verbatim, so there is nothing a separate slot would
+  // say.
+  it('forwards symlink to dispatch symlink with the target', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve(undefined))
+    await new RuntimeVFS(dispatch).symlink('/ram/link', '../t.txt')
+    expect(dispatch).toHaveBeenCalledWith('symlink', '/ram/link', undefined, '../t.txt')
+  })
+
+  it('forwards readlink and returns the target', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve('../t.txt'))
+    const out = await new RuntimeVFS(dispatch).readlink('/ram/link')
+    expect(dispatch).toHaveBeenCalledWith('readlink', '/ram/link')
+    expect(out).toBe('../t.txt')
+  })
+
+  it('refuses a readlink answer that is not a string', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve(7))
+    await expect(new RuntimeVFS(dispatch).readlink('/ram/link')).rejects.toThrow(/expected string/)
+  })
+
+  it('forwards setattr with the fields it was given', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.resolve(undefined))
+    await new RuntimeVFS(dispatch).setattr('/ram/f', { mode: 0o600, nofollow: true })
+    expect(dispatch).toHaveBeenCalledWith('setattr', '/ram/f', undefined, undefined, {
+      mode: 0o600,
+      nofollow: true,
+    })
+  })
+
   it('rethrows dispatch errors', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() => Promise.reject(new Error('boom')))
     await expect(new RuntimeVFS(dispatch).read('/x')).rejects.toThrow(/boom/)

--- a/typescript/packages/core/src/runtime/vfs.ts
+++ b/typescript/packages/core/src/runtime/vfs.ts
@@ -18,6 +18,7 @@ import { normDir } from '../utils/slash.ts'
 import { planFlush } from './handles/index.ts'
 import { PrefixResolver, type MountResolver } from './resolver.ts'
 import type { BridgeDispatchFn } from './types.ts'
+import type { SetAttrFields } from '../types.ts'
 
 /** One directory entry as the mounts report it. */
 export interface VFSEntry {
@@ -35,6 +36,11 @@ export interface VFSStat {
   size: number
   isDir: boolean
   mtimeMs: number
+  // The full st_mode, type bits included, so a chmod the shell made is
+  // what a guest's stat reports. A guest that has no mode field on its
+  // own wire (preview1's filestat carries only a filetype) reads the
+  // type bits and drops the rest.
+  mode: number
 }
 
 export function concatBytes(head: Uint8Array, tail: Uint8Array): Uint8Array {
@@ -48,8 +54,11 @@ export function concatBytes(head: Uint8Array, tail: Uint8Array): Uint8Array {
  * The mount-facing op vocabulary a sandboxed runtime encodes into.
  *
  * One instruction set (read/write/append/stat/readdir/create/truncate/
- * unlink/mkdir/rmdir/rename), one routing table, one place that knows
- * an append may have to become a whole-file write. Encoders hold one of these; they
+ * unlink/mkdir/rmdir/rename/symlink/readlink/setattr), one routing
+ * table, one place that knows an append may have to become a
+ * whole-file write. The last three reach the name plane rather than a
+ * backend, which is what lets a guest create a link or stamp a time on
+ * a mount whose store has neither. Encoders hold one of these; they
  * never inherit it, because a monty encoder is the binding's own `os`
  * callback and a quickjs encoder is a table of host functions.
  *
@@ -117,7 +126,8 @@ export class RuntimeVFS {
       typeof st !== 'object' ||
       typeof st.size !== 'number' ||
       typeof st.isDir !== 'boolean' ||
-      typeof st.mtimeMs !== 'number'
+      typeof st.mtimeMs !== 'number' ||
+      typeof st.mode !== 'number'
     ) {
       throw new TypeError(`runtime vfs: stat ${path} bad shape`)
     }
@@ -186,6 +196,54 @@ export class RuntimeVFS {
   async rename(src: string, dst: string): Promise<void> {
     if (this.mountOf(src) !== this.mountOf(dst)) throw new CrossMountError(src, dst)
     await this.dispatch('rename', src, undefined, dst)
+  }
+
+  /**
+   * Create a namespace symlink at `path` pointing at `target`.
+   *
+   * A link is namespace state, so no backend stores one and the target
+   * is kept verbatim as the guest typed it. The dispatcher answers this
+   * op from the node table itself, which is why a runtime can serve
+   * `os.symlink` at all: the door a surface already holds reaches the
+   * name plane, not just a mount.
+   *
+   * Args:
+   *   path: guest-absolute path of the link to create.
+   *   target: link target, stored as typed.
+   */
+  async symlink(path: string, target: string): Promise<void> {
+    await this.dispatch('symlink', path, undefined, target)
+  }
+
+  /**
+   * The target of the symlink at `path`.
+   *
+   * Throws EINVAL when `path` is not a link, which is what the node
+   * table answers and what POSIX readlink says.
+   */
+  async readlink(path: string): Promise<string> {
+    const out = await this.dispatch('readlink', path)
+    if (typeof out !== 'string') {
+      throw new TypeError(`runtime vfs: readlink ${path} expected string, got ${typeof out}`)
+    }
+    return out
+  }
+
+  /**
+   * Write metadata fields, natively where the backend can hold them.
+   *
+   * The door reads the whole set and stores in the namespace overlay
+   * whatever the backend cannot keep, so a mount with no setattr op
+   * still answers: a utime on an s3 or dropbox mount lands in the name
+   * plane and stat reports it back. Stored, not enforced; the mount
+   * mode is the access control.
+   *
+   * Args:
+   *   path: guest-absolute virtual path.
+   *   attrs: the fields to write, unset ones omitted.
+   */
+  async setattr(path: string, attrs: SetAttrFields): Promise<void> {
+    await this.dispatch('setattr', path, undefined, undefined, attrs)
   }
 
   /**

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -378,6 +378,26 @@ export type FileType = (typeof FileType)[keyof typeof FileType]
 // target travels with the stat row.
 export const LINK_TARGET_KEY = 'link_target'
 
+/**
+ * The metadata fields a `setattr` writes, all optional.
+ *
+ * Spelled the way the op, the CommandOpts bag and the guest bridge
+ * spell them, so one fact keeps one name from a shell line down to a
+ * guest's utime. `nofollow` is not a field but the AT_SYMLINK_NOFOLLOW
+ * bit: it writes the link entry's own attrs rather than its target's.
+ * Lives here rather than beside either consumer because the ops facade
+ * and the runtime bridge both take it and neither may import the
+ * other.
+ */
+export interface SetAttrFields {
+  mode?: number
+  uid?: number | string
+  gid?: number | string
+  atime?: string
+  mtime?: string
+  nofollow?: boolean
+}
+
 export interface FileStatInit {
   name: string
   size?: number | null

--- a/typescript/packages/core/src/utils/errors.ts
+++ b/typescript/packages/core/src/utils/errors.ts
@@ -166,6 +166,21 @@ export function isNoMount(err: unknown): boolean {
   return (err as { noMount?: unknown }).noMount === true
 }
 
+// What an existence probe reads as "nothing here": the path is absent, or
+// a component of it is not traversable. Wider than isMissingPath below,
+// which is the ENOENT-only swallow set, and still deliberately narrower
+// than a walk's tolerance, because a permission or missing-capability
+// error is not absence and mapping it to one would report a path that
+// exists as missing. Mirrors python MISS_ERRORS, and lives here for the
+// same reason that tuple does: the door and the executor's probes both
+// read it and neither may import the other.
+export function isMissError(exc: unknown): boolean {
+  const code = (exc as { code?: string }).code
+  if (code === 'ENOENT' || code === 'ENOTDIR' || code === 'EISDIR') return true
+  const msg = exc instanceof Error ? exc.message : String(exc)
+  return /not found|no such file|not a directory|is a directory/i.test(msg)
+}
+
 // True when the error means the path is simply not there: a stamped ENOENT,
 // or a path outside every mount. This is the whole swallow set for the
 // exists-family probes, mirroring Python's `(FileNotFoundError, ValueError)`.

--- a/typescript/packages/core/src/utils/errors.ts
+++ b/typescript/packages/core/src/utils/errors.ts
@@ -299,6 +299,12 @@ export function isEisdir(err: unknown): boolean {
   return err instanceof Error && (err as Error & { code?: string }).code === 'EISDIR'
 }
 
+// Python's twin is `except FileExistsError`: the name is taken, which is
+// the door's answer to a create that will not overwrite (symlink(2)).
+export function isEexist(err: unknown): boolean {
+  return err instanceof Error && (err as Error & { code?: string }).code === 'EEXIST'
+}
+
 // Python's twin is `except PermissionError`: a refusal (a rule at the
 // command guard or the op door, a read-only mount), which a walk reports
 // per entry the way GNU reports an unreadable one.

--- a/typescript/packages/core/src/utils/stat_view.test.ts
+++ b/typescript/packages/core/src/utils/stat_view.test.ts
@@ -15,7 +15,16 @@
 import { describe, expect, it } from 'vitest'
 
 import { FileStat, FileType } from '../types.ts'
-import { contentSize, DIR_MODE, FILE_MODE, isDir, mtimeMs } from './stat_view.ts'
+import {
+  contentSize,
+  DIR_MODE,
+  FILE_MODE,
+  isDir,
+  isLink,
+  LINK_MODE,
+  mtimeMs,
+  posixMode,
+} from './stat_view.ts'
 
 const NAIVE = '2026-01-02T03:04:05'
 // Date.UTC is TZ-independent, so this pin fails under a local-time
@@ -72,5 +81,33 @@ describe('mode constants', () => {
   it('carry the POSIX type bits', () => {
     expect(DIR_MODE).toBe(0o040755)
     expect(FILE_MODE).toBe(0o100644)
+  })
+})
+
+describe('posixMode', () => {
+  it('keeps the default pair when the backend reports no mode', () => {
+    const dir = new FileStat({ name: 'd', type: FileType.DIRECTORY })
+    const file = new FileStat({ name: 'f', type: FileType.TEXT })
+    expect(posixMode(dir)).toBe(DIR_MODE)
+    expect(posixMode(file)).toBe(FILE_MODE)
+  })
+
+  it('takes the permission bits from the overlay and the type bits from the kind', () => {
+    const st = new FileStat({ name: 'f', type: FileType.TEXT, mode: 0o600 })
+    expect(posixMode(st)).toBe((FILE_MODE & ~0o7777) | 0o600)
+  })
+
+  // No POSIX system consults the bits on a symlink, so a chmod -h that
+  // stored some is not what a stat consumer is told.
+  it('reports a link as lrwxrwxrwx whatever the overlay holds', () => {
+    const st = new FileStat({ name: 'l', type: FileType.SYMLINK, mode: 0o600 })
+    expect(posixMode(st)).toBe(LINK_MODE)
+  })
+})
+
+describe('isLink', () => {
+  it('reads the kind', () => {
+    expect(isLink(new FileStat({ name: 'l', type: FileType.SYMLINK }))).toBe(true)
+    expect(isLink(new FileStat({ name: 'f', type: FileType.TEXT }))).toBe(false)
   })
 })

--- a/typescript/packages/core/src/utils/stat_view.ts
+++ b/typescript/packages/core/src/utils/stat_view.ts
@@ -20,8 +20,13 @@ import { isoTimestamp } from './dates.ts'
 // st_mode); mirrors mirage/utils/stat_view.py.
 const S_IFDIR = 0o040000
 const S_IFREG = 0o100000
+const S_IFLNK = 0o120000
 export const DIR_MODE = S_IFDIR | 0o755
 export const FILE_MODE = S_IFREG | 0o644
+// A link is always lrwxrwxrwx: the bits on a symlink are not consulted
+// by any POSIX system, so this is the one mode every translator reports
+// for one (the FUSE attr fold, find's -type l row, a guest's lstat).
+export const LINK_MODE = S_IFLNK | 0o777
 
 /**
  * A FileStat's mtime as epoch milliseconds, null when unknown.
@@ -43,6 +48,33 @@ export function mtimeMs(st: FileStat): number | null {
 /** Whether a FileStat describes a directory. */
 export function isDir(st: FileStat): boolean {
   return st.type === FileType.DIRECTORY
+}
+
+/** Whether a FileStat describes a symlink. */
+export function isLink(st: FileStat): boolean {
+  return st.type === FileType.SYMLINK
+}
+
+/**
+ * The st_mode a stat consumer should report for one FileStat.
+ *
+ * The type bits come from the entry's kind and the permission bits from
+ * the namespace overlay when a chmod put one there, which is what makes
+ * a metadata write visible to a guest and to a mount alike. A backend
+ * that reports no mode keeps the default rw-r--r-- / rwxr-xr-x pair;
+ * there are no permissions to read on an object store.
+ *
+ * A link is the exception in both halves: its type bits are S_IFLNK and
+ * its permission bits are always 0777, because no POSIX system consults
+ * the bits on a symlink. An overlay mode a `chmod -h` wrote is
+ * therefore not reported here (ownership is, since `chown -h` does
+ * change what `ls -l` shows). Mirrors python's posix_mode.
+ */
+export function posixMode(st: FileStat): number {
+  if (isLink(st)) return LINK_MODE
+  const base = isDir(st) ? DIR_MODE : FILE_MODE
+  if (st.mode === null) return base
+  return (base & ~0o7777) | (st.mode & 0o7777)
 }
 
 /**

--- a/typescript/packages/core/src/workspace/dispatcher/constants.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/constants.ts
@@ -49,6 +49,14 @@ export const POLICY_WRITE_OPS: ReadonlySet<string> = new Set([
 // directions (create and readlink) rather than a router to a mount.
 export const NAMESPACE_TABLE_OPS: ReadonlySet<string> = new Set(['symlink', 'readlink'])
 
+// Ops the node table answers when the path itself is a link, and only
+// then. The name is the whole of what exists there, so forwarding one
+// reaches a backend that has never heard of it: an unlink answered
+// ENOENT with the link still in the table, and a rename moved nothing.
+// `stat` joins them only under `nofollow`, which is how a caller spells
+// lstat; a following stat arrives already resolved to its target.
+export const LINK_ENTRY_OPS: ReadonlySet<string> = new Set(['unlink', 'rename', 'stat'])
+
 // The attribute fields a setattr op can carry, in one place so the
 // requested/residual split and the overlay write read the same names.
 export const SETATTR_KEYS = ['mode', 'uid', 'gid', 'atime', 'mtime'] as const

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
@@ -148,3 +148,85 @@ describe('unlink of a namespace link', () => {
     }
   })
 })
+
+describe('the node table answers every verb that names a link', () => {
+  async function linkWorkspace(): Promise<Workspace> {
+    const parser = await getTestParser()
+    const ram = new RAMResource()
+    const ws = new Workspace(
+      { '/ram': ram },
+      { mode: MountMode.WRITE, shellParserFactory: () => Promise.resolve(parser) },
+    )
+    await ws.execute('echo hi > /ram/a.txt')
+    await ws.execute('mkdir /ram/d')
+    await ws.execute('ln -s a.txt /ram/link')
+    return ws
+  }
+
+  it('renames the link, which no backend can see', async () => {
+    // Same fact as the unlink above, one verb along: a guest's rename of
+    // a link forwarded to a backend that had never heard of the name, so
+    // it answered ENOENT with the link still under the old one.
+    const ws = await linkWorkspace()
+    try {
+      await ws.dispatch('rename', '/ram/link', [PathSpec.fromStrPath('/ram/moved')])
+      expect(DEC.decode((await ws.execute('readlink /ram/moved')).stdout)).toBe('a.txt\n')
+      expect((await ws.execute('readlink /ram/link')).exitCode).toBe(1)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('answers a no-follow stat with the link row', async () => {
+    // lstat asks for the row only the node table holds; a following stat
+    // arrives resolved to the target and must not see a link at all.
+    const ws = await linkWorkspace()
+    try {
+      const row = (await ws.dispatch('stat', '/ram/link', [], { nofollow: true })) as {
+        type: string
+        size: number
+      }
+      expect(row.type).toBe('symlink')
+      expect(row.size).toBe('a.txt'.length)
+      const followed = (await ws.dispatch('stat', '/ram/link')) as { type: string }
+      expect(followed.type).not.toBe('symlink')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('replaces a link that sits at a rename destination', async () => {
+    // rename(2) replaces the destination. A link left in the table there
+    // shadowed the file that had just landed: the listing showed the new
+    // file, every read followed the old link, and the moved content was
+    // reachable under no name at all. mv did this right at the command
+    // tier, so only the surfaces below it (a guest, a kernel mount) saw
+    // the broken state.
+    const ws = await linkWorkspace()
+    try {
+      await ws.dispatch('rename', '/ram/a.txt', [PathSpec.fromStrPath('/ram/link')])
+      expect(DEC.decode((await ws.execute('cat /ram/link')).stdout)).toBe('hi\n')
+      expect((await ws.execute('readlink /ram/link')).exitCode).toBe(1)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('refuses a symlink onto a name that is taken', async () => {
+    // symlink(2) is EEXIST on an occupied name, and only the door can
+    // tell: a file and a directory are the backend's, a link is the node
+    // table's, and a mount root is the registry's. Unchecked, the node
+    // went on top and buried whatever was there.
+    const ws = await linkWorkspace()
+    try {
+      for (const occupied of ['/ram/a.txt', '/ram/d', '/ram/link', '/ram']) {
+        await expect(
+          ws.dispatch('symlink', occupied, [], { target: 'elsewhere' }),
+        ).rejects.toMatchObject({ code: 'EEXIST' })
+      }
+      expect(DEC.decode((await ws.execute('cat /ram/a.txt')).stdout)).toBe('hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -19,8 +19,17 @@ import { CacheManager } from '../../cache/manager.ts'
 import { applyOpLimit, runWithTimeout } from '../../commands/builtin/utils/limit.ts'
 import { getExtension } from '../../commands/resolve.ts'
 import { IOResult, type OpReport } from '../../io/types.ts'
-import { eacces, eaccesReadOnly, einval, enoent } from '../../utils/errors.ts'
-import { Policies, postOpsGate, preOpsGate } from '../../policy/index.ts'
+import {
+  eacces,
+  eaccesReadOnly,
+  einval,
+  enoent,
+  isMissError,
+  isMissingOp,
+  type FsError,
+} from '../../utils/errors.ts'
+import { Policies, PolicyDenied, postOpsGate, preOpsGate } from '../../policy/index.ts'
+import { PolicyError } from '../../policy/errors.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import { ownerPrefix, rstripSlash } from '../../utils/slash.ts'
 import { record, runWithMountPrefix, runWithRevisions } from '../../observe/context.ts'
@@ -436,7 +445,7 @@ export class Dispatcher {
       result = null
     } else {
       const found = this.namespace.readlink(path.virtual)
-      if (found === null) throw einval(path)
+      if (found === null) throw await this.readlinkMiss(path)
       target = found
       result = found
     }
@@ -451,6 +460,109 @@ export class Dispatcher {
     const bound = await postOpsGate(this.policies, opName, path, write, owner ?? '', result)
     if (bound !== null) return (await applyOpLimit(result, bound)) as string | null
     return result
+  }
+
+  /**
+   * The error a readlink of something that is not a link answers.
+   *
+   * readlink(2) splits the two misses and callers read them differently:
+   * a path that is there but is not a link is EINVAL, and one that is
+   * not there at all is ENOENT, which is the code a guest's
+   * `except FileNotFoundError` catches. The node table only knows the
+   * first half, so absence is probed here and only here, on the failure
+   * path, where one extra round trip buys the right errno. Mirrors
+   * Python's Dispatcher._readlink_miss.
+   */
+  private async readlinkMiss(path: PathSpec): Promise<FsError> {
+    return (await this.pathPresent(path)) ? einval(path) : enoent(path)
+  }
+
+  /**
+   * Whether anything at all is at `path`, on every channel.
+   *
+   * Absence takes both channels a backend can answer on: on a prefix
+   * store a directory is not an object but the set of keys under it, so
+   * `stat` misses what `readdir` would list, and a listing has to be
+   * non-empty to count because those stores answer a missing prefix with
+   * `[]`. The namespace is asked first, since a directory that exists
+   * only because a mount or a link sits below it is structure no backend
+   * can see. Mirrors `resolvePathStat`, which cannot be reused here: it
+   * dispatches, and the door is what dispatch is inside of. Mirrors
+   * Python's Dispatcher._path_present.
+   */
+  private async pathPresent(path: PathSpec): Promise<boolean> {
+    if (namespaceStat(this.namespace.mountPrefixes(), this.namespace, path.virtual) !== null) {
+      return true
+    }
+    let resolved: [Resource, PathSpec, MountMode]
+    try {
+      resolved = await this.namespace.resolve(path.virtual, false)
+    } catch {
+      // No mount serves the path and the namespace knows no structure
+      // there, which is exactly the absence being probed for.
+      return false
+    }
+    try {
+      if ((await this.probeOp('stat', resolved)) !== null) return true
+      const entries = await this.probeOp('readdir', resolved)
+      return Array.isArray(entries) && entries.length > 0
+    } catch (err) {
+      if (!(err instanceof PolicyDenied) && !(err instanceof PolicyError)) throw err
+      // A channel that refuses to answer is not evidence of absence.
+      // Reporting "present" keeps the answer at the EINVAL every miss
+      // gave before the split, which asserts nothing the policy is
+      // withholding; reporting absence would assert a fact this door was
+      // not allowed to check.
+      return true
+    }
+  }
+
+  /**
+   * Run one read op for a probe, or null when it found nothing.
+   *
+   * The probe reads on the caller's behalf but not at its request, so it
+   * passes the same admission gate the op would at the door: a policy
+   * that denies `stat` must not be reachable through a readlink. That
+   * refusal is raised, not swallowed, because only the caller knows what
+   * to answer when a channel goes dark.
+   *
+   * The index and the path's filetype are the two kwargs that decide
+   * which registered op answers, so a probe that omitted them would ask
+   * a different question than the door does and report a rendered path
+   * as absent. Python needs no twin of that half: its dispatcher routes
+   * through `Mount.execute_op`, which stamps both itself.
+   *
+   * Args:
+   *   opName: the op to run, `stat` or `readdir`.
+   *   resolved: what the namespace resolved the path to.
+   */
+  private async probeOp(
+    opName: string,
+    resolved: [Resource, PathSpec, MountMode],
+  ): Promise<unknown> {
+    const [resource, scope] = resolved
+    const mount = this.namespace.tryMountFor(scope.virtual)
+    await preOpsGate(this.policies, opName, scope, false, mount?.prefix ?? '', sessionId())
+    const filetype = getExtension(scope.virtual)
+    try {
+      return await this.opsRegistry.call(
+        opName,
+        resource.kind,
+        resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+        scope,
+        [],
+        {
+          ...(resource.index !== undefined ? { index: resource.index } : {}),
+          ...(filetype !== null ? { filetype } : {}),
+        },
+      )
+    } catch (err) {
+      // The "nothing here" set exactly, plus a backend with no such op:
+      // a miss on one channel is not absence on its own, so the caller
+      // tries the other.
+      if (isMissError(err) || isMissingOp(err, opName)) return null
+      throw err
+    }
   }
 
   /**

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -22,6 +22,7 @@ import { IOResult, type OpReport } from '../../io/types.ts'
 import {
   eacces,
   eaccesReadOnly,
+  eexist,
   einval,
   enoent,
   isMissError,
@@ -51,6 +52,7 @@ import {
   DISPATCH_READ_OPS,
   DISPATCH_WRITE_OPS,
   HIDDEN_CREATE_OPS,
+  LINK_ENTRY_OPS,
   NAMESPACE_TABLE_OPS,
   POLICY_WRITE_OPS,
   SETATTR_KEYS,
@@ -185,15 +187,11 @@ export class Dispatcher {
     if (opName === 'rename' && dstArg instanceof PathSpec && !pathAllowed(dstArg.virtual)) {
       throw eacces(dstArg.virtual)
     }
-    // An unlink of a link is the removal half of `symlink`, and the door owns
-    // both: a link has no backend entry, so forwarding it reaches a backend
-    // that has never heard of the name and answers ENOENT with the link still
-    // there. An unlink of anything else is an ordinary backend write.
-    if (
-      NAMESPACE_TABLE_OPS.has(opName) ||
-      (opName === 'unlink' && this.namespace.isLink(path.virtual))
-    ) {
-      return [await this.namespaceTableOp(opName, path, kwargs ?? {}, report), new IOResult()]
+    if (this.tableAnswers(opName, path.virtual, kwargs)) {
+      return [
+        await this.namespaceTableOp(opName, path, args ?? [], kwargs ?? {}, report),
+        new IOResult(),
+      ]
     }
     // `nofollow` is the caller's AT_SYMLINK_NOFOLLOW: an op that acts on
     // a link entry itself (chown -h writing the link's own attrs) keeps
@@ -395,6 +393,12 @@ export class Dispatcher {
       await this.invalidateAfterWriteByPath(p.virtual, observed)
       if (renameDst !== null) {
         await this.invalidateAfterWriteByPath(renameDst.virtual)
+        // rename(2) replaces the destination, so a node the table holds
+        // at that name does not survive the move. A link left there
+        // shadowed the file that had just landed: the listing showed the
+        // new file, every read followed the old link, and the moved
+        // content was reachable under no name at all.
+        await this.namespace.unlink(renameDst.virtual)
       }
     }
     if (opName === 'stat' && result instanceof FileStat) {
@@ -411,38 +415,84 @@ export class Dispatcher {
   }
 
   /**
+   * Whether the node table answers this op instead of a backend.
+   *
+   * `symlink` and `readlink` always, because a link exists nowhere else.
+   * The rest only when the path itself is a link, and then for the same
+   * reason the create and the read are the door's: forwarding reaches a
+   * backend that has never heard of the name. A no-follow stat is the
+   * read half of that fact (lstat asks for the link's own row, which
+   * only the table holds); a following stat never arrives here, since
+   * the follow below rewrote it to the target. Mirrors Python's
+   * Dispatcher._table_answers.
+   */
+  private tableAnswers(
+    opName: string,
+    virtual: string,
+    kwargs: Record<string, unknown> | undefined,
+  ): boolean {
+    if (NAMESPACE_TABLE_OPS.has(opName)) return true
+    if (!LINK_ENTRY_OPS.has(opName)) return false
+    if (opName === 'stat' && kwargs?.nofollow !== true) return false
+    return this.namespace.isLink(virtual)
+  }
+
+  /**
    * Answer a node-table op at the door itself, gated like a backend.
    *
    * A symlink is namespace state with no backend behind it, so the door
-   * owns both directions. Admission still fires exactly as for a
-   * backend write: the link's turf is the longest mount prefix above it
+   * owns every verb that names one. Admission still fires exactly as for
+   * a backend write: the link's turf is the longest mount prefix above it
    * (the same ownership rule the link read filter uses), session grants
    * and both gates run, and the write leaves an OpRecord — a scoped
    * kernel mount refuses exactly like a scoped shell. A link above
    * every mount is bare namespace structure and clears the gates with
-   * an empty prefix. Also answers the `unlink` of a path the node table holds
-   * a link for. Mirrors Python's Dispatcher._namespace_table_op.
+   * an empty prefix. Also answers the `unlink`, `rename` and no-follow
+   * `stat` of a path the node table holds a link for. Mirrors Python's
+   * Dispatcher._namespace_table_op.
    */
   private async namespaceTableOp(
     opName: string,
     path: PathSpec,
+    args: readonly unknown[],
     kwargs: OpKwargs,
     report: OpReport | undefined,
-  ): Promise<string | null> {
+  ): Promise<string | FileStat | null> {
     const start = performance.now()
     const owner = ownerPrefix(this.namespace.mountPrefixes(), path.virtual)
     const write = POLICY_WRITE_OPS.has(opName)
     await preOpsGate(this.policies, opName, path, write, owner ?? '', sessionId())
     let target: string
-    let result: string | null
+    let result: string | FileStat | null = null
     if (opName === 'unlink') {
       target = this.namespace.readlink(path.virtual) ?? ''
       await this.namespace.unlink(path.virtual)
-      result = null
+    } else if (opName === 'rename') {
+      target = this.namespace.readlink(path.virtual) ?? ''
+      const dst = args[0]
+      if (!(dst instanceof PathSpec)) throw new Error('rename op requires dst')
+      // The destination is a create there, gated like the source, the
+      // way the backend path gates both ends of a rename. It is then
+      // replaced as rename(2) replaces it: any node the table holds at
+      // that name (a link, an attr overlay) goes.
+      await preOpsGate(this.policies, opName, dst, true, owner ?? '', sessionId())
+      await this.namespace.unlink(dst.virtual)
+      await this.namespace.rename(path.virtual, dst.virtual)
     } else if (opName === 'symlink') {
       target = String(kwargs.target)
+      // symlink(2) refuses an occupied name, and the door is the only
+      // place that can tell: the node table sees a link, and a probe
+      // sees the file or directory a backend holds. Left unchecked, the
+      // new node shadowed live data (the bytes stayed, the name read as
+      // a link) and could bury a mount root, which is the one name a
+      // deployment configured.
+      if (await this.pathPresent(path)) throw eexist(path)
       await this.namespace.symlink(path.virtual, target, Date.now() / 1000)
-      result = null
+    } else if (opName === 'stat') {
+      const row = this.namespace.linkStatAt(path.virtual)
+      if (row === null) throw enoent(path)
+      target = this.namespace.readlink(path.virtual) ?? ''
+      result = row
     } else {
       const found = this.namespace.readlink(path.virtual)
       if (found === null) throw await this.readlinkMiss(path)
@@ -484,13 +534,14 @@ export class Dispatcher {
    * store a directory is not an object but the set of keys under it, so
    * `stat` misses what `readdir` would list, and a listing has to be
    * non-empty to count because those stores answer a missing prefix with
-   * `[]`. The namespace is asked first, since a directory that exists
-   * only because a mount or a link sits below it is structure no backend
-   * can see. Mirrors `resolvePathStat`, which cannot be reused here: it
-   * dispatches, and the door is what dispatch is inside of. Mirrors
-   * Python's Dispatcher._path_present.
+   * `[]`. The namespace is asked first, since a link, and a directory
+   * that exists only because a mount or a link sits below it, are
+   * structure no backend can see. Mirrors `resolvePathStat`, which
+   * cannot be reused here: it dispatches, and the door is what dispatch
+   * is inside of. Mirrors Python's Dispatcher._path_present.
    */
   private async pathPresent(path: PathSpec): Promise<boolean> {
+    if (this.namespace.isLink(path.virtual)) return true
     if (namespaceStat(this.namespace.mountPrefixes(), this.namespace, path.virtual) !== null) {
       return true
     }

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -32,7 +32,7 @@ import {
 import { Policies, PolicyDenied, postOpsGate, preOpsGate } from '../../policy/index.ts'
 import { PolicyError } from '../../policy/errors.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
-import { ownerPrefix, rstripSlash } from '../../utils/slash.ts'
+import { normDir, ownerPrefix, rstripSlash } from '../../utils/slash.ts'
 import { record, runWithMountPrefix, runWithRevisions } from '../../observe/context.ts'
 import type { OpRecord } from '../../observe/record.ts'
 import type { OpsRegistry } from '../../ops/registry.ts'
@@ -41,7 +41,14 @@ import { NO_FOLLOW_OPS, STAMP_WRITE_OPS } from '../../ops/config.ts'
 import { mergeReaddir, namespaceListing, namespaceStat } from '../../ops/namespace_view.ts'
 import { isMissingPath } from '../../utils/errors.ts'
 import { cachesReads, type Resource } from '../../resource/base.ts'
-import { ConsistencyPolicy, FileStat, MountMode, PathSpec, ResourceName } from '../../types.ts'
+import {
+  ConsistencyPolicy,
+  FileStat,
+  FileType,
+  MountMode,
+  PathSpec,
+  ResourceName,
+} from '../../types.ts'
 import type { DispatchFn } from '../../runtime/types.ts'
 import type { DriftQueue } from '../snapshot/drift.ts'
 import type { Namespace } from '../mount/namespace/namespace.ts'
@@ -528,17 +535,23 @@ export class Dispatcher {
   }
 
   /**
-   * Whether anything at all is at `path`, on every channel.
+   * Whether anything at all is at `path`.
    *
-   * Absence takes both channels a backend can answer on: on a prefix
-   * store a directory is not an object but the set of keys under it, so
-   * `stat` misses what `readdir` would list, and a listing has to be
-   * non-empty to count because those stores answer a missing prefix with
-   * `[]`. The namespace is asked first, since a link, and a directory
-   * that exists only because a mount or a link sits below it, are
-   * structure no backend can see. Mirrors `resolvePathStat`, which
-   * cannot be reused here: it dispatches, and the door is what dispatch
-   * is inside of. Mirrors Python's Dispatcher._path_present.
+   * Four channels, asked in the order of what they prove. The namespace
+   * goes first: a link, and a directory that exists only because a
+   * mount or a link sits below it, are structure no backend can see,
+   * and a mount root is the deployment's own configuration. Then the
+   * backend's row, which settles a file. A directory row settles
+   * nothing, because an API tree synthesizes its directories: a
+   * postgres schema lists `tables/` and `views/` before anything has
+   * asked whether that schema is there, and a grouping mount stats
+   * every path under a live collection as a directory. So a directory
+   * is proven the way the hierarchy kit itself proves one, by appearing
+   * in its parent's listing, which is also the only way a prefix store
+   * can answer for a directory that is nothing but a set of keys.
+   * Cannot reuse `resolvePathStat`: that dispatches, and the door is
+   * what dispatch is inside of. Mirrors Python's
+   * Dispatcher._path_present.
    */
   private async pathPresent(path: PathSpec): Promise<boolean> {
     if (this.namespace.isLink(path.virtual)) return true
@@ -553,10 +566,12 @@ export class Dispatcher {
       // there, which is exactly the absence being probed for.
       return false
     }
+    const mount = this.namespace.tryMountFor(path.virtual)
+    if (mount !== null && normDir(mount.prefix) === normDir(path.virtual)) return true
     try {
-      if ((await this.probeOp('stat', resolved)) !== null) return true
-      const entries = await this.probeOp('readdir', resolved)
-      return Array.isArray(entries) && entries.length > 0
+      const row = (await this.probeOp('stat', resolved)) as FileStat | null
+      if (row !== null && row.type !== FileType.DIRECTORY) return true
+      return await this.listedByParent(path)
     } catch (err) {
       if (!(err instanceof PolicyDenied) && !(err instanceof PolicyError)) throw err
       // A channel that refuses to answer is not evidence of absence.
@@ -566,6 +581,33 @@ export class Dispatcher {
       // not allowed to check.
       return true
     }
+  }
+
+  /**
+   * Whether the path's own name is in its parent's listing.
+   *
+   * Compared on the final segment, because backends disagree on entry
+   * shape: bare names, a trailing slash to mark a directory, or full
+   * paths. The same normalization `mergeReaddir` dedupes on. Mirrors
+   * Python's Dispatcher._listed_by_parent.
+   */
+  private async listedByParent(path: PathSpec): Promise<boolean> {
+    const trimmed = rstripSlash(path.virtual)
+    const cut = trimmed.lastIndexOf('/')
+    const name = trimmed.slice(cut + 1)
+    if (cut < 0 || name === '') return false
+    let resolved: [Resource, PathSpec, MountMode]
+    try {
+      resolved = await this.namespace.resolve(trimmed.slice(0, cut) || '/', false)
+    } catch {
+      return false
+    }
+    const entries = await this.probeOp('readdir', resolved)
+    if (!Array.isArray(entries)) return false
+    return entries.some((entry) => {
+      const segments = rstripSlash(String(entry)).split('/')
+      return segments[segments.length - 1] === name
+    })
   }
 
   /**

--- a/typescript/packages/core/src/workspace/executor/builtins/links/links.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/links/links.ts
@@ -15,6 +15,7 @@
 import { SPECS, parseCommand } from '../../../../commands/spec/index.ts'
 import type { FileStat } from '../../../../types.ts'
 import { FileType, PathSpec } from '../../../../types.ts'
+import { isEacces } from '../../../../utils/errors.ts'
 import { CycleError, gnuBasename } from '../../../../utils/path.ts'
 import { rstripSlash } from '../../../../utils/slash.ts'
 import type { DispatchFn } from '../../../../runtime/types.ts'
@@ -232,8 +233,21 @@ export async function prepareMv(
       const early = await slashedLinkRefusal(namespace, dispatch, src, dst, stat)
       return { items, postUnlink: null, postRename: null, early }
     }
-    await namespace.unlink(targetDst)
-    await namespace.rename(src.virtual, targetDst)
+    // The move is a node-table rename, which the door answers: a link
+    // has no backend entry for the generic mv to move. Reaching the
+    // table directly from here would skip the admission gates every
+    // other mv passes, so the dispatch is the point.
+    try {
+      await dispatch('rename', src, [PathSpec.fromStrPath(targetDst)])
+    } catch (err) {
+      // PolicyDenied and a read-only mount both stamp EACCES.
+      if (!isEacces(err)) throw err
+      const early: Result = fail(
+        'mv',
+        `mv: cannot move '${src.rawPath}' to '${dst.rawPath}': Permission denied\n`,
+      )
+      return { items, postUnlink: null, postRename: null, early }
+    }
     const early: Result = ok('mv')
     return { items, postUnlink: null, postRename: null, early }
   }

--- a/typescript/packages/core/src/workspace/executor/builtins/links/ln.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/links/ln.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { PathSpec, wordText } from '../../../../types.ts'
+import { isEexist, isEisdir, isEnoent } from '../../../../utils/errors.ts'
 import { CycleError, gnuDirname } from '../../../../utils/path.ts'
 import { PolicyDenied } from '../../../../policy/index.ts'
 import type { DispatchFn } from '../../../../runtime/types.ts'
@@ -21,11 +22,16 @@ import type { Session } from '../../../session/session.ts'
 import { absPath, fail, ok, splitFlags, type Result } from '../shared.ts'
 import { posixRelative } from './links.ts'
 
-// ln -s TARGET LINK: create a namespace symbolic link. Flags: -f overwrite
-// an existing link, -v report the link, -r store the target relative to the
-// link's directory (GNU --relative). -n (--no-dereference) and -T
-// (--no-target-directory) are accepted no-ops: a namespace link name is
-// never dereferenced nor treated as a directory to descend into.
+// ln -s TARGET LINK: create a namespace symbolic link. Flags: -f remove the
+// destination first (GNU's own algorithm, so it replaces a regular file too),
+// -v report the link, -r store the target relative to the link's directory
+// (GNU --relative). -n (--no-dereference) and -T (--no-target-directory) are
+// accepted no-ops: a namespace link name is never dereferenced nor treated as
+// a directory to descend into.
+// Divergence: GNU reads a directory destination as "link inside it"
+// (`ln -s f.txt d` creates `d/f.txt`), and mirage refuses the name instead.
+// Refusing is the safe half of that gap: the version before the door owned the
+// existence rule buried the directory under a link node.
 export async function handleLn(
   namespace: Namespace,
   dispatch: DispatchFn,
@@ -63,15 +69,36 @@ export async function handleLn(
     }
     targetTyped = posixRelative(targetAbs, linkDir)
   }
-  const exists = namespace.isLink(linkAbs) && !flags.has('f')
-  if (namespace.isMountRoot(linkAbs) || exists) {
+  if (namespace.isMountRoot(linkAbs)) {
     return fail('ln', `ln: failed to create symbolic link '${wordText(linkArg)}': File exists\n`)
   }
+  const linkSpec = PathSpec.fromStrPath(linkAbs)
+  if (flags.has('f')) {
+    // GNU -f is "remove the destination, then link", which is why it
+    // replaces a regular file and not only a link. The door refuses an
+    // occupied name (symlink(2)'s EEXIST), so the removal is what makes
+    // the flag work rather than a formality; a destination that is not
+    // there is what -f is for, so its miss is the expected case and not
+    // an error.
+    try {
+      await dispatch('unlink', linkSpec)
+    } catch (err) {
+      if (isEisdir(err)) {
+        return fail('ln', `ln: ${wordText(linkArg)}: cannot overwrite directory\n`)
+      }
+      if (!isEnoent(err)) throw err
+    }
+  }
   // The write itself is a dispatch op, so session grants and admission
-  // policies fire at the door; a refusal renders in ln's own words.
+  // policies fire at the door; a refusal renders in ln's own words. The
+  // door owns the existence rule (it is the only layer that can see both
+  // the node table and the backend); ln owns the wording.
   try {
-    await dispatch('symlink', PathSpec.fromStrPath(linkAbs), [], { target: targetTyped })
+    await dispatch('symlink', linkSpec, [], { target: targetTyped })
   } catch (err) {
+    if (isEexist(err)) {
+      return fail('ln', `ln: failed to create symbolic link '${wordText(linkArg)}': File exists\n`)
+    }
     if (err instanceof PolicyDenied) {
       return fail(
         'ln',

--- a/typescript/packages/core/src/workspace/executor/builtins/links/probe.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/links/probe.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { FileStat, FileType, PathSpec } from '../../../../types.ts'
+import { isMissError } from '../../../../utils/errors.ts'
 import { gnuBasename } from '../../../../utils/path.ts'
 import { rstripSlash } from '../../../../utils/slash.ts'
 import type { StatOverlay } from '../../../../ops/types.ts'
@@ -28,18 +29,6 @@ export async function statOrNull(dispatch: DispatchFn, path: PathSpec): Promise<
   } catch {
     return null
   }
-}
-
-// What an existence probe reads as "nothing here": the path is absent, or
-// a component of it is not traversable. Deliberately narrower than a walk's
-// tolerance, because a permission or missing-capability error is not
-// absence, and mapping it to one would report a path that exists as
-// missing. Mirrors python MISS_ERRORS.
-function isMissError(exc: unknown): boolean {
-  const code = (exc as { code?: string }).code
-  if (code === 'ENOENT' || code === 'ENOTDIR' || code === 'EISDIR') return true
-  const msg = exc instanceof Error ? exc.message : String(exc)
-  return /not found|no such file|not a directory|is a directory/i.test(msg)
 }
 
 // What a path is, asked on both channels a backend can answer on.

--- a/typescript/packages/core/src/workspace/executor/builtins/metadata/metadata.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/metadata/metadata.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { PolicyDenied } from '../../../../policy/index.ts'
-import type { FileStat } from '../../../../types.ts'
+import type { FileStat, SetAttrFields } from '../../../../types.ts'
 import { FileType, PathSpec } from '../../../../types.ts'
 import type { DispatchFn } from '../../../../runtime/types.ts'
 import type { Namespace } from '../../../mount/namespace/namespace.ts'
@@ -112,14 +112,6 @@ export function isReadOnlyError(err: unknown): boolean {
   // text happens to contain "read-only".
   if (err instanceof PolicyDenied) return false
   return err instanceof Error && err.message.includes('read-only')
-}
-
-export interface SetAttrFields {
-  mode?: number
-  uid?: number | string
-  gid?: number | string
-  atime?: string
-  mtime?: string
 }
 
 // Route one attribute write through the op door. The door applies what

--- a/typescript/packages/core/src/workspace/executor/builtins/metadata/touch.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/metadata/touch.ts
@@ -30,7 +30,7 @@ import {
   setattrLink,
   setattrVia,
 } from './metadata.ts'
-import type { SetAttrFields } from './metadata.ts'
+import type { SetAttrFields } from '../../../../types.ts'
 
 // touch: set access/modification times, creating missing files. GNU flags:
 // -a/-m select which times, -c no-create, -h no-dereference (writes the

--- a/typescript/packages/core/src/workspace/symlinks.test.ts
+++ b/typescript/packages/core/src/workspace/symlinks.test.ts
@@ -22,6 +22,7 @@ import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { createShellParser, type ShellParser } from '../shell/parse.ts'
 import { MountMode } from '../types.ts'
+import type { Action, OpsContext } from '../policy/index.ts'
 import { applyStateDict, toStateDict } from './snapshot/state.ts'
 import { Workspace } from './workspace/workspace.ts'
 
@@ -78,6 +79,63 @@ describe('symlinks (namespace-backed)', () => {
     await ws.execute('ln -s -f /data/b.txt /data/link.txt')
     const r = await ws.execute('readlink /data/link.txt')
     expect(dec(r.stdout)).toBe('/data/b.txt\n')
+    await ws.close()
+  })
+
+  it('ln -s refuses a name a file already holds', async () => {
+    // GNU refuses an occupied destination; the node table alone cannot
+    // see one. ln checked only its own table, so the link node landed on
+    // top of a live file: the bytes stayed in the backend, unreachable,
+    // and the name read as a dangling link.
+    const ws = buildWorkspace()
+    await ws.execute('echo hi > /data/a.txt')
+    const r = await ws.execute('ln -s /data/other /data/a.txt')
+    expect(r.exitCode).toBe(1)
+    expect(dec(r.stderr)).toBe("ln: failed to create symbolic link '/data/a.txt': File exists\n")
+    expect(dec((await ws.execute('cat /data/a.txt')).stdout)).toBe('hi\n')
+    await ws.close()
+  })
+
+  it('ln -sf replaces a regular file', async () => {
+    // GNU -f removes the destination and then links, so it replaces a
+    // regular file and not only a link (pinned against coreutils 9.7).
+    const ws = buildWorkspace()
+    await ws.execute('echo hi > /data/a.txt')
+    await ws.execute('echo t > /data/t.txt')
+    const r = await ws.execute('ln -sf /data/t.txt /data/a.txt')
+    expect(r.exitCode).toBe(0)
+    expect(dec((await ws.execute('readlink /data/a.txt')).stdout)).toBe('/data/t.txt\n')
+    expect(dec((await ws.execute('cat /data/a.txt')).stdout)).toBe('t\n')
+    await ws.close()
+  })
+
+  it('mv of a link passes the admission gate', async () => {
+    // The link rename is the door's, so a policy that denies it wins. mv
+    // used to move the node itself, which made it the one write in the
+    // shell no admission policy could see.
+    const ram = new RAMResource()
+    const ops = new OpsRegistry()
+    ops.registerResource(ram)
+    const ws = new Workspace(
+      { '/data': ram },
+      {
+        mode: MountMode.WRITE,
+        ops,
+        shellParser: parser,
+        policies: [
+          {
+            preOps: (ctx: OpsContext): Action | null =>
+              ctx.op === 'rename' ? { kind: 'deny', reason: 'frozen' } : null,
+          },
+        ],
+      },
+    )
+    await ws.execute('echo hi > /data/a.txt')
+    await ws.execute('ln -s /data/a.txt /data/lk')
+    const r = await ws.execute('mv /data/lk /data/lk2')
+    expect(r.exitCode).toBe(1)
+    expect(dec(r.stderr)).toBe("mv: cannot move '/data/lk' to '/data/lk2': Permission denied\n")
+    expect(dec((await ws.execute('readlink /data/lk')).stdout)).toBe('/data/a.txt\n')
     await ws.close()
   })
 

--- a/typescript/packages/core/src/workspace/symlinks.test.ts
+++ b/typescript/packages/core/src/workspace/symlinks.test.ts
@@ -21,7 +21,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { createShellParser, type ShellParser } from '../shell/parse.ts'
-import { MountMode } from '../types.ts'
+import { rstripSlash } from '../utils/slash.ts'
+import { FileStat, FileType, MountMode } from '../types.ts'
 import type { Action, OpsContext } from '../policy/index.ts'
 import { applyStateDict, toStateDict } from './snapshot/state.ts'
 import { Workspace } from './workspace/workspace.ts'
@@ -93,6 +94,36 @@ describe('symlinks (namespace-backed)', () => {
     expect(r.exitCode).toBe(1)
     expect(dec(r.stderr)).toBe("ln: failed to create symbolic link '/data/a.txt': File exists\n")
     expect(dec((await ws.execute('cat /data/a.txt')).stdout)).toBe('hi\n')
+    await ws.close()
+  })
+
+  it('ln into a synthesized tree is not an occupied name', async () => {
+    // A directory an API tree invents is not evidence the name is taken.
+    // Those trees answer for a path nobody created: a postgres schema
+    // directory lists tables/ and views/ before anything asks whether
+    // the schema is there, and a grouping mount stats every path under a
+    // live collection as a directory. Refusing on either reading denied
+    // the ordinary case of adding a link inside a mounted tree.
+    const ram = new RAMResource()
+    const ops = new OpsRegistry()
+    ops.registerResource(ram)
+    const real = ops.call.bind(ops)
+    ops.call = async (name, kind, accessor, path, args, kwargs) => {
+      if (name === 'stat') {
+        return new FileStat({
+          name: rstripSlash(path.virtual).split('/').pop() ?? '/',
+          type: FileType.DIRECTORY,
+        })
+      }
+      if (name === 'readdir') return ['tables', 'views']
+      return real(name, kind, accessor, path, args, kwargs)
+    }
+    const ws = new Workspace({ '/data': ram }, { mode: MountMode.WRITE, ops, shellParser: parser })
+    const r = await ws.execute('ln -s /data/x /data/meta_link')
+    expect(r.exitCode).toBe(0)
+    expect(dec(r.stderr)).toBe('')
+    ops.call = real
+    expect(dec((await ws.execute('readlink /data/meta_link')).stdout)).toBe('/data/x\n')
     await ws.close()
   })
 

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -19,7 +19,7 @@ import { type EventDict, Observer } from '../../observe/observer.ts'
 import type { OpRecord } from '../../observe/record.ts'
 import { type OpKwargs, OpsRegistry } from '../../ops/registry.ts'
 import { isMissingPath } from '../../utils/errors.ts'
-import { contentSize, isDir as statIsDir, mtimeMs } from '../../utils/stat_view.ts'
+import { contentSize, isDir as statIsDir, mtimeMs, posixMode } from '../../utils/stat_view.ts'
 import type { Resource } from '../../resource/base.ts'
 import { HISTORY_PREFIX, HistoryViewResource } from '../../resource/history/history.ts'
 import { resourceStateRequiresOverride } from '../../resource/secrets.ts'
@@ -367,7 +367,7 @@ export class Workspace {
   // by the current session all come from the Dispatcher. Reads are raw
   // bytes (no filetype rendering), matching the Python WasmVFS.
   private buildWorkspaceBridge(): BridgeDispatchFn {
-    return async (op, path, bytes, dst) => {
+    return async (op, path, bytes, dst, attrs) => {
       switch (op) {
         case 'read':
           return (await this.dispatch('read', path)) as Uint8Array
@@ -395,6 +395,7 @@ export class Workspace {
             size: contentSize(st),
             isDir: statIsDir(st),
             mtimeMs: mtimeMs(st) ?? 0,
+            mode: posixMode(st),
           }
         }
         case 'create':
@@ -415,6 +416,21 @@ export class Workspace {
         case 'rename': {
           if (dst === undefined) throw new Error('rename op requires dst')
           await this.dispatch('rename', path, [PathSpec.fromStrPath(dst)])
+          return undefined
+        }
+        case 'symlink': {
+          // The target is not a PathSpec: a link stores what was typed,
+          // relative or dangling, and resolving it here would record a
+          // different link than the guest asked for.
+          if (dst === undefined) throw new Error('symlink op requires dst')
+          await this.dispatch('symlink', path, [], { target: dst })
+          return undefined
+        }
+        case 'readlink':
+          return (await this.dispatch('readlink', path)) as string
+        case 'setattr': {
+          if (attrs === undefined) throw new Error('setattr op requires attrs')
+          await this.dispatch('setattr', path, [], attrs as Record<string, unknown>)
           return undefined
         }
         case 'readdir': {

--- a/typescript/packages/node/src/fuse/core.test.ts
+++ b/typescript/packages/node/src/fuse/core.test.ts
@@ -113,6 +113,26 @@ describe('MountCore', () => {
     expect(new TextDecoder().decode(body)).toBe('rewritten, longer than before\n')
   })
 
+  it('reports a link with the node row its own stamps live on', async () => {
+    // A link has no backend inode, so the node table is the only place
+    // its stamps live. Built from the target string alone, getattr
+    // answered the mount's construction time for every link, so a
+    // no-follow touch through the mount was invisible right after it
+    // landed.
+    const ws = new Workspace({ '/data/': new RAMResource() }, { mode: MountMode.WRITE })
+    await ws.execute("echo 'hello' > /data/greeting.txt")
+    await ws.execute('ln -s greeting.txt /data/lk')
+    await ws.dispatch('setattr', '/data/lk', [], {
+      mtime: '2020-01-02T03:04:05Z',
+      nofollow: true,
+    })
+    const core = new MountCore(ws.fs)
+    const attrs = await core.getattr('/data/lk')
+    expect(attrs.mode).toBe(0o120777)
+    expect(attrs.size).toBe('greeting.txt'.length)
+    expect(attrs.mtime.getTime()).toBe(Date.parse('2020-01-02T03:04:05Z'))
+  })
+
   it('throws EINVAL from readlink on a regular file', async () => {
     const core = await mkCore()
     let code: string | undefined

--- a/typescript/packages/node/src/fuse/core.ts
+++ b/typescript/packages/node/src/fuse/core.ts
@@ -192,8 +192,21 @@ export class MountCore {
     return posix.relative(parent, virtualTarget)
   }
 
-  linkStat(target: string): FuseAttr {
+  /**
+   * The attrs a namespace link reports, from its own node row.
+   *
+   * Built from the target string alone, every link over a mount answered
+   * the mount's construction time and the mounting user, so what
+   * `chown -h` and `touch -h` wrote was invisible through the kernel.
+   * The row is the same one the door answers a no-follow stat with. Size
+   * stays the displayable target's length (what this mount's readlink
+   * returns), and the mode is always lrwxrwxrwx: a symlink's permission
+   * bits are not consulted by any POSIX system.
+   */
+  linkStat(target: string, virtual: string): FuseAttr {
     const entry = this.fileStat(new TextEncoder().encode(target).byteLength)
+    const row = this.ops.links?.linkStatAt(virtual) ?? null
+    if (row !== null) this.applyStatAttrs(entry, row)
     entry.mode = 0o120777
     return entry
   }
@@ -283,7 +296,7 @@ export class MountCore {
     // Link check must precede the workspace stat: the fs facade follows
     // namespace links, so stat on a link path reports the target.
     const target = this.linkTarget(path)
-    if (target !== null) return this.linkStat(target)
+    if (target !== null) return this.linkStat(target, this.resolve(path))
     const s = await this.ops.stat(this.resolve(path))
     if (s.type === FileType.DIRECTORY) {
       return this.applyStatAttrs(this.dirStat(), s)


### PR DESCRIPTION
A guest could not create a symlink, read one, or stamp a mode or a time. The three verbs reach the name plane rather than a backend, so they work on a mount whose store holds none of them: wasi, quickjs, pyodide and monty all route through the same ops.

## Transport

`RuntimeVFS` gains `symlink`, `readlink` and `setattr` in both languages, and `BridgeDispatchFn` gains the three cases, where `dst` carries both a rename's destination and a symlink's target. `SetAttrFields` moves to the shared root `types.ts`, because the ops facade and the runtime bridge both take it and neither may import the other.

TS gains the `posixMode` and `LINK_MODE` twins of the python helpers, and `VFSStat.mode` is now required. That closes a real gap rather than adding a field: a quickjs guest's `os.stat().st_mode` was a synthesized constant, so a `chmod 600` the shell had made read back as `0o666`.

## Per engine, and the shim mimics the engine

Measuring the engines first overturned two plan items, so nothing here invents a verb its host does not have.

- **wasi**: `path_symlink`, `path_readlink` and `path_filestat_set_times`. `path_filestat_get` reads `LOOKUP_SYMLINK_FOLLOW` and lstats when the bit is clear. `fstflags` splits each stamp into "write the argument" and "write the host clock", and neither bit set is UTIME_OMIT. `path_link` answers the verb table's refusal for `link`, rendered in preview1 numbers, rather than a hardcoded errno.
- **quickjs**: qjs-wasi has no `symlink`, `readlink` or `lstat`, so the bootstrap gains exactly `os.utimes` and `os.S_IFLNK`, which is what the real binary has.
- **pyodide**: an `S_IFLNK` node, a `readlink` node op, and journal `markSymlink` / `markSetattr`. The preload now copies a link as a link instead of skipping it, one readlink paid only for entries the namespace already marked; before this, a link in a mount tree was simply absent from the guest.
- **monty**: `Path.is_symlink` in both languages. TS reads the readdir mark; python asks readlink, because a python row carries no mark yet.

## Emscripten finalizes a create through setattr

pyodide's journal grew a phantom `setattr` per created file and, worse, split two writes that `markWrite` would have coalesced, because a create is finalized through `node_ops.setattr` with the same shape a guest chmod has. Comparing the fields is not enough on its own: the create genuinely lowers 0o777 to 0o666. `MirageFs.fresh` marks the node `mknod` just made and `changedAttrs` drops a write that moves nothing, so a create journals one write and a no-op utime journals nothing.

## readlink splits its two misses

`readlink` answered EINVAL for every miss. POSIX splits them, and a caller's `except FileNotFoundError` depends on it. Pinned against Linux (`python:3.13-slim`) for all six cases: a link resolves, a file, a directory and a mount root are EINVAL, and a missing path, or one under a missing parent, is ENOENT.

Absence is probed on the failure path only, and it takes both channels a backend can answer on: on a prefix store a directory is not an object but the set of keys under it, so `stat` misses what `readdir` lists, and a listing has to be non-empty because those stores answer a missing prefix with `[]`. The namespace is asked first, since a directory that exists only because a mount or a link sits below it is structure no backend can see. `resolve_path_stat` could not be reused: it dispatches, and this door is what dispatch is inside of.

Three things the probe got wrong first, all now pinned by tests:

- It passes `pre_ops_gate`. It reads on the caller's behalf but not at its request, so a policy denying `stat` must not become reachable through a readlink.
- A refused channel is not absence. It collapses back to EINVAL, which asserts nothing the policy is withholding, where ENOENT would assert a fact this door was not allowed to check.
- The TS dispatcher does not route through `MountEntry.executeOp`. A MountEntry built by the Workspace constructor has no ops registered at all, so the probe calls `opsRegistry.call` and stamps index and filetype the way the dispatcher does.

`os_patch._link_target` swallowed every `OSError` as "not a link", which would have hidden the new ENOENT from `os.lstat`; only EINVAL is swallowed now. The `readlink` command already funnelled every failure into GNU's silent exit 1, and FUSE reads the node table directly, so neither of those changes.

## Also

- `isMissError` moves from `links/probe.ts`, where it was private to one file, to `utils/errors.ts` beside python's `MISS_ERRORS`.
- `docs/typescript/python-fs.mdx` carried a row saying symlinks are refused with EPERM, which was false before this PR too. `os.utimes` added to both JS runtime pages.

## Known gaps, deliberate

- A python readdir row carries no link mark, so a wasi guest's `scandir().is_symlink()` is False and a link to a directory reads as a directory. TS marks it because its bridge holds the namespace; python's door holds only dispatch, so closing it means giving the runtime tier a name-plane door. Next PR.
- pyodide's seed carries no mode and no mtime, so a guest stat there does not reflect a shell chmod (quickjs's now does). Same next PR: both fields ride the row each door already builds.
- Guest hard links stay EPERM, which is what link(2) documents for a filesystem that cannot hold a second name for one inode, and what the verb table already decided.

## Verification

- python suite green, 0 failures
- TS core 728 files, 9573 tests; every TS package typechecks
- pre-commit clean in one pass, nothing reformatted
- layout parity `--strict` at baseline
- integ runtime: 116/0 python, 122/0 TS, including 10 new cases across wasi, pyodide, quickjs and monty
