### PR TITLE
docs(permissions): document the permissions system, rename (approval <id>) to (ask <id>)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -75,6 +75,7 @@
               "home/cache",
               "home/snapshot",
               "home/observer",
+              "home/permissions",
               "home/policy-engine",
               "home/auth"
             ]

--- a/docs/home/cli.mdx
+++ b/docs/home/cli.mdx
@@ -300,7 +300,10 @@ mirage workspace clone demo --at <version> --id demo_at_v1
 | `mirage workspace checkout ID REF` | Restore the live state in place to a version id or branch. |
 | `mirage workspace snapshot ID PATH.tar` | Snapshot to a tar file. |
 | `mirage workspace load PATH.tar [CONFIG] [--id NAME]` | Restore from tar; optional config re-supplies redacted creds. |
-| `mirage session create WS [--id NAME] [-m /prefix[:mode]]...` | Add a named session (own cwd + env), optionally restricted to mounts with a mode ceiling (`read`/`write`/`exec` or `r`/`rw`/`rwx`). |
+| `mirage workspace list-asks WS [--session S] [--all]` | Pending [asks](/home/permissions#asks) raised by `ask` rules; `--all` includes settled decisions. |
+| `mirage workspace allow WS ASK_ID [--scope session] [--note ...]` | Allow a pending ask; default scope `once` answers exactly that line. |
+| `mirage workspace deny WS ASK_ID [--note ...]` | Deny a pending ask; the retry is refused, once. |
+| `mirage session create WS [--id NAME] [--profile NAME] [-m /prefix[:mode]]...` | Add a named session (own cwd + env), optionally under a [permission profile](/home/permissions) or restricted to mounts with a mode ceiling (`read`/`write`/`exec` or `r`/`rw`/`rwx`). |
 | `mirage session list WS` | List sessions for a workspace. |
 | `mirage session delete WS SESSION` | Close a session. |
 | `mirage execute --workspace_id WS [--session_id S] [--background] --command "..."` | Run a command. Pipes stdin automatically when stdout is not a TTY. |

--- a/docs/home/permissions.mdx
+++ b/docs/home/permissions.mdx
@@ -1,0 +1,247 @@
+---
+title: Permissions
+description: Profiles decide what each session may see and run; asks are the questions a guarded command raises and a host answers.
+icon: shield-halved
+---
+
+A workspace serves every agent the same mounts; a **profile** decides what
+one session sees of them and what it may run. Profiles are declared on the
+workspace, sessions are created under one, and every command line an agent
+types passes the same admission gate before anything runs. This page is
+about that gate. (Routing a line to a runtime is a different decision,
+made by the [policy engine](/home/policy-engine).)
+
+```yaml
+mode: WRITE
+mounts:
+  /repo:
+    resource: ram
+  /vault:
+    resource: ram
+
+profiles:
+  guarded:
+    commands:
+      allow: [ls, cat, grep, rm]
+      ask:
+        - reason: removal needs sign-off
+          commands: [rm]
+      deny:
+        - reason: credentials are never read by hand
+          paths: ["/vault/*"]
+  auditor:
+    commands:
+      allow: [ls, cat, grep]
+    paths:
+      hide: [/vault]
+```
+
+A session binds a profile by name at creation and keeps it for life:
+
+```bash
+mirage workspace create workspace.yaml --id demo
+mirage session create demo --id agent_a --profile guarded
+mirage execute -w demo -s agent_a -c "cat /repo/notes.md"
+```
+
+In code, the same two doors: `Workspace(mounts, profiles=...)` and
+`ws.create_session("agent_a", profile="guarded")` in Python,
+`new Workspace({ mounts, profiles })` and
+`ws.createSession('agent_a', { profile: 'guarded' })` in TypeScript.
+A session that names no profile runs under `profiles.default` when the
+workspace defines one, and unrestricted otherwise; the workspace's own
+default session follows the same rule, so a `default` profile governs
+bare `ws.execute(...)` too.
+
+## Two axes and a hider
+
+Every rule in a profile is read by one of two orderings, and hiding is
+neither:
+
+- **The command axis.** A rule naming no path is read by verb alone:
+  `deny` before `ask`, and the `allow` list decides whether the word is
+  a command at all.
+- **The path axis.** A rule carrying paths, and every hide, is read by
+  **anchor depth**: the number of literal components before the first
+  wildcard. `/runbook/frozen/*` is depth 2 and `/runbook/*` is depth 1,
+  so the deeper entry wins wherever both reach, whichever verb it
+  carries. Ties break by verb.
+- **Hiding is not a refusal.** A hidden path answers `ENOENT`, so the
+  session never learns the name; a denied path stays in the listing and
+  fails when read. The same `/vault` can be denied for one role and
+  hidden for another.
+
+### `commands`: allow, ask, deny
+
+`allow` is the session's tool set, not a filter over one: a word missing
+from the list is **not a command** (`sort: command not found`, exit 127,
+absent from `type`, `which` and `man`), an omitted list installs
+everything, and an empty list installs nothing. Shell builtins are
+subjects like everything else, so a list stating only `cat` leaves no
+`echo` and no `cd`. The agent's own shell functions are the one
+exemption, safe because every line of a body passes the gate itself.
+
+`ask` and `deny` take the same rule shape: a `reason`, plus what the rule
+covers.
+
+```yaml
+deny:
+  - reason: pushes go through CI
+    commands: [git push]    # whole lines, by prefix pattern
+  - reason: the rollback plan is frozen
+    commands:               # one command, on these paths
+      rm: ["/runbook/frozen/*"]
+  - reason: credentials are never read by hand
+    paths: ["/vault/*"]     # any command, these paths
+```
+
+A command pattern is a **prefix of the line**: `git push` covers
+`git push origin main`, a `*` token matches any one word, and a bare
+`*` is every command (`git push` and `git push *` are the same rule).
+The same patterns spell the `allow` list.
+
+A rule with `paths` and no command also reaches the VFS op door, so FUSE
+mounts and the cache cannot go around it. A `deny` refuses with
+`<command>: policy denied: <reason>` at exit 126. An `ask` refuses the
+same way until a host answers; see [Asks](#asks) below.
+
+### `paths` and `vars`: hide and show
+
+`paths.hide` makes entries nonexistent for the session: an entry with
+`*`, `?` or `[` is a pattern, anything else an exact path and its whole
+subtree. `paths.show` is the other half of the axis: a mapping of path
+to mode (or a plain list inheriting the mount's mode) that re-opens a
+subtree inside a hidden region when its anchor is deeper than the
+hide's, and states the mode in force below its anchor.
+
+```yaml
+paths:
+  hide:
+    - /vault
+    - patterns: ["*.env"]
+      reason: dotenv files carry credentials
+  show:
+    /vault/policies: read
+```
+
+A hide entry may be a group with a `reason`; the reason lands in an
+operator-only side table and is never shown to the session (a hidden
+path must not explain itself). `vars.hide` does the same for the
+environment: listed names (or globs over names) read as unset.
+
+### `mounts`: narrowing one mount
+
+A profile's `mounts` section is keyed by prefix and only ever narrows.
+A mount the mapping omits keeps the mode it declares in the workspace's
+`mounts:`; a profile can weaken that mode, never raise it. Name patterns
+written in a mount section anchor to that mount, and `commands` here
+carries `ask` and `deny` only, applied to lines working inside the mount
+by cwd or by operand (which is what a path-scoped rule cannot express:
+`cd /repo && git commit` names no path).
+
+```yaml
+profiles:
+  oncall:
+    mounts:
+      /repo:
+        mode: read
+        paths:
+          hide: ["*.env"]
+      /runbook:
+        commands:
+          deny:
+            - reason: the rollback plan is frozen
+              commands:
+                rm: ["/runbook/frozen/*"]
+```
+
+A profile may also state `cwd` and `env` (seeded and exported at session
+creation), and a `script` with its `runtime`: a program evaluated at the
+gate for every command, whose last expression answers allow, deny or ask,
+for the conditions a declarative rule cannot express. Like every rule,
+a script can only restrict, never grant past a deny.
+
+## Asks
+
+An `ask` rule guards a command instead of refusing it outright. When a
+session runs the guarded line, the line does not run; the agent reads
+
+```
+rm: requires approval: removal needs sign-off (ask 5b25c31eb62e)
+```
+
+at exit 126, and the ask lands in the workspace's decision ledger as a
+pending record carrying the session, command, argv, cwd, paths and the
+rule's reason. Decisions are session state, so they persist wherever the
+session store persists. A host answers **allow** or **deny**:
+
+- `allow` with scope `once` (the default) answers exactly that line: the
+  agent's retry passes, and the answer is consumed by the retry that
+  used it.
+- `allow` with scope `session` answers every line the rule covers for
+  that session, and stays.
+- `deny` answers once: the retry is refused in the deny voice
+  (`rm: policy denied: removal needs sign-off`), and running the line
+  again raises a new ask.
+
+### From the CLI
+
+```bash
+mirage workspace list-asks demo                # pending asks
+mirage workspace list-asks demo --session agent_a --all
+mirage workspace allow demo 5b25c31eb62e --note "reviewed"
+mirage workspace allow demo 5b25c31eb62e --scope session
+mirage workspace deny demo 5b25c31eb62e --note "not now"
+```
+
+`list-asks` prints pending asks (every decision with `--all`); `allow`
+and `deny` answer one ask by the id quoted in the refusal and print the
+settled record.
+
+### Over REST
+
+The daemon serves the same door:
+
+```bash
+GET  /v1/workspaces/{id}/asks                # pending; ?all=true for every decision
+GET  /v1/workspaces/{id}/asks?session_id=agent_a
+POST /v1/workspaces/{id}/asks/{ask_id}
+     {"answer": "allow", "scope": "once", "note": "reviewed"}
+```
+
+Each record carries `id`, `session_id`, `agent_id`, `command`, `argv`,
+`cwd`, `paths`, `reason`, `outcome` (null while pending), `scope` and
+`note`. Field casing follows the serving daemon, as everywhere on this
+API: `session_id` from the Python daemon, `sessionId` from the
+TypeScript one. Answering an unknown id is 404; answering an id that was
+already answered is 409, so an operator retrying a click reads "already
+answered", not "not found". `deny` with scope `session` is refused
+(422): a deny answers once, and asking again raises a new record.
+
+### In code
+
+`ws.decisions` is the ledger the CLI and REST doors read:
+`pending(session_id)`, `list(session_id)` and
+`answer(ask_id, outcome, scope, note)`. A host that wants to answer
+inline instead of leaving the ask pending passes `on_ask` (`onAsk`) to
+the workspace: an async handler given the pending record, whose answer
+settles the ask while the line waits, like a tool-approval prompt.
+
+## Dry runs
+
+`ws.explain(line, session_id)` runs the same gate without running the
+line: one `Explanation` per command, with the outcome, the rule that
+spoke and where it was written, the matched operand, and the exact
+`exit_code` and `stderr` the agent would see, byte-identical to the real
+refusal. What a host reads in an explanation and what an agent sees at
+the prompt cannot disagree, because they are the same computation.
+
+## The worked example
+
+The permissions example builds an incident-response workspace in which
+three roles read the same three mounts and see three different
+filesystems, one line per rule interaction:
+[python](https://github.com/strukto-ai/mirage/blob/main/examples/python/permissions/permissions.py),
+[typescript](https://github.com/strukto-ai/mirage/blob/main/examples/typescript/permissions/permissions.ts).
+Its printed table is pinned in CI, so the behaviors this page describes
+are the behaviors the build enforces.

--- a/docs/home/permissions.mdx
+++ b/docs/home/permissions.mdx
@@ -46,7 +46,7 @@ mirage execute -w demo -s agent_a -c "cat /repo/notes.md"
 
 In code, the same two doors: `Workspace(mounts, profiles=...)` and
 `ws.create_session("agent_a", profile="guarded")` in Python,
-`new Workspace({ mounts, profiles })` and
+`new Workspace(mounts, { profiles })` and
 `ws.createSession('agent_a', { profile: 'guarded' })` in TypeScript.
 A session that names no profile runs under `profiles.default` when the
 workspace defines one, and unrestricted otherwise; the workspace's own
@@ -101,9 +101,13 @@ A command pattern is a **prefix of the line**: `git push` covers
 The same patterns spell the `allow` list.
 
 A rule with `paths` and no command also reaches the VFS op door, so FUSE
-mounts and the cache cannot go around it. A `deny` refuses with
-`<command>: policy denied: <reason>` at exit 126. An `ask` refuses the
-same way until a host answers; see [Asks](#asks) below.
+mounts and the cache cannot go around it. A whole-command `deny` refuses
+with `<command>: policy denied: <reason>` at exit 126; a `deny` matched
+through `paths` refuses the operand instead, in the GNU voice
+`<command>: <path>: <reason>` at the command's own operand exit code
+(`cat: /vault/aws.token: credentials are never read by hand`, exit 1).
+An `ask` refuses at 126, naming an ask id, until a host answers; see
+[Asks](#asks) below.
 
 ### `paths` and `vars`: hide and show
 

--- a/docs/typescript/agents/dsh.mdx
+++ b/docs/typescript/agents/dsh.mdx
@@ -196,7 +196,7 @@ With **no approval plugin composed** — a headless run, a cron job, CI — an a
 
 ```
 $ rm /data/notes.txt
-rm: requires approval: deletes are reviewed (approval 0efc4a8f6280)
+rm: requires approval: deletes are reviewed (ask 0efc4a8f6280)
 ```
 
 This is deliberate: the document says `ask`, and silently rewriting that as `deny` would change what the operator wrote. The question is real and answerable, through `ctx.mirage.decisions`:

--- a/examples/python/permissions/permissions.py
+++ b/examples/python/permissions/permissions.py
@@ -177,7 +177,7 @@ LINES = [
 
 # The approval id is a digest of the session, cwd and words; it is
 # stable, and it is noise here.
-APPROVAL_ID = re.compile(r"\(approval [0-9a-f]+\)")
+ASK_ID = re.compile(r"\(ask [0-9a-f]+\)")
 
 
 def answer(out: bytes, err: bytes, code: int) -> str:
@@ -190,7 +190,7 @@ def answer(out: bytes, err: bytes, code: int) -> str:
         code (int): the line's exit code.
     """
     if err:
-        first = APPROVAL_ID.sub("(approval ...)", err.decode()).splitlines()[0]
+        first = ASK_ID.sub("(ask ...)", err.decode()).splitlines()[0]
         return f"[{code}] {first}"
     return f"[{code}] {' '.join(out.decode().split())}".rstrip()
 

--- a/examples/typescript/permissions/permissions.ts
+++ b/examples/typescript/permissions/permissions.ts
@@ -153,7 +153,7 @@ const LINES: [string, string, string][] = [
 
 // The approval id is a digest of the session, cwd and words; it is
 // stable, and it is noise here.
-const APPROVAL_ID = /\(approval [0-9a-f]+\)/
+const ASK_ID = /\(ask [0-9a-f]+\)/
 
 const dec = new TextDecoder()
 
@@ -163,7 +163,7 @@ const dec = new TextDecoder()
  */
 function answer(out: string, err: string, code: number): string {
   if (err !== '') {
-    const first = err.replace(APPROVAL_ID, '(approval ...)').split('\n')[0]
+    const first = err.replace(ASK_ID, '(ask ...)').split('\n')[0]
     return `[${code}] ${first}`
   }
   return `[${code}] ${out.split(/\s+/).filter(Boolean).join(' ')}`.trimEnd()

--- a/integ/cli/himalaya.json
+++ b/integ/cli/himalaya.json
@@ -1045,7 +1045,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "h1: requires approval: outbound mail needs a nod (approval 987968c5e0ff)\n"
+        "stderr": "h1: requires approval: outbound mail needs a nod (ask 987968c5e0ff)\n"
       }
     },
     {

--- a/integ/session/commands/ask.json
+++ b/integ/session/commands/ask.json
@@ -24,7 +24,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "rm: requires approval: sign-off (approval 5b25c31eb62e)\n"
+        "stderr": "rm: requires approval: sign-off (ask 5b25c31eb62e)\n"
       }
     },
     {
@@ -38,7 +38,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "rm: requires approval: sign-off (approval 5b25c31eb62e)\n"
+        "stderr": "rm: requires approval: sign-off (ask 5b25c31eb62e)\n"
       }
     },
     {
@@ -81,7 +81,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "rm: requires approval: sign-off (approval b416c5b1c8fa)\n"
+        "stderr": "rm: requires approval: sign-off (ask b416c5b1c8fa)\n"
       }
     },
     {
@@ -110,7 +110,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "rm: requires approval: sign-off (approval b416c5b1c8fa)\n"
+        "stderr": "rm: requires approval: sign-off (ask b416c5b1c8fa)\n"
       }
     },
     {
@@ -139,7 +139,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "rm: requires approval: sign-off (approval 5bda3012c32d)\n"
+        "stderr": "rm: requires approval: sign-off (ask 5bda3012c32d)\n"
       }
     },
     {
@@ -167,7 +167,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "git: requires approval: log needs a nod (approval f520086f93cb)\n"
+        "stderr": "git: requires approval: log needs a nod (ask f520086f93cb)\n"
       }
     },
     {
@@ -210,7 +210,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "head: requires approval: no standing approval (approval edd518295293)\n"
+        "stderr": "head: requires approval: no standing approval (ask edd518295293)\n"
       }
     }
   ]

--- a/integ/session/commands/conflicts.json
+++ b/integ/session/commands/conflicts.json
@@ -64,7 +64,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "rm: requires approval: both: needs a nod (approval d2c4107e8cd1)\n"
+        "stderr": "rm: requires approval: both: needs a nod (ask d2c4107e8cd1)\n"
       }
     },
     {
@@ -120,7 +120,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "rm: requires approval: both: needs a nod (approval 8a63c4d87a83)\n"
+        "stderr": "rm: requires approval: both: needs a nod (ask 8a63c4d87a83)\n"
       }
     },
     {
@@ -203,7 +203,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "cat: requires approval: span review (approval 18558a102920)\n"
+        "stderr": "cat: requires approval: span review (ask 18558a102920)\n"
       }
     },
     {
@@ -217,7 +217,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "rm: requires approval: carve nod (approval 4b76fdb133ff)\n"
+        "stderr": "rm: requires approval: carve nod (ask 4b76fdb133ff)\n"
       }
     },
     {
@@ -272,7 +272,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "cp: requires approval: outbox nod (approval 69487f1bef15)\n"
+        "stderr": "cp: requires approval: outbox nod (ask 69487f1bef15)\n"
       }
     },
     {
@@ -326,7 +326,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "cp: requires approval: staging nod (approval 6b6e0a5b765b)\n"
+        "stderr": "cp: requires approval: staging nod (ask 6b6e0a5b765b)\n"
       }
     },
     {

--- a/integ/session/commands/script.json
+++ b/integ/session/commands/script.json
@@ -191,7 +191,7 @@
       "expect": {
         "exit": 126,
         "stdout": "",
-        "stderr": "rm: requires approval: scripted sign-off (approval a288d3df2ca1)\n"
+        "stderr": "rm: requires approval: scripted sign-off (ask a288d3df2ca1)\n"
       }
     },
     {

--- a/integ/truth/permissions.json
+++ b/integ/truth/permissions.json
@@ -33,7 +33,7 @@
     "                                                      a deny leaves the name where it is",
     "oncall     cat /vault/aws.token                       [1] cat: /vault/aws.token: credentials are never read by hand",
     "                                                      and refuses the read: paths, depth 1",
-    "oncall     rm /runbook/steps.md                       [126] rm: requires approval: a runbook edit needs a nod (approval ...)",
+    "oncall     rm /runbook/steps.md                       [126] rm: requires approval: a runbook edit needs a nod (ask ...)",
     "                                                      ask at depth 1",
     "oncall     rm /runbook/frozen/rollback.md             [1] rm: /runbook/frozen/rollback.md: the rollback plan is frozen",
     "                                                      deny at depth 2 outranks it",

--- a/python/mirage/policy/policies.py
+++ b/python/mirage/policy/policies.py
@@ -53,15 +53,15 @@ def render_deny(subject: str, deny: Deny) -> tuple[bytes, int]:
 
 def render_pending(subject: str, pending: Pending) -> tuple[bytes, int]:
     """The command plane's rendering of an unanswered ask: refused for
-    now at 126, naming the approval the agent should quote, so the
-    retry after the host grants it passes.
+    now at 126, naming the ask id the agent should quote, so the
+    retry after the host allows it passes.
 
     Args:
         subject (str): the command name.
         pending (Pending): the door's answer.
     """
     return (f"{subject}: requires approval: {pending.reason} "
-            f"(approval {pending.id})\n".encode(), POLICY_DENIED_EXIT)
+            f"(ask {pending.id})\n".encode(), POLICY_DENIED_EXIT)
 
 
 async def pre_ops_gate(policies: "Policies",

--- a/python/tests/policy/test_policies.py
+++ b/python/tests/policy/test_policies.py
@@ -337,5 +337,5 @@ async def test_an_ask_is_illegal_off_the_command_plane():
 
 def test_render_pending_names_the_approval():
     err, code = render_pending("git", Pending("abc123", "sign-off"))
-    assert err == b"git: requires approval: sign-off (approval abc123)\n"
+    assert err == b"git: requires approval: sign-off (ask abc123)\n"
     assert code == 126

--- a/python/tests/policy/test_profile.py
+++ b/python/tests/policy/test_profile.py
@@ -1584,7 +1584,7 @@ async def test_an_asked_line_is_refused_until_the_host_answers():
         assert code == 126
         (request, ) = ws.decisions.pending()
         assert err == (f"rm: requires approval: sign-off "
-                       f"(approval {request.id})\n")
+                       f"(ask {request.id})\n")
         assert (request.command, request.argv, request.cwd,
                 request.paths) == ("rm", ("/scratch/z", ), "/",
                                    ("/scratch/z", ))
@@ -1693,7 +1693,7 @@ async def test_a_coded_ask_routes_to_the_same_door():
         assert code == 126
         (request, ) = ws.decisions.pending()
         assert err == (f"wc: requires approval: looks risky "
-                       f"(approval {request.id})\n")
+                       f"(ask {request.id})\n")
         # The synthesized rule names the program, so a session grant
         # covers every wc line.
         assert request.rule == CommandRule(reason="looks risky",

--- a/typescript/packages/core/src/policy/policies.test.ts
+++ b/typescript/packages/core/src/policy/policies.test.ts
@@ -659,9 +659,7 @@ describe('Ask in the chain', () => {
 
   it('renderPending names the approval', () => {
     const [err, code] = renderPending('git', { kind: 'pending', id: 'abc123', reason: 'sign-off' })
-    expect(new TextDecoder().decode(err)).toBe(
-      'git: requires approval: sign-off (approval abc123)\n',
-    )
+    expect(new TextDecoder().decode(err)).toBe('git: requires approval: sign-off (ask abc123)\n')
     expect(code).toBe(126)
   })
 })

--- a/typescript/packages/core/src/policy/policies.ts
+++ b/typescript/packages/core/src/policy/policies.ts
@@ -51,13 +51,13 @@ export function renderDeny(subject: string, deny: Deny): [Uint8Array, number] {
 
 /**
  * The command plane's rendering of an unanswered ask: refused for now
- * at 126, naming the approval the agent should quote, so the retry
- * after the host grants it passes.
+ * at 126, naming the ask id the agent should quote, so the retry
+ * after the host allows it passes.
  */
 export function renderPending(subject: string, pending: Pending): [Uint8Array, number] {
   return [
     new TextEncoder().encode(
-      `${subject}: requires approval: ${pending.reason} (approval ${pending.id})\n`,
+      `${subject}: requires approval: ${pending.reason} (ask ${pending.id})\n`,
     ),
     POLICY_DENIED_EXIT,
   ]

--- a/typescript/packages/core/src/workspace/state_doors.test.ts
+++ b/typescript/packages/core/src/workspace/state_doors.test.ts
@@ -1762,7 +1762,7 @@ describe('ask end to end', () => {
     const [code, , err] = await line(ws, 'rm /scratch/z')
     expect(code).toBe(126)
     const request = pendingRequest(ws)
-    expect(err).toBe(`rm: requires approval: sign-off (approval ${request.id})\n`)
+    expect(err).toBe(`rm: requires approval: sign-off (ask ${request.id})\n`)
     expect([request.command, request.argv, request.cwd, request.paths]).toEqual([
       'rm',
       ['/scratch/z'],
@@ -1866,7 +1866,7 @@ describe('ask end to end', () => {
     const [code, , err] = await line(ws, 'wc -c /scratch/z')
     expect(code).toBe(126)
     const request = pendingRequest(ws)
-    expect(err).toBe(`wc: requires approval: looks risky (approval ${request.id})\n`)
+    expect(err).toBe(`wc: requires approval: looks risky (ask ${request.id})\n`)
     // The synthesized rule names the program, so a session grant covers
     // every wc line.
     expect(request.rule).toEqual({ reason: 'looks risky', commands: ['wc'] })

--- a/typescript/packages/dsh/src/approval.test.ts
+++ b/typescript/packages/dsh/src/approval.test.ts
@@ -232,9 +232,7 @@ describe('an asked line with no approval channel', () => {
     expect(run.exitCode).toBe(126)
     // The operator's document said `ask`; the refusal says so too, and
     // names the approval a host can grant.
-    expect(run.stderr.text).toMatch(
-      /^rm: requires approval: deletes are reviewed \(approval \w+\)$/m,
-    )
+    expect(run.stderr.text).toMatch(/^rm: requires approval: deletes are reviewed \(ask \w+\)$/m)
     expect(await ws.fs.exists('/data/notes.txt')).toBe(true)
     const pending = ws.decisions.pending('agent')
     expect(pending).toHaveLength(1)


### PR DESCRIPTION
Adds docs/home/permissions.mdx covering profiles (allow/ask/deny rules, the two axes, paths hide/show, mounts narrowing, script and runtime policies), session binding, the ask lifecycle, the workspace list-asks/allow/deny CLI verbs, and the REST asks door. Wires it into docs.json and the CLI page.

Also renames the agent-facing pending marker from "(approval <id>)" to "(ask <id>)" in both languages so the stderr names the same noun the CLI and REST door use, with all pinned occurrences (tests, integ, examples) updated.