### PR TITLE
fix(shell): boot the tree-sitter engine once

### DIFF
--- a/typescript/packages/core/src/shell/parse.ts
+++ b/typescript/packages/core/src/shell/parse.ts
@@ -161,8 +161,21 @@ export function findUnterminatedBacktick(command: string): string | null {
   return opened !== null ? command.slice(opened) : null
 }
 
+// `Parser.init` boots one wasm module for the whole process, so two callers
+// that start at the same time used to race it: the second read the language
+// out of a half-built module and threw "Incompatible language version 0".
+// Every caller now awaits the same boot. A failed boot is not kept, or one bad
+// start would poison every later parser.
+let engineBoot: Promise<void> | null = null
+
 export async function createShellParser(config: ShellParserConfig): Promise<ShellParser> {
-  await Parser.init({ wasmBinary: toArrayBuffer(config.engineWasm) })
+  engineBoot ??= Parser.init({ wasmBinary: toArrayBuffer(config.engineWasm) }).catch(
+    (err: unknown) => {
+      engineBoot = null
+      throw err
+    },
+  )
+  await engineBoot
   const language = await Language.load(toUint8(config.grammarWasm))
   const parser = new Parser()
   parser.setLanguage(language)

--- a/typescript/packages/core/src/shell/parse_boot.test.ts
+++ b/typescript/packages/core/src/shell/parse_boot.test.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+import { createShellParser } from './parse.ts'
+
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
+
+// This file must hold the only parser in its module graph, because the boot it
+// guards happens once per graph. A test that shares a file with an already
+// booted parser cannot see the race.
+describe('createShellParser boots once under concurrency', () => {
+  it('builds every parser when several are created at the same time', async () => {
+    const parsers = await Promise.all(
+      Array.from({ length: 8 }, () => createShellParser({ engineWasm, grammarWasm })),
+    )
+    expect(parsers).toHaveLength(8)
+    for (const parser of parsers) {
+      const root = parser.parse('echo hello')
+      expect(root.type).toBe('program')
+      expect(root.hasError).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

`createShellParser` called `Parser.init` every time. That call boots one wasm
module for the whole process, so two callers that start together race it. The
second one reads the language out of a half-built module and throws:

```
Incompatible language version 0. Compatibility range 13 through 15.
```

Any program that creates two workspaces at the same time can hit this, because
each workspace builds its own parser.

The test fixture already worked around it with a memo in
`workspace_fixture.ts` (`parserPromise ??= createShellParser(...)`), which
shows the guard belongs in the function itself.

## Fix

Every caller awaits the same boot. A failed boot is not cached, so one bad
start does not poison every later parser.

Python does not have this bug. It builds `BASH_LANGUAGE` and `TS_PARSER` once
at import in `python/mirage/shell/parse.py`, so this change makes TypeScript
match it.

## Test

`parse_boot.test.ts` creates 8 parsers at once and parses with each. It is its
own file on purpose: the boot happens once per module graph, so a test sharing
a file with an already booted parser cannot see the race.

Checked it fails first:

```
FAIL src/shell/parse_boot.test.ts
 ❯ Parser.setLanguage web-tree-sitter/src/parser.ts:158:15
 ❯ createShellParser src/shell/parse.ts:168:10
Test Files  1 failed (1)
```

After the change:

```
Test Files  20 passed (20)
     Tests  528 passed (528)      # packages/core src/shell
```

Also run: full `packages/core` suite, prettier, eslint, `tsc --noEmit`.