### PR TITLE
perf(python): stop running coverage on every pytest invocation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,26 @@ cd python
 uv run pytest
 ```
 
+That runs one process. For a faster inner loop, spread a subset across every
+core the way CI does:
+
+```bash
+cd python
+uv run pytest tests/commands -n auto --dist loadscope
+```
+
+The redis tests are the exception: they share one server, so CI runs them
+serially after the parallel batch rather than under `-n` (see
+`.github/workflows/test_python.yml`). Leave them out of an `-n auto` run.
+
+Coverage is not on by default, because nothing reads it. Ask for it when you
+want it:
+
+```bash
+cd python
+uv run pytest --cov=mirage --cov-report=term-missing
+```
+
 Run Python formatting and linting from the repository root:
 
 ```bash

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -277,7 +277,7 @@ per-file-ignores = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=mirage --cov-report=term-missing -q --import-mode=importlib"
+addopts = "-q --import-mode=importlib"
 markers = [
     "network: tests that require network access",
     "no_host_override: skip the tests/server/conftest autouse MIRAGE_ALLOWED_HOSTS=* override",


### PR DESCRIPTION
Part of #886 (CI wall clock).

## What

`pytest`'s `addopts` carried `--cov=mirage --cov-report=term-missing`, so every
invocation instrumented all **72,442 statements** in the package.

Nothing consumed the result. There is no `.coveragerc`, no `fail_under`, and no
workflow uploads or gates on the report. It was traced and printed to nobody.

## Measured

`tests/workspace`, 3337 tests, identical pass counts both ways:

| arm | wall | result |
|---|---|---|
| with coverage | 92s | 3337 passed, 23 skipped |
| without | **39s** | 3337 passed, 23 skipped |

Two earlier A/B reps agree (117s / 106s against 47s / 43s), so ~2.4x on this
subset is a real effect, not noise.

## Blast radius

Six CI steps invoke pytest. Three already pass `--no-cov` and are unaffected.
The other three lose instrumentation nobody read. Coverage does not change test
outcomes, so no result can move.

Verified in a clean worktree:
- `--no-cov` is still a valid flag with `--cov` gone from defaults (4 passed, 12 skipped)
- `tests/workspace` still passes (3337 passed, 23 skipped)
- `--cov` on demand still produces a table (`TOTAL 72442 stmts, 24%`)

## Not done on purpose

`-n auto` is **not** added to `addopts`. It would silently parallelize the redis
step that CI splits out precisely to keep serial:

```
uv run pytest -n 4 --dist loadscope "${ignore_args[@]}"
uv run pytest "${redis_serial[@]}"     # serial on purpose
```

Making the whole suite parallel-safe needs per-worker redis database indices,
which is its own change. `CONTRIBUTING.md` documents the parallel inner loop.