### PR TITLE
fix(kit): a glob narrows a windowed listing instead of filtering it

### DIFF
--- a/integ/resources/discord/window.json
+++ b/integ/resources/discord/window.json
@@ -1,0 +1,43 @@
+{
+  "cases": [
+    {
+      "id": "dc_window_glob_reaches_a_day_before_the_window",
+      "seq": 690240,
+      "targets": [
+        "discord"
+      ],
+      "command": "ls -d '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/'2026-03-15*",
+      "expect": {
+        "exit": 0,
+        "stdout": "/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/2026-03-15\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_window_glob_lists_a_whole_month_before_the_window",
+      "seq": 690241,
+      "targets": [
+        "discord"
+      ],
+      "command": "ls -d '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/'2026-03-* | wc -l",
+      "expect": {
+        "exit": 0,
+        "stdout": "31\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "dc_window_glob_does_not_become_the_channel_listing",
+      "seq": 690242,
+      "targets": [
+        "discord"
+      ],
+      "command": "ls -d '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001/'2026-03-* > /dev/null && ls '/discord/Mirage HQ__100000000000000001/channels/general__200000000000000001' | head -1",
+      "expect": {
+        "exit": 0,
+        "stdout": "2026-05-04\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/resources/gmail/window.json
+++ b/integ/resources/gmail/window.json
@@ -1,0 +1,43 @@
+{
+  "cases": [
+    {
+      "id": "gmail_label_glob_lists_the_days_in_the_span",
+      "seq": 530400,
+      "targets": [
+        "gmail"
+      ],
+      "command": "ls -d /mail/INBOX/2026-01-*",
+      "expect": {
+        "exit": 0,
+        "stdout": "/mail/INBOX/2026-01-05\n/mail/INBOX/2026-01-07\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gmail_label_glob_outside_the_span_matches_nothing",
+      "seq": 530401,
+      "targets": [
+        "gmail"
+      ],
+      "command": "ls -d /mail/INBOX/2025-12-*",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/mail/INBOX/2025-12-*': No such file or directory\n"
+      }
+    },
+    {
+      "id": "gmail_label_glob_reads_a_day_through_the_span",
+      "seq": 530402,
+      "targets": [
+        "gmail"
+      ],
+      "command": "ls /mail/INBOX/2026-01-07*/",
+      "expect": {
+        "exit": 0,
+        "stdout": "Server_alert_worker-3__msg0003.gmail.json\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/resources/lancedb/window.json
+++ b/integ/resources/lancedb/window.json
@@ -1,0 +1,82 @@
+{
+  "cases": [
+    {
+      "id": "lancedb_window_listing_is_capped",
+      "seq": 650400,
+      "targets": [
+        "lancedb-window"
+      ],
+      "command": "ls /db/all/",
+      "expect": {
+        "exit": 0,
+        "stdout": "doc-000.md\ndoc-001.md\ndoc-002.md\ndoc-003.md\ndoc-004.md\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "lancedb_window_row_resolves_past_the_cap",
+      "seq": 650401,
+      "targets": [
+        "lancedb-window"
+      ],
+      "command": "cat /db/all/doc-039.md",
+      "expect": {
+        "exit": 0,
+        "stdout": "# row 39\n\nid: doc-039\nlabel: all\nname: row 39\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "lancedb_window_glob_reaches_past_the_cap",
+      "seq": 650402,
+      "targets": [
+        "lancedb-window"
+      ],
+      "command": "ls -d /db/all/doc-03*",
+      "expect": {
+        "exit": 0,
+        "stdout": "/db/all/doc-030.md\n/db/all/doc-031.md\n/db/all/doc-032.md\n/db/all/doc-033.md\n/db/all/doc-034.md\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "lancedb_window_glob_does_not_become_the_listing",
+      "seq": 650403,
+      "targets": [
+        "lancedb-window"
+      ],
+      "command": "ls -d /db/all/doc-03* > /dev/null && ls /db/all/ | head -1",
+      "expect": {
+        "exit": 0,
+        "stdout": "doc-000.md\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "lancedb_window_glob_with_no_literal_head_stays_capped",
+      "seq": 650404,
+      "targets": [
+        "lancedb-window"
+      ],
+      "command": "ls -d /db/all/*39.md",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/db/all/*39.md': No such file or directory\n"
+      }
+    },
+    {
+      "id": "lancedb_window_a_broad_prefix_is_still_capped",
+      "seq": 650405,
+      "targets": [
+        "lancedb-window"
+      ],
+      "command": "ls -d /db/all/doc-0[12]*",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/db/all/doc-0[12]*': No such file or directory\n"
+      }
+    }
+  ]
+}

--- a/integ/resources/qdrant/window.json
+++ b/integ/resources/qdrant/window.json
@@ -1,0 +1,69 @@
+{
+  "cases": [
+    {
+      "id": "qdrant_window_listing_is_capped",
+      "seq": 640400,
+      "targets": [
+        "qdrant-window"
+      ],
+      "command": "ls /db/all/ | wc -l",
+      "expect": {
+        "exit": 0,
+        "stdout": "10\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "qdrant_window_row_resolves_past_the_cap",
+      "seq": 640401,
+      "targets": [
+        "qdrant-window"
+      ],
+      "command": "cat /db/all/599.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "row 599\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "qdrant_window_glob_pages_past_the_cap",
+      "seq": 640402,
+      "targets": [
+        "qdrant-window"
+      ],
+      "command": "ls -d /db/all/45*.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "/db/all/45.json\n/db/all/450.json\n/db/all/451.json\n/db/all/452.json\n/db/all/453.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "qdrant_window_glob_does_not_become_the_listing",
+      "seq": 640403,
+      "targets": [
+        "qdrant-window"
+      ],
+      "command": "ls -d /db/all/45*.json > /dev/null && ls /db/all/ | head -2",
+      "expect": {
+        "exit": 0,
+        "stdout": "1.json\n1.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "qdrant_window_glob_with_no_literal_head_stays_capped",
+      "seq": 640404,
+      "targets": [
+        "qdrant-window"
+      ],
+      "command": "ls -d /db/all/*99.json",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "ls: cannot access '/db/all/*99.json': No such file or directory\n"
+      }
+    }
+  ]
+}

--- a/integ/resources/slack/window.json
+++ b/integ/resources/slack/window.json
@@ -1,0 +1,56 @@
+{
+  "cases": [
+    {
+      "id": "slack_window_glob_reaches_a_day_before_the_window",
+      "seq": 520400,
+      "targets": [
+        "slack"
+      ],
+      "command": "ls -d /slack/channels/general__C1/2025-11-05*",
+      "expect": {
+        "exit": 0,
+        "stdout": "/slack/channels/general__C1/2025-11-05\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "slack_window_glob_is_clipped_at_channel_creation",
+      "seq": 520401,
+      "targets": [
+        "slack"
+      ],
+      "command": "ls -d /slack/channels/general__C1/2025-11-* | wc -l",
+      "expect": {
+        "exit": 0,
+        "stdout": "28\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "slack_window_glob_does_not_become_the_channel_listing",
+      "seq": 520402,
+      "targets": [
+        "slack"
+      ],
+      "command": "ls -d /slack/channels/general__C1/2025-11-* > /dev/null && ls /slack/channels/general__C1 | head -1",
+      "expect": {
+        "exit": 0,
+        "stdout": "2025-12-14\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "slack_window_glob_reads_a_day_the_window_omits",
+      "seq": 520403,
+      "targets": [
+        "slack"
+      ],
+      "command": "cat /slack/channels/general__C1/2025-11-06*/chat.jsonl | jq -r .text | head -2",
+      "expect": {
+        "exit": 0,
+        "stdout": "welcome Liam to the team, say hi\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -1424,20 +1424,43 @@ LANCEDB_ROWS = [
     },
 ]
 
+# One group holding far more rows than the window facet's row cap, so a
+# glob for a row past the cap can only be answered by narrowing the query.
+LANCEDB_WIDE_CAP = 5
+LANCEDB_WIDE_ROWS = [{
+    "id": f"doc-{i:03d}",
+    "label": "all",
+    "name": f"row {i}"
+} for i in range(40)]
+
 
 class LanceDBService:
 
-    def __init__(self, uri: str) -> None:
+    def __init__(self, uri: str, window: bool) -> None:
         self.uri = uri
+        self.window = window
 
     @classmethod
-    async def create(cls) -> "LanceDBService":
+    async def create(cls, target: dict) -> "LanceDBService":
+        window = target.get("facet") == "window"
         uri = tempfile.mkdtemp(prefix="mirage-integ-lancedb-")
         db = lancedb.connect(uri)
-        db.create_table("animals", data=LANCEDB_ROWS)
-        return cls(uri)
+        if window:
+            db.create_table("wide", data=LANCEDB_WIDE_ROWS)
+        else:
+            db.create_table("animals", data=LANCEDB_ROWS)
+        return cls(uri, window)
 
     def resource(self, mount: dict) -> LanceDBResource:
+        if self.window:
+            return LanceDBResource(
+                LanceDBConfig(uri=self.uri,
+                              table="wide",
+                              group_by=["label"],
+                              id_column="id",
+                              title_column="name",
+                              text_column="name",
+                              max_rows=LANCEDB_WIDE_CAP))
         return LanceDBResource(
             LanceDBConfig(uri=self.uri,
                           group_by=["label", "kind"],
@@ -1458,16 +1481,24 @@ QDRANT_ROWS = [
     (4, "dog", "small", "a small white dog"),
 ]
 
+# Far more points than the window facet's row cap, all in one group, and
+# ids whose text straddles a scroll page so a narrowed listing has to page.
+QDRANT_WIDE_CAP = 5
+QDRANT_WIDE_POINTS = 600
+
 
 class QdrantService:
 
-    def __init__(self, host: str, port: int, collection: str) -> None:
+    def __init__(self, host: str, port: int, collection: str,
+                 window: bool) -> None:
         self.host = host
         self.port = port
         self.collection = collection
+        self.window = window
 
     @classmethod
-    async def create(cls) -> "QdrantService":
+    async def create(cls, target: dict) -> "QdrantService":
+        window = target.get("facet") == "window"
         host = os.environ.get("QDRANT_HOST", "localhost")
         port = int(os.environ.get("QDRANT_PORT", "6333"))
         collection = f"mirage-integ-{uuid.uuid4().hex[:8]}"
@@ -1477,24 +1508,37 @@ class QdrantService:
                 collection,
                 vectors_config=models.VectorParams(
                     size=QDRANT_EMBED_DIM, distance=models.Distance.COSINE))
-            await client.upsert(
-                collection,
-                points=[
-                    models.PointStruct(
-                        id=i,
-                        vector=[0.1] * QDRANT_EMBED_DIM,
-                        payload={
-                            "label":
-                            label,
-                            "kind":
-                            kind,
-                            "name":
-                            name,
-                            "image_bytes":
-                            base64.b64encode(f"PNG-{i}".encode()).decode(),
-                        }) for i, label, kind, name in QDRANT_ROWS
-                ])
-            for field in ("label", "kind"):
+            if window:
+                await client.upsert(
+                    collection,
+                    points=[
+                        models.PointStruct(id=i,
+                                           vector=[0.1] * QDRANT_EMBED_DIM,
+                                           payload={
+                                               "label": "all",
+                                               "name": f"row {i}"
+                                           })
+                        for i in range(1, QDRANT_WIDE_POINTS + 1)
+                    ])
+            else:
+                await client.upsert(
+                    collection,
+                    points=[
+                        models.PointStruct(
+                            id=i,
+                            vector=[0.1] * QDRANT_EMBED_DIM,
+                            payload={
+                                "label":
+                                label,
+                                "kind":
+                                kind,
+                                "name":
+                                name,
+                                "image_bytes":
+                                base64.b64encode(f"PNG-{i}".encode()).decode(),
+                            }) for i, label, kind, name in QDRANT_ROWS
+                    ])
+            for field in (("label", ) if window else ("label", "kind")):
                 await client.create_payload_index(
                     collection,
                     field_name=field,
@@ -1502,9 +1546,18 @@ class QdrantService:
             await asyncio.sleep(2)
         finally:
             await client.close()
-        return cls(host, port, collection)
+        return cls(host, port, collection, window)
 
     def resource(self, mount: dict) -> QdrantResource:
+        if self.window:
+            return QdrantResource(
+                QdrantConfig(host=self.host,
+                             port=self.port,
+                             collection=self.collection,
+                             group_by=["label"],
+                             id_field="id",
+                             text_field="name",
+                             max_rows=QDRANT_WIDE_CAP))
         return QdrantResource(
             QdrantConfig(host=self.host,
                          port=self.port,
@@ -2157,9 +2210,9 @@ async def make_service(target: dict, run_id: str) -> "Service | None":
     if target.get("service") == "chroma":
         return await ChromaService.create()
     if target.get("service") == "qdrant":
-        return await QdrantService.create()
+        return await QdrantService.create(target)
     if target.get("service") == "lancedb":
-        return await LanceDBService.create()
+        return await LanceDBService.create(target)
     if target.get("service") == "notion":
         return await NotionService.create()
     if target.get("service") == "ssh":

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -857,19 +857,43 @@ const LANCEDB_ROWS: ReadonlyArray<Record<string, unknown>> = [
   { id: 4, label: 'dog', kind: 'small', name: 'a small white dog' },
 ]
 
+// One group holding far more rows than the window facet's row cap, so a glob
+// for a row past the cap can only be answered by narrowing the query.
+const LANCEDB_WIDE_CAP = 5
+
+function lancedbWideRows(): Record<string, unknown>[] {
+  const rows: Record<string, unknown>[] = []
+  for (let i = 0; i < 40; i += 1) {
+    rows.push({ id: `doc-${String(i).padStart(3, '0')}`, label: 'all', name: `row ${String(i)}` })
+  }
+  return rows
+}
+
 async function openLancedb(target: Target): Promise<Open> {
+  const window = target.facet === 'window'
   const uri = mkdtempSync(join(tmpdir(), 'mirage-integ-lancedb-'))
   const db = await lancedb.connect(uri)
-  await db.createTable('animals', LANCEDB_ROWS as Record<string, unknown>[])
+  if (window) await db.createTable('wide', lancedbWideRows())
+  else await db.createTable('animals', LANCEDB_ROWS as Record<string, unknown>[])
   const mounts: Record<string, LanceDBResource | [LanceDBResource, MountMode]> = {}
   for (const mount of target.mounts) {
-    const resource = new LanceDBResource({
-      uri,
-      groupBy: ['label', 'kind'],
-      idColumn: 'id',
-      titleColumn: 'name',
-      textColumn: 'name',
-    })
+    const resource = window
+      ? new LanceDBResource({
+          uri,
+          table: 'wide',
+          groupBy: ['label'],
+          idColumn: 'id',
+          titleColumn: 'name',
+          textColumn: 'name',
+          maxRows: LANCEDB_WIDE_CAP,
+        })
+      : new LanceDBResource({
+          uri,
+          groupBy: ['label', 'kind'],
+          idColumn: 'id',
+          titleColumn: 'name',
+          textColumn: 'name',
+        })
     mounts[mount.path] = mount.mode === 'read' ? [resource, MountMode.READ] : resource
   }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
@@ -889,7 +913,13 @@ const QDRANT_ROWS: ReadonlyArray<readonly [number, string, string, string]> = [
   [4, 'dog', 'small', 'a small white dog'],
 ]
 
+// Far more points than the window facet's row cap, all in one group, and ids
+// whose text straddles a scroll page so a narrowed listing has to page.
+const QDRANT_WIDE_CAP = 5
+const QDRANT_WIDE_POINTS = 600
+
 async function openQdrant(target: Target): Promise<Open> {
+  const window = target.facet === 'window'
   const host = process.env.QDRANT_HOST ?? 'localhost'
   const port = Number.parseInt(process.env.QDRANT_PORT ?? '6333', 10)
   const collection = `mirage-integ-${runId()}`
@@ -897,29 +927,51 @@ async function openQdrant(target: Target): Promise<Open> {
   await client.createCollection(collection, {
     vectors: { size: QDRANT_EMBED_DIM, distance: 'Cosine' },
   })
-  await client.upsert(collection, {
-    points: QDRANT_ROWS.map(([id, label, kind, name]) => ({
-      id,
-      vector: Array<number>(QDRANT_EMBED_DIM).fill(0.1),
-      payload: { label, kind, name, image_bytes: btoa(`PNG-${String(id)}`) },
-    })),
-  })
-  for (const field of ['label', 'kind']) {
+  if (window) {
+    const points = []
+    for (let i = 1; i <= QDRANT_WIDE_POINTS; i += 1) {
+      points.push({
+        id: i,
+        vector: Array<number>(QDRANT_EMBED_DIM).fill(0.1),
+        payload: { label: 'all', name: `row ${String(i)}` },
+      })
+    }
+    await client.upsert(collection, { points })
+  } else {
+    await client.upsert(collection, {
+      points: QDRANT_ROWS.map(([id, label, kind, name]) => ({
+        id,
+        vector: Array<number>(QDRANT_EMBED_DIM).fill(0.1),
+        payload: { label, kind, name, image_bytes: btoa(`PNG-${String(id)}`) },
+      })),
+    })
+  }
+  for (const field of window ? ['label'] : ['label', 'kind']) {
     await client.createPayloadIndex(collection, { field_name: field, field_schema: 'keyword' })
   }
   await new Promise((r) => setTimeout(r, 2000))
   const mounts: Record<string, QdrantResource | [QdrantResource, MountMode]> = {}
   for (const mount of target.mounts) {
-    const resource = new QdrantResource({
-      host,
-      port,
-      collection,
-      groupBy: ['label', 'kind'],
-      idField: 'id',
-      textField: 'name',
-      blobField: 'image_bytes',
-      blobExt: 'png',
-    })
+    const resource = window
+      ? new QdrantResource({
+          host,
+          port,
+          collection,
+          groupBy: ['label'],
+          idField: 'id',
+          textField: 'name',
+          maxRows: QDRANT_WIDE_CAP,
+        })
+      : new QdrantResource({
+          host,
+          port,
+          collection,
+          groupBy: ['label', 'kind'],
+          idField: 'id',
+          textField: 'name',
+          blobField: 'image_bytes',
+          blobExt: 'png',
+        })
     mounts[mount.path] = mount.mode === 'read' ? [resource, MountMode.READ] : resource
   }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -1742,14 +1742,20 @@ function labelByName(name: string): GmailLabel | undefined {
   )
 }
 
+// A written date is midnight UTC here, where Gmail reads it as midnight PST;
+// the epoch-second form the API documents for naming an instant is exact, and
+// is the form mirage emits, so both are accepted.
 function gmailDateMs(token: string): number {
   const m = /^(\d{4})\/(\d{1,2})\/(\d{1,2})$/.exec(token)
-  if (m === null) return NaN
-  return Date.UTC(parseInt(m[1] as string, 10), parseInt(m[2] as string, 10) - 1, parseInt(m[3] as string, 10))
+  if (m !== null) {
+    return Date.UTC(parseInt(m[1] as string, 10), parseInt(m[2] as string, 10) - 1, parseInt(m[3] as string, 10))
+  }
+  if (/^\d+$/.test(token)) return parseInt(token, 10) * 1000
+  return NaN
 }
 
 // AND-only Gmail query subset: label:, from:, to:, subject:, is:unread,
-// is:read, after:YYYY/MM/DD, before:YYYY/MM/DD, and bare terms matching
+// is:read, after:<date|epoch>, before:<date|epoch>, and bare terms matching
 // subject or body as case-insensitive substrings.
 function matchGmailQuery(msg: GmailMessage, q: string): boolean {
   for (const token of q.split(/\s+/)) {

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -1300,6 +1300,40 @@
       ]
     },
     {
+      "id": "qdrant-window",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "service": "qdrant",
+      "facet": "window",
+      "mounts": [
+        {
+          "path": "/db",
+          "resource": "qdrant",
+          "backend": "qdrant",
+          "mode": "read"
+        }
+      ]
+    },
+    {
+      "id": "lancedb-window",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "service": "lancedb",
+      "facet": "window",
+      "mounts": [
+        {
+          "path": "/db",
+          "resource": "lancedb",
+          "backend": "lancedb",
+          "mode": "read"
+        }
+      ]
+    },
+    {
       "id": "notion",
       "hosts": [
         "python",

--- a/python/mirage/core/discord/readdir.py
+++ b/python/mirage/core/discord/readdir.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import aiohttp
 
@@ -31,6 +31,7 @@ from mirage.core.discord.render import history_jsonl_bytes
 from mirage.core.discord.scope import detect_scope
 from mirage.core.hierarchy.readdir import DirListing, Listed, make_readdir
 from mirage.core.hierarchy.scope import ScopeMatch
+from mirage.utils.glob_walk import glob_span, has_glob_span
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +45,33 @@ def _is_soft_error(exc: Exception) -> bool:
             and exc.status in SOFT_HTTP_STATUSES)
 
 
-def _date_range(end_date: str, days: int = 30) -> list[str]:
+def _date_range(end_date: str,
+                days: int = 30,
+                span: tuple[date, date] | None = None) -> list[str]:
+    """The channel's day directories, oldest first.
+
+    A day dir is real for any well-formed date under the channel, so the
+    bare listing is a window: the last ``days`` up to the newest
+    message. A glob names its own window instead, clipped at the newest
+    message because nothing was posted after it.
+
+    Args:
+        end_date (str): the newest message's date, ``YYYY-MM-DD``.
+        days (int): how many days the bare window covers.
+        span (tuple[date, date] | None): the glob's half-open range.
+    """
     end = datetime.strptime(end_date, "%Y-%m-%d").date()
-    return [(end - timedelta(days=i)).isoformat()
-            for i in range(days - 1, -1, -1)]
+    if span is None:
+        return [(end - timedelta(days=i)).isoformat()
+                for i in range(days - 1, -1, -1)]
+    start = span[0]
+    last = min(end, span[1] - timedelta(days=1))
+    out = []
+    d = start
+    while d <= last:
+        out.append(d.isoformat())
+        d += timedelta(days=1)
+    return out
 
 
 def _container_entry(name: str, guild_id: str) -> IndexEntry:
@@ -94,7 +118,10 @@ async def _list_channel_days(accessor: DiscordAccessor, match: ScopeMatch,
         end_date = snowflake_to_date(last_msg_id)
     else:
         end_date = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
-    return [(d, history_entry(own.id, d)) for d in _date_range(end_date)]
+    span = glob_span(match.pattern)
+    entries = [(d, history_entry(own.id, d))
+               for d in _date_range(end_date, span=span)]
+    return DirListing(entries=entries, partial=span is not None)
 
 
 async def _day_listing(accessor: DiscordAccessor, channel_id: str,
@@ -207,5 +234,6 @@ readdir = make_readdir(
         "files": _list_files,
     },
     parent_entry_listers={"day": _list_day},
+    pattern_kinds={"channel": has_glob_span},
     leaf_error="enotdir",
 )

--- a/python/mirage/core/gcal/readdir.py
+++ b/python/mirage/core/gcal/readdir.py
@@ -21,7 +21,6 @@ from mirage.core.gcal.day import (WINDOW_AHEAD_DAYS, WINDOW_BACK_DAYS,
                                   clamped_hhmm, day_bounds, days_covered,
                                   event_span, window_bounds)
 from mirage.core.gcal.scope import detect_scope
-from mirage.core.google.date_glob import glob_to_date_range
 from mirage.core.hierarchy.scope import ROOT
 from mirage.core.render.json import compact_json_bytes
 from mirage.resource.gcal.event_entry import (CALENDAR_FILE, PRIMARY_DIR,
@@ -30,6 +29,7 @@ from mirage.resource.gcal.event_entry import (CALENDAR_FILE, PRIMARY_DIR,
                                               make_event_filename)
 from mirage.types import JsonValue, PathSpec
 from mirage.utils.errors import enoent
+from mirage.utils.glob_walk import glob_span
 from mirage.utils.key_prefix import mount_prefix_of
 
 CALENDAR_DIR = "gcal/calendar_dir"
@@ -154,7 +154,7 @@ def day_span(pattern: str | None, today: date,
     Returns:
         tuple[str, str, date, date]: timeMin, timeMax, first day, last day.
     """
-    span = glob_to_date_range(pattern)
+    span = glob_span(pattern)
     if span is not None:
         last = span[1] - timedelta(days=1)
         return day_bounds(span[0].isoformat(),

--- a/python/mirage/core/gmail/date_query.py
+++ b/python/mirage/core/gmail/date_query.py
@@ -12,18 +12,34 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
+
+
+def _epoch(day: date) -> int:
+    return int(
+        datetime(day.year, day.month, day.day,
+                 tzinfo=timezone.utc).timestamp())
 
 
 def span_to_gmail_query(start: date, end: date) -> str:
-    """A Gmail date filter for a half-open range of days.
+    """A Gmail date filter for a half-open range of UTC days.
+
+    The bounds are epoch seconds rather than ``YYYY/MM/DD`` because
+    Gmail reads a written date as "midnight on that date in the PST
+    timezone" and names seconds as the way to mean any other zone, while
+    a message lands in a day directory by its UTC ``internalDate``. The
+    two disagree by the account's offset, so a written date would leave
+    the first hours of the requested day outside the query and every
+    message in them out of the listing. The lower bound is a second
+    early because the operator's inclusivity at the exact second is not
+    documented: an extra message from the day before is dropped by the
+    bucketing, a missing one is not recoverable.
 
     Args:
-        start (date): first day, inclusive.
-        end (date): last day, exclusive.
+        start (date): first UTC day, inclusive.
+        end (date): last UTC day, exclusive.
     """
-    return (f"after:{start.year}/{start.month:02d}/{start.day:02d} "
-            f"before:{end.year}/{end.month:02d}/{end.day:02d}")
+    return f"after:{_epoch(start) - 1} before:{_epoch(end)}"
 
 
 def date_dir_to_gmail_query(name: str) -> str | None:

--- a/python/mirage/core/gmail/date_query.py
+++ b/python/mirage/core/gmail/date_query.py
@@ -15,6 +15,17 @@
 from datetime import date, timedelta
 
 
+def span_to_gmail_query(start: date, end: date) -> str:
+    """A Gmail date filter for a half-open range of days.
+
+    Args:
+        start (date): first day, inclusive.
+        end (date): last day, exclusive.
+    """
+    return (f"after:{start.year}/{start.month:02d}/{start.day:02d} "
+            f"before:{end.year}/{end.month:02d}/{end.day:02d}")
+
+
 def date_dir_to_gmail_query(name: str) -> str | None:
     parts = name.split("-")
     if len(parts) != 3:
@@ -25,6 +36,4 @@ def date_dir_to_gmail_query(name: str) -> str | None:
         d = date(int(parts[0]), int(parts[1]), int(parts[2]))
     except ValueError:
         return None
-    nxt = d + timedelta(days=1)
-    return (f"after:{d.year}/{d.month:02d}/{d.day:02d} "
-            f"before:{nxt.year}/{nxt.month:02d}/{nxt.day:02d}")
+    return span_to_gmail_query(d, d + timedelta(days=1))

--- a/python/mirage/core/gmail/readdir.py
+++ b/python/mirage/core/gmail/readdir.py
@@ -18,7 +18,8 @@ from typing import Any
 
 from mirage.accessor.gmail import GmailAccessor
 from mirage.cache.index import IndexEntry
-from mirage.core.gmail.date_query import date_dir_to_gmail_query
+from mirage.core.gmail.date_query import (date_dir_to_gmail_query,
+                                          span_to_gmail_query)
 from mirage.core.gmail.labels import list_labels
 from mirage.core.gmail.messages import (_extract_attachments, _extract_header,
                                         get_message_raw, list_messages,
@@ -26,6 +27,7 @@ from mirage.core.gmail.messages import (_extract_attachments, _extract_header,
 from mirage.core.gmail.scope import detect_scope
 from mirage.core.hierarchy.readdir import DirListing, Listed, make_readdir
 from mirage.core.hierarchy.scope import ScopeMatch
+from mirage.utils.glob_walk import glob_span, has_glob_span
 from mirage.utils.sanitize import NAME_MAX_BYTES, byte_len, sanitize_label
 
 TITLE_MAX = 80
@@ -164,9 +166,15 @@ async def _list_root(accessor: GmailAccessor, match: ScopeMatch) -> Listed:
 
 async def _list_label(accessor: GmailAccessor, match: ScopeMatch,
                       own: IndexEntry) -> Listed:
+    # The bare listing is a window, the most recent MAX_MESSAGES, so the
+    # day dirs it mints are whichever days those fell on. A glob pushes
+    # its own span into the query instead of filtering that window,
+    # which is the only way to reach a day older than it.
+    span = glob_span(match.pattern)
     msg_ids = await list_messages(
         accessor.token_manager,
         label_id=own.id,
+        query=span_to_gmail_query(*span) if span else None,
         max_results=MAX_MESSAGES,
     )
     groups = await _group_by_date(accessor, msg_ids)
@@ -185,7 +193,7 @@ async def _list_label(accessor: GmailAccessor, match: ScopeMatch,
         seeds[date_str] = children
         for att_dir, att_entries in att_seeds.items():
             seeds[f"{date_str}/{att_dir}"] = att_entries
-    return DirListing(entries=entries, seeds=seeds)
+    return DirListing(entries=entries, seeds=seeds, partial=span is not None)
 
 
 async def _list_day(accessor: GmailAccessor, match: ScopeMatch,
@@ -221,4 +229,5 @@ readdir = make_readdir(
         "attachment_dir": _list_attachment_dir,
     },
     parent_entry_listers={"day": _list_day},
+    pattern_kinds={"label": has_glob_span},
 )

--- a/python/mirage/core/google/date_glob.py
+++ b/python/mirage/core/google/date_glob.py
@@ -12,9 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import date, timedelta
+from datetime import date
 
-from mirage.utils.glob_walk import GLOB_CHARS
+from mirage.utils.glob_walk import glob_span
 
 
 def _iso(d: date) -> str:
@@ -24,6 +24,10 @@ def _iso(d: date) -> str:
 def glob_to_modified_range(pattern: str | None) -> tuple[str, str] | None:
     """Translate a date-prefixed glob into an RFC3339 modifiedTime range.
 
+    Drive's own spelling of the span ``glob_span`` reads; a caller
+    bucketing in a named time zone builds its own bounds from the dates
+    instead, since UTC instants would shift the window by the offset.
+
     Args:
         pattern (str | None): the glob as typed, or None.
 
@@ -31,60 +35,7 @@ def glob_to_modified_range(pattern: str | None) -> tuple[str, str] | None:
         tuple[str, str] | None: (start, end) in UTC, or None when the glob
         does not start with a date prefix.
     """
-    span = glob_to_date_range(pattern)
+    span = glob_span(pattern)
     if span is None:
         return None
     return _iso(span[0]), _iso(span[1])
-
-
-def glob_to_date_range(pattern: str | None) -> tuple[date, date] | None:
-    """Translate a date-prefixed glob into a half-open range of dates.
-
-    Kept separate from ``glob_to_modified_range`` because a caller bucketing
-    in a named time zone has to build its own bounds from the dates; UTC
-    instants would silently shift the window by the zone's offset.
-
-    Args:
-        pattern (str | None): the glob as typed, or None.
-
-    Returns:
-        tuple[date, date] | None: (start, end) with end exclusive, or None
-        when the glob does not start with a date prefix.
-    """
-    if not pattern:
-        return None
-    meta_index = -1
-    for ch in GLOB_CHARS:
-        idx = pattern.find(ch)
-        if idx != -1 and (meta_index == -1 or idx < meta_index):
-            meta_index = idx
-    if meta_index == -1:
-        return None
-    prefix = pattern[:meta_index]
-    prefix = prefix.rstrip("_-")
-    parts = prefix.split("-")
-    try:
-        if len(parts) == 1 and len(parts[0]) == 4:
-            year = int(parts[0])
-            start = date(year, 1, 1)
-            end = date(year + 1, 1, 1)
-        elif len(parts) == 2 and len(parts[0]) == 4 and len(parts[1]) == 2:
-            year = int(parts[0])
-            month = int(parts[1])
-            start = date(year, month, 1)
-            if month == 12:
-                end = date(year + 1, 1, 1)
-            else:
-                end = date(year, month + 1, 1)
-        elif (len(parts) == 3 and len(parts[0]) == 4 and len(parts[1]) == 2
-              and len(parts[2]) == 2):
-            year = int(parts[0])
-            month = int(parts[1])
-            day = int(parts[2])
-            start = date(year, month, day)
-            end = start + timedelta(days=1)
-        else:
-            return None
-    except ValueError:
-        return None
-    return start, end

--- a/python/mirage/core/hierarchy/readdir.py
+++ b/python/mirage/core/hierarchy/readdir.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Literal
 
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
@@ -43,16 +43,26 @@ class DirListing:
         seeds (Mapping[str, list[tuple[str, IndexEntry]]]): descendant
             listings the same fetch proved, keyed by path relative to
             the listed directory (``files``, ``2026-01-05/Report__17``).
+        partial (bool): the entries are a filtered or truncated view
+            rather than the directory's contents, so they must not be
+            cached as the directory: a glob-scoped listing, or one the
+            provider did not finish. The entries themselves are real
+            either way, so the kit caches those and lets the next
+            readdir re-list. ``seeds`` stay full listings of the
+            children this fetch did report, so they are cached as
+            directories as usual.
     """
     entries: list[tuple[str, IndexEntry]]
     seeds: Mapping[str, list[tuple[str,
                                    IndexEntry]]] = field(default_factory=dict)
+    partial: bool = False
 
 
 Listed = list[tuple[str, IndexEntry]] | DirListing
 Lister = Callable[[A, ScopeMatch], Awaitable["Listed | None"]]
 EntryLister = Callable[[A, ScopeMatch, IndexEntry], Awaitable[Listed]]
 Guard = Callable[[A, ScopeMatch, str], Awaitable[None]]
+PatternTest = Callable[[str], bool]
 
 
 def _drop_hidden(
@@ -69,6 +79,7 @@ def make_readdir(
     parent_entry_listers: Mapping[str, EntryLister[A]] | None = None,
     static_root: tuple[str, ...] | None = None,
     guards: Mapping[str, Guard[A]] | None = None,
+    pattern_kinds: Mapping[str, PatternTest] | None = None,
     leaf_error: Literal["enoent", "enotdir"] = "enoent",
 ) -> ReaddirFn[A]:
     """Build a hierarchy readdir: dispatch, guards, index, name joins.
@@ -120,10 +131,19 @@ def make_readdir(
         guards (Mapping[str, Guard]): existence checks that run before
             the index probe, so a vanished container is ENOENT even on a
             warm cache.
+        pattern_kinds (Mapping[str, PatternTest] | None): one entry per
+            kind whose listing is a bounded window, holding the test for
+            whether a glob is one its lister can move the window to
+            (``has_glob_span`` for a date-keyed listing). A glob that
+            passes reaches the lister and the index is not read first,
+            because a cached listing is that same window and would
+            answer the glob with it. Any other glob, and any other kind,
+            keeps the cached listing and never sees a pattern.
         leaf_error (Literal["enoent", "enotdir"]): what listing a leaf
             raises; fixed hierarchies historically answer ENOENT.
     """
 
+    globbed_kinds = pattern_kinds if pattern_kinds is not None else {}
     resolved = entry_listers if entry_listers is not None else {}
     parented = (parent_entry_listers
                 if parent_entry_listers is not None else {})
@@ -151,6 +171,11 @@ def make_readdir(
         match = detect(path)
         if match.kind == INVALID:
             raise enoent(virtual)
+        pushable = globbed_kinds.get(match.kind)
+        globbed = (path_spec.pattern is not None and pushable is not None
+                   and pushable(path_spec.pattern))
+        if globbed:
+            match = replace(match, pattern=path_spec.pattern)
         if match.kind == ROOT and static_root is not None:
             return [f"{prefix}/{d}" for d in static_root]
         lister = listers.get(match.kind)
@@ -164,9 +189,10 @@ def make_readdir(
         guard = guards.get(match.kind) if guards is not None else None
         if guard is not None:
             await guard(accessor, match, virtual)
-        listing = await index.list_dir(virtual_key)
-        if listing.entries is not None:
-            return listing.entries
+        if not globbed:
+            listing = await index.list_dir(virtual_key)
+            if listing.entries is not None:
+                return listing.entries
         if entry_lister is not None or parent_lister is not None:
             proof_key = virtual_key
             if parent_lister is not None:
@@ -181,9 +207,10 @@ def make_readdir(
             # The resolve may have warmed this very listing: a parent's
             # lister can seed a child listing from the same fetch
             # (DirListing.seeds), so ask the index again before fetching.
-            relisted = await index.list_dir(virtual_key)
-            if relisted.entries is not None:
-                return relisted.entries
+            if not globbed:
+                relisted = await index.list_dir(virtual_key)
+                if relisted.entries is not None:
+                    return relisted.entries
             if entry_lister is not None:
                 listed = await entry_lister(accessor, match, own)
             else:
@@ -196,12 +223,18 @@ def make_readdir(
                 raise enoent(virtual)
             listed = maybe
         seeds: Mapping[str, list[tuple[str, IndexEntry]]] = {}
+        partial = False
         if isinstance(listed, DirListing):
             seeds = listed.seeds
+            partial = listed.partial
             listed = listed.entries
         entries = _drop_hidden(listed)
-        await index.set_dir(virtual_key, entries)
         stem = virtual_key.rstrip("/")
+        if partial:
+            for name, entry in entries:
+                await index.put(f"{stem}/{name}", entry)
+        else:
+            await index.set_dir(virtual_key, entries)
         for rel, child_entries in seeds.items():
             await index.set_dir(f"{stem}/{rel.strip('/')}",
                                 _drop_hidden(child_entries))

--- a/python/mirage/core/hierarchy/scope.py
+++ b/python/mirage/core/hierarchy/scope.py
@@ -89,11 +89,19 @@ class ScopeMatch:
         resource_path (str): the raw path that was classified.
         scope (Scope | None): the matched scope; None for root and
             invalid.
+        pattern (str | None): the glob the line typed for the directory's
+            children, set only for a kind named in ``pattern_kinds`` and
+            None everywhere else. A lister whose listing is a window
+            moves that window to the span the glob asks for instead of
+            filtering its own; every other consumer ignores the field,
+            the way a command ignores the ``CommandOpts`` facts it does
+            not read.
     """
     kind: str
     resource_path: str
     slots: dict[str, str] = field(default_factory=dict)
     scope: Scope | None = None
+    pattern: str | None = None
 
 
 def decode_slot(slot: Slot, part: str) -> dict[str, str] | None:

--- a/python/mirage/core/lancedb/query.py
+++ b/python/mirage/core/lancedb/query.py
@@ -32,6 +32,35 @@ def _where(filters: dict[str, str]) -> str:
     return " AND ".join(_eq(col, val) for col, val in filters.items())
 
 
+def _like(column: str, prefix: str) -> str:
+    escaped = prefix
+    for ch in ("\\", "%", "_"):
+        escaped = escaped.replace(ch, "\\" + ch)
+    return (f"CAST({column} AS STRING) LIKE '{_quote(escaped)}%' "
+            "ESCAPE '\\'")
+
+
+def _predicate(column: str, filters: dict[str, str], prefix: str) -> str:
+    """The where clause for a group's filters plus a name prefix.
+
+    The prefix is what a glob narrows the query to: the cap on rows is a
+    window over the table, so filtering the head of it would hide every
+    match past the cap, while a prefix match moves the window onto what
+    the line asked for. LIKE has its own metacharacters, so ``%`` and
+    ``_`` in the prefix are escaped rather than left to widen the match,
+    and the cast is what lets a numeric id column take one.
+
+    Args:
+        column (str): the column the prefix applies to.
+        filters (dict[str, str]): the group filters, if any.
+        prefix (str): the literal name prefix, empty for no prefix.
+    """
+    parts = [_where(filters)] if filters else []
+    if prefix and column:
+        parts.append(_like(column, prefix))
+    return " AND ".join(parts)
+
+
 async def list_tables(accessor: LanceDBAccessor) -> list[str]:
     db = await accessor.db()
     result = await db.list_tables()
@@ -43,12 +72,17 @@ async def table_exists(accessor: LanceDBAccessor, name: str) -> bool:
     return name in await list_tables(accessor)
 
 
-async def distinct_values(accessor: LanceDBAccessor, table: str, column: str,
-                          filters: dict[str, str], limit: int) -> list[str]:
+async def distinct_values(accessor: LanceDBAccessor,
+                          table: str,
+                          column: str,
+                          filters: dict[str, str],
+                          limit: int,
+                          prefix: str = "") -> list[str]:
     tbl = await accessor.table(table)
     query = tbl.query().select([column]).limit(limit)
-    if filters:
-        query = query.where(_where(filters))
+    clause = _predicate(column, filters, prefix)
+    if clause:
+        query = query.where(clause)
     rows = await query.to_list()
     values = {str(row[column]) for row in rows if row.get(column) is not None}
     return sorted(values)
@@ -60,13 +94,18 @@ async def table_columns(accessor: LanceDBAccessor, table: str) -> list[str]:
     return list(schema.names)
 
 
-async def rows_matching(accessor: LanceDBAccessor, table: str,
-                        filters: dict[str, str], columns: list[str],
-                        limit: int) -> list[dict[str, Any]]:
+async def rows_matching(accessor: LanceDBAccessor,
+                        table: str,
+                        filters: dict[str, str],
+                        columns: list[str],
+                        limit: int,
+                        id_column: str = "",
+                        prefix: str = "") -> list[dict[str, Any]]:
     tbl = await accessor.table(table)
     query = tbl.query().select(columns).limit(limit)
-    if filters:
-        query = query.where(_where(filters))
+    clause = _predicate(id_column, filters, prefix)
+    if clause:
+        query = query.where(clause)
     return await query.to_list()
 
 

--- a/python/mirage/core/lancedb/query.py
+++ b/python/mirage/core/lancedb/query.py
@@ -21,11 +21,26 @@ def _quote(value: str) -> str:
     return value.replace("'", "''")
 
 
+def _column(name: str) -> str:
+    """A configured column name, spelled so the parser reads a column.
+
+    Backticks, not double quotes: lance reads a double-quoted word as a
+    string literal, so ``"id" = 'x'`` compares the text ``id`` and
+    matches nothing rather than failing. Quoting is what lets a name
+    with a space or a reserved word through, and a bare name means the
+    same thing quoted.
+
+    Args:
+        name (str): the column name as configured.
+    """
+    return "`" + name.replace("`", "``") + "`"
+
+
 def _eq(column: str, value: str) -> str:
     text = str(value)
     if text.lstrip("-").isdigit():
-        return f"{column} = {text}"
-    return f"{column} = '{_quote(text)}'"
+        return f"{_column(column)} = {text}"
+    return f"{_column(column)} = '{_quote(text)}'"
 
 
 def _where(filters: dict[str, str]) -> str:
@@ -36,7 +51,7 @@ def _like(column: str, prefix: str) -> str:
     escaped = prefix
     for ch in ("\\", "%", "_"):
         escaped = escaped.replace(ch, "\\" + ch)
-    return (f"CAST({column} AS STRING) LIKE '{_quote(escaped)}%' "
+    return (f"CAST({_column(column)} AS STRING) LIKE '{_quote(escaped)}%' "
             "ESCAPE '\\'")
 
 

--- a/python/mirage/core/lancedb/readdir.py
+++ b/python/mirage/core/lancedb/readdir.py
@@ -18,7 +18,8 @@ from mirage.accessor.lancedb import LanceDBAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
 from mirage.core.hierarchy.bind import per_accessor
 from mirage.core.hierarchy.probe import ReaddirFn
-from mirage.core.hierarchy.readdir import Lister, make_readdir
+from mirage.core.hierarchy.readdir import (DirListing, Listed, Lister,
+                                           make_readdir)
 from mirage.core.hierarchy.scope import ROOT, ScopeMatch
 from mirage.core.lancedb.query import (distinct_values, list_tables,
                                        rows_matching, table_columns,
@@ -27,6 +28,7 @@ from mirage.core.lancedb.render import render_card
 from mirage.core.lancedb.scope import detect_for, filters_of, table_of
 from mirage.resource.lancedb.config import LanceDBConfig
 from mirage.types import PathSpec
+from mirage.utils.glob_walk import glob_prefix, has_glob_prefix
 
 GROUP_TYPE = "lancedb/group"
 
@@ -66,17 +68,36 @@ def _row_entries(rows: list[dict[str, Any]],
     return entries
 
 
-async def _children(
-        accessor: LanceDBAccessor, table: str,
-        filters: dict[str, str]) -> list[tuple[str, IndexEntry]] | None:
+def _row_prefix(pattern: str | None) -> str:
+    """The id prefix a leaf glob narrows the row query to.
+
+    A leaf is named ``<row_id>`` plus a codec suffix, so a literal
+    prefix that reached into the suffix is not an id prefix. Cutting at
+    the first dot keeps a superset the glob then filters, which is what
+    stops ``12*.md`` from asking for ids starting ``12.`` and listing
+    nothing.
+
+    Args:
+        pattern (str | None): the glob the line typed, or None.
+    """
+    return glob_prefix(pattern).split(".", 1)[0]
+
+
+async def _children(accessor: LanceDBAccessor,
+                    match: ScopeMatch) -> Listed | None:
     config = accessor.config
+    table = table_of(config, match)
+    filters = filters_of(config, match)
+    pattern = match.pattern
     if not await table_exists(accessor, table):
         return None
     depth = len(filters)
     if depth < len(config.group_by):
+        prefix = glob_prefix(pattern)
         names = await distinct_values(accessor, table, config.group_by[depth],
-                                      filters, config.max_rows)
-        return [(name, _dir_entry(name)) for name in names]
+                                      filters, config.max_rows, prefix)
+        return DirListing(entries=[(name, _dir_entry(name)) for name in names],
+                          partial=bool(prefix))
     # Select every column except the vector and blob ones (schema order, so
     # the projected rows render byte-identically to the full rows read()
     # fetches). Still one data query; the schema lookup is local metadata on
@@ -85,26 +106,26 @@ async def _children(
         c for c in await table_columns(accessor, table)
         if c != config.vector_column and c != config.blob_column
     ]
+    prefix = _row_prefix(pattern)
     rows = await rows_matching(accessor, table, filters, columns,
-                               config.max_rows)
-    return _row_entries(rows, config)
+                               config.max_rows, config.id_column, prefix)
+    return DirListing(entries=_row_entries(rows, config), partial=bool(prefix))
 
 
 async def _list_root(accessor: LanceDBAccessor,
-                     match: ScopeMatch) -> list[tuple[str, IndexEntry]] | None:
+                     match: ScopeMatch) -> Listed | None:
     config = accessor.config
     if not config.table:
+        # Table names come from the catalog, not from a capped query, so
+        # a glob here has nothing to narrow.
         return [(name, _dir_entry(name))
                 for name in await list_tables(accessor)]
-    return await _children(accessor, config.table, {})
+    return await _children(accessor, match)
 
 
-async def _list_group(
-        accessor: LanceDBAccessor,
-        match: ScopeMatch) -> list[tuple[str, IndexEntry]] | None:
-    config = accessor.config
-    return await _children(accessor, table_of(config, match),
-                           filters_of(config, match))
+async def _list_group(accessor: LanceDBAccessor,
+                      match: ScopeMatch) -> Listed | None:
+    return await _children(accessor, match)
 
 
 LISTERS: dict[str, Lister[LanceDBAccessor]] = {
@@ -112,9 +133,13 @@ LISTERS: dict[str, Lister[LanceDBAccessor]] = {
     "group": _list_group,
 }
 
+PATTERN_KINDS = {ROOT: has_glob_prefix, "group": has_glob_prefix}
+
 
 def _build(accessor: LanceDBAccessor) -> ReaddirFn[LanceDBAccessor]:
-    return make_readdir(detect_for(accessor), listers=LISTERS)
+    return make_readdir(detect_for(accessor),
+                        listers=LISTERS,
+                        pattern_kinds=PATTERN_KINDS)
 
 
 readdir_for = per_accessor(_build)

--- a/python/mirage/core/lancedb/readdir.py
+++ b/python/mirage/core/lancedb/readdir.py
@@ -28,7 +28,8 @@ from mirage.core.lancedb.render import render_card
 from mirage.core.lancedb.scope import detect_for, filters_of, table_of
 from mirage.resource.lancedb.config import LanceDBConfig
 from mirage.types import PathSpec
-from mirage.utils.glob_walk import glob_prefix, has_glob_prefix
+from mirage.utils.glob_walk import (glob_prefix, glob_stem_prefix,
+                                    has_glob_prefix)
 
 GROUP_TYPE = "lancedb/group"
 
@@ -68,19 +69,20 @@ def _row_entries(rows: list[dict[str, Any]],
     return entries
 
 
-def _row_prefix(pattern: str | None) -> str:
-    """The id prefix a leaf glob narrows the row query to.
+def _row_prefix(pattern: str | None, config: LanceDBConfig) -> str:
+    """The row-id prefix a leaf glob narrows the row query to.
 
-    A leaf is named ``<row_id>`` plus a codec suffix, so a literal
-    prefix that reached into the suffix is not an id prefix. Cutting at
-    the first dot keeps a superset the glob then filters, which is what
-    stops ``12*.md`` from asking for ids starting ``12.`` and listing
-    nothing.
+    A leaf is named ``<row_id>`` plus whichever suffix the renderer gave
+    it, and only the id half is a prefix the query can test.
 
     Args:
         pattern (str | None): the glob the line typed, or None.
+        config (LanceDBConfig): the mount's config, for the suffixes.
     """
-    return glob_prefix(pattern).split(".", 1)[0]
+    suffixes = [".md"]
+    if config.blob_column:
+        suffixes.append(f".{config.blob_ext}")
+    return glob_stem_prefix(pattern, suffixes)
 
 
 async def _children(accessor: LanceDBAccessor,
@@ -106,7 +108,7 @@ async def _children(accessor: LanceDBAccessor,
         c for c in await table_columns(accessor, table)
         if c != config.vector_column and c != config.blob_column
     ]
-    prefix = _row_prefix(pattern)
+    prefix = _row_prefix(pattern, config)
     rows = await rows_matching(accessor, table, filters, columns,
                                config.max_rows, config.id_column, prefix)
     return DirListing(entries=_row_entries(rows, config), partial=bool(prefix))

--- a/python/mirage/core/qdrant/query.py
+++ b/python/mirage/core/qdrant/query.py
@@ -14,6 +14,7 @@
 
 import logging
 import uuid
+from collections.abc import Callable
 from typing import Any
 
 from qdrant_client import models
@@ -61,20 +62,61 @@ def _candidate_ids(row_id: str) -> list[Any]:
     return [row_id]
 
 
-async def _scroll_raw(client: Any, collection: str, flt: models.Filter | None,
-                      limit: int) -> list[Any]:
+PointTest = Callable[[Any], bool]
+
+
+def id_prefix_test(prefix: str) -> PointTest:
+    """Keep points whose id starts with a literal name prefix.
+
+    Args:
+        prefix (str): the literal prefix a leaf glob asked for.
+    """
+
+    def keep(point: Any) -> bool:
+        return str(point.id).startswith(prefix)
+
+    return keep
+
+
+def value_prefix_test(column: str, prefix: str) -> PointTest:
+    """Keep points whose payload value starts with a literal prefix.
+
+    Args:
+        column (str): the payload field the group level is named from.
+        prefix (str): the literal prefix a group glob asked for.
+    """
+
+    def keep(point: Any) -> bool:
+        value = (point.payload or {}).get(column)
+        return value is not None and str(value).startswith(prefix)
+
+    return keep
+
+
+async def _scroll_raw(client: Any,
+                      collection: str,
+                      flt: models.Filter | None,
+                      limit: int,
+                      keep: PointTest | None = None) -> list[Any]:
+    # Without a test the limit bounds the scroll, which is the ordinary
+    # capped listing. With one it bounds the MATCHES, because qdrant has
+    # no prefix condition for a point id or a keyword field: the only
+    # way to answer a glob for a row past the cap is to keep scrolling
+    # and test each page here. A glob is a targeted request, so it pays
+    # a scan of the collection where the plain listing pays one page.
     points: list[Any] = []
     offset: Any = None
     while len(points) < limit:
         batch, offset = await client.scroll(
             collection_name=collection,
             scroll_filter=flt,
-            limit=min(SCROLL_BATCH, limit - len(points)),
+            limit=SCROLL_BATCH if keep is not None else min(
+                SCROLL_BATCH, limit - len(points)),
             offset=offset,
             with_payload=True,
             with_vectors=False,
         )
-        points.extend(batch)
+        points.extend(batch if keep is None else [p for p in batch if keep(p)])
         if offset is None:
             break
     return points[:limit]
@@ -99,19 +141,22 @@ async def _ensure_indexes(client: Any, accessor: QdrantAccessor,
     accessor._indexes_ensured.add(collection)
 
 
-async def _scroll_all(accessor: QdrantAccessor, collection: str,
-                      filters: dict[str, str], limit: int) -> list[Any]:
+async def _scroll_all(accessor: QdrantAccessor,
+                      collection: str,
+                      filters: dict[str, str],
+                      limit: int,
+                      keep: PointTest | None = None) -> list[Any]:
     client = await accessor.client()
     if not filters:
-        return await _scroll_raw(client, collection, None, limit)
+        return await _scroll_raw(client, collection, None, limit, keep)
     flt = _filter(filters)
     try:
-        return await _scroll_raw(client, collection, flt, limit)
+        return await _scroll_raw(client, collection, flt, limit, keep)
     except UnexpectedResponse as exc:
         if not _is_index_required(exc):
             raise
     await _ensure_indexes(client, accessor, collection)
-    return await _scroll_raw(client, collection, flt, limit)
+    return await _scroll_raw(client, collection, flt, limit, keep)
 
 
 async def list_tables(accessor: QdrantAccessor) -> list[str]:
@@ -125,9 +170,14 @@ async def table_exists(accessor: QdrantAccessor, name: str) -> bool:
     return await client.collection_exists(name)
 
 
-async def distinct_values(accessor: QdrantAccessor, table: str, column: str,
-                          filters: dict[str, str], limit: int) -> list[str]:
-    points = await _scroll_all(accessor, table, filters, limit)
+async def distinct_values(accessor: QdrantAccessor,
+                          table: str,
+                          column: str,
+                          filters: dict[str, str],
+                          limit: int,
+                          prefix: str = "") -> list[str]:
+    keep = value_prefix_test(column, prefix) if prefix else None
+    points = await _scroll_all(accessor, table, filters, limit, keep)
     values = {
         str(payload[column])
         for point in points
@@ -136,10 +186,13 @@ async def distinct_values(accessor: QdrantAccessor, table: str, column: str,
     return sorted(values)
 
 
-async def rows_matching(accessor: QdrantAccessor, table: str,
+async def rows_matching(accessor: QdrantAccessor,
+                        table: str,
                         filters: dict[str, str],
-                        limit: int) -> list[dict[str, Any]]:
-    points = await _scroll_all(accessor, table, filters, limit)
+                        limit: int,
+                        prefix: str = "") -> list[dict[str, Any]]:
+    keep = id_prefix_test(prefix) if prefix else None
+    points = await _scroll_all(accessor, table, filters, limit, keep)
     return [_point_to_row(point, accessor.config.id_field) for point in points]
 
 

--- a/python/mirage/core/qdrant/readdir.py
+++ b/python/mirage/core/qdrant/readdir.py
@@ -28,7 +28,8 @@ from mirage.core.qdrant.render import blob_bytes, render_json, render_text
 from mirage.core.qdrant.scope import detect_for, filters_of, table_of
 from mirage.resource.qdrant.config import QdrantConfig
 from mirage.types import JsonValue, PathSpec
-from mirage.utils.glob_walk import glob_prefix, has_glob_prefix
+from mirage.utils.glob_walk import (glob_prefix, glob_stem_prefix,
+                                    has_glob_prefix)
 
 logger = logging.getLogger(__name__)
 
@@ -92,19 +93,22 @@ def _row_entries(rows: list[dict[str, Any]],
     return entries
 
 
-def _row_prefix(pattern: str | None) -> str:
-    """The id prefix a leaf glob narrows the scroll to.
+def _row_prefix(pattern: str | None, config: QdrantConfig) -> str:
+    """The point-id prefix a leaf glob narrows the scroll to.
 
-    A leaf is named ``<point_id>`` plus a suffix, so a literal prefix
-    that reached into the suffix is not an id prefix. Cutting at the
-    first dot keeps a superset the glob then filters, which is what
-    stops ``12*.json`` from asking for ids starting ``12.`` and listing
-    nothing.
+    A leaf is named ``<point_id>`` plus whichever suffix the renderer
+    gave it, and only the id half is a prefix the scroll can test.
 
     Args:
         pattern (str | None): the glob the line typed, or None.
+        config (QdrantConfig): the mount's config, for the suffixes.
     """
-    return glob_prefix(pattern).split(".", 1)[0]
+    suffixes = [".json"]
+    if config.text_field:
+        suffixes.append(".txt")
+    if config.blob_field:
+        suffixes.append(f".{config.blob_ext}")
+    return glob_stem_prefix(pattern, suffixes)
 
 
 async def _children(accessor: QdrantAccessor,
@@ -122,7 +126,7 @@ async def _children(accessor: QdrantAccessor,
                                       filters, config.max_rows, prefix)
         return DirListing(entries=[(name, _dir_entry(name)) for name in names],
                           partial=bool(prefix))
-    prefix = _row_prefix(pattern)
+    prefix = _row_prefix(pattern, config)
     rows = await rows_matching(accessor, table, filters, config.max_rows,
                                prefix)
     return DirListing(entries=_row_entries(rows, config), partial=bool(prefix))

--- a/python/mirage/core/qdrant/readdir.py
+++ b/python/mirage/core/qdrant/readdir.py
@@ -19,7 +19,8 @@ from mirage.accessor.qdrant import QdrantAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
 from mirage.core.hierarchy.bind import per_accessor
 from mirage.core.hierarchy.probe import ReaddirFn
-from mirage.core.hierarchy.readdir import Lister, make_readdir
+from mirage.core.hierarchy.readdir import (DirListing, Listed, Lister,
+                                           make_readdir)
 from mirage.core.hierarchy.scope import ROOT, ScopeMatch
 from mirage.core.qdrant.query import (distinct_values, list_tables,
                                       rows_matching, table_exists)
@@ -27,6 +28,7 @@ from mirage.core.qdrant.render import blob_bytes, render_json, render_text
 from mirage.core.qdrant.scope import detect_for, filters_of, table_of
 from mirage.resource.qdrant.config import QdrantConfig
 from mirage.types import JsonValue, PathSpec
+from mirage.utils.glob_walk import glob_prefix, has_glob_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -90,36 +92,56 @@ def _row_entries(rows: list[dict[str, Any]],
     return entries
 
 
-async def _children(
-        accessor: QdrantAccessor, table: str,
-        filters: dict[str, str]) -> list[tuple[str, IndexEntry]] | None:
+def _row_prefix(pattern: str | None) -> str:
+    """The id prefix a leaf glob narrows the scroll to.
+
+    A leaf is named ``<point_id>`` plus a suffix, so a literal prefix
+    that reached into the suffix is not an id prefix. Cutting at the
+    first dot keeps a superset the glob then filters, which is what
+    stops ``12*.json`` from asking for ids starting ``12.`` and listing
+    nothing.
+
+    Args:
+        pattern (str | None): the glob the line typed, or None.
+    """
+    return glob_prefix(pattern).split(".", 1)[0]
+
+
+async def _children(accessor: QdrantAccessor,
+                    match: ScopeMatch) -> Listed | None:
     config = accessor.config
+    table = table_of(config, match)
+    filters = filters_of(config, match)
+    pattern = match.pattern
     if not await table_exists(accessor, table):
         return None
     depth = len(filters)
     if depth < len(config.group_by):
+        prefix = glob_prefix(pattern)
         names = await distinct_values(accessor, table, config.group_by[depth],
-                                      filters, config.max_rows)
-        return [(name, _dir_entry(name)) for name in names]
-    rows = await rows_matching(accessor, table, filters, config.max_rows)
-    return _row_entries(rows, config)
+                                      filters, config.max_rows, prefix)
+        return DirListing(entries=[(name, _dir_entry(name)) for name in names],
+                          partial=bool(prefix))
+    prefix = _row_prefix(pattern)
+    rows = await rows_matching(accessor, table, filters, config.max_rows,
+                               prefix)
+    return DirListing(entries=_row_entries(rows, config), partial=bool(prefix))
 
 
 async def _list_root(accessor: QdrantAccessor,
-                     match: ScopeMatch) -> list[tuple[str, IndexEntry]] | None:
+                     match: ScopeMatch) -> Listed | None:
     config = accessor.config
     if not config.collection:
+        # Collection names come from the catalog, not from a capped
+        # scroll, so a glob here has nothing to narrow.
         return [(name, _dir_entry(name))
                 for name in await list_tables(accessor)]
-    return await _children(accessor, config.collection, {})
+    return await _children(accessor, match)
 
 
-async def _list_group(
-        accessor: QdrantAccessor,
-        match: ScopeMatch) -> list[tuple[str, IndexEntry]] | None:
-    config = accessor.config
-    return await _children(accessor, table_of(config, match),
-                           filters_of(config, match))
+async def _list_group(accessor: QdrantAccessor,
+                      match: ScopeMatch) -> Listed | None:
+    return await _children(accessor, match)
 
 
 LISTERS: dict[str, Lister[QdrantAccessor]] = {
@@ -127,9 +149,13 @@ LISTERS: dict[str, Lister[QdrantAccessor]] = {
     "group": _list_group,
 }
 
+PATTERN_KINDS = {ROOT: has_glob_prefix, "group": has_glob_prefix}
+
 
 def _build(accessor: QdrantAccessor) -> ReaddirFn[QdrantAccessor]:
-    return make_readdir(detect_for(accessor), listers=LISTERS)
+    return make_readdir(detect_for(accessor),
+                        listers=LISTERS,
+                        pattern_kinds=PATTERN_KINDS)
 
 
 readdir_for = per_accessor(_build)

--- a/python/mirage/core/slack/readdir.py
+++ b/python/mirage/core/slack/readdir.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import IndexEntry
@@ -27,6 +27,7 @@ from mirage.core.slack.formatters import (channel_dirname, dm_dirname,
 from mirage.core.slack.history import fetch_messages_for_day, messages_to_jsonl
 from mirage.core.slack.scope import detect_scope
 from mirage.core.slack.users import list_users, user_json_bytes
+from mirage.utils.glob_walk import glob_span, has_glob_span
 
 logger = logging.getLogger(__name__)
 
@@ -43,10 +44,27 @@ _SOFT_HISTORY_ERRORS = (
 
 def _date_range(latest_ts: float,
                 created: int,
-                max_days: int = 90) -> list[str]:
+                max_days: int = 90,
+                span: tuple[date, date] | None = None) -> list[str]:
+    """The channel's day directories, newest first.
+
+    A day dir is real for any date the channel has existed for, so the
+    bare listing is a window: the last ``max_days`` up to the newest
+    message. A glob names its own window instead, and then the cap does
+    not apply, because the span is already bounded by what was typed.
+
+    Args:
+        latest_ts (float): timestamp of the newest message.
+        created (int): channel creation timestamp.
+        max_days (int): how many days the bare window covers.
+        span (tuple[date, date] | None): the glob's half-open range.
+    """
     end = datetime.fromtimestamp(latest_ts, tz=timezone.utc).date()
     start = datetime.fromtimestamp(created, tz=timezone.utc).date()
-    if (end - start).days > max_days:
+    if span is not None:
+        start = max(start, span[0])
+        end = min(end, span[1] - timedelta(days=1))
+    elif (end - start).days > max_days:
         start = end - timedelta(days=max_days - 1)
     dates = []
     d = end
@@ -133,21 +151,23 @@ async def _list_users_root(accessor: SlackAccessor,
 async def _list_channel_days(accessor: SlackAccessor, match: ScopeMatch,
                              own: IndexEntry) -> Listed:
     created = int(own.remote_time or 0)
+    span = glob_span(match.pattern)
     latest_ts = await _latest_message_ts(accessor.config, own.id)
     if latest_ts and created:
-        dates = _date_range(latest_ts, created)
+        dates = _date_range(latest_ts, created, span=span)
     elif latest_ts:
-        dates = _date_range(latest_ts, int(latest_ts))
+        dates = _date_range(latest_ts, int(latest_ts), span=span)
     else:
         dates = []
-    return [(d,
-             IndexEntry(
-                 id=f"{own.id}:{d}",
-                 name=d,
-                 resource_type="slack/date_dir",
-                 vfs_name=d,
-                 extra={"channel_id": own.id},
-             )) for d in dates]
+    entries = [(d,
+                IndexEntry(
+                    id=f"{own.id}:{d}",
+                    name=d,
+                    resource_type="slack/date_dir",
+                    vfs_name=d,
+                    extra={"channel_id": own.id},
+                )) for d in dates]
+    return DirListing(entries=entries, partial=span is not None)
 
 
 async def _day_listing(accessor: SlackAccessor, channel_id: str,
@@ -260,6 +280,7 @@ readdir = make_readdir(
     },
     parent_entry_listers={"day": _list_day},
     static_root=VIRTUAL_ROOTS,
+    pattern_kinds={"channel": has_glob_span},
 )
 
 __all__ = ["readdir", "VIRTUAL_ROOTS"]

--- a/python/mirage/utils/glob_walk.py
+++ b/python/mirage/utils/glob_walk.py
@@ -89,6 +89,34 @@ def glob_prefix(pattern: str | None) -> str:
     return unmark_globs(pattern[:meta_index])
 
 
+def glob_stem_prefix(pattern: str | None, suffixes: Sequence[str]) -> str:
+    """The literal prefix a glob puts on the stem of a leaf name.
+
+    A leaf is a stem plus one of the renderer's suffixes, so a literal
+    that has run into a suffix says nothing about the stem and the part
+    that ran in is dropped: `12*.md` narrows to `12`, and `doc-1.m*`
+    narrows to `doc-1` rather than asking for stems that start
+    `doc-1.m`. Only a tail that spells the head of a suffix is dropped,
+    which is what keeps a stem that contains a dot: `acct.2026*` narrows
+    to `acct.2026`, where cutting at the first dot would narrow to
+    `acct` and let the rows nobody asked for eat the window.
+
+    Args:
+        pattern (str | None): the glob as typed, or None.
+        suffixes (Sequence[str]): the suffixes a leaf name can carry.
+
+    Returns:
+        str: the literal stem prefix, empty when there is none.
+    """
+    literal = glob_prefix(pattern)
+    reached = 0
+    for suffix in suffixes:
+        for size in range(1, len(suffix) + 1):
+            if literal.endswith(suffix[:size]):
+                reached = max(reached, size)
+    return literal[:len(literal) - reached]
+
+
 def glob_span(pattern: str | None) -> tuple[date, date] | None:
     """The half-open range of dates a date-prefixed glob asks for.
 

--- a/python/mirage/utils/glob_walk.py
+++ b/python/mirage/utils/glob_walk.py
@@ -15,6 +15,7 @@
 import dataclasses
 import logging
 from collections.abc import Awaitable, Callable, Sequence
+from datetime import date, timedelta
 from typing import Any, Protocol
 
 from mirage.accessor.base import Accessor
@@ -28,6 +29,104 @@ from mirage.utils.key_prefix import rekey
 logger = logging.getLogger(__name__)
 
 GLOB_CHARS = ("*", "?", "[")
+
+
+def _meta_index(pattern: str) -> int:
+    first = -1
+    for ch in GLOB_CHARS:
+        idx = pattern.find(ch)
+        if idx != -1 and (first == -1 or idx < first):
+            first = idx
+    return first
+
+
+def has_glob_span(pattern: str) -> bool:
+    """Whether a glob names a date range a windowed lister can move to.
+
+    The kit's ``pattern_kinds`` table holds one of these per kind: a glob
+    it answers True for reaches the lister and bypasses the index, and
+    any other glob is filtered out of the ordinary cached listing.
+
+    Args:
+        pattern (str): the glob as typed.
+    """
+    return glob_span(pattern) is not None
+
+
+def has_glob_prefix(pattern: str) -> bool:
+    """Whether a glob starts with literal text a query can narrow on.
+
+    The ``pattern_kinds`` twin of ``has_glob_span`` for a backend whose
+    window is a row cap rather than a date range: the literal prefix
+    becomes a prefix match in the query, so the cap covers the region
+    the line named instead of the head of the table.
+
+    Args:
+        pattern (str): the glob as typed.
+    """
+    return bool(glob_prefix(pattern))
+
+
+def glob_prefix(pattern: str | None) -> str:
+    """The literal text a glob starts with, before its first metacharacter.
+
+    A quoted glob character travels under a private mark and stands for
+    that character literally, so the marks are restored here: `'*'ab*`
+    asks for names starting with a real star.
+
+    Args:
+        pattern (str | None): the glob as typed, or None.
+
+    Returns:
+        str: the literal prefix, empty when the glob opens with a
+        metacharacter or carries none at all.
+    """
+    if not pattern:
+        return ""
+    meta_index = _meta_index(pattern)
+    if meta_index == -1:
+        return ""
+    return unmark_globs(pattern[:meta_index])
+
+
+def glob_span(pattern: str | None) -> tuple[date, date] | None:
+    """The half-open range of dates a date-prefixed glob asks for.
+
+    The literal prefix before the first metacharacter is read as a year,
+    a month or a day, so ``2026-*`` spans a year and ``2026-01-05*`` one
+    day. This is what lets a windowed listing honour a glob instead of
+    filtering its own window: the backend moves the window to the span
+    the line named.
+
+    Args:
+        pattern (str | None): the glob as typed, or None.
+
+    Returns:
+        tuple[date, date] | None: (start, end) with end exclusive, or
+        None when the glob does not start with a date prefix.
+    """
+    literal = glob_prefix(pattern)
+    if not literal:
+        return None
+    parts = literal.rstrip("_-").split("-")
+    try:
+        if len(parts) == 1 and len(parts[0]) == 4:
+            year = int(parts[0])
+            return date(year, 1, 1), date(year + 1, 1, 1)
+        if len(parts) == 2 and len(parts[0]) == 4 and len(parts[1]) == 2:
+            year, month = int(parts[0]), int(parts[1])
+            start = date(year, month, 1)
+            if month == 12:
+                return start, date(year + 1, 1, 1)
+            return start, date(year, month + 1, 1)
+        if (len(parts) == 3 and len(parts[0]) == 4 and len(parts[1]) == 2
+                and len(parts[2]) == 2):
+            start = date(int(parts[0]), int(parts[1]), int(parts[2]))
+            return start, start + timedelta(days=1)
+    except ValueError:
+        return None
+    return None
+
 
 # A quoted glob character keeps travelling as a character, under a
 # private mark, because bash tracks quoting per character and not per
@@ -286,8 +385,18 @@ async def expand_pattern(
     for seg in segments[first:]:
         next_level: list[str] = []
         for parent in level:
-            spec = PathSpec.from_str_path(
-                parent, rekey(path.virtual, path.resource_path, parent))
+            # Directory-shaped, carrying the segment as the pattern: a
+            # backend whose listing for this level is a bounded window
+            # moves the window to what the glob asks for instead of
+            # filtering its own (gcal, gdocs and the dated-message
+            # channels). Every other readdir reads the directory off the
+            # same spec and ignores the field. A literal segment carries
+            # none, so it keeps its warm listing.
+            spec = PathSpec(virtual=parent,
+                            directory=parent,
+                            resource_path=rekey(path.virtual,
+                                                path.resource_path, parent),
+                            pattern=seg if has_glob(seg) else None)
             try:
                 entries = await readdir(accessor, spec, index)
             except (FileNotFoundError, NotADirectoryError):

--- a/python/tests/core/discord/test_readdir_date_layout.py
+++ b/python/tests/core/discord/test_readdir_date_layout.py
@@ -58,3 +58,41 @@ async def test_files_under_a_sealed_day_is_enoent(api, accessor, index):
     # The sealed day lists nothing, so its files subdir does not exist.
     with pytest.raises(FileNotFoundError):
         await readdir(accessor, spec(f"/{CHANNEL}/{SEALED_DAY}/files"), index)
+
+
+def globbed(virtual: str, pattern: str) -> PathSpec:
+    return PathSpec(virtual=f"{virtual}/{pattern}",
+                    directory=f"{virtual}/",
+                    resource_path=f"{virtual.lstrip('/')}/{pattern}",
+                    pattern=pattern)
+
+
+async def test_channel_glob_reaches_days_outside_the_window(
+        api, accessor, index):
+    # The bare listing is the 30 days up to the newest message, so a glob
+    # for an older month sees nothing unless it pushes its own span down.
+    result = await readdir(accessor, globbed(f"/{CHANNEL}", "2023-11-*"),
+                           index)
+    assert result[0] == f"/{CHANNEL}/2023-11-01"
+    assert result[-1] == f"/{CHANNEL}/2023-11-30"
+    assert len(result) == 30
+
+
+async def test_channel_glob_is_clipped_at_the_newest_message(
+        api, accessor, index):
+    # The fixture channel's last message is 2024-01-15, and nothing was
+    # posted after it, so the rest of January is not listed.
+    result = await readdir(accessor, globbed(f"/{CHANNEL}", "2024-01-*"),
+                           index)
+    assert result[-1] == f"/{CHANNEL}/2024-01-15"
+    assert len(result) == 15
+
+
+async def test_a_globbed_channel_listing_is_not_the_directory(
+        api, accessor, index):
+    # The glob's answer must not stand in for the channel: a later bare
+    # listing still reports the recent window.
+    await readdir(accessor, globbed(f"/{CHANNEL}", "2023-11-*"), index)
+    result = await readdir(accessor, spec(f"/{CHANNEL}"), index)
+    assert result[-1] == f"/{CHANNEL}/2024-01-15"
+    assert len(result) == 30

--- a/python/tests/core/gmail/test_date_query.py
+++ b/python/tests/core/gmail/test_date_query.py
@@ -12,18 +12,30 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from datetime import date, datetime, timezone
+
 import pytest
 
-from mirage.core.gmail.date_query import date_dir_to_gmail_query
+from mirage.core.gmail.date_query import (date_dir_to_gmail_query,
+                                          span_to_gmail_query)
 
 
+# Epoch seconds for midnight UTC, one second early on the lower bound.
 @pytest.mark.parametrize("name,expected", [
-    ("2026-05-03", "after:2026/05/03 before:2026/05/04"),
-    ("2026-12-31", "after:2026/12/31 before:2027/01/01"),
-    ("2026-01-01", "after:2026/01/01 before:2026/01/02"),
+    ("2026-05-03", "after:1777766399 before:1777852800"),
+    ("2026-12-31", "after:1798675199 before:1798761600"),
+    ("2026-01-01", "after:1767225599 before:1767312000"),
 ])
 def test_date_dir_to_gmail_query_translates(name, expected):
     assert date_dir_to_gmail_query(name) == expected
+
+
+def test_span_bounds_are_utc_seconds():
+    query = span_to_gmail_query(date(2026, 1, 1), date(2026, 2, 1))
+    after, before = (int(term.split(":")[1]) for term in query.split())
+    assert datetime.fromtimestamp(before, tz=timezone.utc) == datetime(
+        2026, 2, 1, tzinfo=timezone.utc)
+    assert before - after == 31 * 86400 + 1
 
 
 @pytest.mark.parametrize("name", [

--- a/python/tests/core/gmail/test_readdir.py
+++ b/python/tests/core/gmail/test_readdir.py
@@ -177,11 +177,11 @@ async def test_readdir_date_dir_uses_after_before_query(accessor, index):
     assert result == []
     date_calls = [
         c for c in captured_calls
-        if c["query"] and "after:2026/05/03" in c["query"]
+        if c["query"] and "after:1777766399" in c["query"]
     ]
     assert len(date_calls) == 1
     assert date_calls[0]["label_id"] == "INBOX"
-    assert "before:2026/05/04" in date_calls[0]["query"]
+    assert "before:1777852800" in date_calls[0]["query"]
 
 
 def _msg_stub(mid, subject, internal_date_ms):
@@ -488,7 +488,7 @@ async def test_label_glob_pushes_its_span_into_the_query(accessor, index):
                      pattern="2026-01-*"), index)
 
     assert result == []
-    assert captured == ["after:2026/01/01 before:2026/02/01"]
+    assert captured == ["after:1767225599 before:1769904000"]
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/gmail/test_readdir.py
+++ b/python/tests/core/gmail/test_readdir.py
@@ -453,3 +453,91 @@ async def test_readdir_message_entry_rendered_size_estimate_in_extra(
     # source message size and lands in extra, never in size.
     assert result.entry.size == len(message_json_bytes(raw))
     assert result.entry.extra["size_estimate"] == 54321
+
+
+@pytest.mark.asyncio
+async def test_label_glob_pushes_its_span_into_the_query(accessor, index):
+    # The bare listing is the most recent MAX_MESSAGES, so a glob for an
+    # older month can only be answered by querying that month.
+    await index.set_dir("/gmail", [
+        ("INBOX",
+         IndexEntry(
+             id="INBOX",
+             name="INBOX",
+             resource_type="gmail/label",
+             vfs_name="INBOX",
+         )),
+    ])
+    captured: list[str | None] = []
+
+    async def fake_list_messages(token_manager,
+                                 label_id=None,
+                                 query=None,
+                                 max_results=50):
+        captured.append(query)
+        return []
+
+    with patch("mirage.core.gmail.readdir.list_messages",
+               new=fake_list_messages):
+        result = await readdir(
+            accessor,
+            PathSpec(resource_path=mount_key("/gmail/INBOX/2026-01-*",
+                                             "/gmail"),
+                     virtual="/gmail/INBOX/2026-01-*",
+                     directory="/gmail/INBOX/",
+                     pattern="2026-01-*"), index)
+
+    assert result == []
+    assert captured == ["after:2026/01/01 before:2026/02/01"]
+
+
+@pytest.mark.asyncio
+async def test_a_globbed_label_listing_is_not_cached_as_the_label(
+        accessor, index):
+    await index.set_dir("/gmail", [
+        ("INBOX",
+         IndexEntry(
+             id="INBOX",
+             name="INBOX",
+             resource_type="gmail/label",
+             vfs_name="INBOX",
+         )),
+    ])
+    raw = {
+        "id": "m1",
+        "internalDate": "1767225600000",
+        "payload": {
+            "headers": [{
+                "name": "Subject",
+                "value": "Hi"
+            }]
+        },
+    }
+
+    async def fake_list_messages(token_manager,
+                                 label_id=None,
+                                 query=None,
+                                 max_results=50):
+        return [{"id": "m1"}] if query else []
+
+    with (patch("mirage.core.gmail.readdir.list_messages",
+                new=fake_list_messages),
+          patch("mirage.core.gmail.readdir.get_message_raw",
+                new=AsyncMock(return_value=raw))):
+        globbed = await readdir(
+            accessor,
+            PathSpec(resource_path=mount_key("/gmail/INBOX/2026-01-*",
+                                             "/gmail"),
+                     virtual="/gmail/INBOX/2026-01-*",
+                     directory="/gmail/INBOX/",
+                     pattern="2026-01-*"), index)
+        assert globbed == ["/gmail/INBOX/2026-01-01"]
+        # The label directory is untouched, so the unglobbed listing goes
+        # back to the recent window rather than answering with January.
+        assert (await index.list_dir("/gmail/INBOX")).entries is None
+        plain = await readdir(
+            accessor,
+            PathSpec(resource_path=mount_key("/gmail/INBOX", "/gmail"),
+                     virtual="/gmail/INBOX",
+                     directory="/gmail/INBOX"), index)
+    assert plain == []

--- a/python/tests/core/gmail/test_stat.py
+++ b/python/tests/core/gmail/test_stat.py
@@ -118,6 +118,22 @@ async def test_stat_date(accessor, index):
 
 
 @pytest.mark.asyncio
+async def test_stat_date_outside_the_listed_window(accessor, index):
+    # The label listing is a bounded window of recent messages, so it never
+    # minted this day; the date query answers for any well-formed one, so the
+    # label's existence is the proof rather than the window. No API mock is
+    # needed precisely because nothing is fetched.
+    await _populate_index(index)
+    result = await stat(
+        accessor,
+        PathSpec(resource_path=mount_key("/gmail/INBOX/2020-01-01", "/gmail"),
+                 virtual="/gmail/INBOX/2020-01-01",
+                 directory="/gmail/INBOX/2020-01-01"), index)
+    assert result.type == FileType.DIRECTORY
+    assert result.name == "2020-01-01"
+
+
+@pytest.mark.asyncio
 async def test_stat_message(accessor, index):
     await _populate_index(index)
     result = await stat(

--- a/python/tests/core/hierarchy/test_readdir.py
+++ b/python/tests/core/hierarchy/test_readdir.py
@@ -20,6 +20,7 @@ from mirage.cache.index import IndexEntry
 from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.core.hierarchy.readdir import DirListing, make_readdir
 from mirage.core.hierarchy.scope import ScopeMatch
+from mirage.types import PathSpec
 from tests.core.hierarchy.conftest import (FakeAccessor, detect_scope,
                                            list_notes, list_rooms, room_guard,
                                            spec)
@@ -249,3 +250,84 @@ def test_a_kind_in_several_lister_tables_fails_at_build():
                      entry_listers={"room_day": _atts_fallback},
                      parent_entry_listers={"room_day": _days_by_room},
                      static_root=("rooms", ))
+
+
+def _any_pattern(pattern: str) -> bool:
+    return True
+
+
+async def _list_windowed(accessor: FakeAccessor,
+                         match: ScopeMatch) -> DirListing:
+    # Stands in for a bounded listing: without a glob it reports the tail
+    # of the tree, with one it reports exactly what the glob asked for.
+    accessor.calls.append(f"window:{match.pattern}")
+    names = ["c.json"] if match.pattern is None else [match.pattern]
+    entries = [(n,
+                IndexEntry(id=n, name=n, resource_type="fake/note",
+                           vfs_name=n)) for n in names]
+    return DirListing(entries=entries, partial=match.pattern is not None)
+
+
+WINDOW_READDIR = make_readdir(
+    detect_scope,
+    listers={
+        "rooms": list_rooms,
+        "room": _list_windowed,
+    },
+    static_root=("rooms", ),
+    pattern_kinds={"room": _any_pattern},
+)
+
+
+def _globbed(mount_path: str, pattern: str) -> PathSpec:
+    base = spec(mount_path)
+    return PathSpec(virtual=base.virtual + "/" + pattern,
+                    directory=base.virtual + "/",
+                    resource_path=base.resource_path + "/" + pattern,
+                    pattern=pattern)
+
+
+def test_a_pattern_kind_hands_the_glob_to_its_lister(accessor):
+    out = asyncio.run(
+        WINDOW_READDIR(accessor, _globbed("/rooms/red", "z.json")))
+    assert out == ["/h/rooms/red/z.json"]
+    assert accessor.calls == ["window:z.json"]
+
+
+def test_an_undeclared_kind_never_sees_a_pattern(accessor):
+    plain = make_readdir(detect_scope,
+                         listers={
+                             "rooms": list_rooms,
+                             "room": _list_windowed
+                         },
+                         static_root=("rooms", ))
+    out = asyncio.run(plain(accessor, _globbed("/rooms/red", "z.json")))
+    assert out == ["/h/rooms/red/c.json"]
+    assert accessor.calls == ["window:None"]
+
+
+def test_a_partial_listing_is_not_cached_as_the_directory(accessor):
+    index = RAMIndexCacheStore()
+    asyncio.run(
+        WINDOW_READDIR(accessor, _globbed("/rooms/red", "z.json"),
+                       index=index))
+    # The entries are real, so they are cached one by one; the directory
+    # is not, so a bare listing still asks the backend.
+    assert asyncio.run(index.get("/h/rooms/red/z.json")).entry is not None
+    assert asyncio.run(index.list_dir("/h/rooms/red")).entries is None
+    out = asyncio.run(WINDOW_READDIR(accessor, spec("/rooms/red"),
+                                     index=index))
+    assert out == ["/h/rooms/red/c.json"]
+    assert accessor.calls == ["window:z.json", "window:None"]
+
+
+def test_a_globbed_listing_does_not_read_a_warm_window(accessor):
+    # The cached listing is the window itself, so answering the glob from
+    # it would hide everything the window leaves out.
+    index = RAMIndexCacheStore()
+    asyncio.run(WINDOW_READDIR(accessor, spec("/rooms/red"), index=index))
+    out = asyncio.run(
+        WINDOW_READDIR(accessor, _globbed("/rooms/red", "z.json"),
+                       index=index))
+    assert out == ["/h/rooms/red/z.json"]
+    assert accessor.calls == ["window:None", "window:z.json"]

--- a/python/tests/core/lancedb/test_query.py
+++ b/python/tests/core/lancedb/test_query.py
@@ -1,0 +1,40 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.core.lancedb.query import _predicate
+
+
+def test_narrows_on_a_name_prefix_with_a_cast():
+    assert _predicate(
+        "id", {}, "doc-1") == ("CAST(id AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
+
+
+def test_escapes_like_metacharacters_in_the_prefix():
+    # An unescaped `_` is LIKE's single-character wildcard, so docX1 would
+    # ride along and could crowd a real match out of the row cap.
+    assert _predicate(
+        "id", {}, "doc_") == ("CAST(id AS STRING) LIKE 'doc\\_%' ESCAPE '\\'")
+    assert _predicate("id", {},
+                      "a%") == ("CAST(id AS STRING) LIKE 'a\\%%' ESCAPE '\\'")
+
+
+def test_ands_the_group_filters_with_the_prefix():
+    assert _predicate("id", {"label": "cat"}, "doc-1") == (
+        "label = 'cat' AND CAST(id AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
+
+
+def test_is_the_filters_alone_with_no_prefix_and_empty_with_neither():
+    assert _predicate("id", {"label": "cat"}, "") == "label = 'cat'"
+    assert _predicate("id", {}, "") == ""
+    assert _predicate("", {}, "doc-1") == ""

--- a/python/tests/core/lancedb/test_query.py
+++ b/python/tests/core/lancedb/test_query.py
@@ -17,24 +17,35 @@ from mirage.core.lancedb.query import _predicate
 
 def test_narrows_on_a_name_prefix_with_a_cast():
     assert _predicate(
-        "id", {}, "doc-1") == ("CAST(id AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
+        "id", {},
+        "doc-1") == ("CAST(`id` AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
 
 
 def test_escapes_like_metacharacters_in_the_prefix():
     # An unescaped `_` is LIKE's single-character wildcard, so docX1 would
     # ride along and could crowd a real match out of the row cap.
     assert _predicate(
-        "id", {}, "doc_") == ("CAST(id AS STRING) LIKE 'doc\\_%' ESCAPE '\\'")
-    assert _predicate("id", {},
-                      "a%") == ("CAST(id AS STRING) LIKE 'a\\%%' ESCAPE '\\'")
+        "id", {},
+        "doc_") == ("CAST(`id` AS STRING) LIKE 'doc\\_%' ESCAPE '\\'")
+    assert _predicate(
+        "id", {}, "a%") == ("CAST(`id` AS STRING) LIKE 'a\\%%' ESCAPE '\\'")
 
 
 def test_ands_the_group_filters_with_the_prefix():
     assert _predicate("id", {"label": "cat"}, "doc-1") == (
-        "label = 'cat' AND CAST(id AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
+        "`label` = 'cat' AND CAST(`id` AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
+
+
+def test_quotes_a_column_name_a_bare_word_could_not_spell():
+    # A space or a reserved word only parses quoted, and lance reads a
+    # double-quoted word as a string literal, so the quotes are backticks.
+    assert _predicate(
+        "document id", {"select": "cat"},
+        "doc-1") == ("`select` = 'cat' AND "
+                     "CAST(`document id` AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
 
 
 def test_is_the_filters_alone_with_no_prefix_and_empty_with_neither():
-    assert _predicate("id", {"label": "cat"}, "") == "label = 'cat'"
+    assert _predicate("id", {"label": "cat"}, "") == "`label` = 'cat'"
     assert _predicate("id", {}, "") == ""
     assert _predicate("", {}, "doc-1") == ""

--- a/python/tests/core/lancedb/test_readdir.py
+++ b/python/tests/core/lancedb/test_readdir.py
@@ -12,9 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import lancedb
 import pytest
 
+from mirage.accessor.lancedb import LanceDBAccessor
+from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.core.lancedb.readdir import readdir
+from mirage.resource.lancedb.config import LanceDBConfig
 from mirage.types import PathSpec
 
 
@@ -50,3 +54,102 @@ async def test_group_lists_next_level(accessor):
 async def test_leaf_lists_row_files(accessor):
     out = await readdir(accessor, _ps("/animals/cat/big"))
     assert _names(out) == {"1.md", "1.png"}
+
+
+def _globbed(path: str, pattern: str) -> PathSpec:
+    return PathSpec(virtual=path,
+                    directory=path,
+                    resource_path=path.strip("/"),
+                    pattern=pattern)
+
+
+CAP = 5
+WIDE = 40
+
+
+@pytest.fixture
+def capped(tmp_path) -> LanceDBAccessor:
+    """A table wider than its own row cap, in one group.
+
+    Args:
+        tmp_path (Path): pytest tmp dir.
+    """
+    uri = str(tmp_path / "wide")
+    db = lancedb.connect(uri)
+    db.create_table("wide",
+                    data=[{
+                        "id": f"doc-{i:03d}",
+                        "label": "all",
+                        "name": f"n{i}",
+                        "vector": [0.1, 0.2],
+                    } for i in range(WIDE)])
+    return LanceDBAccessor(
+        LanceDBConfig(uri=uri,
+                      table="wide",
+                      group_by=["label"],
+                      id_column="id",
+                      title_column="name",
+                      text_column="name",
+                      max_rows=CAP))
+
+
+@pytest.mark.asyncio
+async def test_a_row_glob_reaches_past_the_cap(capped):
+    # The cap covers doc-000..doc-004, so filtering it would answer
+    # nothing; the prefix goes into the query instead.
+    out = await readdir(capped, _globbed("/all", "doc-03*"))
+    assert _names(out) == {f"doc-03{i}.md" for i in range(CAP)}
+
+
+@pytest.mark.asyncio
+async def test_a_glob_with_no_literal_head_stays_capped(capped):
+    # Neither backend can narrow on a leading metacharacter, so this one
+    # is the ordinary capped listing that the glob then filters.
+    out = await readdir(capped, _globbed("/all", "*9.md"))
+    assert _names(out) == {f"doc-00{i}.md" for i in range(CAP)}
+
+
+@pytest.mark.asyncio
+async def test_a_narrowed_listing_is_not_cached_as_the_directory(capped):
+    index = RAMIndexCacheStore()
+    await readdir(capped, _globbed("/all", "doc-03*"), index)
+    listing = await index.list_dir("/all/")
+    assert listing.entries is None
+    plain = await readdir(capped, _ps("/all"), index)
+    assert _names(plain) == {f"doc-00{i}.md" for i in range(CAP)}
+
+
+@pytest.fixture
+def underscored(tmp_path) -> LanceDBAccessor:
+    """Ids whose own text contains a LIKE metacharacter.
+
+    Args:
+        tmp_path (Path): pytest tmp dir.
+    """
+    uri = str(tmp_path / "meta")
+    db = lancedb.connect(uri)
+    db.create_table("meta",
+                    data=[{
+                        "id": rid,
+                        "label": "all",
+                        "name": rid,
+                        "vector": [0.1, 0.2],
+                    } for rid in ("doc_1", "doc_2", "docX1", "a%b", "axb")])
+    return LanceDBAccessor(
+        LanceDBConfig(uri=uri,
+                      table="meta",
+                      group_by=["label"],
+                      id_column="id",
+                      title_column="name",
+                      text_column="name",
+                      max_rows=2))
+
+
+@pytest.mark.asyncio
+async def test_a_like_metacharacter_in_the_prefix_is_escaped(underscored):
+    # An unescaped `_` is LIKE's single-character wildcard, so docX1 would
+    # ride along and could crowd a real match out of the row cap.
+    out = await readdir(underscored, _globbed("/all", "doc_*"))
+    assert _names(out) == {"doc_1.md", "doc_2.md"}
+    out = await readdir(underscored, _globbed("/all", "a%*"))
+    assert _names(out) == {"a%b.md"}

--- a/python/tests/core/qdrant/conftest.py
+++ b/python/tests/core/qdrant/conftest.py
@@ -154,3 +154,35 @@ def qdrant_config() -> QdrantConfig:
 @pytest.fixture
 def accessor(qdrant_config) -> FakeAccessor:
     return FakeAccessor(qdrant_config, FakeQdrantClient())
+
+
+WIDE_CAP = 5
+WIDE_POINTS = 600
+
+
+class WideQdrantClient(FakeQdrantClient):
+    """A collection far wider than one scroll page, counting pages."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.points = [
+            SimpleNamespace(id=i, payload={
+                "label": "all",
+                "name": f"n{i}"
+            }) for i in range(1, WIDE_POINTS + 1)
+        ]
+        self.pages = 0
+
+    async def scroll(self, *args, **kwargs):
+        self.pages += 1
+        return await super().scroll(*args, **kwargs)
+
+
+@pytest.fixture
+def capped() -> FakeAccessor:
+    return FakeAccessor(
+        QdrantConfig(collection=COLLECTION,
+                     group_by=["label"],
+                     id_field="id",
+                     text_field="name",
+                     max_rows=WIDE_CAP), WideQdrantClient())

--- a/python/tests/core/qdrant/test_readdir.py
+++ b/python/tests/core/qdrant/test_readdir.py
@@ -68,3 +68,41 @@ def test_blob_size_leaves_undecodable_values_unknown():
     # the whole directory listing down with it.
     assert _blob_size("UE5HLTE=") == 5
     assert _blob_size(42) is None
+
+
+def _globbed(path: str, pattern: str) -> PathSpec:
+    return PathSpec(virtual=path,
+                    directory=path,
+                    resource_path=path.strip("/"),
+                    pattern=pattern)
+
+
+def _ids(paths: list[str]) -> set[str]:
+    return {p.rsplit("/", 1)[-1].split(".")[0] for p in paths}
+
+
+@pytest.mark.asyncio
+async def test_a_row_glob_reaches_past_the_cap(capped):
+    # The cap covers ids 1..5, so filtering it would answer nothing.
+    # Qdrant has no prefix condition, so the scroll keeps paging and
+    # tests each page until it has as many MATCHES as the cap allows.
+    out = await readdir(capped, _globbed("/all", "45*"))
+    assert _ids(out) == {"45", "450", "451", "452", "453"}
+    assert (await capped.client()).pages > 1
+
+
+@pytest.mark.asyncio
+async def test_a_glob_with_no_literal_head_stays_capped(capped):
+    out = await readdir(capped, _globbed("/all", "*9.json"))
+    assert _ids(out) == {"1", "2", "3", "4", "5"}
+    assert (await capped.client()).pages == 1
+
+
+@pytest.mark.asyncio
+async def test_a_narrowed_listing_is_not_cached_as_the_directory(capped):
+    index = RAMIndexCacheStore()
+    await readdir(capped, _globbed("/all", "45*"), index)
+    listing = await index.list_dir("/all/")
+    assert listing.entries is None
+    plain = await readdir(capped, _ps("/all"), index)
+    assert _ids(plain) == {"1", "2", "3", "4", "5"}

--- a/python/tests/core/slack/test_readdir.py
+++ b/python/tests/core/slack/test_readdir.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -146,6 +146,38 @@ def test_date_range_capped_at_90():
     now = datetime.now(timezone.utc)
     dates = _date_range(now.timestamp(), 1000000000)
     assert len(dates) == 90
+
+
+def test_date_range_glob_span_escapes_the_cap():
+    # A day dir is real for any date the channel has existed for, so a
+    # glob older than the 90-day window must still list its days.
+    now = datetime.now(timezone.utc)
+    dates = _date_range(now.timestamp(),
+                        1000000000,
+                        span=(date(2010, 3, 1), date(2010, 4, 1)))
+    assert dates[0] == "2010-03-31"
+    assert dates[-1] == "2010-03-01"
+    assert len(dates) == 31
+
+
+def test_date_range_glob_span_is_clipped_at_both_ends():
+    # Nothing exists before the channel or after its newest message, so
+    # the span is intersected rather than taken as typed.
+    created = datetime(2010, 3, 10, tzinfo=timezone.utc).timestamp()
+    latest = datetime(2010, 3, 20, tzinfo=timezone.utc).timestamp()
+    dates = _date_range(latest,
+                        int(created),
+                        span=(date(2010, 3, 1), date(2010, 4, 1)))
+    assert dates[0] == "2010-03-20"
+    assert dates[-1] == "2010-03-10"
+
+
+def test_date_range_glob_span_outside_the_channel_is_empty():
+    created = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
+    latest = datetime(2020, 1, 5, tzinfo=timezone.utc).timestamp()
+    assert _date_range(latest,
+                       int(created),
+                       span=(date(2010, 3, 1), date(2010, 4, 1))) == []
 
 
 @pytest.mark.asyncio

--- a/python/tests/utils/test_glob_walk.py
+++ b/python/tests/utils/test_glob_walk.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import dataclasses
+from datetime import date
 
 import pytest
 
@@ -20,11 +21,12 @@ from mirage.accessor.base import NOOPAccessor
 from mirage.context import reset_current_session, set_current_session
 from mirage.shell.escapes import unescape_unquoted
 from mirage.types import HiddenPaths, PathSpec
+from mirage.utils import glob_walk
 from mirage.utils.glob_walk import (DEFAULT_MAX_GLOB_MATCHES, expand_pattern,
-                                    glob_pattern, has_glob, is_word_shaped,
-                                    literal_word, make_resolve_glob,
-                                    mark_escaped_globs, mark_globs,
-                                    resolve_glob_with, spell_match,
+                                    glob_pattern, glob_prefix, glob_span,
+                                    has_glob, is_word_shaped, literal_word,
+                                    make_resolve_glob, mark_escaped_globs,
+                                    mark_globs, resolve_glob_with, spell_match,
                                     unmark_globs)
 from mirage.workspace.session.session import Session
 
@@ -408,3 +410,52 @@ async def test_resolve_glob_with_all_hidden_falls_back_to_literal():
     assert result[0].resolved
     assert result[0].pattern is None
     assert result[0].virtual == "/notion/pages/Roadmap__uuid2/page.*"
+
+
+@pytest.mark.parametrize(
+    "pattern,expected",
+    [
+        ("2026-*", (date(2026, 1, 1), date(2027, 1, 1))),
+        ("2026-01-*", (date(2026, 1, 1), date(2026, 2, 1))),
+        ("2026-12-*", (date(2026, 12, 1), date(2027, 1, 1))),
+        ("2026-01-05*", (date(2026, 1, 5), date(2026, 1, 6))),
+        ("2026-01-05_*", (date(2026, 1, 5), date(2026, 1, 6))),
+        ("2026-01-?", (date(2026, 1, 1), date(2026, 2, 1))),
+        # No metacharacter at all is a literal name, not a span.
+        ("2026-01-05", None),
+        # A prefix that is not a date, an impossible date, and no glob.
+        ("chat*", None),
+        ("2026-13-*", None),
+        ("2026-02-30*", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_glob_span_reads_the_literal_date_prefix(pattern, expected):
+    assert glob_span(pattern) == expected
+
+
+@pytest.mark.parametrize(
+    "pattern,expected",
+    [
+        ("doc-1*", "doc-1"),
+        ("doc-1?.md", "doc-1"),
+        ("doc-1[0-9]", "doc-1"),
+        # A metacharacter first leaves nothing to narrow on, and a word with
+        # none at all is a literal name rather than a glob.
+        ("*.md", ""),
+        ("?abc*", ""),
+        ("doc-10.md", ""),
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_glob_prefix_reads_the_literal_head(pattern, expected):
+    assert glob_prefix(pattern) == expected
+    assert glob_walk.has_glob_prefix(pattern or "") is bool(expected)
+
+
+def test_glob_prefix_restores_a_quoted_metacharacter():
+    # A quoted star travels under a private mark and stands for a literal
+    # star, so it belongs in the prefix as the character it names.
+    assert glob_prefix(mark_globs("*") + "ab*") == "*ab"

--- a/python/tests/utils/test_glob_walk.py
+++ b/python/tests/utils/test_glob_walk.py
@@ -459,3 +459,24 @@ def test_glob_prefix_restores_a_quoted_metacharacter():
     # A quoted star travels under a private mark and stands for a literal
     # star, so it belongs in the prefix as the character it names.
     assert glob_prefix(mark_globs("*") + "ab*") == "*ab"
+
+
+@pytest.mark.parametrize(
+    "pattern,expected",
+    [
+        # The literal has run into the suffix, so the part that ran in
+        # says nothing about the stem and comes off.
+        ("12*.md", "12"),
+        ("doc-1.m*", "doc-1"),
+        ("doc-1.*", "doc-1"),
+        ("doc-1.p*", "doc-1"),
+        # A dot inside the stem is not the suffix, so it stays.
+        ("acct.2026*", "acct.2026"),
+        ("acct.mark*", "acct.mark"),
+        ("doc-1*", "doc-1"),
+        ("*.md", ""),
+        (None, ""),
+    ],
+)
+def test_glob_stem_prefix_drops_only_a_reached_suffix(pattern, expected):
+    assert glob_walk.glob_stem_prefix(pattern, [".md", ".png"]) == expected

--- a/spec/layout_exceptions.json
+++ b/spec/layout_exceptions.json
@@ -1,5 +1,5 @@
 {
- "baseline": 254,
+ "baseline": 253,
  "baseline_reason": "Every divergence below the excused ones predates the gate and each needs its own decision, so --strict fails on a rise rather than demanding zero. Lower this number whenever a divergence is closed; the gate fails on a drop too, so an improvement cannot be silently spent. Items 31-37 of the cleanup plan are scoped from this report. The unit is one module, never one directory: a one-sided directory counts once per module inside it, so it cannot absorb new modules without moving the number. An excused directory is the deliberate exception -- it excuses its whole subtree, because the excuse is that there is no counterpart to mirror, which makes growth inside it expected rather than drift.",
  "directories": {
   "python_only": {

--- a/typescript/packages/browser/src/core/opfs/readdir.ts
+++ b/typescript/packages/browser/src/core/opfs/readdir.ts
@@ -21,7 +21,12 @@ import { isNotFound, isTypeMismatch, iterEntries, norm, resolveDirHandle } from 
 
 export async function readdir(accessor: OPFSAccessor, path: PathSpec): Promise<string[]> {
   const root = accessor.rootHandle
-  const virtual = path.pattern !== null ? path.directory : path.mountPath
+  // A pattern spec addresses the directory whose entries the glob filters,
+  // and the rest of this function works in mount-relative space, so the
+  // directory has to be read off `dir` rather than off the virtual
+  // `directory` string (python strips the prefix by hand for the same
+  // reason).
+  const virtual = (path.pattern !== null ? path.dir : path).mountPath
   let dir: FileSystemDirectoryHandle
   try {
     dir = await resolveDirHandle(root, virtual, { create: false })

--- a/typescript/packages/core/src/accessor/qdrant.test.ts
+++ b/typescript/packages/core/src/accessor/qdrant.test.ts
@@ -109,3 +109,58 @@ describe('QdrantAccessor index auto-create', () => {
     await expect(acc.rowsMatching('c', { code: '100' }, [], 100)).rejects.toThrow('boom')
   })
 })
+
+const WIDE = 600
+const CAP = 5
+
+function widePoints(): { id: number; payload: { code: string; name: string } }[] {
+  const points = []
+  for (let i = 1; i <= WIDE; i += 1)
+    points.push({ id: i, payload: { code: 'all', name: `n${String(i)}` } })
+  return points
+}
+
+function pagingClient(state: { pages: number }) {
+  const points = widePoints()
+  return {
+    scroll(_collection: string, opts: { limit: number; offset: number | null }) {
+      state.pages += 1
+      const start = opts.offset ?? 0
+      const window = points.slice(start, start + opts.limit)
+      const next = start + opts.limit < points.length ? start + opts.limit : null
+      return Promise.resolve({ points: window, next_page_offset: next })
+    },
+    createPayloadIndex(_collection: string, _opts: object) {
+      return Promise.resolve()
+    },
+  }
+}
+
+function wideAccessor(client: unknown): QdrantAccessor {
+  const acc = new QdrantAccessor(
+    resolveQdrantConfig({ url: 'http://x', collection: 'c', idField: 'id', maxRows: CAP }),
+  )
+  ;(acc as unknown as { client: unknown }).client = client
+  return acc
+}
+
+describe('QdrantAccessor prefix scroll', () => {
+  it('bounds the scroll by matches, paging past the cap', async () => {
+    // Qdrant has no prefix condition for a point id, so the only way to reach
+    // a row past the cap is to keep paging and test each page here. Matches
+    // 45 and 450..453 straddle the first page boundary.
+    const state = { pages: 0 }
+    const rows = await wideAccessor(pagingClient(state)).rowsMatching('c', {}, [], CAP, '45')
+
+    expect(rows.map((r) => r.id)).toEqual([45, 450, 451, 452, 453])
+    expect(state.pages).toBeGreaterThan(1)
+  })
+
+  it('bounds the scroll by points when no prefix is given', async () => {
+    const state = { pages: 0 }
+    const rows = await wideAccessor(pagingClient(state)).rowsMatching('c', {}, [], CAP)
+
+    expect(rows.map((r) => r.id)).toEqual([1, 2, 3, 4, 5])
+    expect(state.pages).toBe(1)
+  })
+})

--- a/typescript/packages/core/src/accessor/qdrant.ts
+++ b/typescript/packages/core/src/accessor/qdrant.ts
@@ -18,8 +18,11 @@ import { loadOptionalPeer } from '../utils/optional_peer.ts'
 import {
   buildFilter,
   candidateIds,
+  idPrefixTest,
   pointToRow,
   SCROLL_BATCH,
+  valuePrefixTest,
+  type PointTest,
   type QdrantPoint,
   type QdrantRow,
 } from '../core/qdrant/client.ts'
@@ -65,19 +68,26 @@ export class QdrantAccessor extends Accessor {
     collection: string,
     filter: Record<string, unknown> | undefined,
     limit: number,
+    keep?: PointTest,
   ): Promise<QdrantPoint[]> {
+    // Without a test the limit bounds the scroll, which is the ordinary capped
+    // listing. With one it bounds the MATCHES, because qdrant has no prefix
+    // condition for a point id or a keyword field: the only way to answer a
+    // glob for a row past the cap is to keep scrolling and test each page
+    // here. A glob is a targeted request, so it pays a scan of the collection
+    // where the plain listing pays one page.
     const client = await this.getClient()
     const points: QdrantPoint[] = []
     let offset: string | number | null = null
     while (points.length < limit) {
       const res = (await client.scroll(collection, {
         ...(filter !== undefined ? { filter } : {}),
-        limit: Math.min(SCROLL_BATCH, limit - points.length),
+        limit: keep !== undefined ? SCROLL_BATCH : Math.min(SCROLL_BATCH, limit - points.length),
         offset,
         with_payload: true,
         with_vector: false,
       })) as { points: QdrantPoint[]; next_page_offset?: string | number | null }
-      points.push(...res.points)
+      points.push(...(keep === undefined ? res.points : res.points.filter(keep)))
       const next = res.next_page_offset
       if (next === null || next === undefined) break
       offset = next
@@ -108,16 +118,17 @@ export class QdrantAccessor extends Accessor {
     collection: string,
     filters: Record<string, string>,
     limit: number,
+    keep?: PointTest,
   ): Promise<QdrantPoint[]> {
-    if (Object.keys(filters).length === 0) return this.scrollRaw(collection, undefined, limit)
+    if (Object.keys(filters).length === 0) return this.scrollRaw(collection, undefined, limit, keep)
     const filter = buildFilter(filters)
     try {
-      return await this.scrollRaw(collection, filter, limit)
+      return await this.scrollRaw(collection, filter, limit, keep)
     } catch (err) {
       if (!this.isIndexRequired(err)) throw err
     }
     await this.ensureIndexes(collection)
-    return this.scrollRaw(collection, filter, limit)
+    return this.scrollRaw(collection, filter, limit, keep)
   }
 
   async listTables(): Promise<string[]> {
@@ -137,8 +148,10 @@ export class QdrantAccessor extends Accessor {
     column: string,
     filters: Record<string, string>,
     limit: number,
+    prefix = '',
   ): Promise<string[]> {
-    const points = await this.scrollFiltered(table, filters, limit)
+    const keep = prefix === '' ? undefined : valuePrefixTest(column, prefix)
+    const points = await this.scrollFiltered(table, filters, limit, keep)
     const values = new Set<string>()
     for (const point of points) {
       const value = point.payload?.[column]
@@ -153,8 +166,10 @@ export class QdrantAccessor extends Accessor {
     filters: Record<string, string>,
     _columns: string[],
     limit: number,
+    prefix = '',
   ): Promise<QdrantRow[]> {
-    const points = await this.scrollFiltered(table, filters, limit)
+    const keep = prefix === '' ? undefined : idPrefixTest(prefix)
+    const points = await this.scrollFiltered(table, filters, limit, keep)
     return points.map((point) => pointToRow(point, this.config.idField))
   }
 

--- a/typescript/packages/core/src/core/discord/readdir.test.ts
+++ b/typescript/packages/core/src/core/discord/readdir.test.ts
@@ -85,6 +85,23 @@ describe('dateRangeDescending', () => {
   it('returns [] for malformed input', () => {
     expect(dateRangeDescending('', 30)).toEqual([])
   })
+
+  it('reaches days outside the window for a glob span', () => {
+    const out = dateRangeDescending('2024-01-15', 30, ['2023-11-01', '2023-12-01'])
+    expect(out).toHaveLength(30)
+    expect(out[0]).toBe('2023-11-30')
+    expect(out[29]).toBe('2023-11-01')
+  })
+
+  it('clips a glob span at the newest message', () => {
+    const out = dateRangeDescending('2024-01-15', 30, ['2024-01-01', '2024-02-01'])
+    expect(out).toHaveLength(15)
+    expect(out[0]).toBe('2024-01-15')
+  })
+
+  it('lists nothing for a glob span after the newest message', () => {
+    expect(dateRangeDescending('2024-01-15', 30, ['2025-01-01', '2025-02-01'])).toEqual([])
+  })
 })
 
 describe('readdir root', () => {

--- a/typescript/packages/core/src/core/discord/readdir.ts
+++ b/typescript/packages/core/src/core/discord/readdir.ts
@@ -26,6 +26,7 @@ import { DISCORD_EPOCH, listMessagesForDay } from './history.ts'
 import { listMembers } from './members.ts'
 import { historyJsonlBytes, memberJsonBytes } from './render.ts'
 import { detectScope } from './scope.ts'
+import { globSpan, hasGlobSpan } from '../../utils/glob_walk.ts'
 
 const SOFT_STATUSES = new Set([403, 404, 429])
 
@@ -52,13 +53,33 @@ export function snowflakeToIso(snowflake: string): string | null {
   return epochToIso(Number(ms / 1000n))
 }
 
-export function dateRangeDescending(endDate: string, days = 30): string[] {
+/**
+ * The channel's day directories, newest first.
+ *
+ * A day dir is real for any well-formed date under the channel, so the bare
+ * listing is a window: the last `days` up to the newest message. A glob names
+ * its own window instead, clipped at the newest message because nothing was
+ * posted after it.
+ */
+export function dateRangeDescending(
+  endDate: string,
+  days = 30,
+  span: readonly [string, string] | null = null,
+): string[] {
   const [y, m, d] = endDate.split('-').map((n) => Number.parseInt(n, 10))
   if (y === undefined || m === undefined || d === undefined) return []
-  const end = Date.UTC(y, m - 1, d)
+  const dayMs = 86_400_000
+  let end = Date.UTC(y, m - 1, d)
+  let count = days
+  if (span !== null) {
+    const first = Date.parse(`${span[0]}T00:00:00Z`)
+    end = Math.min(end, Date.parse(`${span[1]}T00:00:00Z`) - dayMs)
+    count = Math.floor((end - first) / dayMs) + 1
+    if (count <= 0) return []
+  }
   const dates: string[] = []
-  for (let i = 0; i < days; i++) {
-    const cursor = new Date(end - i * 86_400_000)
+  for (let i = 0; i < count; i++) {
+    const cursor = new Date(end - i * dayMs)
     const yy = cursor.getUTCFullYear().toString().padStart(4, '0')
     const mm = (cursor.getUTCMonth() + 1).toString().padStart(2, '0')
     const dd = cursor.getUTCDate().toString().padStart(2, '0')
@@ -144,16 +165,16 @@ async function listMembersDir(
 
 function listChannelDays(
   _accessor: DiscordAccessor,
-  _match: ScopeMatch,
+  match: ScopeMatch,
   own: IndexEntry,
 ): Promise<Listed> {
   const lastMsgId = own.remoteTime
   const endDate = lastMsgId !== '' ? snowflakeToDate(lastMsgId) : todayUtc()
-  return Promise.resolve(
-    dateRangeDescending(endDate, 30).map(
-      (d) => [d, DiscordIndexEntry.history(own.id, d)] as [string, IndexEntry],
-    ),
+  const span = globSpan(match.pattern)
+  const entries = dateRangeDescending(endDate, 30, span).map(
+    (d) => [d, DiscordIndexEntry.history(own.id, d)] as [string, IndexEntry],
   )
+  return Promise.resolve({ entries, seeds: {}, partial: span !== null })
 }
 
 /**
@@ -271,5 +292,6 @@ export const readdir = makeReaddir<DiscordAccessor>(detectScope, {
     files: listFiles,
   },
   parentEntryListers: { day: listDay },
+  patternKinds: { channel: hasGlobSpan },
   leafError: 'enotdir',
 })

--- a/typescript/packages/core/src/core/gcal/readdir.ts
+++ b/typescript/packages/core/src/core/gcal/readdir.ts
@@ -25,7 +25,7 @@ import {
 import type { JsonValue, PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
 import { mountPrefixOf } from '../../utils/key_prefix.ts'
-import { globToDateRange } from '../google/date_glob.ts'
+import { globSpan } from '../../utils/glob_walk.ts'
 import {
   WINDOW_AHEAD_DAYS,
   WINDOW_BACK_DAYS,
@@ -130,7 +130,7 @@ function daySpan(
   today: string,
   tz: string,
 ): [string, string, string, string] {
-  const span = globToDateRange(pattern)
+  const span = globSpan(pattern)
   if (span !== null) {
     const last = shiftDay(span[1], -1)
     return [dayBounds(span[0], tz)[0], dayBounds(last, tz)[1], span[0], last]

--- a/typescript/packages/core/src/core/gmail/date_query.test.ts
+++ b/typescript/packages/core/src/core/gmail/date_query.test.ts
@@ -16,10 +16,11 @@ import { describe, expect, it } from 'vitest'
 import { dateDirToGmailQuery, spanToGmailQuery } from './date_query.ts'
 
 describe('dateDirToGmailQuery', () => {
+  // Epoch seconds for midnight UTC, one second early on the lower bound.
   it.each([
-    ['2026-05-03', 'after:2026/05/03 before:2026/05/04'],
-    ['2026-12-31', 'after:2026/12/31 before:2027/01/01'],
-    ['2026-01-01', 'after:2026/01/01 before:2026/01/02'],
+    ['2026-05-03', 'after:1777766399 before:1777852800'],
+    ['2026-12-31', 'after:1798675199 before:1798761600'],
+    ['2026-01-01', 'after:1767225599 before:1767312000'],
   ])('translates %s', (name, expected) => {
     expect(dateDirToGmailQuery(name)).toBe(expected)
   })
@@ -39,7 +40,12 @@ describe('dateDirToGmailQuery', () => {
 })
 
 describe('spanToGmailQuery', () => {
-  it('spells a half-open range the way Gmail reads it', () => {
-    expect(spanToGmailQuery('2026-01-01', '2026-02-01')).toBe('after:2026/01/01 before:2026/02/01')
+  it('bounds a half-open range in UTC seconds', () => {
+    const query = spanToGmailQuery('2026-01-01', '2026-02-01')
+    const [after, before] = query
+      .split(' ')
+      .map((term) => Number.parseInt(term.split(':')[1] ?? '', 10))
+    expect((before ?? 0) * 1000).toBe(Date.UTC(2026, 1, 1))
+    expect((before ?? 0) - (after ?? 0)).toBe(31 * 86_400 + 1)
   })
 })

--- a/typescript/packages/core/src/core/gmail/date_query.test.ts
+++ b/typescript/packages/core/src/core/gmail/date_query.test.ts
@@ -1,0 +1,45 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { dateDirToGmailQuery, spanToGmailQuery } from './date_query.ts'
+
+describe('dateDirToGmailQuery', () => {
+  it.each([
+    ['2026-05-03', 'after:2026/05/03 before:2026/05/04'],
+    ['2026-12-31', 'after:2026/12/31 before:2027/01/01'],
+    ['2026-01-01', 'after:2026/01/01 before:2026/01/02'],
+  ])('translates %s', (name, expected) => {
+    expect(dateDirToGmailQuery(name)).toBe(expected)
+  })
+
+  it.each([
+    [''],
+    ['2026-13-01'],
+    ['2026-02-30'],
+    ['2026-5-3'],
+    ['2026'],
+    ['not-a-date'],
+    ['2026-05'],
+    ['2026-05-03-extra'],
+  ])('rejects %s', (name) => {
+    expect(dateDirToGmailQuery(name)).toBeNull()
+  })
+})
+
+describe('spanToGmailQuery', () => {
+  it('spells a half-open range the way Gmail reads it', () => {
+    expect(spanToGmailQuery('2026-01-01', '2026-02-01')).toBe('after:2026/01/01 before:2026/02/01')
+  })
+})

--- a/typescript/packages/core/src/core/gmail/date_query.ts
+++ b/typescript/packages/core/src/core/gmail/date_query.ts
@@ -12,11 +12,31 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-/** A Gmail date filter for a half-open range of days, as `after:`/`before:`. */
+function epochSeconds(day: string): number {
+  const [y, m, d] = day.split('-')
+  const stamp = Date.UTC(
+    Number.parseInt(y ?? '', 10),
+    Number.parseInt(m ?? '', 10) - 1,
+    Number.parseInt(d ?? '', 10),
+  )
+  return Math.trunc(stamp / 1000)
+}
+
+/**
+ * A Gmail date filter for a half-open range of UTC days.
+ *
+ * The bounds are epoch seconds rather than `YYYY/MM/DD` because Gmail reads a
+ * written date as "midnight on that date in the PST timezone" and names
+ * seconds as the way to mean any other zone, while a message lands in a day
+ * directory by its UTC `internalDate`. The two disagree by the account's
+ * offset, so a written date would leave the first hours of the requested day
+ * outside the query and every message in them out of the listing. The lower
+ * bound is a second early because the operator's inclusivity at the exact
+ * second is not documented: an extra message from the day before is dropped by
+ * the bucketing, a missing one is not recoverable.
+ */
 export function spanToGmailQuery(start: string, end: string): string {
-  const [ys, ms, ds] = start.split('-')
-  const [ye, me, de] = end.split('-')
-  return `after:${ys ?? ''}/${ms ?? ''}/${ds ?? ''} before:${ye ?? ''}/${me ?? ''}/${de ?? ''}`
+  return `after:${String(epochSeconds(start) - 1)} before:${String(epochSeconds(end))}`
 }
 
 /**

--- a/typescript/packages/core/src/core/gmail/date_query.ts
+++ b/typescript/packages/core/src/core/gmail/date_query.ts
@@ -1,0 +1,54 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+/** A Gmail date filter for a half-open range of days, as `after:`/`before:`. */
+export function spanToGmailQuery(start: string, end: string): string {
+  const [ys, ms, ds] = start.split('-')
+  const [ye, me, de] = end.split('-')
+  return `after:${ys ?? ''}/${ms ?? ''}/${ds ?? ''} before:${ye ?? ''}/${me ?? ''}/${de ?? ''}`
+}
+
+/**
+ * A Gmail date filter for one day directory, null when the name is not a
+ * well-formed calendar date.
+ *
+ * The round-trip check is what refuses an impossible day: `Date.UTC` rolls
+ * 2026-02-30 into March rather than failing, where python's `date()` raises.
+ */
+export function dateDirToGmailQuery(name: string): string | null {
+  const parts = name.split('-')
+  if (parts.length !== 3) return null
+  const [y, m, d] = parts
+  if (y?.length !== 4 || m?.length !== 2 || d?.length !== 2) return null
+  if (!/^\d{4}$/.test(y) || !/^\d{2}$/.test(m) || !/^\d{2}$/.test(d)) return null
+  const year = Number.parseInt(y, 10)
+  const month = Number.parseInt(m, 10)
+  const day = Number.parseInt(d, 10)
+  const stamp = Date.UTC(year, month - 1, day)
+  const back = new Date(stamp)
+  if (
+    back.getUTCFullYear() !== year ||
+    back.getUTCMonth() !== month - 1 ||
+    back.getUTCDate() !== day
+  ) {
+    return null
+  }
+  const next = new Date(stamp + 86_400_000)
+  const nn = [
+    next.getUTCFullYear().toString().padStart(4, '0'),
+    (next.getUTCMonth() + 1).toString().padStart(2, '0'),
+    next.getUTCDate().toString().padStart(2, '0'),
+  ].join('-')
+  return spanToGmailQuery(name, nn)
+}

--- a/typescript/packages/core/src/core/gmail/readdir.ts
+++ b/typescript/packages/core/src/core/gmail/readdir.ts
@@ -28,6 +28,8 @@ import {
   messageJsonBytes,
 } from './messages.ts'
 import { detectScope } from './scope.ts'
+import { globSpan, hasGlobSpan } from '../../utils/glob_walk.ts'
+import { dateDirToGmailQuery, spanToGmailQuery } from './date_query.ts'
 
 const TITLE_MAX = 80
 const MSG_SUFFIX = '.gmail.json'
@@ -157,11 +159,17 @@ async function listRoot(accessor: GmailAccessor, _match: ScopeMatch): Promise<Li
 
 async function listLabel(
   accessor: GmailAccessor,
-  _match: ScopeMatch,
+  match: ScopeMatch,
   own: IndexEntry,
 ): Promise<Listed> {
+  // The bare listing is a window, the most recent MAX_MESSAGES, so the day
+  // dirs it mints are whichever days those fell on. A glob pushes its own
+  // span into the query instead of filtering that window, which is the only
+  // way to reach a day older than it.
+  const span = globSpan(match.pattern)
   const msgIds = await listMessages(accessor.tokenManager, {
     labelId: own.id,
+    query: span === null ? null : spanToGmailQuery(span[0], span[1]),
     maxResults: MAX_MESSAGES,
   })
   const groups = await groupByDate(accessor, msgIds)
@@ -185,26 +193,28 @@ async function listLabel(
       seeds[`${dateStr}/${attDir}`] = attEntries
     }
   }
-  return { entries, seeds }
+  return { entries, seeds, partial: span !== null }
 }
 
 async function listDay(
   accessor: GmailAccessor,
   match: ScopeMatch,
-  own: IndexEntry,
+  label: IndexEntry,
 ): Promise<Listed> {
-  // Normally served from the label lister's seed; reached only when the
-  // index evicted the day listing while the date entry survived. The TS
-  // client has no date-scoped query (python pushes one down), so the
-  // fallback replays the label's recent window and keeps the day's bucket.
-  const labelId = typeof own.extra.label_id === 'string' ? own.extra.label_id : ''
-  if (labelId === '') return []
+  // The proof is the label entry, not the day's own: a date query answers for
+  // any well-formed day, including days the label's bounded recent listing
+  // never minted. A day proven by its own entry could only ever be a day
+  // inside that window, which is the case the seed already covers.
+  const day = match.slots.day ?? ''
+  const dateQuery = dateDirToGmailQuery(day)
+  if (dateQuery === null) return []
   const msgIds = await listMessages(accessor.tokenManager, {
-    labelId,
+    labelId: label.id,
+    query: dateQuery,
     maxResults: MAX_MESSAGES,
   })
   const groups = await groupByDate(accessor, msgIds)
-  const { children, seeds } = dateChildren(groups.get(match.slots.day ?? '') ?? [])
+  const { children, seeds } = dateChildren(groups.get(day) ?? [])
   const listing: DirListing = { entries: children, seeds }
   return listing
 }
@@ -222,7 +232,8 @@ export const readdir = makeReaddir<GmailAccessor>(detectScope, {
   listers: { root: listRoot },
   entryListers: {
     label: listLabel,
-    day: listDay,
     attachment_dir: listAttachmentDir,
   },
+  parentEntryListers: { day: listDay },
+  patternKinds: { label: hasGlobSpan },
 })

--- a/typescript/packages/core/src/core/gmail/stat.test.ts
+++ b/typescript/packages/core/src/core/gmail/stat.test.ts
@@ -1,0 +1,85 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { GmailAccessor } from '../../accessor/gmail.ts'
+import { IndexEntry } from '../../cache/index/config.ts'
+import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
+import { FileType, PathSpec } from '../../types.ts'
+import type { TokenManager } from '../google/client.ts'
+import { mountKey } from '../../utils/key_prefix.ts'
+import { stat } from './stat.ts'
+
+const STUB_TM = {} as TokenManager
+const PREFIX = '/gmail'
+
+function makeAccessor(): GmailAccessor {
+  return new GmailAccessor({ tokenManager: STUB_TM })
+}
+
+function spec(virtual: string): PathSpec {
+  return new PathSpec({
+    virtual,
+    directory: virtual,
+    resourcePath: mountKey(virtual, PREFIX),
+  })
+}
+
+async function warm(index: RAMIndexCacheStore): Promise<void> {
+  await index.setDir('/gmail', [
+    [
+      'INBOX',
+      new IndexEntry({
+        id: 'INBOX',
+        name: 'INBOX',
+        resourceType: 'gmail/label',
+        vfsName: 'INBOX',
+      }),
+    ],
+  ])
+  await index.setDir('/gmail/INBOX', [
+    [
+      '2026-04-12',
+      new IndexEntry({
+        id: '2026-04-12',
+        name: '2026-04-12',
+        resourceType: 'gmail/date',
+        vfsName: '2026-04-12',
+      }),
+    ],
+  ])
+}
+
+describe('gmail stat of a day directory', () => {
+  it('answers a day the label listing minted', async () => {
+    const index = new RAMIndexCacheStore()
+    await warm(index)
+    const result = await stat(makeAccessor(), spec('/gmail/INBOX/2026-04-12'), index)
+    expect(result.type).toBe(FileType.DIRECTORY)
+    expect(result.name).toBe('2026-04-12')
+  })
+
+  it('answers a day outside the listed window', async () => {
+    // The label listing is a bounded window of recent messages, so it never
+    // minted this day; the date query answers for any well-formed one, so the
+    // label's existence is the proof rather than the window. Nothing is
+    // fetched, which is why no API mock is needed.
+    const index = new RAMIndexCacheStore()
+    await warm(index)
+    const result = await stat(makeAccessor(), spec('/gmail/INBOX/2020-01-01'), index)
+    expect(result.type).toBe(FileType.DIRECTORY)
+    expect(result.name).toBe('2020-01-01')
+  })
+})

--- a/typescript/packages/core/src/core/gmail/stat.ts
+++ b/typescript/packages/core/src/core/gmail/stat.ts
@@ -14,9 +14,12 @@
 
 import type { GmailAccessor } from '../../accessor/gmail.ts'
 import type { IndexEntry } from '../../cache/index/config.ts'
-import type { PathSpec } from '../../types.ts'
-import { FileStat, FileType } from '../../types.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { FileStat, FileType, PathSpec } from '../../types.ts'
+import { enoent } from '../../utils/errors.ts'
 import { guessType } from '../../utils/filetype.ts'
+import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
+import { resolveEntry } from '../hierarchy/probe.ts'
 import type { ScopeMatch } from '../hierarchy/scope.ts'
 import { makeStat } from '../hierarchy/stat.ts'
 import { readdir } from './readdir.ts'
@@ -30,8 +33,35 @@ function labelStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): File
   })
 }
 
-function dayStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
-  return new FileStat({ name: entry.vfsName, type: FileType.DIRECTORY })
+/**
+ * Stat a day directory, which resolves beyond the listed window.
+ *
+ * The label listing groups a bounded number of recent messages into day dirs,
+ * but the date query answers for any well-formed day, so a day under a label
+ * that exists is a directory whether or not the recent window lists it. A
+ * bogus label is ENOENT.
+ */
+async function statDay(
+  accessor: GmailAccessor,
+  match: ScopeMatch,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<FileStat> {
+  const entry = await resolveEntry(readdir, accessor, path, index)
+  if (entry !== null) {
+    return new FileStat({ name: entry.vfsName, type: FileType.DIRECTORY })
+  }
+  const virtual = path.virtual.replace(/\/+$/, '').split('/').slice(0, -1).join('/')
+  const prefix = mountPrefixOf(path.virtual, path.resourcePath)
+  const labelSpec = new PathSpec({
+    virtual,
+    directory: virtual,
+    resourcePath: mountKey(virtual, prefix),
+  })
+  if ((await resolveEntry(readdir, accessor, labelSpec, index)) === null) {
+    throw enoent(path)
+  }
+  return new FileStat({ name: match.slots.day ?? '', type: FileType.DIRECTORY })
 }
 
 function messageStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry): FileStat {
@@ -63,9 +93,9 @@ function attachmentStat(_match: ScopeMatch, _path: PathSpec, entry: IndexEntry):
 export const stat = makeStat<GmailAccessor>(detectScope, readdir, {
   entryStats: {
     label: labelStat,
-    day: dayStat,
     message: messageStat,
     attachment_dir: attachmentDirStat,
     attachment: attachmentStat,
   },
+  overrides: { day: statDay },
 })

--- a/typescript/packages/core/src/core/google/date_glob.ts
+++ b/typescript/packages/core/src/core/google/date_glob.ts
@@ -12,73 +12,15 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { GLOB_CHARS } from '../../utils/glob_walk.ts'
-
-function day(year: number, month: number, date: number): string {
-  const mm = String(month).padStart(2, '0')
-  const dd = String(date).padStart(2, '0')
-  return `${String(year)}-${mm}-${dd}`
-}
-
-function isValidDate(year: number, month: number, date: number): boolean {
-  if (month < 1 || month > 12 || date < 1) return false
-  const d = new Date(Date.UTC(year, month - 1, date))
-  return d.getUTCFullYear() === year && d.getUTCMonth() === month - 1 && d.getUTCDate() === date
-}
-
-function parseFixedInt(s: string | undefined, expectedLength: number): number | null {
-  if (s?.length !== expectedLength || !/^\d+$/.test(s)) return null
-  return Number.parseInt(s, 10)
-}
+import { globSpan } from '../../utils/glob_walk.ts'
 
 /**
- * Translate a date-prefixed glob into a half-open range of floating dates.
+ * Translate a date-prefixed glob into an RFC3339 modifiedTime range.
  *
- * Kept separate from `globToModifiedRange` because a caller bucketing in a
- * named time zone has to build its own bounds from the dates; UTC instants
- * would silently shift the window by the zone's offset.
+ * Drive's own spelling of the span `globSpan` reads.
  */
-export function globToDateRange(pattern: string | null | undefined): [string, string] | null {
-  if (!pattern) return null
-  let metaIndex = -1
-  for (const ch of GLOB_CHARS) {
-    const idx = pattern.indexOf(ch)
-    if (idx !== -1 && (metaIndex === -1 || idx < metaIndex)) metaIndex = idx
-  }
-  if (metaIndex === -1) return null
-  const prefix = pattern.slice(0, metaIndex).replace(/[_-]+$/, '')
-  const parts = prefix.split('-')
-  if (parts.length === 1) {
-    const year = parseFixedInt(parts[0], 4)
-    if (year === null) return null
-    return [day(year, 1, 1), day(year + 1, 1, 1)]
-  }
-  if (parts.length === 2) {
-    const year = parseFixedInt(parts[0], 4)
-    const month = parseFixedInt(parts[1], 2)
-    if (year === null || month === null) return null
-    if (!isValidDate(year, month, 1)) return null
-    if (month === 12) return [day(year, month, 1), day(year + 1, 1, 1)]
-    return [day(year, month, 1), day(year, month + 1, 1)]
-  }
-  if (parts.length === 3) {
-    const year = parseFixedInt(parts[0], 4)
-    const month = parseFixedInt(parts[1], 2)
-    const date = parseFixedInt(parts[2], 2)
-    if (year === null || month === null || date === null) return null
-    if (!isValidDate(year, month, date)) return null
-    const next = new Date(Date.UTC(year, month - 1, date) + 86400000)
-    return [
-      day(year, month, date),
-      day(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate()),
-    ]
-  }
-  return null
-}
-
-/** Translate a date-prefixed glob into an RFC3339 modifiedTime range. */
 export function globToModifiedRange(pattern: string | null | undefined): [string, string] | null {
-  const span = globToDateRange(pattern)
+  const span = globSpan(pattern)
   if (span === null) return null
   return [`${span[0]}T00:00:00Z`, `${span[1]}T00:00:00Z`]
 }

--- a/typescript/packages/core/src/core/hierarchy/readdir.test.ts
+++ b/typescript/packages/core/src/core/hierarchy/readdir.test.ts
@@ -334,3 +334,73 @@ describe('hierarchy makeReaddir parent-entry listers', () => {
     ).toThrow('kinds in several lister tables')
   })
 })
+
+// Stands in for a bounded listing: without a glob it reports the tail of the
+// tree, with one it reports exactly what the glob asked for.
+const listWindowed: Lister<FakeAccessor> = (accessor, match) => {
+  accessor.calls.push(`window:${match.pattern ?? 'null'}`)
+  const names = match.pattern === null ? ['c.json'] : [match.pattern]
+  const entries = names.map((n): [string, IndexEntry] => [
+    n,
+    new IndexEntry({ id: n, name: n, resourceType: 'fake/note', vfsName: n }),
+  ])
+  return Promise.resolve({ entries, seeds: {}, partial: match.pattern !== null })
+}
+
+const anyPattern = (_pattern: string): boolean => true
+
+const WINDOW_READDIR = makeReaddir<FakeAccessor>(detectScope, {
+  listers: { rooms: listRooms, room: listWindowed },
+  staticRoot: ['rooms'],
+  patternKinds: { room: anyPattern },
+})
+
+function globbed(mountPath: string, pattern: string): PathSpec {
+  const base = spec(mountPath)
+  return new PathSpec({
+    virtual: `${base.virtual}/${pattern}`,
+    directory: `${base.virtual}/`,
+    resourcePath: `${base.resourcePath}/${pattern}`,
+    pattern,
+  })
+}
+
+describe('a windowed listing honours a glob', () => {
+  it('hands the glob to a declared kind, and nothing to an undeclared one', async () => {
+    const accessor = new FakeAccessor()
+    expect(await WINDOW_READDIR(accessor, globbed('/rooms/red', 'z.json'))).toEqual([
+      '/h/rooms/red/z.json',
+    ])
+    const plain = makeReaddir<FakeAccessor>(detectScope, {
+      listers: { rooms: listRooms, room: listWindowed },
+      staticRoot: ['rooms'],
+    })
+    expect(await plain(accessor, globbed('/rooms/red', 'z.json'))).toEqual(['/h/rooms/red/c.json'])
+    expect(accessor.calls).toEqual(['window:z.json', 'window:null'])
+  })
+
+  it('does not cache a partial listing as the directory', async () => {
+    const accessor = new FakeAccessor()
+    const index = new RAMIndexCacheStore()
+    await WINDOW_READDIR(accessor, globbed('/rooms/red', 'z.json'), index)
+    // The entries are real, so they are cached one by one; the directory is
+    // not, so a bare listing still asks the backend.
+    expect((await index.get('/h/rooms/red/z.json')).entry).not.toBeNull()
+    const listed = await index.listDir('/h/rooms/red')
+    expect(listed.entries === undefined || listed.entries === null).toBe(true)
+    expect(await WINDOW_READDIR(accessor, spec('/rooms/red'), index)).toEqual([
+      '/h/rooms/red/c.json',
+    ])
+    expect(accessor.calls).toEqual(['window:z.json', 'window:null'])
+  })
+
+  it('does not answer a glob from a warm window', async () => {
+    const accessor = new FakeAccessor()
+    const index = new RAMIndexCacheStore()
+    await WINDOW_READDIR(accessor, spec('/rooms/red'), index)
+    expect(await WINDOW_READDIR(accessor, globbed('/rooms/red', 'z.json'), index)).toEqual([
+      '/h/rooms/red/z.json',
+    ])
+    expect(accessor.calls).toEqual(['window:null', 'window:z.json'])
+  })
+})

--- a/typescript/packages/core/src/core/hierarchy/readdir.ts
+++ b/typescript/packages/core/src/core/hierarchy/readdir.ts
@@ -35,10 +35,18 @@ import { INVALID, ROOT, type DetectFn, type ScopeMatch } from './scope.ts'
  * so entering a seeded directory costs no second identical fetch. `seeds`
  * keys are paths relative to the listed directory (`files`,
  * `2026-01-05/Report__17`).
+ *
+ * `partial` says the entries are a filtered or truncated view rather than the
+ * directory's contents, so they must not be cached as the directory: a
+ * glob-scoped listing, or one the provider did not finish. The entries
+ * themselves are real either way, so the kit caches those and lets the next
+ * readdir re-list. `seeds` stay full listings of the children this fetch did
+ * report, so they are cached as directories as usual.
  */
 export interface DirListing {
   entries: [string, IndexEntry][]
   seeds: Readonly<Record<string, [string, IndexEntry][]>>
+  partial?: boolean
 }
 
 export type Listed = [string, IndexEntry][] | DirListing
@@ -56,6 +64,8 @@ export type Guard<A extends Accessor> = (
   match: ScopeMatch,
   virtual: string,
 ) => Promise<void>
+
+export type PatternTest = (pattern: string) => boolean
 
 function dropHidden(listed: [string, IndexEntry][]): [string, IndexEntry][] {
   return listed.filter(([name]) => !name.startsWith('.'))
@@ -101,8 +111,14 @@ function dropHidden(listed: [string, IndexEntry][]): [string, IndexEntry][] {
  * tables. `staticRoot` names fixed top-level entries, for backends whose
  * root never changes; it bypasses the index. `guards` are existence checks
  * that run before the index probe, so a vanished container is ENOENT even on
- * a warm cache. `leafError` is what listing a leaf raises; fixed hierarchies
- * historically answer ENOENT.
+ * a warm cache. `patternKinds` holds one entry per kind whose listing is a
+ * bounded window, the test for whether a glob is one its lister can move the
+ * window to (`hasGlobSpan` for a date-keyed listing). A glob that passes
+ * reaches the lister and the index is not read first, because a cached
+ * listing is that same window and would answer the glob with it; any other
+ * glob, and any other kind, keeps the cached listing and never sees a
+ * pattern. `leafError` is what listing
+ * a leaf raises; fixed hierarchies historically answer ENOENT.
  */
 export function makeReaddir<A extends Accessor>(
   detect: DetectFn,
@@ -112,10 +128,12 @@ export function makeReaddir<A extends Accessor>(
     parentEntryListers?: Readonly<Record<string, EntryLister<A>>>
     staticRoot?: readonly string[]
     guards?: Readonly<Record<string, Guard<A>>>
+    patternKinds?: Readonly<Record<string, PatternTest>>
     leafError?: 'enoent' | 'enotdir'
   },
 ): ReaddirFn<A> {
   const { listers, staticRoot, guards } = options
+  const patternKinds = options.patternKinds ?? {}
   const entryListers = options.entryListers ?? {}
   const parentEntryListers = options.parentEntryListers ?? {}
   const leafError = options.leafError ?? 'enoent'
@@ -142,8 +160,11 @@ export function makeReaddir<A extends Accessor>(
     const path = (pathSpec.pattern !== null ? pathSpec.dir : pathSpec).mountPath
     const key = stripSlash(path)
     const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
-    const match = detect(path)
-    if (match.kind === INVALID) throw enoent(pathSpec)
+    const detected = detect(path)
+    if (detected.kind === INVALID) throw enoent(pathSpec)
+    const pushable = patternKinds[detected.kind]
+    const globbed = pathSpec.pattern !== null && pushable?.(pathSpec.pattern) === true
+    const match = globbed ? { ...detected, pattern: pathSpec.pattern } : detected
     if (match.kind === ROOT && staticRoot !== undefined) {
       return staticRoot.map((d) => `${prefix}/${d}`)
     }
@@ -158,8 +179,10 @@ export function makeReaddir<A extends Accessor>(
     }
     const guard = guards?.[match.kind]
     if (guard !== undefined) await guard(accessor, match, virtual)
-    const listing = await store.listDir(virtualKey)
-    if (listing.entries !== undefined && listing.entries !== null) return listing.entries
+    if (!globbed) {
+      const listing = await store.listDir(virtualKey)
+      if (listing.entries !== undefined && listing.entries !== null) return listing.entries
+    }
     let listed: Listed
     if (entryLister !== undefined || parentLister !== undefined) {
       const proofKey =
@@ -181,8 +204,10 @@ export function makeReaddir<A extends Accessor>(
       // The resolve may have warmed this very listing: a parent's lister
       // can seed a child listing from the same fetch (DirListing.seeds),
       // so ask the index again before fetching.
-      const relisted = await store.listDir(virtualKey)
-      if (relisted.entries !== undefined && relisted.entries !== null) return relisted.entries
+      if (!globbed) {
+        const relisted = await store.listDir(virtualKey)
+        if (relisted.entries !== undefined && relisted.entries !== null) return relisted.entries
+      }
       const fetch = entryLister ?? parentLister
       if (fetch === undefined) throw enoent(pathSpec)
       listed = await fetch(accessor, match, own)
@@ -194,13 +219,19 @@ export function makeReaddir<A extends Accessor>(
       throw enoent(pathSpec)
     }
     let seeds: Readonly<Record<string, [string, IndexEntry][]>> = {}
+    let partial = false
     if (!Array.isArray(listed)) {
       seeds = listed.seeds
+      partial = listed.partial === true
       listed = listed.entries
     }
     const entries = dropHidden(listed)
-    await store.setDir(virtualKey, entries)
     const stem = rstripSlash(virtualKey)
+    if (partial) {
+      for (const [name, entry] of entries) await store.put(`${stem}/${name}`, entry)
+    } else {
+      await store.setDir(virtualKey, entries)
+    }
     for (const [rel, childEntries] of Object.entries(seeds)) {
       await store.setDir(`${stem}/${stripSlash(rel)}`, dropHidden(childEntries))
     }

--- a/typescript/packages/core/src/core/hierarchy/scope.ts
+++ b/typescript/packages/core/src/core/hierarchy/scope.ts
@@ -87,11 +87,21 @@ export class Scope {
  * the decoded dynamic segments by name. `resourcePath` is the raw path that
  * was classified. `scope` is the matched scope; null for root and invalid.
  */
+/**
+ * Where in the hierarchy a path landed.
+ *
+ * `pattern` is the glob the line typed for the directory's children, set only
+ * for a kind named in `patternKinds` and null everywhere else. A lister whose
+ * listing is a window moves that window to the span the glob asks for instead
+ * of filtering its own; every other consumer ignores the field, the way a
+ * command ignores the `CommandOpts` facts it does not read.
+ */
 export interface ScopeMatch {
   readonly kind: string
   readonly resourcePath: string
   readonly slots: Record<string, string>
   readonly scope: Scope | null
+  readonly pattern: string | null
 }
 
 export type DetectFn = (path: PathSpec | string) => ScopeMatch
@@ -204,14 +214,15 @@ export function makeDetectScope(scopes: readonly Scope[]): DetectFn {
   return function detectScope(path: PathSpec | string): ScopeMatch {
     const raw = path instanceof PathSpec ? path.mountPath : path
     const key = stripSlash(raw)
-    if (key === '') return { kind: ROOT, resourcePath: raw, slots: {}, scope: null }
+    if (key === '') return { kind: ROOT, resourcePath: raw, slots: {}, scope: null, pattern: null }
     const parts = key.split('/')
     if (parts.some((p) => p.startsWith('.'))) {
-      return { kind: INVALID, resourcePath: raw, slots: {}, scope: null }
+      return { kind: INVALID, resourcePath: raw, slots: {}, scope: null, pattern: null }
     }
     const matched = matchScope(scopes, parts)
-    if (matched === null) return { kind: INVALID, resourcePath: raw, slots: {}, scope: null }
+    if (matched === null)
+      return { kind: INVALID, resourcePath: raw, slots: {}, scope: null, pattern: null }
     const [scope, slots] = matched
-    return { kind: scope.kind, resourcePath: raw, slots, scope }
+    return { kind: scope.kind, resourcePath: raw, slots, scope, pattern: null }
   }
 }

--- a/typescript/packages/core/src/core/lancedb/_driver.ts
+++ b/typescript/packages/core/src/core/lancedb/_driver.ts
@@ -22,12 +22,15 @@ export interface LanceDriver {
     column: string,
     filters: Record<string, string>,
     limit: number,
+    prefix?: string,
   ): Promise<string[]>
   rowsMatching(
     table: string,
     filters: Record<string, string>,
     columns: string[],
     limit: number,
+    idColumn?: string,
+    prefix?: string,
   ): Promise<LanceRow[]>
   rowRecord(table: string, idColumn: string, rowId: string): Promise<LanceRow | null>
   search(table: string, query: string, limit: number): Promise<LanceRow[]>

--- a/typescript/packages/core/src/core/lancedb/readdir.test.ts
+++ b/typescript/packages/core/src/core/lancedb/readdir.test.ts
@@ -79,3 +79,84 @@ describe('lancedb readdir sizes', () => {
     expect(out).toEqual(['/animals/cat/big/1.md', '/animals/cat/big/1.png'])
   })
 })
+
+const CAP = 5
+const WIDE = 40
+
+function wideAccessor(): {
+  accessor: LanceDBAccessor
+  rowsMatching: ReturnType<typeof vi.fn>
+} {
+  // The driver stands in for the store: the cap is a `limit` on the query, so
+  // the fake applies the prefix and the limit in that order, exactly as the
+  // SQL does.
+  const rows: LanceRow[] = []
+  for (let i = 0; i < WIDE; i += 1) rows.push({ id: `doc-${String(i).padStart(3, '0')}` })
+  const rowsMatching = vi
+    .fn()
+    .mockImplementation(
+      (_t: string, _f: unknown, _c: string[], limit: number, _id: string, prefix: string) =>
+        Promise.resolve(rows.filter((r) => String(r.id).startsWith(prefix)).slice(0, limit)),
+    )
+  const driver = {
+    listTables: vi.fn().mockResolvedValue(['wide']),
+    tableColumns: vi.fn().mockResolvedValue(['id']),
+    distinct: vi.fn().mockResolvedValue(['all']),
+    rowsMatching,
+  } as unknown as LanceDriver
+  const wideConfig = resolveLanceDBConfig({
+    uri: '/tmp/db',
+    table: 'wide',
+    groupBy: ['label'],
+    idColumn: 'id',
+    titleColumn: 'id',
+    maxRows: CAP,
+  })
+  return { accessor: new LanceDBAccessor(driver, wideConfig), rowsMatching }
+}
+
+function globbed(virtual: string, pattern: string): PathSpec {
+  return new PathSpec({
+    virtual,
+    directory: virtual,
+    resourcePath: virtual.replace(/^\//, ''),
+    pattern,
+  })
+}
+
+function ids(paths: string[]): string[] {
+  return paths.map((p) => (p.split('/').pop() ?? '').split('.')[0] ?? '')
+}
+
+describe('lancedb readdir narrows a capped listing', () => {
+  it('pushes a row glob prefix into the query', async () => {
+    // The cap covers doc-000..doc-004, so filtering it would answer nothing.
+    const { accessor, rowsMatching } = wideAccessor()
+    const out = await readdir(accessor, globbed('/all', 'doc-03*'), new RAMIndexCacheStore())
+    expect(ids(out)).toEqual(['doc-030', 'doc-031', 'doc-032', 'doc-033', 'doc-034'])
+    expect(rowsMatching.mock.calls[0]?.[5]).toBe('doc-03')
+  })
+
+  it('cuts the prefix at the suffix so a leaf glob cannot ask for a dot', async () => {
+    const { accessor, rowsMatching } = wideAccessor()
+    await readdir(accessor, globbed('/all', 'doc-039.m*'), new RAMIndexCacheStore())
+    expect(rowsMatching.mock.calls[0]?.[5]).toBe('doc-039')
+  })
+
+  it('sends no prefix for a glob with no literal head', async () => {
+    const { accessor, rowsMatching } = wideAccessor()
+    const out = await readdir(accessor, globbed('/all', '*9.md'), new RAMIndexCacheStore())
+    expect(ids(out)).toEqual(['doc-000', 'doc-001', 'doc-002', 'doc-003', 'doc-004'])
+    expect(rowsMatching.mock.calls[0]?.[5]).toBe('')
+  })
+
+  it('does not cache a narrowed listing as the directory', async () => {
+    const { accessor } = wideAccessor()
+    const idx = new RAMIndexCacheStore()
+    await readdir(accessor, globbed('/all', 'doc-03*'), idx)
+    const listed = await idx.listDir('/all/')
+    expect(listed.entries === undefined || listed.entries === null).toBe(true)
+    const plain = await readdir(accessor, spec('/all'), idx)
+    expect(ids(plain)).toEqual(['doc-000', 'doc-001', 'doc-002', 'doc-003', 'doc-004'])
+  })
+})

--- a/typescript/packages/core/src/core/lancedb/readdir.ts
+++ b/typescript/packages/core/src/core/lancedb/readdir.ts
@@ -20,10 +20,11 @@ import type { LanceRow } from './_driver.ts'
 import { PathSpec } from '../../types.ts'
 import { perAccessor } from '../hierarchy/bind.ts'
 import type { ReaddirFn } from '../hierarchy/probe.ts'
-import { makeReaddir, type Lister } from '../hierarchy/readdir.ts'
+import { makeReaddir, type DirListing, type Listed, type Lister } from '../hierarchy/readdir.ts'
 import { ROOT, type ScopeMatch } from '../hierarchy/scope.ts'
 import { renderCard } from './render.ts'
 import { detectFor, filtersOf, tableOf } from './scope.ts'
+import { globPrefix, hasGlobPrefix } from '../../utils/glob_walk.ts'
 
 const GROUP_TYPE = 'lancedb/group'
 
@@ -64,23 +65,41 @@ function rowEntries(rows: LanceRow[], config: LanceDBConfigResolved): [string, I
   return entries
 }
 
-async function children(
-  accessor: LanceDBAccessor,
-  table: string,
-  filters: Record<string, string>,
-): Promise<[string, IndexEntry][] | null> {
+/**
+ * The id prefix a leaf glob narrows the row query to.
+ *
+ * A leaf is named `<rowId>` plus a codec suffix, so a literal prefix that
+ * reached into the suffix is not an id prefix. Cutting at the first dot keeps
+ * a superset the glob then filters, which is what stops `12*.md` from asking
+ * for ids starting `12.` and listing nothing.
+ */
+function rowPrefix(pattern: string | null): string {
+  return globPrefix(pattern).split('.')[0] ?? ''
+}
+
+async function children(accessor: LanceDBAccessor, match: ScopeMatch): Promise<Listed | null> {
   const config = accessor.config
+  const table = tableOf(config, match)
+  const filters = filtersOf(config, match)
+  const pattern = match.pattern
   const tables = await accessor.driver.listTables()
   if (!tables.includes(table)) return null
   const depth = Object.keys(filters).length
   if (depth < config.groupBy.length) {
+    const groupPrefix = globPrefix(pattern)
     const names = await accessor.driver.distinct(
       table,
       config.groupBy[depth] ?? '',
       filters,
       config.maxRows,
+      groupPrefix,
     )
-    return names.map((name): [string, IndexEntry] => [name, dirEntry(name)])
+    const listing: DirListing = {
+      entries: names.map((name): [string, IndexEntry] => [name, dirEntry(name)]),
+      seeds: {},
+      partial: groupPrefix !== '',
+    }
+    return listing
   }
   // Select every column except the vector and blob ones (schema order, so
   // the projected rows render byte-identically to the full rows read()
@@ -89,28 +108,36 @@ async function children(
   const columns = (await accessor.driver.tableColumns(table)).filter(
     (c) => c !== config.vectorColumn && c !== config.blobColumn,
   )
-  const rows = await accessor.driver.rowsMatching(table, filters, columns, config.maxRows)
-  return rowEntries(rows, config)
+  const prefix = rowPrefix(pattern)
+  const rows = await accessor.driver.rowsMatching(
+    table,
+    filters,
+    columns,
+    config.maxRows,
+    config.idColumn,
+    prefix,
+  )
+  const listing: DirListing = {
+    entries: rowEntries(rows, config),
+    seeds: {},
+    partial: prefix !== '',
+  }
+  return listing
 }
 
-async function listRoot(
-  accessor: LanceDBAccessor,
-  _match: ScopeMatch,
-): Promise<[string, IndexEntry][] | null> {
+async function listRoot(accessor: LanceDBAccessor, match: ScopeMatch): Promise<Listed | null> {
   const config = accessor.config
   if (config.table === null) {
+    // Table names come from the catalog, not from a capped query, so a glob
+    // here has nothing to narrow.
     const tables = await accessor.driver.listTables()
     return tables.map((name): [string, IndexEntry] => [name, dirEntry(name)])
   }
-  return children(accessor, config.table, {})
+  return children(accessor, match)
 }
 
-async function listGroup(
-  accessor: LanceDBAccessor,
-  match: ScopeMatch,
-): Promise<[string, IndexEntry][] | null> {
-  const config = accessor.config
-  return children(accessor, tableOf(config, match), filtersOf(config, match))
+async function listGroup(accessor: LanceDBAccessor, match: ScopeMatch): Promise<Listed | null> {
+  return children(accessor, match)
 }
 
 const LISTERS: Record<string, Lister<LanceDBAccessor>> = {
@@ -118,8 +145,10 @@ const LISTERS: Record<string, Lister<LanceDBAccessor>> = {
   group: listGroup,
 }
 
+const PATTERN_KINDS = { [ROOT]: hasGlobPrefix, group: hasGlobPrefix }
+
 function buildReaddir(accessor: LanceDBAccessor): ReaddirFn<LanceDBAccessor> {
-  return makeReaddir(detectFor(accessor), { listers: LISTERS })
+  return makeReaddir(detectFor(accessor), { listers: LISTERS, patternKinds: PATTERN_KINDS })
 }
 
 export const readdirFor = perAccessor(buildReaddir)

--- a/typescript/packages/core/src/core/lancedb/readdir.ts
+++ b/typescript/packages/core/src/core/lancedb/readdir.ts
@@ -24,7 +24,7 @@ import { makeReaddir, type DirListing, type Listed, type Lister } from '../hiera
 import { ROOT, type ScopeMatch } from '../hierarchy/scope.ts'
 import { renderCard } from './render.ts'
 import { detectFor, filtersOf, tableOf } from './scope.ts'
-import { globPrefix, hasGlobPrefix } from '../../utils/glob_walk.ts'
+import { globPrefix, globStemPrefix, hasGlobPrefix } from '../../utils/glob_walk.ts'
 
 const GROUP_TYPE = 'lancedb/group'
 
@@ -66,15 +66,15 @@ function rowEntries(rows: LanceRow[], config: LanceDBConfigResolved): [string, I
 }
 
 /**
- * The id prefix a leaf glob narrows the row query to.
+ * The row-id prefix a leaf glob narrows the row query to.
  *
- * A leaf is named `<rowId>` plus a codec suffix, so a literal prefix that
- * reached into the suffix is not an id prefix. Cutting at the first dot keeps
- * a superset the glob then filters, which is what stops `12*.md` from asking
- * for ids starting `12.` and listing nothing.
+ * A leaf is named `<rowId>` plus whichever suffix the renderer gave it, and
+ * only the id half is a prefix the query can test.
  */
-function rowPrefix(pattern: string | null): string {
-  return globPrefix(pattern).split('.')[0] ?? ''
+function rowPrefix(pattern: string | null, config: LanceDBConfigResolved): string {
+  const suffixes = ['.md']
+  if (config.blobColumn !== null && config.blobColumn !== '') suffixes.push(`.${config.blobExt}`)
+  return globStemPrefix(pattern, suffixes)
 }
 
 async function children(accessor: LanceDBAccessor, match: ScopeMatch): Promise<Listed | null> {
@@ -108,7 +108,7 @@ async function children(accessor: LanceDBAccessor, match: ScopeMatch): Promise<L
   const columns = (await accessor.driver.tableColumns(table)).filter(
     (c) => c !== config.vectorColumn && c !== config.blobColumn,
   )
-  const prefix = rowPrefix(pattern)
+  const prefix = rowPrefix(pattern, config)
   const rows = await accessor.driver.rowsMatching(
     table,
     filters,

--- a/typescript/packages/core/src/core/qdrant/client.ts
+++ b/typescript/packages/core/src/core/qdrant/client.ts
@@ -38,6 +38,22 @@ export function buildFilter(filters: Record<string, string>): Record<string, unk
   }
 }
 
+export type PointTest = (point: QdrantPoint) => boolean
+
+/** Keep points whose id starts with a literal name prefix. */
+export function idPrefixTest(prefix: string): PointTest {
+  return (point) => String(point.id).startsWith(prefix)
+}
+
+/** Keep points whose payload value starts with a literal prefix. */
+export function valuePrefixTest(column: string, prefix: string): PointTest {
+  return (point) => {
+    const value = point.payload?.[column]
+    if (value === null || value === undefined) return false
+    return String(value as string | number | boolean).startsWith(prefix)
+  }
+}
+
 export function pointToRow(point: QdrantPoint, idField: string): QdrantRow {
   const payload = point.payload ?? {}
   const row: QdrantRow = { ...payload }

--- a/typescript/packages/core/src/core/qdrant/readdir.test.ts
+++ b/typescript/packages/core/src/core/qdrant/readdir.test.ts
@@ -99,3 +99,82 @@ describe('qdrant readdir sizes', () => {
     expect(json.entry?.size).toBe(renderJson(broken, config).byteLength)
   })
 })
+
+const CAP = 5
+const WIDE = 40
+
+function cappedAccessor(seen: { prefix: string | undefined }): QdrantAccessor {
+  // The accessor stands in for the scroll: with a prefix the cap bounds the
+  // MATCHES, so the fake filters first and slices second.
+  const rows: QdrantRow[] = []
+  for (let i = 0; i < WIDE; i += 1) rows.push({ id: `doc-${String(i).padStart(3, '0')}` })
+  return {
+    config: resolveQdrantConfig({
+      idField: 'id',
+      collection: 'wide',
+      groupBy: ['label'],
+      maxRows: CAP,
+    }),
+    listTables: () => Promise.resolve(['wide']),
+    tableExists: (name: string) => Promise.resolve(name === 'wide'),
+    distinct: () => Promise.resolve(['all']),
+    rowsMatching: (_t: string, _f: unknown, _c: string[], limit: number, prefix: string) => {
+      seen.prefix = prefix
+      return Promise.resolve(rows.filter((r) => String(r.id).startsWith(prefix)).slice(0, limit))
+    },
+  } as unknown as QdrantAccessor
+}
+
+function globbed(virtual: string, pattern: string): PathSpec {
+  return new PathSpec({
+    virtual,
+    directory: virtual,
+    resourcePath: virtual.replace(/^\//, ''),
+    pattern,
+  })
+}
+
+function ids(paths: string[]): string[] {
+  return [...new Set(paths.map((p) => (p.split('/').pop() ?? '').split('.')[0] ?? ''))]
+}
+
+describe('qdrant readdir narrows a capped listing', () => {
+  it('pushes a row glob prefix into the scroll', async () => {
+    const seen: { prefix: string | undefined } = { prefix: undefined }
+    const out = await readdir(
+      cappedAccessor(seen),
+      globbed('/all', 'doc-03*'),
+      new RAMIndexCacheStore(),
+    )
+    expect(ids(out)).toEqual(['doc-030', 'doc-031', 'doc-032', 'doc-033', 'doc-034'])
+    expect(seen.prefix).toBe('doc-03')
+  })
+
+  it('cuts the prefix at the suffix so a leaf glob cannot ask for a dot', async () => {
+    const seen: { prefix: string | undefined } = { prefix: undefined }
+    await readdir(cappedAccessor(seen), globbed('/all', 'doc-039.js*'), new RAMIndexCacheStore())
+    expect(seen.prefix).toBe('doc-039')
+  })
+
+  it('sends no prefix for a glob with no literal head', async () => {
+    const seen: { prefix: string | undefined } = { prefix: undefined }
+    const out = await readdir(
+      cappedAccessor(seen),
+      globbed('/all', '*9.json'),
+      new RAMIndexCacheStore(),
+    )
+    expect(ids(out)).toEqual(['doc-000', 'doc-001', 'doc-002', 'doc-003', 'doc-004'])
+    expect(seen.prefix).toBe('')
+  })
+
+  it('does not cache a narrowed listing as the directory', async () => {
+    const seen: { prefix: string | undefined } = { prefix: undefined }
+    const acc = cappedAccessor(seen)
+    const idx = new RAMIndexCacheStore()
+    await readdir(acc, globbed('/all', 'doc-03*'), idx)
+    const listed = await idx.listDir('/all/')
+    expect(listed.entries === undefined || listed.entries === null).toBe(true)
+    const plain = await readdir(acc, spec('/all'), idx)
+    expect(ids(plain)).toEqual(['doc-000', 'doc-001', 'doc-002', 'doc-003', 'doc-004'])
+  })
+})

--- a/typescript/packages/core/src/core/qdrant/readdir.ts
+++ b/typescript/packages/core/src/core/qdrant/readdir.ts
@@ -24,7 +24,7 @@ import { makeReaddir, type DirListing, type Listed, type Lister } from '../hiera
 import { ROOT, type ScopeMatch } from '../hierarchy/scope.ts'
 import { blobBytes, renderJson, renderText } from './render.ts'
 import { detectFor, filtersOf, tableOf } from './scope.ts'
-import { globPrefix, hasGlobPrefix } from '../../utils/glob_walk.ts'
+import { globPrefix, globStemPrefix, hasGlobPrefix } from '../../utils/glob_walk.ts'
 
 const GROUP_TYPE = 'qdrant/group'
 
@@ -98,15 +98,16 @@ function rowEntries(rows: QdrantRow[], config: QdrantConfigResolved): [string, I
 }
 
 /**
- * The id prefix a leaf glob narrows the scroll to.
+ * The point-id prefix a leaf glob narrows the scroll to.
  *
- * A leaf is named `<pointId>` plus a suffix, so a literal prefix that reached
- * into the suffix is not an id prefix. Cutting at the first dot keeps a
- * superset the glob then filters, which is what stops `12*.json` from asking
- * for ids starting `12.` and listing nothing.
+ * A leaf is named `<pointId>` plus whichever suffix the renderer gave it, and
+ * only the id half is a prefix the scroll can test.
  */
-function rowPrefix(pattern: string | null): string {
-  return globPrefix(pattern).split('.')[0] ?? ''
+function rowPrefix(pattern: string | null, config: QdrantConfigResolved): string {
+  const suffixes = ['.json']
+  if (config.textField !== null && config.textField !== '') suffixes.push('.txt')
+  if (config.blobField !== null && config.blobField !== '') suffixes.push(`.${config.blobExt}`)
+  return globStemPrefix(pattern, suffixes)
 }
 
 async function children(accessor: QdrantAccessor, match: ScopeMatch): Promise<Listed | null> {
@@ -132,7 +133,7 @@ async function children(accessor: QdrantAccessor, match: ScopeMatch): Promise<Li
     }
     return listing
   }
-  const prefix = rowPrefix(pattern)
+  const prefix = rowPrefix(pattern, config)
   const rows = await accessor.rowsMatching(table, filters, [config.idField], config.maxRows, prefix)
   const listing: DirListing = {
     entries: rowEntries(rows, config),

--- a/typescript/packages/core/src/core/qdrant/readdir.ts
+++ b/typescript/packages/core/src/core/qdrant/readdir.ts
@@ -20,10 +20,11 @@ import type { QdrantRow } from './client.ts'
 import { PathSpec } from '../../types.ts'
 import { perAccessor } from '../hierarchy/bind.ts'
 import type { ReaddirFn } from '../hierarchy/probe.ts'
-import { makeReaddir, type Lister } from '../hierarchy/readdir.ts'
+import { makeReaddir, type DirListing, type Listed, type Lister } from '../hierarchy/readdir.ts'
 import { ROOT, type ScopeMatch } from '../hierarchy/scope.ts'
 import { blobBytes, renderJson, renderText } from './render.ts'
 import { detectFor, filtersOf, tableOf } from './scope.ts'
+import { globPrefix, hasGlobPrefix } from '../../utils/glob_walk.ts'
 
 const GROUP_TYPE = 'qdrant/group'
 
@@ -96,45 +97,64 @@ function rowEntries(rows: QdrantRow[], config: QdrantConfigResolved): [string, I
   return entries
 }
 
-async function children(
-  accessor: QdrantAccessor,
-  table: string,
-  filters: Record<string, string>,
-): Promise<[string, IndexEntry][] | null> {
+/**
+ * The id prefix a leaf glob narrows the scroll to.
+ *
+ * A leaf is named `<pointId>` plus a suffix, so a literal prefix that reached
+ * into the suffix is not an id prefix. Cutting at the first dot keeps a
+ * superset the glob then filters, which is what stops `12*.json` from asking
+ * for ids starting `12.` and listing nothing.
+ */
+function rowPrefix(pattern: string | null): string {
+  return globPrefix(pattern).split('.')[0] ?? ''
+}
+
+async function children(accessor: QdrantAccessor, match: ScopeMatch): Promise<Listed | null> {
   const config = accessor.config
+  const table = tableOf(config, match)
+  const filters = filtersOf(config, match)
+  const pattern = match.pattern
   if (!(await accessor.tableExists(table))) return null
   const depth = Object.keys(filters).length
   if (depth < config.groupBy.length) {
+    const groupPrefix = globPrefix(pattern)
     const names = await accessor.distinct(
       table,
       config.groupBy[depth] ?? '',
       filters,
       config.maxRows,
+      groupPrefix,
     )
-    return names.map((name): [string, IndexEntry] => [name, dirEntry(name)])
+    const listing: DirListing = {
+      entries: names.map((name): [string, IndexEntry] => [name, dirEntry(name)]),
+      seeds: {},
+      partial: groupPrefix !== '',
+    }
+    return listing
   }
-  const rows = await accessor.rowsMatching(table, filters, [config.idField], config.maxRows)
-  return rowEntries(rows, config)
+  const prefix = rowPrefix(pattern)
+  const rows = await accessor.rowsMatching(table, filters, [config.idField], config.maxRows, prefix)
+  const listing: DirListing = {
+    entries: rowEntries(rows, config),
+    seeds: {},
+    partial: prefix !== '',
+  }
+  return listing
 }
 
-async function listRoot(
-  accessor: QdrantAccessor,
-  _match: ScopeMatch,
-): Promise<[string, IndexEntry][] | null> {
+async function listRoot(accessor: QdrantAccessor, match: ScopeMatch): Promise<Listed | null> {
   const config = accessor.config
   if (config.collection === null) {
+    // Collection names come from the catalog, not from a capped scroll, so a
+    // glob here has nothing to narrow.
     const tables = await accessor.listTables()
     return tables.map((name): [string, IndexEntry] => [name, dirEntry(name)])
   }
-  return children(accessor, config.collection, {})
+  return children(accessor, match)
 }
 
-async function listGroup(
-  accessor: QdrantAccessor,
-  match: ScopeMatch,
-): Promise<[string, IndexEntry][] | null> {
-  const config = accessor.config
-  return children(accessor, tableOf(config, match), filtersOf(config, match))
+async function listGroup(accessor: QdrantAccessor, match: ScopeMatch): Promise<Listed | null> {
+  return children(accessor, match)
 }
 
 const LISTERS: Record<string, Lister<QdrantAccessor>> = {
@@ -142,8 +162,10 @@ const LISTERS: Record<string, Lister<QdrantAccessor>> = {
   group: listGroup,
 }
 
+const PATTERN_KINDS = { [ROOT]: hasGlobPrefix, group: hasGlobPrefix }
+
 function buildReaddir(accessor: QdrantAccessor): ReaddirFn<QdrantAccessor> {
-  return makeReaddir(detectFor(accessor), { listers: LISTERS })
+  return makeReaddir(detectFor(accessor), { listers: LISTERS, patternKinds: PATTERN_KINDS })
 }
 
 export const readdirFor = perAccessor(buildReaddir)

--- a/typescript/packages/core/src/core/ram/readdir.ts
+++ b/typescript/packages/core/src/core/ram/readdir.ts
@@ -27,8 +27,13 @@ export async function readdir(
   path: PathSpec,
   index?: IndexCacheStore,
 ): Promise<string[]> {
-  const virtual = path.pattern !== null ? path.directory : path.mountPath
-  const mountPrefix = mountPrefixOf(path.virtual, path.resourcePath)
+  // A pattern spec addresses the directory whose entries the glob filters,
+  // and the rest of this function works in mount-relative space, so the
+  // directory has to be read off `dir` rather than off the virtual
+  // `directory` string (python spells it the same way).
+  const target = path.pattern !== null ? path.dir : path
+  const virtual = target.mountPath
+  const mountPrefix = mountPrefixOf(target.virtual, target.resourcePath)
   // Canonical key: no trailing slash (except root), or the same dir
   // indexes under two keys and cache hits return doubled-slash entries.
   const virtualKey = rstripSlash(mountPrefix + virtual) || '/'

--- a/typescript/packages/core/src/core/slack/readdir.test.ts
+++ b/typescript/packages/core/src/core/slack/readdir.test.ts
@@ -73,6 +73,31 @@ describe('dateRange', () => {
     const ts = Date.UTC(2024, 5, 15) / 1000
     expect(dateRange(ts, ts)).toEqual(['2024-06-15'])
   })
+
+  it('escapes the cap for a glob span older than the window', () => {
+    // A day dir is real for any date the channel has existed for, so a glob
+    // older than the 90-day window must still list its days.
+    const end = Date.UTC(2024, 0, 100) / 1000
+    const start = Date.UTC(2010, 0, 1) / 1000
+    const out = dateRange(end, start, 90, ['2010-03-01', '2010-04-01'])
+    expect(out).toHaveLength(31)
+    expect(out[0]).toBe('2010-03-31')
+    expect(out[30]).toBe('2010-03-01')
+  })
+
+  it('clips a glob span at both ends of the channel', () => {
+    const start = Date.UTC(2010, 2, 10) / 1000
+    const end = Date.UTC(2010, 2, 20) / 1000
+    const out = dateRange(end, start, 90, ['2010-03-01', '2010-04-01'])
+    expect(out[0]).toBe('2010-03-20')
+    expect(out[out.length - 1]).toBe('2010-03-10')
+  })
+
+  it('lists nothing for a glob span the channel never covered', () => {
+    const start = Date.UTC(2020, 0, 1) / 1000
+    const end = Date.UTC(2020, 0, 5) / 1000
+    expect(dateRange(end, start, 90, ['2010-03-01', '2010-04-01'])).toEqual([])
+  })
 })
 
 describe('latestMessageTs', () => {

--- a/typescript/packages/core/src/core/slack/readdir.ts
+++ b/typescript/packages/core/src/core/slack/readdir.ts
@@ -21,6 +21,7 @@ import { channelDirname, dmDirname, fileBlobName, userFilename } from './formatt
 import { fetchMessagesForDay, messagesToJsonl, type SlackMessage } from './history.ts'
 import { detectScope } from './scope.ts'
 import { listUsers, userJsonBytes } from './users.ts'
+import { globSpan, hasGlobSpan } from '../../utils/glob_walk.ts'
 
 export const VIRTUAL_ROOTS = ['channels', 'dms', 'users'] as const
 
@@ -56,19 +57,35 @@ export async function latestMessageTs(
   return Number.parseFloat(messages[0]?.ts ?? '0')
 }
 
-export function dateRange(latestTs: number, created: number, maxDays = 90): string[] {
+/**
+ * The channel's day directories, newest first.
+ *
+ * A day dir is real for any date the channel has existed for, so the bare
+ * listing is a window: the last `maxDays` up to the newest message. A glob
+ * names its own window instead, and then the cap does not apply, because the
+ * span is already bounded by what was typed.
+ */
+export function dateRange(
+  latestTs: number,
+  created: number,
+  maxDays = 90,
+  span: readonly [string, string] | null = null,
+): string[] {
   const endMs = Math.floor(latestTs * 1000)
   const startMs = Math.floor(created * 1000)
   const endDate = new Date(endMs)
   const startDate = new Date(startMs)
-  const endUtc = Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate())
+  let endUtc = Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate())
   let startUtc = Date.UTC(
     startDate.getUTCFullYear(),
     startDate.getUTCMonth(),
     startDate.getUTCDate(),
   )
   const dayMs = 86_400_000
-  if ((endUtc - startUtc) / dayMs > maxDays) {
+  if (span !== null) {
+    startUtc = Math.max(startUtc, Date.parse(`${span[0]}T00:00:00Z`))
+    endUtc = Math.min(endUtc, Date.parse(`${span[1]}T00:00:00Z`) - dayMs)
+  } else if ((endUtc - startUtc) / dayMs > maxDays) {
     startUtc = endUtc - (maxDays - 1) * dayMs
   }
   const dates: string[] = []
@@ -142,20 +159,21 @@ async function listUsersRoot(accessor: SlackAccessor, _match: ScopeMatch): Promi
 
 async function listChannelDays(
   accessor: SlackAccessor,
-  _match: ScopeMatch,
+  match: ScopeMatch,
   own: IndexEntry,
 ): Promise<Listed> {
   const created = Number.parseInt(own.remoteTime !== '' ? own.remoteTime : '0', 10)
+  const span = globSpan(match.pattern)
   const latestTs = await latestMessageTs(accessor, own.id)
   let dates: string[]
   if (latestTs !== null && created > 0) {
-    dates = dateRange(latestTs, created)
+    dates = dateRange(latestTs, created, 90, span)
   } else if (latestTs !== null) {
-    dates = dateRange(latestTs, Math.floor(latestTs))
+    dates = dateRange(latestTs, Math.floor(latestTs), 90, span)
   } else {
     dates = []
   }
-  return dates.map(
+  const entries = dates.map(
     (d) =>
       [
         d,
@@ -168,6 +186,7 @@ async function listChannelDays(
         }),
       ] as [string, IndexEntry],
   )
+  return { entries, seeds: {}, partial: span !== null }
 }
 
 /**
@@ -285,4 +304,5 @@ export const readdir = makeReaddir<SlackAccessor>(detectScope, {
   },
   parentEntryListers: { day: listDay },
   staticRoot: VIRTUAL_ROOTS,
+  patternKinds: { channel: hasGlobSpan },
 })

--- a/typescript/packages/core/src/utils/glob_walk.test.ts
+++ b/typescript/packages/core/src/utils/glob_walk.test.ts
@@ -21,7 +21,10 @@ import { enoent } from './errors.ts'
 import {
   expandPattern,
   globPattern,
+  globPrefix,
+  globSpan,
   hasGlob,
+  hasGlobPrefix,
   isWordShaped,
   literalWord,
   markEscapedGlobs,
@@ -283,5 +286,59 @@ describe('resolveGlobWith under hidden paths', () => {
     expect(result[0]?.resolved).toBe(true)
     expect(result[0]?.pattern).toBeNull()
     expect(result[0]?.virtual).toBe('/notion/pages/Roadmap__uuid2/page.*')
+  })
+})
+
+describe('globSpan', () => {
+  it.each([
+    ['2026-*', ['2026-01-01', '2027-01-01']],
+    ['2026-01-*', ['2026-01-01', '2026-02-01']],
+    ['2026-12-*', ['2026-12-01', '2027-01-01']],
+    ['2026-01-05*', ['2026-01-05', '2026-01-06']],
+    ['2026-01-05_*', ['2026-01-05', '2026-01-06']],
+    ['2026-01-?', ['2026-01-01', '2026-02-01']],
+  ])('reads the literal date prefix of %s', (pattern, expected) => {
+    expect(globSpan(pattern)).toEqual(expected)
+  })
+
+  it.each([
+    // No metacharacter at all is a literal name, not a span.
+    ['2026-01-05'],
+    ['chat*'],
+    ['2026-13-*'],
+    ['2026-02-30*'],
+    [''],
+    [null],
+    [undefined],
+  ])('has no span for %s', (pattern) => {
+    expect(globSpan(pattern)).toBeNull()
+  })
+})
+
+describe('globPrefix', () => {
+  it.each([
+    ['doc-1*', 'doc-1'],
+    ['doc-1?.md', 'doc-1'],
+    ['doc-1[0-9]', 'doc-1'],
+    // A metacharacter first leaves nothing to narrow on, and a word with none
+    // at all is a literal name rather than a glob.
+    ['*.md', ''],
+    ['?abc*', ''],
+    ['doc-10.md', ''],
+    ['', ''],
+  ])('reads the literal head of %s', (pattern, expected) => {
+    expect(globPrefix(pattern)).toBe(expected)
+    expect(hasGlobPrefix(pattern)).toBe(expected !== '')
+  })
+
+  it('has no prefix for a missing pattern', () => {
+    expect(globPrefix(null)).toBe('')
+    expect(globPrefix(undefined)).toBe('')
+  })
+
+  it('restores a quoted metacharacter', () => {
+    // A quoted star travels under a private mark and stands for a literal
+    // star, so it belongs in the prefix as the character it names.
+    expect(globPrefix(markGlobs('*') + 'ab*')).toBe('*ab')
   })
 })

--- a/typescript/packages/core/src/utils/glob_walk.test.ts
+++ b/typescript/packages/core/src/utils/glob_walk.test.ts
@@ -23,6 +23,7 @@ import {
   globPattern,
   globPrefix,
   globSpan,
+  globStemPrefix,
   hasGlob,
   hasGlobPrefix,
   isWordShaped,
@@ -340,5 +341,27 @@ describe('globPrefix', () => {
     // A quoted star travels under a private mark and stands for a literal
     // star, so it belongs in the prefix as the character it names.
     expect(globPrefix(markGlobs('*') + 'ab*')).toBe('*ab')
+  })
+})
+
+describe('globStemPrefix', () => {
+  it.each([
+    // The literal has run into the suffix, so the part that ran in says
+    // nothing about the stem and comes off.
+    ['12*.md', '12'],
+    ['doc-1.m*', 'doc-1'],
+    ['doc-1.*', 'doc-1'],
+    ['doc-1.p*', 'doc-1'],
+    // A dot inside the stem is not the suffix, so it stays.
+    ['acct.2026*', 'acct.2026'],
+    ['acct.mark*', 'acct.mark'],
+    ['doc-1*', 'doc-1'],
+    ['*.md', ''],
+  ])('drops only a reached suffix from %s', (pattern, expected) => {
+    expect(globStemPrefix(pattern, ['.md', '.png'])).toBe(expected)
+  })
+
+  it('has no prefix for a missing pattern', () => {
+    expect(globStemPrefix(null, ['.md'])).toBe('')
   })
 })

--- a/typescript/packages/core/src/utils/glob_walk.ts
+++ b/typescript/packages/core/src/utils/glob_walk.ts
@@ -81,6 +81,28 @@ export function globPrefix(pattern: string | null | undefined): string {
 }
 
 /**
+ * The literal prefix a glob puts on the stem of a leaf name.
+ *
+ * A leaf is a stem plus one of the renderer's suffixes, so a literal that has
+ * run into a suffix says nothing about the stem and the part that ran in is
+ * dropped: `12*.md` narrows to `12`, and `doc-1.m*` narrows to `doc-1` rather
+ * than asking for stems that start `doc-1.m`. Only a tail that spells the head
+ * of a suffix is dropped, which is what keeps a stem that contains a dot:
+ * `acct.2026*` narrows to `acct.2026`, where cutting at the first dot would
+ * narrow to `acct` and let the rows nobody asked for eat the window.
+ */
+export function globStemPrefix(pattern: string | null | undefined, suffixes: string[]): string {
+  const literal = globPrefix(pattern)
+  let reached = 0
+  for (const suffix of suffixes) {
+    for (let size = 1; size <= suffix.length; size += 1) {
+      if (literal.endsWith(suffix.slice(0, size))) reached = Math.max(reached, size)
+    }
+  }
+  return literal.slice(0, literal.length - reached)
+}
+
+/**
  * The half-open range of dates a date-prefixed glob asks for.
  *
  * The literal prefix before the first metacharacter is read as a year, a

--- a/typescript/packages/core/src/utils/glob_walk.ts
+++ b/typescript/packages/core/src/utils/glob_walk.ts
@@ -22,6 +22,107 @@ import { compareCodePoints } from './sort.ts'
 
 export const GLOB_CHARS = ['*', '?', '[']
 
+function isoDay(year: number, month: number, date: number): string {
+  const mm = String(month).padStart(2, '0')
+  const dd = String(date).padStart(2, '0')
+  return `${String(year)}-${mm}-${dd}`
+}
+
+function isValidDate(year: number, month: number, date: number): boolean {
+  if (month < 1 || month > 12 || date < 1) return false
+  const d = new Date(Date.UTC(year, month - 1, date))
+  return d.getUTCFullYear() === year && d.getUTCMonth() === month - 1 && d.getUTCDate() === date
+}
+
+function parseFixedInt(s: string | undefined, expectedLength: number): number | null {
+  if (s?.length !== expectedLength || !/^\d+$/.test(s)) return null
+  return Number.parseInt(s, 10)
+}
+
+/**
+ * Whether a glob names a date range a windowed lister can move to.
+ *
+ * The kit's `patternKinds` table holds one of these per kind: a glob it
+ * answers true for reaches the lister and bypasses the index, and any other
+ * glob is filtered out of the ordinary cached listing.
+ */
+export function hasGlobSpan(pattern: string): boolean {
+  return globSpan(pattern) !== null
+}
+
+/**
+ * Whether a glob starts with literal text a query can narrow on.
+ *
+ * The `patternKinds` twin of `hasGlobSpan` for a backend whose window is a
+ * row cap rather than a date range: the literal prefix becomes a prefix match
+ * in the query, so the cap covers the region the line named instead of the
+ * head of the table.
+ */
+export function hasGlobPrefix(pattern: string): boolean {
+  return globPrefix(pattern) !== ''
+}
+
+/**
+ * The literal text a glob starts with, before its first metacharacter.
+ *
+ * A quoted glob character travels under a private mark and stands for that
+ * character literally, so the marks are restored here: `'*'ab*` asks for
+ * names starting with a real star.
+ */
+export function globPrefix(pattern: string | null | undefined): string {
+  if (!pattern) return ''
+  let metaIndex = -1
+  for (const ch of GLOB_CHARS) {
+    const idx = pattern.indexOf(ch)
+    if (idx !== -1 && (metaIndex === -1 || idx < metaIndex)) metaIndex = idx
+  }
+  if (metaIndex === -1) return ''
+  return unmarkGlobs(pattern.slice(0, metaIndex))
+}
+
+/**
+ * The half-open range of dates a date-prefixed glob asks for.
+ *
+ * The literal prefix before the first metacharacter is read as a year, a
+ * month or a day, so `2026-*` spans a year and `2026-01-05*` one day. This is
+ * what lets a windowed listing honour a glob instead of filtering its own
+ * window: the backend moves the window to the span the line named. Dates are
+ * floating `YYYY-MM-DD`, since a caller bucketing in a named time zone has to
+ * build its own instants from them; UTC instants would shift the window by
+ * the offset.
+ */
+export function globSpan(pattern: string | null | undefined): [string, string] | null {
+  const literal = globPrefix(pattern)
+  if (literal === '') return null
+  const parts = literal.replace(/[_-]+$/, '').split('-')
+  if (parts.length === 1) {
+    const year = parseFixedInt(parts[0], 4)
+    if (year === null) return null
+    return [isoDay(year, 1, 1), isoDay(year + 1, 1, 1)]
+  }
+  if (parts.length === 2) {
+    const year = parseFixedInt(parts[0], 4)
+    const month = parseFixedInt(parts[1], 2)
+    if (year === null || month === null) return null
+    if (!isValidDate(year, month, 1)) return null
+    if (month === 12) return [isoDay(year, month, 1), isoDay(year + 1, 1, 1)]
+    return [isoDay(year, month, 1), isoDay(year, month + 1, 1)]
+  }
+  if (parts.length === 3) {
+    const year = parseFixedInt(parts[0], 4)
+    const month = parseFixedInt(parts[1], 2)
+    const date = parseFixedInt(parts[2], 2)
+    if (year === null || month === null || date === null) return null
+    if (!isValidDate(year, month, date)) return null
+    const next = new Date(Date.UTC(year, month - 1, date) + 86400000)
+    return [
+      isoDay(year, month, date),
+      isoDay(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate()),
+    ]
+  }
+  return null
+}
+
 // A quoted glob character keeps travelling as a character, under a
 // private mark, because bash tracks quoting per character and not per
 // word: `'*'?.txt` still globs, on the `?` alone, and matches only a
@@ -295,7 +396,18 @@ export async function expandPattern<A, I>(
     const nextLevel: string[] = []
     const matcher = globPattern(seg)
     for (const parent of level) {
-      const spec = PathSpec.fromStrPath(parent, rekey(path.virtual, path.resourcePath, parent))
+      // Directory-shaped, carrying the segment as the pattern: a backend
+      // whose listing for this level is a bounded window moves the window to
+      // what the glob asks for instead of filtering its own (gcal, gdocs and
+      // the dated-message channels). Every other readdir reads the directory
+      // off the same spec and ignores the field. A literal segment carries
+      // none, so it keeps its warm listing.
+      const spec = new PathSpec({
+        virtual: parent,
+        directory: parent,
+        resourcePath: rekey(path.virtual, path.resourcePath, parent),
+        pattern: hasGlob(seg) ? seg : null,
+      })
       let entries: string[]
       try {
         entries = await readdir(accessor, spec, index)

--- a/typescript/packages/node/src/core/disk/readdir.ts
+++ b/typescript/packages/node/src/core/disk/readdir.ts
@@ -28,8 +28,14 @@ export async function readdir(
   path: PathSpec,
   index?: IndexCacheStore,
 ): Promise<string[]> {
-  const virtual = path.pattern !== null ? path.directory : path.mountPath
-  const mountPrefix = mountPrefixOf(path.virtual, path.resourcePath)
+  // A pattern spec addresses the directory whose entries the glob filters,
+  // and the rest of this function works in mount-relative space, so the
+  // directory has to be read off `dir` rather than off the virtual
+  // `directory` string (python strips the prefix by hand for the same
+  // reason).
+  const target = path.pattern !== null ? path.dir : path
+  const virtual = target.mountPath
+  const mountPrefix = mountPrefixOf(target.virtual, target.resourcePath)
   // Canonical key: no trailing slash (except root), or the same dir
   // indexes under two keys and cache hits return doubled-slash entries.
   const virtualKey = rstripSlash(mountPrefix + virtual) || '/'

--- a/typescript/packages/node/src/core/redis/readdir.ts
+++ b/typescript/packages/node/src/core/redis/readdir.ts
@@ -27,8 +27,14 @@ export async function readdir(
   path: PathSpec,
   index?: IndexCacheStore,
 ): Promise<string[]> {
-  const virtual = path.pattern !== null ? path.directory : path.mountPath
-  const mountPrefix = mountPrefixOf(path.virtual, path.resourcePath)
+  // A pattern spec addresses the directory whose entries the glob filters,
+  // and the rest of this function works in mount-relative space, so the
+  // directory has to be read off `dir` rather than off the virtual
+  // `directory` string (python strips the prefix by hand for the same
+  // reason).
+  const target = path.pattern !== null ? path.dir : path
+  const virtual = target.mountPath
+  const mountPrefix = mountPrefixOf(target.virtual, target.resourcePath)
   // Canonical key: no trailing slash (except root), or the same dir
   // indexes under two keys and cache hits return doubled-slash entries.
   const virtualKey = rstripSlash(mountPrefix + virtual) || '/'

--- a/typescript/packages/node/src/resource/lancedb/store.test.ts
+++ b/typescript/packages/node/src/resource/lancedb/store.test.ts
@@ -18,24 +18,32 @@ import { predicate } from './store.ts'
 
 describe('lancedb where clause', () => {
   it('narrows on a name prefix, cast so a numeric id column takes one', () => {
-    expect(predicate('id', {}, 'doc-1')).toBe("CAST(id AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
+    expect(predicate('id', {}, 'doc-1')).toBe("CAST(`id` AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
   })
 
   it('escapes LIKE metacharacters in the prefix', () => {
     // An unescaped `_` is LIKE's single-character wildcard, so docX1 would
     // ride along and could crowd a real match out of the row cap.
-    expect(predicate('id', {}, 'doc_')).toBe("CAST(id AS STRING) LIKE 'doc\\_%' ESCAPE '\\'")
-    expect(predicate('id', {}, 'a%')).toBe("CAST(id AS STRING) LIKE 'a\\%%' ESCAPE '\\'")
+    expect(predicate('id', {}, 'doc_')).toBe("CAST(`id` AS STRING) LIKE 'doc\\_%' ESCAPE '\\'")
+    expect(predicate('id', {}, 'a%')).toBe("CAST(`id` AS STRING) LIKE 'a\\%%' ESCAPE '\\'")
   })
 
   it('ands the group filters with the prefix', () => {
     expect(predicate('id', { label: 'cat' }, 'doc-1')).toBe(
-      "label = 'cat' AND CAST(id AS STRING) LIKE 'doc-1%' ESCAPE '\\'",
+      "`label` = 'cat' AND CAST(`id` AS STRING) LIKE 'doc-1%' ESCAPE '\\'",
+    )
+  })
+
+  it('quotes a column name a bare word could not spell', () => {
+    // A space or a reserved word only parses quoted, and lance reads a
+    // double-quoted word as a string literal, so the quotes are backticks.
+    expect(predicate('document id', { select: 'cat' }, 'doc-1')).toBe(
+      "`select` = 'cat' AND CAST(`document id` AS STRING) LIKE 'doc-1%' ESCAPE '\\'",
     )
   })
 
   it('is the filters alone with no prefix, and empty with neither', () => {
-    expect(predicate('id', { label: 'cat' }, '')).toBe("label = 'cat'")
+    expect(predicate('id', { label: 'cat' }, '')).toBe("`label` = 'cat'")
     expect(predicate('id', {}, '')).toBe('')
     expect(predicate('', {}, 'doc-1')).toBe('')
   })

--- a/typescript/packages/node/src/resource/lancedb/store.test.ts
+++ b/typescript/packages/node/src/resource/lancedb/store.test.ts
@@ -1,0 +1,42 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { predicate } from './store.ts'
+
+describe('lancedb where clause', () => {
+  it('narrows on a name prefix, cast so a numeric id column takes one', () => {
+    expect(predicate('id', {}, 'doc-1')).toBe("CAST(id AS STRING) LIKE 'doc-1%' ESCAPE '\\'")
+  })
+
+  it('escapes LIKE metacharacters in the prefix', () => {
+    // An unescaped `_` is LIKE's single-character wildcard, so docX1 would
+    // ride along and could crowd a real match out of the row cap.
+    expect(predicate('id', {}, 'doc_')).toBe("CAST(id AS STRING) LIKE 'doc\\_%' ESCAPE '\\'")
+    expect(predicate('id', {}, 'a%')).toBe("CAST(id AS STRING) LIKE 'a\\%%' ESCAPE '\\'")
+  })
+
+  it('ands the group filters with the prefix', () => {
+    expect(predicate('id', { label: 'cat' }, 'doc-1')).toBe(
+      "label = 'cat' AND CAST(id AS STRING) LIKE 'doc-1%' ESCAPE '\\'",
+    )
+  })
+
+  it('is the filters alone with no prefix, and empty with neither', () => {
+    expect(predicate('id', { label: 'cat' }, '')).toBe("label = 'cat'")
+    expect(predicate('id', {}, '')).toBe('')
+    expect(predicate('', {}, 'doc-1')).toBe('')
+  })
+})

--- a/typescript/packages/node/src/resource/lancedb/store.ts
+++ b/typescript/packages/node/src/resource/lancedb/store.ts
@@ -35,6 +35,29 @@ function whereClause(filters: Record<string, string>): string {
     .join(' AND ')
 }
 
+function likeClause(column: string, prefix: string): string {
+  let escaped = prefix
+  for (const ch of ['\\', '%', '_']) escaped = escaped.split(ch).join(`\\${ch}`)
+  return `CAST(${column} AS STRING) LIKE '${escaped.replace(/'/g, "''")}%' ESCAPE '\\'`
+}
+
+/**
+ * The where clause for a group's filters plus a name prefix.
+ *
+ * The prefix is what a glob narrows the query to: the cap on rows is a window
+ * over the table, so filtering the head of it would hide every match past the
+ * cap, while a prefix match moves the window onto what the line asked for.
+ * LIKE has its own metacharacters, so `%` and `_` in the prefix are escaped
+ * rather than left to widen the match, and the cast is what lets a numeric id
+ * column take one.
+ */
+export function predicate(column: string, filters: Record<string, string>, prefix: string): string {
+  const parts: string[] = []
+  if (Object.keys(filters).length > 0) parts.push(whereClause(filters))
+  if (prefix !== '' && column !== '') parts.push(likeClause(column, prefix))
+  return parts.join(' AND ')
+}
+
 export class LanceDBStore implements LanceDriver {
   private readonly config: LanceDBConfigResolved
   private db: Connection | null = null
@@ -82,10 +105,12 @@ export class LanceDBStore implements LanceDriver {
     column: string,
     filters: Record<string, string>,
     limit: number,
+    prefix = '',
   ): Promise<string[]> {
     const tbl = await this.table(table)
     let query = tbl.query().select([column]).limit(limit)
-    if (Object.keys(filters).length > 0) query = query.where(whereClause(filters))
+    const clause = predicate(column, filters, prefix)
+    if (clause !== '') query = query.where(clause)
     const rows = (await query.toArray()) as LanceRow[]
     const values = new Set<string>()
     for (const row of rows) {
@@ -106,10 +131,13 @@ export class LanceDBStore implements LanceDriver {
     filters: Record<string, string>,
     columns: string[],
     limit: number,
+    idColumn = '',
+    prefix = '',
   ): Promise<LanceRow[]> {
     const tbl = await this.table(table)
     let query = tbl.query().select(columns).limit(limit)
-    if (Object.keys(filters).length > 0) query = query.where(whereClause(filters))
+    const clause = predicate(idColumn, filters, prefix)
+    if (clause !== '') query = query.where(clause)
     return (await query.toArray()) as LanceRow[]
   }
 

--- a/typescript/packages/node/src/resource/lancedb/store.ts
+++ b/typescript/packages/node/src/resource/lancedb/store.ts
@@ -24,9 +24,21 @@ function toStr(value: unknown): string {
   return String(value as string | number | boolean | bigint)
 }
 
+/**
+ * A configured column name, spelled so the parser reads a column.
+ *
+ * Backticks, not double quotes: lance reads a double-quoted word as a string
+ * literal, so `"id" = 'x'` compares the text `id` and matches nothing rather
+ * than failing. Quoting is what lets a name with a space or a reserved word
+ * through, and a bare name means the same thing quoted.
+ */
+function columnRef(name: string): string {
+  return `\`${name.split('`').join('``')}\``
+}
+
 function eqClause(column: string, value: string): string {
-  if (/^-?\d+$/.test(value)) return `${column} = ${value}`
-  return `${column} = '${value.replace(/'/g, "''")}'`
+  if (/^-?\d+$/.test(value)) return `${columnRef(column)} = ${value}`
+  return `${columnRef(column)} = '${value.replace(/'/g, "''")}'`
 }
 
 function whereClause(filters: Record<string, string>): string {
@@ -38,7 +50,7 @@ function whereClause(filters: Record<string, string>): string {
 function likeClause(column: string, prefix: string): string {
   let escaped = prefix
   for (const ch of ['\\', '%', '_']) escaped = escaped.split(ch).join(`\\${ch}`)
-  return `CAST(${column} AS STRING) LIKE '${escaped.replace(/'/g, "''")}%' ESCAPE '\\'`
+  return `CAST(${columnRef(column)} AS STRING) LIKE '${escaped.replace(/'/g, "''")}%' ESCAPE '\\'`
 }
 
 /**


### PR DESCRIPTION
## Summary

A directory whose listing is a bounded window hid paths that `stat` and `readdir` resolve, so a glob and `find` missed them. The kit now hands the glob to the lister for a declared kind, and the lister moves its window to what the line asked for.

- `ScopeMatch.pattern`, `DirListing.partial`, and a per-kind `pattern_kinds` predicate table in the hierarchy kit
- `expand_pattern` built its child spec with `from_str_path`, which cannot carry a pattern, so the existing gcal/gdocs/gsheets/gslides date push-down was unreachable through any shell glob
- slack, discord and gmail push a date span down; lancedb pushes an id prefix as a `LIKE`; qdrant tests each scroll page, since it has no prefix condition for a point id
- four TypeScript readdirs read a virtual path where their pattern branch works in mount-relative space
- gmail's `day` lister and stat converge on python, matching slack and discord in both languages

Deliberate limits, both pinned as goldens: a glob with no literal head (`*39.md`), or one whose literal head is too broad for the row cap (`doc-0[12]*`), is still capped.

## Test plan

- `pre-commit run --all-files`
- `uv run pytest`
- `pnpm -r test`, `pnpm -r typecheck`
- integ on both hosts: new `lancedb-window` and `qdrant-window` targets, plus `lancedb`, `qdrant`, `gmail`, `slack`, `discord`, `ram`, `disk`, `opfs`
- `check_case_targets.py` and `check_layout_parity.py --strict` at baseline (2290, 253)
