### PR TITLE
feat(runtime): the readdir row carries the link mark

### DIFF
--- a/integ/runtime/wasi.json
+++ b/integ/runtime/wasi.json
@@ -383,6 +383,40 @@
       ]
     },
     {
+      "id": "scandir_reports_a_link_as_a_link",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "t.txt": "hello\n",
+              "d/inner.txt": "x\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "ln -s t.txt /ram/lk && ln -s d /ram/dlk",
+          "expect": { "exit": 0 }
+        },
+        {
+          "command": "python3 -c \"import os\nfor e in sorted(os.scandir('/ram'), key=lambda x: x.name):\n    print(e.name, 'link' if e.is_symlink() else ('dir' if e.is_dir() else 'file'))\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "d dir\ndlk link\nlk link\nt.txt file\n"
+          }
+        }
+      ]
+    },
+    {
       "id": "rename_a_link_moves_the_name",
       "hosts": [
         "python"

--- a/integ/runtime/wasi.json
+++ b/integ/runtime/wasi.json
@@ -417,6 +417,40 @@
       ]
     },
     {
+      "id": "scandir_marks_links_through_a_directory_link",
+      "hosts": [
+        "python"
+      ],
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "real/t.txt": "hello\n",
+              "real/sub/deep.txt": "x\n"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "ln -s /ram/real/t.txt /ram/real/lk && ln -s /ram/real/sub /ram/real/dlk && ln -s /ram/real /ram/alias",
+          "expect": { "exit": 0 }
+        },
+        {
+          "command": "python3 -c \"import os\nfor e in sorted(os.scandir('/ram/alias'), key=lambda x: x.name):\n    print(e.name, 'link' if e.is_symlink() else ('dir' if e.is_dir() else 'file'))\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "dlk link\nlk link\nsub dir\nt.txt file\n"
+          }
+        }
+      ]
+    },
+    {
       "id": "rename_a_link_moves_the_name",
       "hosts": [
         "python"

--- a/python/mirage/runtime/python/monty/vfs.py
+++ b/python/mirage/runtime/python/monty/vfs.py
@@ -63,10 +63,17 @@ class MontyVFS:
     def is_link(self, virtual: str) -> bool:
         """Whether the mount's name plane holds a symlink at `virtual`.
 
-        Answered through the readlink op rather than a listing, because
-        a python readdir row carries no link mark: the door resolves
-        entries by stat, and stat follows. One dispatch per question,
-        which is what every other predicate here costs too.
+        Answered through the readlink op, not through the parent's
+        listing, even though a readdir row now carries the mark. Two
+        reasons, and both are about this tier rather than about the
+        mark. The predicate arrives for one path with no listing in
+        hand, and every other predicate here materializes that path
+        alone, so reading the parent would trade one dispatch for a
+        readdir plus a stat per sibling (the TS twin reads the row
+        because its own `exists` and `is_file` already go through that
+        listing). And readlink is the gated channel: the node table has
+        no session, so a mark read outside an admitted listing would
+        answer for a path the door hides.
 
         Args:
             virtual (str): the path to test.

--- a/python/mirage/runtime/resolver.py
+++ b/python/mirage/runtime/resolver.py
@@ -40,12 +40,15 @@ class MountResolver(Protocol):
         ...
 
     def link_children(self, directory: str) -> set[str]:
-        """The names of the symlinks living directly under ``directory``.
+        """The names of the symlinks in the directory ``directory`` names.
 
         Per directory, not per path, because a listing is where the
         answer is needed and one table read serves every entry in it;
         asked per entry it would be a readlink apiece for a fact the
-        name plane can hand over whole.
+        name plane can hand over whole. Answers for the directory the
+        path *names*, resolving a link the way the listing itself is
+        resolved, so a listing through an alias is marked from the
+        directory it actually read.
 
         Args:
             directory (str): absolute virtual directory path.

--- a/python/mirage/runtime/resolver.py
+++ b/python/mirage/runtime/resolver.py
@@ -14,19 +14,21 @@
 
 from typing import Protocol
 
-from mirage.runtime.types import PrefixSource
+from mirage.runtime.types import LinkChildrenSource, PrefixSource
 from mirage.utils.path import owner_prefix
 
 
 class MountResolver(Protocol):
-    """Routing questions about the workspace mount table.
+    """The name-plane questions a runtime asks about the workspace.
 
-    What a runtime holds instead of a flat prefix listing: the two
-    questions routing ever asks (what mounts exist, which one owns a
-    path), answered by whoever owns the table so a consumer never
-    re-implements the longest-prefix rule. Answers use the table's own
-    prefix spelling; a surface with a spelling convention of its own
-    (``RuntimeVFS``) re-spells on its side of the seam.
+    What a runtime holds instead of a flat prefix listing: the
+    questions routing and listing ever ask (what mounts exist, which
+    one owns a path, which names in a directory are links), answered by
+    whoever owns the tables so a consumer never re-implements the
+    longest-prefix rule or reaches for a link table it cannot import.
+    Answers use the table's own prefix spelling; a surface with a
+    spelling convention of its own (``RuntimeVFS``) re-spells on its
+    side of the seam.
     """
 
     def prefixes(self) -> list[str]:
@@ -37,6 +39,19 @@ class MountResolver(Protocol):
         """The prefix owning ``path`` by longest match, or None."""
         ...
 
+    def link_children(self, directory: str) -> set[str]:
+        """The names of the symlinks living directly under ``directory``.
+
+        Per directory, not per path, because a listing is where the
+        answer is needed and one table read serves every entry in it;
+        asked per entry it would be a readlink apiece for a fact the
+        name plane can hand over whole.
+
+        Args:
+            directory (str): absolute virtual directory path.
+        """
+        ...
+
 
 class PrefixResolver:
     """A MountResolver over a live prefix listing.
@@ -44,18 +59,32 @@ class PrefixResolver:
     The one concrete resolver: the workspace wraps whatever view it
     wants a consumer to have (all mounts for the ops facade, a
     sandbox-filtered list for the runtimes) and the matching rule stays
-    ``owner_prefix``'s. Reads the source per call, so mounts added or
-    removed after construction are always picked up.
+    ``owner_prefix``'s. Reads its sources per call, so mounts and links
+    added or removed after construction are always picked up.
+
+    The link source is optional and answers nothing when absent, which
+    is right for a resolver built outside a workspace: there is no node
+    table, so no name can be a link.
 
     Args:
         source (PrefixSource): live prefix listing, read per call.
+        links (LinkChildrenSource | None): live link names per
+            directory, read per listing; None answers no links.
     """
 
-    def __init__(self, source: PrefixSource) -> None:
+    def __init__(self,
+                 source: PrefixSource,
+                 links: LinkChildrenSource | None = None) -> None:
         self._source = source
+        self._links = links
 
     def prefixes(self) -> list[str]:
         return list(self._source())
 
     def owner_of(self, path: str) -> str | None:
         return owner_prefix(self._source(), path)
+
+    def link_children(self, directory: str) -> set[str]:
+        if self._links is None:
+            return set()
+        return self._links(directory)

--- a/python/mirage/runtime/types.py
+++ b/python/mirage/runtime/types.py
@@ -78,6 +78,10 @@ class DispatchFn(Protocol):
 # added or removed after construction are always picked up.
 PrefixSource: TypeAlias = Callable[[], list[str]]
 
+# Live view of the link names one directory owns, read per listing so a
+# link created after construction is always seen.
+LinkChildrenSource: TypeAlias = Callable[[str], set[str]]
+
 
 @dataclass(frozen=True, slots=True)
 class VFSEntry:
@@ -94,9 +98,11 @@ class VFSEntry:
         size (int): rendered content bytes, 0 for directories and for
             entries whose stat answered absent.
         is_dir (bool): the entry is a directory.
-        is_link (bool): the entry is a namespace symlink. The TS
-            bridge marks it from its namespace; python rows carry
-            False until links enter dispatch (R8).
+        is_link (bool): the entry is a namespace symlink. Marked from
+            the name plane, which is the only authority for one: no
+            backend listing reports a link and stat follows, so a
+            directory link would otherwise read as a plain directory
+            and a cyclic one would recurse a whole-tree walk forever.
     """
 
     path: str

--- a/python/mirage/runtime/vfs.py
+++ b/python/mirage/runtime/vfs.py
@@ -184,8 +184,12 @@ class RuntimeVFS:
             path (str): guest-absolute virtual path.
         """
         entries: list[VFSEntry] = []
+        listing = self.call("readdir", path)
+        # After the listing, not before: a directory that will not list
+        # (ENOENT, or a link cycle the namespace refuses to resolve)
+        # must fail as readdir, not as the mark read.
         links = self._link_names(path)
-        for raw in self.call("readdir", path):
+        for raw in listing:
             linked = raw.rstrip("/").rsplit("/", 1)[-1] in links
             if raw.endswith("/"):
                 entries.append(

--- a/python/mirage/runtime/vfs.py
+++ b/python/mirage/runtime/vfs.py
@@ -165,7 +165,7 @@ class RuntimeVFS:
         return self.call("stat", path)
 
     def readdir(self, path: str) -> list[VFSEntry]:
-        """List a directory as resolved entries (the TS bridge's shape).
+        """List a directory as resolved entries (the TS door's shape).
 
         A backend that slash-marks directories skips the stat; every
         other entry is classified by the stat the readdir just
@@ -174,22 +174,50 @@ class RuntimeVFS:
         dangling link) rides as a size-0 file instead of failing the
         whole listing: the guest's own open reports the miss.
 
+        The link mark comes from the name plane, since stat follows and
+        no backend listing reports a link. One table read per listing,
+        and it only ever marks a name the listing itself returned, so a
+        link the session hides stays hidden: the dispatcher filtered it
+        out of the entries above and an unmatched mark marks nothing.
+
         Args:
             path (str): guest-absolute virtual path.
         """
         entries: list[VFSEntry] = []
+        links = self._link_names(path)
         for raw in self.call("readdir", path):
+            linked = raw.rstrip("/").rsplit("/", 1)[-1] in links
             if raw.endswith("/"):
-                entries.append(VFSEntry(path=raw, size=0, is_dir=True))
+                entries.append(
+                    VFSEntry(path=raw, size=0, is_dir=True, is_link=linked))
                 continue
             try:
                 st = self.call("stat", raw)
             except FileNotFoundError:
-                entries.append(VFSEntry(path=raw, size=0, is_dir=False))
+                entries.append(
+                    VFSEntry(path=raw, size=0, is_dir=False, is_link=linked))
                 continue
             entries.append(
-                VFSEntry(path=raw, size=content_size(st), is_dir=is_dir(st)))
+                VFSEntry(path=raw,
+                         size=content_size(st),
+                         is_dir=is_dir(st),
+                         is_link=linked))
         return entries
+
+    def _link_names(self, directory: str) -> set[str]:
+        """The link names the namespace owes `directory`, empty when none.
+
+        Compared by final segment, because backends disagree on entry
+        shape (bare names, trailing-slash names, full paths) and the
+        name is the part they agree on. The same normalization
+        ``merge_readdir`` dedupes on.
+
+        Args:
+            directory (str): guest-absolute virtual path being listed.
+        """
+        if self._resolver is None:
+            return set()
+        return self._resolver.link_children(directory)
 
     def create(self, path: str) -> None:
         self.call("create", path)

--- a/python/mirage/runtime/wasm/vfs.py
+++ b/python/mirage/runtime/wasm/vfs.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from mirage.runtime.vfs import RuntimeVFS
-from mirage.runtime.wasm.abi import FT_DIR, FT_REG
+from mirage.runtime.wasm.abi import FT_DIR, FT_REG, FT_SYMLINK
 from mirage.runtime.wasm.build import BuildDir
 from mirage.runtime.wasm.config import WasmFsConfig
 from mirage.runtime.wasm.constants import READONLY_HINT
@@ -37,7 +37,7 @@ class WasmVFS:
 
     Its second job is shape. `RuntimeVFS` answers in mirage's terms
     (`FileStat`, virtual paths); preview1 asks in its own (`GuestStat`,
-    `FT_DIR`/`FT_REG` pairs, errno). Translating between them is why
+    `(name, filetype)` pairs, errno). Translating between them is why
     quickjs still builds one of these even with no build directory to
     route to.
 
@@ -302,6 +302,10 @@ class WasmVFS:
         Core entries arrive kind-resolved (the door stats what the
         backend does not slash-mark), so a guest's ``d_type`` is real
         instead of FT_UNKNOWN paid off with one lazy stat per entry.
+        A link is reported as one: preview1 has the filetype, the door
+        marks the row, and a guest that reads ``d_type`` (CPython's
+        ``scandir`` does) then answers ``is_symlink`` without a call of
+        its own.
 
         Args:
             path (str): guest-absolute path.
@@ -318,6 +322,9 @@ class WasmVFS:
         for entry in self._require_core().readdir(path):
             base = entry.path.rstrip("/").rsplit("/", 1)[-1]
             if not base:
+                continue
+            if entry.is_link:
+                entries[base] = FT_SYMLINK
                 continue
             entries[base] = FT_DIR if entry.is_dir else FT_REG
         return sorted(entries.items())

--- a/python/mirage/workspace/mount/namespace/namespace.py
+++ b/python/mirage/workspace/mount/namespace/namespace.py
@@ -458,13 +458,34 @@ class Namespace:
         Args:
             directory (str): absolute virtual directory path.
         """
+        return [
+            link_stat(name, meta)
+            for name, meta in self._links_under(directory)
+        ]
+
+    def link_names_under(self, directory: str) -> set[str]:
+        """The names of the links living directly under a directory.
+
+        What a readdir row's link mark needs, which is a name question
+        rather than a stat one: the door already holds every entry's
+        stat and has only to learn which of those names the node table
+        owns.
+
+        Args:
+            directory (str): absolute virtual directory path.
+        """
+        return {name for name, _ in self._links_under(directory)}
+
+    def _links_under(self, directory: str) -> list[tuple[str, NodeMeta]]:
+        """The links living directly under a directory, as (name, meta).
+
+        Args:
+            directory (str): absolute virtual directory path.
+        """
         base = directory.rstrip("/") + "/"
-        out: list[FileStat] = []
-        for path, meta in self._nodes.items():
-            if (meta.target is not None and path.startswith(base)
-                    and "/" not in path[len(base):]):
-                out.append(link_stat(path[len(base):], meta))
-        return out
+        return [(path[len(base):], meta) for path, meta in self._nodes.items()
+                if meta.target is not None and path.startswith(base)
+                and "/" not in path[len(base):]]
 
     async def purge_under(self, directory: str) -> int:
         """Drop every node entry under a directory (``rm -r`` semantics).

--- a/python/mirage/workspace/mount/namespace/namespace.py
+++ b/python/mirage/workspace/mount/namespace/namespace.py
@@ -471,10 +471,18 @@ class Namespace:
         stat and has only to learn which of those names the node table
         owns.
 
+        Resolves a link prefix first, because a listing does: a readdir
+        of ``/data/alias`` is dispatched at ``/data/real`` and answers
+        with that directory's entries, so the marks have to come from
+        there too or every link inside an aliased directory reads as
+        whatever its followed stat said. ``link_stats_under`` needs no
+        such resolution: it is handed the path the router already
+        rewrote.
+
         Args:
             directory (str): absolute virtual directory path.
         """
-        return {name for name, _ in self._links_under(directory)}
+        return {name for name, _ in self._links_under(self.follow(directory))}
 
     def _links_under(self, directory: str) -> list[tuple[str, NodeMeta]]:
         """The links living directly under a directory, as (name, meta).

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -225,7 +225,8 @@ class Workspace:
 
         self._runtimes, self._policy_router = wire_runtime_world(
             self._registry, self.dispatch,
-            PrefixResolver(self._ops.mount_prefixes), runtimes)
+            PrefixResolver(self._ops.mount_prefixes,
+                           self._namespace.link_names_under), runtimes)
         reject_config_script("policy", policy)
         self._policy = policy
 

--- a/python/tests/runtime/test_resolver.py
+++ b/python/tests/runtime/test_resolver.py
@@ -36,6 +36,23 @@ def test_owner_of_answers_none_off_every_mount():
     assert PrefixResolver(lambda: []).owner_of("/data") is None
 
 
+def test_link_children_reflects_the_live_source_per_directory():
+    links = {"/data": {"lnk"}}
+    resolver = PrefixResolver(lambda: ["/data/"],
+                              lambda directory: links.get(directory, set()))
+    assert resolver.link_children("/data") == {"lnk"}
+    assert resolver.link_children("/other") == set()
+    links["/data"] = {"lnk", "later"}
+    assert resolver.link_children("/data") == {"lnk", "later"}
+
+
+def test_link_children_answers_nothing_without_a_link_source():
+    # No node table means no name can be a link, which is the answer a
+    # resolver built outside a workspace owes.
+    assert PrefixResolver(lambda: ["/data/"]).link_children("/data") == set()
+
+
 def test_prefix_resolver_satisfies_the_protocol():
     resolver: MountResolver = PrefixResolver(lambda: ["/data/"])
     assert resolver.owner_of("/data/x") == "/data/"
+    assert resolver.link_children("/data") == set()

--- a/python/tests/runtime/test_vfs.py
+++ b/python/tests/runtime/test_vfs.py
@@ -33,10 +33,12 @@ from mirage.workspace.session import Session
 class ListingVFS(RuntimeVFS):
     """Core double for the readdir lifting: canned listing and stats."""
 
-    def __init__(self, listing, stats):
+    def __init__(self, listing, stats, links=()):
+        names = set(links)
         super().__init__(dispatch=None,
                          loop=None,
-                         resolver=PrefixResolver(lambda: []))
+                         resolver=PrefixResolver(lambda: [],
+                                                 lambda _dir: names))
         self._listing = list(listing)
         self._stats = dict(stats)
         self.stat_calls = []
@@ -160,6 +162,44 @@ def test_readdir_stats_unmarked_directories():
     )
     assert vfs.readdir("/data/") == [
         VFSEntry(path="/data/sub", size=0, is_dir=True),
+    ]
+
+
+def test_readdir_marks_the_names_the_resolver_calls_links():
+    # The mark is the name plane's: stat follows a link, so a live link
+    # to a file reads as that file and nothing in the row says otherwise.
+    vfs = ListingVFS(
+        listing=["/data/lnk", "/data/a.txt"],
+        stats={
+            "/data/lnk": FileStat(name="lnk", size=5, type=FileType.TEXT),
+            "/data/a.txt": FileStat(name="a.txt", size=5, type=FileType.TEXT),
+        },
+        links=["lnk"],
+    )
+    assert vfs.readdir("/data/") == [
+        VFSEntry(path="/data/lnk", size=5, is_dir=False, is_link=True),
+        VFSEntry(path="/data/a.txt", size=5, is_dir=False),
+    ]
+
+
+def test_readdir_marks_a_link_whatever_shape_the_entry_arrived_in():
+    # Backends answer with bare names, trailing-slash names and full
+    # paths; the final segment is the part they agree on.
+    vfs = ListingVFS(
+        listing=["lnk", "/data/dirlink/"],
+        stats={},
+        links=["lnk", "dirlink"],
+    )
+    assert vfs.readdir("/data/") == [
+        VFSEntry(path="lnk", size=0, is_dir=False, is_link=True),
+        VFSEntry(path="/data/dirlink/", size=0, is_dir=True, is_link=True),
+    ]
+
+
+def test_readdir_marks_nothing_without_a_link_source():
+    vfs = ListingVFS(listing=["/data/lnk"], stats={})
+    assert vfs.readdir("/data/") == [
+        VFSEntry(path="/data/lnk", size=0, is_dir=False),
     ]
 
 

--- a/python/tests/runtime/wasm/test_vfs.py
+++ b/python/tests/runtime/wasm/test_vfs.py
@@ -21,7 +21,7 @@ import pytest
 from mirage.ops.namespace_view import merge_readdir
 from mirage.runtime.resolver import PrefixResolver
 from mirage.runtime.vfs import RuntimeVFS
-from mirage.runtime.wasm.abi import FT_DIR, FT_REG
+from mirage.runtime.wasm.abi import FT_DIR, FT_REG, FT_SYMLINK
 from mirage.runtime.wasm.config import WasmFsConfig
 from mirage.runtime.wasm.types import GuestStat
 from mirage.runtime.wasm.vfs import WasmVFS
@@ -48,13 +48,28 @@ class FakeVFS(RuntimeVFS):
                  modified="2026-07-15T00:00:00Z"):
         super().__init__(dispatch=None,
                          loop=None,
-                         resolver=PrefixResolver(lambda: list(prefixes)))
+                         resolver=PrefixResolver(lambda: list(prefixes),
+                                                 self._link_names_under))
         self.files = dict(files or {})
         self.dirs = set(dirs or ())
         self.links = dict(links or {})
         self.modified = modified
         self.attrs = []
         self.calls = []
+
+    def _link_names_under(self, directory):
+        """The link names the node table owes a directory (the workspace's
+        own answer, over the double's link map).
+
+        Args:
+            directory (str): absolute virtual directory path.
+        """
+        base = directory.rstrip("/") + "/"
+        return {
+            path[len(base):]
+            for path in self.links
+            if path.startswith(base) and "/" not in path[len(base):]
+        }
 
     def _raw(self, op, path, **kwargs):
         self.calls.append((op, path, kwargs))
@@ -68,6 +83,11 @@ class FakeVFS(RuntimeVFS):
                                 size=len(target.encode()),
                                 modified=LINK_MTIME,
                                 type=FileType.SYMLINK)
+            # A following stat is the door's default, so a link answers
+            # for its target: the row says nothing about the link and the
+            # mark is the only thing that can.
+            if path in self.links:
+                return self._raw("stat", self.links[path], **kwargs)
             if path in self.files:
                 return FileStat(name=path,
                                 size=len(self.files[path]),
@@ -109,6 +129,7 @@ class FakeVFS(RuntimeVFS):
             prefix = path.rstrip("/") + "/"
             out = [p for p in self.files if p.startswith(prefix)]
             out += [d + "/" for d in self.dirs if d.startswith(prefix)]
+            out += [p for p in self.links if p.startswith(prefix)]
             if not out and path not in self.dirs and path != "/":
                 raise FileNotFoundError(path)
             # The real door merges child-mount names into readdir; the
@@ -193,6 +214,28 @@ def test_readdir_bridge_resolves_kind_from_slash_or_stat():
                      prefixes=["/data/"])
     fs = WasmVFS(core=bridge)
     assert fs.readdir("/data") == [("f.txt", FT_REG), ("sub", FT_DIR)]
+
+
+def test_readdir_reports_a_link_as_a_link():
+    # preview1 has the filetype and the door marks the row, so a guest
+    # that reads d_type (CPython's scandir does) answers is_symlink
+    # without a call of its own. A link to a file stats as that file, so
+    # only the mark can tell them apart.
+    bridge = FakeVFS(files={"/data/f.txt": b""},
+                     links={"/data/l": "/data/f.txt"},
+                     prefixes=["/data/"])
+    fs = WasmVFS(core=bridge)
+    assert fs.readdir("/data") == [("f.txt", FT_REG), ("l", FT_SYMLINK)]
+
+
+def test_readdir_reports_a_link_to_a_directory_as_a_link():
+    # The one that used to read as a plain directory, which is how a
+    # guest walk followed it.
+    bridge = FakeVFS(dirs={"/data/sub"},
+                     links={"/data/dl": "/data/sub"},
+                     prefixes=["/data/"])
+    fs = WasmVFS(core=bridge)
+    assert fs.readdir("/data") == [("dl", FT_SYMLINK), ("sub", FT_DIR)]
 
 
 def test_readdir_root_merges_host_bridge_and_mounts(tmp_path):

--- a/python/tests/workspace/mount/namespace/test_namespace.py
+++ b/python/tests/workspace/mount/namespace/test_namespace.py
@@ -417,6 +417,15 @@ async def test_link_stats_under_is_one_level_only(namespace):
 
 
 @pytest.mark.asyncio
+async def test_link_names_under_is_one_level_of_names(namespace):
+    # What a readdir row's mark needs: the names, one level, no stats.
+    await namespace.symlink("/data/a", "/t1", 1.0)
+    await namespace.symlink("/data/sub/b", "/t2", 1.0)
+    assert namespace.link_names_under("/data") == {"a"}
+    assert namespace.link_names_under("/other") == set()
+
+
+@pytest.mark.asyncio
 async def test_link_stats_below_spans_the_whole_subtree(namespace):
     await namespace.symlink("/data/a", "/t1", 1.0)
     await namespace.symlink("/data/sub/b", "/t2", 1.0)

--- a/python/tests/workspace/mount/namespace/test_namespace.py
+++ b/python/tests/workspace/mount/namespace/test_namespace.py
@@ -426,6 +426,18 @@ async def test_link_names_under_is_one_level_of_names(namespace):
 
 
 @pytest.mark.asyncio
+async def test_link_names_under_answers_for_the_directory_a_link_names(
+        namespace):
+    # A readdir of an alias is dispatched at its target and answers with
+    # that directory's entries, so the marks come from there. Asking the
+    # typed path left every link inside an aliased directory unmarked,
+    # and a dir link inside it then read as a directory a walk recurses.
+    await namespace.symlink("/data/real/lk", "/data/real/t.txt", 1.0)
+    await namespace.symlink("/data/alias", "/data/real", 1.0)
+    assert namespace.link_names_under("/data/alias") == {"lk"}
+
+
+@pytest.mark.asyncio
 async def test_link_stats_below_spans_the_whole_subtree(namespace):
     await namespace.symlink("/data/a", "/t1", 1.0)
     await namespace.symlink("/data/sub/b", "/t2", 1.0)

--- a/typescript/packages/core/src/runtime/conformance.test.ts
+++ b/typescript/packages/core/src/runtime/conformance.test.ts
@@ -604,11 +604,9 @@ function makeCountingBridge(seed: Record<string, string>): CountingBridge {
     }
     if (op === 'readdir') {
       const prefix = path.replace(/\/$/, '') + '/'
-      const entries: { path: string; size: number; isDir: boolean }[] = []
-      for (const [p, content] of files) {
-        if (p.startsWith(prefix) && !p.slice(prefix.length).includes('/')) {
-          entries.push({ path: p, size: content.length, isDir: false })
-        }
+      const entries: string[] = []
+      for (const p of files.keys()) {
+        if (p.startsWith(prefix) && !p.slice(prefix.length).includes('/')) entries.push(p)
       }
       return Promise.resolve(entries)
     }

--- a/typescript/packages/core/src/runtime/python/monty/osaccess.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/osaccess.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, type Mock } from 'vitest'
 import type { BridgeDispatchFn } from '../../types.ts'
 import { RuntimeVFS } from '../../vfs.ts'
 import { MirageOSAccess } from './index.ts'
@@ -25,12 +25,39 @@ function accessOn(
   dispatch: BridgeDispatchFn,
   env: Record<string, string> = {},
   mounts: string[] = ['/ram'],
+  links: string[] = [],
 ): MirageOSAccess {
   return new MirageOSAccess(
     NOT_HANDLED,
     env,
-    new MontyVFS(new RuntimeVFS(dispatch, new PrefixResolver(() => mounts))),
+    new MontyVFS(
+      new RuntimeVFS(
+        dispatch,
+        new PrefixResolver(
+          () => mounts,
+          () => new Set(links),
+        ),
+      ),
+    ),
   )
+}
+
+// The door builds each row from a name plus one stat, so a double
+// standing in for the bridge answers both; a name it did not list stats
+// as a missing path.
+function listing(names: string[], dirs: string[] = []): Mock<BridgeDispatchFn> {
+  return vi.fn<BridgeDispatchFn>((op, path) => {
+    if (op === 'readdir') return Promise.resolve(names)
+    if (op === 'stat' && names.includes(path)) {
+      return Promise.resolve({
+        size: 1,
+        isDir: dirs.includes(path),
+        mtimeMs: 0,
+        mode: dirs.includes(path) ? 0o040755 : 0o100644,
+      })
+    }
+    return Promise.reject(Object.assign(new Error(`gone: ${path}`), { code: 'ENOENT' }))
+  })
 }
 
 const noop = vi.fn<BridgeDispatchFn>(() => Promise.resolve(undefined))
@@ -93,12 +120,7 @@ describe('MirageOSAccess path operations', () => {
   })
 
   it('iterdir yields the entry paths', async () => {
-    const dispatch = vi.fn<BridgeDispatchFn>(() =>
-      Promise.resolve([
-        { path: '/ram/d/a', size: 1, isDir: false },
-        { path: '/ram/d/sub', size: 0, isDir: true },
-      ]),
-    )
+    const dispatch = listing(['/ram/d/a', '/ram/d/sub'], ['/ram/d/sub'])
     expect(await accessOn(dispatch).handle('Path.iterdir', ['/ram/d'])).toEqual([
       '/ram/d/a',
       '/ram/d/sub',
@@ -107,8 +129,9 @@ describe('MirageOSAccess path operations', () => {
 
   it('answers the exists family as booleans, never as a rejection', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'readdir' && path === '/ram/d/') {
-        return Promise.resolve([{ path: '/ram/d/a', size: 1, isDir: false }])
+      if (op === 'readdir' && path === '/ram/d/') return Promise.resolve(['/ram/d/a'])
+      if (op === 'stat' && path === '/ram/d/a') {
+        return Promise.resolve({ size: 1, isDir: false, mtimeMs: 0, mode: 0o100644 })
       }
       return Promise.reject(Object.assign(new Error('gone'), { code: 'ENOENT' }))
     })
@@ -123,16 +146,8 @@ describe('MirageOSAccess path operations', () => {
   // Monty's own tree holds no links, so declining this verb answered
   // False for a link the shell made.
   it('answers is_symlink from the parent listing mark', async () => {
-    const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'readdir' && path === '/ram/d/') {
-        return Promise.resolve([
-          { path: '/ram/d/l', size: 0, isDir: false, isLink: true },
-          { path: '/ram/d/f', size: 1, isDir: false },
-        ])
-      }
-      return Promise.reject(new Error(`unexpected ${op} ${path}`))
-    })
-    const access = accessOn(dispatch)
+    const dispatch = listing(['/ram/d/l', '/ram/d/f'])
+    const access = accessOn(dispatch, {}, ['/ram'], ['l'])
     expect(await access.handle('Path.is_symlink', ['/ram/d/l'])).toBe(true)
     expect(await access.handle('Path.is_symlink', ['/ram/d/f'])).toBe(false)
   })

--- a/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
@@ -62,13 +62,19 @@ function makeBridge(seed: Record<string, Uint8Array>): {
       mutations.push(`rename ${path} ${dst ?? ''}`)
       return Promise.resolve(undefined)
     }
-    const prefix = path
-    const entries: { path: string; size: number; isDir: boolean }[] = []
-    for (const [p, content] of files) {
-      if (p.startsWith(prefix)) {
-        const rest = p.slice(prefix.length)
-        if (!rest.includes('/')) entries.push({ path: p, size: content.length, isDir: false })
+    // The door builds each row from a name plus one stat, so the double
+    // answers both.
+    if (op === 'stat') {
+      const found = files.get(path)
+      if (found === undefined) {
+        return Promise.reject(Object.assign(new Error(path), { code: 'ENOENT' }))
       }
+      return Promise.resolve({ size: found.length, isDir: false, mtimeMs: 0, mode: 0o100644 })
+    }
+    const prefix = path
+    const entries: string[] = []
+    for (const p of files.keys()) {
+      if (p.startsWith(prefix) && !p.slice(prefix.length).includes('/')) entries.push(p)
     }
     if (entries.length === 0) return Promise.reject(new Error(`no such dir: ${prefix}`))
     return Promise.resolve(entries)

--- a/typescript/packages/core/src/runtime/python/monty/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/vfs.test.ts
@@ -12,14 +12,42 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, type Mock } from 'vitest'
 import type { BridgeDispatchFn } from '../../types.ts'
 import { RuntimeVFS } from '../../vfs.ts'
 import { MontyVFS } from './index.ts'
 import { PrefixResolver } from '../../resolver.ts'
 
-function viewOn(dispatch: BridgeDispatchFn, mounts: string[] = ['/ram']): MontyVFS {
-  return new MontyVFS(new RuntimeVFS(dispatch, new PrefixResolver(() => mounts)))
+function viewOn(
+  dispatch: BridgeDispatchFn,
+  mounts: string[] = ['/ram'],
+  links: string[] = [],
+): MontyVFS {
+  return new MontyVFS(
+    new RuntimeVFS(
+      dispatch,
+      new PrefixResolver(
+        () => mounts,
+        () => new Set(links),
+      ),
+    ),
+  )
+}
+
+// The door builds each row from a name plus one stat, so a double
+// standing in for the bridge answers both; a name it did not list stats
+// as a missing path.
+function listingOf(names: string[]): Mock<BridgeDispatchFn> {
+  return vi.fn<BridgeDispatchFn>((op, path) => {
+    if (op === 'readdir') return Promise.resolve(names)
+    if (op === 'stat') {
+      if (!names.includes(path)) {
+        return Promise.reject(Object.assign(new Error(`gone: ${path}`), { code: 'ENOENT' }))
+      }
+      return Promise.resolve({ size: 1, isDir: false, mtimeMs: 0, mode: 0o100644 })
+    }
+    return Promise.resolve(undefined)
+  })
 }
 
 describe('MontyVFS scoping', () => {
@@ -85,30 +113,21 @@ describe('MontyVFS values', () => {
   })
 
   it('lists a directory through its slash-terminated prefix', async () => {
-    const dispatch = vi.fn<BridgeDispatchFn>(() =>
-      Promise.resolve([{ path: '/ram/d/a', size: 1, isDir: false }]),
-    )
+    const dispatch = listingOf(['/ram/d/a'])
     const entries = await viewOn(dispatch).readdir('/ram/d')
     expect(dispatch).toHaveBeenCalledWith('readdir', '/ram/d/')
     expect(entries).toHaveLength(1)
   })
 
   it('finds a path through its parent listing, and answers null for a miss', async () => {
-    const dispatch = vi.fn<BridgeDispatchFn>(() =>
-      Promise.resolve([{ path: '/ram/a', size: 1, isDir: false }]),
-    )
-    const vfs = viewOn(dispatch)
+    const vfs = viewOn(listingOf(['/ram/a']))
     expect(await vfs.entryFor('/ram/a')).toMatchObject({ isDir: false })
     expect(await vfs.entryFor('/ram/nope')).toBeNull()
   })
 })
 
 describe('MontyVFS negative cache', () => {
-  const listing = () =>
-    vi.fn<BridgeDispatchFn>((op) => {
-      if (op === 'readdir') return Promise.resolve([{ path: '/ram/a', size: 1, isDir: false }])
-      return Promise.resolve(undefined)
-    })
+  const listing = () => listingOf(['/ram/a'])
 
   it('remembers an absence, so a repeated probe costs no second listing', async () => {
     // Monty asks whether a path exists on nearly every guest
@@ -152,9 +171,13 @@ describe('MontyVFS negative cache', () => {
     // attached once, so the runtime resets it at the top of each
     // command. Without that a shell command's file stays invisible.
     let created = false
-    const dispatch = vi.fn<BridgeDispatchFn>(() =>
-      Promise.resolve(created ? [{ path: '/ram/late.txt', size: 1, isDir: false }] : []),
-    )
+    const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
+      if (op === 'readdir') return Promise.resolve(created ? ['/ram/late.txt'] : [])
+      if (op === 'stat' && path === '/ram/late.txt') {
+        return Promise.resolve({ size: 1, isDir: false, mtimeMs: 0, mode: 0o100644 })
+      }
+      return Promise.resolve(undefined)
+    })
     const vfs = viewOn(dispatch)
     expect(await vfs.entryFor('/ram/late.txt')).toBeNull()
     created = true
@@ -184,18 +207,13 @@ describe('MontyVFS negative cache', () => {
 // its own. Monty's own tree holds no links, so declining would answer
 // False for one the shell made.
 describe('MontyVFS.isLink', () => {
-  const listing = (entries: unknown[]): BridgeDispatchFn =>
-    vi.fn<BridgeDispatchFn>((op) =>
-      op === 'readdir' ? Promise.resolve(entries) : Promise.resolve(undefined),
-    )
-
   it('reads the mark off the parent listing', async () => {
-    const vfs = viewOn(listing([{ path: '/ram/link', size: 0, isDir: false, isLink: true }]))
+    const vfs = viewOn(listingOf(['/ram/link']), ['/ram'], ['link'])
     expect(await vfs.isLink('/ram/link')).toBe(true)
   })
 
   it('answers false for an entry with no mark', async () => {
-    const vfs = viewOn(listing([{ path: '/ram/f', size: 1, isDir: false }]))
+    const vfs = viewOn(listingOf(['/ram/f']))
     expect(await vfs.isLink('/ram/f')).toBe(false)
   })
 

--- a/typescript/packages/core/src/runtime/python/mount.test.ts
+++ b/typescript/packages/core/src/runtime/python/mount.test.ts
@@ -44,23 +44,34 @@ function makeBridge(): {
     }
     if (op === 'read') return Promise.resolve(files.get(path) ?? new Uint8Array())
     const prefix = path
-    const entries: { path: string; size: number; isDir: boolean }[] = []
+    const entries: string[] = []
     const dirs = new Set<string>()
-    for (const [p, content] of files) {
+    for (const p of files.keys()) {
       if (p.startsWith(prefix)) {
         const rest = p.slice(prefix.length)
         if (!rest.includes('/')) {
-          entries.push({ path: p, size: content.length, isDir: false })
+          entries.push(p)
         } else {
           const seg = rest.split('/', 1)[0] ?? ''
           if (seg !== '') dirs.add(prefix + seg)
         }
       }
     }
+    // The door builds each row from a name plus one stat, so the double
+    // answers both, and a directory is whatever a deeper key implies.
+    if (op === 'stat') {
+      const found = files.get(path)
+      if (found !== undefined) {
+        return Promise.resolve({ size: found.length, isDir: false, mtimeMs: 0, mode: 0o100644 })
+      }
+      const deeper = [...files.keys()].some((p) => p.startsWith(path + '/'))
+      if (deeper) return Promise.resolve({ size: 0, isDir: true, mtimeMs: 0, mode: 0o040755 })
+      return Promise.reject(Object.assign(new Error(`no such file: ${path}`), { code: 'ENOENT' }))
+    }
     // The real door merges child mounts and directories into readdir
     // (R1), so the double reports them too: preload descends through
     // them exactly as it does against a live workspace.
-    for (const d of dirs) entries.push({ path: d, size: 0, isDir: true })
+    for (const d of dirs) entries.push(d)
     return Promise.resolve(entries)
   }
   return { dispatch, calls, files }
@@ -274,8 +285,9 @@ describe('PyodideRuntime mount visibility', () => {
         return Promise.reject(new Error('backend unavailable'))
       }
       if (op === 'read') return Promise.resolve(new Uint8Array())
-      if (op === 'readdir') {
-        return Promise.resolve([{ path: '/ram/log.txt', size: 4, isDir: false }])
+      if (op === 'readdir') return Promise.resolve(['/ram/log.txt'])
+      if (op === 'stat') {
+        return Promise.resolve({ size: 4, isDir: false, mtimeMs: 0, mode: 0o100644 })
       }
       if (op === 'write' && bytes !== undefined) writes.push(new Uint8Array(bytes))
       return Promise.resolve(undefined)

--- a/typescript/packages/core/src/runtime/python/nojspi.test.ts
+++ b/typescript/packages/core/src/runtime/python/nojspi.test.ts
@@ -67,13 +67,17 @@ describe('PyodideRuntime without JSPI', () => {
       await new Promise((resolve) => setTimeout(resolve, 1))
       if (op === 'read') return files.get(path) ?? new Uint8Array()
       if (op === 'readdir') {
-        const entries = []
-        for (const [p, content] of files) {
-          if (p.startsWith(path) && !p.slice(path.length).includes('/')) {
-            entries.push({ path: p, size: content.length, isDir: false })
-          }
-        }
-        return entries
+        return [...files.keys()].filter(
+          (p) => p.startsWith(path) && !p.slice(path.length).includes('/'),
+        )
+      }
+      if (op === 'stat') {
+        const found = files.get(path)
+        if (found === undefined)
+          throw Object.assign(new Error(`no such file: ${path}`), {
+            code: 'ENOENT',
+          })
+        return { size: found.length, isDir: false, mtimeMs: 0, mode: 0o100644 }
       }
       return undefined
     }
@@ -144,8 +148,14 @@ describe('PyodideRuntime without JSPI', () => {
         if (found === undefined) throw new Error(`no such file: ${path}`)
         return found
       }
-      if (op === 'readdir') {
-        return [...files].map(([p, v]) => ({ path: p, size: v.length, isDir: false }))
+      if (op === 'readdir') return [...files.keys()]
+      if (op === 'stat') {
+        const listed = files.get(path)
+        if (listed === undefined)
+          throw Object.assign(new Error(`no such file: ${path}`), {
+            code: 'ENOENT',
+          })
+        return { size: listed.length, isDir: false, mtimeMs: 0, mode: 0o100644 }
       }
       if (op === 'write' && bytes !== undefined) {
         files.set(path, new Uint8Array(bytes))

--- a/typescript/packages/core/src/runtime/python/vfs/preload.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/preload.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it, vi } from 'vitest'
 import { preloadInto } from './preload.ts'
-import { RuntimeVFS } from '../../vfs.ts'
+import { RuntimeVFS, type VFSStat } from '../../vfs.ts'
 import type { BridgeDispatchFn } from '../../types.ts'
 import { PrefixResolver } from '../../resolver.ts'
 
@@ -51,15 +51,32 @@ function makeFakeFS(withLinks = true): FakeFS {
   }
 }
 
+// The door builds each row from a name plus one stat, so a double
+// standing in for the bridge has to answer both.
+function fileStat(size: number): VFSStat {
+  return { size, isDir: false, mtimeMs: 0, mode: 0o100644 }
+}
+
+function dirStat(): VFSStat {
+  return { size: 0, isDir: true, mtimeMs: 0, mode: 0o040755 }
+}
+
+// A resolver whose name plane holds exactly these link names.
+function linksOn(names: string[]): PrefixResolver {
+  return new PrefixResolver(
+    () => ['/ram/'],
+    () => new Set(names),
+  )
+}
+
 describe('preloadInto', () => {
   it('creates the prefix directory and writes flat files', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
       if (op === 'readdir' && path === '/ram/') {
-        return Promise.resolve([
-          { path: '/ram/a.txt', size: 5, isDir: false },
-          { path: '/ram/b.bin', size: 3, isDir: false },
-        ])
+        return Promise.resolve(['/ram/a.txt', '/ram/b.bin'])
       }
+      if (op === 'stat' && path === '/ram/a.txt') return Promise.resolve(fileStat(5))
+      if (op === 'stat' && path === '/ram/b.bin') return Promise.resolve(fileStat(3))
       if (op === 'read' && path === '/ram/a.txt')
         return Promise.resolve(new TextEncoder().encode('hello'))
       if (op === 'read' && path === '/ram/b.bin') return Promise.resolve(new Uint8Array([1, 2, 3]))
@@ -76,10 +93,10 @@ describe('preloadInto', () => {
 
   it('recurses into subdirectories', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'readdir' && path === '/ram/')
-        return Promise.resolve([{ path: '/ram/sub', size: 0, isDir: true }])
-      if (op === 'readdir' && path === '/ram/sub/')
-        return Promise.resolve([{ path: '/ram/sub/c.txt', size: 1, isDir: false }])
+      if (op === 'readdir' && path === '/ram/') return Promise.resolve(['/ram/sub'])
+      if (op === 'stat' && path === '/ram/sub') return Promise.resolve(dirStat())
+      if (op === 'readdir' && path === '/ram/sub/') return Promise.resolve(['/ram/sub/c.txt'])
+      if (op === 'stat' && path === '/ram/sub/c.txt') return Promise.resolve(fileStat(1))
       if (op === 'read' && path === '/ram/sub/c.txt') return Promise.resolve(new Uint8Array([7]))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
@@ -93,8 +110,8 @@ describe('preloadInto', () => {
 
   it('is idempotent: re-running overwrites with the mount content', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'readdir' && path === '/ram/')
-        return Promise.resolve([{ path: '/ram/x', size: 1, isDir: false }])
+      if (op === 'readdir' && path === '/ram/') return Promise.resolve(['/ram/x'])
+      if (op === 'stat' && path === '/ram/x') return Promise.resolve(fileStat(1))
       if (op === 'read' && path === '/ram/x') return Promise.resolve(new Uint8Array([42]))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
@@ -133,11 +150,10 @@ describe('preloadInto', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
       if (op === 'readdir' && path === '/ram/') {
-        return Promise.resolve([
-          { path: '/ram/ok.txt', size: 2, isDir: false },
-          { path: '/ram/bad.txt', size: 4, isDir: false },
-        ])
+        return Promise.resolve(['/ram/ok.txt', '/ram/bad.txt'])
       }
+      if (op === 'stat' && path === '/ram/ok.txt') return Promise.resolve(fileStat(2))
+      if (op === 'stat' && path === '/ram/bad.txt') return Promise.resolve(fileStat(4))
       if (op === 'read' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([1, 2]))
       if (op === 'read' && path === '/ram/bad.txt') return Promise.reject(new Error('unreadable'))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
@@ -156,11 +172,10 @@ describe('preloadInto', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
       if (op === 'readdir' && path === '/ram/') {
-        return Promise.resolve([
-          { path: '/ram/ok.txt', size: 1, isDir: false },
-          { path: '/ram/bad', size: 0, isDir: true },
-        ])
+        return Promise.resolve(['/ram/ok.txt', '/ram/bad'])
       }
+      if (op === 'stat' && path === '/ram/ok.txt') return Promise.resolve(fileStat(1))
+      if (op === 'stat' && path === '/ram/bad') return Promise.resolve(dirStat())
       if (op === 'read' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([7]))
       if (op === 'readdir' && path === '/ram/bad/') return Promise.reject(new Error('subtree fail'))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
@@ -191,11 +206,10 @@ describe('preloadInto', () => {
   it('lets a nested mount root readdir failure fail the whole collection', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
       if (op === 'readdir' && path === '/ram/') {
-        return Promise.resolve([
-          { path: '/ram/ok.txt', size: 1, isDir: false },
-          { path: '/ram/inner', size: 0, isDir: true },
-        ])
+        return Promise.resolve(['/ram/ok.txt', '/ram/inner'])
       }
+      if (op === 'stat' && path === '/ram/ok.txt') return Promise.resolve(fileStat(1))
+      if (op === 'stat' && path === '/ram/inner') return Promise.resolve(dirStat())
       if (op === 'read' && path === '/ram/ok.txt') return Promise.resolve(new Uint8Array([7]))
       if (op === 'readdir' && path === '/ram/inner/') return Promise.reject(new Error('inner boom'))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
@@ -210,14 +224,15 @@ describe('preloadInto', () => {
   // would never terminate.
   it('copies a link as a link and does not walk it', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'readdir' && path === '/ram/') {
-        return Promise.resolve([{ path: '/ram/loop', size: 0, isDir: true, isLink: true }])
-      }
+      if (op === 'readdir' && path === '/ram/') return Promise.resolve(['/ram/loop'])
+      // A link to a directory stats as one, which is exactly why the
+      // mark has to be consulted before the row's isDir.
+      if (op === 'stat' && path === '/ram/loop') return Promise.resolve(dirStat())
       if (op === 'readlink' && path === '/ram/loop') return Promise.resolve('/ram')
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS()
-    await preloadInto(fs, new RuntimeVFS(dispatch), '/ram/')
+    await preloadInto(fs, new RuntimeVFS(dispatch, linksOn(['loop'])), '/ram/')
     expect(fs._links.get('/ram/loop')).toBe('/ram')
     expect(fs._dirs.has('/ram/loop')).toBe(false)
   })
@@ -225,14 +240,13 @@ describe('preloadInto', () => {
   it('skips a link the namespace listed but will not resolve', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'readdir' && path === '/ram/') {
-        return Promise.resolve([{ path: '/ram/l', size: 0, isDir: false, isLink: true }])
-      }
+      if (op === 'readdir' && path === '/ram/') return Promise.resolve(['/ram/l'])
+      if (op === 'stat' && path === '/ram/l') return Promise.resolve(fileStat(0))
       if (op === 'readlink') return Promise.reject(new Error('link vanished'))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS()
-    await preloadInto(fs, new RuntimeVFS(dispatch), '/ram/')
+    await preloadInto(fs, new RuntimeVFS(dispatch, linksOn(['l'])), '/ram/')
     expect(fs._links.size).toBe(0)
     expect(warn).toHaveBeenCalled()
     warn.mockRestore()
@@ -242,13 +256,12 @@ describe('preloadInto', () => {
   // readlink, which is what every seed did before links were reachable.
   it('does not read a link target when the target cannot hold one', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
-      if (op === 'readdir' && path === '/ram/') {
-        return Promise.resolve([{ path: '/ram/l', size: 0, isDir: false, isLink: true }])
-      }
+      if (op === 'readdir' && path === '/ram/') return Promise.resolve(['/ram/l'])
+      if (op === 'stat' && path === '/ram/l') return Promise.resolve(fileStat(0))
       return Promise.reject(new Error(`unexpected ${op} ${path}`))
     })
     const fs = makeFakeFS(false)
-    await preloadInto(fs, new RuntimeVFS(dispatch), '/ram/')
+    await preloadInto(fs, new RuntimeVFS(dispatch, linksOn(['l'])), '/ram/')
     expect(fs._links.size).toBe(0)
     expect(dispatch).not.toHaveBeenCalledWith('readlink', '/ram/l')
   })

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
@@ -93,13 +93,26 @@ describe('MirageFs', () => {
         store.set(dst, moved)
       }
       if (op === 'readdir') {
-        const files = [...store.keys()]
-          .filter((k) => k.startsWith(path))
-          .map((k) => ({ path: k, size: store.get(k)?.length ?? 0, isDir: false }))
-        const linked = [...links.keys()]
-          .filter((k) => k.startsWith(path))
-          .map((k) => ({ path: k, size: 0, isDir: false, isLink: true }))
-        return Promise.resolve([...files, ...linked])
+        const listed = [...store.keys(), ...links.keys()].filter((k) => k.startsWith(path))
+        return Promise.resolve(listed)
+      }
+      if (op === 'stat') {
+        const found = store.get(path)
+        if (found === undefined) {
+          // A link, whose mark rides the resolver, or a path that went
+          // away between the listing and the stat.
+          return Promise.reject(
+            Object.assign(new Error(`no such file: ${path}`), {
+              code: 'ENOENT',
+            }),
+          )
+        }
+        return Promise.resolve({
+          size: found.length,
+          isDir: false,
+          mtimeMs: 0,
+          mode: 0o100644,
+        })
       }
       if (op === 'symlink' && dst !== undefined) links.set(path, dst)
       if (op === 'readlink') {
@@ -110,7 +123,20 @@ describe('MirageFs', () => {
       if (op === 'setattr' && fields !== undefined) attrs.push([path, fields])
       return Promise.resolve(undefined)
     }
-    vfs = new RuntimeVFS(dispatch, new PrefixResolver(() => mounts))
+    // The link source is the double's own name plane, which is what a
+    // workspace hands its runtimes: link names per directory.
+    vfs = new RuntimeVFS(
+      dispatch,
+      new PrefixResolver(
+        () => mounts,
+        (directory) =>
+          new Set(
+            [...links.keys()]
+              .filter((k) => k.startsWith(directory) && !k.slice(directory.length).includes('/'))
+              .map((k) => k.slice(directory.length)),
+          ),
+      ),
+    )
     journal = createJournal()
   }, 60_000)
 

--- a/typescript/packages/core/src/runtime/resolver.test.ts
+++ b/typescript/packages/core/src/runtime/resolver.test.ts
@@ -36,4 +36,22 @@ describe('PrefixResolver', () => {
     expect(resolver.ownerOf('/database')).toBeNull()
     expect(new PrefixResolver(() => []).ownerOf('/data')).toBeNull()
   })
+
+  it('linkChildren reflects the live source, per directory', () => {
+    const links = new Map([['/data', new Set(['lnk'])]])
+    const resolver = new PrefixResolver(
+      () => ['/data/'],
+      (directory) => links.get(directory) ?? new Set(),
+    )
+    expect(resolver.linkChildren('/data')).toEqual(new Set(['lnk']))
+    expect(resolver.linkChildren('/other')).toEqual(new Set())
+    links.set('/data', new Set(['lnk', 'later']))
+    expect(resolver.linkChildren('/data')).toEqual(new Set(['lnk', 'later']))
+  })
+
+  // No node table means no name can be a link, which is the answer a
+  // resolver built outside a workspace owes.
+  it('linkChildren answers nothing without a link source', () => {
+    expect(new PrefixResolver(() => ['/data/']).linkChildren('/data')).toEqual(new Set())
+  })
 })

--- a/typescript/packages/core/src/runtime/resolver.ts
+++ b/typescript/packages/core/src/runtime/resolver.ts
@@ -13,23 +13,33 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { ownerPrefix } from '../utils/slash.ts'
-import type { PrefixSource } from './types.ts'
+import type { LinkChildrenSource, PrefixSource } from './types.ts'
 
 /**
- * Routing questions about the workspace mount table.
+ * The name-plane questions a runtime asks about the workspace.
  *
- * What a runtime holds instead of a flat prefix listing: the two
- * questions routing ever asks (what mounts exist, which one owns a
- * path), answered by whoever owns the table so a consumer never
- * re-implements the longest-prefix rule. Answers use the table's own
- * prefix spelling; a surface with a spelling convention of its own
- * (`RuntimeVFS`) re-spells on its side of the seam.
+ * What a runtime holds instead of a flat prefix listing: the questions
+ * routing and listing ever ask (what mounts exist, which one owns a
+ * path, which names in a directory are links), answered by whoever
+ * owns the tables so a consumer never re-implements the longest-prefix
+ * rule or reaches for a link table it cannot import. Answers use the
+ * table's own prefix spelling; a surface with a spelling convention of
+ * its own (`RuntimeVFS`) re-spells on its side of the seam.
  */
 export interface MountResolver {
   /** The live mount prefixes, in the table's own spelling. */
   prefixes(): string[]
   /** The prefix owning `path` by longest match, or null. */
   ownerOf(path: string): string | null
+  /**
+   * The names of the symlinks living directly under `directory`.
+   *
+   * Per directory, not per path, because a listing is where the answer
+   * is needed and one table read serves every entry in it; asked per
+   * entry it would be a readlink apiece for a fact the name plane can
+   * hand over whole.
+   */
+  linkChildren(directory: string): Set<string>
 }
 
 /**
@@ -37,15 +47,21 @@ export interface MountResolver {
  *
  * The one concrete resolver: the workspace wraps whatever view it
  * wants a consumer to have (a sandbox-filtered list for the runtimes)
- * and the matching rule stays `ownerPrefix`'s. Reads the source per
- * call, so mounts added or removed after construction are always
- * picked up.
+ * and the matching rule stays `ownerPrefix`'s. Reads its sources per
+ * call, so mounts and links added or removed after construction are
+ * always picked up.
+ *
+ * The link source is optional and answers nothing when absent, which
+ * is right for a resolver built outside a workspace: there is no node
+ * table, so no name can be a link.
  */
 export class PrefixResolver implements MountResolver {
   private readonly source: PrefixSource
+  private readonly links: LinkChildrenSource | null
 
-  constructor(source: PrefixSource) {
+  constructor(source: PrefixSource, links: LinkChildrenSource | null = null) {
     this.source = source
+    this.links = links
   }
 
   prefixes(): string[] {
@@ -54,5 +70,10 @@ export class PrefixResolver implements MountResolver {
 
   ownerOf(path: string): string | null {
     return ownerPrefix(this.source(), path)
+  }
+
+  linkChildren(directory: string): Set<string> {
+    if (this.links === null) return new Set()
+    return this.links(directory)
   }
 }

--- a/typescript/packages/core/src/runtime/resolver.ts
+++ b/typescript/packages/core/src/runtime/resolver.ts
@@ -32,12 +32,15 @@ export interface MountResolver {
   /** The prefix owning `path` by longest match, or null. */
   ownerOf(path: string): string | null
   /**
-   * The names of the symlinks living directly under `directory`.
+   * The names of the symlinks in the directory `directory` names.
    *
    * Per directory, not per path, because a listing is where the answer
    * is needed and one table read serves every entry in it; asked per
    * entry it would be a readlink apiece for a fact the name plane can
-   * hand over whole.
+   * hand over whole. Answers for the directory the path *names*,
+   * resolving a link the way the listing itself is resolved, so a
+   * listing through an alias is marked from the directory it actually
+   * read.
    */
   linkChildren(directory: string): Set<string>
 }

--- a/typescript/packages/core/src/runtime/types.ts
+++ b/typescript/packages/core/src/runtime/types.ts
@@ -101,6 +101,12 @@ export type BridgeDispatchFn = (
  */
 export type PrefixSource = () => string[]
 
+/**
+ * Live view of the link names one directory owns, read per listing so a
+ * link created after construction is always seen.
+ */
+export type LinkChildrenSource = (directory: string) => Set<string>
+
 /** One interpreter execution request, language-agnostic. */
 export interface RunArgs {
   code: string

--- a/typescript/packages/core/src/runtime/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/vfs.test.ts
@@ -41,16 +41,98 @@ describe('RuntimeVFS transport', () => {
     expect(Array.from(bytes)).toEqual([9, 9])
   })
 
-  it('forwards readdir to dispatch readdir and returns entries', async () => {
-    const dispatch = vi.fn<BridgeDispatchFn>(() =>
-      Promise.resolve([
-        { path: '/ram/a.txt', size: 4, isDir: false },
-        { path: '/ram/sub', size: 0, isDir: true },
-      ]),
-    )
+  it('resolves each readdir name through stat', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op, path) => {
+      if (op === 'readdir') return Promise.resolve(['/ram/a.txt', '/ram/sub'])
+      return Promise.resolve({
+        size: path === '/ram/a.txt' ? 4 : 0,
+        isDir: path === '/ram/sub',
+        mtimeMs: 0,
+        mode: 0,
+      })
+    })
     const entries = await new RuntimeVFS(dispatch).readdir('/ram/')
-    expect(entries).toHaveLength(2)
-    expect(entries[0]).toEqual({ path: '/ram/a.txt', size: 4, isDir: false })
+    expect(entries).toEqual([
+      { path: '/ram/a.txt', size: 4, isDir: false },
+      { path: '/ram/sub', size: 0, isDir: true },
+    ])
+  })
+
+  // A backend that slash-marks its directories has already said what the
+  // entry is, so the door does not pay a stat to hear it again.
+  it('takes a trailing slash as the answer and skips the stat', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op) => {
+      if (op === 'readdir') return Promise.resolve(['/ram/sub/'])
+      throw new Error('stat should not be called')
+    })
+    expect(await new RuntimeVFS(dispatch).readdir('/ram/')).toEqual([
+      { path: '/ram/sub/', size: 0, isDir: true },
+    ])
+  })
+
+  // A dangling link, or an entry that vanished between the listing and
+  // the stat, must not fail the whole listing.
+  it('degrades a missing entry to a zero row', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op) => {
+      if (op === 'readdir') return Promise.resolve(['/ram/gone'])
+      return Promise.reject(Object.assign(new Error('nope'), { code: 'ENOENT' }))
+    })
+    expect(await new RuntimeVFS(dispatch).readdir('/ram/')).toEqual([
+      { path: '/ram/gone', size: 0, isDir: false },
+    ])
+  })
+
+  it('propagates a stat failure that is not a missing path', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op) => {
+      if (op === 'readdir') return Promise.resolve(['/ram/a.txt'])
+      return Promise.reject(new Error('401 Unauthorized'))
+    })
+    await expect(new RuntimeVFS(dispatch).readdir('/ram/')).rejects.toThrow('401 Unauthorized')
+  })
+
+  // The mark is the name plane's, since stat follows a link and no
+  // backend listing reports one.
+  it('marks the names the resolver calls links', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op) => {
+      if (op === 'readdir') return Promise.resolve(['/ram/lnk', '/ram/a.txt'])
+      return Promise.resolve({ size: 2, isDir: false, mtimeMs: 0, mode: 0 })
+    })
+    const resolver = new PrefixResolver(
+      () => ['/ram/'],
+      () => new Set(['lnk']),
+    )
+    expect(await new RuntimeVFS(dispatch, resolver).readdir('/ram/')).toEqual([
+      { path: '/ram/lnk', size: 2, isDir: false, isLink: true },
+      { path: '/ram/a.txt', size: 2, isDir: false },
+    ])
+  })
+
+  // Every shape a backend answers in reaches the same mark: the name is
+  // the part they agree on.
+  it('marks a link whatever shape the entry arrived in', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op) => {
+      if (op === 'readdir') return Promise.resolve(['lnk', '/ram/dirlink/'])
+      return Promise.reject(Object.assign(new Error('nope'), { code: 'ENOENT' }))
+    })
+    const resolver = new PrefixResolver(
+      () => ['/ram/'],
+      () => new Set(['lnk', 'dirlink']),
+    )
+    expect(await new RuntimeVFS(dispatch, resolver).readdir('/ram/')).toEqual([
+      { path: 'lnk', size: 0, isDir: false, isLink: true },
+      { path: '/ram/dirlink/', size: 0, isDir: true, isLink: true },
+    ])
+  })
+
+  it('marks nothing when no link source was supplied', async () => {
+    const dispatch = vi.fn<BridgeDispatchFn>((op) => {
+      if (op === 'readdir') return Promise.resolve(['/ram/lnk'])
+      return Promise.resolve({ size: 0, isDir: false, mtimeMs: 0, mode: 0 })
+    })
+    const entries = await new RuntimeVFS(dispatch, new PrefixResolver(() => ['/ram/'])).readdir(
+      '/ram/',
+    )
+    expect(entries).toEqual([{ path: '/ram/lnk', size: 0, isDir: false }])
   })
 
   // The target rides the `dst` slot: it is the op's second string and a
@@ -102,7 +184,7 @@ describe('RuntimeVFS transport', () => {
     await expect(new RuntimeVFS(dispatch).readdir('/x')).rejects.toThrow(TypeError)
   })
 
-  it('throws TypeError when readdir entry has bad shape', async () => {
+  it('throws TypeError when a readdir entry is not a name', async () => {
     const dispatch = vi.fn<BridgeDispatchFn>(() =>
       Promise.resolve([{ path: '/x' }] as unknown as never[]),
     )

--- a/typescript/packages/core/src/runtime/vfs.ts
+++ b/typescript/packages/core/src/runtime/vfs.ts
@@ -14,7 +14,7 @@
 
 import { isMissingOp, isMissingPath } from '../utils/errors.ts'
 import { CrossMountError } from './errors.ts'
-import { normDir } from '../utils/slash.ts'
+import { normDir, rstripSlash } from '../utils/slash.ts'
 import { planFlush } from './handles/index.ts'
 import { PrefixResolver, type MountResolver } from './resolver.ts'
 import type { BridgeDispatchFn } from './types.ts'
@@ -41,6 +41,19 @@ export interface VFSStat {
   // own wire (preview1's filestat carries only a filetype) reads the
   // type bits and drops the rest.
   mode: number
+}
+
+/**
+ * An entry's final path segment.
+ *
+ * What a link mark is compared on, because backends disagree on entry
+ * shape (bare names, trailing-slash names, full paths) and the name is
+ * the part they agree on. The same normalization `mergeReaddir`
+ * dedupes on.
+ */
+function baseName(entry: string): string {
+  const trimmed = rstripSlash(entry)
+  return trimmed.slice(trimmed.lastIndexOf('/') + 1)
 }
 
 export function concatBytes(head: Uint8Array, tail: Uint8Array): Uint8Array {
@@ -134,23 +147,52 @@ export class RuntimeVFS {
     return st
   }
 
+  /**
+   * List a directory as resolved entries (Python's `readdir` shape).
+   *
+   * A backend that slash-marks directories skips the stat; every other
+   * entry is classified by the stat the readdir just populated the
+   * index with, so the lookup is RAM, not another API call. An entry
+   * that vanished between list and stat (or a dangling link) rides as
+   * a size-0 file instead of failing the whole listing: the guest's
+   * own open reports the miss.
+   *
+   * The link mark comes from the name plane, since stat follows and no
+   * backend listing reports a link. One table read per listing, and it
+   * only ever marks a name the listing itself returned, so a link the
+   * session hides stays hidden: the dispatcher filtered it out of the
+   * entries above and an unmatched mark marks nothing.
+   */
   async readdir(path: string): Promise<VFSEntry[]> {
     const out = await this.dispatch('readdir', path)
     if (!Array.isArray(out)) {
       throw new TypeError(`runtime vfs: readdir ${path} expected array`)
     }
-    for (const e of out) {
-      if (
-        e === null ||
-        typeof e !== 'object' ||
-        typeof (e as VFSEntry).path !== 'string' ||
-        typeof (e as VFSEntry).size !== 'number' ||
-        typeof (e as VFSEntry).isDir !== 'boolean'
-      ) {
-        throw new TypeError(`runtime vfs: readdir ${path} bad entry shape`)
-      }
-    }
-    return out as VFSEntry[]
+    const links = this.resolver.linkChildren(path)
+    return await Promise.all(
+      out.map(async (raw): Promise<VFSEntry> => {
+        if (typeof raw !== 'string') {
+          throw new TypeError(`runtime vfs: readdir ${path} bad entry shape`)
+        }
+        const linked = links.has(baseName(raw)) ? { isLink: true } : {}
+        // Backends that mark directories with a trailing slash skip the
+        // stat; unmarked entries (e.g. RAM) need one to learn dir-ness.
+        if (raw.endsWith('/')) return { path: raw, size: 0, isDir: true, ...linked }
+        let st: VFSStat
+        try {
+          st = await this.stat(raw)
+        } catch (err) {
+          // A dangling link, or an entry that vanished between list and
+          // stat, must not fail the whole listing; the guest's own open
+          // reports the miss. Anything else (authorization, a timeout, a
+          // backend bug) propagates, or pyodide's syncMounts would
+          // replace a healthy snapshot with a silently degraded one.
+          if (!isMissingPath(err)) throw err
+          return { path: raw, size: 0, isDir: false, ...linked }
+        }
+        return { path: raw, size: st.size, isDir: st.isDir, ...linked }
+      }),
+    )
   }
 
   /**

--- a/typescript/packages/core/src/runtime/vfs.ts
+++ b/typescript/packages/core/src/runtime/vfs.ts
@@ -168,6 +168,9 @@ export class RuntimeVFS {
     if (!Array.isArray(out)) {
       throw new TypeError(`runtime vfs: readdir ${path} expected array`)
     }
+    // After the listing, not before: a directory that will not list
+    // (ENOENT, or a link cycle the namespace refuses to resolve) must
+    // fail as readdir, not as the mark read.
     const links = this.resolver.linkChildren(path)
     return await Promise.all(
       out.map(async (raw): Promise<VFSEntry> => {

--- a/typescript/packages/core/src/workspace/bridge_list.test.ts
+++ b/typescript/packages/core/src/workspace/bridge_list.test.ts
@@ -93,6 +93,20 @@ describe('runtime door readdir', () => {
       isDir: false,
     })
   })
+
+  // Dispatch follows the alias and answers with the target's entries,
+  // so the marks have to come from the target too. Reading them off the
+  // typed path left a link inside an aliased directory unmarked, and a
+  // directory link there then read as a directory a guest walk descends.
+  it('marks the links inside a directory reached through a link', async () => {
+    const { ws } = mkWorld()
+    await ws.dispatch('mkdir', '/data/real')
+    await ws.fs.writeFile('/data/real/t.txt', 'hi')
+    await ws.namespace.symlink('/data/real/lk', '/data/real/t.txt', 1)
+    await ws.namespace.symlink('/data/alias', '/data/real', 1)
+    const entries = await doorOn(ws).readdir('/data/alias')
+    expect(entries.find((e) => e.path.endsWith('/lk'))).toMatchObject({ isLink: true })
+  })
 })
 
 // The wiring itself: the workspace hands its runtimes a resolver that

--- a/typescript/packages/core/src/workspace/bridge_list.test.ts
+++ b/typescript/packages/core/src/workspace/bridge_list.test.ts
@@ -15,14 +15,13 @@
 import { describe, expect, it } from 'vitest'
 import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
+import { MontyRuntime } from '../runtime/python/monty/index.ts'
+import { PrefixResolver } from '../runtime/resolver.ts'
 import type { BridgeDispatchFn } from '../runtime/types.ts'
-import type { VFSEntry } from '../runtime/vfs.ts'
+import { RuntimeVFS } from '../runtime/vfs.ts'
 import { MountMode } from '../types.ts'
+import { getTestParser } from './fixtures/workspace_fixture.ts'
 import { Workspace } from './workspace/workspace.ts'
-
-function bridgeOn(ws: Workspace): BridgeDispatchFn {
-  return (ws as unknown as { buildWorkspaceBridge(): BridgeDispatchFn }).buildWorkspaceBridge()
-}
 
 function mkWorld(): { ws: Workspace; ops: OpsRegistry; resource: RAMResource } {
   const resource = new RAMResource()
@@ -32,15 +31,31 @@ function mkWorld(): { ws: Workspace; ops: OpsRegistry; resource: RAMResource } {
   return { ws, ops, resource }
 }
 
-// The bridge readdir is the sandboxed runtimes' directory read: what it
-// swallows, a guest can never see, and what it fails, pyodide's
+// The door a sandboxed runtime holds, over this workspace's own bridge
+// and the same two sources the workspace hands its runtimes: the mount
+// prefixes and the node table's link names.
+function doorOn(ws: Workspace): RuntimeVFS {
+  const bridge = (
+    ws as unknown as { buildWorkspaceBridge(): BridgeDispatchFn }
+  ).buildWorkspaceBridge()
+  return new RuntimeVFS(
+    bridge,
+    new PrefixResolver(
+      () => ['/data/'],
+      (directory) => ws.namespace.linkNamesUnder(directory),
+    ),
+  )
+}
+
+// The runtime door's readdir is the sandboxed runtimes' directory read:
+// what it swallows, a guest can never see, and what it fails, pyodide's
 // syncMounts treats as the whole tree.
-describe('workspace bridge readdir', () => {
+describe('runtime door readdir', () => {
   it('a dangling link degrades to a zero row instead of failing the listing', async () => {
     const { ws } = mkWorld()
     await ws.fs.writeFile('/data/a.txt', 'hi')
     await ws.namespace.symlink('/data/lnk', '/data/gone', 1)
-    const entries = (await bridgeOn(ws)('readdir', '/data')) as VFSEntry[]
+    const entries = await doorOn(ws).readdir('/data')
     const row = entries.find((e) => e.path.endsWith('/lnk'))
     expect(row).toMatchObject({ size: 0, isDir: false, isLink: true })
   })
@@ -61,6 +76,49 @@ describe('workspace bridge readdir', () => {
       },
       write: false,
     })
-    await expect(bridgeOn(ws)('readdir', '/data')).rejects.toThrow('401 Unauthorized')
+    await expect(doorOn(ws).readdir('/data')).rejects.toThrow('401 Unauthorized')
   })
+
+  // A live link stats as its target, so the row's own kind says nothing
+  // about it; only the node table does.
+  it('marks a live link whose stat followed through to a file', async () => {
+    const { ws } = mkWorld()
+    await ws.fs.writeFile('/data/a.txt', 'hello')
+    await ws.namespace.symlink('/data/lnk', '/data/a.txt', 1)
+    const entries = await doorOn(ws).readdir('/data')
+    expect(entries.find((e) => e.path.endsWith('/lnk'))).toMatchObject({ size: 5, isLink: true })
+    expect(entries.find((e) => e.path.endsWith('/a.txt'))).toEqual({
+      path: '/data/a.txt',
+      size: 5,
+      isDir: false,
+    })
+  })
+})
+
+// The wiring itself: the workspace hands its runtimes a resolver that
+// reaches the node table, so a guest predicate answers about a link the
+// shell made without a readlink of its own.
+describe('a guest sees the marks the workspace wired', () => {
+  it('answers is_symlink for a link the shell made', async () => {
+    const resource = new RAMResource()
+    const ops = new OpsRegistry()
+    for (const op of resource.ops()) ops.register(op)
+    const ws = new Workspace(
+      { '/data': resource },
+      {
+        mode: MountMode.EXEC,
+        ops,
+        shellParser: await getTestParser(),
+        runtimes: [new MontyRuntime()],
+      },
+    )
+    await ws.execute('echo hi > /data/a.txt')
+    await ws.execute('ln -s /data/a.txt /data/lnk')
+    const io = await ws.execute(
+      'python3 -c "from pathlib import Path;' +
+        " print(Path('/data/lnk').is_symlink(), Path('/data/a.txt').is_symlink())\"",
+    )
+    expect(new TextDecoder().decode(io.stdout).trim()).toBe('True False')
+    await ws.close()
+  }, 30_000)
 })

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.test.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.test.ts
@@ -128,6 +128,18 @@ describe('Namespace symlink table', () => {
     await ws.close()
   })
 
+  // A readdir of an alias is dispatched at its target and answers with
+  // that directory's entries, so the marks come from there. Asking the
+  // typed path left every link inside an aliased directory unmarked, and
+  // a dir link inside it then read as a directory a walk recurses.
+  it('linkNamesUnder answers for the directory a link names', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    await ws.namespace.symlink('/data/real/lk', '/data/real/t.txt', 1)
+    await ws.namespace.symlink('/data/alias', '/data/real', 1)
+    expect(ws.namespace.linkNamesUnder('/data/alias')).toEqual(new Set(['lk']))
+    await ws.close()
+  })
+
   it('purgeUnder drops nested entries', async () => {
     const ws = new Workspace({ '/data': new RAMResource() })
     await ws.namespace.symlink('/data/sub/a', '/t1', 1)

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.test.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.test.ts
@@ -118,6 +118,16 @@ describe('Namespace symlink table', () => {
     await ws.close()
   })
 
+  // What a readdir row's mark needs: the names, one level, no stats.
+  it('linkNamesUnder is one level of names', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    await ws.namespace.symlink('/data/a', '/t1', 1)
+    await ws.namespace.symlink('/data/sub/b', '/t2', 1)
+    expect(ws.namespace.linkNamesUnder('/data')).toEqual(new Set(['a']))
+    expect(ws.namespace.linkNamesUnder('/other')).toEqual(new Set())
+    await ws.close()
+  })
+
   it('purgeUnder drops nested entries', async () => {
     const ws = new Workspace({ '/data': new RAMResource() })
     await ws.namespace.symlink('/data/sub/a', '/t1', 1)

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
@@ -382,8 +382,15 @@ export class Namespace {
   // readdir row's link mark needs, which is a name question rather than
   // a stat one: the door already holds every entry's stat and has only
   // to learn which of those names the node table owns.
+  //
+  // Resolves a link prefix first, because a listing does: a readdir of
+  // `/data/alias` is dispatched at `/data/real` and answers with that
+  // directory's entries, so the marks have to come from there too or
+  // every link inside an aliased directory reads as whatever its
+  // followed stat said. `linkStatsUnder` needs no such resolution: it is
+  // handed the path the router already rewrote.
   linkNamesUnder(directory: string): Set<string> {
-    return new Set(this.linksUnder(directory).map(([name]) => name))
+    return new Set(this.linksUnder(this.follow(directory)).map(([name]) => name))
   }
 
   // The links living directly under a directory, as (name, meta).

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
@@ -375,15 +375,28 @@ export class Namespace {
   // are namespace state and invisible to a backend readdir, so listing
   // commands merge these rows into the backend's entries.
   linkStatsUnder(directory: string): FileStat[] {
+    return this.linksUnder(directory).map(([name, meta]) => linkStat(name, meta))
+  }
+
+  // The names of the links living directly under a directory. What a
+  // readdir row's link mark needs, which is a name question rather than
+  // a stat one: the door already holds every entry's stat and has only
+  // to learn which of those names the node table owns.
+  linkNamesUnder(directory: string): Set<string> {
+    return new Set(this.linksUnder(directory).map(([name]) => name))
+  }
+
+  // The links living directly under a directory, as (name, meta).
+  private linksUnder(directory: string): [string, NodeMeta][] {
     const base = rstripSlash(directory) + '/'
-    const out: FileStat[] = []
+    const out: [string, NodeMeta][] = []
     for (const [path, meta] of this.nodeTable) {
       if (
         meta.target !== undefined &&
         path.startsWith(base) &&
         !path.slice(base.length).includes('/')
       ) {
-        out.push(linkStat(path.slice(base.length), meta))
+        out.push([path.slice(base.length), meta])
       }
     }
     return out

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -18,7 +18,6 @@ import { IOResult } from '../../io/types.ts'
 import { type EventDict, Observer } from '../../observe/observer.ts'
 import type { OpRecord } from '../../observe/record.ts'
 import { type OpKwargs, OpsRegistry } from '../../ops/registry.ts'
-import { isMissingPath } from '../../utils/errors.ts'
 import { contentSize, isDir as statIsDir, mtimeMs, posixMode } from '../../utils/stat_view.ts'
 import type { Resource } from '../../resource/base.ts'
 import { HISTORY_PREFIX, HistoryViewResource } from '../../resource/history/history.ts'
@@ -57,7 +56,6 @@ import type { ProvisionResult } from '../../provision/types.ts'
 import { Ops } from '../../ops/ops.ts'
 import type { MountEntry } from '../mount/mount.ts'
 import { MountRegistry } from '../mount/registry.ts'
-import type { VFSEntry } from '../../runtime/vfs.ts'
 import { PrefixResolver } from '../../runtime/resolver.ts'
 import type { BridgeDispatchFn } from '../../runtime/types.ts'
 import { MontyUnavailableError } from '../../runtime/python/monty/index.ts'
@@ -161,7 +159,10 @@ export class Workspace {
     this.shellParserFactory = options.shellParserFactory ?? null
     this.agentId = options.agentId ?? null
     this.watchManager = new WatchManager(this.registry)
-    const sandboxResolver = new PrefixResolver(() => this.sandboxVisibleMounts())
+    const sandboxResolver = new PrefixResolver(
+      () => this.sandboxVisibleMounts(),
+      (directory) => this.namespace.linkNamesUnder(directory),
+    )
     this.runtimes = new Runtimes({
       registry: this.registry,
       entries: options.runtimes,
@@ -433,37 +434,12 @@ export class Workspace {
           await this.dispatch('setattr', path, [], attrs as Record<string, unknown>)
           return undefined
         }
-        case 'readdir': {
-          const entries = ((await this.dispatch('readdir', path)) as string[] | null) ?? []
-          return await Promise.all(
-            entries.map(async (entry): Promise<VFSEntry> => {
-              // Backends that mark directories with a trailing slash
-              // skip the stat; unmarked entries (e.g. RAM) need one to
-              // learn dir-ness.
-              if (entry.endsWith('/')) return { path: entry, size: 0, isDir: true }
-              const isLink = this.namespace.isLink(entry)
-              let stat: FileStat
-              try {
-                stat = (await this.dispatch('stat', entry)) as FileStat
-              } catch (err) {
-                // A dangling link, or an entry that vanished between
-                // list and stat, must not fail the whole listing; the
-                // guest's own open reports the miss. Anything else
-                // (authorization, a timeout, a backend bug) propagates,
-                // or pyodide's syncMounts would replace a healthy
-                // snapshot with a silently degraded one.
-                if (!isMissingPath(err)) throw err
-                return { path: entry, size: 0, isDir: false, ...(isLink ? { isLink } : {}) }
-              }
-              return {
-                path: entry,
-                size: contentSize(stat),
-                isDir: statIsDir(stat),
-                ...(isLink ? { isLink } : {}),
-              }
-            }),
-          )
-        }
+        case 'readdir':
+          // The names as the door merged them, nothing resolved: the
+          // runtime door (`RuntimeVFS.readdir`) stats each entry and
+          // marks the links, so a row is built in one tier and in one
+          // shape in both languages.
+          return ((await this.dispatch('readdir', path)) as string[] | null) ?? []
       }
     }
   }


### PR DESCRIPTION
R8 wave 1, the gap #879 left open: a python readdir row carried no link mark, so a wasi guest's `scandir()` called a directory link a directory and a file link a file. CPython trusts `d_type` and never fell back to lstat, so nothing downstream could recover it.

## The shape

The name plane reaches the runtime tier as a third resolver question. `MountResolver` gains `link_children(directory)` / `linkChildren(directory)`, answered per directory because that is where a listing needs it, and one table read serves every entry in it; asked per entry it would be a readlink apiece. `PrefixResolver` takes an optional link source beside its prefix source, and answers nothing without one, which is right for a resolver built outside a workspace. The workspace supplies it from a new `Namespace.link_names_under` / `linkNamesUnder`, factored out of the existing one-level `link_stats_under` so both read one scan.

The python door then fills `VFSEntry.is_link`, and TS row building moves off the bridge closure into `RuntimeVFS.readdir`, which is where python already built it. That is why the bridge's readdir contract narrows to raw names, and why ten test doubles changed: they answer `stat` now, as the real bridge always did.

`WasmVFS._readdir_core` reports `FT_SYMLINK` for a marked row.

## Visibility

The per-directory read rides the readdir admission, and marking is an intersection: only a name the already-filtered listing returned can be marked, so a link the session hides stays hidden and an unmatched mark marks nothing.

That argument does not extend to a bare per-path predicate, which has no admission at all, so python monty keeps its `readlink`. Two reasons, both about that tier rather than about the mark: its predicates each materialize one path rather than a parent listing, so reading the mark would trade one dispatch for a readdir plus a stat per sibling (TS monty reads the row because its own `exists` and `is_file` already go through that listing), and readlink is the gated channel, where a raw table read would answer for a path the door hides.

## Verification

- python suite green, 0 failures
- TS 13,320 tests across 8 packages, 0 failures; every package typechecks; eslint clean
- integ: runtime 106/0 python with a new wasi case, 124/0 TS; ram+disk 5648/0 on both hosts
- pre-commit clean, stable on a second pass; layout parity `--strict` at baseline
- both new behaviors A/B'd by reverting them: without the wasi filetype the two new unit tests fail and a live guest goes back to reading a directory link as a directory; without the workspace's link source the end-to-end monty case answers `False False`

## Not in scope

- `VFSEntry` still carries no `mode` or `mtime`, so a pyodide guest's stat does not reflect a shell chmod and every seeded file looks modified just now. That is wave 2, and it wants an upstream probe first: it is not known whether monty 0.0.19's `OSAccess` can carry a mode at all.
- A new `lstat` op stays rejected. It would change `ROUTED_VERBS["lstat"]` from `("readlink", "stat")` to one name, which silently unblocks lstat for a deployment that denies readlink today.