### PR TITLE
Restructure docs navigation and setup

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -87,128 +87,127 @@
             ]
           },
           {
-            "group": "Setup",
+            "group": "Resources",
             "pages": [
               {
-                "group": "Object Storage",
-                "icon": "cloud",
+                "group": "Providers",
+                "icon": "grid-2",
                 "pages": [
-                  "home/setup/s3",
-                  "home/setup/r2",
-                  "home/setup/gcs",
-                  "home/setup/oci",
-                  "home/setup/supabase",
-                  "home/setup/minio",
-                  "home/setup/ceph",
-                  "home/setup/seaweedfs",
-                  "home/setup/wasabi",
-                  "home/setup/backblaze",
-                  "home/setup/digitalocean",
-                  "home/setup/tencent",
-                  "home/setup/aliyun",
-                  "home/setup/scaleway",
-                  "home/setup/qingstor"
-                ]
-              },
-              {
-                "group": "Hugging Face",
-                "icon": "/images/huggingface-logo.svg",
-                "pages": [
-                  "home/setup/hf_buckets",
-                  "home/setup/hf_datasets",
-                  "home/setup/hf_models",
-                  "home/setup/hf_spaces"
-                ]
-              },
-              {
-                "group": "Google Workspace",
-                "icon": "google",
-                "pages": [
-                  "home/setup/google"
-                ]
-              },
-              {
-                "group": "Microsoft",
-                "icon": "microsoft",
-                "pages": [
-                  "home/setup/onedrive",
-                  "home/setup/sharepoint"
-                ]
-              },
-              {
-                "group": "Cloud Files",
-                "icon": "folder-open",
-                "pages": [
-                  "home/setup/dropbox",
-                  "home/setup/box",
-                  "home/setup/nextcloud",
-                  "home/setup/databricks"
-                ]
-              },
-              {
-                "group": "Code & DevOps",
-                "icon": "code",
-                "pages": [
-                  "home/setup/github",
-                  "home/setup/linear",
-                  "home/setup/langfuse"
-                ]
-              },
-              {
-                "group": "Messaging",
-                "icon": "comments",
-                "pages": [
-                  "home/setup/slack",
-                  "home/setup/discord",
-                  "home/setup/email"
-                ]
-              },
-              {
-                "group": "Database",
-                "icon": "database",
-                "pages": [
-                  "home/setup/mongodb",
-                  "home/setup/gridfs",
-                  "home/setup/postgres",
-                  "home/setup/chroma",
-                  "home/setup/lancedb",
-                  "home/setup/qdrant"
-                ]
-              },
-              {
-                "group": "Knowledge",
-                "icon": "brain",
-                "pages": [
-                  "home/setup/dify"
-                ]
-              },
-              {
-                "group": "Memory",
-                "icon": "/images/mem0.svg",
-                "pages": [
-                  "home/setup/mem0"
-                ]
-              },
-              {
-                "group": "Notes",
-                "icon": "book",
-                "pages": [
-                  "home/setup/notion"
-                ]
-              },
-              {
-                "group": "Others",
-                "icon": "ellipsis",
-                "pages": [
-                  "home/setup/trello"
+                  "home/setup/resources",
+                  {
+                    "group": "Object Storage",
+                    "icon": "cloud",
+                    "pages": [
+                      "home/setup/s3",
+                      "home/setup/r2",
+                      "home/setup/gcs",
+                      "home/setup/oci",
+                      "home/setup/supabase",
+                      "home/setup/minio",
+                      "home/setup/ceph",
+                      "home/setup/seaweedfs",
+                      "home/setup/wasabi",
+                      "home/setup/backblaze",
+                      "home/setup/digitalocean",
+                      "home/setup/tencent",
+                      "home/setup/aliyun",
+                      "home/setup/scaleway",
+                      "home/setup/qingstor"
+                    ]
+                  },
+                  {
+                    "group": "Hugging Face",
+                    "icon": "/images/huggingface-logo.svg",
+                    "pages": [
+                      "home/setup/hf_buckets",
+                      "home/setup/hf_datasets",
+                      "home/setup/hf_models",
+                      "home/setup/hf_spaces"
+                    ]
+                  },
+                  {
+                    "group": "Cloud & Productivity",
+                    "icon": "folder-open",
+                    "pages": [
+                      "home/setup/google",
+                      "home/setup/onedrive",
+                      "home/setup/sharepoint",
+                      "home/setup/dropbox",
+                      "home/setup/box",
+                      "home/setup/nextcloud",
+                      "home/setup/databricks"
+                    ]
+                  },
+                  {
+                    "group": "Developer & Messaging",
+                    "icon": "code",
+                    "pages": [
+                      "home/setup/github",
+                      "home/setup/linear",
+                      "home/setup/langfuse",
+                      "home/setup/slack",
+                      "home/setup/discord",
+                      "home/setup/email"
+                    ]
+                  },
+                  {
+                    "group": "Data & AI",
+                    "icon": "database",
+                    "pages": [
+                      "home/setup/mongodb",
+                      "home/setup/gridfs",
+                      "home/setup/postgres",
+                      "home/setup/chroma",
+                      "home/setup/lancedb",
+                      "home/setup/qdrant",
+                      "home/setup/dify",
+                      "home/setup/mem0"
+                    ]
+                  },
+                  {
+                    "group": "Notes & Tasks",
+                    "icon": "book",
+                    "pages": [
+                      "home/setup/notion",
+                      "home/setup/trello"
+                    ]
+                  }
                 ]
               }
             ]
           },
           {
-            "group": "FUSE",
-            "icon": "hard-drive",
+            "group": "CLIs",
             "pages": [
+              "home/setup/clis",
+              "home/setup/cli/himalaya",
+              "home/setup/cli/gws",
+              "home/setup/cli/slack",
+              "home/setup/cli/discord",
+              "home/setup/cli/ntn",
+              "home/setup/cli/linear",
+              "home/setup/cli/gh",
+              "home/setup/cli/git"
+            ]
+          },
+          {
+            "group": "Runtimes",
+            "pages": [
+              "home/setup/runtime/python",
+              "home/setup/runtime/javascript",
+              {
+                "group": "Sandbox",
+                "icon": "server",
+                "pages": [
+                  "home/setup/runtime/sandbox",
+                  "home/setup/runtime/sandbox/sandlock",
+                  "home/setup/runtime/sandbox/docker",
+                  "home/setup/runtime/sandbox/smolvm",
+                  "home/setup/runtime/sandbox/daytona",
+                  "home/setup/runtime/sandbox/e2b",
+                  "home/setup/runtime/sandbox/ssh"
+                ]
+              },
               "home/setup/fuse",
               "home/setup/macos",
               "home/setup/linux",
@@ -230,156 +229,132 @@
             ]
           },
           {
-            "group": "Agents",
+            "group": "AI Agents",
             "icon": "robot",
             "pages": [
-              "python/agents/index",
-              "python/agents/openai-agents",
-              "python/agents/langchain",
-              "python/agents/openhands",
-              "python/agents/pydantic-ai",
-              "python/agents/camel",
-              "python/agents/agno",
-              "python/agents/haystack",
-              "python/agents/claude-code",
-              "python/agents/claude-agent-sdk",
-              "python/agents/codex",
-              "python/agents/grok-build"
+              {
+                "group": "Integrations",
+                "icon": "robot",
+                "pages": [
+                  "python/agents/index",
+                  "python/agents/openai-agents",
+                  "python/agents/langchain",
+                  "python/agents/openhands",
+                  "python/agents/pydantic-ai",
+                  "python/agents/camel",
+                  "python/agents/agno",
+                  "python/agents/haystack",
+                  "python/agents/claude-code",
+                  "python/agents/claude-agent-sdk",
+                  "python/agents/codex",
+                  "python/agents/grok-build"
+                ]
+              }
             ]
           },
           {
             "group": "Resources",
             "pages": [
-              "python/resource/index",
               {
-                "group": "Infrastructure",
-                "icon": "server",
+                "group": "Providers",
+                "icon": "grid-2",
                 "pages": [
-                  "python/resource/disk",
-                  "python/resource/ram",
-                  "python/resource/redis",
-                  "python/resource/ssh"
+                  "python/resource/index",
+                  {
+                    "group": "Infrastructure",
+                    "icon": "server",
+                    "pages": [
+                      "python/resource/disk",
+                      "python/resource/ram",
+                      "python/resource/redis",
+                      "python/resource/ssh"
+                    ]
+                  },
+                  {
+                    "group": "Object Storage",
+                    "icon": "cloud",
+                    "pages": [
+                      "python/resource/s3",
+                      "python/resource/r2",
+                      "python/resource/gcs",
+                      "python/resource/supabase",
+                      "python/resource/oci",
+                      "python/resource/minio",
+                      "python/resource/ceph",
+                      "python/resource/seaweedfs",
+                      "python/resource/wasabi",
+                      "python/resource/backblaze",
+                      "python/resource/digitalocean",
+                      "python/resource/tencent",
+                      "python/resource/aliyun",
+                      "python/resource/scaleway",
+                      "python/resource/qingstor"
+                    ]
+                  },
+                  {
+                    "group": "Hugging Face",
+                    "icon": "/images/huggingface-logo.svg",
+                    "pages": [
+                      "python/resource/hf_buckets",
+                      "python/resource/hf_datasets",
+                      "python/resource/hf_models",
+                      "python/resource/hf_spaces"
+                    ]
+                  },
+                  {
+                    "group": "Cloud & Productivity",
+                    "icon": "folder-open",
+                    "pages": [
+                      "python/resource/gmail",
+                      "python/resource/gdrive",
+                      "python/resource/gdocs",
+                      "python/resource/gsheets",
+                      "python/resource/gslides",
+                      "python/resource/onedrive",
+                      "python/resource/sharepoint",
+                      "python/resource/box",
+                      "python/resource/dropbox",
+                      "python/resource/nextcloud",
+                      "python/resource/databricks_volume"
+                    ]
+                  },
+                  {
+                    "group": "Developer & Messaging",
+                    "icon": "code",
+                    "pages": [
+                      "python/resource/github",
+                      "python/resource/linear",
+                      "python/resource/langfuse",
+                      "python/resource/slack",
+                      "python/resource/discord",
+                      "python/resource/email"
+                    ]
+                  },
+                  {
+                    "group": "Data & AI",
+                    "icon": "database",
+                    "pages": [
+                      "python/resource/mongodb",
+                      "python/resource/gridfs",
+                      "python/resource/postgres",
+                      "python/resource/chroma",
+                      "python/resource/lancedb",
+                      "python/resource/qdrant",
+                      "python/resource/dify",
+                      "python/resource/mem0"
+                    ]
+                  },
+                  {
+                    "group": "Notes & Tasks",
+                    "icon": "book",
+                    "pages": [
+                      "python/resource/notion",
+                      "python/resource/trello"
+                    ]
+                  },
+                  "python/resource/new"
                 ]
-              },
-              {
-                "group": "Object Storage",
-                "icon": "cloud",
-                "pages": [
-                  "python/resource/s3",
-                  "python/resource/r2",
-                  "python/resource/gcs",
-                  "python/resource/supabase",
-                  "python/resource/oci",
-                  "python/resource/minio",
-                  "python/resource/ceph",
-                  "python/resource/seaweedfs",
-                  "python/resource/wasabi",
-                  "python/resource/backblaze",
-                  "python/resource/digitalocean",
-                  "python/resource/tencent",
-                  "python/resource/aliyun",
-                  "python/resource/scaleway",
-                  "python/resource/qingstor"
-                ]
-              },
-              {
-                "group": "Hugging Face",
-                "icon": "/images/huggingface-logo.svg",
-                "pages": [
-                  "python/resource/hf_buckets",
-                  "python/resource/hf_datasets",
-                  "python/resource/hf_models",
-                  "python/resource/hf_spaces"
-                ]
-              },
-              {
-                "group": "Google Workspace",
-                "icon": "google",
-                "pages": [
-                  "python/resource/gmail",
-                  "python/resource/gdrive",
-                  "python/resource/gdocs",
-                  "python/resource/gsheets",
-                  "python/resource/gslides"
-                ]
-              },
-              {
-                "group": "Microsoft",
-                "icon": "microsoft",
-                "pages": [
-                  "python/resource/onedrive",
-                  "python/resource/sharepoint"
-                ]
-              },
-              {
-                "group": "Cloud Files",
-                "icon": "folder-open",
-                "pages": [
-                  "python/resource/box",
-                  "python/resource/dropbox",
-                  "python/resource/nextcloud",
-                  "python/resource/databricks_volume"
-                ]
-              },
-              {
-                "group": "Code & DevOps",
-                "icon": "code",
-                "pages": [
-                  "python/resource/github",
-                  "python/resource/linear",
-                  "python/resource/langfuse"
-                ]
-              },
-              {
-                "group": "Messaging",
-                "icon": "comments",
-                "pages": [
-                  "python/resource/slack",
-                  "python/resource/discord",
-                  "python/resource/email"
-                ]
-              },
-              {
-                "group": "Database",
-                "icon": "database",
-                "pages": [
-                  "python/resource/mongodb",
-                  "python/resource/gridfs",
-                  "python/resource/postgres",
-                  "python/resource/chroma",
-                  "python/resource/lancedb",
-                  "python/resource/qdrant"
-                ]
-              },
-              {
-                "group": "Knowledge",
-                "icon": "brain",
-                "pages": [
-                  "python/resource/dify"
-                ]
-              },
-              {
-                "group": "Memory",
-                "icon": "/images/mem0.svg",
-                "pages": [
-                  "python/resource/mem0"
-                ]
-              },
-              {
-                "group": "Notes",
-                "icon": "book",
-                "pages": [
-                  "python/resource/notion"
-                ]
-              },
-              {
-                "group": "Others",
-                "icon": "ellipsis",
-                "pages": [
-                  "python/resource/trello"
-                ]
-              },
-              "python/resource/new"
+              }
             ]
           },
           {
@@ -443,147 +418,130 @@
             ]
           },
           {
-            "group": "Agents",
+            "group": "AI Agents",
             "icon": "robot",
             "pages": [
-              "typescript/agents/index",
-              "typescript/agents/openai",
-              "typescript/agents/langchain",
-              "typescript/agents/pi",
-              "typescript/agents/vercel",
-              "typescript/agents/mastra",
-              "typescript/agents/opencode",
-              "typescript/agents/claude-code",
-              "typescript/agents/claude-agent-sdk",
-              "typescript/agents/codex",
-              "typescript/agents/grok-build",
-              "typescript/agents/dsh"
+              {
+                "group": "Integrations",
+                "icon": "robot",
+                "pages": [
+                  "typescript/agents/index",
+                  "typescript/agents/openai",
+                  "typescript/agents/langchain",
+                  "typescript/agents/pi",
+                  "typescript/agents/vercel",
+                  "typescript/agents/mastra",
+                  "typescript/agents/opencode",
+                  "typescript/agents/claude-code",
+                  "typescript/agents/claude-agent-sdk",
+                  "typescript/agents/codex",
+                  "typescript/agents/grok-build",
+                  "typescript/agents/dsh"
+                ]
+              }
             ]
           },
           {
             "group": "Resources",
             "pages": [
               {
-                "group": "Infrastructure",
-                "icon": "server",
+                "group": "Providers",
+                "icon": "grid-2",
                 "pages": [
-                  "typescript/setup/disk",
-                  "typescript/setup/opfs",
-                  "typescript/setup/redis",
-                  "typescript/setup/ssh"
+                  "typescript/setup/resources",
+                  {
+                    "group": "Infrastructure",
+                    "icon": "server",
+                    "pages": [
+                      "typescript/setup/disk",
+                      "typescript/setup/opfs",
+                      "typescript/setup/redis",
+                      "typescript/setup/ssh"
+                    ]
+                  },
+                  {
+                    "group": "Object Storage",
+                    "icon": "cloud",
+                    "pages": [
+                      "typescript/setup/s3",
+                      "typescript/setup/r2",
+                      "typescript/setup/gcs",
+                      "typescript/setup/oci",
+                      "typescript/setup/supabase",
+                      "typescript/setup/minio",
+                      "typescript/setup/ceph",
+                      "typescript/setup/seaweedfs",
+                      "typescript/setup/wasabi",
+                      "typescript/setup/backblaze",
+                      "typescript/setup/digitalocean",
+                      "typescript/setup/tencent",
+                      "typescript/setup/aliyun",
+                      "typescript/setup/scaleway",
+                      "typescript/setup/qingstor"
+                    ]
+                  },
+                  {
+                    "group": "Hugging Face",
+                    "icon": "/images/huggingface-logo.svg",
+                    "pages": [
+                      "typescript/setup/hf_buckets",
+                      "typescript/setup/hf_datasets",
+                      "typescript/setup/hf_models",
+                      "typescript/setup/hf_spaces"
+                    ]
+                  },
+                  {
+                    "group": "Cloud & Productivity",
+                    "icon": "folder-open",
+                    "pages": [
+                      "typescript/setup/gmail",
+                      "typescript/setup/gdrive",
+                      "typescript/setup/gdocs",
+                      "typescript/setup/gsheets",
+                      "typescript/setup/gslides",
+                      "typescript/setup/onedrive",
+                      "typescript/setup/sharepoint",
+                      "typescript/dropbox",
+                      "typescript/box",
+                      "typescript/setup/databricks_volume"
+                    ]
+                  },
+                  {
+                    "group": "Developer & Messaging",
+                    "icon": "code",
+                    "pages": [
+                      "typescript/setup/github",
+                      "typescript/setup/linear",
+                      "typescript/setup/langfuse",
+                      "typescript/slack",
+                      "typescript/discord",
+                      "typescript/setup/email"
+                    ]
+                  },
+                  {
+                    "group": "Data & AI",
+                    "icon": "database",
+                    "pages": [
+                      "typescript/setup/mongodb",
+                      "typescript/setup/gridfs",
+                      "typescript/setup/postgres",
+                      "typescript/setup/chroma",
+                      "typescript/setup/lancedb",
+                      "typescript/setup/qdrant",
+                      "typescript/setup/mem0"
+                    ]
+                  },
+                  {
+                    "group": "Notes & Tasks",
+                    "icon": "book",
+                    "pages": [
+                      "typescript/setup/notion",
+                      "typescript/setup/trello"
+                    ]
+                  },
+                  "typescript/resource/new"
                 ]
-              },
-              {
-                "group": "Object Storage",
-                "icon": "cloud",
-                "pages": [
-                  "typescript/setup/s3",
-                  "typescript/setup/r2",
-                  "typescript/setup/gcs",
-                  "typescript/setup/oci",
-                  "typescript/setup/supabase",
-                  "typescript/setup/minio",
-                  "typescript/setup/ceph",
-                  "typescript/setup/seaweedfs",
-                  "typescript/setup/wasabi",
-                  "typescript/setup/backblaze",
-                  "typescript/setup/digitalocean",
-                  "typescript/setup/tencent",
-                  "typescript/setup/aliyun",
-                  "typescript/setup/scaleway",
-                  "typescript/setup/qingstor"
-                ]
-              },
-              {
-                "group": "Hugging Face",
-                "icon": "/images/huggingface-logo.svg",
-                "pages": [
-                  "typescript/setup/hf_buckets",
-                  "typescript/setup/hf_datasets",
-                  "typescript/setup/hf_models",
-                  "typescript/setup/hf_spaces"
-                ]
-              },
-              {
-                "group": "Google Workspace",
-                "icon": "google",
-                "pages": [
-                  "typescript/setup/gmail",
-                  "typescript/setup/gdrive",
-                  "typescript/setup/gdocs",
-                  "typescript/setup/gsheets",
-                  "typescript/setup/gslides"
-                ]
-              },
-              {
-                "group": "Microsoft",
-                "icon": "microsoft",
-                "pages": [
-                  "typescript/setup/onedrive",
-                  "typescript/setup/sharepoint"
-                ]
-              },
-              {
-                "group": "Cloud Files",
-                "icon": "folder-open",
-                "pages": [
-                  "typescript/dropbox",
-                  "typescript/box",
-                  "typescript/setup/databricks_volume"
-                ]
-              },
-              {
-                "group": "Code & DevOps",
-                "icon": "code",
-                "pages": [
-                  "typescript/setup/github",
-                  "typescript/setup/linear",
-                  "typescript/setup/langfuse"
-                ]
-              },
-              {
-                "group": "Messaging",
-                "icon": "comments",
-                "pages": [
-                  "typescript/slack",
-                  "typescript/discord",
-                  "typescript/setup/email"
-                ]
-              },
-              {
-                "group": "Database",
-                "icon": "database",
-                "pages": [
-                  "typescript/setup/mongodb",
-                  "typescript/setup/gridfs",
-                  "typescript/setup/postgres",
-                  "typescript/setup/chroma",
-                  "typescript/setup/lancedb",
-                  "typescript/setup/qdrant"
-                ]
-              },
-              {
-                "group": "Memory",
-                "icon": "/images/mem0.svg",
-                "pages": [
-                  "typescript/setup/mem0"
-                ]
-              },
-              {
-                "group": "Notes",
-                "icon": "book",
-                "pages": [
-                  "typescript/setup/notion"
-                ]
-              },
-              {
-                "group": "Others",
-                "icon": "ellipsis",
-                "pages": [
-                  "typescript/setup/trello"
-                ]
-              },
-              "typescript/resource/new"
+              }
             ]
           },
           {

--- a/docs/home/setup/cli/discord.mdx
+++ b/docs/home/setup/cli/discord.mdx
@@ -1,0 +1,29 @@
+---
+title: Discord
+icon: discord
+description: Set up the Discord CLI with Python or TypeScript.
+---
+
+Create a bot token in [Discord setup](/home/setup/discord), then register it on
+an existing `ws`. Commands: [Python](/python/cli/discord) ·
+[TypeScript](/typescript/cli/discord).
+
+<Tabs>
+  <Tab title="Python" icon="/images/python-logo.svg">
+    ```python
+    from mirage.commands.cli.builtin.discord import DISCORD
+    from mirage.core.discord.config import DiscordConfig
+
+    config = DiscordConfig(token="bot-token")
+    ws.register_cli("discord", DISCORD, config.model_dump())
+    ```
+  </Tab>
+  <Tab title="TypeScript" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { DISCORD } from '@struktoai/mirage-core'
+
+    const config = { token: 'bot-token' }
+    ws.registerCli('discord', DISCORD, config)
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/cli/gh.mdx
+++ b/docs/home/setup/cli/gh.mdx
@@ -14,9 +14,8 @@ existing `ws`. Commands: [Python](/python/cli/gh) ·
     from mirage.commands.cli.builtin.gh import GH
     from mirage.core.github.config import GhConfig
 
-    ws.register_cli(
-        "gh", GH, GhConfig(token="github_pat_...", repo="acme/tools")
-    )
+    config = GhConfig(token="github_pat_...", repo="acme/tools")
+    ws.register_cli("gh", GH, config.model_dump())
     ```
   </Tab>
   <Tab title="TypeScript" icon="/images/typescript-logo.svg">

--- a/docs/home/setup/cli/gh.mdx
+++ b/docs/home/setup/cli/gh.mdx
@@ -1,0 +1,29 @@
+---
+title: gh
+icon: github
+description: Set up the GitHub CLI with Python or TypeScript.
+---
+
+Create a token in [GitHub setup](/home/setup/github), then register it on an
+existing `ws`. Commands: [Python](/python/cli/gh) ·
+[TypeScript](/typescript/cli/gh).
+
+<Tabs>
+  <Tab title="Python" icon="/images/python-logo.svg">
+    ```python
+    from mirage.commands.cli.builtin.gh import GH
+    from mirage.core.github.config import GhConfig
+
+    ws.register_cli(
+        "gh", GH, GhConfig(token="github_pat_...", repo="acme/tools")
+    )
+    ```
+  </Tab>
+  <Tab title="TypeScript" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { GH } from '@struktoai/mirage-core'
+
+    ws.registerCli('gh', GH, { token: 'github_pat_...', repo: 'acme/tools' })
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/cli/git.mdx
+++ b/docs/home/setup/cli/git.mdx
@@ -1,0 +1,26 @@
+---
+title: git
+icon: git-alt
+description: Set up the credential-free git CLI with Python or TypeScript.
+---
+
+`git` needs no account config and reads repositories through existing mounts.
+Register it on `ws`. Commands: [Python](/python/cli/git) ·
+[TypeScript](/typescript/cli/git).
+
+<Tabs>
+  <Tab title="Python" icon="/images/python-logo.svg">
+    ```python
+    from mirage.commands.cli.builtin.git import GIT
+
+    ws.register_cli("git", GIT)
+    ```
+  </Tab>
+  <Tab title="TypeScript" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { GIT } from '@struktoai/mirage-core'
+
+    ws.registerCli('git', GIT)
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/cli/gws.mdx
+++ b/docs/home/setup/cli/gws.mdx
@@ -1,0 +1,31 @@
+---
+title: GWS
+icon: google
+description: Set up the Google Workspace CLI with Python or TypeScript.
+---
+
+Create OAuth credentials in [Google Workspace setup](/home/setup/google), then
+register them on an existing `ws`. Commands: [Python](/python/cli/gws) ·
+[TypeScript](/typescript/cli/gws).
+
+<Tabs>
+  <Tab title="Python" icon="/images/python-logo.svg">
+    ```python
+    from mirage.commands.cli.builtin.gws import GWS
+    from mirage.core.google.config import GoogleConfig
+
+    config = GoogleConfig(
+        client_id="...", client_secret="...", refresh_token="..."
+    )
+    ws.register_cli("gws", GWS, config.model_dump())
+    ```
+  </Tab>
+  <Tab title="TypeScript" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { GWS } from '@struktoai/mirage-core'
+
+    const config = { clientId: '...', clientSecret: '...', refreshToken: '...' }
+    ws.registerCli('gws', GWS, config)
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/cli/himalaya.mdx
+++ b/docs/home/setup/cli/himalaya.mdx
@@ -1,0 +1,39 @@
+---
+title: Himalaya
+icon: envelope
+description: Set up the Himalaya mail CLI with Python or TypeScript.
+---
+
+Create credentials in [Email setup](/home/setup/email), then register them on
+an existing `ws`. Commands: [Python](/python/cli/himalaya) ·
+[TypeScript](/typescript/cli/himalaya).
+
+<Tabs>
+  <Tab title="Python" icon="/images/python-logo.svg">
+    ```python
+    from mirage.commands.cli.builtin.himalaya import HIMALAYA
+    from mirage.core.email.config import EmailConfig
+
+    config = EmailConfig(
+        imap_host="imap.example.com",
+        smtp_host="smtp.example.com",
+        username="agent@example.com",
+        password="app-password",
+    )
+    ws.register_cli("himalaya", HIMALAYA, config.model_dump())
+    ```
+  </Tab>
+  <Tab title="TypeScript" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { HIMALAYA } from '@struktoai/mirage-node'
+
+    const config = {
+      imapHost: 'imap.example.com',
+      smtpHost: 'smtp.example.com',
+      username: 'agent@example.com',
+      password: 'app-password',
+    }
+    ws.registerCli('himalaya', HIMALAYA, config)
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/cli/himalaya.mdx
+++ b/docs/home/setup/cli/himalaya.mdx
@@ -10,6 +10,10 @@ an existing `ws`. Commands: [Python](/python/cli/himalaya) ·
 
 <Tabs>
   <Tab title="Python" icon="/images/python-logo.svg">
+    ```bash
+    pip install 'mirage-ai[email]'
+    ```
+
     ```python
     from mirage.commands.cli.builtin.himalaya import HIMALAYA
     from mirage.core.email.config import EmailConfig
@@ -24,6 +28,10 @@ an existing `ws`. Commands: [Python](/python/cli/himalaya) ·
     ```
   </Tab>
   <Tab title="TypeScript" icon="/images/typescript-logo.svg">
+    ```bash
+    pnpm add imapflow mailparser nodemailer
+    ```
+
     ```typescript
     import { HIMALAYA } from '@struktoai/mirage-node'
 

--- a/docs/home/setup/cli/linear.mdx
+++ b/docs/home/setup/cli/linear.mdx
@@ -1,0 +1,29 @@
+---
+title: Linear
+icon: /images/linear-logo.svg
+description: Set up the Linear CLI with Python or TypeScript.
+---
+
+Create an API key in [Linear setup](/home/setup/linear), then register it on an
+existing `ws`. Commands: [Python](/python/cli/linear) ·
+[TypeScript](/typescript/cli/linear).
+
+<Tabs>
+  <Tab title="Python" icon="/images/python-logo.svg">
+    ```python
+    from mirage.commands.cli.builtin.linear import LINEAR
+    from mirage.core.linear.config import LinearConfig
+
+    config = LinearConfig(api_key="lin_api_...")
+    ws.register_cli("linear", LINEAR, config.model_dump())
+    ```
+  </Tab>
+  <Tab title="TypeScript" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { LINEAR } from '@struktoai/mirage-core'
+
+    const config = { apiKey: 'lin_api_...' }
+    ws.registerCli('linear', LINEAR, config)
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/cli/ntn.mdx
+++ b/docs/home/setup/cli/ntn.mdx
@@ -1,0 +1,29 @@
+---
+title: ntn
+icon: /images/notion-logo.svg
+description: Set up the Notion CLI with Python or TypeScript.
+---
+
+Create a token in [Notion setup](/home/setup/notion), then register it on an
+existing `ws`. Commands: [Python](/python/cli/ntn) ·
+[TypeScript](/typescript/cli/ntn).
+
+<Tabs>
+  <Tab title="Python" icon="/images/python-logo.svg">
+    ```python
+    from mirage.commands.cli.builtin.ntn import NTN
+    from mirage.core.notion.config import NotionConfig
+
+    config = NotionConfig(api_key="secret_...")
+    ws.register_cli("ntn", NTN, config.model_dump())
+    ```
+  </Tab>
+  <Tab title="TypeScript" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { NTN } from '@struktoai/mirage-core'
+
+    const config = { apiKey: 'secret_...' }
+    ws.registerCli('ntn', NTN, config)
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/cli/slack.mdx
+++ b/docs/home/setup/cli/slack.mdx
@@ -1,0 +1,29 @@
+---
+title: Slack
+icon: slack
+description: Set up the Slack CLI with Python or TypeScript.
+---
+
+Create tokens in [Slack setup](/home/setup/slack), then register them on an
+existing `ws`. Commands: [Python](/python/cli/slack) ·
+[TypeScript](/typescript/cli/slack).
+
+<Tabs>
+  <Tab title="Python" icon="/images/python-logo.svg">
+    ```python
+    from mirage.commands.cli.builtin.slack import SLACK
+    from mirage.core.slack.config import SlackConfig
+
+    config = SlackConfig(token="xoxb-...", search_token="xoxp-...")
+    ws.register_cli("slack", SLACK, config.model_dump())
+    ```
+  </Tab>
+  <Tab title="TypeScript" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { SLACK } from '@struktoai/mirage-core'
+
+    const config = { token: 'xoxb-...', searchToken: 'xoxp-...' }
+    ws.registerCli('slack', SLACK, config)
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/clis.mdx
+++ b/docs/home/setup/clis.mdx
@@ -1,0 +1,8 @@
+---
+title: Overview
+icon: terminal
+description: Set up Mirage CLIs with Python or TypeScript.
+---
+
+Each page below includes Python and TypeScript setup. Account CLIs reuse the
+credentials documented under **Resources**; `git` needs no account config.

--- a/docs/home/setup/resources.mdx
+++ b/docs/home/setup/resources.mdx
@@ -1,0 +1,9 @@
+---
+title: Overview
+icon: grid-2
+description: Shared provider setup for Mirage resources.
+---
+
+These pages cover credentials and service setup shared by the Python and
+TypeScript resources. Choose a provider below, then use the
+[Resource Matrix](/home/resource-matrix) for implementation support and links.

--- a/docs/home/setup/runtime/javascript.mdx
+++ b/docs/home/setup/runtime/javascript.mdx
@@ -1,0 +1,24 @@
+---
+title: JavaScript
+icon: js
+description: Set up the QuickJS command runtime in either Mirage SDK.
+---
+
+<Tabs>
+  <Tab title="Python SDK" icon="/images/python-logo.svg">
+    ```bash
+    pip install 'mirage-ai[quickjs]'
+    ```
+
+    Download `qjs-wasi.wasm`, then set `MIRAGE_QUICKJS_HOME` to its directory.
+    See the [Python JavaScript runtime](/python/runtime/javascript).
+  </Tab>
+  <Tab title="TypeScript SDK" icon="/images/typescript-logo.svg">
+    ```bash
+    pnpm add quickjs-emscripten
+    ```
+
+    The package includes its WASM asset. See the
+    [TypeScript JavaScript runtime](/typescript/runtime/javascript).
+  </Tab>
+</Tabs>

--- a/docs/home/setup/runtime/python.mdx
+++ b/docs/home/setup/runtime/python.mdx
@@ -16,7 +16,13 @@ description: Set up the Python command runtime in either Mirage SDK.
     the [Python runtime reference](/python/runtime/python).
   </Tab>
   <Tab title="TypeScript SDK" icon="/images/typescript-logo.svg">
-    Pyodide is included and selected by default. Monty is optional:
+    Pyodide is the default. Install its package:
+
+    ```bash
+    pnpm add pyodide
+    ```
+
+    Monty is an optional alternative:
 
     ```bash
     pnpm add @pydantic/monty

--- a/docs/home/setup/runtime/python.mdx
+++ b/docs/home/setup/runtime/python.mdx
@@ -1,0 +1,27 @@
+---
+title: Python
+icon: python
+description: Set up the Python command runtime in either Mirage SDK.
+---
+
+<Tabs>
+  <Tab title="Python SDK" icon="/images/python-logo.svg">
+    Monty is the default. Install its extra:
+
+    ```bash
+    pip install 'mirage-ai[monty]'
+    ```
+
+    WASI, Sandlock, and the host interpreter are optional alternatives. See
+    the [Python runtime reference](/python/runtime/python).
+  </Tab>
+  <Tab title="TypeScript SDK" icon="/images/typescript-logo.svg">
+    Pyodide is included and selected by default. Monty is optional:
+
+    ```bash
+    pnpm add @pydantic/monty
+    ```
+
+    See the [TypeScript runtime reference](/typescript/runtime/python).
+  </Tab>
+</Tabs>

--- a/docs/home/setup/runtime/sandbox.mdx
+++ b/docs/home/setup/runtime/sandbox.mdx
@@ -1,0 +1,12 @@
+---
+title: Overview
+icon: server
+description: Set up an external sandbox runtime for either Mirage SDK.
+---
+
+You create and provision the container, VM, or cloud sandbox; Mirage only
+connects to it. Serve the same workspace mounts at the same paths inside the
+sandbox, then choose a provider below.
+
+Full architecture: [Python](/python/runtime/sandbox) ·
+[TypeScript](/typescript/runtime/sandbox)

--- a/docs/home/setup/runtime/sandbox/daytona.mdx
+++ b/docs/home/setup/runtime/sandbox/daytona.mdx
@@ -1,0 +1,36 @@
+---
+title: Daytona
+icon: /images/daytona-logo.svg
+description: Connect either Mirage SDK to an existing Daytona sandbox.
+---
+
+Create the sandbox, then connect by ID. Details: [Python](/python/runtime/sandbox/daytona) ·
+[TypeScript](/typescript/runtime/sandbox/daytona).
+
+<Tabs>
+  <Tab title="Python SDK" icon="/images/python-logo.svg">
+    ```bash
+    pip install 'mirage-ai[daytona]'
+    ```
+
+    ```python
+    from mirage.runtime.sandbox.daytona import DaytonaRuntime
+
+    runtime = DaytonaRuntime(captures=["python3"], config={"sandbox_id": "sandbox-id"})
+    ```
+  </Tab>
+  <Tab title="TypeScript SDK" icon="/images/typescript-logo.svg">
+    ```bash
+    pnpm add @daytonaio/sdk
+    ```
+
+    ```typescript
+    import { DaytonaRuntime } from '@struktoai/mirage-node'
+
+    const runtime = new DaytonaRuntime({
+      captures: ['python3'],
+      config: { sandboxId: 'sandbox-id' },
+    })
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/runtime/sandbox/docker.mdx
+++ b/docs/home/setup/runtime/sandbox/docker.mdx
@@ -1,0 +1,34 @@
+---
+title: Docker
+icon: /images/docker-logo.svg
+description: Connect either Mirage SDK to an existing Docker container.
+---
+
+Start the container yourself. Live FUSE mounts require `SYS_ADMIN` and
+`/dev/fuse` on Linux. Details: [Python](/python/runtime/sandbox/docker) ·
+[TypeScript](/typescript/runtime/sandbox/docker).
+
+```bash
+docker run -d --cap-add SYS_ADMIN --device /dev/fuse \
+  --name my-sandbox mirage-python-fuse sleep infinity
+```
+
+<Tabs>
+  <Tab title="Python SDK" icon="/images/python-logo.svg">
+    ```python
+    from mirage.runtime.sandbox.docker import DockerRuntime
+
+    runtime = DockerRuntime(captures=["python3"], config={"container": "my-sandbox"})
+    ```
+  </Tab>
+  <Tab title="TypeScript SDK" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { DockerRuntime } from '@struktoai/mirage-node'
+
+    const runtime = new DockerRuntime({
+      captures: ['python3'],
+      config: { container: 'my-sandbox' },
+    })
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/runtime/sandbox/e2b.mdx
+++ b/docs/home/setup/runtime/sandbox/e2b.mdx
@@ -1,0 +1,36 @@
+---
+title: E2B
+icon: /images/e2b-logo.svg
+description: Connect either Mirage SDK to an existing E2B sandbox.
+---
+
+Create the sandbox from a template, then connect by ID. Details:
+[Python](/python/runtime/sandbox/e2b) · [TypeScript](/typescript/runtime/sandbox/e2b).
+
+<Tabs>
+  <Tab title="Python SDK" icon="/images/python-logo.svg">
+    ```bash
+    pip install 'mirage-ai[e2b]'
+    ```
+
+    ```python
+    from mirage.runtime.sandbox.e2b import E2BRuntime
+
+    runtime = E2BRuntime(captures=["python3"], config={"sandbox_id": "sandbox-id"})
+    ```
+  </Tab>
+  <Tab title="TypeScript SDK" icon="/images/typescript-logo.svg">
+    ```bash
+    pnpm add e2b
+    ```
+
+    ```typescript
+    import { E2BRuntime } from '@struktoai/mirage-node'
+
+    const runtime = new E2BRuntime({
+      captures: ['python3'],
+      config: { sandboxId: 'sandbox-id' },
+    })
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/runtime/sandbox/sandlock.mdx
+++ b/docs/home/setup/runtime/sandbox/sandlock.mdx
@@ -1,0 +1,11 @@
+---
+title: Sandlock
+icon: /images/sandlock-logo.svg
+description: Set up the Python-only Sandlock runtime on Linux.
+---
+
+Sandlock confines the host Python interpreter with Landlock and seccomp. It is
+available only in the Python SDK and only on Linux. Install the `sandlock` CLI
+on `PATH`; Mirage needs no extra package.
+
+Continue with [Sandlock setup](/python/runtime/sandbox/sandlock).

--- a/docs/home/setup/runtime/sandbox/smolvm.mdx
+++ b/docs/home/setup/runtime/sandbox/smolvm.mdx
@@ -1,0 +1,33 @@
+---
+title: smolvm
+icon: /images/smolvm-logo.svg
+description: Connect either Mirage SDK to an existing smolvm microVM.
+---
+
+Create and start the machine. Details: [Python](/python/runtime/sandbox/smolvm) ·
+[TypeScript](/typescript/runtime/sandbox/smolvm).
+
+```bash
+smolvm machine create --net --name mirage-box --image my-mirage-image
+smolvm machine start --name mirage-box
+```
+
+<Tabs>
+  <Tab title="Python SDK" icon="/images/python-logo.svg">
+    ```python
+    from mirage.runtime.sandbox.smolvm import SmolvmRuntime
+
+    runtime = SmolvmRuntime(captures=["python3"], config={"machine": "mirage-box"})
+    ```
+  </Tab>
+  <Tab title="TypeScript SDK" icon="/images/typescript-logo.svg">
+    ```typescript
+    import { SmolvmRuntime } from '@struktoai/mirage-node'
+
+    const runtime = new SmolvmRuntime({
+      captures: ['python3'],
+      config: { machine: 'mirage-box' },
+    })
+    ```
+  </Tab>
+</Tabs>

--- a/docs/home/setup/runtime/sandbox/ssh.mdx
+++ b/docs/home/setup/runtime/sandbox/ssh.mdx
@@ -1,0 +1,45 @@
+---
+title: SSH
+icon: /images/ssh-logo.svg
+description: Connect either Mirage SDK to a machine over SSH.
+---
+
+The machine only needs `sshd`. Details: [Python](/python/runtime/sandbox/ssh) ·
+[TypeScript](/typescript/runtime/sandbox/ssh).
+
+<Tabs>
+  <Tab title="Python SDK" icon="/images/python-logo.svg">
+    ```python
+    from mirage.runtime.sandbox.ssh import SSHRuntime
+
+    runtime = SSHRuntime(
+        captures=["python3"],
+        config={
+            "host": "mybox",
+            "username": "deploy",
+            "identity_file": "~/.ssh/id_ed25519",
+        },
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript SDK" icon="/images/typescript-logo.svg">
+    ```bash
+    pnpm add ssh2
+    ```
+
+    ```typescript
+    import { SSHRuntime } from '@struktoai/mirage-node'
+
+    const runtime = new SSHRuntime({
+      captures: ['python3'],
+      config: {
+        host: 'mybox',
+        username: 'deploy',
+        identityFile: '~/.ssh/id_ed25519',
+      },
+    })
+    ```
+
+  </Tab>
+</Tabs>

--- a/docs/home/setup/runtime/sandbox/ssh.mdx
+++ b/docs/home/setup/runtime/sandbox/ssh.mdx
@@ -9,6 +9,10 @@ The machine only needs `sshd`. Details: [Python](/python/runtime/sandbox/ssh) ·
 
 <Tabs>
   <Tab title="Python SDK" icon="/images/python-logo.svg">
+    ```bash
+    pip install 'mirage-ai[ssh]'
+    ```
+
     ```python
     from mirage.runtime.sandbox.ssh import SSHRuntime
 

--- a/docs/python/agents/index.mdx
+++ b/docs/python/agents/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Agents
+title: Overview
 description: Drop a Mirage workspace into the Python agent framework you already use.
 icon: robot
 ---

--- a/docs/python/cli/index.mdx
+++ b/docs/python/cli/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLIs
+title: Overview
 description: "Install typed command-line programs beside your mounts and let agents act on services by name."
 icon: terminal
 ---

--- a/docs/python/resource/index.mdx
+++ b/docs/python/resource/index.mdx
@@ -1,68 +1,18 @@
 ---
-title: Resources
+title: Overview
 icon: grid-2
 description: Python resources you can mount in a Mirage workspace.
 ---
 
-Each page describes a Python-supported resource: what config it needs, what the mounted tree looks like, and any resource-specific behavior. Setup docs (credentials, OAuth, etc.) live under [Setup](/home/setup/s3), these pages focus on mounted layout and behavior.
+Resources are the storage systems and services you mount into a Mirage
+workspace. Open **Providers** in the sidebar to browse every Python-supported
+backend by category.
 
-## Infrastructure
+Each provider page covers the required configuration, mounted tree, and
+resource-specific behavior. Use the [Resource Matrix](/home/resource-matrix)
+to compare Python and TypeScript availability, watch support, and mount
+capabilities at a glance.
 
-- [Disk](/python/resource/disk)
-- [RAM](/python/resource/ram)
-- [Redis](/python/resource/redis)
-- [SSH](/python/resource/ssh)
-
-## Object Storage
-
-- [S3](/python/resource/s3)
-- [R2](/python/resource/r2)
-- [GCS](/python/resource/gcs)
-- [OCI](/python/resource/oci)
-- [Supabase](/python/resource/supabase)
-
-## Cloud Files
-
-- [Databricks Volume](/python/resource/databricks_volume)
-
-## Google Workspace
-
-- [Gmail](/python/resource/gmail)
-- [Google Drive](/python/resource/gdrive)
-- [Google Docs](/python/resource/gdocs)
-- [Google Sheets](/python/resource/gsheets)
-- [Google Slides](/python/resource/gslides)
-
-## Code & DevOps
-
-- [GitHub](/python/resource/github)
-- [Linear](/python/resource/linear)
-- [Langfuse](/python/resource/langfuse)
-
-## Messaging
-
-- [Slack](/python/resource/slack)
-- [Discord](/python/resource/discord)
-- [Email](/python/resource/email)
-
-## Database
-
-- [MongoDB](/python/resource/mongodb)
-- [GridFS](/python/resource/gridfs)
-- [Postgres](/python/resource/postgres)
-- [LanceDB](/python/resource/lancedb)
-- [Qdrant](/python/resource/qdrant)
-
-## Knowledge
-
-- [Dify](/python/resource/dify)
-- [Chroma](/python/resource/chroma)
-
-## Notes
-
-- [Notion](/python/resource/notion)
-
-## Others
-
-- [Trello](/python/resource/trello)
-- [Adding a New Resource](/python/resource/new)
+Provider setup spans local filesystems, object stores, cloud drives,
+collaboration tools, databases, vector stores, and agent memory systems. To
+implement another backend, see [Adding a New Resource](/python/resource/new).

--- a/docs/typescript/agents/index.mdx
+++ b/docs/typescript/agents/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Agents
+title: Overview
 description: Drop a Mirage workspace into the TypeScript agent framework you already use.
 icon: robot
 ---

--- a/docs/typescript/cli/index.mdx
+++ b/docs/typescript/cli/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLIs
+title: Overview
 description: "Install typed command-line programs beside your mounts and let agents act on services by name from Node."
 icon: terminal
 ---

--- a/docs/typescript/setup/resources.mdx
+++ b/docs/typescript/setup/resources.mdx
@@ -1,0 +1,19 @@
+---
+title: Overview
+icon: grid-2
+description: TypeScript resources you can mount in a Mirage workspace.
+---
+
+Resources are the storage systems and services you mount into a Mirage
+workspace. Open **Providers** in the sidebar to browse every
+TypeScript-supported backend by category.
+
+Each provider page covers the required configuration, mounted tree, and
+resource-specific behavior. Use the [Resource Matrix](/home/resource-matrix)
+to compare Python and TypeScript availability, watch support, and mount
+capabilities at a glance.
+
+Provider setup spans local and browser filesystems, object stores, cloud
+drives, collaboration tools, databases, vector stores, and agent memory
+systems. To implement another backend, see
+[Adding a New Resource](/typescript/resource/new).


### PR DESCRIPTION
## Summary

- flatten the Agents and CLI navigation without extra category layers
- align Home resources, CLIs, and runtimes with the Python and TypeScript setup structure
- add concise shared Python and TypeScript setup pages for CLIs and runtimes
- preserve provider-specific icons and links to detailed language references

## Checks

- `pre-commit run --all-files`
- `mintlify validate`
- `mintlify broken-links`