### PR TITLE
Let the integ fakes run somewhere other than a developer's laptop

### DIFF
--- a/integ/server/box_server.py
+++ b/integ/server/box_server.py
@@ -87,6 +87,18 @@ class FakeBox:
     """In-memory Box content tree keyed by item id, root folder id "0"."""
 
     def __init__(self) -> None:
+        # `base` is where the server ended up listening, set by
+        # `start_fake_box` once the port is known. It describes the
+        # listener rather than the contents, so `reset` leaves it alone.
+        self.base = ""
+        self.reset()
+
+    def reset(self) -> None:
+        """The state the process starts in, and what `POST /reset` restores.
+
+        Written here rather than inline in `__init__` so the two cannot
+        drift: a field added to the launch state is reset by construction.
+        """
         self.items: dict[str, dict] = {
             ROOT_ID: {
                 "type": "folder",
@@ -96,7 +108,6 @@ class FakeBox:
                 "modified_at": MODIFIED,
             }
         }
-        self.base = ""
         self._seq = 1000000000
 
     def _new_id(self) -> str:
@@ -255,6 +266,20 @@ class BoxServer:
 
     def __init__(self, state: FakeBox) -> None:
         self.state = state
+
+    async def reset(self, request: web.Request) -> web.Response:
+        """Drop every write since startup. Mirrors `POST /reset` on the
+        other fakes: same path, same empty body, same `{"ok": true}`.
+
+        Args:
+            request (web.Request): the incoming request.
+
+        Returns:
+            web.Response: 200 once the launch state is back.
+        """
+        del request
+        self.state.reset()
+        return web.json_response({"ok": True})
 
     def _authed(self, request: web.Request) -> bool:
         auth = request.headers.get("Authorization", "")
@@ -551,6 +576,7 @@ class BoxServer:
 
 def build_app(server: BoxServer) -> web.Application:
     app = web.Application(client_max_size=8 * 1024 * 1024)
+    app.router.add_post("/reset", server.reset)
     app.router.add_post("/oauth2/token", server.token)
     app.router.add_get("/2.0/folders/{folder_id}/items", server.list_items)
     app.router.add_get("/2.0/folders/{folder_id}", server.folder_info)

--- a/integ/server/box_server.py
+++ b/integ/server/box_server.py
@@ -16,10 +16,22 @@ import argparse
 import asyncio
 import hashlib
 import json
+import os
 import re
 from datetime import datetime, timezone
 
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 # Anchored at run time, mirroring integ/server/onedrive_server.py: real Box
 # stamps modified_at at write time, and the shared find_mtime case (-mtime -1)
@@ -565,7 +577,7 @@ async def start_fake_box() -> tuple[FakeBox, BoxServer, web.AppRunner]:
     server = BoxServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.TCPSite(runner, BIND_HOST, 0)
     await site.start()
     port = site._server.sockets[0].getsockname()[1]
     state.base = f"http://127.0.0.1:{port}"
@@ -577,7 +589,7 @@ async def _serve(port: int) -> None:
     server = BoxServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", port)
+    site = web.TCPSite(runner, BIND_HOST, port)
     await site.start()
     state.base = f"http://127.0.0.1:{port}"
     print(f"BOX_ENDPOINT={state.base}", flush=True)

--- a/integ/server/databricks_server.py
+++ b/integ/server/databricks_server.py
@@ -58,6 +58,14 @@ def _parent(path: str) -> str:
 class VolumeStore:
 
     def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        """The state the process starts in, and what `POST /reset` restores.
+
+        Written here rather than inline in `__init__` so the two cannot
+        drift: a field added to the launch state is reset by construction.
+        """
         self.files: dict[str, tuple[bytes, float]] = {}
         self.dirs: set[str] = {"/"}
 
@@ -212,9 +220,24 @@ async def directories_handler(request: web.Request) -> web.StreamResponse:
     return web.Response(status=405)
 
 
+async def reset_handler(request: web.Request) -> web.Response:
+    """Drop every write since startup. Mirrors `POST /reset` on the other
+    fakes: same path, same empty body, same `{"ok": true}`.
+
+    Args:
+        request (web.Request): the incoming request.
+
+    Returns:
+        web.Response: 200 once the launch state is back.
+    """
+    request.app["store"].reset()
+    return web.json_response({"ok": True})
+
+
 def build_app(store: VolumeStore) -> web.Application:
     app = web.Application(client_max_size=1024**3)
     app["store"] = store
+    app.router.add_post("/reset", reset_handler)
     app.router.add_route("*", FILES_ROUTE, files_handler)
     app.router.add_route("*", DIRS_ROUTE, directories_handler)
     return app

--- a/integ/server/databricks_server.py
+++ b/integ/server/databricks_server.py
@@ -15,6 +15,7 @@
 import argparse
 import asyncio
 import json
+import os
 import posixpath
 import time
 import urllib.error
@@ -26,6 +27,17 @@ from typing import Any
 from urllib.parse import quote, urlencode
 
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 FILES_ROUTE = "/api/2.0/fs/files/{tail:.*}"
 DIRS_ROUTE = "/api/2.0/fs/directories/{tail:.*}"
@@ -361,7 +373,7 @@ async def start_fake_databricks() -> tuple[VolumeStore, web.AppRunner, str]:
     store = VolumeStore()
     runner = web.AppRunner(build_app(store))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.TCPSite(runner, BIND_HOST, 0)
     await site.start()
     port = site._server.sockets[0].getsockname()[1]
     base = f"http://127.0.0.1:{port}"
@@ -372,7 +384,7 @@ async def _serve(port: int) -> None:
     store = VolumeStore()
     runner = web.AppRunner(build_app(store))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", port)
+    site = web.TCPSite(runner, BIND_HOST, port)
     await site.start()
     print(f"DATABRICKS_ENDPOINT=http://127.0.0.1:{port}", flush=True)
     await asyncio.Event().wait()

--- a/integ/server/dify_server.py
+++ b/integ/server/dify_server.py
@@ -14,9 +14,21 @@
 
 import argparse
 import asyncio
+import os
 from typing import Any
 
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 FIXED_UPDATED_AT = 1716282000
 
@@ -207,7 +219,7 @@ async def start_fake_dify() -> tuple[FakeDify, DifyServer, web.AppRunner]:
     server = DifyServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.TCPSite(runner, BIND_HOST, 0)
     await site.start()
     port = site._server.sockets[0].getsockname()[1]
     state.base = f"http://127.0.0.1:{port}"
@@ -219,7 +231,7 @@ async def _serve(port: int) -> None:
     server = DifyServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", port)
+    site = web.TCPSite(runner, BIND_HOST, port)
     await site.start()
     state.base = f"http://127.0.0.1:{port}"
     print(f"DIFY_ENDPOINT={state.base}", flush=True)

--- a/integ/server/discord_server.py
+++ b/integ/server/discord_server.py
@@ -15,10 +15,22 @@
 import argparse
 import asyncio
 import json
+import os
 from pathlib import Path
 from typing import Any
 
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 FIXTURE = Path(
     __file__).resolve().parents[1] / "fixtures" / "discord" / "v1.json"
@@ -537,7 +549,7 @@ async def start_fake_discord(
     server = DiscordServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.TCPSite(runner, BIND_HOST, 0)
     await site.start()
     port = site._server.sockets[0].getsockname()[1]
     state.base = f"http://127.0.0.1:{port}"
@@ -550,7 +562,7 @@ async def _serve(port: int) -> None:
     server = DiscordServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", port)
+    site = web.TCPSite(runner, BIND_HOST, port)
     await site.start()
     state.base = f"http://127.0.0.1:{port}"
     print(f"DISCORD_ENDPOINT={state.base}", flush=True)

--- a/integ/server/dropbox.ts
+++ b/integ/server/dropbox.ts
@@ -112,6 +112,16 @@ class Account {
   readonly searchCursors = new Map<string, { matches: SearchMatchJson[]; start: number; limit: number }>()
   readonly listCursors = new Map<string, DropboxEntryJson[]>()
 
+  // Drop every write since startup. The fields are readonly collections,
+  // so this clears them in place rather than rebuilding the account the
+  // way integ/server/dropbox_server.py rebuilds through __init__.
+  reset(): void {
+    this.folders.clear()
+    this.files.clear()
+    this.searchCursors.clear()
+    this.listCursors.clear()
+  }
+
   addAncestors(path: string): void {
     const parts = path.split('/').slice(1, -1)
     let cur = ''
@@ -260,6 +270,13 @@ function handle(
   req: IncomingMessage,
   res: ServerResponse,
 ): void {
+  // Mirrors POST /reset on the other fakes: same path, same empty body,
+  // same {ok: true}.
+  if (url === '/reset') {
+    account.reset()
+    json(res, { ok: true })
+    return
+  }
   if (url === '/oauth2/token') {
     json(res, { access_token: 'integ-token', expires_in: 14400 })
     return

--- a/integ/server/dropbox.ts
+++ b/integ/server/dropbox.ts
@@ -20,6 +20,17 @@ import {
   type ServerResponse,
 } from 'node:http'
 
+// The interface the fake listens on. Loopback is right on a developer's
+// machine and wrong inside a container: a server on the container's own
+// 127.0.0.1 is invisible to the published port, so a client on the host has
+// its connection accepted and then closed with no response -- while a
+// healthcheck running inside the container sees a healthy server. Set
+// MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+//
+// The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+// interface to listen on, not an address anything can connect to.
+const BIND_HOST = process.env.MIRAGE_BIND_HOST ?? '127.0.0.1'
+
 // Uploads stamp the real clock (find -mtime expects fresh writes to
 // look fresh, like MinIO/moto in the s3 targets).
 function nowStamp(): string {
@@ -441,7 +452,7 @@ export function startFakeDropbox(): Promise<FakeDropbox> {
       })
   })
   return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, BIND_HOST, () => {
       const address = server.address()
       if (address === null || typeof address === 'string') {
         throw new Error('fake dropbox server has no port')

--- a/integ/server/dropbox_server.py
+++ b/integ/server/dropbox_server.py
@@ -78,11 +78,36 @@ class FakeDropbox:
     """
 
     def __init__(self) -> None:
+        # `endpoint` is where the server ended up listening, set by
+        # `start_fake_dropbox` once the port is known. It describes the
+        # listener rather than the contents, so `reset` leaves it alone.
+        self.endpoint = ""
+        self.reset()
+
+    async def handle_reset(self, request: web.Request) -> web.Response:
+        """Drop every write since startup. Mirrors `POST /reset` on the
+        other fakes: same path, same empty body, same `{"ok": true}`.
+
+        Args:
+            request (web.Request): the incoming request.
+
+        Returns:
+            web.Response: 200 once the launch state is back.
+        """
+        del request
+        self.reset()
+        return web.json_response({"ok": True})
+
+    def reset(self) -> None:
+        """The state the process starts in, and what `POST /reset` restores.
+
+        Written here rather than inline in `__init__` so the two cannot
+        drift: a field added to the launch state is reset by construction.
+        """
         self.folders: set[str] = set()
         self.files: dict[str, tuple[bytes, str]] = {}
         self.search_cursors: dict[str, tuple[list, int, int]] = {}
         self.list_cursors: dict[str, list[dict]] = {}
-        self.endpoint = ""
 
     def _add_ancestors(self, path: str) -> None:
         parts = path.split("/")[1:-1]
@@ -410,6 +435,7 @@ async def start_fake_dropbox() -> tuple[FakeDropbox, web.AppRunner]:
     # The columnar fixture's example.h5 is ~1.02 MiB; aiohttp's default
     # client_max_size (1 MiB) would 413 its upload.
     app = web.Application(client_max_size=8 * 1024 * 1024)
+    app.router.add_post("/reset", fake.handle_reset)
     app.router.add_post("/oauth2/token", fake.handle_token)
     app.router.add_post("/2/files/list_folder", fake.handle_list_folder)
     app.router.add_post("/2/files/list_folder/continue",

--- a/integ/server/dropbox_server.py
+++ b/integ/server/dropbox_server.py
@@ -14,10 +14,22 @@
 
 import hashlib
 import json
+import os
 import re
 import time
 
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 
 def _now_stamp() -> str:
@@ -414,7 +426,7 @@ async def start_fake_dropbox() -> tuple[FakeDropbox, web.AppRunner]:
                         fake.handle_search_continue)
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.TCPSite(runner, BIND_HOST, 0)
     await site.start()
     assert runner.addresses
     fake.endpoint = f"http://127.0.0.1:{runner.addresses[0][1]}"

--- a/integ/server/github_server.py
+++ b/integ/server/github_server.py
@@ -17,11 +17,23 @@ import asyncio
 import base64
 import hashlib
 import json
+import os
 import re
 import sys
 from pathlib import Path
 
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 # Deliberate divergences from api.github.com, mirroring how
 # integ/server/dropbox.ts documents its Gmail-search shortcuts:
@@ -1747,7 +1759,7 @@ async def start_fake_github(
     server = GitHubServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.TCPSite(runner, BIND_HOST, 0)
     await site.start()
     port = site._server.sockets[0].getsockname()[1]
     state.base = f"http://127.0.0.1:{port}"
@@ -1907,7 +1919,7 @@ async def _serve(port: int, repos: list[str], metadata: list[str],
     server = GitHubServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", port)
+    site = web.TCPSite(runner, BIND_HOST, port)
     await site.start()
     state.base = f"http://127.0.0.1:{port}"
     print(f"GITHUB_ENDPOINT={state.base}", flush=True)

--- a/integ/server/github_server.py
+++ b/integ/server/github_server.py
@@ -1441,19 +1441,45 @@ class GitHubServer:
         return web.Response(body=data, content_type=content_type.split(";")[0])
 
     async def reset(self, request: web.Request) -> web.Response:
-        """Rebuild the seeded state, dropping every write since startup.
+        """Drop every write since startup, and optionally re-seed.
 
-        The write battery runs once per host against one shared process, so
-        without this the second host reads the first host's writes and the
-        two disagree over state rather than over behaviour.
+        An empty body restores the seed this fake is currently holding --
+        the command line's, until a reset replaces it. That is what the
+        write battery needs: it runs once per host against one shared
+        process, so without a reset the second host reads the first host's
+        writes and the two disagree over state rather than over behaviour.
+
+        A body replaces the seed, which is what a harness moving between
+        scenarios needs. This fake is the one whose launch state is not
+        empty -- its fixtures are git trees named on the command line -- so
+        "put back what the process started with" hands back the *previous*
+        scenario's repositories. Passing the next scenario's spec here is
+        the difference between resetting the fake and restarting it.
+
+        The new spec is kept, so a later empty reset replays *it* rather
+        than the command line: seed once when the scenario changes, then
+        reset freely within it.
 
         Args:
-            request (web.Request): the incoming request.
+            request (web.Request): the incoming request; an optional JSON
+                body of `{"repo": [...], "metadata": [...],
+                "commits": [...]}`, spelled as the command line spells
+                them.
 
         Returns:
             web.Response: 200 once the seed is back.
         """
-        del request
+        body = await request.json() if request.can_read_body else {}
+        if not isinstance(body, dict):
+            return web.json_response(
+                {"error": "reset body must be an "
+                 "object"}, status=400)
+        if body:
+            self.state.seed = (
+                list(body.get("repo") or []),
+                list(body.get("metadata") or []),
+                list(body.get("commits") or []),
+            )
         self.state.repos.clear()
         self.state.login = DEFAULT_LOGIN
         seed_state(self.state, *self.state.seed)

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -58,6 +58,17 @@
 import { createHash } from 'node:crypto'
 import http from 'node:http'
 
+// The interface the fake listens on. Loopback is right on a developer's
+// machine and wrong inside a container: a server on the container's own
+// 127.0.0.1 is invisible to the published port, so a client on the host has
+// its connection accepted and then closed with no response -- while a
+// healthcheck running inside the container sees a healthy server. Set
+// MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+//
+// The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+// interface to listen on, not an address anything can connect to.
+const BIND_HOST = process.env.MIRAGE_BIND_HOST ?? '127.0.0.1'
+
 const FOLDER_MIME = 'application/vnd.google-apps.folder'
 const DOC_MIME = 'application/vnd.google-apps.document'
 const SHEET_MIME = 'application/vnd.google-apps.spreadsheet'
@@ -2959,7 +2970,7 @@ export function startServer(port: number): Promise<http.Server> {
     })
   })
   return new Promise((resolve) => {
-    server.listen(port, '127.0.0.1', () => resolve(server))
+    server.listen(port, BIND_HOST, () => resolve(server))
   })
 }
 

--- a/integ/server/hf_server.py
+++ b/integ/server/hf_server.py
@@ -16,11 +16,23 @@ import argparse
 import asyncio
 import hashlib
 import json
+import os
 from collections import Counter
 from datetime import datetime, timezone
 
 import lz4.frame
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 # Anchored at run time, mirroring moto and the fake Graph: the real Hub
 # stamps lastModified at write time, and a fixed past date would make the
@@ -451,7 +463,7 @@ async def start_fake_hub(
     server = HubServer(hub)
     runner = web.AppRunner(_build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", port)
+    site = web.TCPSite(runner, BIND_HOST, port)
     await site.start()
     assert runner.addresses
     server.port = runner.addresses[0][1]

--- a/integ/server/hf_server.py
+++ b/integ/server/hf_server.py
@@ -242,6 +242,9 @@ class HubServer:
 
     def __init__(self, hub: FakeHub) -> None:
         self.hub = hub
+        # Overwritten with the real port once the site is listening. Set
+        # here so `endpoint` reads rather than raises in between.
+        self.port = 0
 
     async def reset(self, request: web.Request) -> web.Response:
         """Drop every write since startup. Mirrors `POST /reset` on the
@@ -256,7 +259,6 @@ class HubServer:
         del request
         self.hub.reset()
         return web.json_response({"ok": True})
-        self.port = 0
 
     @property
     def endpoint(self) -> str:

--- a/integ/server/hf_server.py
+++ b/integ/server/hf_server.py
@@ -150,6 +150,14 @@ def _serve_hash(data: bytes) -> str:
 class FakeHub:
 
     def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        """The state the process starts in, and what `POST /reset` restores.
+
+        Written here rather than inline in `__init__` so the two cannot
+        drift: a field added to the launch state is reset by construction.
+        """
         # bucket ("ns/name") -> path -> {"data", "modified", "etag"}
         self.buckets: dict[str, dict[str, dict]] = {}
         # xorb hash hex -> ordered decoded chunks
@@ -234,6 +242,20 @@ class HubServer:
 
     def __init__(self, hub: FakeHub) -> None:
         self.hub = hub
+
+    async def reset(self, request: web.Request) -> web.Response:
+        """Drop every write since startup. Mirrors `POST /reset` on the
+        other fakes: same path, same empty body, same `{"ok": true}`.
+
+        Args:
+            request (web.Request): the incoming request.
+
+        Returns:
+            web.Response: 200 once the launch state is back.
+        """
+        del request
+        self.hub.reset()
+        return web.json_response({"ok": True})
         self.port = 0
 
     @property
@@ -435,6 +457,7 @@ def serialized_offset_of(chunk_index: int) -> int:
 
 def _build_app(server: HubServer) -> web.Application:
     app = web.Application(client_max_size=256 * 1024 * 1024)
+    app.router.add_post("/reset", server.reset)
     app.router.add_get("/api/buckets/{ns}/{name}/tree/{path:.*}", server.tree)
     app.router.add_get("/buckets/{ns}/{name}/resolve/{path:.*}",
                        server.resolve)

--- a/integ/server/http_server.py
+++ b/integ/server/http_server.py
@@ -14,8 +14,20 @@
 
 import argparse
 import asyncio
+import os
 
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 HELLO = b"hello from http\n"
 JSON_BODY = b'{"ok": true, "name": "mirage"}\n'
@@ -89,7 +101,7 @@ def build_app() -> web.Application:
 async def serve(port: int) -> None:
     runner = web.AppRunner(build_app())
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", port)
+    site = web.TCPSite(runner, BIND_HOST, port)
     await site.start()
     assert runner.addresses
     bound = runner.addresses[0][1]

--- a/integ/server/http_server.py
+++ b/integ/server/http_server.py
@@ -85,8 +85,26 @@ async def form(request: web.Request) -> web.Response:
                         content_type="text/plain")
 
 
+async def reset(request: web.Request) -> web.Response:
+    """Drop every write since startup, of which there are none.
+
+    This fake accumulates nothing -- its routes are fixed responses. The
+    route exists so every fake answers the same control call, and a
+    harness resetting them in a loop needs no list of exceptions.
+
+    Args:
+        request (web.Request): the incoming request.
+
+    Returns:
+        web.Response: 200, always.
+    """
+    del request
+    return web.json_response({"ok": True})
+
+
 def build_app() -> web.Application:
     app = web.Application()
+    app.router.add_post("/reset", reset)
     app.router.add_get("/hello", hello)
     app.router.add_get("/data.json", json_body)
     app.router.add_get("/bytes.bin", binary)

--- a/integ/server/linear_server.py
+++ b/integ/server/linear_server.py
@@ -15,11 +15,23 @@
 import argparse
 import asyncio
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
 
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 FIXTURE = Path(
     __file__).resolve().parents[1] / "fixtures" / "linear" / "v1.json"
@@ -634,7 +646,7 @@ async def start_fake_linear(
     server = LinearServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.TCPSite(runner, BIND_HOST, 0)
     await site.start()
     port = site._server.sockets[0].getsockname()[1]
     state.base = f"http://127.0.0.1:{port}/graphql"
@@ -647,7 +659,7 @@ async def _serve(port: int) -> None:
     server = LinearServer(state)
     runner = web.AppRunner(build_app(server))
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", port)
+    site = web.TCPSite(runner, BIND_HOST, port)
     await site.start()
     state.base = f"http://127.0.0.1:{port}/graphql"
     print(f"LINEAR_ENDPOINT={state.base}", flush=True)

--- a/integ/server/mem0_server.py
+++ b/integ/server/mem0_server.py
@@ -13,8 +13,20 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import os
 
 from aiohttp import web
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 MEMORIES = [
     {
@@ -118,7 +130,7 @@ async def start_fake_mem0() -> tuple[str, web.AppRunner]:
     app.router.add_route("*", "/{tail:.*}", handle)
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.TCPSite(runner, BIND_HOST, 0)
     await site.start()
     port = site._server.sockets[0].getsockname()[1]
     return f"http://127.0.0.1:{port}", runner

--- a/integ/server/mem0_server.py
+++ b/integ/server/mem0_server.py
@@ -125,8 +125,27 @@ async def handle(request: web.Request) -> web.Response:
     return web.json_response({"detail": "Not found"}, status=404)
 
 
+async def reset(request: web.Request) -> web.Response:
+    """Drop every write since startup, of which there are none.
+
+    This fake accumulates nothing -- MEMORIES and SCORES are module
+    constants and every handler only reads them. The route exists so every
+    fake answers the same control call, and a harness resetting them in a
+    loop needs no list of exceptions.
+
+    Args:
+        request (web.Request): the incoming request.
+
+    Returns:
+        web.Response: 200, always.
+    """
+    del request
+    return web.json_response({"ok": True})
+
+
 async def start_fake_mem0() -> tuple[str, web.AppRunner]:
     app = web.Application()
+    app.router.add_post("/reset", reset)
     app.router.add_route("*", "/{tail:.*}", handle)
     runner = web.AppRunner(app)
     await runner.setup()

--- a/integ/server/notion_server.ts
+++ b/integ/server/notion_server.ts
@@ -56,6 +56,17 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { PrismaClient } from '@prisma/client'
 
+// The interface the fake listens on. Loopback is right on a developer's
+// machine and wrong inside a container: a server on the container's own
+// 127.0.0.1 is invisible to the published port, so a client on the host has
+// its connection accepted and then closed with no response -- while a
+// healthcheck running inside the container sees a healthy server. Set
+// MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+//
+// The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+// interface to listen on, not an address anything can connect to.
+const BIND_HOST = process.env.MIRAGE_BIND_HOST ?? '127.0.0.1'
+
 const HERE = dirname(fileURLToPath(import.meta.url))
 const SCHEMA = join(HERE, '..', 'prisma', 'schema.prisma')
 const FIXTURE = join(HERE, '..', 'fixtures', 'notion', 'v1.json')
@@ -1697,7 +1708,7 @@ export async function startServer(port: number): Promise<Server> {
   const { db, fx } = await createStore(`rest-${String(port)}`)
   const server = serve(db, fx)
   return new Promise((resolve) => {
-    server.listen(port, '127.0.0.1', () => resolve(server))
+    server.listen(port, BIND_HOST, () => resolve(server))
   })
 }
 
@@ -1799,7 +1810,7 @@ export async function startMockMcpServer(): Promise<{ server: Server; port: numb
     })
   })
   return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, BIND_HOST, () => {
       const address = server.address()
       if (address === null || typeof address === 'string') throw new Error('no port')
       resolve({ server, port: address.port })

--- a/integ/server/onedrive_server.py
+++ b/integ/server/onedrive_server.py
@@ -284,18 +284,23 @@ class GraphServer:
 
     def __init__(self, state: FakeGraph) -> None:
         self.state = state
+        # Which drives exist is settled before the first request: the only
+        # callers of `add_drive` are `serve_forever`, reading
+        # MIRAGE_GRAPH_DRIVES, and the test adapter reading its mounts. No
+        # route creates one, so the registry is launch state and `_fresh`
+        # leaves it alone.
+        self.drives: dict[str, FakeGraph] = {state.key: state}
+        self.site_drives: list[str] = [state.key]
         self._fresh()
 
     def _fresh(self) -> None:
-        """Put the server's own state back to what construction gives it.
+        """Put the server's own transient state back to what launch gives it.
 
-        Deliberately does not touch `self.state`: a caller that seeded the
-        drive before handing it over would not expect the constructor to
-        empty it. `reset` resets both, because that is what a caller asking
-        for a reset means.
+        Deliberately touches neither the drives nor their contents: a caller
+        that seeded a drive before handing it over would not expect the
+        constructor to empty it. `reset` empties the drives too, because
+        that is what a caller asking for a reset means.
         """
-        self.drives: dict[str, FakeGraph] = {self.state.key: self.state}
-        self.site_drives: list[str] = [self.state.key]
         self.uploads: dict[str, dict] = {}
         self.monitors: dict[str, dict] = {}
         self.calls: Counter = Counter()
@@ -313,11 +318,13 @@ class GraphServer:
             web.Response: 200 once the launch state is back.
         """
         del request
-        # Both halves: the server holds more than the default drive does --
-        # the drives added since launch, the open upload sessions, the
-        # monitors -- so resetting the drive alone would leave a SharePoint
-        # drive created by the previous run still discoverable.
-        self.state.reset()
+        # Every drive, not just the default: a SharePoint drive named in
+        # MIRAGE_GRAPH_DRIVES holds writes too. Their contents go; the
+        # drives themselves stay, because nothing can recreate one short of
+        # restarting the process, and `FakeGraph.reset` keeps the `key` and
+        # `base` that say which drive this is and where it answers.
+        for drive in self.drives.values():
+            drive.reset()
         self._fresh()
         return web.json_response({"ok": True})
 

--- a/integ/server/onedrive_server.py
+++ b/integ/server/onedrive_server.py
@@ -20,6 +20,17 @@ from datetime import datetime, timedelta, timezone
 
 from aiohttp import web
 
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
+
 # Anchored at run time, mirroring moto (the s3 fake) and real Graph, which
 # stamp lastModifiedDateTime at write time. A fixed past date would make the
 # shared find_mtime case (-mtime -1) exclude every just-written item.
@@ -608,7 +619,7 @@ async def start_fake_graph() -> tuple[FakeGraph, "GraphServer", web.AppRunner]:
     app.router.add_route("*", "/{tail:.*}", server.handle)
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.TCPSite(runner, BIND_HOST, 0)
     await site.start()
     port = site._server.sockets[0].getsockname()[1]
     state.base = f"http://127.0.0.1:{port}"

--- a/integ/server/onedrive_server.py
+++ b/integ/server/onedrive_server.py
@@ -76,10 +76,20 @@ def _parse_range(header: str | None, size: int) -> tuple[int, int]:
 class FakeGraph:
 
     def __init__(self, key: str = "default") -> None:
+        # `key` and `base` describe which workspace this is and where it
+        # is listening, not what it holds, so `reset` leaves them alone.
         self.key = key
+        self.base = ""
+        self.reset()
+
+    def reset(self) -> None:
+        """The state the process starts in, and what `POST /reset` restores.
+
+        Written here rather than inline in `__init__` so the two cannot
+        drift: a field added to the launch state is reset by construction.
+        """
         self.files: dict[str, dict] = {}
         self.dirs: set[str] = {""}
-        self.base = ""
         self._seq = 0
 
     def _tag(self) -> str:
@@ -274,13 +284,42 @@ class GraphServer:
 
     def __init__(self, state: FakeGraph) -> None:
         self.state = state
-        self.drives: dict[str, FakeGraph] = {state.key: state}
-        self.site_drives: list[str] = [state.key]
+        self._fresh()
+
+    def _fresh(self) -> None:
+        """Put the server's own state back to what construction gives it.
+
+        Deliberately does not touch `self.state`: a caller that seeded the
+        drive before handing it over would not expect the constructor to
+        empty it. `reset` resets both, because that is what a caller asking
+        for a reset means.
+        """
+        self.drives: dict[str, FakeGraph] = {self.state.key: self.state}
+        self.site_drives: list[str] = [self.state.key]
         self.uploads: dict[str, dict] = {}
         self.monitors: dict[str, dict] = {}
         self.calls: Counter = Counter()
         self._upload_seq = 0
         self._monitor_seq = 0
+
+    async def reset(self, request: web.Request) -> web.Response:
+        """Drop every write since startup. Mirrors `POST /reset` on the
+        other fakes: same path, same empty body, same `{"ok": true}`.
+
+        Args:
+            request (web.Request): the incoming request.
+
+        Returns:
+            web.Response: 200 once the launch state is back.
+        """
+        del request
+        # Both halves: the server holds more than the default drive does --
+        # the drives added since launch, the open upload sessions, the
+        # monitors -- so resetting the drive alone would leave a SharePoint
+        # drive created by the previous run still discoverable.
+        self.state.reset()
+        self._fresh()
+        return web.json_response({"ok": True})
 
     def add_drive(self, key: str) -> FakeGraph:
         g = FakeGraph(key)
@@ -616,6 +655,7 @@ async def start_fake_graph() -> tuple[FakeGraph, "GraphServer", web.AppRunner]:
     # Real Graph accepts simple PUTs up to 4 MiB; aiohttp's default
     # client_max_size (1 MiB) would 413 them before the handler runs.
     app = web.Application(client_max_size=8 * 1024 * 1024)
+    app.router.add_post("/reset", server.reset)
     app.router.add_route("*", "/{tail:.*}", server.handle)
     runner = web.AppRunner(app)
     await runner.setup()

--- a/integ/server/slack.ts
+++ b/integ/server/slack.ts
@@ -35,6 +35,17 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { PrismaClient } from '@prisma/client'
 
+// The interface the fake listens on. Loopback is right on a developer's
+// machine and wrong inside a container: a server on the container's own
+// 127.0.0.1 is invisible to the published port, so a client on the host has
+// its connection accepted and then closed with no response -- while a
+// healthcheck running inside the container sees a healthy server. Set
+// MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+//
+// The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+// interface to listen on, not an address anything can connect to.
+const BIND_HOST = process.env.MIRAGE_BIND_HOST ?? '127.0.0.1'
+
 const HERE = dirname(fileURLToPath(import.meta.url))
 const SCHEMA = join(HERE, '..', 'prisma', 'schema.prisma')
 const FIXTURE_DIR = join(HERE, '..', 'fixtures', 'slack')
@@ -795,7 +806,7 @@ export async function startServer(port: number): Promise<http.Server> {
     })
   })
   return new Promise((resolve) => {
-    server.listen(port, '127.0.0.1', () => resolve(server))
+    server.listen(port, BIND_HOST, () => resolve(server))
   })
 }
 

--- a/integ/server/ssh_server.py
+++ b/integ/server/ssh_server.py
@@ -15,9 +15,21 @@
 import argparse
 import asyncio
 import functools
+import os
 import tempfile
 
 import asyncssh
+
+# The interface the fake listens on. Loopback is right on a developer's
+# machine and wrong inside a container: a server on the container's own
+# 127.0.0.1 is invisible to the published port, so a client on the host has
+# its connection accepted and then closed with no response -- while a
+# healthcheck running inside the container sees a healthy server. Set
+# MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+#
+# The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+# interface to listen on, not an address anything can connect to.
+BIND_HOST = os.environ.get("MIRAGE_BIND_HOST", "127.0.0.1")
 
 
 class NoAuthServer(asyncssh.SSHServer):
@@ -41,7 +53,7 @@ async def start_server(root: str, port: int = 0) -> asyncssh.SSHAcceptor:
     """
     host_key = asyncssh.generate_private_key("ssh-ed25519")
     return await asyncssh.listen(
-        "127.0.0.1",
+        BIND_HOST,
         port,
         server_host_keys=[host_key],
         server_factory=NoAuthServer,

--- a/integ/server/trello.ts
+++ b/integ/server/trello.ts
@@ -29,6 +29,17 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { PrismaClient } from '@prisma/client'
 
+// The interface the fake listens on. Loopback is right on a developer's
+// machine and wrong inside a container: a server on the container's own
+// 127.0.0.1 is invisible to the published port, so a client on the host has
+// its connection accepted and then closed with no response -- while a
+// healthcheck running inside the container sees a healthy server. Set
+// MIRAGE_BIND_HOST=0.0.0.0 wherever the client is outside the container.
+//
+// The advertised URLs below stay on 127.0.0.1 on purpose: 0.0.0.0 is an
+// interface to listen on, not an address anything can connect to.
+const BIND_HOST = process.env.MIRAGE_BIND_HOST ?? '127.0.0.1'
+
 const HERE = dirname(fileURLToPath(import.meta.url))
 const SCHEMA = join(HERE, '..', 'prisma', 'schema.prisma')
 const FIXTURE = join(HERE, '..', 'fixtures', 'trello', 'v1.json')
@@ -642,7 +653,7 @@ export async function startServer(port: number): Promise<http.Server> {
     })
   })
   return new Promise((resolve) => {
-    server.listen(port, '127.0.0.1', () => resolve(server))
+    server.listen(port, BIND_HOST, () => resolve(server))
   })
 }
 


### PR DESCRIPTION
The integ fakes are written for a developer's machine: they bind loopback,
and each one clears its state a different way, or not at all. Both
assumptions break as soon as the fake runs in a container and the client
does not. Three commits, no behaviour change for existing callers.

## Let every integ fake bind an interface it is told about

A server on the container's own `127.0.0.1` is invisible to the published
port. docker-proxy accepts the connection and closes it with no response, so
the client sees `RemoteDisconnected` / `fetch failed` and a healthcheck
running *inside* the container sees a healthy server. Nothing in the failure
names the cause.

`MIRAGE_BIND_HOST` picks the interface, defaulting to `127.0.0.1` — so a
developer's machine is unchanged and a container sets one variable. 24 sites
across 16 files. The advertised URLs stay on `127.0.0.1` on purpose: `0.0.0.0`
is an interface to listen on, not an address anything connects to.

The constant is repeated per file rather than shared, because
`integ/runners/python/adapters.py:326` deliberately keeps `integ/server/` off
`sys.path` (`integ/redis.py` would shadow the `redis` package), which rules
out sibling imports among the fakes.

```
MIRAGE_BIND_HOST=0.0.0.0   listening on  *:51582
MIRAGE_BIND_HOST=(unset)   listening on  127.0.0.1:51585
```

## Give every integ fake the same POST /reset

Eight fakes had `/reset`; eight did not, so a caller driving a mix of them
needed a different teardown per fake — restart the process, rebuild the
object, or reach into its internals. Now all sixteen answer the same route
with the same empty body.

Where a fake's launch state was written inline in `__init__`, it moved into
`reset()` and `__init__` calls it, so the two cannot drift: a field added to
the launch state is reset by construction.

`onedrive_server.py` needed a split rather than a move. `GraphServer` holds
both its own state and a `FakeGraph` handed in by the caller, and a
constructor that emptied the caller's seeded drive would be a trap, so
`_fresh()` resets only what the server owns and `reset()` resets both — which
is what a caller asking for a reset means.

```
box          2 items      -> 1
databricks   1 file       -> 0
onedrive     2 drives/1 f -> 1/0
dropbox.ts   2 entries    -> 0   200 {"ok":true}
```

## Let github's reset take the seed, like notion's already does

`notion_server.ts` already accepts a seed on `/reset`; github rebuilt from
whatever it was launched with, so re-seeding it meant restarting the process
with different arguments. It now takes `repo` / `metadata` / `commits` in the
body, keeps the previous seed when the body is empty, and 400s on a body that
is not an object.

```
launch A -> empty reset keeps A -> reset+B swaps to B -> empty replays B -> bad body 400
```

## Verification

- **987 Python tests pass, 0 failures**, across all fourteen suites covering a
  changed server (`onedrive github box dropbox databricks_volume hf_buckets
  mem0 linear discord dify slack trello notion ssh`).
- All five TS servers load; `dropbox.ts` reset exercised end to end (above),
  since it has no unit-test coverage.
- Bind and reset both proved live rather than by inspection.
- `pre-commit` clean.

## Two things for a maintainer, not fixed here

**`integ/server/*.ts` is checked by nothing.** Five of the files in this PR
are TypeScript, and no tool reads them:

- `typescript/package.json` — `"typecheck": "pnpm -r --filter './packages/*' typecheck"`, which excludes integ
- `.pre-commit-config.yaml` — the prettier/eslint/knip hooks are scoped `files: ^typescript/.*`
- `integ/package.json` has no typecheck script, and there is no tsconfig under `integ/`

They are installed, then run by `tsx`. Earlier in this branch a malformed
`import {` in `dropbox.ts` passed every hook; the pre-commit run on this PR
still reports "no files to check" for all four TS hooks.

**`/reset` shares the port the client uses.** Low severity and pre-existing —
it was already true of the eight fakes that had the route, and a client can
usually destroy the same state through ordinary calls anyway. It matters a
little more now that it is on sixteen fakes, that notion exempts it from the
bearer check by design, and that github's reset restores a seeded state rather
than an obviously-empty one. If anyone wants it closed, a shared-secret header
on the reset handler is a few lines per fake; a separate control port would be
overkill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
