### PR TITLE
docs(policy): state the pre_ops op-door boundary and pin it

### DIFF
--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -924,8 +924,8 @@ def with_write_guards(fn: OperationFn) -> OperationFn:
     guarded: OperationFn = functools.partial(_mode_call, fn, False, False)
     guarded = functools.partial(_rule_call, guarded)
     guarded = functools.partial(_guarded_call, guarded, False)
-    return functools.partial(_policy_call, (None, ""), guarded, "unlink", True,
-                             False)
+    return functools.partial(_policy_call, _UNBOUND_SCOPE, guarded, "unlink",
+                             True, False)
 
 
 # slot -> (write, first_is_source): whether the op mutates its PathSpec
@@ -951,9 +951,15 @@ _POLICY_SLOTS: dict[str, tuple[bool, bool]] = {
     "dir_copy": (True, True),
 }
 
+# (policies, mount prefix, session id); the unbound spelling for a
+# registration-time wrap, which reads the live context per call.
+_PolicyScope = tuple[Policies | None, str, str]
+_UNBOUND_SCOPE: _PolicyScope = (None, "", "")
 
-def _op_policy_scope() -> tuple[Policies | None, str]:
-    """The policies to consult for this op call, and the mount prefix.
+
+def _op_policy_scope() -> _PolicyScope:
+    """The policies to consult for this op call, the mount prefix, and
+    the session the command runs under.
 
     None is the fast path: no dispatched command bound policies, or
     none of them override pre_ops, at the cost of two contextvar reads
@@ -961,38 +967,42 @@ def _op_policy_scope() -> tuple[Policies | None, str]:
     """
     policies = get_op_policies()
     if policies is None or not policies.wants("pre_ops"):
-        return None, ""
+        return _UNBOUND_SCOPE
     gate = get_mount_gate()
-    return policies, gate[0] if gate is not None else ""
+    sess = get_current_session()
+    return (policies, gate[0] if gate is not None else "",
+            sess.session_id if sess is not None else "")
 
 
-def _live_policy_scope(
-        scope: tuple[Policies | None, str]) -> tuple[Policies | None, str]:
+def _live_policy_scope(scope: _PolicyScope) -> _PolicyScope:
     """The wrap-time scope when it caught a bound command, else the
     call-time context.
 
     The factory applies the guard inside the command's window, so its
     wrap-time capture also covers a reader the output pipeline drains
     after dispatch has reset the context (head/tail/wc bind lazy
-    readers); a registration-time wrap (the object-store overrides,
+    readers), with the prefix and session identity the drained op
+    belongs to; a registration-time wrap (the object-store overrides,
     the loose-write chain) has no window when applied and reads the
     live context instead, which its eager handlers are inside.
 
     Args:
-        scope (tuple[Policies | None, str]): the wrap-time capture.
+        scope (_PolicyScope): the wrap-time capture.
     """
     if scope[0] is not None:
         return scope
     return _op_policy_scope()
 
 
-async def _policy_admit(policies: Policies, prefix: str, op: str, write: bool,
-                        first_source: bool, args: tuple[Any, ...]) -> None:
+async def _policy_admit(policies: Policies, prefix: str, session_id: str,
+                        op: str, write: bool, first_source: bool,
+                        args: tuple[Any, ...]) -> None:
     """Fire pre_ops for each PathSpec positional of one slot call.
 
     Args:
         policies (Policies): the bound admission policies.
         prefix (str): the executing mount's prefix, "" outside one.
+        session_id (str): the session the command runs under.
         op (str): the slot name, which is the op name policies see.
         write (bool): whether the op mutates its paths.
         first_source (bool): whether the leading PathSpec is a
@@ -1003,12 +1013,12 @@ async def _policy_admit(policies: Policies, prefix: str, op: str, write: bool,
     for arg in args:
         if isinstance(arg, PathSpec):
             mutates = write and not (first and first_source)
-            await pre_ops_gate(policies, op, arg, mutates, prefix)
+            await pre_ops_gate(policies, op, arg, mutates, prefix, session_id)
             first = False
 
 
-async def _policy_call(scope: tuple[Policies | None, str], fn: OperationFn,
-                       op: str, write: bool, first_source: bool, *args: Any,
+async def _policy_call(scope: _PolicyScope, fn: OperationFn, op: str,
+                       write: bool, first_source: bool, *args: Any,
                        **kwargs: Any) -> Any:
     """Call a backend op after admitting its paths through pre_ops.
 
@@ -1018,7 +1028,7 @@ async def _policy_call(scope: tuple[Policies | None, str], fn: OperationFn,
     wrappers.
 
     Args:
-        scope (tuple[Policies | None, str]): the wrap-time capture.
+        scope (_PolicyScope): the wrap-time capture.
         fn (OperationFn): the guarded backend op.
         op (str): the slot name.
         write (bool): whether the op mutates its paths.
@@ -1027,33 +1037,35 @@ async def _policy_call(scope: tuple[Policies | None, str], fn: OperationFn,
         *args: the call's positionals, PathSpecs among them.
         **kwargs: forwarded untouched.
     """
-    policies, prefix = _live_policy_scope(scope)
+    policies, prefix, session_id = _live_policy_scope(scope)
     if policies is not None:
-        await _policy_admit(policies, prefix, op, write, first_source, args)
+        await _policy_admit(policies, prefix, session_id, op, write,
+                            first_source, args)
     return await fn(*args, **kwargs)
 
 
-async def _policy_readdir(scope: tuple[Policies | None, str], fn: OperationFn,
-                          *args: Any, **kwargs: Any) -> list[str]:
+async def _policy_readdir(scope: _PolicyScope, fn: OperationFn, *args: Any,
+                          **kwargs: Any) -> list[str]:
     """Readdir admitted through pre_ops for the directory it lists.
 
     Args:
-        scope (tuple[Policies | None, str]): the wrap-time capture.
+        scope (_PolicyScope): the wrap-time capture.
         fn (OperationFn): the guarded backend readdir.
         *args: the call's positionals; the first PathSpec is the
             directory being listed.
         **kwargs: forwarded untouched.
     """
-    policies, prefix = _live_policy_scope(scope)
+    policies, prefix, session_id = _live_policy_scope(scope)
     if policies is not None:
         parent_spec = next(a for a in args if isinstance(a, PathSpec))
-        await pre_ops_gate(policies, "readdir", parent_spec, False, prefix)
+        await pre_ops_gate(policies, "readdir", parent_spec, False, prefix,
+                           session_id)
     entries: list[str] = await fn(*args, **kwargs)
     return entries
 
 
-def _policy_stream(scope: tuple[Policies | None, str], fn: OperationFn, *args:
-                   Any, **kwargs: Any) -> Any:
+def _policy_stream(scope: _PolicyScope, fn: OperationFn, *args: Any,
+                   **kwargs: Any) -> Any:
     """Read-stream admitted through pre_ops before the first chunk.
 
     A plain def for the reason ``_guarded_read_stream`` is one: the
@@ -1063,32 +1075,35 @@ def _policy_stream(scope: tuple[Policies | None, str], fn: OperationFn, *args:
     generator, before any byte is pulled.
 
     Args:
-        scope (tuple[Policies | None, str]): the wrap-time capture.
+        scope (_PolicyScope): the wrap-time capture.
         fn (OperationFn): the guarded backend read_stream.
         *args: the call's positionals; the first PathSpec is the file
             being read.
         **kwargs: forwarded untouched.
     """
-    policies, prefix = _live_policy_scope(scope)
+    policies, prefix, session_id = _live_policy_scope(scope)
     spec = next((a for a in args if isinstance(a, PathSpec)), None)
     if policies is None or spec is None:
         return fn(*args, **kwargs)
-    return _policy_stream_drain(policies, prefix, spec, fn(*args, **kwargs))
+    return _policy_stream_drain(policies, prefix, session_id, spec,
+                                fn(*args, **kwargs))
 
 
 async def _policy_stream_drain(
-        policies: Policies, prefix: str, path: PathSpec,
+        policies: Policies, prefix: str, session_id: str, path: PathSpec,
         source: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
     """Drain ``source`` once the read is admitted; close it if refused.
 
     Args:
         policies (Policies): the bound admission policies.
         prefix (str): the executing mount's prefix.
+        session_id (str): the session the command runs under.
         path (PathSpec): the file being read.
         source (AsyncIterator[bytes]): the not-yet-started inner stream.
     """
     try:
-        await pre_ops_gate(policies, "read_stream", path, False, prefix)
+        await pre_ops_gate(policies, "read_stream", path, False, prefix,
+                           session_id)
     except BaseException:
         close = getattr(source, "aclose", None)
         if close is not None:
@@ -1112,8 +1127,9 @@ def with_policy_guard(ops: CommandIO) -> CommandIO:
     while the read of it is what fails. Ops are named by slot; a
     policy portable across the tiers keys on ``write`` and ``path``.
     Inert unless a dispatched command bound policies overriding
-    pre_ops (``_op_policy_scope``, captured at wrap time so a lazily
-    drained reader still answers, see ``_live_policy_scope``).
+    pre_ops (``_op_policy_scope``, with the mount prefix and session
+    identity captured at wrap time so a lazily drained reader still
+    answers as the command that bound it, see ``_live_policy_scope``).
 
     Args:
         ops (CommandIO): the backend's IO adapter.

--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -27,9 +27,10 @@ from mirage.commands.builtin.generic.du import (DEFAULT_MAX_DU_ENTRIES,
 from mirage.commands.config import CommandFnResult, CommandOpts, ProvisionFn
 from mirage.context import (effective_path_mode, get_admission,
                             get_current_session, get_mount_gate,
-                            hidden_paths_intersect, path_allowed,
-                            readonly_below)
+                            get_op_policies, hidden_paths_intersect,
+                            path_allowed, readonly_below)
 from mirage.ops.types import ChildMounts, StatOverlay
+from mirage.policy.policies import Policies, pre_ops_gate
 from mirage.types import FileStat, FileType, MountMode, PathSpec
 from mirage.utils.errors import MISS_ERRORS, ReadOnlyError, eisdir
 from mirage.utils.glob_walk import DEFAULT_MAX_GLOB_MATCHES, make_resolve_glob
@@ -914,14 +915,221 @@ def with_write_guards(fn: OperationFn) -> OperationFn:
     ``CommandIO`` (the google ``rm`` family binds an index-threaded
     unlink): the same chain in the same order, judging the call's
     PathSpec positionals. A hidden path answers ENOENT, the flavor of
-    the flat mutation slots.
+    the flat mutation slots. The policy arm rides outermost, as it does
+    on the slot chain.
 
     Args:
         fn (OperationFn): the raw backend write.
     """
     guarded: OperationFn = functools.partial(_mode_call, fn, False, False)
     guarded = functools.partial(_rule_call, guarded)
-    return functools.partial(_guarded_call, guarded, False)
+    guarded = functools.partial(_guarded_call, guarded, False)
+    return functools.partial(_policy_call, (None, ""), guarded, "unlink", True,
+                             False)
+
+
+# slot -> (write, first_is_source): whether the op mutates its PathSpec
+# positionals, and whether the leading one is a read-only source (the
+# copy slots), mirroring _MODE_SLOTS' skip_first. The surface is the
+# rule guard's (_RULE_SLOTS); stat/exists and the native find/du slots
+# stay unguarded as presence facts, and readdir/read_stream have their
+# own wrappers below.
+_POLICY_SLOTS: dict[str, tuple[bool, bool]] = {
+    "read_bytes": (False, False),
+    "read_range": (False, False),
+    "write": (True, False),
+    "append": (True, False),
+    "create": (True, False),
+    "truncate": (True, False),
+    "set_attrs": (True, False),
+    "mkdir": (True, False),
+    "unlink": (True, False),
+    "rmdir": (True, False),
+    "rm_r": (True, False),
+    "rename": (True, False),
+    "copy": (True, True),
+    "dir_copy": (True, True),
+}
+
+
+def _op_policy_scope() -> tuple[Policies | None, str]:
+    """The policies to consult for this op call, and the mount prefix.
+
+    None is the fast path: no dispatched command bound policies, or
+    none of them override pre_ops, at the cost of two contextvar reads
+    and one O(1) probe per slot call.
+    """
+    policies = get_op_policies()
+    if policies is None or not policies.wants("pre_ops"):
+        return None, ""
+    gate = get_mount_gate()
+    return policies, gate[0] if gate is not None else ""
+
+
+def _live_policy_scope(
+        scope: tuple[Policies | None, str]) -> tuple[Policies | None, str]:
+    """The wrap-time scope when it caught a bound command, else the
+    call-time context.
+
+    The factory applies the guard inside the command's window, so its
+    wrap-time capture also covers a reader the output pipeline drains
+    after dispatch has reset the context (head/tail/wc bind lazy
+    readers); a registration-time wrap (the object-store overrides,
+    the loose-write chain) has no window when applied and reads the
+    live context instead, which its eager handlers are inside.
+
+    Args:
+        scope (tuple[Policies | None, str]): the wrap-time capture.
+    """
+    if scope[0] is not None:
+        return scope
+    return _op_policy_scope()
+
+
+async def _policy_admit(policies: Policies, prefix: str, op: str, write: bool,
+                        first_source: bool, args: tuple[Any, ...]) -> None:
+    """Fire pre_ops for each PathSpec positional of one slot call.
+
+    Args:
+        policies (Policies): the bound admission policies.
+        prefix (str): the executing mount's prefix, "" outside one.
+        op (str): the slot name, which is the op name policies see.
+        write (bool): whether the op mutates its paths.
+        first_source (bool): whether the leading PathSpec is a
+            read-only source (the copy slots).
+        args: the call's positionals, PathSpecs among them.
+    """
+    first = True
+    for arg in args:
+        if isinstance(arg, PathSpec):
+            mutates = write and not (first and first_source)
+            await pre_ops_gate(policies, op, arg, mutates, prefix)
+            first = False
+
+
+async def _policy_call(scope: tuple[Policies | None, str], fn: OperationFn,
+                       op: str, write: bool, first_source: bool, *args: Any,
+                       **kwargs: Any) -> Any:
+    """Call a backend op after admitting its paths through pre_ops.
+
+    Async, unlike the sync guards it wraps: the hooks are user
+    coroutines. Every slot this wraps returns an awaitable, so the
+    shape is preserved; read_stream and readdir have their own
+    wrappers.
+
+    Args:
+        scope (tuple[Policies | None, str]): the wrap-time capture.
+        fn (OperationFn): the guarded backend op.
+        op (str): the slot name.
+        write (bool): whether the op mutates its paths.
+        first_source (bool): whether the leading PathSpec is a
+            read-only source.
+        *args: the call's positionals, PathSpecs among them.
+        **kwargs: forwarded untouched.
+    """
+    policies, prefix = _live_policy_scope(scope)
+    if policies is not None:
+        await _policy_admit(policies, prefix, op, write, first_source, args)
+    return await fn(*args, **kwargs)
+
+
+async def _policy_readdir(scope: tuple[Policies | None, str], fn: OperationFn,
+                          *args: Any, **kwargs: Any) -> list[str]:
+    """Readdir admitted through pre_ops for the directory it lists.
+
+    Args:
+        scope (tuple[Policies | None, str]): the wrap-time capture.
+        fn (OperationFn): the guarded backend readdir.
+        *args: the call's positionals; the first PathSpec is the
+            directory being listed.
+        **kwargs: forwarded untouched.
+    """
+    policies, prefix = _live_policy_scope(scope)
+    if policies is not None:
+        parent_spec = next(a for a in args if isinstance(a, PathSpec))
+        await pre_ops_gate(policies, "readdir", parent_spec, False, prefix)
+    entries: list[str] = await fn(*args, **kwargs)
+    return entries
+
+
+def _policy_stream(scope: tuple[Policies | None, str], fn: OperationFn, *args:
+                   Any, **kwargs: Any) -> Any:
+    """Read-stream admitted through pre_ops before the first chunk.
+
+    A plain def for the reason ``_guarded_read_stream`` is one: the
+    inner op captures per-call scope eagerly (the read-through cache
+    reads the active manager here), so it is built now, which runs no
+    I/O; the admission itself is async, so it rides the returned
+    generator, before any byte is pulled.
+
+    Args:
+        scope (tuple[Policies | None, str]): the wrap-time capture.
+        fn (OperationFn): the guarded backend read_stream.
+        *args: the call's positionals; the first PathSpec is the file
+            being read.
+        **kwargs: forwarded untouched.
+    """
+    policies, prefix = _live_policy_scope(scope)
+    spec = next((a for a in args if isinstance(a, PathSpec)), None)
+    if policies is None or spec is None:
+        return fn(*args, **kwargs)
+    return _policy_stream_drain(policies, prefix, spec, fn(*args, **kwargs))
+
+
+async def _policy_stream_drain(
+        policies: Policies, prefix: str, path: PathSpec,
+        source: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+    """Drain ``source`` once the read is admitted; close it if refused.
+
+    Args:
+        policies (Policies): the bound admission policies.
+        prefix (str): the executing mount's prefix.
+        path (PathSpec): the file being read.
+        source (AsyncIterator[bytes]): the not-yet-started inner stream.
+    """
+    try:
+        await pre_ops_gate(policies, "read_stream", path, False, prefix)
+    except BaseException:
+        close = getattr(source, "aclose", None)
+        if close is not None:
+            await close()
+        raise
+    async for chunk in source:
+        yield chunk
+
+
+def with_policy_guard(ops: CommandIO) -> CommandIO:
+    """Return ``ops`` whose content and mutation slots admit each
+    PathSpec through the workspace's coded pre_ops hooks.
+
+    The coded-policy arm of the guard chain, applied outside the cache
+    wraps so admission fires before a warm serve, the dispatcher's own
+    order. The surface is the rule guard's plus readdir: content reads
+    (read_bytes, read_stream, read_range), every mutation slot, and
+    the directory a readdir lists. stat/exists and the native find/du
+    slots stay unguarded as presence facts, the mode-000 shape the
+    rule guard already states, so a denied entry still lists and stats
+    while the read of it is what fails. Ops are named by slot; a
+    policy portable across the tiers keys on ``write`` and ``path``.
+    Inert unless a dispatched command bound policies overriding
+    pre_ops (``_op_policy_scope``, captured at wrap time so a lazily
+    drained reader still answers, see ``_live_policy_scope``).
+
+    Args:
+        ops (CommandIO): the backend's IO adapter.
+    """
+    scope = _op_policy_scope()
+    changes: dict[str, Any] = {
+        "readdir": functools.partial(_policy_readdir, scope, ops.readdir),
+        "read_stream": functools.partial(_policy_stream, scope,
+                                         ops.read_stream),
+    }
+    for slot, (write, first_source) in _POLICY_SLOTS.items():
+        fn = getattr(ops, slot)
+        if fn is not None:
+            changes[slot] = functools.partial(_policy_call, scope, fn, slot,
+                                              write, first_source)
+    return replace(ops, **changes)
 
 
 async def _is_implicit_dir(ops: CommandIO, accessor: Accessor, path: PathSpec,

--- a/python/mirage/commands/builtin/generic_bind/factory.py
+++ b/python/mirage/commands/builtin/generic_bind/factory.py
@@ -24,7 +24,8 @@ from mirage.cache.read_through import (cache_aware_read_bytes,
                                        cache_aware_read_stream)
 from mirage.commands.builtin.generic_bind.adapter import (CommandIO,
                                                           with_dir_guard,
-                                                          with_path_guards)
+                                                          with_path_guards,
+                                                          with_policy_guard)
 from mirage.commands.builtin.generic_bind.builders import _BUILDERS
 from mirage.commands.builtin.generic_bind.provision import default_provision
 from mirage.commands.config import CommandOpts, command
@@ -215,7 +216,11 @@ async def _run_with_namespace_globs(ops: CommandIO,
     """
     children = opts.ns.child_mounts if opts.ns is not None else None
     stamped = replace(ops, glob_children=children)
-    bound = with_dir_guard(finish(with_path_guards(stamped)))
+    # The policy guard sits outside the cache wraps (`finish`) so a
+    # coded pre_ops deny fires before a warm serve, the dispatcher's
+    # own order at the op door.
+    bound = with_dir_guard(with_policy_guard(finish(
+        with_path_guards(stamped))))
     return await fn(bound, accessor, paths, texts, opts)
 
 

--- a/python/mirage/commands/builtin/object_store/__init__.py
+++ b/python/mirage/commands/builtin/object_store/__init__.py
@@ -16,7 +16,8 @@ from collections.abc import Callable
 from typing import Any
 
 from mirage.commands.builtin.generic_bind.adapter import (CommandIO,
-                                                          with_path_guards)
+                                                          with_path_guards,
+                                                          with_policy_guard)
 from mirage.commands.builtin.object_store.mkdir import make_mkdir
 from mirage.commands.builtin.object_store.rm import make_rm
 from mirage.commands.builtin.object_store.stat import make_stat
@@ -34,15 +35,16 @@ def make_object_store_commands(resource: str,
     """Build the five keyed-store command overrides for one backend.
 
     The op table is wrapped with the same hidden/rule/mode chain the
-    factory gives every generic command, so an override enforces the
-    session's path axis exactly like the generic it replaces.
+    factory gives every generic command, the policy guard outermost as
+    there, so an override enforces the session's path axis and the
+    coded op policies exactly like the generic it replaces.
 
     Args:
         resource (str): resource name the commands register under.
         io (CommandIO): the backend's op table; must wire the write-side
             slots the overrides consume.
     """
-    io = with_path_guards(io)
+    io = with_policy_guard(with_path_guards(io))
     return [
         make_mkdir(resource, io),
         make_rm(resource, io),

--- a/python/mirage/context/__init__.py
+++ b/python/mirage/context/__init__.py
@@ -15,12 +15,13 @@
 from mirage.context.session_context import (  # isort: skip
     DEFAULT_UMASK, dotglob_active, effective_mount_mode, effective_path_mode,
     get_admission, get_current_session, get_current_session_for,
-    get_mount_gate, hidden_paths_active, hidden_paths_intersect, path_allowed,
-    path_rules_active, readonly_below, redirect_paths_for,
-    redirect_target_judged, require_mount_writable, reset_admission,
-    reset_current_session, reset_mount_gate, reset_redirect_paths,
-    session_path_allowed, session_umask, set_admission, set_current_session,
-    set_mount_gate, set_redirect_paths, strongest_mode_under)
+    get_mount_gate, get_op_policies, hidden_paths_active,
+    hidden_paths_intersect, path_allowed, path_rules_active, readonly_below,
+    redirect_paths_for, redirect_target_judged, require_mount_writable,
+    reset_admission, reset_current_session, reset_mount_gate,
+    reset_op_policies, reset_redirect_paths, session_path_allowed,
+    session_umask, set_admission, set_current_session, set_mount_gate,
+    set_op_policies, set_redirect_paths, strongest_mode_under)
 
 __all__ = [
     "DEFAULT_UMASK",
@@ -31,6 +32,7 @@ __all__ = [
     "get_current_session",
     "get_current_session_for",
     "get_mount_gate",
+    "get_op_policies",
     "hidden_paths_active",
     "hidden_paths_intersect",
     "path_allowed",
@@ -41,6 +43,7 @@ __all__ = [
     "require_mount_writable",
     "reset_admission",
     "reset_mount_gate",
+    "reset_op_policies",
     "reset_redirect_paths",
     "session_path_allowed",
     "session_umask",
@@ -48,6 +51,7 @@ __all__ = [
     "set_admission",
     "set_current_session",
     "set_mount_gate",
+    "set_op_policies",
     "set_redirect_paths",
     "strongest_mode_under",
 ]

--- a/python/mirage/context/__init__.py
+++ b/python/mirage/context/__init__.py
@@ -21,7 +21,8 @@ from mirage.context.session_context import (  # isort: skip
     reset_admission, reset_current_session, reset_mount_gate,
     reset_op_policies, reset_redirect_paths, session_path_allowed,
     session_umask, set_admission, set_current_session, set_mount_gate,
-    set_op_policies, set_redirect_paths, strongest_mode_under)
+    set_op_policies, set_redirect_paths, strongest_mode_under,
+    suspend_op_policies)
 
 __all__ = [
     "DEFAULT_UMASK",
@@ -54,4 +55,5 @@ __all__ = [
     "set_op_policies",
     "set_redirect_paths",
     "strongest_mode_under",
+    "suspend_op_policies",
 ]

--- a/python/mirage/context/session_context.py
+++ b/python/mirage/context/session_context.py
@@ -24,6 +24,7 @@ from mirage.utils.hidden import (anchor_depth, hides_intersect, is_glob,
                                  path_visible, show_head, shown_mode)
 
 if TYPE_CHECKING:
+    from mirage.policy.policies import Policies
     from mirage.workspace.session.manager import SessionManager
     from mirage.workspace.session.session import Session
 
@@ -248,6 +249,39 @@ def get_admission() -> "EntryGate | None":
     when no admitted command is bound (a command constructed outside
     the dispatcher, or a line no gate judged)."""
     return _current_admission.get()
+
+
+_op_policies: ContextVar["Policies | None"] = ContextVar(
+    "mirage_op_policies",
+    default=None,
+)
+
+
+def set_op_policies(policies: "Policies") -> Token[Any]:
+    """Bind the workspace's admission policies to the current async
+    context, for the run of one command.
+
+    Set by command dispatch around routing, the same window the
+    admission gate binds in, so the command tier's policy guard can
+    fire ``pre_ops`` for the backend I/O a handler performs. Read at
+    call time by ``with_policy_guard``; unset outside a dispatched
+    command (a generic invoked directly in a test), where the guard
+    is inert.
+
+    Args:
+        policies (Policies): the workspace's admission policies.
+    """
+    return _op_policies.set(policies)
+
+
+def reset_op_policies(token: Token[Any]) -> None:
+    """Restore the previous policies binding."""
+    _op_policies.reset(token)
+
+
+def get_op_policies() -> "Policies | None":
+    """The policies bound to the running command, None outside one."""
+    return _op_policies.get()
 
 
 _current_mount_gate: ContextVar[tuple[str, MountMode] | None] = ContextVar(

--- a/python/mirage/context/session_context.py
+++ b/python/mirage/context/session_context.py
@@ -274,6 +274,19 @@ def set_op_policies(policies: "Policies") -> Token[Any]:
     return _op_policies.set(policies)
 
 
+def suspend_op_policies() -> Token[Any]:
+    """Unbind the op policies for a delegated sub-command whose door
+    the caller has already cleared.
+
+    find's ``-delete`` admits each removal itself, in find's own
+    refusal voice, and then delegates the mutation to ``rm``; without
+    the suspension the delegated slot would admit the same deletion a
+    second time, so a counting or budget policy would see one removal
+    twice.
+    """
+    return _op_policies.set(None)
+
+
 def reset_op_policies(token: Token[Any]) -> None:
     """Restore the previous policies binding."""
     _op_policies.reset(token)

--- a/python/mirage/policy/base.py
+++ b/python/mirage/policy/base.py
@@ -35,22 +35,25 @@ class Policy:
         return None
 
     async def pre_ops(self, ctx: OpsContext) -> Action | None:
-        """Admit or refuse one VFS op at an op door.
+        """Admit or refuse one VFS op, at the op doors and on the
+        command tier's backend I/O.
 
         The doors are the dispatcher and the ops facade, which is also
         how FUSE, the runtime guests, ``find -delete`` and the warm
-        cache arrive: shell redirects and the namespace-routed commands
-        (touch/chmod/ln) clear this gate too. Backend I/O inside a
-        mount command's handler (cat, grep -r, sed -i, rm) does not
-        pass through here: such a line is admitted whole at
-        pre_command, and per-path control on that tier belongs to the
-        declarative permissions document, whose rules hold walks to
-        per-entry checks.
+        cache arrive; a mount command's handler (cat, grep -r, sed -i,
+        rm) admits each content read, mutation and readdir through the
+        same hook (``with_policy_guard``), before its own warm cache.
+        On that tier the op is named by adapter slot (read_bytes,
+        read_stream, rm_r, ...), so a policy portable across the tiers
+        keys on ``write`` and ``path``; stat/exists and native find/du
+        enumeration stay unguarded as presence facts (mode-000 shape: a
+        denied entry lists and stats, the read of it fails), and a
+        native subtree op (rm_r, dir_copy) admits as the one op the
+        backend performs.
 
         The hot path: fires per op (thousands under one recursive
-        cascade or FUSE walk), so keep the hook cheap; expensive
-        decisions belong at pre_command or precomputed into policy
-        state.
+        command), so keep the hook cheap; expensive decisions belong at
+        pre_command or precomputed into policy state.
 
         Args:
             ctx (OpsContext): the op about to run.
@@ -74,9 +77,10 @@ class Policy:
         """Observe one completed VFS op; a Deny suppresses its result,
         a Limit caps a byte-producing one.
 
-        Same coverage as pre_ops: the op doors only, never the backend
-        I/O inside a mount command's handler. The command tier's result
-        plane is post_execute, which bounds the finished line's output.
+        The op doors only, never the backend I/O inside a mount
+        command's handler (which admits through pre_ops but reports no
+        per-op result). The command tier's result plane is
+        post_execute, which bounds the finished line's output.
 
         Args:
             ctx (OpsResultContext): the op and its raw result.

--- a/python/mirage/policy/base.py
+++ b/python/mirage/policy/base.py
@@ -74,9 +74,12 @@ class Policy:
         """Observe one completed VFS op; a Deny suppresses its result,
         a Limit caps a byte-producing one.
 
-        Same coverage as pre_ops: the op doors only, never the backend
-        I/O inside a mount command's handler. The command tier's result
-        plane is post_execute, which bounds the finished line's output.
+        Narrower than pre_ops: the dispatcher and facade doors only,
+        never the backend I/O inside a mount command's handler, and not
+        ``find -delete``, which admits each deletion through pre_ops
+        and then routes into the command tier, so no per-op result
+        reports here. The command tier's result plane is post_execute,
+        which bounds the finished line's output.
 
         Args:
             ctx (OpsResultContext): the op and its raw result.

--- a/python/mirage/policy/base.py
+++ b/python/mirage/policy/base.py
@@ -35,11 +35,22 @@ class Policy:
         return None
 
     async def pre_ops(self, ctx: OpsContext) -> Action | None:
-        """Admit or refuse one VFS op, whatever door it entered.
+        """Admit or refuse one VFS op at an op door.
+
+        The doors are the dispatcher and the ops facade, which is also
+        how FUSE, the runtime guests, ``find -delete`` and the warm
+        cache arrive: shell redirects and the namespace-routed commands
+        (touch/chmod/ln) clear this gate too. Backend I/O inside a
+        mount command's handler (cat, grep -r, sed -i, rm) does not
+        pass through here: such a line is admitted whole at
+        pre_command, and per-path control on that tier belongs to the
+        declarative permissions document, whose rules hold walks to
+        per-entry checks.
 
         The hot path: fires per op (thousands under one recursive
-        command), so keep the hook cheap; expensive decisions belong at
-        pre_command or precomputed into policy state.
+        cascade or FUSE walk), so keep the hook cheap; expensive
+        decisions belong at pre_command or precomputed into policy
+        state.
 
         Args:
             ctx (OpsContext): the op about to run.
@@ -62,6 +73,10 @@ class Policy:
     async def post_ops(self, ctx: OpsResultContext) -> Action | None:
         """Observe one completed VFS op; a Deny suppresses its result,
         a Limit caps a byte-producing one.
+
+        Same coverage as pre_ops: the op doors only, never the backend
+        I/O inside a mount command's handler. The command tier's result
+        plane is post_execute, which bounds the finished line's output.
 
         Args:
             ctx (OpsResultContext): the op and its raw result.

--- a/python/mirage/workspace/executor/find_action_dispatch.py
+++ b/python/mirage/workspace/executor/find_action_dispatch.py
@@ -13,7 +13,8 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.commands.spec.types import FlagValue
-from mirage.context import get_current_session
+from mirage.context import (get_current_session, reset_op_policies,
+                            suspend_op_policies)
 from mirage.io.stream import materialize
 from mirage.io.types import ByteSource
 from mirage.ops.types import ChildMounts, NamespaceView, StatPath
@@ -89,16 +90,24 @@ async def _apply_find_actions(
                 # command rule sees it; it is a removal all the same, so
                 # it clears the op door a path rule guards (the same
                 # gate `ws.ops`, FUSE and a redirect clear), by the
-                # session the line runs under. -d so directories emptied
-                # by the deepest-first pass are removable, matching GNU
+                # session the line runs under, and a refusal reports in
+                # find's voice. The delegated rm's own slots are
+                # suspended for the call, so the deletion admits
+                # exactly once. -d so directories emptied by the
+                # deepest-first pass are removable, matching GNU
                 # -delete's rmdir behavior.
                 sess = get_current_session()
                 await pre_ops_gate(registry.policies, "unlink", ps, True,
                                    mount.prefix,
                                    sess.session_id if sess is not None else "")
-                _, rm_io = await mount.execute_cmd("rm", [ps], [], {"d": True},
-                                                   stdin=None,
-                                                   cwd=cwd)
+                token = suspend_op_policies()
+                try:
+                    _, rm_io = await mount.execute_cmd("rm", [ps], [],
+                                                       {"d": True},
+                                                       stdin=None,
+                                                       cwd=cwd)
+                finally:
+                    reset_op_policies(token)
             except (FileNotFoundError, NotADirectoryError, PermissionError,
                     ValueError) as exc:
                 # GNU words it with the errno text; a policy refusal

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -17,7 +17,8 @@ import dataclasses
 from typing import Any
 
 from mirage.commands.builtin.utils.limit import run_with_timeout
-from mirage.context import redirect_paths_for, reset_admission, set_admission
+from mirage.context import (redirect_paths_for, reset_admission,
+                            reset_op_policies, set_admission, set_op_policies)
 from mirage.io import IOResult
 from mirage.io.types import materialize
 from mirage.policy import PolicyDenied, resolve_limit
@@ -389,18 +390,27 @@ async def _run_argv(
     # ── run ────────────────────────────────────
     # The admitted command's gate is bound for its run and reset after,
     # so its own I/O can ask about the entries the gate did not see and
-    # a nested line binds its own (see ``Admitted``).
-    if admitted is None:
-        return await _route_argv(recurse, dispatch, registry, namespace,
-                                 execute_fn, argv, session, stdin, call_stack,
-                                 job_table, cancel, routing_decision, row)
-    token = set_admission(admitted)
+    # a nested line binds its own (see ``Admitted``). The workspace's
+    # policies bind in the same window, whether or not a gate judged the
+    # line, so the command tier's policy guard can fire pre_ops for the
+    # backend I/O a handler performs.
+    ptoken = set_op_policies(registry.policies)
     try:
-        return await _route_argv(recurse, dispatch, registry, namespace,
-                                 execute_fn, argv, session, stdin, call_stack,
-                                 job_table, cancel, routing_decision, row)
+        if admitted is None:
+            return await _route_argv(recurse, dispatch, registry, namespace,
+                                     execute_fn, argv, session, stdin,
+                                     call_stack, job_table, cancel,
+                                     routing_decision, row)
+        token = set_admission(admitted)
+        try:
+            return await _route_argv(recurse, dispatch, registry, namespace,
+                                     execute_fn, argv, session, stdin,
+                                     call_stack, job_table, cancel,
+                                     routing_decision, row)
+        finally:
+            reset_admission(token)
     finally:
-        reset_admission(token)
+        reset_op_policies(ptoken)
 
 
 async def _route_argv(

--- a/python/tests/commands/builtin/generic_bind/test_adapter.py
+++ b/python/tests/commands/builtin/generic_bind/test_adapter.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import dataclasses
 import errno
 
 import pytest
@@ -25,6 +26,7 @@ from mirage.commands.builtin.generic_bind.adapter import (CommandIO, Operation,
                                                           with_dir_guard)
 from mirage.commands.config import CommandOpts
 from mirage.ops.types import NamespaceView
+from mirage.policy import Action, Deny, OpsContext, Policy
 from mirage.types import ContentType, FileStat, FileType, PathSpec
 from mirage.utils.glob_walk import DEFAULT_MAX_GLOB_MATCHES
 
@@ -332,6 +334,172 @@ async def test_rule_guard_asks_the_bound_gate_and_leaves_stat_alone():
     assert ("read", "/data/locked/y") in calls
     assert ("rename", "/data/a", "/data/locked/y") not in calls
     assert ("rename", "/data/a", "/data/b") in calls
+
+
+class _SealedRead(Policy):
+    """Refuse reads of one path; record every op asked."""
+
+    def __init__(self, sealed: str) -> None:
+        self.sealed = sealed
+        self.asked: list[tuple[str, str, bool]] = []
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        self.asked.append((ctx.op, ctx.path.virtual, ctx.write))
+        if not ctx.write and ctx.path.virtual == self.sealed:
+            return Deny("sealed")
+        return None
+
+
+def _policy_probe_ops(calls: list[tuple[str, ...]]) -> CommandIO:
+    """A CommandIO whose slots record their calls; closures on `calls`."""
+
+    async def read_bytes(accessor, path, index=None):
+        calls.append(("read", path.virtual))
+        return b"x"
+
+    def read_stream(accessor, path, index=None):
+        return _probe_chunks(calls, path)
+
+    async def stat(accessor, path, index=None):
+        calls.append(("stat", path.virtual))
+        return FileStat(name="k",
+                        type=FileType.FILE,
+                        content=ContentType.TEXT,
+                        size=1)
+
+    async def readdir(accessor, path, index=None):
+        calls.append(("readdir", path.virtual))
+        return ["a"]
+
+    async def copy(accessor, src, dst):
+        calls.append(("copy", src.virtual, dst.virtual))
+
+    async def unlink(accessor, path, index=None):
+        calls.append(("unlink", path.virtual))
+
+    return CommandIO(readdir=readdir,
+                     read_bytes=read_bytes,
+                     read_stream=read_stream,
+                     stat=stat,
+                     is_mounted=lambda a: True,
+                     copy=copy,
+                     unlink=unlink)
+
+
+async def _probe_chunks(calls: list[tuple[str, ...]], path: PathSpec):
+    calls.append(("stream", path.virtual))
+    yield b"x"
+
+
+@pytest.mark.asyncio
+async def test_policy_guard_admits_slots_and_leaves_stat_alone():
+    from mirage.commands.builtin.generic_bind.adapter import with_policy_guard
+    from mirage.context import (reset_mount_gate, reset_op_policies,
+                                set_mount_gate, set_op_policies)
+    from mirage.policy.policies import Policies
+    from mirage.types import MountMode
+
+    calls: list[tuple[str, ...]] = []
+    raw = _policy_probe_ops(calls)
+    acc = NOOPAccessor()
+    # No binding: every slot runs as is, and no hook fires.
+    assert await with_policy_guard(raw).read_bytes(
+        acc, _spec("/data/secret")) == b"x"
+    calls.clear()
+
+    policy = _SealedRead("/data/secret")
+    ptoken = set_op_policies(Policies([policy]))
+    gtoken = set_mount_gate("/data", MountMode.WRITE)
+    try:
+        ops = with_policy_guard(raw)
+        with pytest.raises(PermissionError) as excinfo:
+            await ops.read_bytes(acc, _spec("/data/secret"))
+        assert excinfo.value.errno == errno.EACCES
+        assert ("read", "/data/secret") not in calls
+        # The stream gates before its first chunk.
+        with pytest.raises(PermissionError):
+            async for _ in ops.read_stream(acc, _spec("/data/secret")):
+                pass
+        assert ("stream", "/data/secret") not in calls
+        # stat is not a guarded slot: deny is present and refused.
+        assert (await ops.stat(acc, _spec("/data/secret"))).size == 1
+        # readdir asks about the directory it lists.
+        assert await ops.readdir(acc, _spec("/data/dir")) == ["a"]
+        # A copy's source is a read; its destination is a write.
+        await ops.copy(acc, _spec("/data/src"), _spec("/data/dst"))
+        # A write slot asks with write=True.
+        await ops.unlink(acc, _spec("/data/gone"))
+    finally:
+        reset_mount_gate(gtoken)
+        reset_op_policies(ptoken)
+    assert ("read_bytes", "/data/secret", False) in policy.asked
+    assert ("read_stream", "/data/secret", False) in policy.asked
+    assert ("readdir", "/data/dir", False) in policy.asked
+    assert ("copy", "/data/src", False) in policy.asked
+    assert ("copy", "/data/dst", True) in policy.asked
+    assert ("unlink", "/data/gone", True) in policy.asked
+    assert not any(op == "stat" for op, _, _ in policy.asked)
+
+
+@pytest.mark.asyncio
+async def test_policy_guard_wrap_time_capture_covers_late_drains():
+    # head/tail/wc bind lazy readers the pipeline drains after dispatch
+    # has reset the context; the guard captured at wrap time still
+    # answers (_live_policy_scope).
+    from mirage.commands.builtin.generic_bind.adapter import with_policy_guard
+    from mirage.context import (reset_mount_gate, reset_op_policies,
+                                set_mount_gate, set_op_policies)
+    from mirage.policy.policies import Policies
+    from mirage.types import MountMode
+
+    calls: list[tuple[str, ...]] = []
+    raw = _policy_probe_ops(calls)
+    acc = NOOPAccessor()
+    policy = _SealedRead("/data/secret")
+    ptoken = set_op_policies(Policies([policy]))
+    gtoken = set_mount_gate("/data", MountMode.WRITE)
+    try:
+        ops = with_policy_guard(raw)
+    finally:
+        reset_mount_gate(gtoken)
+        reset_op_policies(ptoken)
+    # Both the slot call and the drain happen outside the window now.
+    with pytest.raises(PermissionError):
+        async for _ in ops.read_stream(acc, _spec("/data/secret")):
+            pass
+    assert ("stream", "/data/secret") not in calls
+    with pytest.raises(PermissionError):
+        await ops.read_bytes(acc, _spec("/data/secret"))
+
+
+@pytest.mark.asyncio
+async def test_policy_guard_admits_before_a_warm_serve():
+    # The guard wraps outside the cache tier (`finish` in the factory),
+    # so a warm reader below it never answers a refused read.
+    from mirage.commands.builtin.generic_bind.adapter import with_policy_guard
+    from mirage.context import (reset_mount_gate, reset_op_policies,
+                                set_mount_gate, set_op_policies)
+    from mirage.policy.policies import Policies
+    from mirage.types import MountMode
+
+    calls: list[tuple[str, ...]] = []
+    warm = dataclasses.replace(_policy_probe_ops(calls), read_bytes=_warm_read)
+    acc = NOOPAccessor()
+    policy = _SealedRead("/data/secret")
+    ptoken = set_op_policies(Policies([policy]))
+    gtoken = set_mount_gate("/data", MountMode.WRITE)
+    try:
+        ops = with_policy_guard(warm)
+        with pytest.raises(PermissionError):
+            await ops.read_bytes(acc, _spec("/data/secret"))
+        assert await ops.read_bytes(acc, _spec("/data/open")) == b"warm"
+    finally:
+        reset_mount_gate(gtoken)
+        reset_op_policies(ptoken)
+
+
+async def _warm_read(accessor, path, index=None):
+    return b"warm"
 
 
 def _keyed_read_ops(implicit_dirs: set[str] | None = None,

--- a/python/tests/context/test_session_context.py
+++ b/python/tests/context/test_session_context.py
@@ -223,6 +223,20 @@ def test_the_admission_binding_is_scoped_to_one_command():
     assert not path_rules_active()
 
 
+def test_the_op_policies_binding_is_scoped_to_one_command():
+    from mirage.context import (get_op_policies, reset_op_policies,
+                                set_op_policies)
+    from mirage.policy.policies import Policies
+    assert get_op_policies() is None
+    policies = Policies([])
+    token = set_op_policies(policies)
+    try:
+        assert get_op_policies() is policies
+    finally:
+        reset_op_policies(token)
+    assert get_op_policies() is None
+
+
 def test_effective_path_mode_is_the_anchor_depth_rule():
     sess = Session(session_id="agent",
                    mount_modes={"/repo": MountMode.READ},

--- a/python/tests/workspace/workspace/test_policies.py
+++ b/python/tests/workspace/workspace/test_policies.py
@@ -554,6 +554,58 @@ async def test_shell_rm_r_admits_through_pre_ops():
         await ws.close()
 
 
+@pytest.mark.asyncio
+async def test_find_delete_admits_each_deletion_exactly_once():
+    # find's -delete admits the removal itself (in find's own refusal
+    # voice) and suspends the delegated rm's slots, so a counting or
+    # budget policy sees one deletion once, not twice.
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        await ws.execute("mkdir -p /data/d")
+        await ws.ops.write("/data/d/x.txt", b"x\n")
+        rec = OpRecorder()
+        ws.policies.add(rec)
+        removed = await ws.execute("find /data/d -name x.txt -delete")
+        assert removed.exit_code == 0
+        gone = await ws.execute("cat /data/d/x.txt")
+        assert gone.exit_code != 0
+        writes = [a for a in rec.asked if a[1] == "/data/d/x.txt" and a[2]]
+        assert writes == [("unlink", "/data/d/x.txt", True)]
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_pre_ops_sees_the_session_on_the_command_tier():
+    # OpsContext.session_id names the session on the command tier
+    # exactly as at the op doors, including for a reader the pipeline
+    # drains after dispatch (head), so a session-scoped policy holds on
+    # both.
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        await ws.ops.write("/data/ok.txt", b"fine\n")
+        rec = SessionRecorder()
+        ws.policies.add(rec)
+        assert (await ws.execute("cat /data/ok.txt")).exit_code == 0
+        assert (await ws.execute("head -c 3 /data/ok.txt")).exit_code == 0
+        reads = [(op, sid) for op, path, sid in rec.asked
+                 if path == "/data/ok.txt"]
+        assert reads
+        assert all(sid == ws.default_session_id for _, sid in reads)
+    finally:
+        await ws.close()
+
+
+class SessionRecorder(Policy):
+
+    def __init__(self) -> None:
+        self.asked: list[tuple[str, str, str]] = []
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        self.asked.append((ctx.op, ctx.path.virtual, ctx.session_id))
+        return None
+
+
 class CapLines(Policy):
 
     async def post_execute(self, ctx: ExecuteResultContext) -> Action | None:

--- a/python/tests/workspace/workspace/test_policies.py
+++ b/python/tests/workspace/workspace/test_policies.py
@@ -418,18 +418,21 @@ class SealedPaths(Policy):
     async def pre_ops(self, ctx: OpsContext) -> Action | None:
         if not ctx.write and ctx.path.virtual == "/data/secret.txt":
             return Deny("secret is sealed")
-        if ctx.write and ctx.path.virtual.startswith("/data/prod/"):
+        # The subtree spelling covers the root too: a native tree op
+        # (rm_r) admits as one op on the root, per the pre_ops
+        # docstring.
+        if ctx.write and (ctx.path.virtual == "/data/prod"
+                          or ctx.path.virtual.startswith("/data/prod/")):
             return Deny("prod is read-only")
         return None
 
 
 @pytest.mark.asyncio
-async def test_pre_ops_binds_op_doors_not_command_tier_io():
+async def test_pre_ops_binds_op_doors_and_command_tier_io():
     # The documented boundary (Policy.pre_ops): coded op hooks fire at
-    # the op doors, not for the backend I/O inside a mount command's
-    # handler. Both sides are pinned so a move of the boundary is loud;
-    # the command-tier half is the known gap the follow-up closes, at
-    # which point these assertions flip to refusals.
+    # the op doors AND for the backend I/O inside a mount command's
+    # handler (with_policy_guard). Both tiers are pinned so a move of
+    # the boundary is loud.
     ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
     try:
         await ws.execute("mkdir -p /data/prod")
@@ -444,16 +447,109 @@ async def test_pre_ops_binds_op_doors_not_command_tier_io():
         redirect = await ws.execute("echo hi > /data/prod/new.txt")
         assert redirect.exit_code != 0
 
-        # The command tier does not consult pre_ops: the handler calls
-        # the backend cores directly, so the read serves and the
-        # deletion lands.
+        # The command tier consults the same hooks: the read refuses
+        # in the command's own voice and the deletion never lands.
         leak = await ws.execute("cat /data/secret.txt")
-        assert leak.exit_code == 0
-        assert leak.stdout == b"sealed\n"
+        assert leak.exit_code != 0
+        assert leak.stdout in (None, b"")
+        assert b"cat: /data/secret.txt: Permission denied" in leak.stderr
         removed = await ws.execute("rm /data/prod/keep.txt")
+        assert removed.exit_code != 0
+        assert b"cannot remove" in removed.stderr
+        kept = await ws.execute("cat /data/prod/keep.txt")
+        assert kept.exit_code == 0
+        assert kept.stdout == b"keep\n"
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_pre_ops_holds_walks_and_lazy_readers():
+    # A walk is held per entry (GNU's unreadable-file shape: the other
+    # entries still serve, stderr names the refused one), and a reader
+    # the output pipeline drains after dispatch (head binds a lazy
+    # stream) still answers through the wrap-time capture.
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        await ws.ops.write("/data/secret.txt", b"sealed\n")
+        await ws.ops.write("/data/ok.txt", b"has sealed word\n")
+        ws.policies.add(SealedPaths())
+
+        walked = await ws.execute("grep -r sealed /data")
+        assert walked.exit_code == 2
+        assert b"/data/ok.txt:has sealed word" in walked.stdout
+        assert b"sealed\n" not in walked.stdout.replace(
+            b"has sealed word\n", b"")
+        assert b"grep: /data/secret.txt: Permission denied" in walked.stderr
+
+        lazy = await ws.execute("head -c 3 /data/secret.txt")
+        assert lazy.exit_code != 0
+        assert b"head: /data/secret.txt: Permission denied" in lazy.stderr
+        fine = await ws.execute("head -c 3 /data/ok.txt")
+        assert fine.exit_code == 0
+        assert fine.stdout == b"has"
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_pre_ops_denied_entries_still_list_and_stat():
+    # Presence facts stay unguarded on the command tier (mode-000
+    # shape): a read-denied entry lists and stats, the read of it is
+    # what fails.
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        await ws.ops.write("/data/secret.txt", b"sealed\n")
+        ws.policies.add(SealedPaths())
+        listing = await ws.execute("ls -l /data")
+        assert listing.exit_code == 0
+        assert b"secret.txt" in listing.stdout
+        found = await ws.execute("find /data -type f")
+        assert found.exit_code == 0
+        assert b"/data/secret.txt" in found.stdout
+    finally:
+        await ws.close()
+
+
+class OpRecorder(Policy):
+
+    def __init__(self) -> None:
+        self.asked: list[tuple[str, str, bool]] = []
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        self.asked.append((ctx.op, ctx.path.virtual, ctx.write))
+        return None
+
+
+@pytest.mark.asyncio
+async def test_shell_rm_r_admits_through_pre_ops():
+    # The cascade asymmetry closed: an ops-door rmdir cascade always
+    # admitted per deletion while a shell rm -r admitted nothing. The
+    # shell tree removal now admits the op the backend performs (the
+    # native rm_r here), and a write-deny refuses it outright.
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        await ws.execute("mkdir -p /data/prod/sub")
+        await ws.ops.write("/data/prod/a.txt", b"a\n")
+        await ws.ops.write("/data/prod/sub/b.txt", b"b\n")
+        rec = OpRecorder()
+        ws.policies.add(rec)
+        removed = await ws.execute("rm -r /data/prod")
         assert removed.exit_code == 0
-        gone = await ws.execute("cat /data/prod/keep.txt")
-        assert gone.exit_code != 0
+        writes = [a for a in rec.asked if a[2]]
+        assert ("rm_r", "/data/prod", True) in writes
+    finally:
+        await ws.close()
+
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        await ws.execute("mkdir -p /data/prod")
+        await ws.ops.write("/data/prod/a.txt", b"a\n")
+        ws.policies.add(SealedPaths())
+        refused = await ws.execute("rm -r /data/prod")
+        assert refused.exit_code != 0
+        survives = await ws.execute("cat /data/prod/a.txt")
+        assert survives.exit_code == 0
     finally:
         await ws.close()
 

--- a/python/tests/workspace/workspace/test_policies.py
+++ b/python/tests/workspace/workspace/test_policies.py
@@ -413,6 +413,51 @@ async def test_pre_ops_policy_holds_on_the_dispatcher_door():
         await ws.close()
 
 
+class SealedPaths(Policy):
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        if not ctx.write and ctx.path.virtual == "/data/secret.txt":
+            return Deny("secret is sealed")
+        if ctx.write and ctx.path.virtual.startswith("/data/prod/"):
+            return Deny("prod is read-only")
+        return None
+
+
+@pytest.mark.asyncio
+async def test_pre_ops_binds_op_doors_not_command_tier_io():
+    # The documented boundary (Policy.pre_ops): coded op hooks fire at
+    # the op doors, not for the backend I/O inside a mount command's
+    # handler. Both sides are pinned so a move of the boundary is loud;
+    # the command-tier half is the known gap the follow-up closes, at
+    # which point these assertions flip to refusals.
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        await ws.execute("mkdir -p /data/prod")
+        await ws.ops.write("/data/secret.txt", b"sealed\n")
+        await ws.ops.write("/data/prod/keep.txt", b"keep\n")
+        ws.policies.add(SealedPaths())
+
+        # The doors hold: the ops facade, and a dispatcher-routed
+        # redirect write.
+        with pytest.raises(PermissionError):
+            await ws.ops.read("/data/secret.txt")
+        redirect = await ws.execute("echo hi > /data/prod/new.txt")
+        assert redirect.exit_code != 0
+
+        # The command tier does not consult pre_ops: the handler calls
+        # the backend cores directly, so the read serves and the
+        # deletion lands.
+        leak = await ws.execute("cat /data/secret.txt")
+        assert leak.exit_code == 0
+        assert leak.stdout == b"sealed\n"
+        removed = await ws.execute("rm /data/prod/keep.txt")
+        assert removed.exit_code == 0
+        gone = await ws.execute("cat /data/prod/keep.txt")
+        assert gone.exit_code != 0
+    finally:
+        await ws.close()
+
+
 class CapLines(Policy):
 
     async def post_execute(self, ctx: ExecuteResultContext) -> Action | None:

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
@@ -34,8 +34,9 @@ import {
   runWithOpPolicies,
   runWithSession,
 } from '../../../context/session_context.ts'
+import type { Policy } from '../../../policy/base.ts'
 import { Policies } from '../../../policy/policies.ts'
-import type { Action, OpsContext, Policy } from '../../../policy/types.ts'
+import type { Action, OpsContext } from '../../../policy/types.ts'
 import { Session } from '../../../workspace/session/session.ts'
 
 const accessor = {} as never

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.test.ts
@@ -16,7 +16,7 @@ import { stripSlash } from '../../../utils/slash.ts'
 import { describe, expect, it } from 'vitest'
 import type { Accessor } from '../../../accessor/base.ts'
 import type { CommandOpts } from '../../config.ts'
-import { FileStat, FileType, PathSpec } from '../../../types.ts'
+import { FileStat, FileType, MountMode, PathSpec } from '../../../types.ts'
 import { eacces, eisdir, enoent } from '../../../utils/errors.ts'
 import {
   dirAwareStat,
@@ -24,10 +24,18 @@ import {
   makeResolveGlob,
   withDirGuard,
   withHiddenGuard,
+  withPolicyGuard,
   withRuleGuard,
   type CommandIO,
 } from './adapter.ts'
-import { runWithAdmission, runWithSession } from '../../../context/session_context.ts'
+import {
+  runWithAdmission,
+  runWithMountGate,
+  runWithOpPolicies,
+  runWithSession,
+} from '../../../context/session_context.ts'
+import { Policies } from '../../../policy/policies.ts'
+import type { Action, OpsContext, Policy } from '../../../policy/types.ts'
 import { Session } from '../../../workspace/session/session.ts'
 
 const accessor = {} as never
@@ -296,6 +304,140 @@ describe('withRuleGuard', () => {
     ])
     expect(calls).not.toContainEqual(['rename', '/data/a', '/data/locked/y'])
     expect(calls).toContainEqual(['rename', '/data/a', '/data/b'])
+  })
+})
+
+/** Refuse reads of one path; record every op asked. */
+class SealedRead implements Policy {
+  readonly asked: [string, string, boolean][] = []
+  private readonly sealed: string
+  constructor(sealed: string) {
+    this.sealed = sealed
+  }
+  preOps(ctx: OpsContext): Action | null {
+    this.asked.push([ctx.op, ctx.path.virtual, ctx.write])
+    if (!ctx.write && ctx.path.virtual === this.sealed) {
+      return { kind: 'deny', reason: 'sealed' }
+    }
+    return null
+  }
+}
+
+describe('withPolicyGuard', () => {
+  const spec = (virtual: string): PathSpec =>
+    new PathSpec({
+      virtual,
+      directory: virtual.slice(0, virtual.lastIndexOf('/')) || '/',
+      resourcePath: virtual,
+      resolved: true,
+    })
+
+  function probeOps(calls: string[][]): CommandIO {
+    async function* stream(_a: Accessor, path: PathSpec): AsyncGenerator<Uint8Array> {
+      calls.push(['stream', path.virtual])
+      yield await Promise.resolve(new Uint8Array([1]))
+    }
+    return {
+      readdir: (_a, path) => {
+        calls.push(['readdir', path.virtual])
+        return Promise.resolve(['a'])
+      },
+      readBytes: (_a, path) => {
+        calls.push(['read', path.virtual])
+        return Promise.resolve(new Uint8Array([1]))
+      },
+      readStream: stream,
+      stat: (_a, path) => {
+        calls.push(['stat', path.virtual])
+        return Promise.resolve(new FileStat({ name: 'k', type: FileType.TEXT, size: 1 }))
+      },
+      isMounted: () => true,
+      copy: (_a, src, dst) => {
+        calls.push(['copy', src.virtual, dst.virtual])
+        return Promise.resolve()
+      },
+      unlink: (_a, path) => {
+        calls.push(['unlink', path.virtual])
+        return Promise.resolve()
+      },
+    }
+  }
+
+  it('admits slots and leaves stat alone', async () => {
+    const calls: string[][] = []
+    const raw = probeOps(calls)
+    // No binding: every slot runs as is, and no hook fires.
+    expect(await withPolicyGuard(raw).readBytes(accessor, spec('/data/secret'))).toEqual(
+      new Uint8Array([1]),
+    )
+    calls.length = 0
+
+    const policy = new SealedRead('/data/secret')
+    await runWithOpPolicies(new Policies([policy]), () =>
+      runWithMountGate('/data', MountMode.WRITE, async () => {
+        const ops = withPolicyGuard(raw)
+        await expect(ops.readBytes(accessor, spec('/data/secret'))).rejects.toThrow('sealed')
+        expect(calls).not.toContainEqual(['read', '/data/secret'])
+        // The stream gates before its first chunk.
+        await expect(drain(ops.readStream(accessor, spec('/data/secret')))).rejects.toThrow(
+          'sealed',
+        )
+        expect(calls).not.toContainEqual(['stream', '/data/secret'])
+        // stat is not a guarded slot: deny is present and refused.
+        expect((await ops.stat(accessor, spec('/data/secret'))).size).toBe(1)
+        // readdir asks about the directory it lists.
+        expect(await ops.readdir(accessor, spec('/data/dir'))).toEqual(['a'])
+        // A copy's source is a read; its destination is a write.
+        const copy = ops.copy
+        if (copy === undefined) throw new Error('copy slot missing')
+        await copy(accessor, spec('/data/src'), spec('/data/dst'))
+        // A write slot asks with write=true.
+        const unlink = ops.unlink
+        if (unlink === undefined) throw new Error('unlink slot missing')
+        await unlink(accessor, spec('/data/gone'))
+      }),
+    )
+    expect(policy.asked).toContainEqual(['read_bytes', '/data/secret', false])
+    expect(policy.asked).toContainEqual(['read_stream', '/data/secret', false])
+    expect(policy.asked).toContainEqual(['readdir', '/data/dir', false])
+    expect(policy.asked).toContainEqual(['copy', '/data/src', false])
+    expect(policy.asked).toContainEqual(['copy', '/data/dst', true])
+    expect(policy.asked).toContainEqual(['unlink', '/data/gone', true])
+    expect(policy.asked.some(([op]) => op === 'stat')).toBe(false)
+  })
+
+  it('wrap-time capture covers late drains', async () => {
+    // head/tail/wc bind lazy readers the pipeline drains after dispatch
+    // has reset the context; the guard captured at wrap time still
+    // answers (livePolicyScope).
+    const calls: string[][] = []
+    const raw = probeOps(calls)
+    const policy = new SealedRead('/data/secret')
+    const ops = await runWithOpPolicies(new Policies([policy]), () =>
+      Promise.resolve(withPolicyGuard(raw)),
+    )
+    // Both the slot call and the drain happen outside the window now.
+    await expect(drain(ops.readStream(accessor, spec('/data/secret')))).rejects.toThrow('sealed')
+    expect(calls).not.toContainEqual(['stream', '/data/secret'])
+    await expect(ops.readBytes(accessor, spec('/data/secret'))).rejects.toThrow('sealed')
+  })
+
+  it('admits before a warm serve', async () => {
+    // The guard wraps outside the cache tier (`finish` in the factory),
+    // so a warm reader below it never answers a refused read.
+    const calls: string[][] = []
+    const warm: CommandIO = {
+      ...probeOps(calls),
+      readBytes: () => Promise.resolve(new TextEncoder().encode('warm')),
+    }
+    const policy = new SealedRead('/data/secret')
+    await runWithOpPolicies(new Policies([policy]), async () => {
+      const ops = withPolicyGuard(warm)
+      await expect(ops.readBytes(accessor, spec('/data/secret'))).rejects.toThrow('sealed')
+      expect(await ops.readBytes(accessor, spec('/data/open'))).toEqual(
+        new TextEncoder().encode('warm'),
+      )
+    })
   })
 })
 

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -730,14 +730,24 @@ export function withPathGuards<A extends Accessor = Accessor>(ops: CommandIO<A>)
   return withHiddenGuard(withRuleGuard(withModeGuard(ops)))
 }
 
+/** The policies to consult for one slot call, with the mount prefix
+ * and session identity the call belongs to. */
+interface OpPolicyScope {
+  policies: Policies
+  /** The wrap site's mount prefix; null resolves per path at admit
+   * time (a registration-time wrap has no one mount). */
+  prefix: string | null
+  sessionId: string
+}
+
 /**
- * The policies to consult for this op call: null is the fast path (no
+ * The scope to consult for this op call: null is the fast path (no
  * dispatched command bound policies, or none of them override preOps).
  */
-function opPolicyScope(): Policies | null {
+function opPolicyScope(prefix: string | null): OpPolicyScope | null {
   const policies = getOpPolicies()
   if (!policies?.wants('preOps')) return null
-  return policies
+  return { policies, prefix, sessionId: getCurrentSession()?.sessionId ?? '' }
 }
 
 /**
@@ -747,35 +757,36 @@ function opPolicyScope(): Policies | null {
  * The factory applies the guard inside the command's window, so its
  * wrap-time capture also covers a reader the output pipeline drains
  * after dispatch has reset the context (head/tail/wc bind lazy
- * readers); a registration-time wrap (the object-store overrides, the
- * loose-write chain) has no window when applied and reads the live
- * context instead, which its eager handlers are inside.
+ * readers), with the prefix and session identity the drained op
+ * belongs to; a registration-time wrap (the object-store overrides,
+ * the loose-write chain) has no window when applied and reads the
+ * live context instead, which its eager handlers are inside.
  */
-function livePolicyScope(scope: Policies | null): Policies | null {
-  return scope ?? opPolicyScope()
+function livePolicyScope(scope: OpPolicyScope | null): OpPolicyScope | null {
+  return scope ?? opPolicyScope(null)
 }
 
 /** Fire preOps for one PathSpec of one slot call; the op is the slot
  * name in its shared snake spelling, so a policy portable across the
  * languages and tiers sees one vocabulary. */
 async function policyAdmit(
-  policies: Policies,
+  scope: OpPolicyScope,
   op: string,
   path: PathSpec,
   write: boolean,
 ): Promise<void> {
-  const prefix = mountGateFor(path.virtual)?.[0] ?? ''
-  await preOpsGate(policies, op, path, write, prefix, getCurrentSession()?.sessionId ?? '')
+  const prefix = scope.prefix ?? mountGateFor(path.virtual)?.[0] ?? ''
+  await preOpsGate(scope.policies, op, path, write, prefix, scope.sessionId)
 }
 
 /** Drain `source` once the read is admitted, before any byte is
  * pulled; the inner iterable was built eagerly by the caller. */
 async function* policyStream(
-  policies: Policies,
+  scope: OpPolicyScope,
   path: PathSpec,
   source: AsyncIterable<Uint8Array>,
 ): AsyncIterable<Uint8Array> {
-  await policyAdmit(policies, 'read_stream', path, false)
+  await policyAdmit(scope, 'read_stream', path, false)
   yield* source
 }
 
@@ -791,11 +802,18 @@ async function* policyStream(
  * stay unguarded as presence facts, the mode-000 shape the rule guard
  * already states, so a denied entry still lists and stats while the
  * read of it is what fails. Inert unless a dispatched command bound
- * policies overriding preOps (`opPolicyScope`, captured at wrap time
- * so a lazily drained reader still answers, see `livePolicyScope`).
+ * policies overriding preOps (`opPolicyScope`, with the mount prefix
+ * and session identity captured at wrap time so a lazily drained
+ * reader still answers as the command that bound it, see
+ * `livePolicyScope`; `prefix` arrives from the wrap site because the
+ * fallback mount-gate storage resolves by path, which a drained
+ * reader no longer has a live gate for).
  */
-export function withPolicyGuard<A extends Accessor = Accessor>(ops: CommandIO<A>): CommandIO<A> {
-  const scope = opPolicyScope()
+export function withPolicyGuard<A extends Accessor = Accessor>(
+  ops: CommandIO<A>,
+  prefix?: string,
+): CommandIO<A> {
+  const scope = opPolicyScope(prefix ?? null)
   const guarded: CommandIO<A> = {
     ...ops,
     readdir: async (accessor, path, index) => {
@@ -946,7 +964,7 @@ export function withWriteGuards<A extends Accessor, R>(
   fn: (accessor: A, path: PathSpec, index?: IndexCacheStore) => Promise<R> | R,
 ): (accessor: A, path: PathSpec, index?: IndexCacheStore) => Promise<R> {
   return async (accessor, path, index) => {
-    const p = opPolicyScope()
+    const p = opPolicyScope(null)
     if (p !== null) await policyAdmit(p, 'unlink', path, true)
     refuseHidden(path, false)
     ruleCheck(path)

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -17,11 +17,13 @@ import {
   effectivePathMode,
   getAdmission,
   getCurrentSession,
+  getOpPolicies,
   hiddenPathsIntersect,
   mountGateFor,
   pathAllowed,
   readonlyBelow,
 } from '../../../context/session_context.ts'
+import { preOpsGate, type Policies } from '../../../policy/policies.ts'
 import { moveReveals } from '../../../utils/hidden.ts'
 import { removeRemnants, visibleBelow, type RemnantChannel } from '../../../utils/remnants.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
@@ -729,21 +731,227 @@ export function withPathGuards<A extends Accessor = Accessor>(ops: CommandIO<A>)
 }
 
 /**
+ * The policies to consult for this op call: null is the fast path (no
+ * dispatched command bound policies, or none of them override preOps).
+ */
+function opPolicyScope(): Policies | null {
+  const policies = getOpPolicies()
+  if (!policies?.wants('preOps')) return null
+  return policies
+}
+
+/**
+ * The wrap-time scope when it caught a bound command, else the
+ * call-time context.
+ *
+ * The factory applies the guard inside the command's window, so its
+ * wrap-time capture also covers a reader the output pipeline drains
+ * after dispatch has reset the context (head/tail/wc bind lazy
+ * readers); a registration-time wrap (the object-store overrides, the
+ * loose-write chain) has no window when applied and reads the live
+ * context instead, which its eager handlers are inside.
+ */
+function livePolicyScope(scope: Policies | null): Policies | null {
+  return scope ?? opPolicyScope()
+}
+
+/** Fire preOps for one PathSpec of one slot call; the op is the slot
+ * name in its shared snake spelling, so a policy portable across the
+ * languages and tiers sees one vocabulary. */
+async function policyAdmit(
+  policies: Policies,
+  op: string,
+  path: PathSpec,
+  write: boolean,
+): Promise<void> {
+  const prefix = mountGateFor(path.virtual)?.[0] ?? ''
+  await preOpsGate(policies, op, path, write, prefix, getCurrentSession()?.sessionId ?? '')
+}
+
+/** Drain `source` once the read is admitted, before any byte is
+ * pulled; the inner iterable was built eagerly by the caller. */
+async function* policyStream(
+  policies: Policies,
+  path: PathSpec,
+  source: AsyncIterable<Uint8Array>,
+): AsyncIterable<Uint8Array> {
+  await policyAdmit(policies, 'read_stream', path, false)
+  yield* source
+}
+
+/**
+ * Return `ops` whose content and mutation slots admit each PathSpec
+ * through the workspace's coded preOps hooks.
+ *
+ * The coded-policy arm of the guard chain, applied outside the cache
+ * wraps so admission fires before a warm serve, the dispatcher's own
+ * order. The surface is the rule guard's plus readdir: content reads
+ * (readBytes, readStream, readRange), every mutation slot, and the
+ * directory a readdir lists. stat/exists and the native find/du slots
+ * stay unguarded as presence facts, the mode-000 shape the rule guard
+ * already states, so a denied entry still lists and stats while the
+ * read of it is what fails. Inert unless a dispatched command bound
+ * policies overriding preOps (`opPolicyScope`, captured at wrap time
+ * so a lazily drained reader still answers, see `livePolicyScope`).
+ */
+export function withPolicyGuard<A extends Accessor = Accessor>(ops: CommandIO<A>): CommandIO<A> {
+  const scope = opPolicyScope()
+  const guarded: CommandIO<A> = {
+    ...ops,
+    readdir: async (accessor, path, index) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'readdir', path, false)
+      return ops.readdir(accessor, path, index)
+    },
+    readBytes: async (accessor, path, index) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'read_bytes', path, false)
+      return ops.readBytes(accessor, path, index)
+    },
+    readStream: (accessor, path, index) => {
+      const p = livePolicyScope(scope)
+      const inner = ops.readStream(accessor, path, index)
+      if (p === null) return inner
+      return policyStream(p, path, inner)
+    },
+  }
+  const rr = ops.readRange
+  if (rr !== undefined) {
+    guarded.readRange = async (accessor, path, index, offset, size) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'read_range', path, false)
+      return rr(accessor, path, index, offset, size)
+    }
+  }
+  const w = ops.write
+  if (w !== undefined) {
+    guarded.write = async (accessor, path, data) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'write', path, true)
+      return w(accessor, path, data)
+    }
+  }
+  const mk = ops.mkdir
+  if (mk !== undefined) {
+    guarded.mkdir = async (accessor, path, parents) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'mkdir', path, true)
+      return mk(accessor, path, parents)
+    }
+  }
+  const ap = ops.append
+  if (ap !== undefined) {
+    guarded.append = async (accessor, path, data) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'append', path, true)
+      return ap(accessor, path, data)
+    }
+  }
+  const cr = ops.create
+  if (cr !== undefined) {
+    guarded.create = async (accessor, path) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'create', path, true)
+      return cr(accessor, path)
+    }
+  }
+  const ul = ops.unlink
+  if (ul !== undefined) {
+    guarded.unlink = async (accessor, path) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'unlink', path, true)
+      return ul(accessor, path)
+    }
+  }
+  const rd = ops.rmdir
+  if (rd !== undefined) {
+    guarded.rmdir = async (accessor, path) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'rmdir', path, true)
+      return rd(accessor, path)
+    }
+  }
+  const rt = ops.rmR
+  if (rt !== undefined) {
+    guarded.rmR = async (accessor, path) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'rm_r', path, true)
+      return rt(accessor, path)
+    }
+  }
+  const tr = ops.truncate
+  if (tr !== undefined) {
+    guarded.truncate = async (accessor, path, length) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'truncate', path, true)
+      return tr(accessor, path, length)
+    }
+  }
+  const sa = ops.setAttrs
+  if (sa !== undefined) {
+    guarded.setAttrs = async (accessor: A, path: PathSpec, ...rest: unknown[]) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) await policyAdmit(p, 'set_attrs', path, true)
+      return sa(accessor, path, ...rest)
+    }
+  }
+  const rn = ops.rename
+  if (rn !== undefined) {
+    guarded.rename = async (accessor, src, dst) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) {
+        await policyAdmit(p, 'rename', src, true)
+        await policyAdmit(p, 'rename', dst, true)
+      }
+      return rn(accessor, src, dst)
+    }
+  }
+  const cp = ops.copy
+  if (cp !== undefined) {
+    guarded.copy = async (accessor, src, dst) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) {
+        await policyAdmit(p, 'copy', src, false)
+        await policyAdmit(p, 'copy', dst, true)
+      }
+      return cp(accessor, src, dst)
+    }
+  }
+  const dc = ops.dirCopy
+  if (dc !== undefined) {
+    guarded.dirCopy = async (accessor, src, dst) => {
+      const p = livePolicyScope(scope)
+      if (p !== null) {
+        await policyAdmit(p, 'dir_copy', src, false)
+        await policyAdmit(p, 'dir_copy', dst, true)
+      }
+      return dc(accessor, src, dst)
+    }
+  }
+  return guarded
+}
+
+/**
  * Guard one bare backend write the way the adapter guards a slot.
  *
  * For a bespoke command wired from loose functions rather than a
  * `CommandIO` (the google `rm` family binds an index-threaded unlink):
  * the same chain in the same order, judging the written path. A hidden
- * path answers ENOENT, the flavor of the flat mutation slots.
+ * path answers ENOENT, the flavor of the flat mutation slots. The
+ * policy arm rides outermost, as it does on the slot chain, and reads
+ * the live context (this wrap happens at registration, its handlers
+ * are eager).
  */
 export function withWriteGuards<A extends Accessor, R>(
-  fn: (accessor: A, path: PathSpec, index?: IndexCacheStore) => R,
-): (accessor: A, path: PathSpec, index?: IndexCacheStore) => R {
-  return (accessor, path, index) => {
+  fn: (accessor: A, path: PathSpec, index?: IndexCacheStore) => Promise<R> | R,
+): (accessor: A, path: PathSpec, index?: IndexCacheStore) => Promise<R> {
+  return async (accessor, path, index) => {
+    const p = opPolicyScope()
+    if (p !== null) await policyAdmit(p, 'unlink', path, true)
     refuseHidden(path, false)
     ruleCheck(path)
     modeCheck(path)
-    return fn(accessor, path, index)
+    return await fn(accessor, path, index)
   }
 }
 

--- a/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
@@ -27,6 +27,7 @@ import {
   supports,
   withDirGuard,
   withPathGuards,
+  withPolicyGuard,
 } from './adapter.ts'
 import { BUILDERS } from './builders/index.ts'
 import { defaultProvision } from './provision.ts'
@@ -180,14 +181,19 @@ export function makeGenericCommands<A extends Accessor = Accessor>(
     // refuses an explicit `undefined` for an optional field, so an absent
     // namespace has to mean an absent key rather than an undefined value.
     // Python's `glob_children` is `| None` and takes the uniform path.
+    // The policy guard sits outside the cache wraps (`finish`) so a
+    // coded preOps deny fires before a warm serve, the dispatcher's
+    // own order at the op door.
     const fn: CommandFn = (accessor, paths, texts, opts) =>
       b.fn(
         withDirGuard(
-          finish(
-            withPathGuards(
-              opts.ns?.childMounts === undefined
-                ? raw
-                : { ...raw, globChildren: opts.ns.childMounts },
+          withPolicyGuard(
+            finish(
+              withPathGuards(
+                opts.ns?.childMounts === undefined
+                  ? raw
+                  : { ...raw, globChildren: opts.ns.childMounts },
+              ),
             ),
           ),
         ),

--- a/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/factory.ts
@@ -183,7 +183,9 @@ export function makeGenericCommands<A extends Accessor = Accessor>(
     // Python's `glob_children` is `| None` and takes the uniform path.
     // The policy guard sits outside the cache wraps (`finish`) so a
     // coded preOps deny fires before a warm serve, the dispatcher's
-    // own order at the op door.
+    // own order at the op door; the invocation's mount prefix rides
+    // into its wrap-time scope for readers drained after the gate
+    // scopes return.
     const fn: CommandFn = (accessor, paths, texts, opts) =>
       b.fn(
         withDirGuard(
@@ -195,6 +197,7 @@ export function makeGenericCommands<A extends Accessor = Accessor>(
                   : { ...raw, globChildren: opts.ns.childMounts },
               ),
             ),
+            opts.mountPrefix,
           ),
         ),
         accessor,

--- a/typescript/packages/core/src/commands/builtin/object_store/index.ts
+++ b/typescript/packages/core/src/commands/builtin/object_store/index.ts
@@ -15,7 +15,7 @@
 import type { Accessor } from '../../../accessor/base.ts'
 import type { RegisteredCommand } from '../../config.ts'
 import type { CommandIO } from '../generic_bind/index.ts'
-import { withPathGuards } from '../generic_bind/adapter.ts'
+import { withPathGuards, withPolicyGuard } from '../generic_bind/adapter.ts'
 import { makeMkdir } from './mkdir.ts'
 import { makeRm } from './rm.ts'
 import { makeStat } from './stat.ts'
@@ -31,8 +31,9 @@ export const OBJECT_STORE_OVERRIDES = new Set(['stat', 'rm', 'mkdir', 'tee', 'to
  * Build the five keyed-store command overrides for one backend.
  *
  * The op table is wrapped with the same hidden/rule/mode chain the
- * factory gives every generic command, so an override enforces the
- * session's path axis exactly like the generic it replaces.
+ * factory gives every generic command, the policy guard outermost as
+ * there, so an override enforces the session's path axis and the coded
+ * op policies exactly like the generic it replaces.
  *
  * @param resource resource name the commands register under
  * @param io the backend's op table; must wire the write-side slots the
@@ -42,7 +43,7 @@ export function makeObjectStoreCommands<A extends Accessor>(
   resource: string,
   rawIo: CommandIO<A>,
 ): RegisteredCommand[] {
-  const io = withPathGuards(rawIo)
+  const io = withPolicyGuard(withPathGuards(rawIo))
   return [
     ...makeMkdir(resource, io),
     ...makeRm(resource, io),

--- a/typescript/packages/core/src/context/session_context.test.ts
+++ b/typescript/packages/core/src/context/session_context.test.ts
@@ -19,6 +19,7 @@ import {
   getAdmission,
   getCurrentSession,
   getCurrentSessionFor,
+  getOpPolicies,
   hiddenPathsActive,
   hiddenPathsIntersect,
   pathAllowed,
@@ -27,11 +28,13 @@ import {
   requireMountWritable,
   runWithAdmission,
   runWithMountGate,
+  runWithOpPolicies,
   runWithSession,
   sessionPathAllowed,
   strongestModeUnder,
 } from './session_context.ts'
 import { asyncContextIsolatesTasks } from '../utils/async_context.ts'
+import { Policies } from '../policy/policies.ts'
 import { MountMode, weakerMode } from '../types.ts'
 import { SessionManager } from '../workspace/session/manager.ts'
 import { Session } from '../workspace/session/session.ts'
@@ -380,5 +383,17 @@ describe('the admission binding', () => {
     })
     expect(getAdmission()).toBeNull()
     expect(pathRulesActive()).toBe(false)
+  })
+})
+
+describe('the op-policies binding', () => {
+  it('is scoped to one command', async () => {
+    expect(getOpPolicies()).toBeNull()
+    const policies = new Policies([])
+    await runWithOpPolicies(policies, () => {
+      expect(getOpPolicies()).toBe(policies)
+      return Promise.resolve()
+    })
+    expect(getOpPolicies()).toBeNull()
   })
 })

--- a/typescript/packages/core/src/context/session_context.ts
+++ b/typescript/packages/core/src/context/session_context.ts
@@ -208,7 +208,7 @@ export function pathRulesActive(): boolean {
   return getAdmission()?.scoped ?? false
 }
 
-const opPoliciesStorage = createAsyncContext<Policies>()
+const opPoliciesStorage = createAsyncContext<Policies | null>()
 
 /**
  * Bind the workspace's admission policies for the duration of `fn`:
@@ -222,6 +222,19 @@ const opPoliciesStorage = createAsyncContext<Policies>()
  */
 export function runWithOpPolicies<T>(policies: Policies, fn: () => Promise<T>): Promise<T> {
   return Promise.resolve(opPoliciesStorage.run(policies, fn))
+}
+
+/**
+ * Unbind the op policies for the duration of `fn`: a delegated
+ * sub-command whose door the caller has already cleared.
+ *
+ * find's `-delete` admits each removal itself, in find's own refusal
+ * voice, and then delegates the mutation to `rm`; without the
+ * suspension the delegated slot would admit the same deletion a second
+ * time, so a counting or budget policy would see one removal twice.
+ */
+export function runWithSuspendedOpPolicies<T>(fn: () => Promise<T>): Promise<T> {
+  return Promise.resolve(opPoliciesStorage.run(null, fn))
 }
 
 /** The policies bound to the running command, null outside one. */

--- a/typescript/packages/core/src/context/session_context.ts
+++ b/typescript/packages/core/src/context/session_context.ts
@@ -25,6 +25,7 @@ import {
   shownMode,
 } from '../utils/hidden.ts'
 import { erofsReadOnly } from '../utils/errors.ts'
+import type { Policies } from '../policy/policies.ts'
 import type { EntryGate, PathSpec } from '../types.ts'
 import { MOUNT_MODE_RANK, MountMode, weakerMode } from '../types.ts'
 
@@ -205,6 +206,27 @@ export function getAdmission(): EntryGate | null {
  */
 export function pathRulesActive(): boolean {
   return getAdmission()?.scoped ?? false
+}
+
+const opPoliciesStorage = createAsyncContext<Policies>()
+
+/**
+ * Bind the workspace's admission policies for the duration of `fn`:
+ * the run of one command.
+ *
+ * Bound by command dispatch around routing, the same window the
+ * admission gate binds in, so the command tier's policy guard can fire
+ * `preOps` for the backend I/O a handler performs. Read at wrap or
+ * call time by `withPolicyGuard`; unset outside a dispatched command
+ * (a generic invoked directly in a test), where the guard is inert.
+ */
+export function runWithOpPolicies<T>(policies: Policies, fn: () => Promise<T>): Promise<T> {
+  return Promise.resolve(opPoliciesStorage.run(policies, fn))
+}
+
+/** The policies bound to the running command, null outside one. */
+export function getOpPolicies(): Policies | null {
+  return opPoliciesStorage.getStore() ?? null
 }
 
 const mountGateStorage = createAsyncContext<readonly [string, MountMode]>()

--- a/typescript/packages/core/src/policy/base.ts
+++ b/typescript/packages/core/src/policy/base.ts
@@ -48,10 +48,12 @@ export interface Policy {
    */
   preOps?(ctx: OpsContext): Action | null | Promise<Action | null>
   /** Observe one completed VFS op; a Deny suppresses its result, a
-   * Limit caps a byte-producing one. Same coverage as preOps: the op
-   * doors only, never the backend I/O inside a mount command's
-   * handler. The command tier's result plane is postExecute, which
-   * bounds the finished line's output. */
+   * Limit caps a byte-producing one. Narrower than preOps: the
+   * dispatcher and facade doors only, never the backend I/O inside a
+   * mount command's handler, and not `find -delete`, which admits
+   * each deletion through preOps and then routes into the command
+   * tier, so no per-op result reports here. The command tier's result
+   * plane is postExecute, which bounds the finished line's output. */
   postOps?(ctx: OpsResultContext): Action | null | Promise<Action | null>
   /**
    * Bound one finished execute() line's output. A Limit returned here

--- a/typescript/packages/core/src/policy/base.ts
+++ b/typescript/packages/core/src/policy/base.ts
@@ -33,25 +33,30 @@ import type {
 export interface Policy {
   preCommand?(ctx: CommandContext): Action | null | Promise<Action | null>
   /**
-   * Admit or refuse one VFS op at an op door. The doors are the
-   * dispatcher and the ops facade (`ws.fs`), which is also how FUSE,
-   * the runtime guests, `find -delete` and the warm cache arrive:
-   * shell redirects and the namespace-routed commands (touch/chmod/ln)
-   * clear this gate too. Backend I/O inside a mount command's handler
-   * (cat, grep -r, sed -i, rm) does not pass through here: such a
-   * line is admitted whole at preCommand, and per-path control on
-   * that tier belongs to the declarative permissions document, whose
-   * rules hold walks to per-entry checks. The hot path: fires per op
-   * (thousands under one recursive cascade or FUSE walk), so keep the
-   * hook cheap; expensive decisions belong at preCommand or
-   * precomputed into policy state.
+   * Admit or refuse one VFS op, at the op doors and on the command
+   * tier's backend I/O. The doors are the dispatcher and the ops
+   * facade (`ws.fs`), which is also how FUSE, the runtime guests,
+   * `find -delete` and the warm cache arrive; a mount command's
+   * handler (cat, grep -r, sed -i, rm) admits each content read,
+   * mutation and readdir through the same hook (`withPolicyGuard`),
+   * before its own warm cache. On that tier the op is named by
+   * adapter slot in its shared snake spelling (read_bytes,
+   * read_stream, rm_r, ...), so a policy portable across the tiers
+   * keys on `write` and `path`; stat/exists and native find/du
+   * enumeration stay unguarded as presence facts (mode-000 shape: a
+   * denied entry lists and stats, the read of it fails), and a native
+   * subtree op (rm_r, dir_copy) admits as the one op the backend
+   * performs. The hot path: fires per op (thousands under one
+   * recursive command), so keep the hook cheap; expensive decisions
+   * belong at preCommand or precomputed into policy state.
    */
   preOps?(ctx: OpsContext): Action | null | Promise<Action | null>
   /** Observe one completed VFS op; a Deny suppresses its result, a
-   * Limit caps a byte-producing one. Same coverage as preOps: the op
-   * doors only, never the backend I/O inside a mount command's
-   * handler. The command tier's result plane is postExecute, which
-   * bounds the finished line's output. */
+   * Limit caps a byte-producing one. The op doors only, never the
+   * backend I/O inside a mount command's handler (which admits
+   * through preOps but reports no per-op result). The command tier's
+   * result plane is postExecute, which bounds the finished line's
+   * output. */
   postOps?(ctx: OpsResultContext): Action | null | Promise<Action | null>
   /**
    * Bound one finished execute() line's output. A Limit returned here

--- a/typescript/packages/core/src/policy/base.ts
+++ b/typescript/packages/core/src/policy/base.ts
@@ -33,13 +33,25 @@ import type {
 export interface Policy {
   preCommand?(ctx: CommandContext): Action | null | Promise<Action | null>
   /**
-   * Admit or refuse one VFS op, whatever door it entered. The hot
-   * path: fires per op, so keep the hook cheap; expensive decisions
-   * belong at preCommand or precomputed into policy state.
+   * Admit or refuse one VFS op at an op door. The doors are the
+   * dispatcher and the ops facade (`ws.fs`), which is also how FUSE,
+   * the runtime guests, `find -delete` and the warm cache arrive:
+   * shell redirects and the namespace-routed commands (touch/chmod/ln)
+   * clear this gate too. Backend I/O inside a mount command's handler
+   * (cat, grep -r, sed -i, rm) does not pass through here: such a
+   * line is admitted whole at preCommand, and per-path control on
+   * that tier belongs to the declarative permissions document, whose
+   * rules hold walks to per-entry checks. The hot path: fires per op
+   * (thousands under one recursive cascade or FUSE walk), so keep the
+   * hook cheap; expensive decisions belong at preCommand or
+   * precomputed into policy state.
    */
   preOps?(ctx: OpsContext): Action | null | Promise<Action | null>
   /** Observe one completed VFS op; a Deny suppresses its result, a
-   * Limit caps a byte-producing one. */
+   * Limit caps a byte-producing one. Same coverage as preOps: the op
+   * doors only, never the backend I/O inside a mount command's
+   * handler. The command tier's result plane is postExecute, which
+   * bounds the finished line's output. */
   postOps?(ctx: OpsResultContext): Action | null | Promise<Action | null>
   /**
    * Bound one finished execute() line's output. A Limit returned here

--- a/typescript/packages/core/src/workspace/executor/find_action_dispatch.ts
+++ b/typescript/packages/core/src/workspace/executor/find_action_dispatch.ts
@@ -14,7 +14,7 @@
 
 import { stripSlash } from '../../utils/slash.ts'
 import { type ByteSource, materialize } from '../../io/types.ts'
-import { getCurrentSession } from '../../context/session_context.ts'
+import { getCurrentSession, runWithSuspendedOpPolicies } from '../../context/session_context.ts'
 import { preOpsGate } from '../../policy/policies.ts'
 import { PathSpec } from '../../types.ts'
 import type { MountRegistry } from '../mount/registry.ts'
@@ -74,9 +74,11 @@ export async function applyFindActions(
         // -delete is find's own action, not an `rm` line, so no command
         // rule sees it; it is a removal all the same, so it clears the
         // op door a path rule guards (the same gate `ws.ops`, FUSE and a
-        // redirect clear), by the session the line runs under. -d so
-        // directories emptied by the deepest-first pass are removable,
-        // matching GNU -delete's rmdir behavior.
+        // redirect clear), by the session the line runs under, and a
+        // refusal reports in find's voice. The delegated rm's own slots
+        // are suspended for the call, so the deletion admits exactly
+        // once. -d so directories emptied by the deepest-first pass are
+        // removable, matching GNU -delete's rmdir behavior.
         await preOpsGate(
           registry.policies,
           'unlink',
@@ -85,7 +87,9 @@ export async function applyFindActions(
           mount.prefix,
           getCurrentSession()?.sessionId ?? '',
         )
-        const [, rmIo] = await mount.executeCmd('rm', [ps], [], { d: true }, { stdin: null, cwd })
+        const [, rmIo] = await runWithSuspendedOpPolicies(() =>
+          mount.executeCmd('rm', [ps], [], { d: true }, { stdin: null, cwd }),
+        )
         if (rmIo.exitCode !== 0) {
           const errBytes = await materialize(rmIo.stderr)
           if (errBytes.length > 0) errors.push(errBytes)

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -16,7 +16,11 @@ import type { ShellVar } from '../../shell/variable.ts'
 import { sessionEntry, setSessionEntry } from '../session/session.ts'
 import { seedVar, setAttr } from '../session/state.ts'
 import { VarAttr } from '../../shell/variable.ts'
-import { redirectPathsFor, runWithAdmission } from '../../context/session_context.ts'
+import {
+  redirectPathsFor,
+  runWithAdmission,
+  runWithOpPolicies,
+} from '../../context/session_context.ts'
 import type { Runtime } from '../../runtime/base.ts'
 import type { PolicyDecision } from '../../runtime/policy/index.ts'
 import { mergeSignals } from '../abort.ts'
@@ -521,7 +525,10 @@ async function runArgv(
 
   // The admitted command's gate is bound for its run and handed back
   // after, so its own I/O can ask about the entries the gate did not see
-  // and a nested line binds its own (see `Admitted`).
+  // and a nested line binds its own (see `Admitted`). The workspace's
+  // policies bind in the same window, whether or not a gate judged the
+  // line, so the command tier's policy guard can fire preOps for the
+  // backend I/O a handler performs.
   const route = () =>
     routeArgv(
       recurse,
@@ -540,8 +547,9 @@ async function runArgv(
       signal,
       row,
     )
-  if (admitted === null) return route()
-  return runWithAdmission(admitted, route)
+  const gated = admitted
+  if (gated === null) return runWithOpPolicies(registry.policies, route)
+  return runWithOpPolicies(registry.policies, () => runWithAdmission(gated, route))
 }
 
 async function routeArgv(

--- a/typescript/packages/core/src/workspace/state_doors.test.ts
+++ b/typescript/packages/core/src/workspace/state_doors.test.ts
@@ -563,35 +563,53 @@ describe('the remaining session writers clear the same gate', () => {
   })
 })
 
-/** Seal one file's reads and one subtree's writes at the op doors. */
+/** Seal one file's reads and one subtree's writes wherever preOps fires. */
 class SealedPaths implements Policy {
   preOps(ctx: OpsContext): Action | null {
     if (!ctx.write && ctx.path.virtual === '/a/secret.txt') {
       return { kind: 'deny', reason: 'secret is sealed' }
     }
-    if (ctx.write && ctx.path.virtual.startsWith('/a/prod/')) {
+    // The subtree spelling covers the root too: a native tree op
+    // (rm_r) admits as one op on the root, per the preOps docstring.
+    if (ctx.write && (ctx.path.virtual === '/a/prod' || ctx.path.virtual.startsWith('/a/prod/'))) {
       return { kind: 'deny', reason: 'prod is read-only' }
     }
     return null
   }
 }
 
-describe('op hooks bind at the op doors, not the command tier', () => {
-  it('preOps refuses the doors while handler I/O passes', async () => {
+/** Record every op preOps is asked about; allow them all. */
+class OpRecorder implements Policy {
+  readonly asked: [string, string, boolean][] = []
+  preOps(ctx: OpsContext): Action | null {
+    this.asked.push([ctx.op, ctx.path.virtual, ctx.write])
+    return null
+  }
+}
+
+async function makeSealedWs(policies: Policy[]): Promise<Workspace> {
+  // Seeded through the door (not the raw store) so the index knows the
+  // implicit /a/prod directory, then the policies join, mirroring the
+  // python twin's setup order.
+  const parser = await getTestParser()
+  const resource = new RAMResource()
+  resource.store.files.set('/secret.txt', ENC.encode('sealed\n'))
+  resource.store.files.set('/ok.txt', ENC.encode('has sealed word\n'))
+  const ws = new Workspace({ '/a': resource }, { mode: MountMode.WRITE, shellParser: parser })
+  open.push(ws)
+  await ws.execute('mkdir -p /a/prod')
+  await ws.fs.writeFile('/a/prod/keep.txt', ENC.encode('keep\n'))
+  for (const p of policies) ws.policies.add(p)
+  return ws
+}
+
+describe('op hooks bind at the op doors and the command tier', () => {
+  it('preOps refuses the doors and handler I/O alike', async () => {
     // The documented boundary (Policy.preOps): coded op hooks fire at
-    // the op doors, not for the backend I/O inside a mount command's
-    // handler. Both sides are pinned so a move of the boundary is
-    // loud; the command-tier half is the known gap the follow-up
-    // closes, at which point these assertions flip to refusals.
-    const parser = await getTestParser()
-    const resource = new RAMResource()
-    resource.store.files.set('/secret.txt', ENC.encode('sealed\n'))
-    resource.store.files.set('/prod/keep.txt', ENC.encode('keep\n'))
-    const ws = new Workspace(
-      { '/a': resource },
-      { mode: MountMode.WRITE, shellParser: parser, policies: [new SealedPaths()] },
-    )
-    open.push(ws)
+    // the op doors AND for the backend I/O inside a mount command's
+    // handler (withPolicyGuard). Both tiers are pinned so a move of
+    // the boundary is loud.
+    const ws = await makeSealedWs([new SealedPaths()])
 
     // The doors hold: the fs facade, and a dispatcher-routed redirect
     // write.
@@ -599,16 +617,70 @@ describe('op hooks bind at the op doors, not the command tier', () => {
     const redirect = await ws.execute('echo hi > /a/prod/new.txt')
     expect(redirect.exitCode).not.toBe(0)
 
-    // The command tier does not consult preOps: the handler calls the
-    // backend cores directly, so the read serves and the deletion
-    // lands.
+    // The command tier consults the same hooks: the read refuses in
+    // the command's own voice and the deletion never lands.
     const leak = await ws.execute('cat /a/secret.txt')
-    expect(leak.exitCode).toBe(0)
-    expect(stdoutStr(leak)).toBe('sealed\n')
+    expect(leak.exitCode).not.toBe(0)
+    expect(stdoutStr(leak)).toBe('')
+    expect(stderrStr(leak)).toContain('cat: /a/secret.txt: Permission denied')
     const removed = await ws.execute('rm /a/prod/keep.txt')
+    expect(removed.exitCode).not.toBe(0)
+    const kept = await ws.execute('cat /a/prod/keep.txt')
+    expect(kept.exitCode).toBe(0)
+    expect(stdoutStr(kept)).toBe('keep\n')
+  })
+
+  it('preOps holds walks and lazy readers', async () => {
+    // A walk is held per entry (GNU's unreadable-file shape: the other
+    // entries still serve, stderr names the refused one), and a reader
+    // the output pipeline drains after dispatch (head binds a lazy
+    // stream) still answers through the wrap-time capture.
+    const ws = await makeSealedWs([new SealedPaths()])
+    const walked = await ws.execute('grep -r sealed /a')
+    expect(walked.exitCode).toBe(2)
+    expect(stdoutStr(walked)).toContain('/a/ok.txt:has sealed word')
+    expect(stdoutStr(walked)).not.toContain('sealed\n')
+    expect(stderrStr(walked)).toContain('grep: /a/secret.txt: Permission denied')
+
+    const lazy = await ws.execute('head -c 3 /a/secret.txt')
+    expect(lazy.exitCode).not.toBe(0)
+    expect(stderrStr(lazy)).toContain('head: /a/secret.txt: Permission denied')
+    const fine = await ws.execute('head -c 3 /a/ok.txt')
+    expect(fine.exitCode).toBe(0)
+    expect(stdoutStr(fine)).toBe('has')
+  })
+
+  it('denied entries still list and stat', async () => {
+    // Presence facts stay unguarded on the command tier (mode-000
+    // shape): a read-denied entry lists and stats, the read of it is
+    // what fails.
+    const ws = await makeSealedWs([new SealedPaths()])
+    const listing = await ws.execute('ls -l /a')
+    expect(listing.exitCode).toBe(0)
+    expect(stdoutStr(listing)).toContain('secret.txt')
+    const found = await ws.execute('find /a -type f')
+    expect(found.exitCode).toBe(0)
+    expect(stdoutStr(found)).toContain('/a/secret.txt')
+  })
+
+  it('shell rm -r admits through preOps', async () => {
+    // The cascade asymmetry closed: an ops-door rmdir cascade always
+    // admitted per deletion while a shell rm -r admitted nothing. The
+    // shell tree removal now admits the op the backend performs, and
+    // the subtree write-deny refuses it outright.
+    const recorder = new OpRecorder()
+    const ws = await makeSealedWs([recorder])
+    const removed = await ws.execute('rm -r /a/prod')
     expect(removed.exitCode).toBe(0)
-    const gone = await ws.execute('cat /a/prod/keep.txt')
-    expect(gone.exitCode).not.toBe(0)
+    expect(
+      recorder.asked.some(([op, path, write]) => write && path === '/a/prod' && op === 'rm_r'),
+    ).toBe(true)
+
+    const sealed = await makeSealedWs([new SealedPaths()])
+    const refused = await sealed.execute('rm -r /a/prod')
+    expect(refused.exitCode).not.toBe(0)
+    const survives = await sealed.execute('cat /a/prod/keep.txt')
+    expect(survives.exitCode).toBe(0)
   })
 })
 

--- a/typescript/packages/core/src/workspace/state_doors.test.ts
+++ b/typescript/packages/core/src/workspace/state_doors.test.ts
@@ -563,6 +563,55 @@ describe('the remaining session writers clear the same gate', () => {
   })
 })
 
+/** Seal one file's reads and one subtree's writes at the op doors. */
+class SealedPaths implements Policy {
+  preOps(ctx: OpsContext): Action | null {
+    if (!ctx.write && ctx.path.virtual === '/a/secret.txt') {
+      return { kind: 'deny', reason: 'secret is sealed' }
+    }
+    if (ctx.write && ctx.path.virtual.startsWith('/a/prod/')) {
+      return { kind: 'deny', reason: 'prod is read-only' }
+    }
+    return null
+  }
+}
+
+describe('op hooks bind at the op doors, not the command tier', () => {
+  it('preOps refuses the doors while handler I/O passes', async () => {
+    // The documented boundary (Policy.preOps): coded op hooks fire at
+    // the op doors, not for the backend I/O inside a mount command's
+    // handler. Both sides are pinned so a move of the boundary is
+    // loud; the command-tier half is the known gap the follow-up
+    // closes, at which point these assertions flip to refusals.
+    const parser = await getTestParser()
+    const resource = new RAMResource()
+    resource.store.files.set('/secret.txt', ENC.encode('sealed\n'))
+    resource.store.files.set('/prod/keep.txt', ENC.encode('keep\n'))
+    const ws = new Workspace(
+      { '/a': resource },
+      { mode: MountMode.WRITE, shellParser: parser, policies: [new SealedPaths()] },
+    )
+    open.push(ws)
+
+    // The doors hold: the fs facade, and a dispatcher-routed redirect
+    // write.
+    await expect(ws.fs.readFile('/a/secret.txt')).rejects.toThrow('secret is sealed')
+    const redirect = await ws.execute('echo hi > /a/prod/new.txt')
+    expect(redirect.exitCode).not.toBe(0)
+
+    // The command tier does not consult preOps: the handler calls the
+    // backend cores directly, so the read serves and the deletion
+    // lands.
+    const leak = await ws.execute('cat /a/secret.txt')
+    expect(leak.exitCode).toBe(0)
+    expect(stdoutStr(leak)).toBe('sealed\n')
+    const removed = await ws.execute('rm /a/prod/keep.txt')
+    expect(removed.exitCode).toBe(0)
+    const gone = await ws.execute('cat /a/prod/keep.txt')
+    expect(gone.exitCode).not.toBe(0)
+  })
+})
+
 async function makeHiddenVarsWs(): Promise<Workspace> {
   const ws = await makeWs()
   const sess = ws.createSession('agent', { mounts: { '/a': MountMode.WRITE } })

--- a/typescript/packages/core/src/workspace/state_doors.test.ts
+++ b/typescript/packages/core/src/workspace/state_doors.test.ts
@@ -587,6 +587,15 @@ class OpRecorder implements Policy {
   }
 }
 
+/** Record each op with the identity fields a scoped policy keys on. */
+class IdentityRecorder implements Policy {
+  readonly asked: [string, string, string, string][] = []
+  preOps(ctx: OpsContext): Action | null {
+    this.asked.push([ctx.op, ctx.path.virtual, ctx.prefix, ctx.sessionId ?? ''])
+    return null
+  }
+}
+
 async function makeSealedWs(policies: Policy[]): Promise<Workspace> {
   // Seeded through the door (not the raw store) so the index knows the
   // implicit /a/prod directory, then the policies join, mirroring the
@@ -681,6 +690,37 @@ describe('op hooks bind at the op doors and the command tier', () => {
     expect(refused.exitCode).not.toBe(0)
     const survives = await sealed.execute('cat /a/prod/keep.txt')
     expect(survives.exitCode).toBe(0)
+  })
+
+  it('find -delete admits each deletion exactly once', async () => {
+    // find's -delete admits the removal itself (in find's own refusal
+    // voice) and suspends the delegated rm's slots, so a counting or
+    // budget policy sees one deletion once, not twice.
+    const recorder = new OpRecorder()
+    const ws = await makeSealedWs([recorder])
+    const removed = await ws.execute('find /a/prod -name keep.txt -delete')
+    expect(removed.exitCode).toBe(0)
+    const gone = await ws.execute('cat /a/prod/keep.txt')
+    expect(gone.exitCode).not.toBe(0)
+    const writes = recorder.asked.filter(([, path, write]) => path === '/a/prod/keep.txt' && write)
+    expect(writes).toEqual([['unlink', '/a/prod/keep.txt', true]])
+  })
+
+  it('preOps sees the session and prefix on lazy drains', async () => {
+    // OpsContext.prefix and .sessionId name the command's identity on
+    // the command tier exactly as at the op doors, including for a
+    // reader the pipeline drains after the gate scopes return (head
+    // binds a lazy stream); both ride the wrap-time capture.
+    const recorder = new IdentityRecorder()
+    const ws = await makeSealedWs([recorder])
+    expect((await ws.execute('cat /a/ok.txt')).exitCode).toBe(0)
+    expect((await ws.execute('head -c 3 /a/ok.txt')).exitCode).toBe(0)
+    const reads = recorder.asked.filter(([, path]) => path === '/a/ok.txt')
+    expect(reads.length).toBeGreaterThan(0)
+    for (const [, , prefix, sessionId] of reads) {
+      expect(prefix).toBe('/a')
+      expect(sessionId).toBe(ws.defaultSessionId)
+    }
   })
 })
 


### PR DESCRIPTION
Coded `Policy.pre_ops`/`post_ops` fire at the op doors (dispatcher, ops facade, FUSE, runtime guests, `find -delete`, the warm-cache regate), not for the backend I/O inside a mount command's handler; the old "whatever door it entered" wording oversold that. This states the real boundary in both languages' docstrings and pins both sides with a workspace-level meta-test (cat serves and rm deletes past a coded deny today, while the facade and redirect writes refuse), so any move of the boundary is loud.

A follow-up PR binds pre_ops on the command tier and flips the command-tier assertions to refusals.