### PR TITLE
ci(python): run main pytest suite with xdist

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -94,7 +94,24 @@ jobs:
         env:
           REDIS_URL: redis://localhost:6379/0
           MONGODB_URI: mongodb://localhost:27017
-        run: uv run pytest --ignore=tests/agents/camel
+        run: |
+          redis_serial=(
+            tests/cache/file/test_redis_cache.py
+            tests/cache/index/test_redis.py
+            tests/cache/index/test_redis_order.py
+            tests/commands/builtin/redis
+            tests/core/redis
+            tests/observe/test_redis_store.py
+            tests/ops/redis
+            tests/resource/redis
+            tests/shell/console/redis/test_store.py
+          )
+          ignore_args=(--ignore=tests/agents/camel)
+          for path in "${redis_serial[@]}"; do
+            ignore_args+=("--ignore=$path")
+          done
+          uv run pytest -n 4 --dist loadscope "${ignore_args[@]}"
+          uv run pytest "${redis_serial[@]}"
 
       # Each truth file owns the command it was captured against, so this
       # list is paths only and cannot drift from what is asserted. The

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -263,6 +263,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=7.0.0",
     "pytest-httpx>=0.36.0",
+    "pytest-xdist>=3.8.0",
     "mypy>=2.3.0",
     "lz4>=4.4.5",
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1800,6 +1800,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fakeredis"
 version = "2.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4322,6 +4331,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
+    { name = "pytest-xdist" },
     { name = "python-dotenv" },
 ]
 
@@ -4350,10 +4360,10 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jq", specifier = ">=1.11.0" },
-    { name = "mcp", specifier = ">=1.28.1" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.33.0" },
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=4.2.0" },
     { name = "markitdown", marker = "extra == 'camel'", specifier = ">=0.1.5" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=2.0.6" },
     { name = "mfusepy", marker = "extra == 'fuse'", specifier = ">=1.0.0" },
     { name = "mirage-ai", extras = ["agno"], marker = "extra == 'all'" },
@@ -4440,6 +4450,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-httpx", specifier = ">=0.36.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
@@ -9759,6 +9770,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/5574834da9499066fa1a5ea9c336f94dba2eae02298d36dab192fcf95c86/pytest_httpx-0.36.0.tar.gz", hash = "sha256:9edb66a5fd4388ce3c343189bc67e7e1cb50b07c2e3fc83b97d511975e8a831b", size = 56793, upload-time = "2025-12-02T16:34:57.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/d2/1eb1ea9c84f0d2033eb0b49675afdc71aa4ea801b74615f00f3c33b725e3/pytest_httpx-0.36.0-py3-none-any.whl", hash = "sha256:bd4c120bb80e142df856e825ec9f17981effb84d159f9fa29ed97e2357c3a9c8", size = 20229, upload-time = "2025-12-02T16:34:56.45Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Python CI time is mostly in the main pytest run.

Run the non-Redis main suite with `pytest-xdist` using `-n 4 --dist loadscope`, and keep the Redis-backed tests serial.
