### PR TITLE
fix(postgres): refuse a readdir on a schema that does not exist

### DIFF
--- a/docs/python/resource/new.mdx
+++ b/docs/python/resource/new.mdx
@@ -30,20 +30,28 @@ async def read_bytes(accessor, path, index=None) -> bytes: ...
 async def stat(accessor, path, index=None) -> FileStat: ...
 
 
-def make_jira_resource(config) -> GenericResource:
-    io = CommandIO(
-        readdir=readdir,
-        read_bytes=read_bytes,
-        read_stream=partial(stream_from_bytes, read_bytes),
-        stat=stat,
-        is_mounted=lambda a: True,
-        local=False,
-    )
-    return GenericResource(name="jira", accessor=JiraAccessor(config), io=io,
-                           prompt="Issues rendered as .json files.")
+class JiraResource(GenericResource):
+    CONFIG_CLS = JiraConfig
+
+    def __init__(self, config: JiraConfig) -> None:
+        super().__init__(
+            name="jira",
+            accessor=JiraAccessor(config),
+            io=CommandIO(
+                readdir=readdir,
+                read_bytes=read_bytes,
+                read_stream=partial(stream_from_bytes, read_bytes),
+                stat=stat,
+                is_mounted=lambda a: True,
+                local=False,
+            ),
+            prompt="Issues rendered as .json files.",
+        )
 ```
 
-Mount it like any builtin: `Workspace({"/jira/": make_jira_resource(cfg)})`.
+Mount it like any builtin: `Workspace({"/jira/": JiraResource(cfg)})`. A class rather than a
+factory function, because that is what the registry and the config reference below both name;
+`examples/python/other/custom_resource.py` is the same shape end to end.
 
 The escape hatches mirror what builtins use: optional `CommandIO` fields unlock more surface (`write` enables the byte-mutation family; `find` and `du` become native fast paths), `overrides=` suppresses a generic command you replace, and `commands=[...]` adds bespoke `@command` verbs.
 

--- a/docs/python/resource/new.mdx
+++ b/docs/python/resource/new.mdx
@@ -16,12 +16,19 @@ Everything an out-of-tree backend needs is exported from `mirage.sdk` — that m
 ```python
 from functools import partial
 
+from pydantic import BaseModel, SecretStr
+
 from mirage.sdk import (Accessor, CommandIO, FileStat, GenericResource,
                         stream_from_bytes)
 
 
+class JiraConfig(BaseModel):
+    site: str
+    token: SecretStr
+
+
 class JiraAccessor(Accessor):
-    def __init__(self, config):
+    def __init__(self, config: JiraConfig) -> None:
         self.client = make_client(config)
 
 

--- a/integ/resources/postgres/probe.json
+++ b/integ/resources/postgres/probe.json
@@ -211,6 +211,97 @@
         "stdout": "",
         "stderr": "ls: cannot access '/pg/.hidden': No such file or directory\n"
       }
+    },
+    {
+      "id": "pg_ls_unknown_schema",
+      "seq": 610106,
+      "targets": [
+        "postgres"
+      ],
+      "command": "ls /pg/nope",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/pg/nope': No such file or directory\n"
+      }
+    },
+    {
+      "id": "pg_test_d_unknown_schema",
+      "seq": 610107,
+      "targets": [
+        "postgres"
+      ],
+      "command": "test -d /pg/nope",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "pg_find_unknown_schema",
+      "seq": 610108,
+      "targets": [
+        "postgres"
+      ],
+      "command": "find /pg/nope",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "find: '/pg/nope': No such file or directory\n"
+      }
+    },
+    {
+      "id": "pg_stat_unknown_schema",
+      "seq": 610109,
+      "targets": [
+        "postgres"
+      ],
+      "command": "stat /pg/nope",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "stat: /pg/nope: No such file or directory\n"
+      }
+    },
+    {
+      "id": "pg_ls_kind_under_unknown_schema",
+      "seq": 610110,
+      "targets": [
+        "postgres"
+      ],
+      "command": "ls /pg/nope/tables",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/pg/nope/tables': No such file or directory\n"
+      }
+    },
+    {
+      "id": "pg_ls_unknown_entity",
+      "seq": 610111,
+      "targets": [
+        "postgres"
+      ],
+      "command": "ls /pg/public/tables/ghost",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/pg/public/tables/ghost': No such file or directory\n"
+      }
+    },
+    {
+      "id": "pg_cat_file_under_unknown_entity",
+      "seq": 610112,
+      "targets": [
+        "postgres"
+      ],
+      "command": "cat /pg/public/tables/ghost/rows.jsonl",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "cat: /pg/public/tables/ghost/rows.jsonl: No such file or directory\n"
+      }
     }
   ]
 }

--- a/python/mirage/core/nextcloud/du/__init__.py
+++ b/python/mirage/core/nextcloud/du/__init__.py
@@ -14,5 +14,6 @@
 
 from mirage.core.nextcloud.du.entries import entries
 from mirage.core.nextcloud.du.size import size
+from mirage.core.nextcloud.du.walk import stat_or_null
 
-__all__ = ["entries", "size"]
+__all__ = ["entries", "size", "stat_or_null"]

--- a/python/mirage/core/nextcloud/du/entries.py
+++ b/python/mirage/core/nextcloud/du/entries.py
@@ -18,7 +18,7 @@ from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.nextcloud.stat import stat
+from mirage.core.nextcloud.du.walk import stat_or_null
 from mirage.types import FileType, PathSpec
 
 logger = logging.getLogger(__name__)
@@ -35,10 +35,7 @@ async def entries(
         accessor (NextcloudAccessor): Nextcloud accessor.
         path (PathSpec): target path.
     """
-    try:
-        info = await stat(accessor, path, index=index)
-    except FileNotFoundError:
-        info = None
+    info = await stat_or_null(accessor, path, index=index)
     if info is not None and info.type != FileType.DIRECTORY:
         return [], info.size or 0
     pfx = path.mount_path.strip("/")

--- a/python/mirage/core/nextcloud/du/walk.py
+++ b/python/mirage/core/nextcloud/du/walk.py
@@ -12,37 +12,27 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from opendal.exceptions import NotFound
-
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.nextcloud.du.walk import stat_or_null
-from mirage.types import FileType, PathSpec
+from mirage.core.nextcloud.stat import stat
+from mirage.types import FileStat, PathSpec
 
 
-async def size(accessor: NextcloudAccessor,
-               path: PathSpec,
-               index: IndexCacheStore = NULL_INDEX) -> int:
-    """Recursive byte size of everything under a path.
+async def stat_or_null(accessor: NextcloudAccessor,
+                       path: PathSpec,
+                       index: IndexCacheStore = NULL_INDEX) -> FileStat | None:
+    """The path's row, or None when nothing is there.
+
+    A du walk starts from a path it cannot assume exists, and both
+    callers ask the same question: is this a file to size directly, a
+    directory to scan, or nothing at all.
 
     Args:
         accessor (NextcloudAccessor): Nextcloud accessor.
         path (PathSpec): target path.
+        index (IndexCacheStore): listing cache.
     """
-    info = await stat_or_null(accessor, path, index=index)
-    if info is not None and info.type != FileType.DIRECTORY:
-        return info.size or 0
-    pfx = path.mount_path.strip("/")
-    scan_path = pfx + "/" if pfx else "/"
-    op = accessor.operator()
-    total = 0
     try:
-        async for entry in await op.scan(scan_path):
-            if entry.path.endswith("/"):
-                continue
-            meta = entry.metadata
-            if meta is not None:
-                total += int(meta.content_length or 0)
-    except NotFound:
-        return 0
-    return total
+        return await stat(accessor, path, index=index)
+    except FileNotFoundError:
+        return None

--- a/python/mirage/core/postgres/readdir.py
+++ b/python/mirage/core/postgres/readdir.py
@@ -18,6 +18,32 @@ from mirage.core.hierarchy.readdir import make_readdir
 from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.core.postgres import client
 from mirage.core.postgres.scope import ENTITY_FILES, KIND_DIRS, detect_scope
+from mirage.utils.errors import enoent
+
+
+async def schema_guard(accessor: PostgresAccessor, match: ScopeMatch,
+                       virtual: str) -> None:
+    pool = await accessor.pool()
+    async with pool.acquire() as conn:
+        schemas = await client.list_schemas(conn, accessor.config.schemas)
+    if match.slots["schema"] not in schemas:
+        raise enoent(virtual)
+
+
+async def entity_guard(accessor: PostgresAccessor, match: ScopeMatch,
+                       virtual: str) -> None:
+    schema = match.slots["schema"]
+    kind = match.slots["kind"]
+    pool = await accessor.pool()
+    async with pool.acquire() as conn:
+        if kind == "tables":
+            names = await client.list_tables(conn, schema)
+        else:
+            views = await client.list_views(conn, schema)
+            mviews = await client.list_matviews(conn, schema)
+            names = sorted(set(views) | set(mviews))
+    if match.slots["entity"] not in names:
+        raise enoent(virtual)
 
 
 async def _list_root(accessor: PostgresAccessor,
@@ -88,5 +114,15 @@ readdir = make_readdir(
         "schema": _list_schema,
         "kind": _list_entities,
         "entity": _list_entity_files,
+    },
+    # Every lister below answers from the path alone, so without these a
+    # schema or entity that does not exist reads as a real directory:
+    # tables/ and views/ under any first segment, the entity files under
+    # any third, and an empty listing (not ENOENT) for a missing schema's
+    # tables/. Same guards stat runs, so the two answer alike.
+    guards={
+        "schema": schema_guard,
+        "kind": schema_guard,
+        "entity": entity_guard,
     },
 )

--- a/python/mirage/core/postgres/stat.py
+++ b/python/mirage/core/postgres/stat.py
@@ -21,35 +21,9 @@ from mirage.cache.index import IndexCacheStore
 from mirage.core.hierarchy.scope import ScopeMatch
 from mirage.core.hierarchy.stat import make_stat
 from mirage.core.postgres import client
-from mirage.core.postgres.readdir import readdir
+from mirage.core.postgres.readdir import entity_guard, readdir, schema_guard
 from mirage.core.postgres.scope import detect_scope
 from mirage.types import ContentType, FileStat, FileType, PathSpec
-from mirage.utils.errors import enoent
-
-
-async def _schema_guard(accessor: PostgresAccessor, match: ScopeMatch,
-                        virtual: str) -> None:
-    pool = await accessor.pool()
-    async with pool.acquire() as conn:
-        schemas = await client.list_schemas(conn, accessor.config.schemas)
-    if match.slots["schema"] not in schemas:
-        raise enoent(virtual)
-
-
-async def _entity_guard(accessor: PostgresAccessor, match: ScopeMatch,
-                        virtual: str) -> None:
-    schema = match.slots["schema"]
-    kind = match.slots["kind"]
-    pool = await accessor.pool()
-    async with pool.acquire() as conn:
-        if kind == "tables":
-            names = await client.list_tables(conn, schema)
-        else:
-            views = await client.list_views(conn, schema)
-            mviews = await client.list_matviews(conn, schema)
-            names = sorted(set(views) | set(mviews))
-    if match.slots["entity"] not in names:
-        raise enoent(virtual)
 
 
 def _schema_extra(match: ScopeMatch) -> dict[str, str]:
@@ -73,7 +47,7 @@ def _entity_extra(match: ScopeMatch) -> dict[str, str]:
 
 async def _rows_stat(accessor: PostgresAccessor, match: ScopeMatch,
                      path: PathSpec, index: IndexCacheStore) -> FileStat:
-    await _entity_guard(accessor, match, path.virtual)
+    await entity_guard(accessor, match, path.virtual)
     schema = match.slots["schema"]
     kind = match.slots["kind"]
     entity = match.slots["entity"]
@@ -107,11 +81,11 @@ stat = make_stat(
     detect_scope,
     readdir,
     guards={
-        "schema": _schema_guard,
-        "kind": _schema_guard,
-        "entity": _entity_guard,
-        "entity_schema": _entity_guard,
-        "entity_semantic": _entity_guard,
+        "schema": schema_guard,
+        "kind": schema_guard,
+        "entity": entity_guard,
+        "entity_schema": entity_guard,
+        "entity_semantic": entity_guard,
     },
     extras={
         "schema": _schema_extra,

--- a/python/mirage/workspace/executor/builtins/links/probe.py
+++ b/python/mirage/workspace/executor/builtins/links/probe.py
@@ -34,7 +34,10 @@ async def resolve_path_stat(dispatch: DispatchFn,
     missing path with ``[]`` rather than raising, and cannot hold an
     empty directory anyway (one with no keys under it does not exist).
     Measured across every integ target: an implicit directory answers
-    here, a missing path does not.
+    here, a missing path does not. That holds only while a backend's
+    readdir refuses a path it cannot prove: postgres answered
+    ``tables``/``views`` under any first segment, and every absent
+    schema read as a directory here.
 
     Args:
         dispatch (DispatchFn): op dispatcher.

--- a/python/tests/core/nextcloud/du/test_walk.py
+++ b/python/tests/core/nextcloud/du/test_walk.py
@@ -1,0 +1,26 @@
+import pytest
+
+from mirage.core.nextcloud.du import stat_or_null
+from mirage.types import FileType, PathSpec
+
+
+@pytest.mark.asyncio
+async def test_stat_or_null_returns_the_row_for_a_file(make_acc):
+    acc = make_acc({"data/a.json": b"12345"})
+    info = await stat_or_null(acc, PathSpec.from_str_path("/data/a.json"))
+    assert info is not None
+    assert info.size == 5
+
+
+@pytest.mark.asyncio
+async def test_stat_or_null_returns_the_row_for_a_directory(make_acc):
+    acc = make_acc({"data/a.json": b"12345"})
+    info = await stat_or_null(acc, PathSpec.from_str_path("/data"))
+    assert info is not None
+    assert info.type == FileType.DIRECTORY
+
+
+@pytest.mark.asyncio
+async def test_stat_or_null_answers_none_for_a_missing_path(make_acc):
+    acc = make_acc({})
+    assert await stat_or_null(acc, PathSpec.from_str_path("/nope")) is None

--- a/python/tests/core/postgres/test_readdir.py
+++ b/python/tests/core/postgres/test_readdir.py
@@ -62,17 +62,20 @@ async def test_readdir_root_lists_database_json_and_schemas(accessor, index):
 
 @pytest.mark.asyncio
 async def test_readdir_schema_lists_kinds(accessor, index):
-    result = await readdir(
-        accessor,
-        PathSpec(resource_path="public",
-                 virtual="/public",
-                 directory="/public"), index)
+    with patch("mirage.core.postgres.readdir.client") as mc:
+        mc.list_schemas = AsyncMock(return_value=["public"])
+        result = await readdir(
+            accessor,
+            PathSpec(resource_path="public",
+                     virtual="/public",
+                     directory="/public"), index)
     assert result == ["/public/tables", "/public/views"]
 
 
 @pytest.mark.asyncio
 async def test_readdir_tables_kind_lists_tables(accessor, index):
     with patch("mirage.core.postgres.readdir.client") as mc:
+        mc.list_schemas = AsyncMock(return_value=["public"])
         mc.list_tables = AsyncMock(return_value=["users", "orders"])
         result = await readdir(
             accessor,
@@ -86,6 +89,7 @@ async def test_readdir_tables_kind_lists_tables(accessor, index):
 @pytest.mark.asyncio
 async def test_readdir_views_kind_unions_views_and_matviews(accessor, index):
     with patch("mirage.core.postgres.readdir.client") as mc:
+        mc.list_schemas = AsyncMock(return_value=["public"])
         mc.list_views = AsyncMock(return_value=["customer_360"])
         mc.list_matviews = AsyncMock(return_value=["daily_revenue"])
         result = await readdir(
@@ -99,11 +103,13 @@ async def test_readdir_views_kind_unions_views_and_matviews(accessor, index):
 
 @pytest.mark.asyncio
 async def test_readdir_entity_lists_schema_and_rows(accessor, index):
-    result = await readdir(
-        accessor,
-        PathSpec(resource_path="public/tables/users",
-                 virtual="/public/tables/users",
-                 directory="/public/tables/users"), index)
+    with patch("mirage.core.postgres.readdir.client") as mc:
+        mc.list_tables = AsyncMock(return_value=["users"])
+        result = await readdir(
+            accessor,
+            PathSpec(resource_path="public/tables/users",
+                     virtual="/public/tables/users",
+                     directory="/public/tables/users"), index)
     assert result == [
         "/public/tables/users/schema.json",
         "/public/tables/users/semantic.json",
@@ -113,11 +119,14 @@ async def test_readdir_entity_lists_schema_and_rows(accessor, index):
 
 @pytest.mark.asyncio
 async def test_readdir_view_entity_lists_schema_and_rows(accessor, index):
-    result = await readdir(
-        accessor,
-        PathSpec(resource_path="analytics/views/daily_revenue",
-                 virtual="/analytics/views/daily_revenue",
-                 directory="/analytics/views/daily_revenue"), index)
+    with patch("mirage.core.postgres.readdir.client") as mc:
+        mc.list_views = AsyncMock(return_value=["daily_revenue"])
+        mc.list_matviews = AsyncMock(return_value=[])
+        result = await readdir(
+            accessor,
+            PathSpec(resource_path="analytics/views/daily_revenue",
+                     virtual="/analytics/views/daily_revenue",
+                     directory="/analytics/views/daily_revenue"), index)
     assert result == [
         "/analytics/views/daily_revenue/schema.json",
         "/analytics/views/daily_revenue/semantic.json",
@@ -148,3 +157,40 @@ async def test_readdir_caches_root_listing(accessor, index):
             index)
     assert first == second
     assert mock_list_schemas.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_readdir_unknown_schema_raises(accessor, index):
+    with patch("mirage.core.postgres.readdir.client") as mc:
+        mc.list_schemas = AsyncMock(return_value=["public"])
+        with pytest.raises(FileNotFoundError):
+            await readdir(
+                accessor,
+                PathSpec(resource_path="nope.txt",
+                         virtual="/nope.txt",
+                         directory="/nope.txt"), index)
+
+
+@pytest.mark.asyncio
+async def test_readdir_kind_under_unknown_schema_raises(accessor, index):
+    with patch("mirage.core.postgres.readdir.client") as mc:
+        mc.list_schemas = AsyncMock(return_value=["public"])
+        mc.list_tables = AsyncMock(return_value=[])
+        with pytest.raises(FileNotFoundError):
+            await readdir(
+                accessor,
+                PathSpec(resource_path="nope/tables",
+                         virtual="/nope/tables",
+                         directory="/nope/tables"), index)
+
+
+@pytest.mark.asyncio
+async def test_readdir_unknown_entity_raises(accessor, index):
+    with patch("mirage.core.postgres.readdir.client") as mc:
+        mc.list_tables = AsyncMock(return_value=["users"])
+        with pytest.raises(FileNotFoundError):
+            await readdir(
+                accessor,
+                PathSpec(resource_path="public/tables/ghost",
+                         virtual="/public/tables/ghost",
+                         directory="/public/tables/ghost"), index)

--- a/spec/layout_exceptions.json
+++ b/spec/layout_exceptions.json
@@ -1,5 +1,5 @@
 {
- "baseline": 255,
+ "baseline": 254,
  "baseline_reason": "Every divergence below the excused ones predates the gate and each needs its own decision, so --strict fails on a rise rather than demanding zero. Lower this number whenever a divergence is closed; the gate fails on a drop too, so an improvement cannot be silently spent. Items 31-37 of the cleanup plan are scoped from this report. The unit is one module, never one directory: a one-sided directory counts once per module inside it, so it cannot absorb new modules without moving the number. An excused directory is the deliberate exception -- it excuses its whole subtree, because the excuse is that there is no counterpart to mirror, which makes growth inside it expected rather than drift.",
  "directories": {
   "python_only": {

--- a/spec/parity_exceptions.json
+++ b/spec/parity_exceptions.json
@@ -45,9 +45,9 @@
   },
   "unconstructible_resources": {
     "browser": {
-      "databricks_volume": "Registers commands in the browser bundle but has no browser registry factory. Both it and jaeger are pure HTTP, so the omission looks accidental rather than a runtime limit \u2014 confirm the intended browser scope before wiring them up.",
+      "databricks_volume": "Node-only on purpose, and not for want of a factory: the Databricks Files API sends no CORS headers, so a browser fetch is blocked whatever the config says. docs/typescript/setup/databricks_volume.mdx states it. The commands still register because they live in core, which every bundle carries.",
       "history": "See python: the history view mount is workspace-internal.",
-      "jaeger": "Registers commands in the browser bundle but has no browser registry factory. See databricks_volume."
+      "jaeger": "Same as databricks_volume, measured rather than assumed: on jaegertracing/jaeger:latest a GET carrying an Origin comes back with no Access-Control-Allow-Origin and the CORS preflight OPTIONS is a 404, so the query API is unreachable from a page. A deployment that fronts Jaeger with a CORS-adding proxy can register its own factory."
     },
     "node": {
       "history": "See python: the history view mount is workspace-internal."

--- a/typescript/packages/core/src/core/postgres/glob.test.ts
+++ b/typescript/packages/core/src/core/postgres/glob.test.ts
@@ -17,6 +17,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./readdir.ts', () => ({
   readdir: vi.fn(),
+  schemaGuard: vi.fn(),
+  entityGuard: vi.fn(),
 }))
 
 import { PostgresAccessor } from '../../accessor/postgres.ts'

--- a/typescript/packages/core/src/core/postgres/readdir.test.ts
+++ b/typescript/packages/core/src/core/postgres/readdir.test.ts
@@ -54,6 +54,7 @@ describe('readdir', () => {
   })
 
   it('lists schema: tables and views directories', async () => {
+    vi.mocked(client.listSchemas).mockResolvedValue(['public'])
     const out = await readdir(
       makeAccessor(),
       new PathSpec({
@@ -66,6 +67,7 @@ describe('readdir', () => {
   })
 
   it('lists kind=tables', async () => {
+    vi.mocked(client.listSchemas).mockResolvedValue(['public'])
     vi.mocked(client.listTables).mockResolvedValue(['users', 'orders'])
     const out = await readdir(
       makeAccessor(),
@@ -79,6 +81,7 @@ describe('readdir', () => {
   })
 
   it('lists kind=views: union of views and matviews, sorted', async () => {
+    vi.mocked(client.listSchemas).mockResolvedValue(['public'])
     vi.mocked(client.listViews).mockResolvedValue(['z_view'])
     vi.mocked(client.listMatviews).mockResolvedValue(['a_mview', 'z_view'])
     const out = await readdir(
@@ -93,6 +96,7 @@ describe('readdir', () => {
   })
 
   it('lists entity: schema.json + semantic.json + rows.jsonl', async () => {
+    vi.mocked(client.listTables).mockResolvedValue(['users'])
     const out = await readdir(
       makeAccessor(),
       new PathSpec({
@@ -131,6 +135,49 @@ describe('readdir', () => {
           virtual: '/pg/public/tables/users/schema.json',
           directory: '/pg/public/tables/users/',
           resourcePath: mountKey('/pg/public/tables/users/schema.json', '/pg'),
+        }),
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('refuses a schema that does not exist', async () => {
+    vi.mocked(client.listSchemas).mockResolvedValue(['public'])
+    await expect(
+      readdir(
+        makeAccessor(),
+        new PathSpec({
+          virtual: '/pg/nope.txt',
+          directory: '/pg/nope.txt',
+          resourcePath: mountKey('/pg/nope.txt', '/pg'),
+        }),
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('refuses a kind directory under a schema that does not exist', async () => {
+    vi.mocked(client.listSchemas).mockResolvedValue(['public'])
+    vi.mocked(client.listTables).mockResolvedValue([])
+    await expect(
+      readdir(
+        makeAccessor(),
+        new PathSpec({
+          virtual: '/pg/nope/tables',
+          directory: '/pg/nope/tables',
+          resourcePath: mountKey('/pg/nope/tables', '/pg'),
+        }),
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('refuses an entity that does not exist', async () => {
+    vi.mocked(client.listTables).mockResolvedValue(['users'])
+    await expect(
+      readdir(
+        makeAccessor(),
+        new PathSpec({
+          virtual: '/pg/public/tables/ghost',
+          directory: '/pg/public/tables/ghost',
+          resourcePath: mountKey('/pg/public/tables/ghost', '/pg'),
         }),
       ),
     ).rejects.toMatchObject({ code: 'ENOENT' })

--- a/typescript/packages/core/src/core/postgres/readdir.ts
+++ b/typescript/packages/core/src/core/postgres/readdir.ts
@@ -17,8 +17,36 @@ import { IndexEntry } from '../../cache/index/config.ts'
 import { makeReaddir } from '../hierarchy/readdir.ts'
 import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { compareCodePoints } from '../../utils/sort.ts'
+import { enoent } from '../../utils/errors.ts'
 import { listMatviews, listSchemas, listTables, listViews } from './client.ts'
 import { detectScope, ENTITY_FILES, KIND_DIRS } from './scope.ts'
+
+export async function schemaGuard(
+  accessor: PostgresAccessor,
+  match: ScopeMatch,
+  virtual: string,
+): Promise<void> {
+  const schemas = await listSchemas(accessor, accessor.config.schemas)
+  if (!schemas.includes(match.slots.schema ?? '')) throw enoent(virtual)
+}
+
+export async function entityGuard(
+  accessor: PostgresAccessor,
+  match: ScopeMatch,
+  virtual: string,
+): Promise<void> {
+  const schema = match.slots.schema ?? ''
+  const kind = match.slots.kind ?? ''
+  let names: string[]
+  if (kind === 'tables') {
+    names = await listTables(accessor, schema)
+  } else {
+    const views = await listViews(accessor, schema)
+    const mviews = await listMatviews(accessor, schema)
+    names = [...new Set([...views, ...mviews])]
+  }
+  if (!names.includes(match.slots.entity ?? '')) throw enoent(virtual)
+}
 
 async function listRoot(
   accessor: PostgresAccessor,
@@ -102,5 +130,15 @@ export const readdir = makeReaddir<PostgresAccessor>(detectScope, {
     schema: listSchema,
     kind: listEntities,
     entity: listEntityFiles,
+  },
+  // Every lister above answers from the path alone, so without these a
+  // schema or entity that does not exist reads as a real directory:
+  // tables/ and views/ under any first segment, the entity files under
+  // any third, and an empty listing (not ENOENT) for a missing schema's
+  // tables/. Same guards stat runs, so the two answer alike.
+  guards: {
+    schema: schemaGuard,
+    kind: schemaGuard,
+    entity: entityGuard,
   },
 })

--- a/typescript/packages/core/src/core/postgres/stat.ts
+++ b/typescript/packages/core/src/core/postgres/stat.ts
@@ -15,49 +15,13 @@
 import type { PostgresAccessor } from '../../accessor/postgres.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, type PathSpec } from '../../types.ts'
-import { enoent } from '../../utils/errors.ts'
 import { sha256Hex } from '../../utils/hash.ts'
 import { compactJsonBytes } from '../render/json.ts'
 import { makeStat } from '../hierarchy/stat.ts'
 import type { ScopeMatch } from '../hierarchy/scope.ts'
-import {
-  estimatedRowCount,
-  fetchColumns,
-  listMatviews,
-  listSchemas,
-  listTables,
-  listViews,
-  tableSizeBytes,
-} from './client.ts'
-import { readdir } from './readdir.ts'
+import { estimatedRowCount, fetchColumns, tableSizeBytes } from './client.ts'
+import { entityGuard, readdir, schemaGuard } from './readdir.ts'
 import { detectScope } from './scope.ts'
-
-async function schemaGuard(
-  accessor: PostgresAccessor,
-  match: ScopeMatch,
-  virtual: string,
-): Promise<void> {
-  const schemas = await listSchemas(accessor, accessor.config.schemas)
-  if (!schemas.includes(match.slots.schema ?? '')) throw enoent(virtual)
-}
-
-async function entityGuard(
-  accessor: PostgresAccessor,
-  match: ScopeMatch,
-  virtual: string,
-): Promise<void> {
-  const schema = match.slots.schema ?? ''
-  const kind = match.slots.kind ?? ''
-  let names: string[]
-  if (kind === 'tables') {
-    names = await listTables(accessor, schema)
-  } else {
-    const views = await listViews(accessor, schema)
-    const mviews = await listMatviews(accessor, schema)
-    names = [...new Set([...views, ...mviews])]
-  }
-  if (!names.includes(match.slots.entity ?? '')) throw enoent(virtual)
-}
 
 function schemaExtra(match: ScopeMatch): Record<string, string> {
   return { schema: match.slots.schema ?? '' }

--- a/typescript/packages/core/src/workspace/executor/builtins/links/probe.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/links/probe.ts
@@ -42,6 +42,9 @@ export async function statOrNull(dispatch: DispatchFn, path: PathSpec): Promise<
 // path with [] rather than raising, and cannot hold an empty directory
 // anyway (one with no keys under it does not exist). Measured across every
 // integ target: an implicit directory answers here, a missing path does not.
+// That holds only while a backend's readdir refuses a path it cannot prove:
+// postgres answered tables/views under any first segment, and every absent
+// schema read as a directory here.
 export async function resolvePathStat(
   dispatch: DispatchFn,
   path: PathSpec,


### PR DESCRIPTION
Three things: the postgres readdir bug, the nextcloud du parity gap (K1b), and the resource-docs read-through (G5).

## postgres readdir answered for schemas that do not exist

Every postgres lister answered from the path alone, so `tables/` and `views/` existed under any first segment and the entity files under any third. The kit already has the mechanism for this: `stat` wired `guards` and `readdir` did not, so the two disagreed about the same path.

Measured before, on a live postgres:

```
ls /pg/nope.txt      exit 1  ls: cannot access '/pg/nope.txt/tables': No such file or directory
                             ls: cannot access '/pg/nope.txt/views': No such file or directory
test -d /pg/nope.txt exit 0
find /pg/nope.txt    exit 0  /pg/nope.txt/tables
                             /pg/nope.txt/views
ls /pg/nope/tables   exit 0  (an empty directory, not an absent one)
cat /pg/nope/tables/whatever/rows.jsonl   cat: ...: Is a directory
stat /pg/nope.txt    exit 0  type=directory
```

After, all seven report absence with GNU's wording and exit codes, and `ls`/`find`/`stat`/`tree` now answer for a missing postgres path exactly as they do for a missing ram path.

The two guards move from `stat.py` to `readdir.py` and are passed to `make_readdir`, which is where mongodb has kept its own since it was written. `stat.py` imports them back, so both ops run the same check and cannot drift.

Also worth knowing: this falsified the docstring on `resolve_path_stat`, whose second channel reads a non-empty readdir as proof of a directory. It claimed the invariant was measured across every integ target, and postgres was the counterexample. The claim is true again; both languages now record what it depends on.

**mongodb does not share the defect**, checked rather than assumed: the same five probes against a live mongo all report absence, because its readdir already wires `database_guard`/`entity_guard`. An AST sweep over every kit backend found no other lister that answers from the path alone without a guard. lancedb and qdrant look similar in that they guard only on `stat`, but their listers return `None` for a missing container, which the kit turns into ENOENT.

New integ coverage: seven cases in `integ/resources/postgres/probe.json` pinning `ls`, `test -d`, `find`, `stat` and `cat` on a nonexistent schema, a kind directory under one, and a nonexistent entity. `68 passed` on both hosts.

## K1b, nextcloud du

Both du callers opened with the same `try/except FileNotFoundError` around `stat`, which TypeScript has had factored as `du/walk.ts` since the module landed. Layout parity read it as `typescript-only ['walk']`; the baseline drops to 254.

The other K1b item was the two browser registry factories, and the answer turned out to be that neither should exist. `parity_exceptions.json` guessed the omissions were accidental because both backends are pure HTTP. They are not: `docs/typescript/setup/databricks_volume.mdx` has said all along that the Databricks Files API refuses cross-origin browser requests, and `jaegertracing/jaeger:latest` answers a GET carrying an `Origin` with no `Access-Control-Allow-Origin` and a 404 for the CORS preflight. Both entries now record that instead of inviting the next reader to wire them up. The commands still register in the browser bundle because they live in `core`, which every bundle carries.

## G5, resource docs read-through

Both `new.mdx` pages already describe the derived-ops model, name `GenericResource`, and cover the colon reference and registration, so there was one real finding. The python page built the resource in a factory function and then the three snippets under it named a `JiraResource` class the reader never got: the `register_resource` call, the entry point, and the config reference. It is now a `GenericResource` subclass, matching the typescript page and `examples/python/other/custom_resource.py`.

Separately, and not fixed here: **jaeger has no documentation at all**. No `docs/python/resource/jaeger.mdx`, no `docs/typescript/setup/jaeger.mdx`, no resource-matrix row, no `docs.json` entry, for a backend that is registry-constructible in python and node, has commands, ops and a prompt, and runs a real container in CI. Langfuse, its closest sibling, has all three pages. Worth its own PR.

## Verification

- python `pytest` (FUSE excluded) exit 0, no failures
- TS core 9704 passed, node 2461 passed, browser 258 passed
- `pre-commit run --all-files` clean; spec drift, spec parity, width table clean
- layout parity 254/254, case targets 2290/2290
- integ both hosts: postgres 68, mongodb 58, ram 2846, disk 2804
