### PR TITLE
fix(permissions): resolve mutation semantics below a hidden path

### DIFF
--- a/integ/resources/ssh/hidden.json
+++ b/integ/resources/ssh/hidden.json
@@ -1,0 +1,44 @@
+{
+  "cases": [
+    {
+      "id": "ssh_subtree_prep",
+      "seq": 923360,
+      "targets": [
+        "ssh"
+      ],
+      "command": "mkdir -p /data/qsubh/sec && echo k > /data/qsubh/sec/k",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ssh_subtree_rmdir_visibly_empty_succeeds",
+      "seq": 923361,
+      "targets": [
+        "ssh"
+      ],
+      "command": "ls -a /data/qsubh && rmdir /data/qsubh",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      "session": "veiled"
+    },
+    {
+      "id": "ssh_subtree_took_the_remnants",
+      "seq": 923362,
+      "targets": [
+        "ssh"
+      ],
+      "command": "test -e /data/qsubh",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/session/commands/hidden.json
+++ b/integ/session/commands/hidden.json
@@ -459,6 +459,46 @@
         "stdout": "",
         "stderr": ""
       }
+    },
+    {
+      "id": "subtree_guarded_prep",
+      "seq": 923345,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mkdir -p /scratch/keep && echo h > /scratch/keep/h",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_read_only_remnant_keeps_the_refusal",
+      "seq": 923346,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "rmdir /scratch/keep",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "rmdir: failed to remove '/scratch/keep': Directory not empty\n"
+      },
+      "session": "guarded"
+    },
+    {
+      "id": "subtree_read_only_remnant_survived",
+      "seq": 923347,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "cat /scratch/keep/h",
+      "expect": {
+        "exit": 0,
+        "stdout": "h\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/session/commands/hidden.json
+++ b/integ/session/commands/hidden.json
@@ -365,6 +365,100 @@
         "stdout": "",
         "stderr": ""
       }
+    },
+    {
+      "id": "subtree_screened_prep",
+      "seq": 923338,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mkdir -p /scratch/pen/box/sec && echo v > /scratch/pen/box/a.txt && echo s > /scratch/pen/box/sec/k",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_file_mv_under_an_anchored_pattern_passes",
+      "seq": 923339,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mv /scratch/pen/box/a.txt /scratch/pen/box/b.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      "session": "screened"
+    },
+    {
+      "id": "subtree_dir_mv_under_an_anchored_pattern_refuses",
+      "seq": 923340,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mv /scratch/pen/box /scratch/pen/moved",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "mv: cannot move '/scratch/pen/box' to '/scratch/pen/moved': Permission denied\n"
+      },
+      "session": "screened"
+    },
+    {
+      "id": "subtree_mv_b_prep",
+      "seq": 923341,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mkdir /scratch/dst",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_mv_b_refusal_makes_no_backup",
+      "seq": 923342,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mv -b -T /scratch/box /scratch/dst",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "mv: cannot move '/scratch/box' to '/scratch/dst': Permission denied\n"
+      },
+      "session": "boxed"
+    },
+    {
+      "id": "subtree_mv_b_destination_intact",
+      "seq": 923343,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "test -d /scratch/dst",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_mv_b_no_backup_appeared",
+      "seq": 923344,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "test -e /scratch/dst~",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/session/commands/hidden.json
+++ b/integ/session/commands/hidden.json
@@ -123,6 +123,248 @@
         "stdout": "k\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "subtree_hidden_prep",
+      "seq": 923320,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mkdir -p /scratch/box/sec /scratch/only /scratch/gone/sec /scratch/bag && echo v > /scratch/box/a.txt && echo s > /scratch/box/sec/k && echo x > /scratch/only/h && echo s > /scratch/gone/sec/k && echo a > /scratch/gone/a.txt && echo t > /scratch/bag/x.tkn && echo a > /scratch/bag/a.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_mv_reveal_refused",
+      "seq": 923321,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mv /scratch/box /scratch/moved",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "mv: cannot move '/scratch/box' to '/scratch/moved': Permission denied\n"
+      },
+      "session": "boxed"
+    },
+    {
+      "id": "subtree_mv_refusal_left_the_source",
+      "seq": 923322,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "find /scratch/box",
+      "expect": {
+        "exit": 0,
+        "stdout": "/scratch/box\n/scratch/box/a.txt\n/scratch/box/sec\n/scratch/box/sec/k\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_cp_copies_the_visible_view",
+      "seq": 923323,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "cp -r /scratch/box /scratch/boxcopy",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      "session": "boxed"
+    },
+    {
+      "id": "subtree_cp_copy_holds_no_hidden_name",
+      "seq": 923324,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "find /scratch/boxcopy",
+      "expect": {
+        "exit": 0,
+        "stdout": "/scratch/boxcopy\n/scratch/boxcopy/a.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_rmdir_visibly_empty_succeeds",
+      "seq": 923325,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "ls -a /scratch/only && rmdir /scratch/only",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      "session": "boxed"
+    },
+    {
+      "id": "subtree_rmdir_took_the_remnants",
+      "seq": 923326,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "test -e /scratch/only",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_rm_r_destroys_hidden_below",
+      "seq": 923327,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "rm -r /scratch/gone",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      "session": "boxed"
+    },
+    {
+      "id": "subtree_rm_r_took_everything",
+      "seq": 923328,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "test -e /scratch/gone",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_mv_name_pattern_rides_along",
+      "seq": 923329,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mv /scratch/bag /scratch/sack",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      "session": "tagged"
+    },
+    {
+      "id": "subtree_moved_file_stays_hidden",
+      "seq": 923330,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "ls /scratch/sack",
+      "expect": {
+        "exit": 0,
+        "stdout": "a.txt\n",
+        "stderr": ""
+      },
+      "session": "tagged"
+    },
+    {
+      "id": "subtree_moved_content_survived",
+      "seq": 923331,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "cat /scratch/sack/x.tkn",
+      "expect": {
+        "exit": 0,
+        "stdout": "t\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_cross_mount_mv_refuses_too",
+      "seq": 923332,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mv /scratch/box /repo/boxmoved",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "mv: cannot move '/scratch/box' to '/repo/boxmoved': Permission denied\n"
+      },
+      "session": "boxed"
+    },
+    {
+      "id": "subtree_cross_mount_refusal_left_the_source",
+      "seq": 923333,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "test -e /scratch/box/sec/k",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_cross_prep",
+      "seq": 923334,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mkdir -p /scratch/bag2 && echo t > /scratch/bag2/y.tkn && echo a > /scratch/bag2/a.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_cross_mount_mv_under_a_name_pattern_moves_the_visible",
+      "seq": 923335,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "mv /scratch/bag2 /repo/bag2",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      "session": "tagged"
+    },
+    {
+      "id": "subtree_cross_move_dropped_the_hidden_remnant",
+      "seq": 923336,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "ls /repo/bag2",
+      "expect": {
+        "exit": 0,
+        "stdout": "a.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_cross_move_source_fully_gone",
+      "seq": 923337,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "test -e /scratch/bag2",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/session/commands/hidden.json
+++ b/integ/session/commands/hidden.json
@@ -499,6 +499,46 @@
         "stdout": "h\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "subtree_mounted_prep",
+      "seq": 923350,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "rm -r /vault/d/sub && mkdir -p /vault/d/sec && echo k > /vault/d/sec/k",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "subtree_visible_mounted_child_keeps_the_refusal",
+      "seq": 923351,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "ls /vault/d && rmdir /vault/d",
+      "expect": {
+        "exit": 1,
+        "stdout": "inner\n",
+        "stderr": "rmdir: failed to remove '/vault/d': Directory not empty\n"
+      },
+      "session": "shrouded"
+    },
+    {
+      "id": "subtree_mounted_child_refusal_kept_the_remnant",
+      "seq": 923352,
+      "targets": [
+        "ram-commands"
+      ],
+      "command": "cat /vault/d/sec/k",
+      "expect": {
+        "exit": 0,
+        "stdout": "k\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -2398,6 +2398,7 @@
             ]
           }
         },
+        "guarded": "guarded",
         "sealed": {
           "paths": {
             "hide": [
@@ -2548,6 +2549,16 @@
           "paths": {
             "show": {
               "/scratch/pine/keep": "r"
+            }
+          }
+        },
+        "guarded": {
+          "paths": {
+            "hide": [
+              "/scratch/keep/h"
+            ],
+            "show": {
+              "/scratch/keep/h": "r"
             }
           }
         },

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -2375,6 +2375,22 @@
             ]
           }
         },
+        "boxed": {
+          "paths": {
+            "hide": [
+              "/scratch/box/sec",
+              "/scratch/only/h",
+              "/scratch/gone/sec"
+            ]
+          }
+        },
+        "tagged": {
+          "paths": {
+            "hide": [
+              "*.tkn"
+            ]
+          }
+        },
         "sealed": {
           "paths": {
             "hide": [

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -2391,6 +2391,13 @@
             ]
           }
         },
+        "screened": {
+          "paths": {
+            "hide": [
+              "/scratch/pen/*/sec"
+            ]
+          }
+        },
         "sealed": {
           "paths": {
             "hide": [

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -1106,7 +1106,16 @@
           "backend": "ssh",
           "root": "links"
         }
-      ]
+      ],
+      "sessions": {
+        "veiled": {
+          "paths": {
+            "hide": [
+              "/data/qsubh/sec"
+            ]
+          }
+        }
+      }
     },
     {
       "id": "nextcloud",
@@ -2403,6 +2412,13 @@
           "paths": {
             "hide": [
               "/vault/d/inner"
+            ]
+          }
+        },
+        "shrouded": {
+          "paths": {
+            "hide": [
+              "/vault/d/sec"
             ]
           }
         },

--- a/python/mirage/commands/builtin/generic/crossmount/relay/mv.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/mv.py
@@ -20,6 +20,7 @@ from mirage.commands.builtin.generic.crossmount.utils import (
     flat_scopes, relay, transfer_primitives)
 from mirage.commands.builtin.generic.mv import mv as generic_mv
 from mirage.commands.builtin.generic.mv import parse_mv_flags
+from mirage.commands.builtin.generic_bind.adapter import refuse_reveal
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagValue, FlagView
 from mirage.runtime.types import DispatchFn
@@ -58,4 +59,5 @@ async def run_mv(
                                 unlink=p(relay, dispatch, "unlink"),
                                 rmdir=p(relay, dispatch, "rmdir")),
                             flags=parse_mv_flags(fl),
-                            backend_key=storage_key)
+                            backend_key=storage_key,
+                            guard=refuse_reveal)

--- a/python/mirage/commands/builtin/generic/mv.py
+++ b/python/mirage/commands/builtin/generic/mv.py
@@ -293,6 +293,7 @@ async def mv(
     flags: MvFlags,
     backend_key: Callable[[PathSpec], str] | None = None,
     readdir: ReaddirFn | None = None,
+    guard: Callable[[PathSpec, PathSpec], None] | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Move sources to a destination, fanning out into a directory.
 
@@ -318,6 +319,11 @@ async def mv(
         readdir (ReaddirFn | None): Directory lister for backup version
             scans and the ``-T`` empty-directory probe; the primitive
             strategy's own lister is used when None.
+        guard (Callable | None): Judges one (source, target) pair before
+            a primitive move touches anything, raising to refuse it; the
+            adapter wires the hidden-reveal check here so a cross-mount
+            move refuses exactly where a native rename's own slot would,
+            instead of half-copying first.
 
     Returns:
         tuple[ByteSource | None, IOResult]: Verbose output and recorded
@@ -404,6 +410,13 @@ async def mv(
         if not ok:
             continue
         if isinstance(strategy, PrimitiveMove):
+            if guard is not None:
+                try:
+                    guard(src, target)
+                except FS_ERRORS as exc:
+                    errors.append(f"mv: cannot move '{src.virtual}' to "
+                                  f"'{target.virtual}': {fs_strerror(exc)}")
+                    continue
             entries = await walk(strategy.readdir, stat, src)
             copied_all, wrote_any = await copy_entries("mv", strategy, stat,
                                                        src, target, entries,

--- a/python/mirage/commands/builtin/generic/mv.py
+++ b/python/mirage/commands/builtin/generic/mv.py
@@ -320,10 +320,11 @@ async def mv(
             scans and the ``-T`` empty-directory probe; the primitive
             strategy's own lister is used when None.
         guard (Callable | None): Judges one (source, target) pair before
-            a primitive move touches anything, raising to refuse it; the
-            adapter wires the hidden-reveal check here so a cross-mount
-            move refuses exactly where a native rename's own slot would,
-            instead of half-copying first.
+            the move touches anything, the backup included, raising to
+            refuse it; the adapter wires the hidden-reveal check here so
+            a refused move mutates nothing (no half-copy, no destination
+            renamed aside by ``-b``). Consulted only for a directory
+            source, since a file carries nothing below it to reveal.
 
     Returns:
         tuple[ByteSource | None, IOResult]: Verbose output and recorded
@@ -405,18 +406,21 @@ async def mv(
                 errors.append(f"mv: cannot overwrite '{target.virtual}': "
                               "Directory not empty")
                 continue
+        # The reveal guard answers before the backup so a refused move
+        # cannot leave the destination renamed aside; only a directory
+        # source has anything below it to re-anchor, so a file passes.
+        if guard is not None and src_is_dir:
+            try:
+                guard(src, target)
+            except FS_ERRORS as exc:
+                errors.append(f"mv: cannot move '{src.virtual}' to "
+                              f"'{target.virtual}': {fs_strerror(exc)}")
+                continue
         backup, ok = await make_backup(policy, strategy, stat, readdir, target,
                                        writes, errors)
         if not ok:
             continue
         if isinstance(strategy, PrimitiveMove):
-            if guard is not None:
-                try:
-                    guard(src, target)
-                except FS_ERRORS as exc:
-                    errors.append(f"mv: cannot move '{src.virtual}' to "
-                                  f"'{target.virtual}': {fs_strerror(exc)}")
-                    continue
             entries = await walk(strategy.readdir, stat, src)
             copied_all, wrote_any = await copy_entries("mv", strategy, stat,
                                                        src, target, entries,

--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -449,9 +449,9 @@ async def _guarded_rmdir(fn: OperationFn,
                          readdir: OperationFn,
                          stat: StatOp,
                          unlink: OperationFn | None,
+                         children: ChildMounts | None,
                          *args: Any,
                          index: IndexCacheStore = NULL_INDEX,
-                         children: ChildMounts | None = None,
                          **kwargs: Any) -> Any:
     """rmdir that removes a directory the session sees as empty.
 
@@ -472,18 +472,20 @@ async def _guarded_rmdir(fn: OperationFn,
             listing the visible/hidden split is judged on.
         stat (StatOp): the raw backend stat, classifying walked entries.
         unlink (OperationFn | None): the raw backend unlink.
+        children (ChildMounts | None): child names the namespace owes
+            the directory (nested mount roots and symlinks), captured
+            from ``glob_children`` at wrap time, which holds the
+            invocation's fact because the factory applies this guard
+            per invocation, after stamping it. The children join the
+            emptiness judgment, never the walk: a visible mounted
+            child keeps the refusal exactly as the ops plane's merged
+            listing does, while the cascade itself only ever removes
+            what the backend holds.
         *args: the call's positionals; the first PathSpec is the
             directory.
         index (IndexCacheStore): the invocation's cache index, threaded
             by the callers so the fallback listing resolves on an
             indexed backend the way the command's own listings did.
-        children (ChildMounts | None): child names the namespace owes
-            the directory (nested mount roots and symlinks), prebound
-            per invocation by ``with_namespace_children``. They join
-            the emptiness judgment, never the walk: a visible mounted
-            child keeps the refusal exactly as the ops plane's merged
-            listing does, while the cascade itself only ever removes
-            what the backend holds.
         **kwargs: forwarded untouched.
     """
     target: PathSpec | None = None
@@ -701,14 +703,15 @@ _GUARD_EACCES_SLOTS = ("write", "mkdir", "append", "create")
 def with_hidden_guard(ops: CommandIO) -> CommandIO:
     """Return ``ops`` whose slots refuse hidden paths like missing ones.
 
-    The commands factory hands this copy to every generic command, the
-    same shape as ``with_read_cache``, so hidden-path enforcement lands
-    once for the whole command tier (resolve_glob derives from the
-    wrapped readdir). The module-level IO constants stay raw: the ops
-    tables built from them serve the dispatcher, which enforces hiding
-    itself at the door, and their tests introspect slot identity. The
-    guards read the current session at call time, so one wrapped copy
-    is shared across sessions.
+    The commands factory applies this to every generic command, per
+    invocation and after stamping ``glob_children``, so a guard that
+    consumes a namespace fact captures the invocation's value at wrap
+    time (the rmdir guard's emptiness judgment does); enforcement
+    still lands once for the whole command tier (resolve_glob derives
+    from the wrapped readdir). The module-level IO constants stay raw:
+    the ops tables built from them serve the dispatcher, which
+    enforces hiding itself at the door, and their tests introspect
+    slot identity. The guards read the current session at call time.
 
     Args:
         ops (CommandIO): the backend's IO adapter.
@@ -731,40 +734,11 @@ def with_hidden_guard(ops: CommandIO) -> CommandIO:
                                               assume_dir)
     if ops.rmdir is not None:
         changes["rmdir"] = functools.partial(_guarded_rmdir, ops.rmdir,
-                                             ops.readdir, ops.stat, ops.unlink)
+                                             ops.readdir, ops.stat, ops.unlink,
+                                             ops.glob_children)
     if ops.exists is not None:
         changes["exists"] = functools.partial(_guarded_exists, ops.exists)
     return replace(ops, **changes)
-
-
-def with_namespace_children(ops: CommandIO,
-                            children: ChildMounts | None) -> CommandIO:
-    """Return ``ops`` carrying the invocation's namespace children.
-
-    The adapter is built once per backend while the child names a
-    directory owes to nested mounts and symlinks are session-scoped, so
-    the fact lands here, per invocation. Two consumers read it: glob
-    resolution and the dir guard read the ``glob_children`` field off
-    the stamped copy, and the hidden guard's rmdir was bound before any
-    invocation exists, so its slot is rebound with the fact as the
-    ``children`` keyword ``_guarded_rmdir`` declares. That keyword is
-    only ever prebound here, onto the guard the factory installed two
-    lines earlier, so no backend rmdir can receive it.
-
-    Args:
-        ops (CommandIO): the backend's IO adapter, path-guarded by the
-            factory.
-        children (ChildMounts | None): the invocation's namespace child
-            fact, from ``opts.ns.child_mounts``.
-    """
-    stamped = replace(ops, glob_children=children)
-    if children is None or stamped.rmdir is None:
-        return stamped
-    # OperationFn rather than RmdirOp: the keyword belongs to the
-    # guard's own signature, not the backend op contract the slot is
-    # typed as.
-    slot: OperationFn = stamped.rmdir
-    return replace(stamped, rmdir=functools.partial(slot, children=children))
 
 
 _RULE_SLOTS = ("read_bytes", "read_stream", "read_range", "write", "append",

--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -35,6 +35,7 @@ from mirage.utils.errors import MISS_ERRORS, ReadOnlyError, eisdir
 from mirage.utils.glob_walk import DEFAULT_MAX_GLOB_MATCHES, make_resolve_glob
 from mirage.utils.hidden import move_reveals
 from mirage.utils.path import norm, parent
+from mirage.utils.remnants import remove_remnants, visible_below
 
 OperationFn = Callable[..., Any]
 
@@ -404,9 +405,50 @@ async def _guarded_pair(fn: OperationFn, stat: StatOp, assume_dir: bool, *args:
     return await fn(*args, **kwargs)
 
 
+@dataclass(frozen=True, slots=True)
+class _SlotChannel:
+    """The command plane's remnant channel: the refused rmdir's sibling
+    slots, still mode- and rule-guarded but below the visibility
+    filter, so the cascade can see what it must destroy while every
+    deletion still answers for its own path's mode.
+
+    Args:
+        lead (tuple): the call's leading positionals (the accessor).
+        index (IndexCacheStore): the invocation's cache index.
+        readdir_fn (OperationFn): the sibling readdir slot.
+        stat_fn (OperationFn): the sibling stat slot.
+        unlink_fn (OperationFn): the sibling unlink slot.
+        rmdir_fn (OperationFn): the raw rmdir the guard wraps.
+    """
+
+    lead: tuple[Any, ...]
+    index: IndexCacheStore
+    readdir_fn: OperationFn
+    stat_fn: OperationFn
+    unlink_fn: OperationFn
+    rmdir_fn: OperationFn
+
+    async def readdir(self, spec: PathSpec) -> list[str]:
+        entries: list[str] = await self.readdir_fn(*self.lead,
+                                                   spec,
+                                                   index=self.index)
+        return entries
+
+    async def stat(self, spec: PathSpec) -> FileStat:
+        row: FileStat = await self.stat_fn(*self.lead, spec, index=self.index)
+        return row
+
+    async def unlink(self, spec: PathSpec) -> None:
+        await self.unlink_fn(*self.lead, spec)
+
+    async def rmdir(self, spec: PathSpec) -> None:
+        await self.rmdir_fn(*self.lead, spec, index=self.index)
+
+
 async def _guarded_rmdir(fn: OperationFn,
                          readdir: OperationFn,
-                         rm_r: OperationFn | None,
+                         stat: StatOp,
+                         unlink: OperationFn | None,
                          *args: Any,
                          index: IndexCacheStore = NULL_INDEX,
                          **kwargs: Any) -> Any:
@@ -417,13 +459,18 @@ async def _guarded_rmdir(fn: OperationFn,
     something invisible exists, so the remnants go with the directory:
     a session's mutation may destroy what it cannot see, never learn of
     it. Any visible child keeps the refusal, and a backend with no
-    recursive remove keeps it too, having no way to take the remnants.
+    unlink keeps it too, having no way to take the remnants. The
+    removal is the shared ``remove_remnants`` walk over the sibling
+    slots, which revalidates visibility before every deletion and
+    keeps the mode guard on each one; any cascade failure answers with
+    the backend's original refusal, exactly as the ops plane does.
 
     Args:
         fn (OperationFn): the raw backend rmdir.
         readdir (OperationFn): the raw backend readdir, for the real
             listing the visible/hidden split is judged on.
-        rm_r (OperationFn | None): the backend's recursive remove.
+        stat (StatOp): the raw backend stat, classifying walked entries.
+        unlink (OperationFn | None): the raw backend unlink.
         *args: the call's positionals; the first PathSpec is the
             directory.
         index (IndexCacheStore): the invocation's cache index, threaded
@@ -440,7 +487,7 @@ async def _guarded_rmdir(fn: OperationFn,
     try:
         return await fn(*args, index=index, **kwargs)
     except OSError as exc:
-        if (target is None or rm_r is None
+        if (target is None or unlink is None
                 or exc.errno not in (errno.ENOTEMPTY, errno.EEXIST)
                 or not hidden_paths_intersect(target.virtual)):
             raise
@@ -450,12 +497,13 @@ async def _guarded_rmdir(fn: OperationFn,
                 break
             lead.append(arg)
         entries = await readdir(*lead, target, index=index)
-        base = target.virtual.rstrip("/")
-        if not entries or any(
-                path_allowed(f"{base}/{e.rstrip('/').rsplit('/', 1)[-1]}")
-                for e in entries):
+        if not entries or visible_below(target.virtual, entries, path_allowed):
             raise
-        await rm_r(*lead, target)
+        channel = _SlotChannel(tuple(lead), index, readdir, stat, unlink, fn)
+        try:
+            await remove_remnants(channel, path_allowed, target)
+        except OSError as cascade:
+            raise exc from cascade
         return None
 
 
@@ -672,7 +720,7 @@ def with_hidden_guard(ops: CommandIO) -> CommandIO:
                                               assume_dir)
     if ops.rmdir is not None:
         changes["rmdir"] = functools.partial(_guarded_rmdir, ops.rmdir,
-                                             ops.readdir, ops.rm_r)
+                                             ops.readdir, ops.stat, ops.unlink)
     if ops.exists is not None:
         changes["exists"] = functools.partial(_guarded_exists, ops.exists)
     return replace(ops, **changes)

--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -25,12 +25,15 @@ from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.commands.builtin.generic.du import (DEFAULT_MAX_DU_ENTRIES,
                                                 DuEntries)
 from mirage.commands.config import CommandFnResult, CommandOpts, ProvisionFn
-from mirage.context import (effective_path_mode, get_admission, get_mount_gate,
-                            path_allowed, readonly_below)
+from mirage.context import (effective_path_mode, get_admission,
+                            get_current_session, get_mount_gate,
+                            hidden_paths_intersect, path_allowed,
+                            readonly_below)
 from mirage.ops.types import ChildMounts, StatOverlay
 from mirage.types import FileStat, FileType, MountMode, PathSpec
 from mirage.utils.errors import MISS_ERRORS, ReadOnlyError, eisdir
 from mirage.utils.glob_walk import DEFAULT_MAX_GLOB_MATCHES, make_resolve_glob
+from mirage.utils.hidden import move_reveals
 from mirage.utils.path import norm, parent
 
 OperationFn = Callable[..., Any]
@@ -303,6 +306,94 @@ async def _guarded_readdir(fn: OperationFn, *args: Any,
     ]
 
 
+def refuse_reveal(src: PathSpec, dst: PathSpec) -> None:
+    """Refuse a relocation that would surface a hidden path.
+
+    A rename or a native directory copy re-anchors everything below its
+    source, and a hide's coverage does not move with the content, so
+    hidden bytes would land at paths the session can see. EACCES on the
+    source, which mv and cp render in GNU's permission-denied voice.
+
+    Args:
+        src (PathSpec): the subtree being moved or copied.
+        dst (PathSpec): where it would land.
+    """
+    sess = get_current_session()
+    if sess is None:
+        return
+    if move_reveals(sess.hidden_paths, sess.shown_paths, src.virtual,
+                    dst.virtual):
+        raise PermissionError(errno.EACCES, os.strerror(errno.EACCES),
+                              src.virtual)
+
+
+def _guarded_pair(fn: OperationFn, *args: Any, **kwargs: Any) -> Any:
+    """Rename/dir-copy guard: ``_guarded_call``'s per-path checks, then
+    the subtree reveal check on the (src, dst) pair.
+
+    Args:
+        fn (OperationFn): the raw backend op.
+        *args: the call's positionals, source then destination among
+            them.
+        **kwargs: forwarded untouched.
+    """
+    specs = [arg for arg in args if isinstance(arg, PathSpec)]
+    for position, spec in enumerate(specs):
+        _refuse_hidden(spec, create=position > 0)
+    if len(specs) >= 2:
+        refuse_reveal(specs[0], specs[1])
+    return fn(*args, **kwargs)
+
+
+async def _guarded_rmdir(fn: OperationFn, readdir: OperationFn,
+                         rm_r: OperationFn | None, *args: Any,
+                         **kwargs: Any) -> Any:
+    """rmdir that removes a directory the session sees as empty.
+
+    The backend refuses a directory still holding entries, but when
+    every remaining entry is hidden the refusal would leak that
+    something invisible exists, so the remnants go with the directory:
+    a session's mutation may destroy what it cannot see, never learn of
+    it. Any visible child keeps the refusal, and a backend with no
+    recursive remove keeps it too, having no way to take the remnants.
+
+    Args:
+        fn (OperationFn): the raw backend rmdir.
+        readdir (OperationFn): the raw backend readdir, for the real
+            listing the visible/hidden split is judged on.
+        rm_r (OperationFn | None): the backend's recursive remove.
+        *args: the call's positionals; the first PathSpec is the
+            directory.
+        **kwargs: forwarded untouched.
+    """
+    target: PathSpec | None = None
+    for arg in args:
+        if isinstance(arg, PathSpec):
+            _refuse_hidden(arg, create=False)
+            if target is None:
+                target = arg
+    try:
+        return await fn(*args, **kwargs)
+    except OSError as exc:
+        if (target is None or rm_r is None
+                or exc.errno not in (errno.ENOTEMPTY, errno.EEXIST)
+                or not hidden_paths_intersect(target.virtual)):
+            raise
+        lead: list[Any] = []
+        for arg in args:
+            if isinstance(arg, PathSpec):
+                break
+            lead.append(arg)
+        entries = await readdir(*lead, target)
+        base = target.virtual.rstrip("/")
+        if not entries or any(
+                path_allowed(f"{base}/{e.rstrip('/').rsplit('/', 1)[-1]}")
+                for e in entries):
+            raise
+        await rm_r(*lead, target)
+        return None
+
+
 async def _guarded_exists(fn: OperationFn, *args: Any, **kwargs: Any) -> bool:
     """Exists that answers False for a hidden path, never a refusal.
 
@@ -477,8 +568,8 @@ class CommandIO:
 
 
 _GUARD_ENOENT_SLOTS = ("read_bytes", "read_stream", "stat", "read_range",
-                       "set_attrs", "unlink", "rmdir", "rm_r", "truncate",
-                       "rename", "copy", "dir_copy", "find")
+                       "set_attrs", "unlink", "rm_r", "truncate", "copy",
+                       "find")
 
 _GUARD_EACCES_SLOTS = ("write", "mkdir", "append", "create")
 
@@ -509,6 +600,13 @@ def with_hidden_guard(ops: CommandIO) -> CommandIO:
         fn = getattr(ops, slot)
         if fn is not None:
             changes[slot] = functools.partial(_guarded_call, fn, True)
+    for slot in ("rename", "dir_copy"):
+        fn = getattr(ops, slot)
+        if fn is not None:
+            changes[slot] = functools.partial(_guarded_pair, fn)
+    if ops.rmdir is not None:
+        changes["rmdir"] = functools.partial(_guarded_rmdir, ops.rmdir,
+                                             ops.readdir, ops.rm_r)
     if ops.exists is not None:
         changes["exists"] = functools.partial(_guarded_exists, ops.exists)
     return replace(ops, **changes)

--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -506,7 +506,15 @@ async def _guarded_rmdir(fn: OperationFn,
             if isinstance(arg, PathSpec):
                 break
             lead.append(arg)
-        entries = await readdir(*lead, target, index=index)
+        # Both folds catch ``Exception``, not just ``OSError``: an API
+        # backend's failure is not always an errno (box raises its own
+        # error type), and a raw backend exception here would reveal
+        # exactly what the refusal exists to hide. Cancellation and
+        # system exits still propagate.
+        try:
+            entries = await readdir(*lead, target, index=index)
+        except Exception as listing:
+            raise exc from listing
         merged = list(entries)
         if children is not None:
             merged.extend(children(target.virtual))
@@ -515,7 +523,7 @@ async def _guarded_rmdir(fn: OperationFn,
         channel = _SlotChannel(tuple(lead), index, readdir, stat, unlink, fn)
         try:
             await remove_remnants(channel, path_allowed, target)
-        except OSError as cascade:
+        except Exception as cascade:
             raise exc from cascade
         return None
 

--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -132,6 +132,21 @@ class PathOp(Protocol):
         ...
 
 
+class RmdirOp(Protocol):
+    """Remove an empty directory. ``index`` joins the read-family slots'
+    contract because the hidden-remnant guard turns a refused rmdir into
+    a raw listing of the same directory, and an indexed backend cannot
+    list a nested path through ``NULL_INDEX``; the backend itself does
+    not consult it."""
+
+    def __call__(self,
+                 accessor: Any,
+                 path: PathSpec,
+                 /,
+                 index: IndexCacheStore = ...) -> Awaitable[None]:
+        ...
+
+
 class RmTreeOp(Protocol):
     """Remove a subtree. The builders ignore any returned value
     (databricks reports the removed keys for its own rename path), so
@@ -306,13 +321,8 @@ async def _guarded_readdir(fn: OperationFn, *args: Any,
     ]
 
 
-def refuse_reveal(src: PathSpec, dst: PathSpec) -> None:
-    """Refuse a relocation that would surface a hidden path.
-
-    A rename or a native directory copy re-anchors everything below its
-    source, and a hide's coverage does not move with the content, so
-    hidden bytes would land at paths the session can see. EACCES on the
-    source, which mv and cp render in GNU's permission-denied voice.
+def _move_would_reveal(src: PathSpec, dst: PathSpec) -> bool:
+    """Whether the session's hides make this relocation a reveal.
 
     Args:
         src (PathSpec): the subtree being moved or copied.
@@ -320,19 +330,65 @@ def refuse_reveal(src: PathSpec, dst: PathSpec) -> None:
     """
     sess = get_current_session()
     if sess is None:
-        return
-    if move_reveals(sess.hidden_paths, sess.shown_paths, src.virtual,
-                    dst.virtual):
+        return False
+    return move_reveals(sess.hidden_paths, sess.shown_paths, src.virtual,
+                        dst.virtual)
+
+
+def refuse_reveal(src: PathSpec, dst: PathSpec) -> None:
+    """Refuse a relocation that would surface a hidden path.
+
+    A rename or a native directory copy re-anchors everything below its
+    source, and a hide's coverage does not move with the content, so
+    hidden bytes would land at paths the session can see. EACCES on the
+    source, which mv and cp render in GNU's permission-denied voice.
+    Only a directory has anything below it to re-anchor, so callers
+    check this for a source they know is a directory and skip it for a
+    file.
+
+    Args:
+        src (PathSpec): the subtree being moved or copied.
+        dst (PathSpec): where it would land.
+    """
+    if _move_would_reveal(src, dst):
         raise PermissionError(errno.EACCES, os.strerror(errno.EACCES),
                               src.virtual)
 
 
-def _guarded_pair(fn: OperationFn, *args: Any, **kwargs: Any) -> Any:
+async def _pair_src_is_dir(stat: StatOp, accessor: Any, src: PathSpec) -> bool:
+    """Whether a pair op's source stats as a directory.
+
+    Args:
+        stat (StatOp): the backend stat, for classifying the source.
+        accessor (Any): the pair call's leading accessor.
+        src (PathSpec): the source being classified.
+    """
+    try:
+        row = await stat(accessor, src)
+    except FileNotFoundError:
+        # Nothing moves; the op itself reports the absence.
+        return False
+    except OSError:
+        # Unanswerable classification fails toward refusal.
+        return True
+    return row.type is FileType.DIRECTORY
+
+
+async def _guarded_pair(fn: OperationFn, stat: StatOp, assume_dir: bool, *args:
+                        Any, **kwargs: Any) -> Any:
     """Rename/dir-copy guard: ``_guarded_call``'s per-path checks, then
     the subtree reveal check on the (src, dst) pair.
 
+    Only a directory source can carry hidden content into view, so a
+    rename whose source stats as a file passes; a dir-copy source is a
+    directory by contract and skips the probe.
+
     Args:
         fn (OperationFn): the raw backend op.
+        stat (StatOp): the raw backend stat, probed only when the
+            reveal check trips.
+        assume_dir (bool): the slot's contract already makes the source
+            a directory (dir_copy), so no probe is needed.
         *args: the call's positionals, source then destination among
             them.
         **kwargs: forwarded untouched.
@@ -340,13 +396,19 @@ def _guarded_pair(fn: OperationFn, *args: Any, **kwargs: Any) -> Any:
     specs = [arg for arg in args if isinstance(arg, PathSpec)]
     for position, spec in enumerate(specs):
         _refuse_hidden(spec, create=position > 0)
-    if len(specs) >= 2:
-        refuse_reveal(specs[0], specs[1])
-    return fn(*args, **kwargs)
+    reveal = len(specs) >= 2 and _move_would_reveal(specs[0], specs[1])
+    if reveal and (assume_dir
+                   or await _pair_src_is_dir(stat, args[0], specs[0])):
+        raise PermissionError(errno.EACCES, os.strerror(errno.EACCES),
+                              specs[0].virtual)
+    return await fn(*args, **kwargs)
 
 
-async def _guarded_rmdir(fn: OperationFn, readdir: OperationFn,
-                         rm_r: OperationFn | None, *args: Any,
+async def _guarded_rmdir(fn: OperationFn,
+                         readdir: OperationFn,
+                         rm_r: OperationFn | None,
+                         *args: Any,
+                         index: IndexCacheStore = NULL_INDEX,
                          **kwargs: Any) -> Any:
     """rmdir that removes a directory the session sees as empty.
 
@@ -364,6 +426,9 @@ async def _guarded_rmdir(fn: OperationFn, readdir: OperationFn,
         rm_r (OperationFn | None): the backend's recursive remove.
         *args: the call's positionals; the first PathSpec is the
             directory.
+        index (IndexCacheStore): the invocation's cache index, threaded
+            by the callers so the fallback listing resolves on an
+            indexed backend the way the command's own listings did.
         **kwargs: forwarded untouched.
     """
     target: PathSpec | None = None
@@ -373,7 +438,7 @@ async def _guarded_rmdir(fn: OperationFn, readdir: OperationFn,
             if target is None:
                 target = arg
     try:
-        return await fn(*args, **kwargs)
+        return await fn(*args, index=index, **kwargs)
     except OSError as exc:
         if (target is None or rm_r is None
                 or exc.errno not in (errno.ENOTEMPTY, errno.EEXIST)
@@ -384,7 +449,7 @@ async def _guarded_rmdir(fn: OperationFn, readdir: OperationFn,
             if isinstance(arg, PathSpec):
                 break
             lead.append(arg)
-        entries = await readdir(*lead, target)
+        entries = await readdir(*lead, target, index=index)
         base = target.virtual.rstrip("/")
         if not entries or any(
                 path_allowed(f"{base}/{e.rstrip('/').rsplit('/', 1)[-1]}")
@@ -505,7 +570,7 @@ class CommandIO:
     exists: ExistsOp | None = None
     mkdir: MkdirOp | None = None
     unlink: PathOp | None = None
-    rmdir: PathOp | None = None
+    rmdir: RmdirOp | None = None
     rm_r: RmTreeOp | None = None
     rename: PairOp | None = None
     copy: PairOp | None = None
@@ -600,10 +665,11 @@ def with_hidden_guard(ops: CommandIO) -> CommandIO:
         fn = getattr(ops, slot)
         if fn is not None:
             changes[slot] = functools.partial(_guarded_call, fn, True)
-    for slot in ("rename", "dir_copy"):
+    for slot, assume_dir in (("rename", False), ("dir_copy", True)):
         fn = getattr(ops, slot)
         if fn is not None:
-            changes[slot] = functools.partial(_guarded_pair, fn)
+            changes[slot] = functools.partial(_guarded_pair, fn, ops.stat,
+                                              assume_dir)
     if ops.rmdir is not None:
         changes["rmdir"] = functools.partial(_guarded_rmdir, ops.rmdir,
                                              ops.readdir, ops.rm_r)

--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -451,6 +451,7 @@ async def _guarded_rmdir(fn: OperationFn,
                          unlink: OperationFn | None,
                          *args: Any,
                          index: IndexCacheStore = NULL_INDEX,
+                         children: ChildMounts | None = None,
                          **kwargs: Any) -> Any:
     """rmdir that removes a directory the session sees as empty.
 
@@ -476,6 +477,13 @@ async def _guarded_rmdir(fn: OperationFn,
         index (IndexCacheStore): the invocation's cache index, threaded
             by the callers so the fallback listing resolves on an
             indexed backend the way the command's own listings did.
+        children (ChildMounts | None): child names the namespace owes
+            the directory (nested mount roots and symlinks), prebound
+            per invocation by ``with_namespace_children``. They join
+            the emptiness judgment, never the walk: a visible mounted
+            child keeps the refusal exactly as the ops plane's merged
+            listing does, while the cascade itself only ever removes
+            what the backend holds.
         **kwargs: forwarded untouched.
     """
     target: PathSpec | None = None
@@ -497,7 +505,10 @@ async def _guarded_rmdir(fn: OperationFn,
                 break
             lead.append(arg)
         entries = await readdir(*lead, target, index=index)
-        if not entries or visible_below(target.virtual, entries, path_allowed):
+        merged = list(entries)
+        if children is not None:
+            merged.extend(children(target.virtual))
+        if not entries or visible_below(target.virtual, merged, path_allowed):
             raise
         channel = _SlotChannel(tuple(lead), index, readdir, stat, unlink, fn)
         try:
@@ -724,6 +735,36 @@ def with_hidden_guard(ops: CommandIO) -> CommandIO:
     if ops.exists is not None:
         changes["exists"] = functools.partial(_guarded_exists, ops.exists)
     return replace(ops, **changes)
+
+
+def with_namespace_children(ops: CommandIO,
+                            children: ChildMounts | None) -> CommandIO:
+    """Return ``ops`` carrying the invocation's namespace children.
+
+    The adapter is built once per backend while the child names a
+    directory owes to nested mounts and symlinks are session-scoped, so
+    the fact lands here, per invocation. Two consumers read it: glob
+    resolution and the dir guard read the ``glob_children`` field off
+    the stamped copy, and the hidden guard's rmdir was bound before any
+    invocation exists, so its slot is rebound with the fact as the
+    ``children`` keyword ``_guarded_rmdir`` declares. That keyword is
+    only ever prebound here, onto the guard the factory installed two
+    lines earlier, so no backend rmdir can receive it.
+
+    Args:
+        ops (CommandIO): the backend's IO adapter, path-guarded by the
+            factory.
+        children (ChildMounts | None): the invocation's namespace child
+            fact, from ``opts.ns.child_mounts``.
+    """
+    stamped = replace(ops, glob_children=children)
+    if children is None or stamped.rmdir is None:
+        return stamped
+    # OperationFn rather than RmdirOp: the keyword belongs to the
+    # guard's own signature, not the backend op contract the slot is
+    # typed as.
+    slot: OperationFn = stamped.rmdir
+    return replace(stamped, rmdir=functools.partial(slot, children=children))
 
 
 _RULE_SLOTS = ("read_bytes", "read_stream", "read_range", "write", "append",

--- a/python/mirage/commands/builtin/generic_bind/builders/cp.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/cp.py
@@ -27,7 +27,7 @@ from mirage.commands.builtin.generic_bind.adapter import (Builder, CommandIO,
 from mirage.commands.config import CommandOpts
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagView
-from mirage.context import path_rules_active
+from mirage.context import hidden_paths_intersect, path_rules_active
 from mirage.io.types import ByteSource, IOResult
 from mirage.ops.types import StatOverlay
 from mirage.types import NativeCopy, PathSpec, PrimitiveCopy
@@ -97,13 +97,17 @@ async def cp(ops: CommandIO, accessor: Accessor, paths: list[PathSpec],
     dir_copy = partial(ops.dir_copy, accessor) if ops.dir_copy else None
     mkdir = partial(ops.mkdir, accessor) if ops.mkdir else None
     strategy: NativeCopy | PrimitiveCopy
-    if path_rules_active() and ops.write is not None and mkdir is not None:
+    guarded = path_rules_active() or any(
+        hidden_paths_intersect(p.virtual) for p in paths)
+    if guarded and ops.write is not None and mkdir is not None:
         # A native copy moves a tree in one backend call and a native
         # find lists it, neither of which passes an entry through the
-        # guard the way a read does; while a path rule scopes cp, the
-        # primitive walk copies entry by entry (the cross-mount relay's
-        # own path), which is also where GNU's per-entry refusals are
-        # worded.
+        # guard the way a read does; while a path rule scopes cp, or a
+        # hide could cover an entry under an operand (the native find
+        # listed hidden names and the per-file read then printed them
+        # in its refusal), the primitive walk copies entry by entry
+        # (the cross-mount relay's own path), which is also where GNU's
+        # per-entry refusals are worded.
         strategy = PrimitiveCopy(read_bytes=bound_op(ops.read_bytes, accessor,
                                                      opts.index),
                                  write=partial(_write, ops.write, accessor),

--- a/python/mirage/commands/builtin/generic_bind/builders/mv.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/mv.py
@@ -18,7 +18,8 @@ from mirage.accessor.base import Accessor
 from mirage.commands.builtin.generic.mv import mv as generic_mv
 from mirage.commands.builtin.generic.mv import parse_mv_flags
 from mirage.commands.builtin.generic_bind.adapter import (Builder, CommandIO,
-                                                          Operation, bound_op)
+                                                          Operation, bound_op,
+                                                          refuse_reveal)
 from mirage.commands.builtin.generic_bind.builders.cp import overlayable_stat
 from mirage.commands.config import CommandOpts
 from mirage.commands.spec import SPECS
@@ -42,7 +43,8 @@ async def mv(ops: CommandIO, accessor: Accessor, paths: list[PathSpec],
             rename=partial(ops.require(Operation.RENAME), accessor)),
         stat=overlayable_stat(ops, accessor, opts.index, overlay),
         flags=parsed,
-        readdir=bound_op(ops.readdir, accessor, opts.index))
+        readdir=bound_op(ops.readdir, accessor, opts.index),
+        guard=refuse_reveal)
 
 
 BUILDER = Builder('mv',

--- a/python/mirage/commands/builtin/generic_bind/builders/rm.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/rm.py
@@ -96,7 +96,7 @@ async def rm(ops: CommandIO, accessor: Accessor, paths: list[PathSpec],
                         errors.append(f"rm: cannot remove '{p.raw_path}': "
                                       "Directory not empty")
                         continue
-                    await ops.rmdir(accessor, p)
+                    await ops.rmdir(accessor, p, index=opts.index)
                     entry_lines = [f"removed directory '{p.virtual}'"]
                 else:
                     errors.append(

--- a/python/mirage/commands/builtin/generic_bind/builders/rmdir.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/rmdir.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
+
 from mirage.accessor.base import Accessor
 from mirage.commands.builtin.generic_bind.adapter import (Builder, CommandIO,
                                                           Operation)
@@ -64,7 +66,20 @@ async def rmdir(ops: CommandIO, accessor: Accessor, paths: list[PathSpec],
             errors.append(f"rmdir: failed to remove '{p.raw_path}': "
                           "Directory not empty")
             continue
-        await rmdir_fn(accessor, p, index=opts.index)
+        try:
+            await rmdir_fn(accessor, p, index=opts.index)
+        except OSError as exc:
+            # The listing above showed the session an empty directory,
+            # but the slot may still refuse not-empty: the hidden-
+            # remnant guard re-raises the backend's refusal when its
+            # cascade cannot finish (a mode-protected remnant, a
+            # visible entry appearing mid-walk). GNU's voice, not the
+            # raw errno repr.
+            if exc.errno not in (errno.ENOTEMPTY, errno.EEXIST):
+                raise
+            errors.append(f"rmdir: failed to remove '{p.raw_path}': "
+                          "Directory not empty")
+            continue
         removed[p.mount_path] = b""
         if v:
             verbose_parts.append(f"rmdir: removing directory, '{p.raw_path}'")

--- a/python/mirage/commands/builtin/generic_bind/builders/rmdir.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/rmdir.py
@@ -64,7 +64,7 @@ async def rmdir(ops: CommandIO, accessor: Accessor, paths: list[PathSpec],
             errors.append(f"rmdir: failed to remove '{p.raw_path}': "
                           "Directory not empty")
             continue
-        await rmdir_fn(accessor, p)
+        await rmdir_fn(accessor, p, index=opts.index)
         removed[p.mount_path] = b""
         if v:
             verbose_parts.append(f"rmdir: removing directory, '{p.raw_path}'")

--- a/python/mirage/commands/builtin/generic_bind/factory.py
+++ b/python/mirage/commands/builtin/generic_bind/factory.py
@@ -22,9 +22,8 @@ from mirage.cache.context import active_cache_manager
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.cache.read_through import (cache_aware_read_bytes,
                                        cache_aware_read_stream)
-from mirage.commands.builtin.generic_bind.adapter import (CommandIO,
-                                                          with_dir_guard,
-                                                          with_path_guards)
+from mirage.commands.builtin.generic_bind.adapter import (
+    CommandIO, with_dir_guard, with_namespace_children, with_path_guards)
 from mirage.commands.builtin.generic_bind.builders import _BUILDERS
 from mirage.commands.builtin.generic_bind.provision import default_provision
 from mirage.commands.config import CommandOpts, command
@@ -196,7 +195,7 @@ async def _run_with_namespace_globs(ops: CommandIO, fn: Callable[..., Any],
         opts (CommandOpts): the per-invocation option bag.
     """
     children = opts.ns.child_mounts if opts.ns is not None else None
-    bound = with_dir_guard(replace(ops, glob_children=children))
+    bound = with_dir_guard(with_namespace_children(ops, children))
     return await fn(bound, accessor, paths, texts, opts)
 
 

--- a/python/mirage/commands/builtin/generic_bind/factory.py
+++ b/python/mirage/commands/builtin/generic_bind/factory.py
@@ -22,8 +22,9 @@ from mirage.cache.context import active_cache_manager
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.cache.read_through import (cache_aware_read_bytes,
                                        cache_aware_read_stream)
-from mirage.commands.builtin.generic_bind.adapter import (
-    CommandIO, with_dir_guard, with_namespace_children, with_path_guards)
+from mirage.commands.builtin.generic_bind.adapter import (CommandIO,
+                                                          with_dir_guard,
+                                                          with_path_guards)
 from mirage.commands.builtin.generic_bind.builders import _BUILDERS
 from mirage.commands.builtin.generic_bind.provision import default_provision
 from mirage.commands.config import CommandOpts, command
@@ -161,33 +162,51 @@ def with_stat_cache(ops: CommandIO) -> CommandIO:
     return replace(ops, stat=functools.partial(_cached_stat, ops.stat))
 
 
-async def _run_with_namespace_globs(ops: CommandIO, fn: Callable[..., Any],
-                                    accessor: Accessor, paths: list[PathSpec],
-                                    texts: list[str],
+def _read_wraps(ops: CommandIO) -> CommandIO:
+    return with_slash_guard(with_read_cache(ops))
+
+
+def _stat_wraps(ops: CommandIO) -> CommandIO:
+    return with_slash_guard(with_stat_cache(ops))
+
+
+def _write_wraps(ops: CommandIO) -> CommandIO:
+    return with_slash_guard(ops)
+
+
+async def _run_with_namespace_globs(ops: CommandIO,
+                                    finish: Callable[[CommandIO], CommandIO],
+                                    fn: Callable[..., Any], accessor: Accessor,
+                                    paths: list[PathSpec], texts: list[str],
                                     opts: CommandOpts) -> Any:
-    """Run a builder with an adapter whose globs see the namespace and
-    whose reads refuse a directory.
+    """Run a builder with an adapter that carries the invocation's
+    namespace facts below every guard.
 
     A nested mount's keys live in another resource and no resource stores
     a symlink, so a glob resolved by one backend's readdir misses both,
     while the same names are already merged into a listing. The adapter
     is built once per backend and the names are session-scoped, so the
-    fact is stamped on here, per invocation, from ``opts.ns``:
-    every builder then keeps calling ``ops.resolve_glob`` unchanged.
-
-    ``with_dir_guard`` is applied here rather than beside the other
-    wrappers in ``make_generic_commands`` because it reads the same
-    namespace fact: a directory that exists only because a mount or a
-    link sits under it is invisible to the backend, so the guard has to
-    close over an adapter that already carries ``glob_children``. The
-    stamp happens whether or not the namespace owes this directory
-    anything, so there is one code path rather than two.
+    fact is stamped on here, per invocation, from ``opts.ns`` -- and the
+    whole guard chain is applied on top of the stamped copy, so every
+    guard that consumes a namespace fact simply reads it off the
+    adapter it wraps: glob resolution derives from ``glob_children``,
+    the dir guard closes over it, and the hidden guard's rmdir captures
+    it for its emptiness judgment. Binding the guards at registration
+    instead would strand them behind partials built before any
+    invocation exists, which is exactly the wiring that made the rmdir
+    guard blind to a mounted child. The stamp happens whether or not
+    the namespace owes this directory anything, so there is one code
+    path rather than two; the guards read the current session at call
+    time, so per-invocation binding changes cost, not behavior.
 
     ``ops`` stays the first bound argument, because that partial slot is
-    how the adapter is reached for a registered command.
+    how the adapter is reached for a registered command; it arrives raw
+    and is guarded here.
 
     Args:
-        ops (CommandIO): the backend's IO adapter.
+        ops (CommandIO): the backend's raw IO adapter.
+        finish (Callable): the builder tier's cache and slash wraps,
+            chosen at registration from the builder's read/write kind.
         fn (Callable): the builder's command function.
         accessor (Accessor): backend handle.
         paths (list[PathSpec]): the command's path operands.
@@ -195,7 +214,8 @@ async def _run_with_namespace_globs(ops: CommandIO, fn: Callable[..., Any],
         opts (CommandOpts): the per-invocation option bag.
     """
     children = opts.ns.child_mounts if opts.ns is not None else None
-    bound = with_dir_guard(with_namespace_children(ops, children))
+    stamped = replace(ops, glob_children=children)
+    bound = with_dir_guard(finish(with_path_guards(stamped)))
     return await fn(bound, accessor, paths, texts, opts)
 
 
@@ -228,23 +248,25 @@ def make_generic_commands(
     for b in _BUILDERS:
         if b.name in skip:
             continue
-        # Hidden-path, rule and mode enforcement wrap here, once for
-        # every generic command; the raw adapter stays untouched for
+        raw = ops_over.get(b.name, ops)
+        # Path guards are applied per invocation, over the stamped
+        # adapter, inside _run_with_namespace_globs; this registration
+        # copy exists for provision estimates, which bind here and read
+        # the session at call time. The raw adapter stays untouched for
         # the ops tables, whose door does its own enforcement.
-        base_ops = with_path_guards(ops_over.get(b.name, ops))
+        base_ops = with_path_guards(raw)
         # A read-only backend (no write op) can't run the byte-mutation
         # commands (cp/mv/tee/gunzip/...), so don't register a command that
         # would crash when invoked.
         if not base_ops.supports(b.requirements):
             continue
         if b.read:
-            cmd_ops = with_read_cache(base_ops)
+            finish = _read_wraps
         elif not b.write:
-            cmd_ops = with_stat_cache(base_ops)
+            finish = _stat_wraps
         else:
-            cmd_ops = base_ops
-        cmd_ops = with_slash_guard(cmd_ops)
-        bound = functools.partial(_run_with_namespace_globs, cmd_ops, b.fn)
+            finish = _write_wraps
+        bound = functools.partial(_run_with_namespace_globs, raw, finish, b.fn)
         provision: Callable[..., Any] | None
         if b.name in prov_over:
             provision = prov_over[b.name]

--- a/python/mirage/core/box/rmdir.py
+++ b/python/mirage/core/box/rmdir.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.box import BoxAccessor
 from mirage.cache.context import invalidate_after_unlink, invalidate_subtree
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.box.api import delete_file, delete_folder
 from mirage.core.box.client import BoxApiError
 from mirage.core.box.resolve import path_parts, resolve_item
@@ -21,7 +22,9 @@ from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotdir, enotempty
 
 
-async def rmdir(accessor: BoxAccessor, path: PathSpec) -> None:
+async def rmdir(accessor: BoxAccessor,
+                path: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     parts = path_parts(path)
     item = await resolve_item(accessor, parts)
     if item is None:

--- a/python/mirage/core/disk/rmdir.py
+++ b/python/mirage/core/disk/rmdir.py
@@ -18,6 +18,7 @@ import aiofiles.os
 
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.types import PathSpec
 
 
@@ -28,7 +29,9 @@ def _resolve(root: Path, path: str) -> Path:
     return resolved
 
 
-async def rmdir(accessor: DiskAccessor, path_spec: PathSpec) -> None:
+async def rmdir(accessor: DiskAccessor,
+                path_spec: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     path = path_spec.mount_path
     p = _resolve(accessor.root, path)
     await aiofiles.os.rmdir(p)

--- a/python/mirage/core/dropbox/rmdir.py
+++ b/python/mirage/core/dropbox/rmdir.py
@@ -16,6 +16,7 @@ import time
 
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.dropbox.api import delete_path, get_metadata, list_folder
 from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.paths import dropbox_path_of
@@ -24,7 +25,9 @@ from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotdir, enotempty
 
 
-async def rmdir(accessor: DropboxAccessor, path: PathSpec) -> None:
+async def rmdir(accessor: DropboxAccessor,
+                path: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     """Remove an empty folder.
 
     delete_v2 removes a folder RECURSIVELY; kernel/GNU rmdir must fail
@@ -34,6 +37,8 @@ async def rmdir(accessor: DropboxAccessor, path: PathSpec) -> None:
     Args:
         accessor (DropboxAccessor): Dropbox accessor.
         path (PathSpec): folder to remove.
+        index (IndexCacheStore): accepted for the rmdir slot's shape;
+            unused.
     """
     api_path = dropbox_path_of(accessor, path)
     try:

--- a/python/mirage/core/gdrive/rmdir.py
+++ b/python/mirage/core/gdrive/rmdir.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.gdrive.resolve import eacces_on_denied, resolve_key
 from mirage.core.google.drive import delete_file, list_files
 from mirage.types import PathSpec
@@ -21,7 +22,9 @@ from mirage.utils.errors import enoent, enotdir, enotempty
 
 
 @eacces_on_denied
-async def rmdir(accessor: GDriveAccessor, path: PathSpec) -> None:
+async def rmdir(accessor: GDriveAccessor,
+                path: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     """Remove an empty folder.
 
     A Drive ``files.delete`` on a folder removes every descendant with
@@ -36,6 +39,8 @@ async def rmdir(accessor: GDriveAccessor, path: PathSpec) -> None:
     Args:
         accessor (GDriveAccessor): Google Drive accessor.
         path (PathSpec): folder to remove.
+        index (IndexCacheStore): accepted for the rmdir slot's shape;
+            unused.
     """
     virtual = path.virtual
     key = path.resource_path

--- a/python/mirage/core/nextcloud/rmdir.py
+++ b/python/mirage/core/nextcloud/rmdir.py
@@ -2,11 +2,14 @@ from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotempty
 
 
-async def rmdir(accessor: NextcloudAccessor, path: PathSpec) -> None:
+async def rmdir(accessor: NextcloudAccessor,
+                path: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     """Remove an empty collection.
 
     WebDAV DELETE on a collection is recursive (RFC 4918 9.6.1), so this
@@ -24,6 +27,8 @@ async def rmdir(accessor: NextcloudAccessor, path: PathSpec) -> None:
     Args:
         accessor (NextcloudAccessor): Nextcloud accessor.
         path (PathSpec): collection to remove.
+        index (IndexCacheStore): accepted for the rmdir slot's shape;
+            unused.
     """
     key = path.mount_path.strip("/") + "/"
     stem = key.strip("/")

--- a/python/mirage/core/object_store/driver.py
+++ b/python/mirage/core/object_store/driver.py
@@ -57,6 +57,18 @@ class PathFn(Protocol[A_contra]):
         ...
 
 
+class RmdirFn(Protocol[A_contra]):
+    """``PathFn`` plus the rmdir slot's optional ``index``, which rides
+    the call for the command tier's hidden-remnant listing; the store
+    itself never consults it."""
+
+    def __call__(self,
+                 accessor: A_contra,
+                 path_spec: PathSpec,
+                 index: IndexCacheStore = ...) -> Awaitable[None]:
+        ...
+
+
 class PairFn(Protocol[A_contra]):
 
     def __call__(self, accessor: A_contra, src_spec: PathSpec,

--- a/python/mirage/core/object_store/remove.py
+++ b/python/mirage/core/object_store/remove.py
@@ -14,7 +14,9 @@
 
 from mirage.cache.context import (invalidate_after_unlink,
                                   invalidate_ancestors, invalidate_subtree)
-from mirage.core.object_store.driver import A, C, ObjectStoreDriver, PathFn
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.object_store.driver import (A, C, ObjectStoreDriver, PathFn,
+                                             RmdirFn)
 from mirage.types import PathSpec
 from mirage.utils import key_prefix as kp
 from mirage.utils.errors import enoent, enotempty
@@ -68,7 +70,7 @@ def make_remove_prefix(driver: ObjectStoreDriver[A, C]) -> PathFn[A]:
     return remove_prefix
 
 
-def make_rmdir(driver: ObjectStoreDriver[A, C]) -> PathFn[A]:
+def make_rmdir(driver: ObjectStoreDriver[A, C]) -> RmdirFn[A]:
     """Build POSIX ``rmdir`` over one driver: refuse a non-empty prefix.
 
     Not ``make_remove_prefix``. On a keyed store an empty directory is
@@ -96,7 +98,9 @@ def make_rmdir(driver: ObjectStoreDriver[A, C]) -> PathFn[A]:
         driver (ObjectStoreDriver): the store's native surface.
     """
 
-    async def rmdir(accessor: A, path_spec: PathSpec) -> None:
+    async def rmdir(accessor: A,
+                    path_spec: PathSpec,
+                    index: IndexCacheStore = NULL_INDEX) -> None:
         path = path_spec.mount_path
         pfx = kp.apply_dir(driver.key_prefix_of(accessor), path)
         is_root = not path.strip("/")

--- a/python/mirage/core/onedrive/rmdir.py
+++ b/python/mirage/core/onedrive/rmdir.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.msgraph.drive_ops import drive_root_empty
 from mirage.core.onedrive.client import (drive_loc, graph_delete, item_url,
                                          split_path)
@@ -21,7 +22,9 @@ from mirage.types import PathSpec
 from mirage.utils.errors import enotempty
 
 
-async def rmdir(accessor: OneDriveAccessor, path: PathSpec) -> None:
+async def rmdir(accessor: OneDriveAccessor,
+                path: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     """Remove an empty folder.
 
     A Graph ``DELETE /drives/{id}/items/{item}`` removes a folder and
@@ -35,6 +38,8 @@ async def rmdir(accessor: OneDriveAccessor, path: PathSpec) -> None:
     Args:
         accessor (OneDriveAccessor): OneDrive accessor.
         path (PathSpec): folder to remove.
+        index (IndexCacheStore): accepted for the rmdir slot's shape;
+            unused.
     """
     _, stripped = split_path(path)
     if not stripped:

--- a/python/mirage/core/ram/rmdir.py
+++ b/python/mirage/core/ram/rmdir.py
@@ -14,12 +14,15 @@
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.types import PathSpec
 from mirage.utils.errors import enotempty
 from mirage.utils.path import norm
 
 
-async def rmdir(accessor: RAMAccessor, path_spec: PathSpec) -> None:
+async def rmdir(accessor: RAMAccessor,
+                path_spec: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     path = path_spec.mount_path
     store = accessor.store
     p = norm(path)

--- a/python/mirage/core/redis/rmdir.py
+++ b/python/mirage/core/redis/rmdir.py
@@ -14,12 +14,15 @@
 
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.types import PathSpec
 from mirage.utils.errors import enotempty
 from mirage.utils.path import norm
 
 
-async def rmdir(accessor: RedisAccessor, path_spec: PathSpec) -> None:
+async def rmdir(accessor: RedisAccessor,
+                path_spec: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     path = path_spec.mount_path
     store = accessor.store
     p = norm(path)

--- a/python/mirage/core/sharepoint/rmdir.py
+++ b/python/mirage/core/sharepoint/rmdir.py
@@ -1,5 +1,6 @@
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.msgraph.drive_ops import drive_root_empty
 from mirage.core.sharepoint.client import graph_delete, item_url, split_path
 from mirage.core.sharepoint.resolve import drive_loc, resolve
@@ -7,7 +8,9 @@ from mirage.types import PathSpec
 from mirage.utils.errors import enotempty
 
 
-async def rmdir(accessor: SharePointAccessor, path: PathSpec) -> None:
+async def rmdir(accessor: SharePointAccessor,
+                path: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     """Remove an empty folder.
 
     A Graph ``DELETE /drives/{id}/items/{item}`` removes a folder and
@@ -21,6 +24,8 @@ async def rmdir(accessor: SharePointAccessor, path: PathSpec) -> None:
     Args:
         accessor (SharePointAccessor): SharePoint accessor.
         path (PathSpec): folder to remove.
+        index (IndexCacheStore): accepted for the rmdir slot's shape;
+            unused.
     """
     _, stripped = split_path(path)
     if not stripped:

--- a/python/mirage/core/ssh/rmdir.py
+++ b/python/mirage/core/ssh/rmdir.py
@@ -22,6 +22,25 @@ from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotdir, enotempty
 
 
+async def _holds_entries(sftp: asyncssh.SFTPClient, remote: str) -> bool:
+    """Whether the remote directory still lists children.
+
+    The probe behind the version-3 arm below: it decides between "not
+    empty" and every other refusal the one generic code covers. A probe
+    that fails is a negative probe, never an error to surface; the
+    caller re-raises what the server said.
+
+    Args:
+        sftp (asyncssh.SFTPClient): open SFTP session.
+        remote (str): absolute remote path of the directory.
+    """
+    try:
+        names = await sftp.listdir(remote)
+    except (OSError, asyncssh.Error):
+        return False
+    return any(name not in (".", "..") for name in names)
+
+
 async def rmdir(accessor: SSHAccessor,
                 path: PathSpec,
                 index: IndexCacheStore = NULL_INDEX) -> None:
@@ -29,10 +48,15 @@ async def rmdir(accessor: SSHAccessor,
 
     The server enforces emptiness, so the work here is naming its
     refusal in the same vocabulary every other backend uses. SFTP 3 has
-    one code for it (``SFTPFailure``, carrying only the server's message
-    string), and later protocol versions split ``SFTPDirNotEmpty`` out;
-    only the typed one can be mapped, so a version-3 server still
-    reaches the caller as itself.
+    one generic code for it (``SFTPFailure``, carrying only the server's
+    message string), and later protocol versions split
+    ``SFTPDirNotEmpty`` out; OpenSSH speaks version 3, so the generic
+    code is what a not-empty rmdir actually answers in practice. It also
+    covers other refusals, so one listing probe decides instead of a
+    blind translation: only a directory that still shows entries
+    converts to ENOTEMPTY, anything else keeps the server's own answer.
+    Without the conversion the hidden-remnant guard never fires on ssh
+    (it keys on the errno), and the raw SFTP failure leaks.
 
     Args:
         accessor (SSHAccessor): SSH accessor.
@@ -42,12 +66,17 @@ async def rmdir(accessor: SSHAccessor,
     """
     config = accessor.config
     sftp = await accessor.sftp()
+    remote = _abs(config, path.mount_path)
     try:
-        await sftp.rmdir(_abs(config, path.mount_path))
+        await sftp.rmdir(remote)
     except asyncssh.SFTPNoSuchFile as exc:
         raise enoent(path) from exc
     except asyncssh.SFTPDirNotEmpty as exc:
         raise enotempty(path) from exc
     except asyncssh.SFTPNotADirectory as exc:
         raise enotdir(path) from exc
+    except asyncssh.SFTPFailure as exc:
+        if await _holds_entries(sftp, remote):
+            raise enotempty(path) from exc
+        raise
     await invalidate_after_unlink(path)

--- a/python/mirage/core/ssh/rmdir.py
+++ b/python/mirage/core/ssh/rmdir.py
@@ -16,12 +16,15 @@ import asyncssh
 
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.context import invalidate_after_unlink
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.ssh.client import _abs
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotdir, enotempty
 
 
-async def rmdir(accessor: SSHAccessor, path: PathSpec) -> None:
+async def rmdir(accessor: SSHAccessor,
+                path: PathSpec,
+                index: IndexCacheStore = NULL_INDEX) -> None:
     """Remove an empty directory over SFTP.
 
     The server enforces emptiness, so the work here is naming its
@@ -34,6 +37,8 @@ async def rmdir(accessor: SSHAccessor, path: PathSpec) -> None:
     Args:
         accessor (SSHAccessor): SSH accessor.
         path (PathSpec): directory to remove.
+        index (IndexCacheStore): accepted for the rmdir slot's shape;
+            unused.
     """
     config = accessor.config
     sftp = await accessor.sftp()

--- a/python/mirage/utils/hidden.py
+++ b/python/mirage/utils/hidden.py
@@ -381,6 +381,11 @@ def move_reveals(hidden: HiddenPaths | None, shown: ShownPaths | None,
     space could reach below ``src`` refuses, failing toward refusal the
     way ``readonly_below`` blames a pattern.
 
+    Spec-only: nothing here stats. A ``src`` that is a regular file has
+    nothing below it to re-anchor, so the callers gate this check on the
+    source being a directory (statting where they can, failing toward
+    refusal where they cannot).
+
     Args:
         hidden (HiddenPaths | None): the spec, None means unrestricted.
         shown (ShownPaths | None): the session's show entries.

--- a/python/mirage/utils/hidden.py
+++ b/python/mirage/utils/hidden.py
@@ -364,6 +364,52 @@ def path_covers(hidden: HiddenPaths | None,
                              for head in heads)
 
 
+def move_reveals(hidden: HiddenPaths | None, shown: ShownPaths | None,
+                 src: str, dst: str) -> bool:
+    """Whether relocating ``src`` to ``dst`` could surface a hidden path.
+
+    The reveal half of the subtree law: a session's mutation may destroy
+    what it cannot see (``rm -r``, a remnant ``rmdir``), but may never
+    reveal it, and a rename or a native directory copy is the relocation
+    that would. Three arms, one per entry kind. A component pattern
+    follows the name wherever the content goes, so it never reveals. An
+    exact entry anchored strictly below ``src`` re-anchors to ``dst``
+    plus its suffix, and reveals when the session would see that mapped
+    path (a show anchored below the mapped path counts, through
+    ``path_visible``'s own carve-out rule). An anchored pattern's
+    coverage does not move with the content, so any pattern whose match
+    space could reach below ``src`` refuses, failing toward refusal the
+    way ``readonly_below`` blames a pattern.
+
+    Args:
+        hidden (HiddenPaths | None): the spec, None means unrestricted.
+        shown (ShownPaths | None): the session's show entries.
+        src (str): absolute virtual path being moved or copied.
+        dst (str): absolute virtual path it would land at.
+    """
+    if hidden is None or (not hidden.paths and not hidden.patterns):
+        return False
+    s = _norm_abs(src)
+    d = _norm_abs(dst)
+    if s == "/":
+        return True
+    for entry in hidden.paths:
+        e = _norm_abs(entry)
+        if not e.startswith(s + "/"):
+            continue
+        mapped = ("" if d == "/" else d) + e[len(s):]
+        if path_visible(hidden, shown, mapped):
+            return True
+    for pat in hidden.patterns:
+        if "/" not in pat:
+            continue
+        head = _pattern_head(pat)
+        if (head == s or head.startswith(s + "/") or head == "/"
+                or s.startswith(head + "/")):
+            return True
+    return False
+
+
 def classify_shows(entries: Iterable[ShowEntry]) -> ShownPaths | None:
     """Compile document show entries into the session's shape.
 

--- a/python/mirage/utils/remnants.py
+++ b/python/mirage/utils/remnants.py
@@ -1,0 +1,157 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import errno
+import os
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Protocol
+
+from mirage.types import FileStat, FileType, PathSpec
+
+Allowed = Callable[[str], bool]
+
+
+class VisibleRemnant(OSError):
+    """A remnant cascade met an entry the session can see.
+
+    Raised by ``remove_remnants`` before the visible entry is touched:
+    the caller's not-empty refusal is then simply true in the session's
+    own view, so every arm answers this by re-raising that original
+    refusal rather than deleting visible data.
+
+    Args:
+        virtual (str): absolute virtual path of the visible entry.
+    """
+
+    def __init__(self, virtual: str) -> None:
+        super().__init__(errno.ENOTEMPTY, os.strerror(errno.ENOTEMPTY),
+                         virtual)
+
+
+class RemnantChannel(Protocol):
+    """The four ops a remnant cascade speaks, on one plane's own
+    protected channel.
+
+    The channel carries every protection axis except visibility: a
+    deletion must still answer for its path's mode and rules exactly as
+    a first-class op would (the command plane binds its mode- and
+    rule-guarded slots, the dispatchers route through their own op
+    door), while the visibility filter stays off because the cascade
+    exists to see and destroy what the session cannot. The cascade
+    never sprinkles those checks itself; wiring a raw, unguarded
+    channel here is the bug this contract exists to prevent.
+    """
+
+    def readdir(self, spec: PathSpec) -> Awaitable[list[str]]:
+        ...
+
+    def stat(self, spec: PathSpec) -> Awaitable[FileStat]:
+        ...
+
+    def unlink(self, spec: PathSpec) -> Awaitable[None]:
+        ...
+
+    def rmdir(self, spec: PathSpec) -> Awaitable[None]:
+        ...
+
+
+def entry_name(entry: str) -> str:
+    """One listing entry's bare child name.
+
+    Cold object-store listings mark a directory with a trailing slash,
+    and some backends report whole paths rather than names; both
+    normalize to the last component.
+
+    Args:
+        entry (str): one name from a backend readdir.
+    """
+    return entry.rstrip("/").rsplit("/", 1)[-1]
+
+
+def visible_below(base: str, names: Iterable[str], allowed: Allowed) -> bool:
+    """Whether any listed name is visible as a child of ``base``.
+
+    The one emptiness predicate every remnant arm judges with, fed
+    every name source its plane can enumerate (the backend listing,
+    and on the ops plane the namespace's merged children too), so
+    "visibly empty" cannot mean different things at different doors.
+
+    Args:
+        base (str): absolute virtual path of the directory.
+        names (Iterable[str]): child names to test.
+        allowed (Allowed): the session's visibility predicate.
+    """
+    root = base.rstrip("/")
+    return any(allowed(f"{root}/{entry_name(n)}") for n in names)
+
+
+def child_spec(spec: PathSpec, name: str) -> PathSpec:
+    """The child PathSpec one cascade step descends to.
+
+    Args:
+        spec (PathSpec): the directory being walked.
+        name (str): the child's bare name.
+    """
+    base = spec.virtual.rstrip("/")
+    key = spec.resource_path.rstrip("/")
+    return PathSpec(virtual=f"{base}/{name}",
+                    directory=spec.virtual,
+                    resource_path=f"{key}/{name}" if key else name)
+
+
+async def remove_remnants(channel: RemnantChannel, allowed: Allowed,
+                          spec: PathSpec) -> None:
+    """Remove one directory and everything under it, children first,
+    revalidating visibility at every step.
+
+    The walk lists raw, but the moment any entry is visible the whole
+    cascade aborts with ``VisibleRemnant`` before that entry is
+    touched: between the caller's classification and each deletion
+    another writer may have created something visible, and destroying
+    it would turn an ostensibly empty rmdir into data loss. An entry
+    that vanishes mid-walk is a completed removal (a prefix-store
+    directory disappears with its last child), not an error. Every op
+    goes through the channel, so the plane's other protections refuse
+    exactly as they would a first-class op; the caller answers any
+    cascade failure with its original refusal.
+
+    Args:
+        channel (RemnantChannel): the plane's guarded raw ops.
+        allowed (Allowed): the session's visibility predicate.
+        spec (PathSpec): the directory being removed.
+    """
+    try:
+        entries = await channel.readdir(spec)
+    except FileNotFoundError:
+        return
+    for entry in entries:
+        name = entry_name(str(entry))
+        child = child_spec(spec, name)
+        if allowed(child.virtual):
+            raise VisibleRemnant(child.virtual)
+        try:
+            row = await channel.stat(child)
+        except FileNotFoundError:
+            continue
+        if isinstance(row, FileStat) and row.type is FileType.DIRECTORY:
+            await remove_remnants(channel, allowed, child)
+        else:
+            try:
+                await channel.unlink(child)
+            except FileNotFoundError:
+                continue
+    try:
+        await channel.rmdir(spec)
+    except FileNotFoundError:
+        return

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -230,11 +230,13 @@ class Dispatcher:
             # hides stay where they are written, so hidden content would
             # land at paths the session can see. Destroying hidden
             # content is silent (rm_r, the remnant rmdir below);
-            # relocating it into view is refused.
+            # relocating it into view is refused. Only a directory has
+            # anything below it to re-anchor, so a file source passes.
             sess = get_current_session()
-            if sess is not None and move_reveals(
-                    sess.hidden_paths, sess.shown_paths, path.virtual,
-                    dst.virtual):
+            if (sess is not None
+                    and move_reveals(sess.hidden_paths, sess.shown_paths,
+                                     path.virtual, dst.virtual)
+                    and await self._moved_source_is_dir(path)):
                 raise PermissionError(errno.EACCES, os.strerror(errno.EACCES),
                                       path.virtual)
         if self._table_answers(op, path.virtual, kwargs):
@@ -385,6 +387,29 @@ class Dispatcher:
             # report above already carries the moved count.
             result = await apply_op_limit(result, bound)
         return result, IOResult()
+
+    async def _moved_source_is_dir(self, path: PathSpec) -> bool:
+        """Whether a rename's source stats as a directory.
+
+        Only a directory can carry hidden content into view, so the
+        reveal refusal probes the source before it fires and lets a
+        file rename pass. An absent source moves nothing (the rename
+        itself reports it); a source the mount cannot classify fails
+        toward refusal, the same stance the pattern arm takes.
+
+        Args:
+            path (PathSpec): the rename's source.
+        """
+        mount = self._namespace.try_mount_for(path.virtual)
+        if mount is None:
+            return True
+        try:
+            row = await mount.execute_op("stat", path.virtual)
+        except FileNotFoundError:
+            return False
+        except OSError:
+            return True
+        return not isinstance(row, FileStat) or row.type is FileType.DIRECTORY
 
     async def _rmdir_remnants(self, mount: MountEntry, path: PathSpec,
                               refusal: OSError) -> None:

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -13,8 +13,10 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import errno
+import functools
 import os
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -132,11 +134,25 @@ class _MountChannel:
     would. Only the dispatcher's own visibility filter sits above that
     door, which is what lets the cascade see hidden entries.
 
+    Each deletion also discharges the dispatcher's own write
+    invalidation, the way normal dispatch does for its one op and the
+    TS ``fencedCall`` does per call: ``execute_op`` runs outside the
+    cache-manager context command execution establishes, so the cores'
+    invalidation cannot land, and the dispatch-level invalidation of
+    the rmdir target covers the root and its ancestors, never the
+    cascade's descendants. Invalidation runs even when the op fails: a
+    missing-path failure means the tree changed under the walk, and
+    the walk's own earlier listing is exactly the entry that must not
+    survive.
+
     Args:
         mount (MountEntry): the mount owning the subtree.
+        invalidate (Callable): the dispatcher's write invalidation,
+            bound to that mount.
     """
 
     mount: MountEntry
+    invalidate: Callable[[PathSpec], Awaitable[None]]
 
     async def readdir(self, spec: PathSpec) -> list[str]:
         return await self.mount.execute_op("readdir", spec.virtual)
@@ -145,10 +161,16 @@ class _MountChannel:
         return await self.mount.execute_op("stat", spec.virtual)
 
     async def unlink(self, spec: PathSpec) -> None:
-        await self.mount.execute_op("unlink", spec.virtual)
+        try:
+            await self.mount.execute_op("unlink", spec.virtual)
+        finally:
+            await self.invalidate(spec)
 
     async def rmdir(self, spec: PathSpec) -> None:
-        await self.mount.execute_op("rmdir", spec.virtual)
+        try:
+            await self.mount.execute_op("rmdir", spec.virtual)
+        finally:
+            await self.invalidate(spec)
 
 
 class Dispatcher:
@@ -478,8 +500,10 @@ class Dispatcher:
             self._namespace, path.virtual)
         if not entries or visible_below(path.virtual, merged, path_allowed):
             raise refusal
+        channel = _MountChannel(
+            mount, functools.partial(self.invalidate_after_write, mount))
         try:
-            await remove_remnants(_MountChannel(mount), path_allowed, path)
+            await remove_remnants(channel, path_allowed, path)
         except OSError as exc:
             raise refusal from exc
 

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -483,10 +483,11 @@ class Dispatcher:
         walk; a visible child (in the backend listing or owed by the
         namespace), or any cascade failure (a mode-protected entry, a
         policy-refused deletion, a visible entry appearing mid-walk),
-        re-raises the backend's refusal. ``PolicyDenied`` is a
-        ``PermissionError``, so the ``OSError`` fold below covers it and
-        a policy's protection of a hidden path never surfaces as its
-        own denial.
+        re-raises the backend's refusal. The folds catch ``Exception``,
+        not just ``OSError``, because an API backend's failure is not
+        always an errno (box raises its own error type), and a raw
+        backend exception here would reveal exactly what the refusal
+        exists to hide; cancellation and system exits still propagate.
 
         Args:
             mount (MountEntry): the mount owning the directory.
@@ -497,7 +498,7 @@ class Dispatcher:
             raise refusal
         try:
             entries = await mount.execute_op("readdir", path.virtual)
-        except OSError as exc:
+        except Exception as exc:
             # A backend that cannot list (or later, remove) the
             # remnants keeps the original refusal: the door has no way
             # to take them.
@@ -517,8 +518,26 @@ class Dispatcher:
             functools.partial(self.invalidate_after_write, mount))
         try:
             await remove_remnants(channel, path_allowed, path)
-        except OSError as exc:
+        except Exception as exc:
             raise refusal from exc
+        # The namespace's own nodes under the subtree go with it: a
+        # hidden link is invisible to every backend, so the walk above
+        # cannot take it, and left in the table it would resurface the
+        # removed tree the moment the hide lifts (a link synthesizes
+        # its ancestors). Classification proved every link below is
+        # hidden -- a visible one contributes its child segment to the
+        # merged listing above -- so this is the walk's own
+        # revalidate-then-destroy applied to the name plane: a link
+        # that became visible mid-cascade keeps the refusal like any
+        # visible remnant, and the purge also drops the attr overlays
+        # of paths the cascade just destroyed, as ``rm`` does.
+        base = path.virtual.rstrip("/") + "/"
+        links_below = [
+            p for p in self._namespace.symlink_targets() if p.startswith(base)
+        ]
+        if any(path_allowed(p) for p in links_below):
+            raise refusal
+        await self._namespace.purge_under(path.virtual)
 
     async def _admit_cascade(self, mount: MountEntry, op: str,
                              path: PathSpec) -> None:

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -134,24 +134,31 @@ class _MountChannel:
     would. Only the dispatcher's own visibility filter sits above that
     door, which is what lets the cascade see hidden entries.
 
-    Each deletion also discharges the dispatcher's own write
-    invalidation, the way normal dispatch does for its one op and the
-    TS ``fencedCall`` does per call: ``execute_op`` runs outside the
-    cache-manager context command execution establishes, so the cores'
-    invalidation cannot land, and the dispatch-level invalidation of
-    the rmdir target covers the root and its ancestors, never the
-    cascade's descendants. Invalidation runs even when the op fails: a
-    missing-path failure means the tree changed under the walk, and
-    the walk's own earlier listing is exactly the entry that must not
-    survive.
+    Each deletion answers the same pre-ops admission a dispatched op
+    answers, with its own child path: the gate that admitted the rmdir
+    judged the directory, not what the cascade found under it, and a
+    policy that protects one of those paths must refuse its deletion
+    exactly as it would refuse a first-class op. Each deletion also
+    discharges the dispatcher's own write invalidation, the way normal
+    dispatch does for its one op and the TS ``fencedCall`` does per
+    call: ``execute_op`` runs outside the cache-manager context command
+    execution establishes, so the cores' invalidation cannot land, and
+    the dispatch-level invalidation of the rmdir target covers the root
+    and its ancestors, never the cascade's descendants. Invalidation
+    runs even when the op fails: a missing-path failure means the tree
+    changed under the walk, and the walk's own earlier listing is
+    exactly the entry that must not survive.
 
     Args:
         mount (MountEntry): the mount owning the subtree.
+        admit (Callable): the dispatcher's pre-ops gate, bound to that
+            mount; raises to refuse a deletion.
         invalidate (Callable): the dispatcher's write invalidation,
             bound to that mount.
     """
 
     mount: MountEntry
+    admit: Callable[[str, PathSpec], Awaitable[None]]
     invalidate: Callable[[PathSpec], Awaitable[None]]
 
     async def readdir(self, spec: PathSpec) -> list[str]:
@@ -161,12 +168,14 @@ class _MountChannel:
         return await self.mount.execute_op("stat", spec.virtual)
 
     async def unlink(self, spec: PathSpec) -> None:
+        await self.admit("unlink", spec)
         try:
             await self.mount.execute_op("unlink", spec.virtual)
         finally:
             await self.invalidate(spec)
 
     async def rmdir(self, spec: PathSpec) -> None:
+        await self.admit("rmdir", spec)
         try:
             await self.mount.execute_op("rmdir", spec.virtual)
         finally:
@@ -473,8 +482,11 @@ class Dispatcher:
         go with the directory through the shared ``remove_remnants``
         walk; a visible child (in the backend listing or owed by the
         namespace), or any cascade failure (a mode-protected entry, a
-        visible entry appearing mid-walk), re-raises the backend's
-        refusal.
+        policy-refused deletion, a visible entry appearing mid-walk),
+        re-raises the backend's refusal. ``PolicyDenied`` is a
+        ``PermissionError``, so the ``OSError`` fold below covers it and
+        a policy's protection of a hidden path never surfaces as its
+        own denial.
 
         Args:
             mount (MountEntry): the mount owning the directory.
@@ -501,11 +513,30 @@ class Dispatcher:
         if not entries or visible_below(path.virtual, merged, path_allowed):
             raise refusal
         channel = _MountChannel(
-            mount, functools.partial(self.invalidate_after_write, mount))
+            mount, functools.partial(self._admit_cascade, mount),
+            functools.partial(self.invalidate_after_write, mount))
         try:
             await remove_remnants(channel, path_allowed, path)
         except OSError as exc:
             raise refusal from exc
+
+    async def _admit_cascade(self, mount: MountEntry, op: str,
+                             path: PathSpec) -> None:
+        """Hold one cascade deletion to the pre-ops admission a
+        dispatched op answers.
+
+        The gate that admitted the rmdir judged the directory; each
+        deletion below it names its own path here, so a policy that
+        denies ``unlink`` of a protected file refuses it even when the
+        rmdir above was allowed.
+
+        Args:
+            mount (MountEntry): the mount owning the subtree.
+            op (str): the deletion op ("unlink" or "rmdir").
+            path (PathSpec): the child being removed.
+        """
+        await pre_ops_gate(self._namespace.registry.policies, op, path, True,
+                           mount.prefix, _session_id())
 
     def _table_answers(self, op: str, virtual: str, kwargs: dict[str,
                                                                  Any]) -> bool:

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -15,6 +15,7 @@
 import errno
 import os
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
@@ -38,6 +39,7 @@ from mirage.utils.hidden import move_reveals
 from mirage.utils.key_prefix import mount_key
 from mirage.utils.path import norm_dir, owner_prefix
 from mirage.utils.ranges import slice_window
+from mirage.utils.remnants import remove_remnants, visible_below
 from mirage.workspace.mount import MountEntry
 from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.mount.namespace.overlay import merge_overlay_stat
@@ -120,6 +122,33 @@ def _window(kwargs: dict[str, Any]) -> tuple[int, int | None]:
     size = kwargs.get("size")
     return (offset if isinstance(offset, int) else 0,
             size if isinstance(size, int) else None)
+
+
+@dataclass(frozen=True, slots=True)
+class _MountChannel:
+    """The ops plane's remnant channel: every step goes through
+    ``Mount.execute_op``, the same door a first-class op takes, so the
+    mode axis refuses a protected path exactly as normal dispatch
+    would. Only the dispatcher's own visibility filter sits above that
+    door, which is what lets the cascade see hidden entries.
+
+    Args:
+        mount (MountEntry): the mount owning the subtree.
+    """
+
+    mount: MountEntry
+
+    async def readdir(self, spec: PathSpec) -> list[str]:
+        return await self.mount.execute_op("readdir", spec.virtual)
+
+    async def stat(self, spec: PathSpec) -> FileStat:
+        return await self.mount.execute_op("stat", spec.virtual)
+
+    async def unlink(self, spec: PathSpec) -> None:
+        await self.mount.execute_op("unlink", spec.virtual)
+
+    async def rmdir(self, spec: PathSpec) -> None:
+        await self.mount.execute_op("rmdir", spec.virtual)
 
 
 class Dispatcher:
@@ -419,8 +448,11 @@ class Dispatcher:
         the session's view of the directory is empty the refusal would
         leak that something invisible exists. A session's mutation may
         destroy what it cannot see, never learn of it, so the remnants
-        go with the directory; a visible child, or a backend with no
-        recursive remove to take them, re-raises the backend's refusal.
+        go with the directory through the shared ``remove_remnants``
+        walk; a visible child (in the backend listing or owed by the
+        namespace), or any cascade failure (a mode-protected entry, a
+        visible entry appearing mid-walk), re-raises the backend's
+        refusal.
 
         Args:
             mount (MountEntry): the mount owning the directory.
@@ -436,49 +468,20 @@ class Dispatcher:
             # remnants keeps the original refusal: the door has no way
             # to take them.
             raise refusal from exc
-        base = path.virtual.rstrip("/")
-        if not entries or any(
-                path_allowed(f"{base}/{e.rstrip('/').rsplit('/', 1)[-1]}")
-                for e in entries):
+        # Emptiness is the door's own readdir pipeline: backend entries
+        # merged with the namespace's children (nested mounts, links)
+        # and judged by visibility, so a visible child no backend can
+        # see keeps the refusal instead of reporting a successful rmdir
+        # while the mounted child remains.
+        merged = merge_readdir(
+            entries, [m.prefix for m in self._namespace.registry.mounts()],
+            self._namespace, path.virtual)
+        if not entries or visible_below(path.virtual, merged, path_allowed):
             raise refusal
         try:
-            await self._remove_subtree(mount, path.virtual)
+            await remove_remnants(_MountChannel(mount), path_allowed, path)
         except OSError as exc:
             raise refusal from exc
-
-    async def _remove_subtree(self, mount: MountEntry, virtual: str) -> None:
-        """Remove one directory and everything under it, entry by entry.
-
-        No backend registers a recursive-remove op at this door, so the
-        remnant removal walks the raw listings itself, children first.
-        An entry that vanishes mid-walk is a completed removal (a
-        prefix-store directory disappears with its last child), not an
-        error.
-
-        Args:
-            mount (MountEntry): the mount owning the subtree.
-            virtual (str): absolute virtual path of the directory.
-        """
-        entries = await mount.execute_op("readdir", virtual)
-        base = virtual.rstrip("/")
-        for entry in entries:
-            name = str(entry).rstrip("/").rsplit("/", 1)[-1]
-            child = f"{base}/{name}"
-            try:
-                row = await mount.execute_op("stat", child)
-            except FileNotFoundError:
-                continue
-            if isinstance(row, FileStat) and row.type is FileType.DIRECTORY:
-                await self._remove_subtree(mount, child)
-            else:
-                try:
-                    await mount.execute_op("unlink", child)
-                except FileNotFoundError:
-                    continue
-        try:
-            await mount.execute_op("rmdir", virtual)
-        except FileNotFoundError:
-            return
 
     def _table_answers(self, op: str, virtual: str, kwargs: dict[str,
                                                                  Any]) -> bool:

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -21,7 +21,8 @@ from typing import Any
 from mirage.cache.file import io as cache_io
 from mirage.cache.manager import CacheManager
 from mirage.commands.builtin.utils.limit import apply_op_limit
-from mirage.context import get_current_session, path_allowed
+from mirage.context import (get_current_session, hidden_paths_intersect,
+                            path_allowed)
 from mirage.io import IOResult, OpReport
 from mirage.observe.context import record
 from mirage.observe.record import OpRecord
@@ -33,6 +34,7 @@ from mirage.policy.errors import PolicyDenied, PolicyError
 from mirage.types import (ConsistencyPolicy, FileStat, FileType, PathSpec,
                           ResourceName)
 from mirage.utils.errors import MISS_ERRORS, no_mount
+from mirage.utils.hidden import move_reveals
 from mirage.utils.key_prefix import mount_key
 from mirage.utils.path import norm_dir, owner_prefix
 from mirage.utils.ranges import slice_window
@@ -223,6 +225,18 @@ class Dispatcher:
                 and not path_allowed(dst.virtual)):
             raise PermissionError(errno.EACCES, os.strerror(errno.EACCES),
                                   dst.virtual)
+        if op == "rename" and isinstance(dst, PathSpec):
+            # A rename re-anchors everything below its source while the
+            # hides stay where they are written, so hidden content would
+            # land at paths the session can see. Destroying hidden
+            # content is silent (rm_r, the remnant rmdir below);
+            # relocating it into view is refused.
+            sess = get_current_session()
+            if sess is not None and move_reveals(
+                    sess.hidden_paths, sess.shown_paths, path.virtual,
+                    dst.virtual):
+                raise PermissionError(errno.EACCES, os.strerror(errno.EACCES),
+                                      path.virtual)
         if self._table_answers(op, path.virtual, kwargs):
             return (await self._namespace_table_op(op, path, kwargs,
                                                    report), IOResult())
@@ -325,6 +339,14 @@ class Dispatcher:
                 await self._reconciler.on_op_missing(op, path.virtual)
                 raise
             _memory_answered(report)
+        except OSError as exc:
+            if op != "rmdir" or exc.errno not in (errno.ENOTEMPTY,
+                                                  errno.EEXIST):
+                raise
+            await self._rmdir_remnants(mount, path, exc)
+            result = None
+            if report is not None:
+                report.served(None, None)
         else:
             # The op ran, whatever invalidation, the post gate, or an
             # output cap do next: stamped here so a failure in any of
@@ -363,6 +385,75 @@ class Dispatcher:
             # report above already carries the moved count.
             result = await apply_op_limit(result, bound)
         return result, IOResult()
+
+    async def _rmdir_remnants(self, mount: MountEntry, path: PathSpec,
+                              refusal: OSError) -> None:
+        """Take a visibly-empty directory's hidden remnants with it.
+
+        The backend refused the rmdir because entries remain, but when
+        the session's view of the directory is empty the refusal would
+        leak that something invisible exists. A session's mutation may
+        destroy what it cannot see, never learn of it, so the remnants
+        go with the directory; a visible child, or a backend with no
+        recursive remove to take them, re-raises the backend's refusal.
+
+        Args:
+            mount (MountEntry): the mount owning the directory.
+            path (PathSpec): the directory being removed.
+            refusal (OSError): the backend's not-empty error.
+        """
+        if not hidden_paths_intersect(path.virtual):
+            raise refusal
+        try:
+            entries = await mount.execute_op("readdir", path.virtual)
+        except OSError as exc:
+            # A backend that cannot list (or later, remove) the
+            # remnants keeps the original refusal: the door has no way
+            # to take them.
+            raise refusal from exc
+        base = path.virtual.rstrip("/")
+        if not entries or any(
+                path_allowed(f"{base}/{e.rstrip('/').rsplit('/', 1)[-1]}")
+                for e in entries):
+            raise refusal
+        try:
+            await self._remove_subtree(mount, path.virtual)
+        except OSError as exc:
+            raise refusal from exc
+
+    async def _remove_subtree(self, mount: MountEntry, virtual: str) -> None:
+        """Remove one directory and everything under it, entry by entry.
+
+        No backend registers a recursive-remove op at this door, so the
+        remnant removal walks the raw listings itself, children first.
+        An entry that vanishes mid-walk is a completed removal (a
+        prefix-store directory disappears with its last child), not an
+        error.
+
+        Args:
+            mount (MountEntry): the mount owning the subtree.
+            virtual (str): absolute virtual path of the directory.
+        """
+        entries = await mount.execute_op("readdir", virtual)
+        base = virtual.rstrip("/")
+        for entry in entries:
+            name = str(entry).rstrip("/").rsplit("/", 1)[-1]
+            child = f"{base}/{name}"
+            try:
+                row = await mount.execute_op("stat", child)
+            except FileNotFoundError:
+                continue
+            if isinstance(row, FileStat) and row.type is FileType.DIRECTORY:
+                await self._remove_subtree(mount, child)
+            else:
+                try:
+                    await mount.execute_op("unlink", child)
+                except FileNotFoundError:
+                    continue
+        try:
+            await mount.execute_op("rmdir", virtual)
+        except FileNotFoundError:
+            return
 
     def _table_answers(self, op: str, virtual: str, kwargs: dict[str,
                                                                  Any]) -> bool:

--- a/python/tests/commands/builtin/generic_bind/test_adapter.py
+++ b/python/tests/commands/builtin/generic_bind/test_adapter.py
@@ -537,31 +537,71 @@ async def test_dir_guard_keeps_a_refusal_on_a_file_the_parent_lists():
 async def test_guarded_rmdir_threads_the_index_to_the_fallback_listing(
         monkeypatch):
     # The remnant fallback lists the refused directory raw; on an
-    # indexed backend that listing only resolves through the
+    # indexed backend those listings only resolve through the
     # invocation's index, so the wrapper must hand it on rather than
-    # falling back to NULL_INDEX.
+    # falling back to NULL_INDEX — to the classification readdir and to
+    # every listing the shared cascade walk takes after it.
     marker = IndexCacheStore()
     seen: list[IndexCacheStore | None] = []
-    removed: list[str] = []
+    removed: list[tuple[str, str]] = []
+    files = {"/m/d/h"}
 
-    async def rmdir(_accessor, _path, index=None):
-        raise OSError(errno.ENOTEMPTY, "not empty")
+    async def rmdir(_accessor, path, index=None):
+        if files:
+            raise OSError(errno.ENOTEMPTY, "not empty")
+        removed.append(("rmdir", path.virtual))
 
     async def readdir(_accessor, _path, index=None):
         seen.append(index)
-        return ["h"]
+        return ["h"] if files else []
 
-    async def rm_r(_accessor, path):
-        removed.append(path.virtual)
+    async def stat_fn(_accessor, path, index=None):
+        if path.virtual in files:
+            return FileStat(type=FileType.FILE, name=path.virtual)
+        raise FileNotFoundError(path.virtual)
+
+    async def unlink(_accessor, path):
+        files.discard(path.virtual)
+        removed.append(("unlink", path.virtual))
 
     monkeypatch.setattr(adapter, "hidden_paths_intersect", lambda _v: True)
     monkeypatch.setattr(adapter, "path_allowed", lambda v: v == "/m/d")
     spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
     await adapter._guarded_rmdir(rmdir,
                                  readdir,
-                                 rm_r,
+                                 stat_fn,
+                                 unlink,
                                  NOOPAccessor(),
                                  spec,
                                  index=marker)
-    assert seen == [marker]
-    assert removed == ["/m/d"]
+    assert seen == [marker, marker]
+    assert removed == [("unlink", "/m/d/h"), ("rmdir", "/m/d")]
+
+
+@pytest.mark.asyncio
+async def test_guarded_rmdir_answers_a_cascade_failure_with_the_refusal(
+        monkeypatch):
+    # A deletion the channel refuses (a mode-protected entry) must
+    # surface as the backend's own not-empty refusal, never as the
+    # cascade's error: the session was told the directory is empty, and
+    # the protected content stays.
+    async def rmdir(_accessor, _path, index=None):
+        raise OSError(errno.ENOTEMPTY, "not empty")
+
+    async def readdir(_accessor, _path, index=None):
+        return ["h"]
+
+    async def stat_fn(_accessor, path, index=None):
+        return FileStat(type=FileType.FILE, name=path.virtual)
+
+    async def unlink(_accessor, path):
+        raise PermissionError(errno.EROFS, "Read-only file system",
+                              path.virtual)
+
+    monkeypatch.setattr(adapter, "hidden_paths_intersect", lambda _v: True)
+    monkeypatch.setattr(adapter, "path_allowed", lambda v: v == "/m/d")
+    spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
+    with pytest.raises(OSError) as exc:
+        await adapter._guarded_rmdir(rmdir, readdir, stat_fn, unlink,
+                                     NOOPAccessor(), spec)
+    assert exc.value.errno == errno.ENOTEMPTY

--- a/python/tests/commands/builtin/generic_bind/test_adapter.py
+++ b/python/tests/commands/builtin/generic_bind/test_adapter.py
@@ -12,9 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
+
 import pytest
 
+import mirage.commands.builtin.generic_bind.adapter as adapter
 from mirage.accessor.base import NOOPAccessor
+from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic_bind.adapter import (CommandIO, Operation,
                                                           dir_aware_stat,
                                                           dir_aware_stream,
@@ -527,3 +531,37 @@ async def test_dir_guard_keeps_a_refusal_on_a_file_the_parent_lists():
                   is_mounted=lambda _a: True))
     with pytest.raises(PermissionError):
         await ops.read_bytes(None, PathSpec.from_str_path("/asked/a"))
+
+
+@pytest.mark.asyncio
+async def test_guarded_rmdir_threads_the_index_to_the_fallback_listing(
+        monkeypatch):
+    # The remnant fallback lists the refused directory raw; on an
+    # indexed backend that listing only resolves through the
+    # invocation's index, so the wrapper must hand it on rather than
+    # falling back to NULL_INDEX.
+    marker = IndexCacheStore()
+    seen: list[IndexCacheStore | None] = []
+    removed: list[str] = []
+
+    async def rmdir(_accessor, _path, index=None):
+        raise OSError(errno.ENOTEMPTY, "not empty")
+
+    async def readdir(_accessor, _path, index=None):
+        seen.append(index)
+        return ["h"]
+
+    async def rm_r(_accessor, path):
+        removed.append(path.virtual)
+
+    monkeypatch.setattr(adapter, "hidden_paths_intersect", lambda _v: True)
+    monkeypatch.setattr(adapter, "path_allowed", lambda v: v == "/m/d")
+    spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
+    await adapter._guarded_rmdir(rmdir,
+                                 readdir,
+                                 rm_r,
+                                 NOOPAccessor(),
+                                 spec,
+                                 index=marker)
+    assert seen == [marker]
+    assert removed == ["/m/d"]

--- a/python/tests/commands/builtin/generic_bind/test_adapter.py
+++ b/python/tests/commands/builtin/generic_bind/test_adapter.py
@@ -605,3 +605,85 @@ async def test_guarded_rmdir_answers_a_cascade_failure_with_the_refusal(
         await adapter._guarded_rmdir(rmdir, readdir, stat_fn, unlink,
                                      NOOPAccessor(), spec)
     assert exc.value.errno == errno.ENOTEMPTY
+
+
+@pytest.mark.asyncio
+async def test_guarded_rmdir_counts_a_visible_mounted_child_as_content(
+        monkeypatch):
+    # The backend listing holds only hidden entries, but the namespace
+    # owes the directory a visible mounted child no backend can list.
+    # The children fact joins the emptiness judgment, so the refusal
+    # stays and the cascade never starts.
+    removed: list[str] = []
+
+    async def rmdir(_accessor, _path, index=None):
+        raise OSError(errno.ENOTEMPTY, "not empty")
+
+    async def readdir(_accessor, _path, index=None):
+        return ["h"]
+
+    async def stat_fn(_accessor, path, index=None):
+        return FileStat(type=FileType.FILE, name=path.virtual)
+
+    async def unlink(_accessor, path):
+        removed.append(path.virtual)
+
+    monkeypatch.setattr(adapter, "hidden_paths_intersect", lambda _v: True)
+    monkeypatch.setattr(adapter, "path_allowed", lambda v: v in
+                        ("/m/d", "/m/d/m"))
+    spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
+    with pytest.raises(OSError) as exc:
+        await adapter._guarded_rmdir(rmdir,
+                                     readdir,
+                                     stat_fn,
+                                     unlink,
+                                     NOOPAccessor(),
+                                     spec,
+                                     children=lambda _v: ["m"])
+    assert exc.value.errno == errno.ENOTEMPTY
+    assert removed == []
+
+
+@pytest.mark.asyncio
+async def test_with_namespace_children_hands_the_fact_to_the_rmdir_guard(
+        monkeypatch):
+    # The hidden guard's rmdir is bound before any invocation exists,
+    # so the per-invocation stamp rebinds the slot with the namespace
+    # children; the builder keeps calling ops.rmdir unchanged and a
+    # visible mounted child still keeps the refusal.
+    removed: list[str] = []
+
+    async def rmdir(_accessor, _path, index=None):
+        raise OSError(errno.ENOTEMPTY, "not empty")
+
+    async def readdir(_accessor, _path, index=None):
+        return ["h"]
+
+    async def stat_fn(_accessor, path, index=None):
+        return FileStat(type=FileType.FILE, name=path.virtual)
+
+    async def unlink(_accessor, path):
+        removed.append(path.virtual)
+
+    async def unused(*_args):
+        raise AssertionError("not used")
+
+    monkeypatch.setattr(adapter, "hidden_paths_intersect", lambda _v: True)
+    monkeypatch.setattr(adapter, "path_allowed", lambda v: v in
+                        ("/m/d", "/m/d/m"))
+    base = CommandIO(readdir=readdir,
+                     read_bytes=unused,
+                     read_stream=unused,
+                     stat=stat_fn,
+                     is_mounted=lambda _a: True,
+                     unlink=unlink,
+                     rmdir=rmdir)
+    ops = adapter.with_namespace_children(adapter.with_hidden_guard(base),
+                                          lambda _v: ["m"])
+    assert ops.glob_children is not None
+    assert ops.rmdir is not None
+    spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
+    with pytest.raises(OSError) as exc:
+        await ops.rmdir(NOOPAccessor(), spec)
+    assert exc.value.errno == errno.ENOTEMPTY
+    assert removed == []

--- a/python/tests/commands/builtin/generic_bind/test_adapter.py
+++ b/python/tests/commands/builtin/generic_bind/test_adapter.py
@@ -609,6 +609,58 @@ async def test_guarded_rmdir_answers_a_cascade_failure_with_the_refusal(
 
 
 @pytest.mark.asyncio
+async def test_guarded_rmdir_folds_a_non_oserror_cascade_failure(monkeypatch):
+    # An API backend's failure is not always an errno (box raises its
+    # own error type); a raw backend exception escaping the fold would
+    # reveal exactly what the refusal exists to hide.
+    async def rmdir(_accessor, _path, index=None):
+        raise OSError(errno.ENOTEMPTY, "not empty")
+
+    async def readdir(_accessor, _path, index=None):
+        return ["h"]
+
+    async def stat_fn(_accessor, path, index=None):
+        return FileStat(type=FileType.FILE, name=path.virtual)
+
+    async def unlink(_accessor, _path):
+        raise RuntimeError("api exploded")
+
+    monkeypatch.setattr(adapter, "hidden_paths_intersect", lambda _v: True)
+    monkeypatch.setattr(adapter, "path_allowed", lambda v: v == "/m/d")
+    spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
+    with pytest.raises(OSError) as exc:
+        await adapter._guarded_rmdir(rmdir, readdir, stat_fn, unlink, None,
+                                     NOOPAccessor(), spec)
+    assert exc.value.errno == errno.ENOTEMPTY
+
+
+@pytest.mark.asyncio
+async def test_guarded_rmdir_folds_a_failed_fallback_listing(monkeypatch):
+    # A backend that cannot list the remnants keeps the original
+    # refusal, whatever error type it failed with, exactly as the ops
+    # plane answers.
+    async def rmdir(_accessor, _path, index=None):
+        raise OSError(errno.ENOTEMPTY, "not empty")
+
+    async def readdir(_accessor, _path, index=None):
+        raise RuntimeError("api exploded")
+
+    async def stat_fn(_accessor, path, index=None):
+        return FileStat(type=FileType.FILE, name=path.virtual)
+
+    async def unlink(_accessor, _path):
+        raise AssertionError("never reached")
+
+    monkeypatch.setattr(adapter, "hidden_paths_intersect", lambda _v: True)
+    monkeypatch.setattr(adapter, "path_allowed", lambda v: v == "/m/d")
+    spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
+    with pytest.raises(OSError) as exc:
+        await adapter._guarded_rmdir(rmdir, readdir, stat_fn, unlink, None,
+                                     NOOPAccessor(), spec)
+    assert exc.value.errno == errno.ENOTEMPTY
+
+
+@pytest.mark.asyncio
 async def test_guarded_rmdir_counts_a_visible_mounted_child_as_content(
         monkeypatch):
     # The backend listing holds only hidden entries, but the namespace

--- a/python/tests/commands/builtin/generic_bind/test_adapter.py
+++ b/python/tests/commands/builtin/generic_bind/test_adapter.py
@@ -571,6 +571,7 @@ async def test_guarded_rmdir_threads_the_index_to_the_fallback_listing(
                                  readdir,
                                  stat_fn,
                                  unlink,
+                                 None,
                                  NOOPAccessor(),
                                  spec,
                                  index=marker)
@@ -602,7 +603,7 @@ async def test_guarded_rmdir_answers_a_cascade_failure_with_the_refusal(
     monkeypatch.setattr(adapter, "path_allowed", lambda v: v == "/m/d")
     spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
     with pytest.raises(OSError) as exc:
-        await adapter._guarded_rmdir(rmdir, readdir, stat_fn, unlink,
+        await adapter._guarded_rmdir(rmdir, readdir, stat_fn, unlink, None,
                                      NOOPAccessor(), spec)
     assert exc.value.errno == errno.ENOTEMPTY
 
@@ -633,24 +634,18 @@ async def test_guarded_rmdir_counts_a_visible_mounted_child_as_content(
                         ("/m/d", "/m/d/m"))
     spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
     with pytest.raises(OSError) as exc:
-        await adapter._guarded_rmdir(rmdir,
-                                     readdir,
-                                     stat_fn,
-                                     unlink,
-                                     NOOPAccessor(),
-                                     spec,
-                                     children=lambda _v: ["m"])
+        await adapter._guarded_rmdir(rmdir, readdir, stat_fn, unlink,
+                                     lambda _v: ["m"], NOOPAccessor(), spec)
     assert exc.value.errno == errno.ENOTEMPTY
     assert removed == []
 
 
 @pytest.mark.asyncio
-async def test_with_namespace_children_hands_the_fact_to_the_rmdir_guard(
-        monkeypatch):
-    # The hidden guard's rmdir is bound before any invocation exists,
-    # so the per-invocation stamp rebinds the slot with the namespace
-    # children; the builder keeps calling ops.rmdir unchanged and a
-    # visible mounted child still keeps the refusal.
+async def test_hidden_guard_rmdir_reads_the_stamped_children(monkeypatch):
+    # The guard is applied over an adapter already stamped with the
+    # invocation's glob_children (the factory's per-invocation order),
+    # so a visible mounted child joins its emptiness judgment and the
+    # builder keeps calling ops.rmdir unchanged.
     removed: list[str] = []
 
     async def rmdir(_accessor, _path, index=None):
@@ -677,10 +672,9 @@ async def test_with_namespace_children_hands_the_fact_to_the_rmdir_guard(
                      stat=stat_fn,
                      is_mounted=lambda _a: True,
                      unlink=unlink,
-                     rmdir=rmdir)
-    ops = adapter.with_namespace_children(adapter.with_hidden_guard(base),
-                                          lambda _v: ["m"])
-    assert ops.glob_children is not None
+                     rmdir=rmdir,
+                     glob_children=lambda _v: ["m"])
+    ops = adapter.with_hidden_guard(base)
     assert ops.rmdir is not None
     spec = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
     with pytest.raises(OSError) as exc:

--- a/python/tests/core/ssh/test_rmdir.py
+++ b/python/tests/core/ssh/test_rmdir.py
@@ -1,0 +1,103 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import errno
+
+import asyncssh
+import pytest
+
+from mirage.accessor.ssh import SSHAccessor
+from mirage.core.ssh.config import SSHConfig
+from mirage.core.ssh.rmdir import rmdir
+from mirage.types import PathSpec
+
+
+class _FakeSFTP:
+    """Just enough of asyncssh's SFTPClient for rmdir.
+
+    Args:
+        refusal (Exception | None): what rmdir raises; None removes.
+        names (list[str] | None): what listdir reports beside the dot
+            entries; None makes the probe itself fail.
+    """
+
+    def __init__(self, refusal: Exception | None,
+                 names: list[str] | None) -> None:
+        self.refusal = refusal
+        self.names = names
+        self.removed: list[str] = []
+        self.listed: list[str] = []
+
+    async def rmdir(self, remote: str) -> None:
+        if self.refusal is not None:
+            raise self.refusal
+        self.removed.append(remote)
+
+    async def listdir(self, remote: str) -> list[str]:
+        self.listed.append(remote)
+        if self.names is None:
+            raise asyncssh.SFTPNoSuchFile("No such file")
+        return [".", "..", *self.names]
+
+
+def _accessor(sftp: _FakeSFTP) -> SSHAccessor:
+    accessor = SSHAccessor(SSHConfig(host="example.test"))
+    accessor._sftp = sftp
+    return accessor
+
+
+@pytest.mark.asyncio
+async def test_rmdir_removes_and_reports_nothing():
+    sftp = _FakeSFTP(None, [])
+    await rmdir(_accessor(sftp), PathSpec.from_str_path("/d"))
+    assert len(sftp.removed) == 1
+    assert sftp.listed == []
+
+
+@pytest.mark.asyncio
+async def test_a_typed_not_empty_maps_to_enotempty():
+    sftp = _FakeSFTP(asyncssh.SFTPDirNotEmpty("Directory not empty"), ["h"])
+    with pytest.raises(OSError) as exc:
+        await rmdir(_accessor(sftp), PathSpec.from_str_path("/d"))
+    assert exc.value.errno == errno.ENOTEMPTY
+
+
+@pytest.mark.asyncio
+async def test_a_version_3_not_empty_refusal_converts_to_enotempty():
+    # OpenSSH speaks SFTP 3, whose one generic code covers not-empty;
+    # the listing probe is what tells it apart, and without the
+    # conversion the hidden-remnant guard never fires on ssh.
+    sftp = _FakeSFTP(asyncssh.SFTPFailure("Failure"), ["h"])
+    with pytest.raises(OSError) as exc:
+        await rmdir(_accessor(sftp), PathSpec.from_str_path("/d"))
+    assert exc.value.errno == errno.ENOTEMPTY
+    assert len(sftp.listed) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_version_3_failure_on_an_empty_listing_stays_itself():
+    # The generic code covers refusals beyond not-empty; a directory
+    # the probe shows empty keeps the server's own answer.
+    sftp = _FakeSFTP(asyncssh.SFTPFailure("Failure"), [])
+    with pytest.raises(asyncssh.SFTPFailure):
+        await rmdir(_accessor(sftp), PathSpec.from_str_path("/d"))
+
+
+@pytest.mark.asyncio
+async def test_a_version_3_failure_with_a_failing_probe_stays_itself():
+    # A probe that fails is a negative probe: the server's answer
+    # stands, nothing is swallowed.
+    sftp = _FakeSFTP(asyncssh.SFTPFailure("Failure"), None)
+    with pytest.raises(asyncssh.SFTPFailure):
+        await rmdir(_accessor(sftp), PathSpec.from_str_path("/d"))

--- a/python/tests/utils/test_hidden.py
+++ b/python/tests/utils/test_hidden.py
@@ -14,9 +14,9 @@
 
 from mirage.types import HiddenPaths, HiddenVars, MountMode, ShowEntry
 from mirage.utils.hidden import (classify_paths, classify_shows, hide_depth,
-                                 hides_intersect, path_covers, path_hidden,
-                                 path_visible, show_depth, show_head,
-                                 shown_mode, var_hidden)
+                                 hides_intersect, move_reveals, path_covers,
+                                 path_hidden, path_visible, show_depth,
+                                 show_head, shown_mode, var_hidden)
 
 
 def test_none_hides_nothing():
@@ -322,3 +322,51 @@ def test_a_globbed_show_keeps_its_anchor_traversable():
     rehidden = classify_paths(["/repo", "/repo/public"])
     assert not path_visible(rehidden, shown, "/repo/public")
     assert not path_visible(rehidden, shown, "/repo/public/index.html")
+
+
+def test_move_reveals_an_exact_entry_below_the_source():
+    # /m/data/secret re-anchors to /m/moved/secret, which nothing hides.
+    spec = classify_paths(["/m/data/secret"])
+    assert move_reveals(spec, None, "/m/data", "/m/moved")
+    # An entry not below the source moves nothing.
+    assert not move_reveals(spec, None, "/m/other", "/m/moved")
+    # The entry itself is the source: the operand is hidden and the
+    # per-path guard answered before this predicate is asked.
+    assert not move_reveals(spec, None, "/m/data/secret/deep", "/m/x")
+    assert not move_reveals(None, None, "/m/data", "/m/moved")
+
+
+def test_move_does_not_reveal_when_the_mapped_path_stays_hidden():
+    spec = classify_paths(["/m/d/sec", "/m/moved/sec"])
+    assert not move_reveals(spec, None, "/m/d", "/m/moved")
+    assert move_reveals(spec, None, "/m/d", "/m/elsewhere")
+
+
+def test_component_patterns_follow_the_name_and_never_reveal():
+    spec = classify_paths(["*.env"])
+    assert not move_reveals(spec, None, "/m/d", "/m/moved")
+
+
+def test_anchored_patterns_refuse_toward_refusal():
+    # The pattern's coverage does not move with the content, and its
+    # match space cannot be enumerated, so any pattern that could reach
+    # below the source refuses: head at the source, below it, or above
+    # it with the wildcard region spanning the source.
+    below = classify_paths(["/m/d/sec/*"])
+    assert move_reveals(below, None, "/m/d", "/m/moved")
+    at = classify_paths(["/m/d/*"])
+    assert move_reveals(at, None, "/m/d", "/m/moved")
+    above = classify_paths(["/m/*/secret"])
+    assert move_reveals(above, None, "/m/d", "/m/moved")
+    unrelated = classify_paths(["/other/*/secret"])
+    assert not move_reveals(unrelated, None, "/m/d", "/m/moved")
+
+
+def test_a_show_below_the_mapped_path_counts_as_a_reveal():
+    # The mapped anchor lands hidden under /m/moved, but a visible show
+    # anchored strictly below it re-opens a road in, which pathVisible's
+    # carve-out rule reports as visibility.
+    hidden = classify_paths(["/m/d/sec", "/m/moved"])
+    shown = classify_shows([ShowEntry("/m/moved/sec/open")])
+    assert move_reveals(hidden, shown, "/m/d", "/m/moved")
+    assert not move_reveals(hidden, None, "/m/d", "/m/moved")

--- a/python/tests/utils/test_remnants.py
+++ b/python/tests/utils/test_remnants.py
@@ -1,0 +1,150 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import errno
+
+import pytest
+
+from mirage.types import FileStat, FileType, PathSpec
+from mirage.utils.remnants import (VisibleRemnant, child_spec, entry_name,
+                                   remove_remnants, visible_below)
+
+
+def _spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual.rsplit("/", 1)[0] or "/",
+                    resource_path=virtual.lstrip("/"))
+
+
+def _nothing_visible(virtual: str) -> bool:
+    return False
+
+
+class TreeChannel:
+    """A dict-backed channel recording every removal in call order."""
+
+    def __init__(self, dirs: set[str], files: set[str]) -> None:
+        self.dirs = set(dirs)
+        self.files = set(files)
+        self.removed: list[tuple[str, str]] = []
+        self.readonly: set[str] = set()
+        # Listed but gone by stat time: the mid-walk vanish case.
+        self.ghosts: set[str] = set()
+
+    async def readdir(self, spec: PathSpec) -> list[str]:
+        base = spec.virtual.rstrip("/")
+        if base not in self.dirs:
+            raise FileNotFoundError(base)
+        names = set()
+        for p in self.dirs | self.files | self.ghosts:
+            if p.startswith(base + "/"):
+                names.add(p[len(base) + 1:].split("/", 1)[0])
+        return sorted(names)
+
+    async def stat(self, spec: PathSpec) -> FileStat:
+        if spec.virtual in self.dirs:
+            return FileStat(name=spec.virtual, type=FileType.DIRECTORY)
+        if spec.virtual in self.files:
+            return FileStat(name=spec.virtual, type=FileType.FILE)
+        raise FileNotFoundError(spec.virtual)
+
+    async def unlink(self, spec: PathSpec) -> None:
+        if spec.virtual in self.readonly:
+            raise PermissionError(errno.EROFS, "Read-only file system",
+                                  spec.virtual)
+        if spec.virtual not in self.files:
+            raise FileNotFoundError(spec.virtual)
+        self.files.remove(spec.virtual)
+        self.removed.append(("unlink", spec.virtual))
+
+    async def rmdir(self, spec: PathSpec) -> None:
+        if spec.virtual not in self.dirs:
+            raise FileNotFoundError(spec.virtual)
+        self.dirs.remove(spec.virtual)
+        self.removed.append(("rmdir", spec.virtual))
+
+
+@pytest.mark.asyncio
+async def test_removes_a_nested_tree_children_first():
+    ch = TreeChannel(dirs={"/d", "/d/sub"}, files={"/d/a", "/d/sub/b"})
+    await remove_remnants(ch, _nothing_visible, _spec("/d"))
+    assert not ch.dirs and not ch.files
+    assert ch.removed.index(("unlink", "/d/sub/b")) < ch.removed.index(
+        ("rmdir", "/d/sub"))
+    assert ch.removed[-1] == ("rmdir", "/d")
+
+
+@pytest.mark.asyncio
+async def test_a_visible_entry_aborts_before_it_is_touched():
+    ch = TreeChannel(dirs={"/d", "/d/sec"},
+                     files={"/d/sec/k", "/d/sec/new.txt"})
+    with pytest.raises(VisibleRemnant) as exc:
+        await remove_remnants(ch, lambda v: v == "/d/sec/new.txt", _spec("/d"))
+    assert exc.value.errno == errno.ENOTEMPTY
+    assert "/d/sec/new.txt" in ch.files
+    assert "/d" in ch.dirs and "/d/sec" in ch.dirs
+
+
+@pytest.mark.asyncio
+async def test_entries_vanished_mid_walk_are_completed_removals():
+    ch = TreeChannel(dirs={"/d"}, files={"/d/a"})
+    ch.ghosts.add("/d/ghost")
+    await remove_remnants(ch, _nothing_visible, _spec("/d"))
+    assert not ch.dirs and not ch.files
+
+
+@pytest.mark.asyncio
+async def test_a_directory_vanished_before_its_listing_is_done():
+    ch = TreeChannel(dirs=set(), files=set())
+    await remove_remnants(ch, _nothing_visible, _spec("/d"))
+    assert ch.removed == []
+
+
+@pytest.mark.asyncio
+async def test_a_channel_refusal_propagates_to_the_caller():
+    # The channel carries the plane's mode axis; a read-only entry
+    # refuses the deletion and the cascade must surface that, so the
+    # arm can fall back to its original refusal.
+    ch = TreeChannel(dirs={"/d"}, files={"/d/k"})
+    ch.readonly.add("/d/k")
+    with pytest.raises(PermissionError):
+        await remove_remnants(ch, _nothing_visible, _spec("/d"))
+    assert "/d" in ch.dirs and "/d/k" in ch.files
+
+
+def test_visible_below_normalizes_slashes_and_paths():
+    seen: list[str] = []
+
+    def probe(virtual: str) -> bool:
+        seen.append(virtual)
+        return virtual == "/d/pub"
+
+    assert visible_below("/d/", ["sec/", "/d/pub"], probe)
+    assert seen == ["/d/sec", "/d/pub"]
+    assert not visible_below("/d", ["sec", "hidden.txt"], _nothing_visible)
+
+
+def test_entry_name_takes_the_last_component():
+    assert entry_name("sub/") == "sub"
+    assert entry_name("/a/b/c") == "c"
+    assert entry_name("plain") == "plain"
+
+
+def test_child_spec_appends_to_the_resource_key():
+    parent = PathSpec(virtual="/m/d", directory="/m", resource_path="d")
+    child = child_spec(parent, "x")
+    assert child.virtual == "/m/d/x"
+    assert child.resource_path == "d/x"
+    root = PathSpec(virtual="/m", directory="/", resource_path="")
+    assert child_spec(root, "x").resource_path == "x"

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -25,6 +25,7 @@ from mirage.types import (ConsistencyPolicy, FileType, HiddenPaths, MountMode,
                           PathSpec)
 from mirage.workspace import Workspace
 from mirage.workspace.dispatcher import Dispatcher
+from mirage.workspace.dispatcher.dispatcher import _MountChannel
 from mirage.workspace.session import Session
 
 
@@ -332,3 +333,65 @@ async def test_symlink_refuses_an_occupied_name(occupied):
                               PathSpec.from_str_path(occupied),
                               target="elsewhere")
         assert (await ws.execute("cat /ram/a.txt")).stdout == b"hi\n"
+
+
+@pytest.mark.asyncio
+async def test_the_remnant_channel_invalidates_each_deletion():
+    # The cascade's execute_op calls run outside the cache-manager
+    # context command execution establishes, so the channel discharges
+    # the dispatcher's write invalidation itself, per deletion; the
+    # dispatch-level invalidation of the rmdir target covers only the
+    # root and its ancestors. Reads stay invalidation-free, and a
+    # failing deletion still invalidates: a missing-path failure means
+    # the tree changed under the walk, and the walk's own earlier
+    # listing must not survive it.
+    mount = MagicMock()
+    mount.execute_op = AsyncMock(return_value=["h"])
+    seen: list[str] = []
+
+    async def invalidate(spec: PathSpec) -> None:
+        seen.append(spec.virtual)
+
+    channel = _MountChannel(mount, invalidate)
+    await channel.readdir(_path("/data/d"))
+    await channel.stat(_path("/data/d/h"))
+    assert seen == []
+    await channel.unlink(_path("/data/d/h"))
+    await channel.rmdir(_path("/data/d"))
+    assert seen == ["/data/d/h", "/data/d"]
+    mount.execute_op = AsyncMock(side_effect=FileNotFoundError("/data/d/h"))
+    with pytest.raises(FileNotFoundError):
+        await channel.unlink(_path("/data/d/h"))
+    assert seen == ["/data/d/h", "/data/d", "/data/d/h"]
+
+
+@pytest.mark.asyncio
+async def test_ops_rmdir_cascade_invalidates_each_remnant(monkeypatch):
+    # A direct dispatcher caller (FUSE, ws.ops) establishes no
+    # cache-manager context, so the cores' own invalidation cannot land
+    # during the remnant cascade; every deletion must reach the
+    # dispatcher's write invalidation, not only the rmdir target, or
+    # the cached listings and bodies below the directory survive its
+    # deletion.
+    ws = Workspace({"/a": RAMResource()}, mode=MountMode.WRITE)
+    io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k")
+    assert io.exit_code == 0, io.stderr
+    sess = ws.create_session("rev", profile={"paths": {"hide": ["/a/d/sec"]}})
+    recorded: list[str] = []
+    real = Dispatcher.invalidate_after_write
+
+    async def spy(self, mount, path, observed=None):
+        recorded.append(path.virtual)
+        await real(self, mount, path, observed=observed)
+
+    monkeypatch.setattr(Dispatcher, "invalidate_after_write", spy)
+    token = set_current_session(sess)
+    try:
+        await ws.ops.rmdir("/a/d")
+    finally:
+        reset_current_session(token)
+    assert "/a/d/sec/k" in recorded
+    assert "/a/d/sec" in recorded
+    assert "/a/d" in recorded
+    gone = await ws.execute("test -e /a/d")
+    assert gone.exit_code == 1

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -27,6 +27,7 @@ from mirage.types import (ConsistencyPolicy, FileType, HiddenPaths, MountMode,
 from mirage.workspace import Workspace
 from mirage.workspace.dispatcher import Dispatcher
 from mirage.workspace.dispatcher.dispatcher import _MountChannel
+from mirage.workspace.mount.mount import MountEntry
 from mirage.workspace.session import Session
 
 
@@ -426,6 +427,82 @@ async def test_a_policy_denied_remnant_keeps_the_refusal():
     io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k")
     assert io.exit_code == 0, io.stderr
     sess = ws.create_session("rev", profile={"paths": {"hide": ["/a/d/sec"]}})
+    token = set_current_session(sess)
+    try:
+        with pytest.raises(OSError) as exc:
+            await ws.ops.rmdir("/a/d")
+    finally:
+        reset_current_session(token)
+    assert exc.value.errno in (errno.ENOTEMPTY, errno.EEXIST)
+    kept = await ws.execute("cat /a/d/sec/k")
+    assert (kept.stdout or b"") == b"k\n"
+
+
+@pytest.mark.asyncio
+async def test_ops_rmdir_takes_hidden_namespace_links_with_it():
+    # A hidden link is invisible to every backend, so the cascade walk
+    # cannot take it; left in the node table it synthesizes /a/d right
+    # back once the hide lifts, resurfacing the removed tree.
+    ws = Workspace({"/a": RAMResource()}, mode=MountMode.WRITE)
+    io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k"
+                          " && ln -s /a/t /a/d/lnk")
+    assert io.exit_code == 0, io.stderr
+    sess = ws.create_session(
+        "rev", profile={"paths": {
+            "hide": ["/a/d/sec", "/a/d/lnk"]
+        }})
+    token = set_current_session(sess)
+    try:
+        await ws.ops.rmdir("/a/d")
+    finally:
+        reset_current_session(token)
+    # No session, no hides: the tree must be gone, link included.
+    linkless = await ws.execute("readlink /a/d/lnk")
+    assert linkless.exit_code != 0
+    gone = await ws.execute("test -e /a/d")
+    assert gone.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_a_visible_link_below_keeps_the_rmdir_refusal():
+    # A visible link joins the merged emptiness judgment, so the
+    # refusal stands and nothing (backend remnant or node table) is
+    # destroyed.
+    ws = Workspace({"/a": RAMResource()}, mode=MountMode.WRITE)
+    io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k"
+                          " && ln -s /a/t /a/d/lnk")
+    assert io.exit_code == 0, io.stderr
+    sess = ws.create_session("rev", profile={"paths": {"hide": ["/a/d/sec"]}})
+    token = set_current_session(sess)
+    try:
+        with pytest.raises(OSError) as exc:
+            await ws.ops.rmdir("/a/d")
+    finally:
+        reset_current_session(token)
+    assert exc.value.errno in (errno.ENOTEMPTY, errno.EEXIST)
+    kept = await ws.execute("cat /a/d/sec/k")
+    assert (kept.stdout or b"") == b"k\n"
+    link = await ws.execute("readlink /a/d/lnk")
+    assert link.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_a_non_oserror_cascade_failure_keeps_the_refusal(monkeypatch):
+    # An API backend's failure is not always an errno (box raises its
+    # own error type); a raw backend exception escaping the fold would
+    # reveal exactly what the refusal exists to hide.
+    ws = Workspace({"/a": RAMResource()}, mode=MountMode.WRITE)
+    io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k")
+    assert io.exit_code == 0, io.stderr
+    sess = ws.create_session("rev", profile={"paths": {"hide": ["/a/d/sec"]}})
+    real = MountEntry.execute_op
+
+    async def boom(self, op, virtual, **kwargs):
+        if op == "unlink" and virtual == "/a/d/sec/k":
+            raise RuntimeError("api exploded")
+        return await real(self, op, virtual, **kwargs)
+
+    monkeypatch.setattr(MountEntry, "execute_op", boom)
     token = set_current_session(sess)
     try:
         with pytest.raises(OSError) as exc:

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -42,6 +43,14 @@ class DenyWrites(Policy):
     async def pre_ops(self, ctx: OpsContext) -> Action | None:
         if ctx.write:
             return Deny("no writes\n")
+        return None
+
+
+class DenyRemnantUnlink(Policy):
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        if ctx.op == "unlink" and ctx.path.virtual == "/a/d/sec/k":
+            return Deny("protected\n")
         return None
 
 
@@ -339,26 +348,33 @@ async def test_symlink_refuses_an_occupied_name(occupied):
 async def test_the_remnant_channel_invalidates_each_deletion():
     # The cascade's execute_op calls run outside the cache-manager
     # context command execution establishes, so the channel discharges
-    # the dispatcher's write invalidation itself, per deletion; the
-    # dispatch-level invalidation of the rmdir target covers only the
-    # root and its ancestors. Reads stay invalidation-free, and a
-    # failing deletion still invalidates: a missing-path failure means
-    # the tree changed under the walk, and the walk's own earlier
-    # listing must not survive it.
+    # the dispatcher's write invalidation itself, per deletion, and
+    # holds each deletion to the pre-ops admission with its own child
+    # path; the dispatch-level invalidation of the rmdir target covers
+    # only the root and its ancestors. Reads stay gate- and
+    # invalidation-free, and a failing deletion still invalidates: a
+    # missing-path failure means the tree changed under the walk, and
+    # the walk's own earlier listing must not survive it.
     mount = MagicMock()
     mount.execute_op = AsyncMock(return_value=["h"])
     seen: list[str] = []
+    admitted: list[tuple[str, str]] = []
+
+    async def admit(op: str, spec: PathSpec) -> None:
+        admitted.append((op, spec.virtual))
 
     async def invalidate(spec: PathSpec) -> None:
         seen.append(spec.virtual)
 
-    channel = _MountChannel(mount, invalidate)
+    channel = _MountChannel(mount, admit, invalidate)
     await channel.readdir(_path("/data/d"))
     await channel.stat(_path("/data/d/h"))
     assert seen == []
+    assert admitted == []
     await channel.unlink(_path("/data/d/h"))
     await channel.rmdir(_path("/data/d"))
     assert seen == ["/data/d/h", "/data/d"]
+    assert admitted == [("unlink", "/data/d/h"), ("rmdir", "/data/d")]
     mount.execute_op = AsyncMock(side_effect=FileNotFoundError("/data/d/h"))
     with pytest.raises(FileNotFoundError):
         await channel.unlink(_path("/data/d/h"))
@@ -395,3 +411,27 @@ async def test_ops_rmdir_cascade_invalidates_each_remnant(monkeypatch):
     assert "/a/d" in recorded
     gone = await ws.execute("test -e /a/d")
     assert gone.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_a_policy_denied_remnant_keeps_the_refusal():
+    # The gate that admitted the rmdir judged the directory; each
+    # cascade deletion answers pre_ops with its own child path, so a
+    # policy that protects the hidden file refuses its unlink, the
+    # cascade folds the denial into the original not-empty refusal,
+    # and the protected content survives.
+    ws = Workspace({"/a": RAMResource()},
+                   mode=MountMode.WRITE,
+                   policies=[DenyRemnantUnlink()])
+    io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k")
+    assert io.exit_code == 0, io.stderr
+    sess = ws.create_session("rev", profile={"paths": {"hide": ["/a/d/sec"]}})
+    token = set_current_session(sess)
+    try:
+        with pytest.raises(OSError) as exc:
+            await ws.ops.rmdir("/a/d")
+    finally:
+        reset_current_session(token)
+    assert exc.value.errno in (errno.ENOTEMPTY, errno.EEXIST)
+    kept = await ws.execute("cat /a/d/sec/k")
+    assert (kept.stdout or b"") == b"k\n"

--- a/python/tests/workspace/test_path_axis.py
+++ b/python/tests/workspace/test_path_axis.py
@@ -13,7 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import errno
 
+from mirage.context import reset_current_session, set_current_session
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode
 from mirage.workspace import Workspace
@@ -455,3 +457,63 @@ def test_rm_r_still_destroys_hidden_content_below():
     assert removed.exit_code == 0, removed.stderr
     gone = _host(ws, "test -e /repo/box")
     assert gone.exit_code == 1
+
+
+def test_a_read_only_hidden_remnant_keeps_the_refusal():
+    # A show may state a mode at the same anchor a hide covers (the
+    # hide wins visibility on the tie), leaving content the session
+    # cannot see that its mode still protects. Every cascade deletion
+    # answers for its own path's mode, so the protected remnant
+    # survives and the rmdir keeps a not-empty refusal.
+    ws = _boxed(
+        {"paths": {
+            "hide": ["/repo/only/h"],
+            "show": {
+                "/repo/only/h": "r"
+            }
+        }})
+    refused = _run(ws, "rmdir /repo/only")
+    assert refused.exit_code == 1
+    assert (refused.stderr or b"") == (
+        b"rmdir: failed to remove '/repo/only': Directory not empty\n")
+    kept = _host(ws, "cat /repo/only/h")
+    assert (kept.stdout or b"") == b"h\n"
+
+
+def test_ops_rmdir_keeps_the_refusal_when_a_mounted_child_remains():
+    # Ops-plane twin of the visible-child rule: the backend cannot see
+    # a mount nested below the directory, so the remnant arm judges
+    # emptiness on the door's merged listing. The visible mounted child
+    # keeps the not-empty refusal instead of the arm destroying the
+    # hidden backend remnants and reporting a successful rmdir while
+    # the mount remains.
+    ws = Workspace({
+        "/a": RAMResource(),
+        "/a/d/m": RAMResource()
+    },
+                   mode=MountMode.WRITE)
+
+    async def seed():
+        io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k"
+                              )
+        assert io.exit_code == 0, io.stderr
+
+    asyncio.run(seed())
+    sess = ws.create_session("rev", profile={"paths": {"hide": ["/a/d/sec"]}})
+
+    async def probe():
+        try:
+            await ws.ops.rmdir("/a/d")
+        except OSError as exc:
+            return exc
+        return None
+
+    token = set_current_session(sess)
+    try:
+        refused = asyncio.run(probe())
+    finally:
+        reset_current_session(token)
+    assert refused is not None
+    assert refused.errno in (errno.ENOTEMPTY, errno.EEXIST)
+    kept = _host(ws, "cat /a/d/sec/k")
+    assert (kept.stdout or b"") == b"k\n"

--- a/python/tests/workspace/test_path_axis.py
+++ b/python/tests/workspace/test_path_axis.py
@@ -387,6 +387,39 @@ def test_mv_rides_a_component_pattern_hide_along():
     assert survived.exit_code == 0 and (survived.stdout or b"") == b"t\n"
 
 
+def test_mv_of_a_file_under_an_anchored_pattern_hide_passes():
+    # /repo/*/sec could match below any directory under /repo, so a
+    # directory move refuses conservatively, but a regular file carries
+    # nothing below it: renaming one reveals nothing.
+    ws = _boxed({"paths": {"hide": ["/repo/*/sec"]}})
+    moved = _run(ws, "mv /repo/box/a.txt /repo/box/b.txt")
+    assert moved.exit_code == 0, moved.stderr
+    listing = _run(ws, "ls /repo/box")
+    assert b"b.txt" in (listing.stdout or b"")
+
+
+def test_mv_of_a_directory_under_an_anchored_pattern_hide_refuses():
+    ws = _boxed({"paths": {"hide": ["/repo/*/sec"]}})
+    refused = _run(ws, "mv /repo/box /repo/moved")
+    assert refused.exit_code == 1
+    assert b"Permission denied" in (refused.stderr or b"")
+
+
+def test_mv_b_refusal_leaves_the_destination_backup_free():
+    # The reveal guard answers before -b renames the destination aside,
+    # so a refused move mutates nothing: no backup, destination intact.
+    ws = _boxed({"paths": {"hide": ["/repo/box/sec"]}})
+    prep = _run(ws, "mkdir /repo/moved")
+    assert prep.exit_code == 0, prep.stderr
+    refused = _run(ws, "mv -b -T /repo/box /repo/moved")
+    assert refused.exit_code == 1
+    assert b"Permission denied" in (refused.stderr or b"")
+    intact = _host(ws, "test -d /repo/moved")
+    assert intact.exit_code == 0
+    backup = _host(ws, "test -e /repo/moved~")
+    assert backup.exit_code == 1
+
+
 def test_cp_r_copies_the_visible_view_silently():
     ws = _boxed({"paths": {"hide": ["/repo/box/sec"]}})
     copied = _run(ws, "cp -r /repo/box /repo/copy")

--- a/python/tests/workspace/test_path_axis.py
+++ b/python/tests/workspace/test_path_axis.py
@@ -336,3 +336,89 @@ def test_a_fork_carries_the_carve_out():
     assert b"No such file or directory" in (forked.stderr or b"")
     ok = _run(ws, "(cat /repo/public/index.html)")
     assert ok.exit_code == 0
+
+
+def _boxed(profile: dict) -> Workspace:
+    ws = Workspace({"/repo": RAMResource()}, mode=MountMode.WRITE)
+
+    async def seed():
+        io = await ws.execute("mkdir -p /repo/box/sec /repo/only && "
+                              "printf 'v\\n' > /repo/box/a.txt && "
+                              "printf 's\\n' > /repo/box/sec/k && "
+                              "printf 't\\n' > /repo/box/x.tkn && "
+                              "printf 'h\\n' > /repo/only/h")
+        assert io.exit_code == 0, io.stderr
+
+    asyncio.run(seed())
+    ws.create_session("rev", profile=profile)
+    return ws
+
+
+def _host(ws: Workspace, line: str):
+
+    async def go():
+        return await ws.execute(line)
+
+    return asyncio.run(go())
+
+
+def test_mv_that_would_reveal_hidden_content_refuses():
+    # The hide anchors at /repo/box/sec; the move would re-anchor its
+    # content to /repo/moved/sec, which nothing hides, so it refuses in
+    # GNU's permission-denied voice and the source stays whole.
+    ws = _boxed({"paths": {"hide": ["/repo/box/sec"]}})
+    refused = _run(ws, "mv /repo/box /repo/moved")
+    assert refused.exit_code == 1
+    assert (refused.stderr or b"") == (
+        b"mv: cannot move '/repo/box' to '/repo/moved': Permission denied\n")
+    intact = _host(ws, "test -e /repo/box/sec/k")
+    assert intact.exit_code == 0
+
+
+def test_mv_rides_a_component_pattern_hide_along():
+    # *.tkn follows the name wherever the content goes, so nothing is
+    # revealed and the move proceeds, the hidden file riding along.
+    ws = _boxed({"paths": {"hide": ["*.tkn"]}})
+    ok = _run(ws, "mv /repo/box /repo/moved")
+    assert ok.exit_code == 0, ok.stderr
+    listing = _run(ws, "ls /repo/moved")
+    assert (listing.stdout or b"") == b"a.txt\nsec\n"
+    survived = _host(ws, "cat /repo/moved/x.tkn")
+    assert survived.exit_code == 0 and (survived.stdout or b"") == b"t\n"
+
+
+def test_cp_r_copies_the_visible_view_silently():
+    ws = _boxed({"paths": {"hide": ["/repo/box/sec"]}})
+    copied = _run(ws, "cp -r /repo/box /repo/copy")
+    assert copied.exit_code == 0, copied.stderr
+    assert (copied.stderr or b"") == b""
+    listing = _host(ws, "find /repo/copy")
+    assert (listing.stdout
+            or b"") == (b"/repo/copy\n/repo/copy/a.txt\n/repo/copy/x.tkn\n")
+
+
+def test_rmdir_takes_hidden_remnants_with_the_directory():
+    # The session sees an empty directory; a not-empty refusal would
+    # leak that something invisible exists, so the remnants go with it.
+    ws = _boxed({"paths": {"hide": ["/repo/only/h"]}})
+    empty = _run(ws, "ls -a /repo/only")
+    assert (empty.stdout or b"") == b""
+    removed = _run(ws, "rmdir /repo/only")
+    assert removed.exit_code == 0, removed.stderr
+    gone = _host(ws, "test -e /repo/only")
+    assert gone.exit_code == 1
+
+
+def test_rmdir_with_a_visible_child_keeps_the_refusal():
+    ws = _boxed({"paths": {"hide": ["/repo/box/sec"]}})
+    refused = _run(ws, "rmdir /repo/box")
+    assert refused.exit_code == 1
+    assert b"Directory not empty" in (refused.stderr or b"")
+
+
+def test_rm_r_still_destroys_hidden_content_below():
+    ws = _boxed({"paths": {"hide": ["/repo/box/sec"]}})
+    removed = _run(ws, "rm -r /repo/box")
+    assert removed.exit_code == 0, removed.stderr
+    gone = _host(ws, "test -e /repo/box")
+    assert gone.exit_code == 1

--- a/python/tests/workspace/test_path_axis.py
+++ b/python/tests/workspace/test_path_axis.py
@@ -480,6 +480,34 @@ def test_a_read_only_hidden_remnant_keeps_the_refusal():
     assert (kept.stdout or b"") == b"h\n"
 
 
+def test_a_mounted_child_keeps_the_command_planes_refusal():
+    # Command-plane twin of the ops door's merged emptiness: the
+    # backend listing holds only hidden entries, but the namespace owes
+    # the directory a visible mounted child no backend can list. The
+    # stamped children join the guard's emptiness judgment, so the
+    # not-empty refusal stays instead of the cascade destroying the
+    # hidden remnant and reporting success while the mount remains.
+    ws = Workspace({
+        "/repo": RAMResource(),
+        "/repo/only/m": RAMResource()
+    },
+                   mode=MountMode.WRITE)
+
+    async def seed():
+        io = await ws.execute(
+            "mkdir -p /repo/only && printf 'h\\n' > /repo/only/h")
+        assert io.exit_code == 0, io.stderr
+
+    asyncio.run(seed())
+    ws.create_session("rev", profile={"paths": {"hide": ["/repo/only/h"]}})
+    refused = _run(ws, "rmdir /repo/only")
+    assert refused.exit_code == 1
+    assert (refused.stderr or b"") == (
+        b"rmdir: failed to remove '/repo/only': Directory not empty\n")
+    kept = _host(ws, "cat /repo/only/h")
+    assert (kept.stdout or b"") == b"h\n"
+
+
 def test_ops_rmdir_keeps_the_refusal_when_a_mounted_child_remains():
     # Ops-plane twin of the visible-child rule: the backend cannot see
     # a mount nested below the directory, so the remnant arm judges

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/mv.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { PathSpec } from '../../../../../types.ts'
+import { refuseReveal } from '../../../generic_bind/adapter.ts'
 import { mvGeneric, parseMvFlags } from '../../mv.ts'
 import type { CrossResult, DispatchFn } from '../types.ts'
 import { flatten, readBytesOp, readdirOp, statOp } from '../utils.ts'
@@ -55,5 +56,7 @@ export async function runMv(
     parseMvFlags(new FlagView(flagKwargs, specOf('mv'))),
     undefined,
     storageKey,
+    undefined,
+    refuseReveal,
   )
 }

--- a/typescript/packages/core/src/commands/builtin/generic/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mv.ts
@@ -292,6 +292,12 @@ export async function mvGeneric(
   index?: IndexCacheStore,
   backendKey?: BackendKeyFn,
   readdir?: ReaddirFn,
+  // Judges one (source, target) pair before a primitive move touches
+  // anything, throwing to refuse it; the adapter wires the
+  // hidden-reveal check here so a cross-mount move refuses exactly
+  // where a native rename's own slot would, instead of half-copying
+  // first.
+  guard?: (src: PathSpec, dst: PathSpec) => void,
 ): Promise<[ByteSource | null, IOResult]> {
   const keyOf = backendKey ?? backendKeyDefault
   const [sources, dstOperand] = splitOperands('mv', paths, flags.targetDir, flags.noTargetDir)
@@ -410,6 +416,17 @@ export async function mvGeneric(
     )
     if (!made.ok) continue
     if (isPrimitiveMove(strategy)) {
+      if (guard !== undefined) {
+        try {
+          guard(src, target)
+        } catch (err) {
+          if (!isFsError(err)) throw err
+          errors.push(
+            `mv: cannot move '${src.virtual}' to '${target.virtual}': ${String(fsStrerror(err))}`,
+          )
+          continue
+        }
+      }
       const entries = await cpWalk(strategy.readdir, stat, src, index)
       const { copiedAll, wroteAny } = await copyEntries(
         'mv',

--- a/typescript/packages/core/src/commands/builtin/generic/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mv.ts
@@ -292,11 +292,12 @@ export async function mvGeneric(
   index?: IndexCacheStore,
   backendKey?: BackendKeyFn,
   readdir?: ReaddirFn,
-  // Judges one (source, target) pair before a primitive move touches
-  // anything, throwing to refuse it; the adapter wires the
-  // hidden-reveal check here so a cross-mount move refuses exactly
-  // where a native rename's own slot would, instead of half-copying
-  // first.
+  // Judges one (source, target) pair before the move touches anything,
+  // the backup included, throwing to refuse it; the adapter wires the
+  // hidden-reveal check here so a refused move mutates nothing (no
+  // half-copy, no destination renamed aside by -b). Consulted only for
+  // a directory source, since a file carries nothing below it to
+  // reveal.
   guard?: (src: PathSpec, dst: PathSpec) => void,
 ): Promise<[ByteSource | null, IOResult]> {
   const keyOf = backendKey ?? backendKeyDefault
@@ -404,6 +405,20 @@ export async function mvGeneric(
         continue
       }
     }
+    // The reveal guard answers before the backup so a refused move
+    // cannot leave the destination renamed aside; only a directory
+    // source has anything below it to re-anchor, so a file passes.
+    if (guard !== undefined && srcIsDir) {
+      try {
+        guard(src, target)
+      } catch (err) {
+        if (!isFsError(err)) throw err
+        errors.push(
+          `mv: cannot move '${src.virtual}' to '${target.virtual}': ${String(fsStrerror(err))}`,
+        )
+        continue
+      }
+    }
     const made = await makeBackup(
       policy,
       strategy,
@@ -416,17 +431,6 @@ export async function mvGeneric(
     )
     if (!made.ok) continue
     if (isPrimitiveMove(strategy)) {
-      if (guard !== undefined) {
-        try {
-          guard(src, target)
-        } catch (err) {
-          if (!isFsError(err)) throw err
-          errors.push(
-            `mv: cannot move '${src.virtual}' to '${target.virtual}': ${String(fsStrerror(err))}`,
-          )
-          continue
-        }
-      }
       const entries = await cpWalk(strategy.readdir, stat, src, index)
       const { copiedAll, wroteAny } = await copyEntries(
         'mv',

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
@@ -23,10 +23,13 @@ import {
   dirAwareStream,
   makeResolveGlob,
   withDirGuard,
+  withHiddenGuard,
+  withNamespaceChildren,
   withRuleGuard,
   type CommandIO,
 } from './adapter.ts'
-import { runWithAdmission } from '../../../context/session_context.ts'
+import { runWithAdmission, runWithSession } from '../../../context/session_context.ts'
+import { Session } from '../../../workspace/session/session.ts'
 
 const accessor = {} as never
 // No namespace facts, which is what a command bound outside a workspace
@@ -461,5 +464,50 @@ describe('withDirGuard', () => {
     await expect(
       ops.readBytes(accessor, PathSpec.fromStrPath('/locked.txt'), undefined),
     ).rejects.toMatchObject({ code: 'EACCES' })
+  })
+})
+
+describe('withNamespaceChildren', () => {
+  it('a visible mounted child keeps the rmdir refusal', async () => {
+    // The hidden guard's rmdir closure is bound before any invocation
+    // exists, so the per-invocation stamp rebinds the slot with the
+    // namespace children; the builder keeps calling ops.rmdir
+    // unchanged, the visible mounted child joins the emptiness
+    // judgment, and the not-empty refusal stays with the cascade never
+    // started.
+    const removed: string[] = []
+    const notEmpty = (): Error => {
+      const err = new Error('ENOTEMPTY: directory not empty') as Error & { code: string }
+      err.code = 'ENOTEMPTY'
+      return err
+    }
+    const base: CommandIO = {
+      readdir: () => Promise.resolve(['h']),
+      readBytes: () => Promise.reject(new Error('not used')),
+      readStream: () => {
+        throw new Error('not used')
+      },
+      stat: (_a, path) =>
+        Promise.resolve(new FileStat({ name: path.virtual, type: FileType.TEXT })),
+      isMounted: () => true,
+      unlink: (_a, path) => {
+        removed.push(path.virtual)
+        return Promise.resolve()
+      },
+      rmdir: () => Promise.reject(notEmpty()),
+    }
+    const ops = withNamespaceChildren(withHiddenGuard(base), (parent) =>
+      parent === '/m/d' ? ['m'] : [],
+    )
+    expect(ops.globChildren).toBeDefined()
+    const rmdir = ops.rmdir
+    if (rmdir === undefined) throw new Error('rmdir slot missing')
+    const sess = new Session({ sessionId: 'narrowed' })
+    sess.hiddenPaths = { paths: ['/m/d/h'] }
+    const spec = new PathSpec({ virtual: '/m/d', directory: '/m', resourcePath: 'd' })
+    await runWithSession(sess, async () => {
+      await expect(rmdir(accessor, spec)).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    })
+    expect(removed).toEqual([])
   })
 })

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
@@ -505,4 +505,37 @@ describe('withHiddenGuard rmdir under namespace children', () => {
     })
     expect(removed).toEqual([])
   })
+
+  it('a failed fallback listing keeps the rmdir refusal', async () => {
+    // A backend that cannot list the remnants keeps the original
+    // refusal, whatever error type it failed with: a raw backend
+    // failure here would reveal exactly what the refusal exists to
+    // hide.
+    const notEmpty = (): Error => {
+      const err = new Error('ENOTEMPTY: directory not empty') as Error & { code: string }
+      err.code = 'ENOTEMPTY'
+      return err
+    }
+    const base: CommandIO = {
+      readdir: () => Promise.reject(new Error('api exploded')),
+      readBytes: () => Promise.reject(new Error('not used')),
+      readStream: () => {
+        throw new Error('not used')
+      },
+      stat: (_a, path) =>
+        Promise.resolve(new FileStat({ name: path.virtual, type: FileType.TEXT })),
+      isMounted: () => true,
+      unlink: () => Promise.reject(new Error('never reached')),
+      rmdir: () => Promise.reject(notEmpty()),
+    }
+    const ops = withHiddenGuard(base)
+    const rmdir = ops.rmdir
+    if (rmdir === undefined) throw new Error('rmdir slot missing')
+    const sess = new Session({ sessionId: 'narrowed' })
+    sess.hiddenPaths = { paths: ['/m/d/h'] }
+    const spec = new PathSpec({ virtual: '/m/d', directory: '/m', resourcePath: 'd' })
+    await runWithSession(sess, async () => {
+      await expect(rmdir(accessor, spec)).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+    })
+  })
 })

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
@@ -24,7 +24,6 @@ import {
   makeResolveGlob,
   withDirGuard,
   withHiddenGuard,
-  withNamespaceChildren,
   withRuleGuard,
   type CommandIO,
 } from './adapter.ts'
@@ -467,14 +466,12 @@ describe('withDirGuard', () => {
   })
 })
 
-describe('withNamespaceChildren', () => {
+describe('withHiddenGuard rmdir under namespace children', () => {
   it('a visible mounted child keeps the rmdir refusal', async () => {
-    // The hidden guard's rmdir closure is bound before any invocation
-    // exists, so the per-invocation stamp rebinds the slot with the
-    // namespace children; the builder keeps calling ops.rmdir
-    // unchanged, the visible mounted child joins the emptiness
-    // judgment, and the not-empty refusal stays with the cascade never
-    // started.
+    // The guard is applied over an adapter already stamped with the
+    // invocation's globChildren (the factory's per-invocation order),
+    // so the visible mounted child joins the emptiness judgment and
+    // the not-empty refusal stays with the cascade never started.
     const removed: string[] = []
     const notEmpty = (): Error => {
       const err = new Error('ENOTEMPTY: directory not empty') as Error & { code: string }
@@ -495,11 +492,9 @@ describe('withNamespaceChildren', () => {
         return Promise.resolve()
       },
       rmdir: () => Promise.reject(notEmpty()),
+      globChildren: (parent: string) => (parent === '/m/d' ? ['m'] : []),
     }
-    const ops = withNamespaceChildren(withHiddenGuard(base), (parent) =>
-      parent === '/m/d' ? ['m'] : [],
-    )
-    expect(ops.globChildren).toBeDefined()
+    const ops = withHiddenGuard(base)
     const rmdir = ops.rmdir
     if (rmdir === undefined) throw new Error('rmdir slot missing')
     const sess = new Session({ sessionId: 'narrowed' })

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -39,7 +39,7 @@ import {
   type ReaddirFn,
   type StatFn,
 } from '../../../types.ts'
-import { eacces, eisdir, enoent, erofsReadOnly } from '../../../utils/errors.ts'
+import { eacces, eisdir, enoent, erofsReadOnly, isMissError } from '../../../utils/errors.ts'
 import type { ChildMounts } from '../../../ops/types.ts'
 import { DEFAULT_MAX_GLOB_MATCHES, resolveGlobWith } from '../../../utils/glob_walk.ts'
 import { norm, parent } from '../../../utils/path.ts'
@@ -72,6 +72,16 @@ type WriteOp<A extends Accessor = Accessor> = (
 type ExistsOp<A extends Accessor = Accessor> = (accessor: A, path: PathSpec) => Promise<boolean>
 
 type PathOp<A extends Accessor = Accessor> = (accessor: A, path: PathSpec) => Promise<void>
+
+// `PathOp` plus the rmdir slot's optional `index`: the hidden-remnant
+// guard turns a refused rmdir into a raw listing of the same directory,
+// and an indexed backend cannot list a nested path without it. Backend
+// rmdirs keep their two-parameter shape and simply never receive it.
+type RmdirOp<A extends Accessor = Accessor> = (
+  accessor: A,
+  path: PathSpec,
+  index?: IndexCacheStore,
+) => Promise<void>
 
 type MkdirOp<A extends Accessor = Accessor> = (
   accessor: A,
@@ -146,7 +156,7 @@ export interface CommandIO<A extends Accessor = Accessor> {
   exists?: ExistsOp<A>
   mkdir?: MkdirOp<A>
   unlink?: PathOp<A>
-  rmdir?: PathOp<A>
+  rmdir?: RmdirOp<A>
   rmR?: PathOp<A>
   rename?: RenameOp<A>
   copy?: CopyOp<A>
@@ -191,18 +201,42 @@ function visibleChildren(entries: string[], parent: PathSpec): string[] {
   })
 }
 
+/** Whether the session's hides make this relocation a reveal. */
+function moveWouldReveal(src: PathSpec, dst: PathSpec): boolean {
+  const sess = getCurrentSession()
+  if (sess === null) return false
+  return moveReveals(sess.hiddenPaths, sess.shownPaths, src.virtual, dst.virtual)
+}
+
 /** Refuse a relocation that would surface a hidden path.
  *
  * A rename or a native directory copy re-anchors everything below its
  * source, and a hide's coverage does not move with the content, so
  * hidden bytes would land at paths the session can see. EACCES on the
- * source, which mv and cp render in GNU's permission-denied voice. */
+ * source, which mv and cp render in GNU's permission-denied voice.
+ * Only a directory has anything below it to re-anchor, so callers
+ * check this for a source they know is a directory and skip it for a
+ * file. */
 export function refuseReveal(src: PathSpec, dst: PathSpec): void {
-  const sess = getCurrentSession()
-  if (sess === null) return
-  if (moveReveals(sess.hiddenPaths, sess.shownPaths, src.virtual, dst.virtual)) {
-    throw eacces(src.virtual)
+  if (moveWouldReveal(src, dst)) throw eacces(src.virtual)
+}
+
+/** Whether a pair op's source stats as a directory, probed only when
+ * the reveal check trips: an absent source moves nothing (the op
+ * itself reports it), and an unanswerable one fails toward refusal. */
+async function pairSrcIsDir<A extends Accessor>(
+  stat: StatOp<A>,
+  accessor: A,
+  src: PathSpec,
+): Promise<boolean> {
+  let row: FileStat
+  try {
+    row = await stat(accessor, src, undefined)
+  } catch (err) {
+    if (isMissError(err)) return false
+    return true
   }
+  return row.type === FileType.DIRECTORY
 }
 
 /**
@@ -296,10 +330,10 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
     // take the remnants.
     const rawReaddir = ops.readdir
     const rawRmR = ops.rmR
-    guarded.rmdir = async (accessor, path) => {
+    guarded.rmdir = async (accessor, path, index) => {
       refuseHidden(path, false)
       try {
-        await rd(accessor, path)
+        await rd(accessor, path, index)
         return
       } catch (exc) {
         const code = (exc as { code?: string }).code
@@ -310,7 +344,7 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
         ) {
           throw exc
         }
-        const entries = await rawReaddir(accessor, path)
+        const entries = await rawReaddir(accessor, path, index)
         const base = path.virtual.replace(/\/+$/, '')
         const visible = entries.some((e) => {
           const trimmed = e.replace(/\/+$/, '')
@@ -337,10 +371,14 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
   }
   const rn = ops.rename
   if (rn !== undefined) {
-    guarded.rename = (accessor, src, dst) => {
+    // Only a directory source can carry hidden content into view, so a
+    // rename whose source stats as a file passes the reveal check.
+    guarded.rename = async (accessor, src, dst) => {
       refuseHidden(src, false)
       refuseHidden(dst, true)
-      refuseReveal(src, dst)
+      if (moveWouldReveal(src, dst) && (await pairSrcIsDir(ops.stat, accessor, src))) {
+        throw eacces(src.virtual)
+      }
       return rn(accessor, src, dst)
     }
   }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -16,10 +16,13 @@ import type { Accessor } from '../../../accessor/base.ts'
 import {
   effectivePathMode,
   getAdmission,
+  getCurrentSession,
+  hiddenPathsIntersect,
   mountGateFor,
   pathAllowed,
   readonlyBelow,
 } from '../../../context/session_context.ts'
+import { moveReveals } from '../../../utils/hidden.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import type { StatOverlay } from '../../../ops/types.ts'
 import type { FindOptions } from '../../../resource/base.ts'
@@ -188,6 +191,20 @@ function visibleChildren(entries: string[], parent: PathSpec): string[] {
   })
 }
 
+/** Refuse a relocation that would surface a hidden path.
+ *
+ * A rename or a native directory copy re-anchors everything below its
+ * source, and a hide's coverage does not move with the content, so
+ * hidden bytes would land at paths the session can see. EACCES on the
+ * source, which mv and cp render in GNU's permission-denied voice. */
+export function refuseReveal(src: PathSpec, dst: PathSpec): void {
+  const sess = getCurrentSession()
+  if (sess === null) return
+  if (moveReveals(sess.hiddenPaths, sess.shownPaths, src.virtual, dst.virtual)) {
+    throw eacces(src.virtual)
+  }
+}
+
 /**
  * Return `ops` whose slots refuse hidden paths like missing ones.
  *
@@ -270,9 +287,38 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
   }
   const rd = ops.rmdir
   if (rd !== undefined) {
-    guarded.rmdir = (accessor, path) => {
+    // The backend refuses a directory still holding entries, but when
+    // every remaining entry is hidden the refusal would leak that
+    // something invisible exists, so the remnants go with the
+    // directory: a session's mutation may destroy what it cannot see,
+    // never learn of it. Any visible child keeps the refusal, and a
+    // backend with no recursive remove keeps it too, having no way to
+    // take the remnants.
+    const rawReaddir = ops.readdir
+    const rawRmR = ops.rmR
+    guarded.rmdir = async (accessor, path) => {
       refuseHidden(path, false)
-      return rd(accessor, path)
+      try {
+        await rd(accessor, path)
+        return
+      } catch (exc) {
+        const code = (exc as { code?: string }).code
+        if (
+          rawRmR === undefined ||
+          (code !== 'ENOTEMPTY' && code !== 'EEXIST') ||
+          !hiddenPathsIntersect(path.virtual)
+        ) {
+          throw exc
+        }
+        const entries = await rawReaddir(accessor, path)
+        const base = path.virtual.replace(/\/+$/, '')
+        const visible = entries.some((e) => {
+          const trimmed = e.replace(/\/+$/, '')
+          return pathAllowed(`${base}/${trimmed.slice(trimmed.lastIndexOf('/') + 1)}`)
+        })
+        if (entries.length === 0 || visible) throw exc
+        await rawRmR(accessor, path)
+      }
     }
   }
   const rt = ops.rmR
@@ -294,6 +340,7 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
     guarded.rename = (accessor, src, dst) => {
       refuseHidden(src, false)
       refuseHidden(dst, true)
+      refuseReveal(src, dst)
       return rn(accessor, src, dst)
     }
   }
@@ -310,6 +357,7 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
     guarded.dirCopy = (accessor, src, dst) => {
       refuseHidden(src, false)
       refuseHidden(dst, true)
+      refuseReveal(src, dst)
       return dc(accessor, src, dst)
     }
   }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -23,6 +23,7 @@ import {
   readonlyBelow,
 } from '../../../context/session_context.ts'
 import { moveReveals } from '../../../utils/hidden.ts'
+import { removeRemnants, visibleBelow, type RemnantChannel } from '../../../utils/remnants.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import type { StatOverlay } from '../../../ops/types.ts'
 import type { FindOptions } from '../../../resource/base.ts'
@@ -326,10 +327,15 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
     // something invisible exists, so the remnants go with the
     // directory: a session's mutation may destroy what it cannot see,
     // never learn of it. Any visible child keeps the refusal, and a
-    // backend with no recursive remove keeps it too, having no way to
-    // take the remnants.
+    // backend with no unlink keeps it too, having no way to take the
+    // remnants. The removal is the shared removeRemnants walk over the
+    // sibling slots, which revalidates visibility before every
+    // deletion and keeps the mode guard on each one; any cascade
+    // failure answers with the backend's original refusal, exactly as
+    // the ops plane does.
     const rawReaddir = ops.readdir
-    const rawRmR = ops.rmR
+    const rawStat = ops.stat
+    const rawUnlink = ops.unlink
     guarded.rmdir = async (accessor, path, index) => {
       refuseHidden(path, false)
       try {
@@ -338,20 +344,27 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
       } catch (exc) {
         const code = (exc as { code?: string }).code
         if (
-          rawRmR === undefined ||
+          rawUnlink === undefined ||
           (code !== 'ENOTEMPTY' && code !== 'EEXIST') ||
           !hiddenPathsIntersect(path.virtual)
         ) {
           throw exc
         }
         const entries = await rawReaddir(accessor, path, index)
-        const base = path.virtual.replace(/\/+$/, '')
-        const visible = entries.some((e) => {
-          const trimmed = e.replace(/\/+$/, '')
-          return pathAllowed(`${base}/${trimmed.slice(trimmed.lastIndexOf('/') + 1)}`)
-        })
-        if (entries.length === 0 || visible) throw exc
-        await rawRmR(accessor, path)
+        if (entries.length === 0 || visibleBelow(path.virtual, entries, pathAllowed)) {
+          throw exc
+        }
+        const channel: RemnantChannel = {
+          readdir: (at) => rawReaddir(accessor, at, index),
+          stat: (at) => rawStat(accessor, at, index),
+          unlink: (at) => rawUnlink(accessor, at),
+          rmdir: (at) => rd(accessor, at, index),
+        }
+        try {
+          await removeRemnants(channel, pathAllowed, path)
+        } catch {
+          throw exc
+        }
       }
     }
   }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -78,10 +78,14 @@ type PathOp<A extends Accessor = Accessor> = (accessor: A, path: PathSpec) => Pr
 // guard turns a refused rmdir into a raw listing of the same directory,
 // and an indexed backend cannot list a nested path without it. Backend
 // rmdirs keep their two-parameter shape and simply never receive it.
+// `children` widens the type the same structural way for the same
+// guard: the namespace children join its emptiness judgment, prebound
+// per invocation by `withNamespaceChildren`, and no backend reads them.
 type RmdirOp<A extends Accessor = Accessor> = (
   accessor: A,
   path: PathSpec,
   index?: IndexCacheStore,
+  children?: ChildMounts,
 ) => Promise<void>
 
 type MkdirOp<A extends Accessor = Accessor> = (
@@ -336,7 +340,7 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
     const rawReaddir = ops.readdir
     const rawStat = ops.stat
     const rawUnlink = ops.unlink
-    guarded.rmdir = async (accessor, path, index) => {
+    guarded.rmdir = async (accessor, path, index, children) => {
       refuseHidden(path, false)
       try {
         await rd(accessor, path, index)
@@ -351,7 +355,12 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
           throw exc
         }
         const entries = await rawReaddir(accessor, path, index)
-        if (entries.length === 0 || visibleBelow(path.virtual, entries, pathAllowed)) {
+        // The namespace children join the emptiness judgment, never
+        // the walk: a visible mounted child keeps the refusal exactly
+        // as the ops plane's merged listing does, while the cascade
+        // itself only ever removes what the backend holds.
+        const merged = children === undefined ? entries : [...entries, ...children(path.virtual)]
+        if (entries.length === 0 || visibleBelow(path.virtual, merged, pathAllowed)) {
           throw exc
         }
         const channel: RemnantChannel = {
@@ -708,6 +717,36 @@ export function withModeGuard<A extends Accessor = Accessor>(ops: CommandIO<A>):
  */
 export function withPathGuards<A extends Accessor = Accessor>(ops: CommandIO<A>): CommandIO<A> {
   return withHiddenGuard(withRuleGuard(withModeGuard(ops)))
+}
+
+/**
+ * Return `ops` carrying the invocation's namespace children.
+ *
+ * The adapter is built once per backend while the child names a
+ * directory owes to nested mounts and symlinks are session-scoped, so
+ * the fact lands here, per invocation. Two consumers read it: glob
+ * resolution and the dir guard read the `globChildren` field off the
+ * stamped copy, and the hidden guard's rmdir closure was bound before
+ * any invocation exists, so its slot is rebound with the fact as the
+ * trailing `children` parameter the guard declares. Backend rmdirs
+ * keep their shorter shape and simply never read it, the same
+ * structural widening `index` rode in on. An absent namespace returns
+ * `ops` untouched because exactOptionalPropertyTypes refuses an
+ * explicit `undefined` for an optional field; Python's `glob_children`
+ * is `| None` and takes the uniform path.
+ */
+export function withNamespaceChildren<A extends Accessor = Accessor>(
+  ops: CommandIO<A>,
+  children: ChildMounts | undefined,
+): CommandIO<A> {
+  if (children === undefined) return ops
+  const stamped: CommandIO<A> = { ...ops, globChildren: children }
+  const slot = ops.rmdir
+  if (slot === undefined) return stamped
+  return {
+    ...stamped,
+    rmdir: (accessor, path, index) => slot(accessor, path, index, children),
+  }
 }
 
 /**

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -78,14 +78,10 @@ type PathOp<A extends Accessor = Accessor> = (accessor: A, path: PathSpec) => Pr
 // guard turns a refused rmdir into a raw listing of the same directory,
 // and an indexed backend cannot list a nested path without it. Backend
 // rmdirs keep their two-parameter shape and simply never receive it.
-// `children` widens the type the same structural way for the same
-// guard: the namespace children join its emptiness judgment, prebound
-// per invocation by `withNamespaceChildren`, and no backend reads them.
 type RmdirOp<A extends Accessor = Accessor> = (
   accessor: A,
   path: PathSpec,
   index?: IndexCacheStore,
-  children?: ChildMounts,
 ) => Promise<void>
 
 type MkdirOp<A extends Accessor = Accessor> = (
@@ -340,7 +336,10 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
     const rawReaddir = ops.readdir
     const rawStat = ops.stat
     const rawUnlink = ops.unlink
-    guarded.rmdir = async (accessor, path, index, children) => {
+    // Captured at wrap time, which holds the invocation's fact because
+    // the factory applies this guard per invocation, after stamping it.
+    const children = ops.globChildren
+    guarded.rmdir = async (accessor, path, index) => {
       refuseHidden(path, false)
       try {
         await rd(accessor, path, index)
@@ -717,36 +716,6 @@ export function withModeGuard<A extends Accessor = Accessor>(ops: CommandIO<A>):
  */
 export function withPathGuards<A extends Accessor = Accessor>(ops: CommandIO<A>): CommandIO<A> {
   return withHiddenGuard(withRuleGuard(withModeGuard(ops)))
-}
-
-/**
- * Return `ops` carrying the invocation's namespace children.
- *
- * The adapter is built once per backend while the child names a
- * directory owes to nested mounts and symlinks are session-scoped, so
- * the fact lands here, per invocation. Two consumers read it: glob
- * resolution and the dir guard read the `globChildren` field off the
- * stamped copy, and the hidden guard's rmdir closure was bound before
- * any invocation exists, so its slot is rebound with the fact as the
- * trailing `children` parameter the guard declares. Backend rmdirs
- * keep their shorter shape and simply never read it, the same
- * structural widening `index` rode in on. An absent namespace returns
- * `ops` untouched because exactOptionalPropertyTypes refuses an
- * explicit `undefined` for an optional field; Python's `glob_children`
- * is `| None` and takes the uniform path.
- */
-export function withNamespaceChildren<A extends Accessor = Accessor>(
-  ops: CommandIO<A>,
-  children: ChildMounts | undefined,
-): CommandIO<A> {
-  if (children === undefined) return ops
-  const stamped: CommandIO<A> = { ...ops, globChildren: children }
-  const slot = ops.rmdir
-  if (slot === undefined) return stamped
-  return {
-    ...stamped,
-    rmdir: (accessor, path, index) => slot(accessor, path, index, children),
-  }
 }
 
 /**

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -353,7 +353,17 @@ export function withHiddenGuard<A extends Accessor = Accessor>(ops: CommandIO<A>
         ) {
           throw exc
         }
-        const entries = await rawReaddir(accessor, path, index)
+        // The fallback listing folds into the refusal exactly as the
+        // cascade below does: a backend that cannot list the remnants
+        // keeps the original refusal, whatever error type it failed
+        // with, because a raw backend failure here would reveal
+        // exactly what the refusal exists to hide.
+        let entries: string[]
+        try {
+          entries = await rawReaddir(accessor, path, index)
+        } catch {
+          throw exc
+        }
         // The namespace children join the emptiness judgment, never
         // the walk: a visible mounted child keeps the refusal exactly
         // as the ops plane's merged listing does, while the cascade

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/cp.ts
@@ -16,7 +16,7 @@ import type { IndexCacheStore } from '../../../../cache/index/store.ts'
 import type { StatOverlay } from '../../../../ops/types.ts'
 import type { Accessor } from '../../../../accessor/base.ts'
 import type { NativeCopy, PathSpec, PrimitiveCopy, StatFn } from '../../../../types.ts'
-import { pathRulesActive } from '../../../../context/session_context.ts'
+import { hiddenPathsIntersect, pathRulesActive } from '../../../../context/session_context.ts'
 import { walkFind } from '../../../../core/generic/find.ts'
 import { cpGeneric, parseCpFlags } from '../../generic/cp.ts'
 import type { Builder, CommandIO } from '../adapter.ts'
@@ -65,12 +65,16 @@ export const CP_BUILDER: Builder = {
     const parsed = parseCpFlags(new FlagView(opts.flags, specOf('cp')))
     // A native copy moves a tree in one backend call and a native find
     // lists it, neither of which passes an entry through the guard the
-    // way a read does; while a path rule scopes cp, the primitive walk
-    // copies entry by entry (the cross-mount relay's own path), which is
-    // also where GNU's per-entry refusals are worded.
+    // way a read does; while a path rule scopes cp, or a hide could
+    // cover an entry under an operand (the native find listed hidden
+    // names and the per-file read then printed them in its refusal),
+    // the primitive walk copies entry by entry (the cross-mount
+    // relay's own path), which is also where GNU's per-entry refusals
+    // are worded.
     const { write } = ops
+    const guarded = pathRulesActive() || paths.some((p) => hiddenPathsIntersect(p.virtual))
     const strategy: NativeCopy | PrimitiveCopy =
-      pathRulesActive() && write !== undefined && mkdir !== undefined
+      guarded && write !== undefined && mkdir !== undefined
         ? {
             readBytes: (p: PathSpec) => ops.readBytes(accessor, p, idx),
             write: (p: PathSpec, data: Uint8Array) => write(accessor, p, data),

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/mv.ts
@@ -15,6 +15,7 @@
 import type { PathSpec } from '../../../../types.ts'
 import { mvGeneric, parseMvFlags } from '../../generic/mv.ts'
 import type { Builder } from '../adapter.ts'
+import { refuseReveal } from '../adapter.ts'
 import { overlayableStat } from './cp.ts'
 import { FlagView } from '../../../spec/types.ts'
 import { specOf } from '../../../spec/builtins.ts'
@@ -38,6 +39,7 @@ export const MV_BUILDER: Builder = {
       idx,
       undefined,
       (p: PathSpec) => ops.readdir(accessor, p, idx),
+      refuseReveal,
     )
   },
 }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/rm.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/rm.ts
@@ -103,7 +103,7 @@ export const RM_BUILDER: Builder = {
               errors.push(`rm: cannot remove '${p.rawPath}': Directory not empty`)
               continue
             }
-            await rmdir(accessor, p)
+            await rmdir(accessor, p, idx)
             entryLines = [`removed directory '${p.virtual}'`]
           } else {
             errors.push(`rm: cannot remove '${p.rawPath}': Is a directory`)

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/rmdir.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/rmdir.ts
@@ -66,7 +66,7 @@ export const RMDIR_BUILDER: Builder = {
         errors.push(`rmdir: failed to remove '${p.rawPath}': Directory not empty`)
         continue
       }
-      await rmdir(accessor, p)
+      await rmdir(accessor, p, idx)
       if (verbose) lines.push(`rmdir: removing directory, '${p.rawPath}'`)
     }
     const out = lines.length > 0 ? formatRecords(lines) : null

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/rmdir.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/rmdir.ts
@@ -66,7 +66,19 @@ export const RMDIR_BUILDER: Builder = {
         errors.push(`rmdir: failed to remove '${p.rawPath}': Directory not empty`)
         continue
       }
-      await rmdir(accessor, p, idx)
+      try {
+        await rmdir(accessor, p, idx)
+      } catch (exc) {
+        // The listing above showed the session an empty directory, but
+        // the slot may still refuse not-empty: the hidden-remnant guard
+        // re-raises the backend's refusal when its cascade cannot
+        // finish (a mode-protected remnant, a visible entry appearing
+        // mid-walk). GNU's voice, not the raw error.
+        const code = (exc as { code?: string }).code
+        if (code !== 'ENOTEMPTY' && code !== 'EEXIST') throw exc
+        errors.push(`rmdir: failed to remove '${p.rawPath}': Directory not empty`)
+        continue
+      }
       if (verbose) lines.push(`rmdir: removing directory, '${p.rawPath}'`)
     }
     const out = lines.length > 0 ? formatRecords(lines) : null

--- a/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
@@ -26,6 +26,7 @@ import {
   resolveGlobOf,
   supports,
   withDirGuard,
+  withNamespaceChildren,
   withPathGuards,
 } from './adapter.ts'
 import { BUILDERS } from './builders/index.ts'
@@ -162,17 +163,9 @@ export function makeGenericCommands<A extends Accessor = Accessor>(
     // only because a mount or a link sits under it is invisible to the
     // backend, so the guard has to close over an adapter that already
     // carries globChildren.
-    // The conditional spread is not a leftover: exactOptionalPropertyTypes
-    // refuses an explicit `undefined` for an optional field, so an absent
-    // namespace has to mean an absent key rather than an undefined value.
-    // Python's `glob_children` is `| None` and takes the uniform path.
     const fn: CommandFn = (accessor, paths, texts, opts) =>
       b.fn(
-        withDirGuard(
-          opts.ns?.childMounts === undefined
-            ? cmdOps
-            : { ...cmdOps, globChildren: opts.ns.childMounts },
-        ),
+        withDirGuard(withNamespaceChildren(cmdOps, opts.ns?.childMounts)),
         accessor,
         paths,
         texts,

--- a/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
@@ -26,7 +26,6 @@ import {
   resolveGlobOf,
   supports,
   withDirGuard,
-  withNamespaceChildren,
   withPathGuards,
 } from './adapter.ts'
 import { BUILDERS } from './builders/index.ts'
@@ -118,6 +117,21 @@ function withReadCache<A extends Accessor>(ops: CommandIO<A>): CommandIO<A> {
   }
 }
 
+// The builder tier's cache and slash wraps, chosen at registration from
+// the builder's read/write kind and applied per invocation on top of
+// the path guards (mirror Python's _read_wraps/_stat_wraps/_write_wraps).
+function readWraps<A extends Accessor>(ops: CommandIO<A>): CommandIO<A> {
+  return withSlashGuard(withReadCache(ops))
+}
+
+function statWraps<A extends Accessor>(ops: CommandIO<A>): CommandIO<A> {
+  return withSlashGuard(withStatCache(ops))
+}
+
+function writeWraps<A extends Accessor>(ops: CommandIO<A>): CommandIO<A> {
+  return withSlashGuard(ops)
+}
+
 export interface MakeGenericCommandsOptions<A extends Accessor = Accessor> {
   overrides?: ReadonlySet<string>
   provisionOverrides?: Record<string, ProvisionFn<A>>
@@ -137,35 +151,46 @@ export function makeGenericCommands<A extends Accessor = Accessor>(
   const commands: RegisteredCommand[] = []
   for (const b of BUILDERS) {
     if (skip.has(b.name)) continue
-    // Hidden-path, rule and mode enforcement wrap here, once for every
-    // generic command; the raw adapter stays untouched for the ops
-    // tables, whose door does its own enforcement.
-    const baseOps = withPathGuards((opsOver[b.name] ?? ops) as CommandIO)
+    const raw = (opsOver[b.name] ?? ops) as CommandIO
+    // Path guards are applied per invocation, over the stamped adapter,
+    // inside the command closure below; this registration copy exists
+    // for provision estimates, which bind here and read the session at
+    // call time. The raw adapter stays untouched for the ops tables,
+    // whose door does its own enforcement.
+    const baseOps = withPathGuards(raw)
     // A backend missing an op a command cannot run without (cp/mv/tee/
     // gunzip/...) doesn't get the command registered, rather than getting
     // one that crashes when invoked.
     if (!supports(baseOps, b.requirements ?? [])) continue
-    const cmdOps = withSlashGuard(
-      b.read === true
-        ? withReadCache(baseOps)
-        : b.write === true
-          ? baseOps
-          : withStatCache(baseOps),
-    )
-    // A glob resolved by one backend cannot see a nested mount root or a
-    // symlink: the mount keys live in another resource and no resource
-    // stores a link. The adapter is built once per backend and the names
-    // are session-scoped, so the fact is stamped on per invocation and
-    // every builder keeps calling resolveGlobOf(ops) unchanged.
-    //
-    // withDirGuard wraps here rather than beside the other guards above
-    // because it reads the same namespace fact: a directory that exists
-    // only because a mount or a link sits under it is invisible to the
-    // backend, so the guard has to close over an adapter that already
-    // carries globChildren.
+    const finish = b.read === true ? readWraps : b.write === true ? writeWraps : statWraps
+    // A nested mount's keys live in another resource and no resource
+    // stores a symlink, so a glob resolved by one backend's readdir
+    // misses both. The names are session-scoped, so the fact is stamped
+    // per invocation, and the whole guard chain is applied on top of
+    // the stamped copy: every guard that consumes a namespace fact
+    // simply reads it off the adapter it wraps (glob resolution derives
+    // from globChildren, the dir guard closes over it, the hidden
+    // guard's rmdir captures it for its emptiness judgment). Binding
+    // the guards at registration instead would strand them behind
+    // closures built before any invocation exists, which is exactly the
+    // wiring that made the rmdir guard blind to a mounted child. The
+    // guards read the current session at call time, so per-invocation
+    // binding changes cost, not behavior.
+    // The conditional spread is not a leftover: exactOptionalPropertyTypes
+    // refuses an explicit `undefined` for an optional field, so an absent
+    // namespace has to mean an absent key rather than an undefined value.
+    // Python's `glob_children` is `| None` and takes the uniform path.
     const fn: CommandFn = (accessor, paths, texts, opts) =>
       b.fn(
-        withDirGuard(withNamespaceChildren(cmdOps, opts.ns?.childMounts)),
+        withDirGuard(
+          finish(
+            withPathGuards(
+              opts.ns?.childMounts === undefined
+                ? raw
+                : { ...raw, globChildren: opts.ns.childMounts },
+            ),
+          ),
+        ),
         accessor,
         paths,
         texts,

--- a/typescript/packages/core/src/utils/hidden.test.ts
+++ b/typescript/packages/core/src/utils/hidden.test.ts
@@ -20,6 +20,7 @@ import {
   hideDepth,
   hidesIntersect,
   isGlob,
+  moveReveals,
   pathCovers,
   pathHidden,
   pathVisible,
@@ -313,5 +314,41 @@ describe('a globbed show keeps its anchor traversable', () => {
     const rehidden = classifyPaths(['/repo', '/repo/public'])
     expect(pathVisible(rehidden, shown, '/repo/public')).toBe(false)
     expect(pathVisible(rehidden, shown, '/repo/public/index.html')).toBe(false)
+  })
+})
+
+describe('moveReveals', () => {
+  it('an exact entry below the source reveals at its mapped path', () => {
+    const spec = classifyPaths(['/m/data/secret'])
+    expect(moveReveals(spec, null, '/m/data', '/m/moved')).toBe(true)
+    expect(moveReveals(spec, null, '/m/other', '/m/moved')).toBe(false)
+    // The entry itself is the source: the operand is hidden and the
+    // per-path guard answered before this predicate is asked.
+    expect(moveReveals(spec, null, '/m/data/secret/deep', '/m/x')).toBe(false)
+    expect(moveReveals(null, null, '/m/data', '/m/moved')).toBe(false)
+  })
+
+  it('no reveal when the mapped path stays hidden', () => {
+    const spec = classifyPaths(['/m/d/sec', '/m/moved/sec'])
+    expect(moveReveals(spec, null, '/m/d', '/m/moved')).toBe(false)
+    expect(moveReveals(spec, null, '/m/d', '/m/elsewhere')).toBe(true)
+  })
+
+  it('component patterns follow the name and never reveal', () => {
+    expect(moveReveals(classifyPaths(['*.env']), null, '/m/d', '/m/moved')).toBe(false)
+  })
+
+  it('anchored patterns fail toward refusal', () => {
+    expect(moveReveals(classifyPaths(['/m/d/sec/*']), null, '/m/d', '/m/moved')).toBe(true)
+    expect(moveReveals(classifyPaths(['/m/d/*']), null, '/m/d', '/m/moved')).toBe(true)
+    expect(moveReveals(classifyPaths(['/m/*/secret']), null, '/m/d', '/m/moved')).toBe(true)
+    expect(moveReveals(classifyPaths(['/other/*/secret']), null, '/m/d', '/m/moved')).toBe(false)
+  })
+
+  it('a show below the mapped path counts as a reveal', () => {
+    const hidden = classifyPaths(['/m/d/sec', '/m/moved'])
+    const shown = classifyShows([{ path: '/m/moved/sec/open', mode: null }])
+    expect(moveReveals(hidden, shown, '/m/d', '/m/moved')).toBe(true)
+    expect(moveReveals(hidden, null, '/m/d', '/m/moved')).toBe(false)
   })
 })

--- a/typescript/packages/core/src/utils/hidden.ts
+++ b/typescript/packages/core/src/utils/hidden.ts
@@ -347,6 +347,51 @@ export function hidesIntersect(hidden: HiddenPaths | null | undefined, virtual: 
     })
 }
 
+/**
+ * Whether relocating `src` to `dst` could surface a hidden path.
+ *
+ * The reveal half of the subtree law: a session's mutation may destroy
+ * what it cannot see (`rm -r`, a remnant `rmdir`), but may never reveal
+ * it, and a rename or a native directory copy is the relocation that
+ * would. Three arms, one per entry kind. A component pattern follows
+ * the name wherever the content goes, so it never reveals. An exact
+ * entry anchored strictly below `src` re-anchors to `dst` plus its
+ * suffix, and reveals when the session would see that mapped path (a
+ * show anchored below the mapped path counts, through `pathVisible`'s
+ * own carve-out rule). An anchored pattern's coverage does not move
+ * with the content, so any pattern whose match space could reach below
+ * `src` refuses, failing toward refusal the way `readonlyBelow` blames
+ * a pattern.
+ */
+export function moveReveals(
+  hidden: HiddenPaths | null | undefined,
+  shown: ShownPaths | null | undefined,
+  src: string,
+  dst: string,
+): boolean {
+  if (hidden == null) return false
+  const paths = hidden.paths ?? []
+  const patterns = hidden.patterns ?? []
+  if (paths.length === 0 && patterns.length === 0) return false
+  const s = normAbs(src)
+  const d = normAbs(dst)
+  if (s === '/') return true
+  for (const entry of paths) {
+    const e = normAbs(entry)
+    if (!e.startsWith(s + '/')) continue
+    const mapped = (d === '/' ? '' : d) + e.slice(s.length)
+    if (pathVisible(hidden, shown, mapped)) return true
+  }
+  for (const pat of patterns) {
+    if (!pat.includes('/')) continue
+    const head = patternHead(pat)
+    if (head === s || head.startsWith(s + '/') || head === '/' || s.startsWith(head + '/')) {
+      return true
+    }
+  }
+  return false
+}
+
 /** Whether the session's spec hides this variable name. */
 export function varHidden(hidden: HiddenVars | null | undefined, name: string): boolean {
   if (hidden == null) return false

--- a/typescript/packages/core/src/utils/remnants.test.ts
+++ b/typescript/packages/core/src/utils/remnants.test.ts
@@ -1,0 +1,172 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { FileStat, FileType, PathSpec } from '../types.ts'
+import { VisibleRemnant, childSpec, entryName, removeRemnants, visibleBelow } from './remnants.ts'
+
+function spec(virtual: string): PathSpec {
+  return new PathSpec({
+    virtual,
+    directory: virtual.slice(0, virtual.lastIndexOf('/')) || '/',
+    resourcePath: virtual.replace(/^\/+/, ''),
+  })
+}
+
+function nothingVisible(): boolean {
+  return false
+}
+
+function miss(virtual: string): Error {
+  const err = new Error(`ENOENT: ${virtual}`) as Error & { code: string }
+  err.code = 'ENOENT'
+  return err
+}
+
+class TreeChannel {
+  dirs: Set<string>
+  files: Set<string>
+  removed: [string, string][] = []
+  readonly_ = new Set<string>()
+  // Listed but gone by stat time: the mid-walk vanish case.
+  ghosts = new Set<string>()
+
+  constructor(dirs: string[], files: string[]) {
+    this.dirs = new Set(dirs)
+    this.files = new Set(files)
+  }
+
+  readdir(at: PathSpec): Promise<string[]> {
+    const base = at.virtual.replace(/\/+$/, '')
+    if (!this.dirs.has(base)) return Promise.reject(miss(base))
+    const names = new Set<string>()
+    for (const p of [...this.dirs, ...this.files, ...this.ghosts]) {
+      if (p.startsWith(`${base}/`)) {
+        names.add(p.slice(base.length + 1).split('/', 1)[0] ?? '')
+      }
+    }
+    return Promise.resolve([...names].sort())
+  }
+
+  stat(at: PathSpec): Promise<FileStat> {
+    if (this.dirs.has(at.virtual)) {
+      return Promise.resolve(new FileStat({ name: at.virtual, type: FileType.DIRECTORY }))
+    }
+    if (this.files.has(at.virtual)) {
+      return Promise.resolve(new FileStat({ name: at.virtual, type: FileType.TEXT }))
+    }
+    return Promise.reject(miss(at.virtual))
+  }
+
+  unlink(at: PathSpec): Promise<void> {
+    if (this.readonly_.has(at.virtual)) {
+      const err = new Error(`EROFS: ${at.virtual}`) as Error & { code: string }
+      err.code = 'EROFS'
+      return Promise.reject(err)
+    }
+    if (!this.files.has(at.virtual)) return Promise.reject(miss(at.virtual))
+    this.files.delete(at.virtual)
+    this.removed.push(['unlink', at.virtual])
+    return Promise.resolve()
+  }
+
+  rmdir(at: PathSpec): Promise<void> {
+    if (!this.dirs.has(at.virtual)) return Promise.reject(miss(at.virtual))
+    this.dirs.delete(at.virtual)
+    this.removed.push(['rmdir', at.virtual])
+    return Promise.resolve()
+  }
+}
+
+describe('removeRemnants', () => {
+  it('removes a nested tree children first', async () => {
+    const ch = new TreeChannel(['/d', '/d/sub'], ['/d/a', '/d/sub/b'])
+    await removeRemnants(ch, nothingVisible, spec('/d'))
+    expect(ch.dirs.size).toBe(0)
+    expect(ch.files.size).toBe(0)
+    const unlinked = ch.removed.findIndex(([, p]) => p === '/d/sub/b')
+    const subGone = ch.removed.findIndex(([op, p]) => op === 'rmdir' && p === '/d/sub')
+    expect(unlinked).toBeLessThan(subGone)
+    expect(ch.removed[ch.removed.length - 1]).toEqual(['rmdir', '/d'])
+  })
+
+  it('aborts on a visible entry before it is touched', async () => {
+    const ch = new TreeChannel(['/d', '/d/sec'], ['/d/sec/k', '/d/sec/new.txt'])
+    await expect(
+      removeRemnants(ch, (v) => v === '/d/sec/new.txt', spec('/d')),
+    ).rejects.toBeInstanceOf(VisibleRemnant)
+    expect(ch.files.has('/d/sec/new.txt')).toBe(true)
+    expect(ch.dirs.has('/d')).toBe(true)
+    expect(ch.dirs.has('/d/sec')).toBe(true)
+  })
+
+  it('treats entries vanished mid-walk as completed removals', async () => {
+    const ch = new TreeChannel(['/d'], ['/d/a'])
+    ch.ghosts.add('/d/ghost')
+    await removeRemnants(ch, nothingVisible, spec('/d'))
+    expect(ch.dirs.size).toBe(0)
+    expect(ch.files.size).toBe(0)
+  })
+
+  it('is done when the directory vanished before its listing', async () => {
+    const ch = new TreeChannel([], [])
+    await removeRemnants(ch, nothingVisible, spec('/d'))
+    expect(ch.removed).toEqual([])
+  })
+
+  it('propagates a channel refusal to the caller', async () => {
+    // The channel carries the plane's mode axis; a read-only entry
+    // refuses the deletion and the cascade must surface that, so the
+    // arm can fall back to its original refusal.
+    const ch = new TreeChannel(['/d'], ['/d/k'])
+    ch.readonly_.add('/d/k')
+    await expect(removeRemnants(ch, nothingVisible, spec('/d'))).rejects.toMatchObject({
+      code: 'EROFS',
+    })
+    expect(ch.dirs.has('/d')).toBe(true)
+    expect(ch.files.has('/d/k')).toBe(true)
+  })
+})
+
+describe('visibleBelow', () => {
+  it('normalizes slashes and whole paths to child names', () => {
+    const seen: string[] = []
+    const probe = (v: string): boolean => {
+      seen.push(v)
+      return v === '/d/pub'
+    }
+    expect(visibleBelow('/d/', ['sec/', '/d/pub'], probe)).toBe(true)
+    expect(seen).toEqual(['/d/sec', '/d/pub'])
+    expect(visibleBelow('/d', ['sec', 'hidden.txt'], nothingVisible)).toBe(false)
+  })
+})
+
+describe('entryName', () => {
+  it('takes the last component', () => {
+    expect(entryName('sub/')).toBe('sub')
+    expect(entryName('/a/b/c')).toBe('c')
+    expect(entryName('plain')).toBe('plain')
+  })
+})
+
+describe('childSpec', () => {
+  it('appends to the resource key', () => {
+    const parent = new PathSpec({ virtual: '/m/d', directory: '/m', resourcePath: 'd' })
+    const child = childSpec(parent, 'x')
+    expect(child.virtual).toBe('/m/d/x')
+    expect(child.resourcePath).toBe('d/x')
+    const root = new PathSpec({ virtual: '/m', directory: '/', resourcePath: '' })
+    expect(childSpec(root, 'x').resourcePath).toBe('x')
+  })
+})

--- a/typescript/packages/core/src/utils/remnants.ts
+++ b/typescript/packages/core/src/utils/remnants.ts
@@ -1,0 +1,149 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { FileStat, FileType, PathSpec } from '../types.ts'
+import { isMissingPath } from './errors.ts'
+
+export type Allowed = (virtual: string) => boolean
+
+/**
+ * A remnant cascade met an entry the session can see.
+ *
+ * Thrown by `removeRemnants` before the visible entry is touched: the
+ * caller's not-empty refusal is then simply true in the session's own
+ * view, so every arm answers this by re-raising that original refusal
+ * rather than deleting visible data.
+ */
+export class VisibleRemnant extends Error {
+  readonly code = 'ENOTEMPTY'
+  readonly virtual: string
+
+  constructor(virtual: string) {
+    super(`ENOTEMPTY: directory not empty, '${virtual}'`)
+    this.name = 'VisibleRemnant'
+    this.virtual = virtual
+  }
+}
+
+/**
+ * The four ops a remnant cascade speaks, on one plane's own protected
+ * channel.
+ *
+ * The channel carries every protection axis except visibility: a
+ * deletion must still answer for its path's mode and rules exactly as
+ * a first-class op would (the command plane binds its mode- and
+ * rule-guarded slots, the dispatcher routes through its own fenced op
+ * door), while the visibility filter stays off because the cascade
+ * exists to see and destroy what the session cannot. The cascade never
+ * sprinkles those checks itself; wiring a raw, unguarded channel here
+ * is the bug this contract exists to prevent.
+ */
+export interface RemnantChannel {
+  readdir(spec: PathSpec): Promise<string[]>
+  stat(spec: PathSpec): Promise<unknown>
+  unlink(spec: PathSpec): Promise<void>
+  rmdir(spec: PathSpec): Promise<void>
+}
+
+/**
+ * One listing entry's bare child name. Cold object-store listings mark
+ * a directory with a trailing slash, and some backends report whole
+ * paths rather than names; both normalize to the last component.
+ */
+export function entryName(entry: string): string {
+  const trimmed = entry.replace(/\/+$/, '')
+  return trimmed.slice(trimmed.lastIndexOf('/') + 1)
+}
+
+/**
+ * Whether any listed name is visible as a child of `base`.
+ *
+ * The one emptiness predicate every remnant arm judges with, fed every
+ * name source its plane can enumerate (the backend listing, and on the
+ * ops plane the namespace's merged children too), so "visibly empty"
+ * cannot mean different things at different doors.
+ */
+export function visibleBelow(base: string, names: Iterable<string>, allowed: Allowed): boolean {
+  const root = base.replace(/\/+$/, '')
+  for (const name of names) {
+    if (allowed(`${root}/${entryName(name)}`)) return true
+  }
+  return false
+}
+
+/** The child PathSpec one cascade step descends to. */
+export function childSpec(spec: PathSpec, name: string): PathSpec {
+  const base = spec.virtual.replace(/\/+$/, '')
+  const key = spec.resourcePath.replace(/\/+$/, '')
+  return new PathSpec({
+    virtual: `${base}/${name}`,
+    directory: spec.virtual,
+    resourcePath: key === '' ? name : `${key}/${name}`,
+  })
+}
+
+/**
+ * Remove one directory and everything under it, children first,
+ * revalidating visibility at every step.
+ *
+ * The walk lists raw, but the moment any entry is visible the whole
+ * cascade aborts with `VisibleRemnant` before that entry is touched:
+ * between the caller's classification and each deletion another writer
+ * may have created something visible, and destroying it would turn an
+ * ostensibly empty rmdir into data loss. An entry that vanishes
+ * mid-walk is a completed removal (a prefix-store directory disappears
+ * with its last child), not an error. Every op goes through the
+ * channel, so the plane's other protections refuse exactly as they
+ * would a first-class op; the caller answers any cascade failure with
+ * its original refusal.
+ */
+export async function removeRemnants(
+  channel: RemnantChannel,
+  allowed: Allowed,
+  spec: PathSpec,
+): Promise<void> {
+  let entries: string[]
+  try {
+    entries = await channel.readdir(spec)
+  } catch (err) {
+    if (isMissingPath(err)) return
+    throw err
+  }
+  for (const entry of entries) {
+    const name = entryName(entry)
+    const child = childSpec(spec, name)
+    if (allowed(child.virtual)) throw new VisibleRemnant(child.virtual)
+    let row: unknown
+    try {
+      row = await channel.stat(child)
+    } catch (err) {
+      if (isMissingPath(err)) continue
+      throw err
+    }
+    if (row instanceof FileStat && row.type === FileType.DIRECTORY) {
+      await removeRemnants(channel, allowed, child)
+    } else {
+      try {
+        await channel.unlink(child)
+      } catch (err) {
+        if (!isMissingPath(err)) throw err
+      }
+    }
+  }
+  try {
+    await channel.rmdir(spec)
+  } catch (err) {
+    if (!isMissingPath(err)) throw err
+  }
+}

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -64,7 +64,13 @@ import {
   POLICY_WRITE_OPS,
   SETATTR_KEYS,
 } from './constants.ts'
-import { effectivePathMode, getCurrentSession, pathAllowed } from '../../context/session_context.ts'
+import {
+  effectivePathMode,
+  getCurrentSession,
+  hiddenPathsIntersect,
+  pathAllowed,
+} from '../../context/session_context.ts'
+import { moveReveals } from '../../utils/hidden.ts'
 
 const NOOP_ACCESSOR_INSTANCE = new NOOPAccessor()
 
@@ -189,6 +195,20 @@ export class Dispatcher {
     const dstArg = args?.[0]
     if (opName === 'rename' && dstArg instanceof PathSpec && !pathAllowed(dstArg.virtual)) {
       throw eacces(dstArg.virtual)
+    }
+    if (opName === 'rename' && dstArg instanceof PathSpec) {
+      // A rename re-anchors everything below its source while the hides
+      // stay where they are written, so hidden content would land at
+      // paths the session can see. Destroying hidden content is silent
+      // (rmR, the remnant rmdir below); relocating it into view is
+      // refused.
+      const sess = getCurrentSession()
+      if (
+        sess !== null &&
+        moveReveals(sess.hiddenPaths, sess.shownPaths, path.virtual, dstArg.virtual)
+      ) {
+        throw eacces(path.virtual)
+      }
     }
     if (this.tableAnswers(opName, path.virtual, kwargs)) {
       return [
@@ -375,13 +395,19 @@ export class Dispatcher {
         ),
       )
     } catch (err) {
-      const fallback = isMissingPath(err) ? this.namespaceResult(opName, p.virtual) : null
-      if (fallback === null) {
-        await this.reconciler.onOpMissing(opName, p.virtual, err)
-        throw err
+      const code = (err as { code?: string }).code
+      if (opName === 'rmdir' && (code === 'ENOTEMPTY' || code === 'EEXIST')) {
+        await this.rmdirRemnants(resource, scope, err)
+        result = null
+      } else {
+        const fallback = isMissingPath(err) ? this.namespaceResult(opName, p.virtual) : null
+        if (fallback === null) {
+          await this.reconciler.onOpMissing(opName, p.virtual, err)
+          throw err
+        }
+        result = fallback
+        memoryAnswered(report)
       }
-      result = fallback
-      memoryAnswered(report)
     }
     // The op ran, whatever invalidation, the post gate, or an output
     // cap do next: stamped here so a failure in any of them cannot
@@ -433,6 +459,87 @@ export class Dispatcher {
    * the follow below rewrote it to the target. Mirrors Python's
    * Dispatcher._table_answers.
    */
+  /**
+   * Take a visibly-empty directory's hidden remnants with it.
+   *
+   * The backend refused the rmdir because entries remain, but when the
+   * session's view of the directory is empty the refusal would leak
+   * that something invisible exists. A session's mutation may destroy
+   * what it cannot see, never learn of it, so the remnants go with the
+   * directory; a visible child, or a backend with no recursive remove
+   * to take them, re-raises the backend's refusal.
+   */
+  private async rmdirRemnants(resource: Resource, path: PathSpec, refusal: unknown): Promise<void> {
+    if (!hiddenPathsIntersect(path.virtual)) throw refusal
+    const accessor = resource.accessor ?? NOOP_ACCESSOR_INSTANCE
+    let entries: unknown
+    try {
+      entries = await this.opsRegistry.call('readdir', resource.kind, accessor, path)
+    } catch {
+      // A backend that cannot list (or later, remove) the remnants
+      // keeps the original refusal: the door has no way to take them.
+      throw refusal
+    }
+    if (!Array.isArray(entries)) throw refusal
+    const base = path.virtual.replace(/\/+$/, '')
+    const visible = entries.some((e) => {
+      const trimmed = String(e).replace(/\/+$/, '')
+      return pathAllowed(`${base}/${trimmed.slice(trimmed.lastIndexOf('/') + 1)}`)
+    })
+    if (entries.length === 0 || visible) throw refusal
+    try {
+      await this.removeSubtree(resource, path)
+    } catch {
+      throw refusal
+    }
+  }
+
+  /**
+   * Remove one directory and everything under it, entry by entry.
+   *
+   * No backend registers a recursive-remove op at this door, so the
+   * remnant removal walks the raw listings itself, children first. An
+   * entry that vanishes mid-walk is a completed removal (a prefix-store
+   * directory disappears with its last child), not an error.
+   */
+  private async removeSubtree(resource: Resource, spec: PathSpec): Promise<void> {
+    const accessor = resource.accessor ?? NOOP_ACCESSOR_INSTANCE
+    const entries = await this.opsRegistry.call('readdir', resource.kind, accessor, spec)
+    if (!Array.isArray(entries)) return
+    const base = spec.virtual.replace(/\/+$/, '')
+    const baseKey = spec.resourcePath.replace(/\/+$/, '')
+    for (const entry of entries) {
+      const trimmed = String(entry).replace(/\/+$/, '')
+      const name = trimmed.slice(trimmed.lastIndexOf('/') + 1)
+      const child = new PathSpec({
+        virtual: `${base}/${name}`,
+        directory: spec.virtual,
+        resourcePath: baseKey === '' ? name : `${baseKey}/${name}`,
+      })
+      let row: unknown
+      try {
+        row = await this.opsRegistry.call('stat', resource.kind, accessor, child)
+      } catch (err) {
+        if (isMissingPath(err)) continue
+        throw err
+      }
+      if (row instanceof FileStat && row.type === FileType.DIRECTORY) {
+        await this.removeSubtree(resource, child)
+      } else {
+        try {
+          await this.opsRegistry.call('unlink', resource.kind, accessor, child)
+        } catch (err) {
+          if (!isMissingPath(err)) throw err
+        }
+      }
+    }
+    try {
+      await this.opsRegistry.call('rmdir', resource.kind, accessor, spec)
+    } catch (err) {
+      if (!isMissingPath(err)) throw err
+    }
+  }
+
   private tableAnswers(
     opName: string,
     virtual: string,

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -576,7 +576,9 @@ export class Dispatcher {
    * namespace's children (nested mounts, links) and judged by
    * visibility, so a visible child no backend can see keeps the
    * refusal instead of reporting a successful rmdir while the mounted
-   * child remains.
+   * child remains. The namespace's own hidden nodes under the subtree
+   * (links, attr overlays) are purged with it, so the removed tree
+   * cannot resurface from the node table once the hide lifts.
    */
   private async rmdirRemnants(
     resource: Resource,
@@ -616,6 +618,22 @@ export class Dispatcher {
     } catch {
       throw refusal
     }
+    // The namespace's own nodes under the subtree go with it: a hidden
+    // link is invisible to every backend, so the walk above cannot
+    // take it, and left in the table it would resurface the removed
+    // tree the moment the hide lifts (a link synthesizes its
+    // ancestors). Classification proved every link below is hidden --
+    // a visible one contributes its child segment to the merged
+    // listing above -- so this is the walk's own revalidate-then-
+    // destroy applied to the name plane: a link that became visible
+    // mid-cascade keeps the refusal like any visible remnant, and the
+    // purge also drops the attr overlays of paths the cascade just
+    // destroyed, as `rm` does.
+    const base = rstripSlash(path.virtual) + '/'
+    for (const link of this.namespace.symlinkTargets().keys()) {
+      if (link.startsWith(base) && pathAllowed(link)) throw refusal
+    }
+    await this.namespace.purgeUnder(path.virtual)
   }
 
   private tableAnswers(

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -71,6 +71,7 @@ import {
   pathAllowed,
 } from '../../context/session_context.ts'
 import { moveReveals } from '../../utils/hidden.ts'
+import { removeRemnants, visibleBelow, type RemnantChannel } from '../../utils/remnants.ts'
 
 const NOOP_ACCESSOR_INSTANCE = new NOOPAccessor()
 
@@ -399,7 +400,7 @@ export class Dispatcher {
     } catch (err) {
       const code = (err as { code?: string }).code
       if (opName === 'rmdir' && (code === 'ENOTEMPTY' || code === 'EEXIST')) {
-        await this.rmdirRemnants(resource, scope, err)
+        await this.rmdirRemnants(resource, scope, mountPrefix, mode, err)
         result = null
       } else {
         const fallback = isMissingPath(err) ? this.namespaceResult(opName, p.virtual) : null
@@ -471,6 +472,47 @@ export class Dispatcher {
   }
 
   /**
+   * The door's own channel for internal walks: the TS twin of Python's
+   * Mount.execute_op. The same mode fence, index stamping and
+   * mount-prefix context normal dispatch applies, plus the
+   * dispatcher's own write invalidation, because raw registry calls
+   * run outside the cache context dispatch establishes, so the cores'
+   * invalidation cannot land. Invalidation runs even when the op
+   * fails: a missing-path failure means the tree changed under the
+   * walk, and the walk's own earlier listing is exactly the entry that
+   * must not survive. Only the visibility filter stays off, which is
+   * what lets a remnant walk see hidden entries. Every internal
+   * registry call in this class routes through here; a bare
+   * opsRegistry.call outside dispatch is a bug.
+   */
+  private async fencedCall(
+    resource: Resource,
+    mountPrefix: string,
+    mode: MountMode,
+    opName: string,
+    spec: PathSpec,
+  ): Promise<unknown> {
+    const write = this.opsRegistry.find(opName, resource.kind)?.write === true
+    if (write && effectivePathMode(spec.virtual, mountPrefix, mode) === MountMode.READ) {
+      throw erofsReadOnly(`mount at '${spec.virtual}' is read-only`, spec)
+    }
+    try {
+      return await runWithMountPrefix(rstripSlash(mountPrefix), () =>
+        this.opsRegistry.call(
+          opName,
+          resource.kind,
+          resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+          spec,
+          [],
+          this.indexKwargs(resource),
+        ),
+      )
+    } finally {
+      if (write) await this.invalidateAfterWriteByPath(spec.virtual)
+    }
+  }
+
+  /**
    * Whether a rename's source stats as a directory.
    *
    * Only a directory can carry hidden content into view, so the reveal
@@ -488,16 +530,15 @@ export class Dispatcher {
       // No mount to ask; classification fails toward refusal.
       return true
     }
-    const [resource, scope] = resolved
+    const [resource, scope, mode] = resolved
     let row: unknown
     try {
-      row = await this.opsRegistry.call(
+      row = await this.fencedCall(
+        resource,
+        this.namespace.mountFor(path.virtual).prefix,
+        mode,
         'stat',
-        resource.kind,
-        resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
         scope,
-        [],
-        this.indexKwargs(resource),
       )
     } catch (err) {
       // An absent source moves nothing; the rename itself reports it.
@@ -515,100 +556,53 @@ export class Dispatcher {
    * session's view of the directory is empty the refusal would leak
    * that something invisible exists. A session's mutation may destroy
    * what it cannot see, never learn of it, so the remnants go with the
-   * directory; a visible child, or a backend with no recursive remove
-   * to take them, re-raises the backend's refusal.
+   * directory through the shared removeRemnants walk; a visible child,
+   * or any cascade failure (a mode-protected entry, a visible entry
+   * appearing mid-walk), re-raises the backend's refusal. Emptiness is
+   * the door's own readdir pipeline: backend entries merged with the
+   * namespace's children (nested mounts, links) and judged by
+   * visibility, so a visible child no backend can see keeps the
+   * refusal instead of reporting a successful rmdir while the mounted
+   * child remains.
    */
-  private async rmdirRemnants(resource: Resource, path: PathSpec, refusal: unknown): Promise<void> {
+  private async rmdirRemnants(
+    resource: Resource,
+    path: PathSpec,
+    mountPrefix: string,
+    mode: MountMode,
+    refusal: unknown,
+  ): Promise<void> {
     if (!hiddenPathsIntersect(path.virtual)) throw refusal
-    const accessor = resource.accessor ?? NOOP_ACCESSOR_INSTANCE
     let entries: unknown
     try {
-      entries = await this.opsRegistry.call(
-        'readdir',
-        resource.kind,
-        accessor,
-        path,
-        [],
-        this.indexKwargs(resource),
-      )
+      entries = await this.fencedCall(resource, mountPrefix, mode, 'readdir', path)
     } catch {
       // A backend that cannot list (or later, remove) the remnants
       // keeps the original refusal: the door has no way to take them.
       throw refusal
     }
     if (!Array.isArray(entries)) throw refusal
-    const base = path.virtual.replace(/\/+$/, '')
-    const visible = entries.some((e) => {
-      const trimmed = String(e).replace(/\/+$/, '')
-      return pathAllowed(`${base}/${trimmed.slice(trimmed.lastIndexOf('/') + 1)}`)
-    })
-    if (entries.length === 0 || visible) throw refusal
+    const names = entries.map(String)
+    const merged = mergeReaddir(names, this.namespace.mountPrefixes(), this.namespace, path.virtual)
+    if (names.length === 0 || visibleBelow(path.virtual, merged, pathAllowed)) throw refusal
+    const channel: RemnantChannel = {
+      readdir: async (at) => {
+        const listed = await this.fencedCall(resource, mountPrefix, mode, 'readdir', at)
+        return Array.isArray(listed) ? listed.map(String) : []
+      },
+      stat: (at) => this.fencedCall(resource, mountPrefix, mode, 'stat', at),
+      unlink: async (at) => {
+        await this.fencedCall(resource, mountPrefix, mode, 'unlink', at)
+      },
+      rmdir: async (at) => {
+        await this.fencedCall(resource, mountPrefix, mode, 'rmdir', at)
+      },
+    }
     try {
-      await this.removeSubtree(resource, path)
+      await removeRemnants(channel, pathAllowed, path)
     } catch {
       throw refusal
     }
-  }
-
-  /**
-   * Remove one directory and everything under it, entry by entry.
-   *
-   * No backend registers a recursive-remove op at this door, so the
-   * remnant removal walks the raw listings itself, children first. An
-   * entry that vanishes mid-walk is a completed removal (a prefix-store
-   * directory disappears with its last child), not an error. Each
-   * removal invalidates through the dispatcher's own door: the raw
-   * registry calls run outside the cache context normal dispatch
-   * establishes, so the cores' own invalidation cannot land, and the
-   * listing the walk itself put in the index would otherwise keep the
-   * removed directory answering "exists" to a readdir-backed probe.
-   */
-  private async removeSubtree(resource: Resource, spec: PathSpec): Promise<void> {
-    const accessor = resource.accessor ?? NOOP_ACCESSOR_INSTANCE
-    const kwargs = this.indexKwargs(resource)
-    const entries = await this.opsRegistry.call(
-      'readdir',
-      resource.kind,
-      accessor,
-      spec,
-      [],
-      kwargs,
-    )
-    if (!Array.isArray(entries)) return
-    const base = spec.virtual.replace(/\/+$/, '')
-    const baseKey = spec.resourcePath.replace(/\/+$/, '')
-    for (const entry of entries) {
-      const trimmed = String(entry).replace(/\/+$/, '')
-      const name = trimmed.slice(trimmed.lastIndexOf('/') + 1)
-      const child = new PathSpec({
-        virtual: `${base}/${name}`,
-        directory: spec.virtual,
-        resourcePath: baseKey === '' ? name : `${baseKey}/${name}`,
-      })
-      let row: unknown
-      try {
-        row = await this.opsRegistry.call('stat', resource.kind, accessor, child, [], kwargs)
-      } catch (err) {
-        if (isMissingPath(err)) continue
-        throw err
-      }
-      if (row instanceof FileStat && row.type === FileType.DIRECTORY) {
-        await this.removeSubtree(resource, child)
-      } else {
-        try {
-          await this.opsRegistry.call('unlink', resource.kind, accessor, child, [], kwargs)
-        } catch (err) {
-          if (!isMissingPath(err)) throw err
-        }
-        await this.invalidateAfterWriteByPath(child.virtual)
-      }
-    }
-    try {
-      await this.opsRegistry.call('rmdir', resource.kind, accessor, spec, [], kwargs)
-    } catch (err) {
-      if (!isMissingPath(err)) throw err
-    }
-    await this.invalidateAfterWriteByPath(spec.virtual)
   }
 
   private tableAnswers(

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -473,8 +473,10 @@ export class Dispatcher {
 
   /**
    * The door's own channel for internal walks: the TS twin of Python's
-   * Mount.execute_op. The same mode fence, index stamping and
-   * mount-prefix context normal dispatch applies, plus the
+   * Mount.execute_op plus the dispatcher-side duties around it. The
+   * same mode fence, index stamping and mount-prefix context normal
+   * dispatch applies, plus the pre-ops admission for writes (Python
+   * spells this on the channel as `_admit_cascade`) and the
    * dispatcher's own write invalidation, because raw registry calls
    * run outside the cache context dispatch establishes, so the cores'
    * invalidation cannot land. Invalidation runs even when the op
@@ -493,8 +495,19 @@ export class Dispatcher {
     spec: PathSpec,
   ): Promise<unknown> {
     const write = this.opsRegistry.find(opName, resource.kind)?.write === true
-    if (write && effectivePathMode(spec.virtual, mountPrefix, mode) === MountMode.READ) {
-      throw erofsReadOnly(`mount at '${spec.virtual}' is read-only`, spec)
+    if (write) {
+      // The same pre-ops admission a dispatched op answers, with the
+      // walk's own child path: the gate that admitted the rmdir judged
+      // the directory, not what the cascade found under it, and a
+      // policy that protects one of those paths must refuse its
+      // deletion exactly as it would refuse a first-class op. The
+      // caller folds the denial into its original refusal, so a
+      // policy's protection of a hidden path never surfaces as its own
+      // denial.
+      await preOpsGate(this.policies, opName, spec, true, mountPrefix, sessionId())
+      if (effectivePathMode(spec.virtual, mountPrefix, mode) === MountMode.READ) {
+        throw erofsReadOnly(`mount at '${spec.virtual}' is read-only`, spec)
+      }
     }
     try {
       return await runWithMountPrefix(rstripSlash(mountPrefix), () =>

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -201,11 +201,13 @@ export class Dispatcher {
       // stay where they are written, so hidden content would land at
       // paths the session can see. Destroying hidden content is silent
       // (rmR, the remnant rmdir below); relocating it into view is
-      // refused.
+      // refused. Only a directory has anything below it to re-anchor,
+      // so a file source passes.
       const sess = getCurrentSession()
       if (
         sess !== null &&
-        moveReveals(sess.hiddenPaths, sess.shownPaths, path.virtual, dstArg.virtual)
+        moveReveals(sess.hiddenPaths, sess.shownPaths, path.virtual, dstArg.virtual) &&
+        (await this.movedSourceIsDir(path))
       ) {
         throw eacces(path.virtual)
       }
@@ -460,6 +462,53 @@ export class Dispatcher {
    * Dispatcher._table_answers.
    */
   /**
+   * The index kwargs normal dispatch stamps on every registered op, for
+   * the door's own raw registry calls: an indexed backend cannot
+   * resolve a nested path without it.
+   */
+  private indexKwargs(resource: Resource): OpKwargs {
+    return resource.index !== undefined ? { index: resource.index } : {}
+  }
+
+  /**
+   * Whether a rename's source stats as a directory.
+   *
+   * Only a directory can carry hidden content into view, so the reveal
+   * refusal probes the source before it fires and lets a file rename
+   * pass. An absent source moves nothing (the rename itself reports
+   * it); a source the mount cannot classify fails toward refusal, the
+   * same stance the pattern arm takes. Mirrors Python's
+   * Dispatcher._moved_source_is_dir.
+   */
+  private async movedSourceIsDir(path: PathSpec): Promise<boolean> {
+    let resolved: [Resource, PathSpec, MountMode]
+    try {
+      resolved = await this.namespace.resolve(path.virtual, false)
+    } catch {
+      // No mount to ask; classification fails toward refusal.
+      return true
+    }
+    const [resource, scope] = resolved
+    let row: unknown
+    try {
+      row = await this.opsRegistry.call(
+        'stat',
+        resource.kind,
+        resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+        scope,
+        [],
+        this.indexKwargs(resource),
+      )
+    } catch (err) {
+      // An absent source moves nothing; the rename itself reports it.
+      if (isMissingPath(err)) return false
+      // Unanswerable classification fails toward refusal.
+      return true
+    }
+    return !(row instanceof FileStat) || row.type === FileType.DIRECTORY
+  }
+
+  /**
    * Take a visibly-empty directory's hidden remnants with it.
    *
    * The backend refused the rmdir because entries remain, but when the
@@ -474,7 +523,14 @@ export class Dispatcher {
     const accessor = resource.accessor ?? NOOP_ACCESSOR_INSTANCE
     let entries: unknown
     try {
-      entries = await this.opsRegistry.call('readdir', resource.kind, accessor, path)
+      entries = await this.opsRegistry.call(
+        'readdir',
+        resource.kind,
+        accessor,
+        path,
+        [],
+        this.indexKwargs(resource),
+      )
     } catch {
       // A backend that cannot list (or later, remove) the remnants
       // keeps the original refusal: the door has no way to take them.
@@ -500,11 +556,24 @@ export class Dispatcher {
    * No backend registers a recursive-remove op at this door, so the
    * remnant removal walks the raw listings itself, children first. An
    * entry that vanishes mid-walk is a completed removal (a prefix-store
-   * directory disappears with its last child), not an error.
+   * directory disappears with its last child), not an error. Each
+   * removal invalidates through the dispatcher's own door: the raw
+   * registry calls run outside the cache context normal dispatch
+   * establishes, so the cores' own invalidation cannot land, and the
+   * listing the walk itself put in the index would otherwise keep the
+   * removed directory answering "exists" to a readdir-backed probe.
    */
   private async removeSubtree(resource: Resource, spec: PathSpec): Promise<void> {
     const accessor = resource.accessor ?? NOOP_ACCESSOR_INSTANCE
-    const entries = await this.opsRegistry.call('readdir', resource.kind, accessor, spec)
+    const kwargs = this.indexKwargs(resource)
+    const entries = await this.opsRegistry.call(
+      'readdir',
+      resource.kind,
+      accessor,
+      spec,
+      [],
+      kwargs,
+    )
     if (!Array.isArray(entries)) return
     const base = spec.virtual.replace(/\/+$/, '')
     const baseKey = spec.resourcePath.replace(/\/+$/, '')
@@ -518,7 +587,7 @@ export class Dispatcher {
       })
       let row: unknown
       try {
-        row = await this.opsRegistry.call('stat', resource.kind, accessor, child)
+        row = await this.opsRegistry.call('stat', resource.kind, accessor, child, [], kwargs)
       } catch (err) {
         if (isMissingPath(err)) continue
         throw err
@@ -527,17 +596,19 @@ export class Dispatcher {
         await this.removeSubtree(resource, child)
       } else {
         try {
-          await this.opsRegistry.call('unlink', resource.kind, accessor, child)
+          await this.opsRegistry.call('unlink', resource.kind, accessor, child, [], kwargs)
         } catch (err) {
           if (!isMissingPath(err)) throw err
         }
+        await this.invalidateAfterWriteByPath(child.virtual)
       }
     }
     try {
-      await this.opsRegistry.call('rmdir', resource.kind, accessor, spec)
+      await this.opsRegistry.call('rmdir', resource.kind, accessor, spec, [], kwargs)
     } catch (err) {
       if (!isMissingPath(err)) throw err
     }
+    await this.invalidateAfterWriteByPath(spec.virtual)
   }
 
   private tableAnswers(

--- a/typescript/packages/core/src/workspace/path_axis.test.ts
+++ b/typescript/packages/core/src/workspace/path_axis.test.ts
@@ -311,3 +311,137 @@ describe('the path axis end to end', () => {
     expect(ok.exitCode).toBe(0)
   })
 })
+
+async function boxed(profile: object): Promise<Workspace> {
+  const parser = await getTestParser()
+  const repo = new RAMResource()
+  const registry = new OpsRegistry()
+  registry.registerResource(repo)
+  const ws = new Workspace(
+    { '/repo': [repo, MountMode.WRITE] as const },
+    { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+  )
+  open.push(ws)
+  const io = await ws.execute(
+    'mkdir -p /repo/box/sec /repo/only && ' +
+      "printf 'v\\n' > /repo/box/a.txt && " +
+      "printf 's\\n' > /repo/box/sec/k && " +
+      "printf 't\\n' > /repo/box/x.tkn && " +
+      "printf 'h\\n' > /repo/only/h",
+  )
+  expect(io.exitCode).toBe(0)
+  ws.createSession('rev', { profile: parseSessionProfile(profile) })
+  return ws
+}
+
+describe('subtree mutations against hides', () => {
+  it('mv that would reveal hidden content refuses', async () => {
+    // The hide anchors at /repo/box/sec; the move would re-anchor its
+    // content to /repo/moved/sec, which nothing hides, so it refuses
+    // in GNU's permission-denied voice and the source stays whole.
+    const ws = await boxed({ paths: { hide: ['/repo/box/sec'] } })
+    const refused = await ws.execute('mv /repo/box /repo/moved', { sessionId: 'rev' })
+    expect(refused.exitCode).toBe(1)
+    expect(stderrStr(refused)).toBe(
+      "mv: cannot move '/repo/box' to '/repo/moved': Permission denied\n",
+    )
+    const intact = await ws.execute('test -e /repo/box/sec/k')
+    expect(intact.exitCode).toBe(0)
+  })
+
+  it('mv rides a component-pattern hide along', async () => {
+    // *.tkn follows the name wherever the content goes, so nothing is
+    // revealed and the move proceeds, the hidden file riding along.
+    const ws = await boxed({ paths: { hide: ['*.tkn'] } })
+    const ok = await ws.execute('mv /repo/box /repo/moved', { sessionId: 'rev' })
+    expect(ok.exitCode).toBe(0)
+    const listing = await ws.execute('ls /repo/moved', { sessionId: 'rev' })
+    expect(stdoutStr(listing)).toBe('a.txt\nsec\n')
+    const survived = await ws.execute('cat /repo/moved/x.tkn')
+    expect(survived.exitCode).toBe(0)
+    expect(stdoutStr(survived)).toBe('t\n')
+  })
+
+  it('cp -r copies the visible view silently', async () => {
+    const ws = await boxed({ paths: { hide: ['/repo/box/sec'] } })
+    const copied = await ws.execute('cp -r /repo/box /repo/copy', { sessionId: 'rev' })
+    expect(copied.exitCode).toBe(0)
+    expect(stderrStr(copied)).toBe('')
+    const listing = await ws.execute('find /repo/copy')
+    expect(stdoutStr(listing)).toBe('/repo/copy\n/repo/copy/a.txt\n/repo/copy/x.tkn\n')
+  })
+
+  it('rmdir takes hidden remnants with the directory', async () => {
+    // The session sees an empty directory; a not-empty refusal would
+    // leak that something invisible exists, so the remnants go with it.
+    const ws = await boxed({ paths: { hide: ['/repo/only/h'] } })
+    const empty = await ws.execute('ls -a /repo/only', { sessionId: 'rev' })
+    expect(stdoutStr(empty)).toBe('')
+    const removed = await ws.execute('rmdir /repo/only', { sessionId: 'rev' })
+    expect(removed.exitCode).toBe(0)
+    const gone = await ws.execute('test -e /repo/only')
+    expect(gone.exitCode).toBe(1)
+  })
+
+  it('rmdir with a visible child keeps the refusal', async () => {
+    const ws = await boxed({ paths: { hide: ['/repo/box/sec'] } })
+    const refused = await ws.execute('rmdir /repo/box', { sessionId: 'rev' })
+    expect(refused.exitCode).toBe(1)
+    expect(stderrStr(refused)).toContain('Directory not empty')
+  })
+
+  it('rm -r still destroys hidden content below', async () => {
+    const ws = await boxed({ paths: { hide: ['/repo/box/sec'] } })
+    const removed = await ws.execute('rm -r /repo/box', { sessionId: 'rev' })
+    expect(removed.exitCode).toBe(0)
+    const gone = await ws.execute('test -e /repo/box')
+    expect(gone.exitCode).toBe(1)
+  })
+})
+
+async function twoMounts(profile: object): Promise<Workspace> {
+  const parser = await getTestParser()
+  const a = new RAMResource()
+  const b = new RAMResource()
+  const registry = new OpsRegistry()
+  registry.registerResource(a)
+  registry.registerResource(b)
+  const ws = new Workspace(
+    { '/a': [a, MountMode.WRITE] as const, '/b': [b, MountMode.WRITE] as const },
+    { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+  )
+  open.push(ws)
+  const io = await ws.execute(
+    'mkdir -p /a/box/sec /a/bag && ' +
+      "printf 'v\\n' > /a/box/a.txt && printf 's\\n' > /a/box/sec/k && " +
+      "printf 't\\n' > /a/bag/x.tkn && printf 'v\\n' > /a/bag/a.txt",
+  )
+  expect(io.exitCode).toBe(0)
+  ws.createSession('rev', { profile: parseSessionProfile(profile) })
+  return ws
+}
+
+describe('cross-mount moves against hides', () => {
+  it('a cross-mount mv refuses the reveal too', async () => {
+    const ws = await twoMounts({ paths: { hide: ['/a/box/sec'] } })
+    const refused = await ws.execute('mv /a/box /b/box', { sessionId: 'rev' })
+    expect(refused.exitCode).toBe(1)
+    expect(stderrStr(refused)).toBe("mv: cannot move '/a/box' to '/b/box': Permission denied\n")
+    const intact = await ws.execute('test -e /a/box/sec/k')
+    expect(intact.exitCode).toBe(0)
+  })
+
+  it('a name-pattern hide moves the visible and drops the remnant', async () => {
+    // The filtered walk cannot copy what the session cannot see, and
+    // refusing here would make EACCES an existence oracle, so the
+    // remove phase takes the remnant with the source: destroy silently,
+    // never reveal.
+    const ws = await twoMounts({ paths: { hide: ['*.tkn'] } })
+    const moved = await ws.execute('mv /a/bag /b/bag', { sessionId: 'rev' })
+    expect(moved.exitCode).toBe(0)
+    const dest = await ws.execute('find /b/bag')
+    expect(stdoutStr(dest)).toBe('/b/bag\n/b/bag/a.txt\n')
+    const gone = await ws.execute('test -e /a/bag')
+    expect(gone.exitCode).toBe(1)
+  })
+})

--- a/typescript/packages/core/src/workspace/path_axis.test.ts
+++ b/typescript/packages/core/src/workspace/path_axis.test.ts
@@ -362,6 +362,40 @@ describe('subtree mutations against hides', () => {
     expect(stdoutStr(survived)).toBe('t\n')
   })
 
+  it('mv of a file under an anchored-pattern hide passes', async () => {
+    // /repo/*/sec could match below any directory under /repo, so a
+    // directory move refuses conservatively, but a regular file
+    // carries nothing below it: renaming one reveals nothing.
+    const ws = await boxed({ paths: { hide: ['/repo/*/sec'] } })
+    const moved = await ws.execute('mv /repo/box/a.txt /repo/box/b.txt', { sessionId: 'rev' })
+    expect(moved.exitCode).toBe(0)
+    const listing = await ws.execute('ls /repo/box', { sessionId: 'rev' })
+    expect(stdoutStr(listing)).toContain('b.txt')
+  })
+
+  it('mv of a directory under an anchored-pattern hide refuses', async () => {
+    const ws = await boxed({ paths: { hide: ['/repo/*/sec'] } })
+    const refused = await ws.execute('mv /repo/box /repo/moved', { sessionId: 'rev' })
+    expect(refused.exitCode).toBe(1)
+    expect(stderrStr(refused)).toContain('Permission denied')
+  })
+
+  it('mv -b refusal leaves the destination backup-free', async () => {
+    // The reveal guard answers before -b renames the destination
+    // aside, so a refused move mutates nothing: no backup, destination
+    // intact.
+    const ws = await boxed({ paths: { hide: ['/repo/box/sec'] } })
+    const prep = await ws.execute('mkdir /repo/moved', { sessionId: 'rev' })
+    expect(prep.exitCode).toBe(0)
+    const refused = await ws.execute('mv -b -T /repo/box /repo/moved', { sessionId: 'rev' })
+    expect(refused.exitCode).toBe(1)
+    expect(stderrStr(refused)).toContain('Permission denied')
+    const intact = await ws.execute('test -d /repo/moved')
+    expect(intact.exitCode).toBe(0)
+    const backup = await ws.execute('test -e /repo/moved~')
+    expect(backup.exitCode).toBe(1)
+  })
+
   it('cp -r copies the visible view silently', async () => {
     const ws = await boxed({ paths: { hide: ['/repo/box/sec'] } })
     const copied = await ws.execute('cp -r /repo/box /repo/copy', { sessionId: 'rev' })

--- a/typescript/packages/core/src/workspace/path_axis.test.ts
+++ b/typescript/packages/core/src/workspace/path_axis.test.ts
@@ -448,6 +448,36 @@ describe('subtree mutations against hides', () => {
     const kept = await ws.execute('cat /repo/only/h')
     expect(stdoutStr(kept)).toBe('h\n')
   })
+
+  it('a mounted child keeps the command plane refusal', async () => {
+    // Command-plane twin of the ops door's merged emptiness: the
+    // backend listing holds only hidden entries, but the namespace
+    // owes the directory a visible mounted child no backend can list.
+    // The stamped children join the guard's emptiness judgment, so the
+    // not-empty refusal stays instead of the cascade destroying the
+    // hidden remnant and reporting success while the mount remains.
+    const parser = await getTestParser()
+    const repo = new RAMResource()
+    const m = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(repo)
+    registry.registerResource(m)
+    const ws = new Workspace(
+      { '/repo': [repo, MountMode.WRITE] as const, '/repo/only/m': [m, MountMode.WRITE] as const },
+      { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+    )
+    open.push(ws)
+    const io = await ws.execute("mkdir -p /repo/only && printf 'h\\n' > /repo/only/h")
+    expect(io.exitCode).toBe(0)
+    ws.createSession('rev', {
+      profile: parseSessionProfile({ paths: { hide: ['/repo/only/h'] } }),
+    })
+    const refused = await ws.execute('rmdir /repo/only', { sessionId: 'rev' })
+    expect(refused.exitCode).toBe(1)
+    expect(stderrStr(refused)).toBe("rmdir: failed to remove '/repo/only': Directory not empty\n")
+    const kept = await ws.execute('cat /repo/only/h')
+    expect(stdoutStr(kept)).toBe('h\n')
+  })
 })
 
 describe('the ops door against hides', () => {

--- a/typescript/packages/core/src/workspace/path_axis.test.ts
+++ b/typescript/packages/core/src/workspace/path_axis.test.ts
@@ -585,6 +585,67 @@ describe('the ops door against hides', () => {
     const kept = await ws.execute('cat /a/d/sec/k')
     expect(stdoutStr(kept)).toBe('k\n')
   })
+
+  it('takes hidden namespace links with the removed directory', async () => {
+    // A hidden link is invisible to every backend, so the cascade walk
+    // cannot take it; left in the node table it synthesizes /a/d right
+    // back once the hide lifts, resurfacing the removed tree.
+    const parser = await getTestParser()
+    const a = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(a)
+    const ws = new Workspace(
+      { '/a': [a, MountMode.WRITE] as const },
+      { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+    )
+    open.push(ws)
+    const io = await ws.execute(
+      "mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k && ln -s /a/t /a/d/lnk",
+    )
+    expect(io.exitCode).toBe(0)
+    const sess = ws.createSession('rev', {
+      profile: parseSessionProfile({ paths: { hide: ['/a/d/sec', '/a/d/lnk'] } }),
+    })
+    await runWithSession(sess, async () => {
+      await ws.dispatch('rmdir', '/a/d')
+    })
+    // No session, no hides: the tree must be gone, link included.
+    const linkless = await ws.execute('readlink /a/d/lnk')
+    expect(linkless.exitCode).not.toBe(0)
+    const gone = await ws.execute('test -e /a/d')
+    expect(gone.exitCode).toBe(1)
+  })
+
+  it('a visible link below keeps the rmdir refusal', async () => {
+    // A visible link joins the merged emptiness judgment, so the
+    // refusal stands and nothing (backend remnant or node table) is
+    // destroyed.
+    const parser = await getTestParser()
+    const a = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(a)
+    const ws = new Workspace(
+      { '/a': [a, MountMode.WRITE] as const },
+      { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+    )
+    open.push(ws)
+    const io = await ws.execute(
+      "mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k && ln -s /a/t /a/d/lnk",
+    )
+    expect(io.exitCode).toBe(0)
+    const sess = ws.createSession('rev', {
+      profile: parseSessionProfile({ paths: { hide: ['/a/d/sec'] } }),
+    })
+    await runWithSession(sess, async () => {
+      await expect(ws.dispatch('rmdir', '/a/d')).rejects.toMatchObject({
+        code: 'ENOTEMPTY',
+      })
+    })
+    const kept = await ws.execute('cat /a/d/sec/k')
+    expect(stdoutStr(kept)).toBe('k\n')
+    const link = await ws.execute('readlink /a/d/lnk')
+    expect(link.exitCode).toBe(0)
+  })
 })
 
 async function twoMounts(profile: object): Promise<Workspace> {

--- a/typescript/packages/core/src/workspace/path_axis.test.ts
+++ b/typescript/packages/core/src/workspace/path_axis.test.ts
@@ -17,9 +17,20 @@ import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { MountMode } from '../types.ts'
 import { parseSessionProfile } from '../policy/profile.ts'
+import type { Action, OpsContext, Policy } from '../policy/index.ts'
 import { runWithSession } from '../context/session_context.ts'
 import { getTestParser, stderrStr, stdoutStr } from './fixtures/workspace_fixture.ts'
 import { Workspace } from './workspace/workspace.ts'
+
+/** Refuse the unlink of one exact path, whatever door asked. */
+class DenyRemnantUnlink implements Policy {
+  preOps(ctx: OpsContext): Action | null {
+    if (ctx.op === 'unlink' && ctx.path.virtual === '/a/d/sec/k') {
+      return { kind: 'deny', reason: 'protected' }
+    }
+    return null
+  }
+}
 
 const CARVE_PROFILE = parseSessionProfile({
   mounts: { '/repo': 'r' },
@@ -525,6 +536,40 @@ describe('the ops door against hides', () => {
     const ws = new Workspace(
       { '/a': [a, MountMode.WRITE] as const, '/a/d/m': [m, MountMode.WRITE] as const },
       { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+    )
+    open.push(ws)
+    const io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k")
+    expect(io.exitCode).toBe(0)
+    const sess = ws.createSession('rev', {
+      profile: parseSessionProfile({ paths: { hide: ['/a/d/sec'] } }),
+    })
+    await runWithSession(sess, async () => {
+      await expect(ws.dispatch('rmdir', '/a/d')).rejects.toMatchObject({
+        code: 'ENOTEMPTY',
+      })
+    })
+    const kept = await ws.execute('cat /a/d/sec/k')
+    expect(stdoutStr(kept)).toBe('k\n')
+  })
+
+  it('a policy denied remnant keeps the refusal', async () => {
+    // The gate that admitted the rmdir judged the directory; each
+    // cascade deletion answers preOps with its own child path, so a
+    // policy that protects the hidden file refuses its unlink, the
+    // cascade folds the denial into the original not-empty refusal,
+    // and the protected content survives.
+    const parser = await getTestParser()
+    const a = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(a)
+    const ws = new Workspace(
+      { '/a': [a, MountMode.WRITE] as const },
+      {
+        mode: MountMode.WRITE,
+        ops: registry,
+        shellParser: parser,
+        policies: [new DenyRemnantUnlink()],
+      },
     )
     open.push(ws)
     const io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k")

--- a/typescript/packages/core/src/workspace/path_axis.test.ts
+++ b/typescript/packages/core/src/workspace/path_axis.test.ts
@@ -17,6 +17,7 @@ import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { MountMode } from '../types.ts'
 import { parseSessionProfile } from '../policy/profile.ts'
+import { runWithSession } from '../context/session_context.ts'
 import { getTestParser, stderrStr, stdoutStr } from './fixtures/workspace_fixture.ts'
 import { Workspace } from './workspace/workspace.ts'
 
@@ -430,6 +431,84 @@ describe('subtree mutations against hides', () => {
     expect(removed.exitCode).toBe(0)
     const gone = await ws.execute('test -e /repo/box')
     expect(gone.exitCode).toBe(1)
+  })
+
+  it('a read-only hidden remnant keeps the refusal', async () => {
+    // A show may state a mode at the same anchor a hide covers (the
+    // hide wins visibility on the tie), leaving content the session
+    // cannot see that its mode still protects. Every cascade deletion
+    // answers for its own path's mode, so the protected remnant
+    // survives and the rmdir keeps a not-empty refusal.
+    const ws = await boxed({
+      paths: { hide: ['/repo/only/h'], show: { '/repo/only/h': 'r' } },
+    })
+    const refused = await ws.execute('rmdir /repo/only', { sessionId: 'rev' })
+    expect(refused.exitCode).toBe(1)
+    expect(stderrStr(refused)).toBe("rmdir: failed to remove '/repo/only': Directory not empty\n")
+    const kept = await ws.execute('cat /repo/only/h')
+    expect(stdoutStr(kept)).toBe('h\n')
+  })
+})
+
+describe('the ops door against hides', () => {
+  it('leaves a read-only hidden remnant intact and keeps the refusal', async () => {
+    // The dispatcher's cascade routes every deletion through the same
+    // mode fence normal dispatch applies, so FUSE and ws.fs callers
+    // cannot destroy a mode-protected remnant either.
+    const parser = await getTestParser()
+    const repo = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(repo)
+    const ws = new Workspace(
+      { '/repo': [repo, MountMode.WRITE] as const },
+      { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+    )
+    open.push(ws)
+    const io = await ws.execute("mkdir -p /repo/only && printf 'h\\n' > /repo/only/h")
+    expect(io.exitCode).toBe(0)
+    const sess = ws.createSession('rev', {
+      profile: parseSessionProfile({
+        paths: { hide: ['/repo/only/h'], show: { '/repo/only/h': 'r' } },
+      }),
+    })
+    await runWithSession(sess, async () => {
+      await expect(ws.dispatch('rmdir', '/repo/only')).rejects.toMatchObject({
+        code: 'ENOTEMPTY',
+      })
+    })
+    const kept = await ws.execute('cat /repo/only/h')
+    expect(stdoutStr(kept)).toBe('h\n')
+  })
+
+  it('keeps the refusal when a visible mounted child remains', async () => {
+    // The backend cannot see a mount nested below the directory, so
+    // the remnant arm judges emptiness on the door's merged listing:
+    // the visible mounted child keeps the not-empty refusal instead of
+    // the arm destroying the hidden backend remnants and reporting a
+    // successful rmdir while the mount remains.
+    const parser = await getTestParser()
+    const a = new RAMResource()
+    const m = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(a)
+    registry.registerResource(m)
+    const ws = new Workspace(
+      { '/a': [a, MountMode.WRITE] as const, '/a/d/m': [m, MountMode.WRITE] as const },
+      { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+    )
+    open.push(ws)
+    const io = await ws.execute("mkdir -p /a/d/sec && printf 'k\\n' > /a/d/sec/k")
+    expect(io.exitCode).toBe(0)
+    const sess = ws.createSession('rev', {
+      profile: parseSessionProfile({ paths: { hide: ['/a/d/sec'] } }),
+    })
+    await runWithSession(sess, async () => {
+      await expect(ws.dispatch('rmdir', '/a/d')).rejects.toMatchObject({
+        code: 'ENOTEMPTY',
+      })
+    })
+    const kept = await ws.execute('cat /a/d/sec/k')
+    expect(stdoutStr(kept)).toBe('k\n')
   })
 })
 

--- a/typescript/packages/node/src/core/ssh/rmdir.test.ts
+++ b/typescript/packages/node/src/core/ssh/rmdir.test.ts
@@ -35,7 +35,10 @@ describe('core/ssh/rmdir', () => {
     expect(await exists(accessor, spec('/d'))).toBe(false)
   })
 
-  it('errors on a non-empty directory', async () => {
+  it('converts the version-3 not-empty refusal to ENOTEMPTY', async () => {
+    // SFTP 3 answers a not-empty rmdir with its one generic FAILURE
+    // code; the listing probe converts it so the boundary speaks
+    // errno, which is what the hidden-remnant guard keys on.
     const accessor = makeFakeAccessor({
       files: new Map([['/d/x', { data: new Uint8Array() }]]),
       dirs: new Map([
@@ -43,7 +46,7 @@ describe('core/ssh/rmdir', () => {
         ['/d', {}],
       ]),
     })
-    await expect(rmdir(accessor, spec('/d'))).rejects.toThrow()
+    await expect(rmdir(accessor, spec('/d'))).rejects.toMatchObject({ code: 'ENOTEMPTY' })
   })
 
   it('throws ENOENT when missing', async () => {

--- a/typescript/packages/node/src/core/ssh/rmdir.ts
+++ b/typescript/packages/node/src/core/ssh/rmdir.ts
@@ -14,23 +14,56 @@
 
 import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
-import { enoent } from '@struktoai/mirage-core/utils/errors'
+import { enoent, enotempty } from '@struktoai/mirage-core/utils/errors'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
-import { isNoSuchFile, joinRoot, stripPrefix } from './utils.ts'
+import { isFailure, isNoSuchFile, joinRoot, stripPrefix } from './utils.ts'
 
+// The probe behind the version-3 arm below: whether the directory
+// still lists children. A probe that fails is a negative probe, never
+// an error to surface; the caller re-raises what the server said.
+async function holdsEntries(accessor: SSHAccessor, remote: string): Promise<boolean> {
+  const sftp = await accessor.sftp()
+  try {
+    return await new Promise<boolean>((resolveFn, rejectFn) => {
+      sftp.readdir(remote, (err, entries) => {
+        if (err !== undefined) {
+          rejectFn(err)
+          return
+        }
+        resolveFn(entries.some((e) => e.filename !== '.' && e.filename !== '..'))
+      })
+    })
+  } catch {
+    return false
+  }
+}
+
+// SFTP 3 has one generic code for a not-empty refusal (SSH_FX_FAILURE),
+// which is what ssh2 always speaks, so one listing probe decides
+// instead of a blind translation: only a directory that still shows
+// entries converts to ENOTEMPTY, anything else keeps the server's own
+// answer. Without the conversion the hidden-remnant guard never fires
+// on ssh (it keys on the errno), and the raw SFTP failure leaks.
 export async function rmdir(accessor: SSHAccessor, p: PathSpec): Promise<void> {
   const sftp = await accessor.sftp()
   const virtual = stripPrefix(p)
   const remote = joinRoot(accessor.config.root ?? '/', virtual)
-  await new Promise<void>((resolveFn, rejectFn) => {
-    sftp.rmdir(remote, (err) => {
-      if (!err) {
-        resolveFn()
-        return
-      }
-      if (isNoSuchFile(err)) rejectFn(enoent(p))
-      else rejectFn(err)
+  try {
+    await new Promise<void>((resolveFn, rejectFn) => {
+      sftp.rmdir(remote, (err) => {
+        if (!err) {
+          resolveFn()
+          return
+        }
+        if (isNoSuchFile(err)) rejectFn(enoent(p))
+        else rejectFn(err)
+      })
     })
-  })
+  } catch (err) {
+    if (isFailure(err) && (await holdsEntries(accessor, remote))) {
+      throw enotempty(p)
+    }
+    throw err
+  }
   await invalidateAfterUnlink(p)
 }

--- a/typescript/packages/node/src/core/ssh/utils.ts
+++ b/typescript/packages/node/src/core/ssh/utils.ts
@@ -45,6 +45,15 @@ export function isNoSuchFile(err: unknown): boolean {
   return code === 2
 }
 
+// SFTP 3's one generic refusal (SSH_FX_FAILURE): the only vocabulary a
+// version-3 server has for a not-empty rmdir, among other refusals.
+export function isFailure(err: unknown): boolean {
+  if (err === null || err === undefined) return false
+  if (typeof err !== 'object') return false
+  const code = (err as { code?: unknown }).code
+  return code === 4
+}
+
 export function isDirectoryAttrs(attrs: { mode?: number }): boolean {
   if (attrs.mode === undefined) return false
   return (attrs.mode & S_IFMT) === S_IFDIR


### PR DESCRIPTION
Settles what mutating commands do to content hidden by a session's paths.hide, under one rule: a session's mutation may destroy what it cannot see, but may never reveal it.

- mv and native dir-copy refuse with EACCES when relocating a directory would carry a hidden path out of hide coverage ("mv: cannot move 'a' to 'b': Permission denied"). A component pattern like *.tkn never refuses: it follows the name, so the file rides along still hidden.
- cp -r copies only the visible view, silently. The strategy fork now also triggers on hides intersecting an operand, so the native copy can no longer leak the hidden dir name or print the hidden path in stderr.
- rmdir on a directory the session sees as empty succeeds and removes the hidden remnants (a not-empty refusal would leak existence). rm -r keeps deleting hidden content: hide is visibility, a deny rule is protection.
- Enforced on both planes: the command-plane slot wrappers in generic_bind/adapter and the dispatcher for FUSE/guest runtimes, in both languages. Cross-mount mv gets the same refusal through a guard on the generic.

New move_reveals/moveReveals predicate in utils/hidden, unit twins, workspace behavior tests, and 18 battery cases (boxed/tagged sessions) green on both hosts.