### PR TITLE
test: add gws slides CLI coverage

### DIFF
--- a/integ/cli/gws.json
+++ b/integ/cli/gws.json
@@ -222,6 +222,45 @@
       }
     },
     {
+      "id": "gw_slides_get_seeded",
+      "seq": 563017,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws slides presentations get --params '{\"presentationId\": \"pres0001\"}' | jq -c '{presentationId, title, slides: (.slides | length)}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"presentationId\":\"pres0001\",\"title\":\"Launch Deck\",\"slides\":1}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_slides_create",
+      "seq": 563018,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws slides presentations create --json '{\"title\": \"CLI Deck\"}' | jq -c '{presentationId: (.presentationId | length > 0), title, slides: (.slides | length)}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"presentationId\":true,\"title\":\"CLI Deck\",\"slides\":1}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_slides_batch_update",
+      "seq": 563019,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "P=$(gws slides presentations create --json '{\"title\": \"CLI Deck\"}' | jq -r .presentationId) && gws slides presentations batchUpdate --params \"{\\\"presentationId\\\": \\\"$P\\\"}\" --json '{\"requests\": [{\"createSlide\": {}}]}' | jq -c --arg p \"$P\" '{presentationId: (.presentationId == $p), createdSlides: (.replies | length)}' && gws slides presentations get --params \"{\\\"presentationId\\\": \\\"$P\\\"}\" | jq -c --arg p \"$P\" '{presentationId: (.presentationId == $p), slides: (.slides | length)}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"presentationId\":true,\"createdSlides\":1}\n{\"presentationId\":true,\"slides\":2}\n",
+        "stderr": ""
+      }
+    },
+    {
       "id": "gw_gmail_triage",
       "seq": 563020,
       "targets": [

--- a/python/tests/commands/cli/builtin/gws/test_tree.py
+++ b/python/tests/commands/cli/builtin/gws/test_tree.py
@@ -41,6 +41,9 @@ def test_passthroughs_nest_by_discovery_resource():
     assert [v.name for v in leaf("drive", "files").subcommands] == [
         "list", "get", "create", "update", "copy", "delete", "export"
     ]
+    assert [v.name for v in leaf("slides").subcommands] == ["presentations"]
+    assert [v.name for v in leaf("slides", "presentations").subcommands
+            ] == ["get", "create", "batchUpdate"]
     assert [v.name for v in leaf("gmail", "users", "messages").subcommands
             ] == ["list", "get", "send", "trash", "attachments"]
     assert leaf("gmail", "users", "messages", "attachments",
@@ -58,6 +61,9 @@ def test_bespoke_verbs_drop_the_plus_marker():
 
 def test_writes_follow_http_semantics():
     assert not leaf("drive", "files", "list").write
+    assert not leaf("slides", "presentations", "get").write
+    assert leaf("slides", "presentations", "create").write
+    assert leaf("slides", "presentations", "batchUpdate").write
     assert leaf("drive", "files", "delete").write
     assert leaf("sheets", "spreadsheets", "batchUpdate").write
     assert not leaf("gmail", "triage").write

--- a/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
@@ -86,6 +86,12 @@ describe('gws tree', () => {
       'delete',
       'export',
     ])
+    expect(leaf('slides').subcommands.map((v) => v.name)).toEqual(['presentations'])
+    expect(leaf('slides', 'presentations').subcommands.map((v) => v.name)).toEqual([
+      'get',
+      'create',
+      'batchUpdate',
+    ])
     expect(leaf('gmail', 'users', 'messages').subcommands.map((v) => v.name)).toEqual([
       'list',
       'get',
@@ -109,6 +115,9 @@ describe('gws tree', () => {
     ).toEqual(['read', 'write', 'append'])
     expect(leaf('docs', 'write').write).toBe(true)
     expect(leaf('drive', 'files', 'list').write).toBe(false)
+    expect(leaf('slides', 'presentations', 'get').write).toBe(false)
+    expect(leaf('slides', 'presentations', 'create').write).toBe(true)
+    expect(leaf('slides', 'presentations', 'batchUpdate').write).toBe(true)
     expect(leaf('drive', 'files', 'delete').write).toBe(true)
   })
 


### PR DESCRIPTION
Add missing `gws slides` CLI coverage.

- integ: `presentations get/create/batchUpdate`
- unit: pin slides tree shape + write flags in python/typescript
- verified on `cli-gws` python target
