### PR TITLE
test(gws): cover drive permissions and gmail trash

### DIFF
--- a/integ/cli/gws.json
+++ b/integ/cli/gws.json
@@ -222,6 +222,45 @@
       }
     },
     {
+      "id": "gw_drive_permissions_create",
+      "seq": 563076,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "F=$(gws drive files create --json '{\"name\": \"Perm Create\", \"mimeType\": \"text/plain\"}' | jq -r .id) && gws drive permissions create --params \"{\\\"fileId\\\": \\\"$F\\\"}\" --json '{\"role\": \"reader\", \"type\": \"anyone\"}' | jq -c '{permissionId: (.id | length > 0), role, type}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"permissionId\":true,\"role\":\"reader\",\"type\":\"anyone\"}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_drive_permissions_list",
+      "seq": 563077,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "F=$(gws drive files create --json '{\"name\": \"Perm List\", \"mimeType\": \"text/plain\"}' | jq -r .id) && gws drive permissions create --params \"{\\\"fileId\\\": \\\"$F\\\"}\" --json '{\"role\": \"reader\", \"type\": \"anyone\"}' > /dev/null && gws drive permissions list --params \"{\\\"fileId\\\": \\\"$F\\\"}\" | jq -c '.permissions | map({role, type})'",
+      "expect": {
+        "exit": 0,
+        "stdout": "[{\"role\":\"reader\",\"type\":\"anyone\"}]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_drive_permissions_delete",
+      "seq": 563078,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "F=$(gws drive files create --json '{\"name\": \"Perm Delete\", \"mimeType\": \"text/plain\"}' | jq -r .id) && P=$(gws drive permissions create --params \"{\\\"fileId\\\": \\\"$F\\\"}\" --json '{\"role\": \"reader\", \"type\": \"anyone\"}' | jq -r .id) && gws drive permissions delete --params \"{\\\"fileId\\\": \\\"$F\\\", \\\"permissionId\\\": \\\"$P\\\"}\" && gws drive permissions list --params \"{\\\"fileId\\\": \\\"$F\\\"}\" | jq -r '.permissions | length'",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n",
+        "stderr": ""
+      }
+    },
+    {
       "id": "gw_slides_get_seeded",
       "seq": 563017,
       "targets": [
@@ -427,6 +466,19 @@
       "expect": {
         "exit": 0,
         "stdout": "marcus@example.com\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_gmail_messages_trash_passthrough",
+      "seq": 563079,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws gmail users messages trash --params '{\"userId\": \"me\", \"id\": \"msg0002\"}' > /dev/null && gws gmail users messages get --params '{\"userId\": \"me\", \"id\": \"msg0002\"}' | jq -c '.labelIds'",
+      "expect": {
+        "exit": 0,
+        "stdout": "[\"TRASH\"]\n",
         "stderr": ""
       }
     },

--- a/python/tests/commands/cli/builtin/gws/test_tree.py
+++ b/python/tests/commands/cli/builtin/gws/test_tree.py
@@ -44,6 +44,8 @@ def test_passthroughs_nest_by_discovery_resource():
     assert [v.name for v in leaf("slides").subcommands] == ["presentations"]
     assert [v.name for v in leaf("slides", "presentations").subcommands
             ] == ["get", "create", "batchUpdate"]
+    assert [v.name for v in leaf("drive", "permissions").subcommands
+            ] == ["create", "list", "delete"]
     assert [v.name for v in leaf("gmail", "users", "messages").subcommands
             ] == ["list", "get", "send", "trash", "attachments"]
     assert leaf("gmail", "users", "messages", "attachments",
@@ -65,7 +67,11 @@ def test_writes_follow_http_semantics():
     assert leaf("slides", "presentations", "create").write
     assert leaf("slides", "presentations", "batchUpdate").write
     assert leaf("drive", "files", "delete").write
+    assert not leaf("drive", "permissions", "list").write
+    assert leaf("drive", "permissions", "create").write
+    assert leaf("drive", "permissions", "delete").write
     assert leaf("sheets", "spreadsheets", "batchUpdate").write
+    assert leaf("gmail", "users", "messages", "trash").write
     assert not leaf("gmail", "triage").write
 
 

--- a/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
@@ -92,6 +92,11 @@ describe('gws tree', () => {
       'create',
       'batchUpdate',
     ])
+    expect(leaf('drive', 'permissions').subcommands.map((v) => v.name)).toEqual([
+      'create',
+      'list',
+      'delete',
+    ])
     expect(leaf('gmail', 'users', 'messages').subcommands.map((v) => v.name)).toEqual([
       'list',
       'get',
@@ -119,6 +124,10 @@ describe('gws tree', () => {
     expect(leaf('slides', 'presentations', 'create').write).toBe(true)
     expect(leaf('slides', 'presentations', 'batchUpdate').write).toBe(true)
     expect(leaf('drive', 'files', 'delete').write).toBe(true)
+    expect(leaf('drive', 'permissions', 'list').write).toBe(false)
+    expect(leaf('drive', 'permissions', 'create').write).toBe(true)
+    expect(leaf('drive', 'permissions', 'delete').write).toBe(true)
+    expect(leaf('gmail', 'users', 'messages', 'trash').write).toBe(true)
   })
 
   it('nests calendar passthroughs by discovery resource', () => {


### PR DESCRIPTION
## Summary
- add the remaining GWS CLI coverage for Drive permissions and Gmail trash
- cover the Python and TypeScript GWS trees for the new verbs

## Testing
- `uv run pytest tests/commands/cli/builtin/gws/test_tree.py tests/commands/cli/builtin/gws/test_api.py -q --no-cov`
- `GWS_URL=http://127.0.0.1:19999 PYTHONPATH=python python/.venv/bin/python integ/runners/python/main.py --target cli-gws --strict`
