### PR TITLE
fix(box): rename and copy refuse a destination they were destroying

### DIFF
--- a/integ/unix/overwrite/mv.json
+++ b/integ/unix/overwrite/mv.json
@@ -65,6 +65,38 @@
       }
     },
     {
+      "id": "ow_mv_T_onto_existing_empty_dir",
+      "seq": 203008,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir /data/ow/e && mv -T /data/ow/s/t /data/ow/e && ls /data/ow/e",
+      "expect": {
+        "exit": 0,
+        "stdout": "f.txt\n",
+        "stderr": ""
+      }
+    },
+    {
       "id": "ow_mv_n_skips_existing_nonempty_dir",
       "seq": 203007,
       "targets": [

--- a/python/mirage/core/box/copy.py
+++ b/python/mirage/core/box/copy.py
@@ -17,10 +17,10 @@ from typing import Any
 from mirage.accessor.box import BoxAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.box.api import (copy_file, copy_folder, delete_file,
-                                 delete_folder, list_folder_items)
+                                 list_folder_items)
 from mirage.core.box.resolve import path_parts, resolve_item, resolve_parent_id
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent
+from mirage.utils.errors import eisdir, enoent, enotdir
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
 
@@ -47,10 +47,15 @@ async def _copy_into(accessor: BoxAccessor, item: dict[str, Any],
         raise enoent(dst.virtual)
     new_name = dst_parts[-1]
     if existing is not None and existing["id"] != item["id"]:
+        # Folder onto folder already merged above, so what is left is a type
+        # mismatch or a file replacing a file. cp refuses either mismatch
+        # (rename(2)'s own errnos), mirroring gdrive and the msgraph
+        # copy_tree; only a file gives way to a file.
         if existing.get("type") == "folder":
-            await delete_folder(tm, existing["id"], recursive=True)
-        else:
-            await delete_file(tm, existing["id"])
+            raise eisdir(dst.virtual)
+        if item.get("type") == "folder":
+            raise enotdir(dst.virtual)
+        await delete_file(tm, existing["id"])
     if item.get("type") == "folder":
         await copy_folder(tm, item["id"], dst_parent, name=new_name)
     else:

--- a/python/mirage/core/box/rename.py
+++ b/python/mirage/core/box/rename.py
@@ -16,9 +16,10 @@ from mirage.accessor.box import BoxAccessor
 from mirage.cache.context import invalidate_subtree
 from mirage.core.box.api import (delete_file, delete_folder, update_file,
                                  update_folder)
+from mirage.core.box.client import BoxApiError
 from mirage.core.box.resolve import path_parts, resolve_item, resolve_parent_id
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent
+from mirage.utils.errors import enoent, enotempty
 
 
 async def rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec) -> None:
@@ -33,11 +34,18 @@ async def rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec) -> None:
         raise enoent(dst.virtual)
     new_name = dst_parts[-1]
     # GNU mv overwrites the destination; Box 409s on a name clash, so clear
-    # an existing dst of the same kind first.
+    # an existing dst first. A file or an empty folder goes; a non-empty
+    # folder is mv's "Directory not empty", which recursive=false gets from
+    # Box for free, exactly as rmdir does.
     existing = await resolve_item(accessor, dst_parts)
     if existing is not None and existing["id"] != item["id"]:
         if existing.get("type") == "folder":
-            await delete_folder(tm, existing["id"], recursive=True)
+            try:
+                await delete_folder(tm, existing["id"], recursive=False)
+            except BoxApiError as exc:
+                if exc.status == 409:
+                    raise enotempty(dst) from exc
+                raise
         else:
             await delete_file(tm, existing["id"])
     if item.get("type") == "folder":

--- a/python/mirage/core/box/rename.py
+++ b/python/mirage/core/box/rename.py
@@ -19,7 +19,7 @@ from mirage.core.box.api import (delete_file, delete_folder, update_file,
 from mirage.core.box.client import BoxApiError
 from mirage.core.box.resolve import path_parts, resolve_item, resolve_parent_id
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent, enotempty
+from mirage.utils.errors import eisdir, enoent, enotdir, enotempty
 
 
 async def rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec) -> None:
@@ -34,12 +34,18 @@ async def rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec) -> None:
         raise enoent(dst.virtual)
     new_name = dst_parts[-1]
     # GNU mv overwrites the destination; Box 409s on a name clash, so clear
-    # an existing dst first. A file or an empty folder goes; a non-empty
-    # folder is mv's "Directory not empty", which recursive=false gets from
-    # Box for free, exactly as rmdir does.
+    # an existing dst first. A type mismatch is refused with rename(2)'s own
+    # errnos and outranks emptiness, since real rename answers EISDIR for a
+    # file onto a directory whether or not that directory has children. Only
+    # a folder gives way to a folder, and then only an empty one: a non-empty
+    # one is mv's "Directory not empty", which recursive=false gets from Box
+    # for free, exactly as rmdir does.
     existing = await resolve_item(accessor, dst_parts)
     if existing is not None and existing["id"] != item["id"]:
+        src_is_folder = item.get("type") == "folder"
         if existing.get("type") == "folder":
+            if not src_is_folder:
+                raise eisdir(dst.virtual)
             try:
                 await delete_folder(tm, existing["id"], recursive=False)
             except BoxApiError as exc:
@@ -47,6 +53,8 @@ async def rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec) -> None:
                     raise enotempty(dst) from exc
                 raise
         else:
+            if src_is_folder:
+                raise enotdir(dst.virtual)
             await delete_file(tm, existing["id"])
     if item.get("type") == "folder":
         await update_folder(tm,

--- a/python/tests/core/box/test_write.py
+++ b/python/tests/core/box/test_write.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from mirage.core.box.client import BoxApiError
 from mirage.core.box.copy import copy
 from mirage.core.box.mkdir import mkdir
 from mirage.core.box.rename import rename
@@ -195,6 +197,95 @@ async def test_rename_moves_file(root_accessor):
                                 "200",
                                 name="b.txt",
                                 parent_id="100")
+
+
+@pytest.mark.asyncio
+async def test_rename_replaces_empty_folder_destination(root_accessor):
+    with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
+         patch("mirage.core.box.rename.delete_folder",
+               new_callable=AsyncMock) as df, \
+         patch("mirage.core.box.rename.update_file",
+               new_callable=AsyncMock) as uf, \
+         patch("mirage.core.box.rename.invalidate_subtree",
+               new_callable=AsyncMock):
+        await rename(root_accessor, _spec("/data/a.txt"), _spec("/data/sub"))
+    df.assert_awaited_once_with(root_accessor.token_manager,
+                                "300",
+                                recursive=False)
+    uf.assert_awaited_once_with(root_accessor.token_manager,
+                                "200",
+                                name="sub",
+                                parent_id="100")
+
+
+@pytest.mark.asyncio
+async def test_rename_refuses_nonempty_folder_destination(root_accessor):
+    # Box decides the emptiness, not us: recursive=false 409s on a folder
+    # with children, and that is mv's "Directory not empty".
+    with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
+         patch("mirage.core.box.rename.delete_folder",
+               new_callable=AsyncMock,
+               side_effect=BoxApiError("conflict", 409)), \
+         patch("mirage.core.box.rename.update_file",
+               new_callable=AsyncMock) as uf, \
+         patch("mirage.core.box.rename.update_folder",
+               new_callable=AsyncMock) as uo, \
+         patch("mirage.core.box.rename.invalidate_subtree",
+               new_callable=AsyncMock):
+        with pytest.raises(OSError) as caught:
+            await rename(root_accessor, _spec("/data/a.txt"),
+                         _spec("/data/sub"))
+    assert caught.value.errno == errno.ENOTEMPTY
+    assert uf.await_count == 0
+    assert uo.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_rename_unmapped_folder_error_propagates(root_accessor):
+    with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
+         patch("mirage.core.box.rename.delete_folder",
+               new_callable=AsyncMock,
+               side_effect=BoxApiError("boom", 500)), \
+         patch("mirage.core.box.rename.update_file",
+               new_callable=AsyncMock), \
+         patch("mirage.core.box.rename.invalidate_subtree",
+               new_callable=AsyncMock):
+        with pytest.raises(BoxApiError):
+            await rename(root_accessor, _spec("/data/a.txt"),
+                         _spec("/data/sub"))
+
+
+@pytest.mark.asyncio
+async def test_copy_file_onto_folder_raises_isdir(root_accessor):
+    # cp refuses a type mismatch rather than replacing: this branch used to
+    # recursively delete the destination folder.
+    with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
+         patch("mirage.core.box.copy.copy_file",
+               new_callable=AsyncMock) as cf, \
+         patch("mirage.core.box.copy.delete_file",
+               new_callable=AsyncMock) as df, \
+         patch("mirage.core.box.copy.invalidate_after_write",
+               new_callable=AsyncMock):
+        with pytest.raises(IsADirectoryError):
+            await copy(root_accessor, _spec("/data/a.txt"), _spec("/data/sub"))
+    assert cf.await_count == 0
+    assert df.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_copy_folder_onto_file_raises_notdir(root_accessor):
+    with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
+         patch("mirage.core.box.copy.list_folder_items", new=_fake_list), \
+         patch("mirage.core.box.copy.copy_folder",
+               new_callable=AsyncMock) as cd, \
+         patch("mirage.core.box.copy.delete_file",
+               new_callable=AsyncMock) as df, \
+         patch("mirage.core.box.copy.invalidate_after_write",
+               new_callable=AsyncMock):
+        with pytest.raises(NotADirectoryError):
+            await copy(root_accessor, _spec("/data/sub"), _spec("/data/a.txt"))
+    assert cd.await_count == 0
+    assert df.await_count == 0
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/box/test_write.py
+++ b/python/tests/core/box/test_write.py
@@ -46,8 +46,14 @@ _TREE = {
             "name": "sub",
             "type": "folder"
         },
+        {
+            "id": "400",
+            "name": "dst",
+            "type": "folder"
+        },
     ],
     "300": [],
+    "400": [],
 }
 
 
@@ -204,17 +210,17 @@ async def test_rename_replaces_empty_folder_destination(root_accessor):
     with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
          patch("mirage.core.box.rename.delete_folder",
                new_callable=AsyncMock) as df, \
-         patch("mirage.core.box.rename.update_file",
-               new_callable=AsyncMock) as uf, \
+         patch("mirage.core.box.rename.update_folder",
+               new_callable=AsyncMock) as uo, \
          patch("mirage.core.box.rename.invalidate_subtree",
                new_callable=AsyncMock):
-        await rename(root_accessor, _spec("/data/a.txt"), _spec("/data/sub"))
+        await rename(root_accessor, _spec("/data/sub"), _spec("/data/dst"))
     df.assert_awaited_once_with(root_accessor.token_manager,
-                                "300",
+                                "400",
                                 recursive=False)
-    uf.assert_awaited_once_with(root_accessor.token_manager,
-                                "200",
-                                name="sub",
+    uo.assert_awaited_once_with(root_accessor.token_manager,
+                                "300",
+                                name="dst",
                                 parent_id="100")
 
 
@@ -226,17 +232,13 @@ async def test_rename_refuses_nonempty_folder_destination(root_accessor):
          patch("mirage.core.box.rename.delete_folder",
                new_callable=AsyncMock,
                side_effect=BoxApiError("conflict", 409)), \
-         patch("mirage.core.box.rename.update_file",
-               new_callable=AsyncMock) as uf, \
          patch("mirage.core.box.rename.update_folder",
                new_callable=AsyncMock) as uo, \
          patch("mirage.core.box.rename.invalidate_subtree",
                new_callable=AsyncMock):
         with pytest.raises(OSError) as caught:
-            await rename(root_accessor, _spec("/data/a.txt"),
-                         _spec("/data/sub"))
+            await rename(root_accessor, _spec("/data/sub"), _spec("/data/dst"))
     assert caught.value.errno == errno.ENOTEMPTY
-    assert uf.await_count == 0
     assert uo.await_count == 0
 
 
@@ -246,13 +248,47 @@ async def test_rename_unmapped_folder_error_propagates(root_accessor):
          patch("mirage.core.box.rename.delete_folder",
                new_callable=AsyncMock,
                side_effect=BoxApiError("boom", 500)), \
-         patch("mirage.core.box.rename.update_file",
+         patch("mirage.core.box.rename.update_folder",
                new_callable=AsyncMock), \
          patch("mirage.core.box.rename.invalidate_subtree",
                new_callable=AsyncMock):
         with pytest.raises(BoxApiError):
+            await rename(root_accessor, _spec("/data/sub"), _spec("/data/dst"))
+
+
+@pytest.mark.asyncio
+async def test_rename_file_onto_folder_raises_isdir(root_accessor):
+    # rename(2) answers EISDIR for a file onto a directory whether or not
+    # that directory has children, so the type check outranks emptiness and
+    # the folder is never deleted to find out.
+    with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
+         patch("mirage.core.box.rename.delete_folder",
+               new_callable=AsyncMock) as df, \
+         patch("mirage.core.box.rename.update_file",
+               new_callable=AsyncMock) as uf, \
+         patch("mirage.core.box.rename.invalidate_subtree",
+               new_callable=AsyncMock):
+        with pytest.raises(IsADirectoryError):
             await rename(root_accessor, _spec("/data/a.txt"),
                          _spec("/data/sub"))
+    assert df.await_count == 0
+    assert uf.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_rename_folder_onto_file_raises_notdir(root_accessor):
+    with patch("mirage.core.box.resolve.list_folder_items", new=_fake_list), \
+         patch("mirage.core.box.rename.delete_file",
+               new_callable=AsyncMock) as df, \
+         patch("mirage.core.box.rename.update_folder",
+               new_callable=AsyncMock) as uo, \
+         patch("mirage.core.box.rename.invalidate_subtree",
+               new_callable=AsyncMock):
+        with pytest.raises(NotADirectoryError):
+            await rename(root_accessor, _spec("/data/sub"),
+                         _spec("/data/a.txt"))
+    assert df.await_count == 0
+    assert uo.await_count == 0
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/core/src/core/box/write.test.ts
+++ b/typescript/packages/core/src/core/box/write.test.ts
@@ -45,7 +45,7 @@ import {
   invalidateSubtree,
 } from '../../cache/context.ts'
 import { PathSpec } from '../../types.ts'
-import type { BoxTokenManager } from './client.ts'
+import { BoxApiError, type BoxTokenManager } from './client.ts'
 import * as api from './api.ts'
 import { copy, mkdir, rename, rmR, rmdir, unlink, write } from './write.ts'
 
@@ -143,6 +143,56 @@ describe('box write ops', () => {
     expect(evicted).toEqual(['/data/b.txt', '/data/a.txt'])
     expect(vi.mocked(invalidateAfterUnlink)).not.toHaveBeenCalled()
     expect(vi.mocked(invalidateAfterWrite)).not.toHaveBeenCalled()
+  })
+
+  it('rename replaces an empty folder destination', async () => {
+    vi.mocked(api.updateFile).mockClear()
+    await rename(makeAccessor(), spec('/data/a.txt'), spec('/data/sub'))
+    expect(vi.mocked(api.deleteFolder)).toHaveBeenCalledWith(STUB_TM, '300', false)
+    expect(vi.mocked(api.updateFile)).toHaveBeenCalledWith(STUB_TM, '200', {
+      name: 'sub',
+      parentId: '100',
+    })
+  })
+
+  it('rename refuses a non-empty folder destination with ENOTEMPTY', async () => {
+    // Box decides the emptiness, not us: recursive=false 409s on a folder
+    // with children, and that is mv's "Directory not empty".
+    vi.mocked(api.updateFile).mockClear()
+    vi.mocked(api.deleteFolder).mockRejectedValueOnce(new BoxApiError('conflict', 409))
+    await expect(
+      rename(makeAccessor(), spec('/data/a.txt'), spec('/data/sub')),
+    ).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    expect(vi.mocked(api.updateFile)).not.toHaveBeenCalled()
+  })
+
+  it('rename propagates a destination error Box did not call a conflict', async () => {
+    vi.mocked(api.updateFile).mockClear()
+    vi.mocked(api.deleteFolder).mockRejectedValueOnce(new BoxApiError('boom', 500))
+    await expect(
+      rename(makeAccessor(), spec('/data/a.txt'), spec('/data/sub')),
+    ).rejects.toBeInstanceOf(BoxApiError)
+    expect(vi.mocked(api.updateFile)).not.toHaveBeenCalled()
+  })
+
+  it('copy refuses a file onto an existing folder with EISDIR', async () => {
+    // cp refuses a type mismatch rather than replacing: this branch used to
+    // recursively delete the destination folder.
+    vi.mocked(api.copyFile).mockClear()
+    vi.mocked(api.deleteFile).mockClear()
+    await expect(
+      copy(makeAccessor(), spec('/data/a.txt'), spec('/data/sub')),
+    ).rejects.toMatchObject({ code: 'EISDIR' })
+    expect(vi.mocked(api.copyFile)).not.toHaveBeenCalled()
+    expect(vi.mocked(api.deleteFile)).not.toHaveBeenCalled()
+  })
+
+  it('copy refuses a folder onto an existing file with ENOTDIR', async () => {
+    vi.mocked(api.deleteFile).mockClear()
+    await expect(
+      copy(makeAccessor(), spec('/data/sub'), spec('/data/a.txt')),
+    ).rejects.toMatchObject({ code: 'ENOTDIR' })
+    expect(vi.mocked(api.deleteFile)).not.toHaveBeenCalled()
   })
 
   it('copy copies a file into the dst parent', async () => {

--- a/typescript/packages/core/src/core/box/write.test.ts
+++ b/typescript/packages/core/src/core/box/write.test.ts
@@ -26,6 +26,7 @@ vi.mock('./api.ts', async () => {
     deleteFile: vi.fn(),
     deleteFolder: vi.fn(),
     updateFile: vi.fn(),
+    updateFolder: vi.fn(),
     copyFile: vi.fn(),
   }
 })
@@ -60,8 +61,10 @@ const TREE: Record<string, ApiModule.BoxItem[]> = {
   '100': [
     { type: 'file', id: '200', name: 'a.txt', size: 5 },
     { type: 'folder', id: '300', name: 'sub' },
+    { type: 'folder', id: '400', name: 'dst' },
   ],
   '300': [],
+  '400': [],
 }
 
 function spec(virtual: string): PathSpec {
@@ -146,11 +149,11 @@ describe('box write ops', () => {
   })
 
   it('rename replaces an empty folder destination', async () => {
-    vi.mocked(api.updateFile).mockClear()
-    await rename(makeAccessor(), spec('/data/a.txt'), spec('/data/sub'))
-    expect(vi.mocked(api.deleteFolder)).toHaveBeenCalledWith(STUB_TM, '300', false)
-    expect(vi.mocked(api.updateFile)).toHaveBeenCalledWith(STUB_TM, '200', {
-      name: 'sub',
+    vi.mocked(api.updateFolder).mockClear()
+    await rename(makeAccessor(), spec('/data/sub'), spec('/data/dst'))
+    expect(vi.mocked(api.deleteFolder)).toHaveBeenCalledWith(STUB_TM, '400', false)
+    expect(vi.mocked(api.updateFolder)).toHaveBeenCalledWith(STUB_TM, '300', {
+      name: 'dst',
       parentId: '100',
     })
   })
@@ -158,21 +161,44 @@ describe('box write ops', () => {
   it('rename refuses a non-empty folder destination with ENOTEMPTY', async () => {
     // Box decides the emptiness, not us: recursive=false 409s on a folder
     // with children, and that is mv's "Directory not empty".
-    vi.mocked(api.updateFile).mockClear()
+    vi.mocked(api.updateFolder).mockClear()
     vi.mocked(api.deleteFolder).mockRejectedValueOnce(new BoxApiError('conflict', 409))
     await expect(
-      rename(makeAccessor(), spec('/data/a.txt'), spec('/data/sub')),
+      rename(makeAccessor(), spec('/data/sub'), spec('/data/dst')),
     ).rejects.toMatchObject({ code: 'ENOTEMPTY' })
-    expect(vi.mocked(api.updateFile)).not.toHaveBeenCalled()
+    expect(vi.mocked(api.updateFolder)).not.toHaveBeenCalled()
   })
 
   it('rename propagates a destination error Box did not call a conflict', async () => {
-    vi.mocked(api.updateFile).mockClear()
+    vi.mocked(api.updateFolder).mockClear()
     vi.mocked(api.deleteFolder).mockRejectedValueOnce(new BoxApiError('boom', 500))
     await expect(
-      rename(makeAccessor(), spec('/data/a.txt'), spec('/data/sub')),
+      rename(makeAccessor(), spec('/data/sub'), spec('/data/dst')),
     ).rejects.toBeInstanceOf(BoxApiError)
+    expect(vi.mocked(api.updateFolder)).not.toHaveBeenCalled()
+  })
+
+  it('rename refuses a file onto a folder with EISDIR', async () => {
+    // rename(2) answers EISDIR for a file onto a directory whether or not
+    // that directory has children, so the type check outranks emptiness and
+    // the folder is never deleted to find out.
+    vi.mocked(api.deleteFolder).mockClear()
+    vi.mocked(api.updateFile).mockClear()
+    await expect(
+      rename(makeAccessor(), spec('/data/a.txt'), spec('/data/sub')),
+    ).rejects.toMatchObject({ code: 'EISDIR' })
+    expect(vi.mocked(api.deleteFolder)).not.toHaveBeenCalled()
     expect(vi.mocked(api.updateFile)).not.toHaveBeenCalled()
+  })
+
+  it('rename refuses a folder onto a file with ENOTDIR', async () => {
+    vi.mocked(api.deleteFile).mockClear()
+    vi.mocked(api.updateFolder).mockClear()
+    await expect(
+      rename(makeAccessor(), spec('/data/sub'), spec('/data/a.txt')),
+    ).rejects.toMatchObject({ code: 'ENOTDIR' })
+    expect(vi.mocked(api.deleteFile)).not.toHaveBeenCalled()
+    expect(vi.mocked(api.updateFolder)).not.toHaveBeenCalled()
   })
 
   it('copy refuses a file onto an existing folder with EISDIR', async () => {

--- a/typescript/packages/core/src/core/box/write.ts
+++ b/typescript/packages/core/src/core/box/write.ts
@@ -144,13 +144,28 @@ export async function rmR(accessor: BoxAccessor, path: PathSpec): Promise<void> 
   await invalidateSubtree(path)
 }
 
-async function clearDest(accessor: BoxAccessor, dstParts: string[], srcId: string): Promise<void> {
+async function clearDest(
+  accessor: BoxAccessor,
+  dst: PathSpec,
+  dstParts: string[],
+  srcId: string,
+): Promise<void> {
   // GNU mv/cp overwrite; Box 409s on a name clash, so clear an existing dst.
+  // A file or an empty folder goes; a non-empty folder is mv's "Directory not
+  // empty", which recursive=false gets from Box for free, as rmdir does.
   const existing = await resolveItem(accessor, dstParts)
   if (existing === null || existing.id === srcId) return
   const tm = accessor.tokenManager
-  if (existing.type === 'folder') await deleteFolder(tm, existing.id, true)
-  else await deleteFile(tm, existing.id)
+  if (existing.type !== 'folder') {
+    await deleteFile(tm, existing.id)
+    return
+  }
+  try {
+    await deleteFolder(tm, existing.id, false)
+  } catch (error) {
+    if (error instanceof BoxApiError && error.status === 409) throw enotempty(dst)
+    throw error
+  }
 }
 
 export async function rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec): Promise<void> {
@@ -160,7 +175,7 @@ export async function rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec
   const dstParts = pathParts(dst)
   const dstParent = await resolveParentId(accessor, dstParts)
   if (dstParent === null) throw enoent(dst.virtual)
-  await clearDest(accessor, dstParts, item.id)
+  await clearDest(accessor, dst, dstParts, item.id)
   const newName = dstParts[dstParts.length - 1] ?? ''
   if (item.type === 'folder')
     await updateFolder(tm, item.id, { name: newName, parentId: dstParent })
@@ -193,8 +208,13 @@ async function copyInto(accessor: BoxAccessor, item: BoxItem, dst: PathSpec): Pr
   if (dstParent === null) throw enoent(dst.virtual)
   const newName = dstParts[dstParts.length - 1] ?? ''
   if (existing !== null && existing.id !== item.id) {
-    if (existing.type === 'folder') await deleteFolder(tm, existing.id, true)
-    else await deleteFile(tm, existing.id)
+    // Folder onto folder already merged above, so what is left is a type
+    // mismatch or a file replacing a file. cp refuses either mismatch
+    // (rename(2)'s own errnos), mirroring gdrive and the msgraph copyTree;
+    // only a file gives way to a file.
+    if (existing.type === 'folder') throw eisdir(dst.virtual)
+    if (item.type === 'folder') throw enotdir(dst.virtual)
+    await deleteFile(tm, existing.id)
   }
   if (item.type === 'folder') await copyFolder(tm, item.id, dstParent, newName)
   else await copyFile(tm, item.id, dstParent, newName)

--- a/typescript/packages/core/src/core/box/write.ts
+++ b/typescript/packages/core/src/core/box/write.ts
@@ -148,18 +148,23 @@ async function clearDest(
   accessor: BoxAccessor,
   dst: PathSpec,
   dstParts: string[],
-  srcId: string,
+  src: BoxItem,
 ): Promise<void> {
   // GNU mv/cp overwrite; Box 409s on a name clash, so clear an existing dst.
-  // A file or an empty folder goes; a non-empty folder is mv's "Directory not
+  // A type mismatch is refused with rename(2)'s own errnos and outranks
+  // emptiness, since real rename answers EISDIR for a file onto a directory
+  // whether or not that directory has children. Only a folder gives way to a
+  // folder, and then only an empty one: a non-empty one is mv's "Directory not
   // empty", which recursive=false gets from Box for free, as rmdir does.
   const existing = await resolveItem(accessor, dstParts)
-  if (existing === null || existing.id === srcId) return
+  if (existing === null || existing.id === src.id) return
   const tm = accessor.tokenManager
   if (existing.type !== 'folder') {
+    if (src.type === 'folder') throw enotdir(dst.virtual)
     await deleteFile(tm, existing.id)
     return
   }
+  if (src.type !== 'folder') throw eisdir(dst.virtual)
   try {
     await deleteFolder(tm, existing.id, false)
   } catch (error) {
@@ -175,7 +180,7 @@ export async function rename(accessor: BoxAccessor, src: PathSpec, dst: PathSpec
   const dstParts = pathParts(dst)
   const dstParent = await resolveParentId(accessor, dstParts)
   if (dstParent === null) throw enoent(dst.virtual)
-  await clearDest(accessor, dst, dstParts, item.id)
+  await clearDest(accessor, dst, dstParts, item)
   const newName = dstParts[dstParts.length - 1] ?? ''
   if (item.type === 'folder')
     await updateFolder(tm, item.id, { name: newName, parentId: dstParent })


### PR DESCRIPTION
box was the one cloud drive that cleared a destination its siblings refuse.

| | file onto existing folder | folder onto non-empty folder |
|---|---|---|
| onedrive / sharepoint | refuse (409) | refuse (409) |
| gdrive | `eisdir` | `enotempty` |
| dropbox | re-raise the conflict | re-raise the conflict |
| box, before | recursive delete | recursive delete |

## What changed

`rename` deletes the destination with `recursive=false` and reads Box's 409 as ENOTEMPTY. That is what box's own `rmdir` already does, so an empty folder still gives way and a non-empty one does not, and it costs no extra API call where gdrive and dropbox each spend a bounded listing to decide the same thing.

`copy` refuses both type mismatches with `rename(2)`'s own errnos, EISDIR and ENOTDIR, matching gdrive and the msgraph `copy_tree`. Only a file still replaces a file. `delete_folder` is no longer imported in the python module, so the destructive call is gone rather than guarded.

## Reachability

Neither was reachable from a shell line. Generic `mv` refuses a non-empty directory target before any backend rename runs, and that guard is deliberately not gated on `no_target_dir`, so `-T` is covered too; generic `cp` and `mv` both refuse the type mismatch. `rename` is reachable through `os.rename`, `os.replace` and `os.renames`, which `runtime/verbs.py` maps onto the one rename op that `ops/generic/factory.py` passes straight to the backend. `copy` has no `os` verb, so it is reachable only through a direct `ws.ops` call.

## Tests

Five unit tests per language in the existing box write-surface files: the empty-folder replace, the non-empty refusal, a non-409 error propagating unchanged, and the two copy mismatches. Each fails against the old code.

One integ case, `ow_mv_T_onto_existing_empty_dir`, on the same 20 targets as its siblings, golden pinned against GNU mv on `debian:stable-slim` first. It covers the empty-folder replace that `rename` now routes through `recursive=false`, and is the first coverage of that branch for gdrive, dropbox, onedrive and sharepoint as well. It does not catch the original defect, whose only route has no integ mechanism today, since runtime cases carry no `targets` field and cannot be pointed at a box mount.

## Verified

- python suite green, TS core suite green (738 files, 9947 tests)
- integ box target green on both hosts against the mock, 2306 passed, and on ram and disk
- `check_case_targets.py` unchanged at 2290, since the new case matches its directory's modal target set
- `pre-commit run --all-files` clean