### PR TITLE
feat(permissions): asks door, workspace list-asks/allow/deny over the decision ledger

### DIFF
--- a/integ/parity.sh
+++ b/integ/parity.sh
@@ -3,9 +3,9 @@
 # Python CLI and the TypeScript CLI, records normalized results per language,
 # then asserts (1) the two languages produce identical results and (2) the
 # results match the expected values. Covers subshell isolation, sessions,
-# per-session mount modes, git-backed versioning, and fuse config wiring.
-# Uses RAM mounts only (no redis/minio/fuse kernel deps), so it runs
-# anywhere both CLIs are built.
+# per-session mount modes, asks (list-asks/allow/deny), git-backed
+# versioning, and fuse config wiring. Uses RAM mounts only (no
+# redis/minio/fuse kernel deps), so it runs anywhere both CLIs are built.
 #
 # Usage: parity.sh "<py-cli>" "<ts-cli>"
 set -uo pipefail
@@ -48,6 +48,20 @@ profiles:
     paths:
       hide:
         - /side
+YML
+
+ASKS_YAML=/tmp/parity-asks.yaml
+cat > "$ASKS_YAML" <<'YML'
+mode: WRITE
+mounts:
+  /:
+    resource: ram
+profiles:
+  default:
+    commands:
+      ask:
+        - reason: removal needs sign-off
+          commands: [rm]
 YML
 
 # The workspace default stays WRITE so the implicit scratch root (always
@@ -158,6 +172,25 @@ probe() {
   echo "mode.exec_allowed=$($cli execute -w gx -s withexec -c 'python3 -c "print(1)"' </dev/null | sout)"
   $cli workspace delete gx >/dev/null 2>&1 </dev/null || true
 
+  # ── asks: an ask rule pends at 126; allow passes the retry once, deny refuses it ──
+  local ask_id
+  $cli workspace delete aw >/dev/null 2>&1 </dev/null || true
+  $cli workspace create "$ASKS_YAML" --id aw >/dev/null </dev/null
+  $cli execute -w aw -c 'touch /f.txt /g.txt' </dev/null >/dev/null
+  echo "ask.refused=$($cli execute -w aw -c 'rm /f.txt' </dev/null | sexit)"
+  echo "ask.pending_count=$($cli workspace list-asks aw </dev/null | jq 'length')"
+  echo "ask.reason=$($cli workspace list-asks aw </dev/null | jq -r '.[0].reason')"
+  ask_id="$($cli workspace list-asks aw </dev/null | jq -r '.[0].id')"
+  echo "ask.allow_scope=$($cli workspace allow aw "$ask_id" </dev/null | jq -r '.scope')"
+  echo "ask.retry=$($cli execute -w aw -c 'rm /f.txt' </dev/null | sexit)"
+  echo "ask.spent=$($cli workspace list-asks aw --all </dev/null | jq 'length')"
+  $cli execute -w aw -c 'rm /g.txt' </dev/null >/dev/null
+  ask_id="$($cli workspace list-asks aw </dev/null | jq -r '.[0].id')"
+  echo "ask.deny_outcome=$($cli workspace deny aw "$ask_id" --note veto </dev/null | jq -r '.outcome')"
+  echo "ask.denied_err=$($cli execute -w aw -c 'rm /g.txt' </dev/null | serr)"
+  echo "ask.drained=$($cli workspace list-asks aw </dev/null | jq 'length')"
+  $cli workspace delete aw >/dev/null 2>&1 </dev/null || true
+
   # ── versioning: commit/branch/log/clone/checkout/diff (git-backed) ──
   $cli workspace delete vw >/dev/null 2>&1 </dev/null || true
   $cli workspace create "$YAML" --id vw >/dev/null </dev/null
@@ -259,6 +292,15 @@ expect "mode.lister_inherits" "l"
 expect "mode.capped_ro" "denied"
 expect "mode.exec_denied_err" "python3: root mount '/' is not in EXEC mode"
 expect "mode.exec_allowed" "1"
+expect "ask.refused" "126"
+expect "ask.pending_count" "1"
+expect "ask.reason" "removal needs sign-off"
+expect "ask.allow_scope" "once"
+expect "ask.retry" "0"
+expect "ask.spent" "0"
+expect "ask.deny_outcome" "deny"
+expect "ask.denied_err" "rm: policy denied: removal needs sign-off"
+expect "ask.drained" "0"
 expect "version.log" "second,first"
 expect "version.branch_log" "first"
 expect "ws.get_mounts" "/"
@@ -285,4 +327,4 @@ if [ "$fail" != "0" ]; then
   exit 1
 fi
 echo
-echo "CLI feature parity OK (subshell, sessions, session modes, versioning, fuse; py == ts)."
+echo "CLI feature parity OK (subshell, sessions, session modes, asks, versioning, fuse; py == ts)."

--- a/python/mirage/cli/workspace.py
+++ b/python/mirage/cli/workspace.py
@@ -22,7 +22,7 @@ import yaml
 from mirage.cli.client import make_client
 from mirage.cli.output import (emit, fail, format_age, format_table,
                                handle_response)
-from mirage.config import _interpolate_env, load_config
+from mirage.config import _absolutize_scripts, _interpolate_env, load_config
 
 app = typer.Typer(no_args_is_help=True, help="Manage workspaces.")
 
@@ -38,12 +38,20 @@ def _resolve_config(path: Path) -> dict[str, Any]:
     they sourced ``.env.development`` etc.) is the source of truth.
     Missing vars fail fast here rather than producing a confusing
     error after a network round-trip.
+
+    Validated here, but sent in the document's own spelling, the way
+    the TypeScript CLI sends it: the daemon runs the same check, and
+    the compiled dump does not re-validate (a CommandRule dumps its
+    compiler-set ``mount`` field, which the document grammar refuses
+    as never typed).
     """
     try:
-        cfg = load_config(path)
+        load_config(path)
     except ValueError as e:
         fail(str(e), exit_code=2)
-    return cfg.model_dump()
+    resolved = _resolve_config_arg(path)
+    _absolutize_scripts(resolved, path.resolve().parent)
+    return resolved
 
 
 def _resolve_config_arg(path: Path) -> dict[str, Any]:
@@ -101,6 +109,19 @@ def _format_workspace_detail(detail: dict[str, Any]) -> str:
             shown = "n/a (not tracked)" if value is None else value
             lines.append(f"  {key:<16} {shown}")
     return "\n".join(lines)
+
+
+def _format_asks(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "No asks."
+    rows = [[
+        item["id"],
+        item["session_id"],
+        " ".join([item["command"], *item["argv"]]),
+        item["outcome"] or "pending",
+        item["reason"],
+    ] for item in items]
+    return format_table(["ID", "SESSION", "COMMAND", "STATUS", "REASON"], rows)
 
 
 def _format_version_log(versions: list[dict[str, Any]]) -> str:
@@ -329,6 +350,75 @@ def diff_cmd(
                            f"/v1/workspaces/{workspace_id}/diff",
                            params=params)
     emit(handle_response(r), human=_format_diff)
+
+
+@app.command("list-asks")
+def list_asks_cmd(
+    workspace_id: str = typer.Argument(..., help="Workspace id."),
+    session: str = typer.Option("",
+                                "--session",
+                                help="Only this session's asks."),
+    all_records: bool = typer.Option(
+        False,
+        "--all",
+        help="Include settled decisions, not just pending asks."),
+) -> None:
+    """List pending asks (every decision with --all)."""
+    params: dict[str, str] = {}
+    if session:
+        params["session_id"] = session
+    if all_records:
+        params["all"] = "true"
+    with make_client() as client:
+        client.ensure_running(allow_spawn=False)
+        r = client.request("GET",
+                           f"/v1/workspaces/{workspace_id}/asks",
+                           params=params)
+    emit(handle_response(r), human=_format_asks)
+
+
+@app.command("allow")
+def allow_cmd(
+    workspace_id: str = typer.Argument(..., help="Workspace id."),
+    ask_id: str = typer.Argument(...,
+                                 help="Ask id, as quoted in the refusal."),
+    scope: str = typer.Option(
+        "once",
+        "--scope",
+        help="once answers the exact line; session answers every line "
+        "the rule covers."),
+    note: str = typer.Option("",
+                             "--note",
+                             help="What to record alongside the answer."),
+) -> None:
+    """Allow a pending ask; the retry of the asked line passes."""
+    body = {"answer": "allow", "scope": scope, "note": note}
+    with make_client() as client:
+        client.ensure_running(allow_spawn=False)
+        r = client.request("POST",
+                           f"/v1/workspaces/{workspace_id}/asks/{ask_id}",
+                           json=body)
+    emit(handle_response(r),
+         human=lambda d: f"Allowed {d['id']} ({d['scope']}).")
+
+
+@app.command("deny")
+def deny_cmd(
+    workspace_id: str = typer.Argument(..., help="Workspace id."),
+    ask_id: str = typer.Argument(...,
+                                 help="Ask id, as quoted in the refusal."),
+    note: str = typer.Option("",
+                             "--note",
+                             help="What to record alongside the answer."),
+) -> None:
+    """Deny a pending ask; the retry is refused in the deny voice, once."""
+    body = {"answer": "deny", "note": note}
+    with make_client() as client:
+        client.ensure_running(allow_spawn=False)
+        r = client.request("POST",
+                           f"/v1/workspaces/{workspace_id}/asks/{ask_id}",
+                           json=body)
+    emit(handle_response(r), human=lambda d: f"Denied {d['id']}.")
 
 
 @app.command("checkout")

--- a/python/mirage/server/app.py
+++ b/python/mirage/server/app.py
@@ -33,8 +33,8 @@ from mirage.server.paths import (mirage_home, pid_file_path,
                                  snapshot_root_path, state_root_path,
                                  version_root_path)
 from mirage.server.registry import WorkspaceRegistry
-from mirage.server.routers import (execute, health, jobs, sessions, versions,
-                                   workspaces)
+from mirage.server.routers import (asks, execute, health, jobs, sessions,
+                                   versions, workspaces)
 from mirage.server.version.backend import LocalBackend
 
 logger = logging.getLogger(__name__)
@@ -148,6 +148,7 @@ def build_app(idle_grace_seconds: float = 30.0,
     app.include_router(workspaces.router)
     app.include_router(versions.router)
     app.include_router(sessions.router)
+    app.include_router(asks.router)
     app.include_router(execute.router)
     app.include_router(jobs.router)
     app.include_router(health.router)

--- a/python/mirage/server/routers/asks.py
+++ b/python/mirage/server/routers/asks.py
@@ -79,6 +79,12 @@ async def list_asks(
     so the door only picks which query to run."""
     entry = _require_entry(request, workspace_id)
     await entry.runner.call(entry.runner.ws.ensure_sessions_loaded())
+    # The ledger reads a named session through SessionManager.get, which
+    # raises for an unknown id; a mistyped filter is the caller's error,
+    # answered in the sessions router's voice rather than as a 500.
+    if session_id and not any(s.session_id == session_id
+                              for s in entry.runner.ws.list_sessions()):
+        raise HTTPException(status_code=404, detail="session not found")
     decisions = entry.runner.ws.decisions
     records = (decisions.list(session_id)
                if include_settled else decisions.pending(session_id))

--- a/python/mirage/server/routers/asks.py
+++ b/python/mirage/server/routers/asks.py
@@ -1,0 +1,127 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import dataclasses
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from mirage.policy.types import Decision, Outcome, Scope
+from mirage.server.registry import WorkspaceEntry, WorkspaceRegistry
+
+router = APIRouter(prefix="/v1/workspaces/{workspace_id}/asks")
+
+
+class AskResponse(BaseModel):
+    id: str
+    session_id: str
+    agent_id: str
+    command: str
+    argv: list[str]
+    cwd: str
+    paths: list[str]
+    reason: str
+    outcome: str | None
+    scope: str
+    note: str
+
+
+class AnswerAskRequest(BaseModel):
+    answer: Literal["allow", "deny"]
+    scope: Literal["once", "session"] = "once"
+    note: str = ""
+
+
+def _require_entry(request: Request, workspace_id: str) -> WorkspaceEntry:
+    registry: WorkspaceRegistry = request.app.state.registry
+    if workspace_id not in registry:
+        raise HTTPException(status_code=404, detail="workspace not found")
+    return registry.get(workspace_id)
+
+
+def _to_response(record: Decision) -> AskResponse:
+    return AskResponse(
+        id=record.id,
+        session_id=record.session_id,
+        agent_id=record.agent_id,
+        command=record.command,
+        argv=list(record.argv),
+        cwd=record.cwd,
+        paths=list(record.paths),
+        reason=record.reason,
+        outcome=record.outcome.value if record.outcome is not None else None,
+        scope=record.scope.value,
+        note=record.note,
+    )
+
+
+@router.get("", response_model=list[AskResponse])
+async def list_asks(
+        workspace_id: str,
+        request: Request,
+        session_id: str = "",
+        include_settled: bool = Query(False, alias="all"),
+) -> list[AskResponse]:
+    """The workspace's asks: pending by default, every decision under
+    ``all=true``. The ledger already serves both views from one store,
+    so the door only picks which query to run."""
+    entry = _require_entry(request, workspace_id)
+    await entry.runner.call(entry.runner.ws.ensure_sessions_loaded())
+    decisions = entry.runner.ws.decisions
+    records = (decisions.list(session_id)
+               if include_settled else decisions.pending(session_id))
+    return [_to_response(r) for r in records]
+
+
+@router.post("/{ask_id}", response_model=AskResponse)
+async def answer_ask(workspace_id: str, ask_id: str, req: AnswerAskRequest,
+                     request: Request) -> AskResponse:
+    """Answer one waiting ask, allow or deny, and return the settled
+    record. A known id with nothing waiting is 409 rather than 404, so
+    an operator retrying a click reads "already answered", not "not
+    found"."""
+    entry = _require_entry(request, workspace_id)
+    await entry.runner.call(entry.runner.ws.ensure_sessions_loaded())
+    if req.answer == "deny" and req.scope == "session":
+        # covers() never lets a session-scoped deny answer anything: a
+        # deny refuses the retry once, and asking again raises a new
+        # record. Recording one would be a rule that can never speak.
+        raise HTTPException(
+            status_code=422,
+            detail="a deny answers once; asking again raises a new record")
+    decisions = entry.runner.ws.decisions
+    held = decisions.list()
+    waiting = next((r for r in held if r.id == ask_id and r.outcome is None),
+                   None)
+    if waiting is None:
+        if any(r.id == ask_id for r in held):
+            raise HTTPException(status_code=409,
+                                detail=f"ask already answered: {ask_id}")
+        raise HTTPException(status_code=404, detail="ask not found")
+    outcome = Outcome.ALLOW if req.answer == "allow" else Outcome.DENY
+    scope = Scope(req.scope)
+    try:
+        await entry.runner.call(
+            decisions.answer(ask_id, outcome, scope, req.note))
+    except KeyError as exc:
+        # Answered between our read and the write: the id exists but
+        # nothing is waiting under it any more.
+        raise HTTPException(status_code=409,
+                            detail=f"ask already answered: {ask_id}") from exc
+    return _to_response(
+        dataclasses.replace(waiting,
+                            outcome=outcome,
+                            scope=scope,
+                            note=req.note))

--- a/python/tests/cli/test_cli_end_to_end.py
+++ b/python/tests/cli/test_cli_end_to_end.py
@@ -398,3 +398,74 @@ def test_execute_limit_error_exits_1(daemon, tmp_path):
              "cat /f.txt",
              expect_exit=1)
     _run_cli(daemon["env"], "workspace", "delete", "sg-err")
+
+
+ASK_PROFILE_YAML = """\
+mounts:
+  /:
+    resource: ram
+    mode: WRITE
+profiles:
+  guarded:
+    commands:
+      ask:
+        - commands: [rm]
+          reason: removal needs sign-off
+"""
+
+
+def test_ask_allow_deny_round_trip(daemon, tmp_path):
+    cfg = _write_named(tmp_path, "asks.yaml", ASK_PROFILE_YAML)
+    _run_cli(daemon["env"], "workspace", "create", str(cfg), "--id", "asks-ws")
+    _run_cli(daemon["env"], "session", "create", "asks-ws", "--id", "agent_a",
+             "--profile", "guarded")
+    _run_cli(daemon["env"], "execute", "-w", "asks-ws", "-s", "agent_a", "-c",
+             "touch /f.txt /g.txt")
+
+    _run_cli(daemon["env"],
+             "execute",
+             "-w",
+             "asks-ws",
+             "-s",
+             "agent_a",
+             "-c",
+             "rm /f.txt",
+             expect_exit=126)
+    asks = _run_cli(daemon["env"], "workspace", "list-asks", "asks-ws")
+    assert len(asks) == 1
+    assert asks[0]["outcome"] is None
+    assert asks[0]["command"] == "rm"
+
+    allowed = _run_cli(daemon["env"], "workspace", "allow", "asks-ws",
+                       asks[0]["id"])
+    assert allowed["outcome"] == "allow"
+    assert allowed["scope"] == "once"
+    _run_cli(daemon["env"], "execute", "-w", "asks-ws", "-s", "agent_a", "-c",
+             "rm /f.txt")
+
+    _run_cli(daemon["env"],
+             "execute",
+             "-w",
+             "asks-ws",
+             "-s",
+             "agent_a",
+             "-c",
+             "rm /g.txt",
+             expect_exit=126)
+    asks = _run_cli(daemon["env"], "workspace", "list-asks", "asks-ws",
+                    "--session", "agent_a")
+    denied = _run_cli(daemon["env"], "workspace", "deny", "asks-ws",
+                      asks[0]["id"], "--note", "not now")
+    assert denied["outcome"] == "deny"
+    assert denied["note"] == "not now"
+    _run_cli(daemon["env"],
+             "execute",
+             "-w",
+             "asks-ws",
+             "-s",
+             "agent_a",
+             "-c",
+             "rm /g.txt",
+             expect_exit=126)
+    assert _run_cli(daemon["env"], "workspace", "list-asks", "asks-ws") == []
+    _run_cli(daemon["env"], "workspace", "delete", "asks-ws")

--- a/python/tests/server/test_asks.py
+++ b/python/tests/server/test_asks.py
@@ -1,0 +1,240 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from mirage.server import build_app
+
+ASK_REASON = "removal needs sign-off"
+
+
+def _guarded_config() -> dict:
+    return {
+        "config": {
+            "mounts": {
+                "/": {
+                    "resource": "ram",
+                    "mode": "WRITE"
+                }
+            },
+            "profiles": {
+                "guarded": {
+                    "commands": {
+                        "ask": [{
+                            "commands": ["rm"],
+                            "reason": ASK_REASON,
+                        }],
+                    },
+                },
+            },
+        },
+    }
+
+
+async def _create_workspace(client: AsyncClient) -> str:
+    r = await client.post("/v1/workspaces", json=_guarded_config())
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _create_session(client: AsyncClient, wid: str, sid: str) -> None:
+    r = await client.post(f"/v1/workspaces/{wid}/sessions",
+                          json={
+                              "session_id": sid,
+                              "profile": "guarded"
+                          })
+    assert r.status_code == 201, r.text
+
+
+async def _raise_ask(client: AsyncClient, wid: str, sid: str) -> str:
+    """Run the guarded line once: it is refused pending and the ask id
+    is what the pending list now holds."""
+    r = await client.post(f"/v1/workspaces/{wid}/execute",
+                          json={
+                              "command": "rm /f.txt",
+                              "session_id": sid
+                          })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["exit_code"] == 126
+    assert "requires approval" in body["stderr"]
+    r = await client.get(f"/v1/workspaces/{wid}/asks?session_id={sid}")
+    assert r.status_code == 200
+    pending = r.json()
+    assert len(pending) == 1
+    return pending[0]["id"]
+
+
+@pytest.mark.asyncio
+async def test_ask_allow_round_trip():
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://test") as client:
+        wid = await _create_workspace(client)
+        await _create_session(client, wid, "agent_a")
+        await client.post(f"/v1/workspaces/{wid}/execute",
+                          json={
+                              "command": "touch /f.txt",
+                              "session_id": "agent_a"
+                          })
+        ask_id = await _raise_ask(client, wid, "agent_a")
+
+        r = await client.get(f"/v1/workspaces/{wid}/asks")
+        record = r.json()[0]
+        assert record["id"] == ask_id
+        assert record["session_id"] == "agent_a"
+        assert record["command"] == "rm"
+        assert record["argv"] == ["/f.txt"]
+        assert record["reason"] == ASK_REASON
+        assert record["outcome"] is None
+
+        r = await client.post(f"/v1/workspaces/{wid}/asks/{ask_id}",
+                              json={
+                                  "answer": "allow",
+                                  "note": "reviewed"
+                              })
+        assert r.status_code == 200, r.text
+        settled = r.json()
+        assert settled["outcome"] == "allow"
+        assert settled["scope"] == "once"
+        assert settled["note"] == "reviewed"
+
+        r = await client.get(f"/v1/workspaces/{wid}/asks")
+        assert r.json() == []
+        r = await client.get(f"/v1/workspaces/{wid}/asks?all=true")
+        assert [a["id"] for a in r.json()] == [ask_id]
+
+        r = await client.post(f"/v1/workspaces/{wid}/execute",
+                              json={
+                                  "command": "rm /f.txt",
+                                  "session_id": "agent_a"
+                              })
+        assert r.json()["exit_code"] == 0, r.text
+        # The ONCE answer is consumed by the retry that used it.
+        r = await client.get(f"/v1/workspaces/{wid}/asks?all=true")
+        assert r.json() == []
+
+
+@pytest.mark.asyncio
+async def test_ask_deny_refuses_the_retry():
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://test") as client:
+        wid = await _create_workspace(client)
+        await _create_session(client, wid, "agent_a")
+        ask_id = await _raise_ask(client, wid, "agent_a")
+
+        r = await client.post(f"/v1/workspaces/{wid}/asks/{ask_id}",
+                              json={"answer": "deny"})
+        assert r.status_code == 200, r.text
+        assert r.json()["outcome"] == "deny"
+
+        r = await client.post(f"/v1/workspaces/{wid}/execute",
+                              json={
+                                  "command": "rm /f.txt",
+                                  "session_id": "agent_a"
+                              })
+        body = r.json()
+        assert body["exit_code"] == 126
+        assert "policy denied" in body["stderr"]
+        assert ASK_REASON in body["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_session_scope_covers_the_next_matching_line():
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://test") as client:
+        wid = await _create_workspace(client)
+        await _create_session(client, wid, "agent_a")
+        await client.post(f"/v1/workspaces/{wid}/execute",
+                          json={
+                              "command": "touch /f.txt /g.txt",
+                              "session_id": "agent_a"
+                          })
+        ask_id = await _raise_ask(client, wid, "agent_a")
+
+        r = await client.post(f"/v1/workspaces/{wid}/asks/{ask_id}",
+                              json={
+                                  "answer": "allow",
+                                  "scope": "session"
+                              })
+        assert r.status_code == 200, r.text
+        assert r.json()["scope"] == "session"
+
+        for target in ("/f.txt", "/g.txt"):
+            r = await client.post(f"/v1/workspaces/{wid}/execute",
+                                  json={
+                                      "command": f"rm {target}",
+                                      "session_id": "agent_a"
+                                  })
+            assert r.json()["exit_code"] == 0, r.text
+
+
+@pytest.mark.asyncio
+async def test_list_asks_filters_by_session():
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://test") as client:
+        wid = await _create_workspace(client)
+        await _create_session(client, wid, "agent_a")
+        await _create_session(client, wid, "agent_b")
+        await _raise_ask(client, wid, "agent_a")
+        await _raise_ask(client, wid, "agent_b")
+
+        r = await client.get(f"/v1/workspaces/{wid}/asks")
+        assert {a["session_id"] for a in r.json()} == {"agent_a", "agent_b"}
+        r = await client.get(f"/v1/workspaces/{wid}/asks?session_id=agent_b")
+        assert [a["session_id"] for a in r.json()] == ["agent_b"]
+
+
+@pytest.mark.asyncio
+async def test_answer_refusals():
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://test") as client:
+        wid = await _create_workspace(client)
+        await _create_session(client, wid, "agent_a")
+        ask_id = await _raise_ask(client, wid, "agent_a")
+
+        r = await client.post(f"/v1/workspaces/{wid}/asks/{ask_id}",
+                              json={"answer": "ask"})
+        assert r.status_code == 422
+
+        r = await client.post(f"/v1/workspaces/{wid}/asks/{ask_id}",
+                              json={
+                                  "answer": "deny",
+                                  "scope": "session"
+                              })
+        assert r.status_code == 422
+
+        r = await client.post(f"/v1/workspaces/{wid}/asks/nope",
+                              json={"answer": "allow"})
+        assert r.status_code == 404
+
+        r = await client.post(f"/v1/workspaces/{wid}/asks/{ask_id}",
+                              json={"answer": "allow"})
+        assert r.status_code == 200
+        r = await client.post(f"/v1/workspaces/{wid}/asks/{ask_id}",
+                              json={"answer": "allow"})
+        assert r.status_code == 409
+
+        r = await client.get("/v1/workspaces/nope/asks")
+        assert r.status_code == 404

--- a/python/tests/server/test_asks.py
+++ b/python/tests/server/test_asks.py
@@ -202,6 +202,8 @@ async def test_list_asks_filters_by_session():
         assert {a["session_id"] for a in r.json()} == {"agent_a", "agent_b"}
         r = await client.get(f"/v1/workspaces/{wid}/asks?session_id=agent_b")
         assert [a["session_id"] for a in r.json()] == ["agent_b"]
+        r = await client.get(f"/v1/workspaces/{wid}/asks?session_id=nope")
+        assert r.status_code == 404, r.text
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/cli/src/e2e.test.ts
+++ b/typescript/packages/cli/src/e2e.test.ts
@@ -342,6 +342,79 @@ describe('mirage CLI end-to-end', () => {
     await runCli(env, ['workspace', 'delete', 'perm-ws'])
   }, 30000)
 
+  it('an ask rule is answered through list-asks, allow and deny', async () => {
+    // The asks door end to end: the guarded line is refused pending at
+    // 126 quoting an id, `workspace list-asks` shows that id, `allow`
+    // passes the retry (and the once answer is consumed by it), `deny`
+    // refuses the retry in the deny voice.
+    const cfgPath = join(tmp, 'asks-cfg.yaml')
+    writeFileSync(
+      cfgPath,
+      [
+        'mounts:',
+        '  /:',
+        '    resource: ram',
+        '    mode: write',
+        'profiles:',
+        '  default:',
+        '    commands:',
+        '      ask:',
+        '        - reason: removal needs sign-off',
+        '          commands: [rm]',
+        '',
+      ].join('\n'),
+    )
+    await runCli(env, ['workspace', 'create', cfgPath, '--id', 'asks-ws'])
+    await runCli(env, ['execute', '-w', 'asks-ws', '-c', 'touch /f.txt /g.txt'])
+
+    const refused = await runCliRaw(env, ['execute', '-w', 'asks-ws', '-c', 'rm /f.txt'])
+    expect(refused.status).toBe(126)
+    const stderr = (refused.parsed as { stderr: string }).stderr
+    expect(stderr).toContain('requires approval: removal needs sign-off')
+
+    const asks = (await runCli(env, ['workspace', 'list-asks', 'asks-ws'])) as {
+      id: string
+      command: string
+      outcome: string | null
+    }[]
+    expect(asks).toHaveLength(1)
+    const askId = asks[0]?.id ?? ''
+    expect(stderr).toContain(askId)
+    expect(asks[0]?.outcome).toBeNull()
+
+    const allowed = (await runCli(env, ['workspace', 'allow', 'asks-ws', askId])) as {
+      outcome: string
+      scope: string
+    }
+    expect(allowed.outcome).toBe('allow')
+    expect(allowed.scope).toBe('once')
+    const retried = await runCliRaw(env, ['execute', '-w', 'asks-ws', '-c', 'rm /f.txt'])
+    expect(retried.status).toBe(0)
+
+    const refusedAgain = await runCliRaw(env, ['execute', '-w', 'asks-ws', '-c', 'rm /g.txt'])
+    expect(refusedAgain.status).toBe(126)
+    const nextAsks = (await runCli(env, ['workspace', 'list-asks', 'asks-ws'])) as {
+      id: string
+    }[]
+    const denied = (await runCli(env, [
+      'workspace',
+      'deny',
+      'asks-ws',
+      nextAsks[0]?.id ?? '',
+      '--note',
+      'not now',
+    ])) as { outcome: string; note: string }
+    expect(denied.outcome).toBe('deny')
+    expect(denied.note).toBe('not now')
+    const deniedRun = await runCliRaw(env, ['execute', '-w', 'asks-ws', '-c', 'rm /g.txt'])
+    expect(deniedRun.status).toBe(126)
+    expect((deniedRun.parsed as { stderr: string }).stderr).toContain('policy denied')
+
+    const drained = (await runCli(env, ['workspace', 'list-asks', 'asks-ws'])) as unknown[]
+    expect(drained).toHaveLength(0)
+    await runCli(env, ['workspace', 'delete', 'asks-ws'])
+  }, 30000)
+
   it('background execution can be waited on', async () => {
     const cfgPath = writeRamConfig(tmp, 'bg-cfg.yaml')
     const created = (await runCli(env, ['workspace', 'create', cfgPath, '--id', 'bg-ws'])) as {

--- a/typescript/packages/cli/src/main.test.ts
+++ b/typescript/packages/cli/src/main.test.ts
@@ -31,15 +31,18 @@ describe('mirage CLI program', () => {
     const sub = ws?.commands.map((c) => c.name()).sort() ?? []
     expect(sub).toEqual(
       [
+        'allow',
         'branch',
         'checkout',
         'clone',
         'commit',
         'create',
         'delete',
+        'deny',
         'diff',
         'get',
         'list',
+        'list-asks',
         'load',
         'log',
         'snapshot',

--- a/typescript/packages/cli/src/workspace.ts
+++ b/typescript/packages/cli/src/workspace.ts
@@ -120,6 +120,34 @@ function formatWorkspaceDetail(d: WorkspaceDetail): string {
   return lines.join('\n')
 }
 
+interface AskRecord {
+  id: string
+  sessionId: string
+  agentId: string
+  command: string
+  argv: string[]
+  cwd: string
+  paths: string[]
+  reason: string
+  outcome: string | null
+  scope: string
+  note: string
+}
+
+function formatAsks(items: AskRecord[]): string {
+  if (items.length === 0) return 'No asks.'
+  return formatTable(
+    ['ID', 'SESSION', 'COMMAND', 'STATUS', 'REASON'],
+    items.map((a) => [
+      a.id,
+      a.sessionId,
+      [a.command, ...a.argv].join(' '),
+      a.outcome ?? 'pending',
+      a.reason,
+    ]),
+  )
+}
+
 interface VersionLogItem {
   id: string
   message: string
@@ -289,6 +317,55 @@ export function registerWorkspaceCommands(program: Command): void {
         emit((await handleResponse(r)) as DiffResult, formatDiff)
       },
     )
+
+  ws.command('list-asks')
+    .description('List pending asks (every decision with --all).')
+    .argument('<id>')
+    .option('--session <sessionId>', "Only this session's asks")
+    .option('--all', 'Include settled decisions, not just pending asks')
+    .action(async (id: string, opts: { session?: string; all?: boolean }) => {
+      const params = new URLSearchParams()
+      if (opts.session !== undefined) params.set('sessionId', opts.session)
+      if (opts.all === true) params.set('all', 'true')
+      const c = buildClient()
+      await c.ensureRunning({ allowSpawn: false })
+      const qs = params.toString()
+      const r = await c.request('GET', `/v1/workspaces/${id}/asks${qs === '' ? '' : `?${qs}`}`)
+      emit((await handleResponse(r)) as AskRecord[], formatAsks)
+    })
+
+  ws.command('allow')
+    .description('Allow a pending ask; the retry of the asked line passes.')
+    .argument('<id>')
+    .argument('<askId>', 'Ask id, as quoted in the refusal')
+    .option(
+      '--scope <scope>',
+      'once answers the exact line; session answers every line the rule covers',
+      'once',
+    )
+    .option('--note <note>', 'What to record alongside the answer', '')
+    .action(async (id: string, askId: string, opts: { scope: string; note: string }) => {
+      const c = buildClient()
+      await c.ensureRunning({ allowSpawn: false })
+      const r = await c.request('POST', `/v1/workspaces/${id}/asks/${askId}`, {
+        body: JSON.stringify({ answer: 'allow', scope: opts.scope, note: opts.note }),
+      })
+      emit((await handleResponse(r)) as AskRecord, (d) => `Allowed ${d.id} (${d.scope}).`)
+    })
+
+  ws.command('deny')
+    .description('Deny a pending ask; the retry is refused in the deny voice, once.')
+    .argument('<id>')
+    .argument('<askId>', 'Ask id, as quoted in the refusal')
+    .option('--note <note>', 'What to record alongside the answer', '')
+    .action(async (id: string, askId: string, opts: { note: string }) => {
+      const c = buildClient()
+      await c.ensureRunning({ allowSpawn: false })
+      const r = await c.request('POST', `/v1/workspaces/${id}/asks/${askId}`, {
+        body: JSON.stringify({ answer: 'deny', note: opts.note }),
+      })
+      emit((await handleResponse(r)) as AskRecord, (d) => `Denied ${d.id}.`)
+    })
 
   ws.command('checkout')
     .description('Restore a workspace in place to one of its versions.')

--- a/typescript/packages/server/src/app.ts
+++ b/typescript/packages/server/src/app.ts
@@ -20,6 +20,7 @@ import { JobTable } from './jobs.ts'
 import type { AuthConfig } from './auth/index.ts'
 import { registerAuth, resolveAuthConfig } from './auth/index.ts'
 import { isHostAllowed, resolveAllowedHosts } from './host_validation.ts'
+import { registerAsksRoutes } from './routers/asks.ts'
 import { registerExecuteRoutes } from './routers/execute.ts'
 import { registerHealthRoutes } from './routers/health.ts'
 import { registerJobsRoutes } from './routers/jobs.ts'
@@ -96,6 +97,7 @@ export function buildApp(options: BuildAppOptions = {}) {
   registerWorkspacesRoutes(app, { registry, snapshotRoot, stateRoot })
   registerVersionsRoutes(app, { registry, versionBackend })
   registerSessionsRoutes(app, { registry })
+  registerAsksRoutes(app, { registry })
   registerExecuteRoutes(app, { registry, jobs })
   registerJobsRoutes(app, { jobs })
   app.addHook('onClose', async () => {

--- a/typescript/packages/server/src/routers/asks.test.ts
+++ b/typescript/packages/server/src/routers/asks.test.ts
@@ -1,0 +1,255 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { buildApp } from '../app.ts'
+
+const ASK_REASON = 'removal needs sign-off'
+
+interface AskRow {
+  id: string
+  sessionId: string
+  command: string
+  argv: string[]
+  reason: string
+  outcome: string | null
+  scope: string
+  note: string
+}
+
+async function createWs(app: ReturnType<typeof buildApp>, id: string): Promise<void> {
+  const r = await app.inject({
+    method: 'POST',
+    url: '/v1/workspaces',
+    payload: {
+      id,
+      config: {
+        mounts: { '/': { resource: 'ram', mode: 'write' } },
+        profiles: {
+          guarded: { commands: { ask: [{ commands: ['rm'], reason: ASK_REASON }] } },
+        },
+      },
+    },
+  })
+  expect(r.statusCode).toBe(201)
+}
+
+async function createSession(
+  app: ReturnType<typeof buildApp>,
+  wsId: string,
+  sessionId: string,
+): Promise<void> {
+  const r = await app.inject({
+    method: 'POST',
+    url: `/v1/workspaces/${wsId}/sessions`,
+    payload: { sessionId, profile: 'guarded' },
+  })
+  expect(r.statusCode).toBe(201)
+}
+
+async function execute(
+  app: ReturnType<typeof buildApp>,
+  wsId: string,
+  sessionId: string,
+  command: string,
+): Promise<{ exitCode: number; stderr: string }> {
+  const r = await app.inject({
+    method: 'POST',
+    url: `/v1/workspaces/${wsId}/execute`,
+    payload: { command, sessionId },
+  })
+  expect(r.statusCode).toBe(200)
+  return r.json<{ exitCode: number; stderr: string }>()
+}
+
+async function raiseAsk(
+  app: ReturnType<typeof buildApp>,
+  wsId: string,
+  sessionId: string,
+): Promise<string> {
+  const refused = await execute(app, wsId, sessionId, 'rm /f.txt')
+  expect(refused.exitCode).toBe(126)
+  expect(refused.stderr).toContain('requires approval')
+  const r = await app.inject({
+    method: 'GET',
+    url: `/v1/workspaces/${wsId}/asks?sessionId=${sessionId}`,
+  })
+  expect(r.statusCode).toBe(200)
+  const pending = r.json<AskRow[]>()
+  expect(pending).toHaveLength(1)
+  const first = pending[0]
+  if (first === undefined) throw new Error('no pending ask')
+  return first.id
+}
+
+describe('asks router', () => {
+  it('lists the pending ask, allow passes the retry, once is consumed', async () => {
+    const app = buildApp()
+    await createWs(app, 'asks-allow')
+    await createSession(app, 'asks-allow', 'agent_a')
+    await execute(app, 'asks-allow', 'agent_a', 'touch /f.txt')
+    const askId = await raiseAsk(app, 'asks-allow', 'agent_a')
+
+    const list = await app.inject({ method: 'GET', url: '/v1/workspaces/asks-allow/asks' })
+    const rows = list.json<AskRow[]>()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      id: askId,
+      sessionId: 'agent_a',
+      command: 'rm',
+      argv: ['/f.txt'],
+      reason: ASK_REASON,
+      outcome: null,
+    })
+
+    const answered = await app.inject({
+      method: 'POST',
+      url: `/v1/workspaces/asks-allow/asks/${askId}`,
+      payload: { answer: 'allow', note: 'reviewed' },
+    })
+    expect(answered.statusCode).toBe(200)
+    expect(answered.json<AskRow>()).toMatchObject({
+      id: askId,
+      outcome: 'allow',
+      scope: 'once',
+      note: 'reviewed',
+    })
+
+    const pendingAfter = await app.inject({ method: 'GET', url: '/v1/workspaces/asks-allow/asks' })
+    expect(pendingAfter.json<AskRow[]>()).toHaveLength(0)
+    const allAfter = await app.inject({
+      method: 'GET',
+      url: '/v1/workspaces/asks-allow/asks?all=true',
+    })
+    expect(allAfter.json<AskRow[]>().map((a) => a.id)).toEqual([askId])
+
+    const retried = await execute(app, 'asks-allow', 'agent_a', 'rm /f.txt')
+    expect(retried.exitCode).toBe(0)
+    // The ONCE answer is consumed by the retry that used it.
+    const spent = await app.inject({
+      method: 'GET',
+      url: '/v1/workspaces/asks-allow/asks?all=true',
+    })
+    expect(spent.json<AskRow[]>()).toHaveLength(0)
+    await app.close()
+  })
+
+  it('deny refuses the retry in the deny voice', async () => {
+    const app = buildApp()
+    await createWs(app, 'asks-deny')
+    await createSession(app, 'asks-deny', 'agent_a')
+    const askId = await raiseAsk(app, 'asks-deny', 'agent_a')
+
+    const answered = await app.inject({
+      method: 'POST',
+      url: `/v1/workspaces/asks-deny/asks/${askId}`,
+      payload: { answer: 'deny' },
+    })
+    expect(answered.statusCode).toBe(200)
+    expect(answered.json<AskRow>().outcome).toBe('deny')
+
+    const retried = await execute(app, 'asks-deny', 'agent_a', 'rm /f.txt')
+    expect(retried.exitCode).toBe(126)
+    expect(retried.stderr).toContain('policy denied')
+    expect(retried.stderr).toContain(ASK_REASON)
+    await app.close()
+  })
+
+  it('a session-scoped allow covers the next matching line', async () => {
+    const app = buildApp()
+    await createWs(app, 'asks-scope')
+    await createSession(app, 'asks-scope', 'agent_a')
+    await execute(app, 'asks-scope', 'agent_a', 'touch /f.txt /g.txt')
+    const askId = await raiseAsk(app, 'asks-scope', 'agent_a')
+
+    const answered = await app.inject({
+      method: 'POST',
+      url: `/v1/workspaces/asks-scope/asks/${askId}`,
+      payload: { answer: 'allow', scope: 'session' },
+    })
+    expect(answered.statusCode).toBe(200)
+    expect(answered.json<AskRow>().scope).toBe('session')
+
+    for (const target of ['/f.txt', '/g.txt']) {
+      const retried = await execute(app, 'asks-scope', 'agent_a', `rm ${target}`)
+      expect(retried.exitCode).toBe(0)
+    }
+    await app.close()
+  })
+
+  it('filters the listing by session', async () => {
+    const app = buildApp()
+    await createWs(app, 'asks-filter')
+    await createSession(app, 'asks-filter', 'agent_a')
+    await createSession(app, 'asks-filter', 'agent_b')
+    await raiseAsk(app, 'asks-filter', 'agent_a')
+    await raiseAsk(app, 'asks-filter', 'agent_b')
+
+    const all = await app.inject({ method: 'GET', url: '/v1/workspaces/asks-filter/asks' })
+    expect(new Set(all.json<AskRow[]>().map((a) => a.sessionId))).toEqual(
+      new Set(['agent_a', 'agent_b']),
+    )
+    const one = await app.inject({
+      method: 'GET',
+      url: '/v1/workspaces/asks-filter/asks?sessionId=agent_b',
+    })
+    expect(one.json<AskRow[]>().map((a) => a.sessionId)).toEqual(['agent_b'])
+    await app.close()
+  })
+
+  it('refuses bad answers and tells already-answered from unknown', async () => {
+    const app = buildApp()
+    await createWs(app, 'asks-err')
+    await createSession(app, 'asks-err', 'agent_a')
+    const askId = await raiseAsk(app, 'asks-err', 'agent_a')
+
+    const asAsk = await app.inject({
+      method: 'POST',
+      url: `/v1/workspaces/asks-err/asks/${askId}`,
+      payload: { answer: 'ask' },
+    })
+    expect(asAsk.statusCode).toBe(422)
+
+    const sessionDeny = await app.inject({
+      method: 'POST',
+      url: `/v1/workspaces/asks-err/asks/${askId}`,
+      payload: { answer: 'deny', scope: 'session' },
+    })
+    expect(sessionDeny.statusCode).toBe(422)
+
+    const unknown = await app.inject({
+      method: 'POST',
+      url: '/v1/workspaces/asks-err/asks/nope',
+      payload: { answer: 'allow' },
+    })
+    expect(unknown.statusCode).toBe(404)
+
+    const first = await app.inject({
+      method: 'POST',
+      url: `/v1/workspaces/asks-err/asks/${askId}`,
+      payload: { answer: 'allow' },
+    })
+    expect(first.statusCode).toBe(200)
+    const again = await app.inject({
+      method: 'POST',
+      url: `/v1/workspaces/asks-err/asks/${askId}`,
+      payload: { answer: 'allow' },
+    })
+    expect(again.statusCode).toBe(409)
+
+    const noWs = await app.inject({ method: 'GET', url: '/v1/workspaces/nope/asks' })
+    expect(noWs.statusCode).toBe(404)
+    await app.close()
+  })
+})

--- a/typescript/packages/server/src/routers/asks.test.ts
+++ b/typescript/packages/server/src/routers/asks.test.ts
@@ -205,6 +205,11 @@ describe('asks router', () => {
       url: '/v1/workspaces/asks-filter/asks?sessionId=agent_b',
     })
     expect(one.json<AskRow[]>().map((a) => a.sessionId)).toEqual(['agent_b'])
+    const unknown = await app.inject({
+      method: 'GET',
+      url: '/v1/workspaces/asks-filter/asks?sessionId=nope',
+    })
+    expect(unknown.statusCode).toBe(404)
     await app.close()
   })
 
@@ -220,6 +225,12 @@ describe('asks router', () => {
       payload: { answer: 'ask' },
     })
     expect(asAsk.statusCode).toBe(422)
+
+    const noBody = await app.inject({
+      method: 'POST',
+      url: `/v1/workspaces/asks-err/asks/${askId}`,
+    })
+    expect(noBody.statusCode).toBe(422)
 
     const sessionDeny = await app.inject({
       method: 'POST',

--- a/typescript/packages/server/src/routers/asks.ts
+++ b/typescript/packages/server/src/routers/asks.ts
@@ -84,13 +84,20 @@ export function registerAsksRoutes(app: FastifyInstance, deps: AsksRoutesDeps): 
       const ws = deps.registry.get(wsId).runner.ws
       await ws.ensureSessionsLoaded()
       const sessionId = req.query.sessionId ?? ''
+      // The ledger reads a named session through SessionManager.get,
+      // which throws for an unknown id; a mistyped filter is the
+      // caller's error, answered in the sessions router's voice rather
+      // than as a 500.
+      if (sessionId !== '' && !ws.listSessions().some((s) => s.sessionId === sessionId)) {
+        return reply.status(404).send({ detail: 'session not found' })
+      }
       const records =
         req.query.all === 'true' ? ws.decisions.list(sessionId) : ws.decisions.pending(sessionId)
       return records.map(toResponse)
     },
   )
 
-  app.post<{ Params: WsAskParams; Body: AnswerAskBody }>(
+  app.post<{ Params: WsAskParams; Body: AnswerAskBody | undefined }>(
     '/v1/workspaces/:wsId/asks/:askId',
     async (req, reply) => {
       // Answer one waiting ask, allow or deny, and return the settled
@@ -101,11 +108,15 @@ export function registerAsksRoutes(app: FastifyInstance, deps: AsksRoutesDeps): 
       if (!deps.registry.has(wsId)) {
         return reply.status(404).send({ detail: 'workspace not found' })
       }
-      const answer = req.body.answer
+      // Fastify's generic type does not validate at runtime: a POST
+      // with no JSON body reaches here with req.body undefined, and
+      // that is the caller's 422, not a 500.
+      const body: AnswerAskBody = req.body ?? {}
+      const answer = body.answer
       if (answer !== 'allow' && answer !== 'deny') {
         return reply.status(422).send({ detail: "answer must be 'allow' or 'deny'" })
       }
-      const scope = req.body.scope ?? 'once'
+      const scope = body.scope ?? 'once'
       if (scope !== 'once' && scope !== 'session') {
         return reply.status(422).send({ detail: "scope must be 'once' or 'session'" })
       }
@@ -117,7 +128,7 @@ export function registerAsksRoutes(app: FastifyInstance, deps: AsksRoutesDeps): 
           .status(422)
           .send({ detail: 'a deny answers once; asking again raises a new record' })
       }
-      const note = req.body.note ?? ''
+      const note = body.note ?? ''
       const ws = deps.registry.get(wsId).runner.ws
       await ws.ensureSessionsLoaded()
       const held = ws.decisions.list()

--- a/typescript/packages/server/src/routers/asks.ts
+++ b/typescript/packages/server/src/routers/asks.ts
@@ -1,0 +1,137 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { FastifyInstance } from 'fastify'
+import type { WorkspaceRegistry } from '../registry.ts'
+import { Outcome, Scope, type Decision } from '@struktoai/mirage-core/policy/index'
+
+export interface AsksRoutesDeps {
+  registry: WorkspaceRegistry
+}
+
+interface WsIdParams {
+  wsId: string
+}
+
+interface WsAskParams {
+  wsId: string
+  askId: string
+}
+
+interface ListAsksQuery {
+  sessionId?: string
+  all?: string
+}
+
+interface AnswerAskBody {
+  answer?: string
+  scope?: string
+  note?: string
+}
+
+interface AskResponse {
+  id: string
+  sessionId: string
+  agentId: string
+  command: string
+  argv: string[]
+  cwd: string
+  paths: string[]
+  reason: string
+  outcome: string | null
+  scope: string
+  note: string
+}
+
+function toResponse(record: Decision): AskResponse {
+  return {
+    id: record.id,
+    sessionId: record.sessionId,
+    agentId: record.agentId,
+    command: record.command,
+    argv: [...record.argv],
+    cwd: record.cwd,
+    paths: [...record.paths],
+    reason: record.reason,
+    outcome: record.outcome,
+    scope: record.scope,
+    note: record.note,
+  }
+}
+
+export function registerAsksRoutes(app: FastifyInstance, deps: AsksRoutesDeps): void {
+  app.get<{ Params: WsIdParams; Querystring: ListAsksQuery }>(
+    '/v1/workspaces/:wsId/asks',
+    async (req, reply) => {
+      // The workspace's asks: pending by default, every decision under
+      // all=true. The ledger already serves both views from one store,
+      // so the door only picks which query to run.
+      const { wsId } = req.params
+      if (!deps.registry.has(wsId)) {
+        return reply.status(404).send({ detail: 'workspace not found' })
+      }
+      const ws = deps.registry.get(wsId).runner.ws
+      await ws.ensureSessionsLoaded()
+      const sessionId = req.query.sessionId ?? ''
+      const records =
+        req.query.all === 'true' ? ws.decisions.list(sessionId) : ws.decisions.pending(sessionId)
+      return records.map(toResponse)
+    },
+  )
+
+  app.post<{ Params: WsAskParams; Body: AnswerAskBody }>(
+    '/v1/workspaces/:wsId/asks/:askId',
+    async (req, reply) => {
+      // Answer one waiting ask, allow or deny, and return the settled
+      // record. A known id with nothing waiting is 409 rather than 404,
+      // so an operator retrying a click reads "already answered", not
+      // "not found".
+      const { wsId, askId } = req.params
+      if (!deps.registry.has(wsId)) {
+        return reply.status(404).send({ detail: 'workspace not found' })
+      }
+      const answer = req.body.answer
+      if (answer !== 'allow' && answer !== 'deny') {
+        return reply.status(422).send({ detail: "answer must be 'allow' or 'deny'" })
+      }
+      const scope = req.body.scope ?? 'once'
+      if (scope !== 'once' && scope !== 'session') {
+        return reply.status(422).send({ detail: "scope must be 'once' or 'session'" })
+      }
+      if (answer === 'deny' && scope === 'session') {
+        // covers() never lets a session-scoped deny answer anything: a
+        // deny refuses the retry once, and asking again raises a new
+        // record. Recording one would be a rule that can never speak.
+        return reply
+          .status(422)
+          .send({ detail: 'a deny answers once; asking again raises a new record' })
+      }
+      const note = req.body.note ?? ''
+      const ws = deps.registry.get(wsId).runner.ws
+      await ws.ensureSessionsLoaded()
+      const held = ws.decisions.list()
+      const waiting = held.find((r) => r.id === askId && r.outcome === null)
+      if (waiting === undefined) {
+        if (held.some((r) => r.id === askId)) {
+          return reply.status(409).send({ detail: `ask already answered: ${askId}` })
+        }
+        return reply.status(404).send({ detail: 'ask not found' })
+      }
+      const outcome = answer === 'allow' ? Outcome.ALLOW : Outcome.DENY
+      const scopeValue = scope === 'once' ? Scope.ONCE : Scope.SESSION
+      await ws.decisions.answer(askId, outcome, scopeValue, note)
+      return toResponse({ ...waiting, outcome, scope: scopeValue, note })
+    },
+  )
+}


### PR DESCRIPTION
The host-side door for pending asks, mirrored in both languages over `ws.decisions`.

REST:
- `GET /v1/workspaces/:id/asks` lists pending asks (`?all=true` includes settled decisions, `session_id`/`sessionId` filters one session).
- `POST /v1/workspaces/:id/asks/:askId` with `{answer: allow|deny, scope: once|session, note}` answers a waiting ask and returns the settled record. A known id with nothing waiting is 409 (already answered), an unknown id 404. `deny` at `session` scope is refused (422): a deny answers once, asking again raises a new record.

CLI, on the workspace noun in both languages:
- `mirage workspace list-asks <ws> [--session <id>] [--all]`
- `mirage workspace allow <ws> <ask-id> [--scope session] [--note <text>]`
- `mirage workspace deny <ws> <ask-id> [--note <text>]`

Also fixes a pre-existing bug the e2e caught: the python `workspace create` sent the compiled config (`model_dump()`), which the daemon re-validates and refuses for any ask/deny rule (the compiled CommandRule carries the compiler-set `mount` field the document grammar treats as never typed). It now validates client-side and sends the document in its own spelling, as the TypeScript CLI already did.

Tests: twin 5-case router suites (allow round-trip with once-consumption, deny voice on the retry, session scope, session filter, the refusal ladder) and a CLI e2e in each language walking YAML ask profile -> 126 refusal -> list-asks -> allow passes the retry -> deny refuses it; the TS e2e pins that the id quoted in the agent's stderr is the id list-asks prints.