### PR TITLE
perf(integ): run targets concurrently and report where the time goes

### DIFF
--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -279,7 +279,7 @@ jobs:
 
       - name: Run declarative battery on Nextcloud
         working-directory: integ
-        run: pnpm exec tsx runners/typescript/main.ts --target nextcloud --strict
+        run: pnpm exec tsx runners/typescript/main.ts --target nextcloud --strict --profile
 
       - name: Start MinIO
         run: |
@@ -434,7 +434,7 @@ jobs:
             -p qjs-wasi.wasm -O /tmp/quickjs/qjs-wasi.wasm
 
       - name: Run declarative battery (python hosts)
-        run: ./python/.venv/bin/python integ/runners/python/main.py --facet core --strict --allow-skip chroma,lancedb,nextcloud,notion,postgres,qdrant
+        run: ./python/.venv/bin/python integ/runners/python/main.py --facet core --strict --target-jobs 4 --profile --allow-skip chroma,lancedb,nextcloud,notion,postgres,qdrant
 
       # Moved here from the `integ` job when the HTTP fixture server became a
       # TypeScript kit fake: the adapter still starts it, but the interpreter is
@@ -518,7 +518,7 @@ jobs:
 
       - name: Run declarative battery (typescript hosts)
         working-directory: integ
-        run: pnpm exec tsx runners/typescript/main.ts --facet core --strict --allow-skip chroma,lancedb,nextcloud,notion,postgres,qdrant
+        run: pnpm exec tsx runners/typescript/main.ts --facet core --strict --target-jobs 4 --profile --allow-skip chroma,lancedb,nextcloud,notion,postgres,qdrant
 
       # The fixture server is python (started by the adapter through
       # startPythonServer), so this runs here rather than in integ-ts, which
@@ -780,7 +780,7 @@ jobs:
           exit 1
 
       - name: Run declarative battery on nextcloud
-        run: ./python/.venv/bin/python integ/runners/python/main.py --target nextcloud --strict
+        run: ./python/.venv/bin/python integ/runners/python/main.py --target nextcloud --strict --profile
 
       # disk and ssh need nothing (tempdir, in-process SFTP server);
       # dropbox is an out-of-process fake started below; s3 and gridfs need a

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -625,6 +625,10 @@ def scenario_verb(case: dict) -> str:
 _LEADING_ASSIGN = re.compile(
     r"^[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|\"[^\"]*\"|\([^)]*\)|\S*)\s*")
 _LEADING_SEP = re.compile(r"^(?:;|&&|\|\||&)\s*")
+# `out=$(cat <<END` is the command `cat`, but the assignment above ends at the
+# space and leaves `<<END` as the first word. Tried before it, so the `\S*`
+# arm never gets to swallow `$(cat`.
+_LEADING_CMDSUB = re.compile(r"^(?:[A-Za-z_][A-Za-z0-9_]*=)?\$\(\s*")
 
 
 def command_verb(command: str) -> str:
@@ -643,7 +647,8 @@ def command_verb(command: str) -> str:
     """
     rest = command.strip()
     while rest:
-        match = _LEADING_ASSIGN.match(rest) or _LEADING_SEP.match(rest)
+        match = (_LEADING_CMDSUB.match(rest) or _LEADING_ASSIGN.match(rest)
+                 or _LEADING_SEP.match(rest))
         if match is None or match.end() == 0:
             break
         rest = rest[match.end():]
@@ -731,8 +736,12 @@ class Report:
         by_target: dict[str, list[float]] = {}
         for target, _case_id, elapsed, _verb in self.samples:
             by_target.setdefault(target, []).append(elapsed)
-        for target, raw in sorted(by_target.items(),
-                                  key=lambda kv: -sum(kv[1])):
+        # Ranked on ``wall``, the column this table exists to show. Ranking
+        # on the case total instead buried a target whose cost is setup: 100s
+        # of setup and 1s of cases sorted below a target with 2s of cases.
+        for target, raw in sorted(
+                by_target.items(),
+                key=lambda kv: -self.target_wall.get(kv[0], sum(kv[1]))):
             ordered = sorted(raw)
             wall = self.target_wall.get(target, sum(raw))
             out.append(f"{target:<22} {len(raw):>6} {_secs(wall):>9} "

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -621,7 +621,11 @@ class Report:
     stream: bool = True
     held: list[str] = field(default_factory=list)
     samples: list[tuple[str, str, float, str]] = field(default_factory=list)
-    lifecycle: list[tuple[str, float]] = field(default_factory=list)
+    # Wall time for the whole target, which the per-case samples cannot see:
+    # opening it, seeding fixtures and cleaning up all sit outside
+    # ``run_case``, and on nextcloud the fixture seed alone is dozens of
+    # remote writes.
+    target_wall: dict[str, float] = field(default_factory=dict)
 
     def _say(self, line: str) -> None:
         if self.stream:
@@ -645,22 +649,22 @@ class Report:
             self.passed += 1
             self._say(f"ok   [{target}] {case_id}")
 
-    def record_lifecycle(self, target: str, seconds: float) -> None:
-        """Record time a target spent outside its cases.
+    def note_target_wall(self, target: str, seconds: float) -> None:
+        """Add a target's whole-run wall time.
 
         Args:
-            target (str): the target id.
-            seconds (float): opening, seeding and closing, none of which is
-                inside a case and none of which the samples can see.
+            target (str): target id.
+            seconds (float): wall time for opening, running and cleaning it up.
         """
-        self.lifecycle.append((target, seconds))
+        self.target_wall[target] = self.target_wall.get(target, 0.0) + seconds
 
     def absorb(self, other: "Report") -> None:
         self.passed += other.passed
         self.failed += other.failed
         self.failures.extend(other.failures)
         self.samples.extend(other.samples)
-        self.lifecycle.extend(other.lifecycle)
+        for target, seconds in other.target_wall.items():
+            self.note_target_wall(target, seconds)
         for line in other.held:
             print(line)
 
@@ -681,25 +685,20 @@ class Report:
         """
         if not self.samples:
             return ""
-        # Setup is not free and is not in any case: seeding a fixture onto
-        # a remote target is a mkdir and a tee per file. Reported beside the
-        # case time so the row accounts for the target's whole wall clock.
-        setup: dict[str, float] = {}
-        for target, seconds in self.lifecycle:
-            setup[target] = setup.get(target, 0.0) + seconds
+        # ``wall`` is the whole target, ``in cases`` is only what the cases
+        # spent inside it. The gap between them is setup and teardown.
         out = ["", "=== profile: per target ==="]
-        out.append(f"{'target':<22} {'cases':>6} {'in_case':>9} "
-                   f"{'setup':>8} {'total':>9} {'p50':>8} {'p90':>8} "
-                   f"{'max':>9}")
+        out.append(f"{'target':<22} {'cases':>6} {'wall':>9} {'in cases':>9} "
+                   f"{'p50':>8} {'p90':>8} {'max':>9}")
         by_target: dict[str, list[float]] = {}
         for target, _case_id, elapsed, _verb in self.samples:
             by_target.setdefault(target, []).append(elapsed)
         for target, raw in sorted(by_target.items(),
                                   key=lambda kv: -sum(kv[1])):
             ordered = sorted(raw)
-            over = setup.get(target, 0.0)
-            out.append(f"{target:<22} {len(raw):>6} {_secs(sum(raw)):>9} "
-                       f"{_secs(over):>8} {_secs(sum(raw) + over):>9} "
+            wall = self.target_wall.get(target, sum(raw))
+            out.append(f"{target:<22} {len(raw):>6} {_secs(wall):>9} "
+                       f"{_secs(sum(raw)):>9} "
                        f"{_secs(_at(ordered, 0.5)):>8} "
                        f"{_secs(_at(ordered, 0.9)):>8} "
                        f"{_secs(ordered[-1]):>9}")

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -629,6 +629,12 @@ _LEADING_SEP = re.compile(r"^(?:;|&&|\|\||&)\s*")
 # space and leaves `<<END` as the first word. Tried before it, so the `\S*`
 # arm never gets to swallow `$(cat`.
 _LEADING_CMDSUB = re.compile(r"^(?:[A-Za-z_][A-Za-z0-9_]*=)?\$\(\s*")
+# A subshell or brace group is a wrapper, not the command: `(cd d && grep x)`
+# was recorded as `(cd`. Stripping the delimiter re-enters the loop, so
+# `((echo a); echo b)` peels both. It does NOT make the row `grep`: knowing
+# that `cd` is a prelude is shell semantics, and this labels a row rather
+# than parsing a line.
+_LEADING_GROUP = re.compile(r"^[({]\s*")
 
 
 def command_verb(command: str) -> str:
@@ -647,8 +653,8 @@ def command_verb(command: str) -> str:
     """
     rest = command.strip()
     while rest:
-        match = (_LEADING_CMDSUB.match(rest) or _LEADING_ASSIGN.match(rest)
-                 or _LEADING_SEP.match(rest))
+        match = (_LEADING_CMDSUB.match(rest) or _LEADING_GROUP.match(rest)
+                 or _LEADING_ASSIGN.match(rest) or _LEADING_SEP.match(rest))
         if match is None or match.end() == 0:
             break
         rest = rest[match.end():]

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -621,11 +621,7 @@ class Report:
     stream: bool = True
     held: list[str] = field(default_factory=list)
     samples: list[tuple[str, str, float, str]] = field(default_factory=list)
-    # Wall time for the whole target, which the per-case samples cannot see:
-    # opening it, seeding fixtures and cleaning up all sit outside
-    # ``run_case``, and on nextcloud the fixture seed alone is dozens of
-    # remote writes.
-    target_wall: dict[str, float] = field(default_factory=dict)
+    lifecycle: list[tuple[str, float]] = field(default_factory=list)
 
     def _say(self, line: str) -> None:
         if self.stream:
@@ -649,22 +645,22 @@ class Report:
             self.passed += 1
             self._say(f"ok   [{target}] {case_id}")
 
-    def note_target_wall(self, target: str, seconds: float) -> None:
-        """Add a target's whole-run wall time.
+    def record_lifecycle(self, target: str, seconds: float) -> None:
+        """Record time a target spent outside its cases.
 
         Args:
-            target (str): target id.
-            seconds (float): wall time for opening, running and cleaning it up.
+            target (str): the target id.
+            seconds (float): opening, seeding and closing, none of which is
+                inside a case and none of which the samples can see.
         """
-        self.target_wall[target] = self.target_wall.get(target, 0.0) + seconds
+        self.lifecycle.append((target, seconds))
 
     def absorb(self, other: "Report") -> None:
         self.passed += other.passed
         self.failed += other.failed
         self.failures.extend(other.failures)
         self.samples.extend(other.samples)
-        for target, seconds in other.target_wall.items():
-            self.note_target_wall(target, seconds)
+        self.lifecycle.extend(other.lifecycle)
         for line in other.held:
             print(line)
 
@@ -685,20 +681,25 @@ class Report:
         """
         if not self.samples:
             return ""
-        # ``wall`` is the whole target, ``in cases`` is only what the cases
-        # spent inside it. The gap between them is setup and teardown.
+        # Setup is not free and is not in any case: seeding a fixture onto
+        # a remote target is a mkdir and a tee per file. Reported beside the
+        # case time so the row accounts for the target's whole wall clock.
+        setup: dict[str, float] = {}
+        for target, seconds in self.lifecycle:
+            setup[target] = setup.get(target, 0.0) + seconds
         out = ["", "=== profile: per target ==="]
-        out.append(f"{'target':<22} {'cases':>6} {'wall':>9} {'in cases':>9} "
-                   f"{'p50':>8} {'p90':>8} {'max':>9}")
+        out.append(f"{'target':<22} {'cases':>6} {'in_case':>9} "
+                   f"{'setup':>8} {'total':>9} {'p50':>8} {'p90':>8} "
+                   f"{'max':>9}")
         by_target: dict[str, list[float]] = {}
         for target, _case_id, elapsed, _verb in self.samples:
             by_target.setdefault(target, []).append(elapsed)
         for target, raw in sorted(by_target.items(),
                                   key=lambda kv: -sum(kv[1])):
             ordered = sorted(raw)
-            wall = self.target_wall.get(target, sum(raw))
-            out.append(f"{target:<22} {len(raw):>6} {_secs(wall):>9} "
-                       f"{_secs(sum(raw)):>9} "
+            over = setup.get(target, 0.0)
+            out.append(f"{target:<22} {len(raw):>6} {_secs(sum(raw)):>9} "
+                       f"{_secs(over):>8} {_secs(sum(raw) + over):>9} "
                        f"{_secs(_at(ordered, 0.5)):>8} "
                        f"{_secs(_at(ordered, 0.9)):>8} "
                        f"{_secs(ordered[-1]):>9}")

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -597,6 +597,28 @@ def _at(ordered: list[float], quantile: float) -> float:
     return ordered[min(len(ordered) - 1, max(0, index))]
 
 
+def scenario_verb(case: dict) -> str:
+    """Name the command a case runs, scenario cases included.
+
+    A consistency case carries no ``command``: its commands live in the
+    scenario steps, so reading the field straight off it labelled every one
+    of them as unknown.
+
+    Args:
+        case (dict): the case being recorded.
+
+    Returns:
+        str: the command line to take a verb from, or "" when it has none.
+    """
+    command = case.get("command")
+    if isinstance(command, str):
+        return command
+    for step in case.get("scenario") or []:
+        if isinstance(step, dict) and isinstance(step.get("command"), str):
+            return step["command"]
+    return ""
+
+
 def command_verb(command: str) -> str:
     """First real word of a command, skipping leading VAR=value assignments.
 

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import json
+import math
 import os
 import re
 import subprocess
@@ -578,7 +579,21 @@ def _secs(value: float) -> str:
 
 
 def _at(ordered: list[float], quantile: float) -> float:
-    index = round(quantile * (len(ordered) - 1))
+    """Pick the sample at a quantile, the same way the TypeScript host does.
+
+    ``floor(x + 0.5)`` rather than ``round``: python rounds a half to even
+    and JS ``Math.round`` rounds it up, so an even sample count made the two
+    hosts choose different indexes and report different percentiles for the
+    same ordered data.
+
+    Args:
+        ordered (list[float]): samples, ascending.
+        quantile (float): 0 to 1.
+
+    Returns:
+        float: the chosen sample.
+    """
+    index = math.floor(quantile * (len(ordered) - 1) + 0.5)
     return ordered[min(len(ordered) - 1, max(0, index))]
 
 

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -621,6 +621,11 @@ class Report:
     stream: bool = True
     held: list[str] = field(default_factory=list)
     samples: list[tuple[str, str, float, str]] = field(default_factory=list)
+    # Wall time for the whole target, which the per-case samples cannot see:
+    # opening it, seeding fixtures and cleaning up all sit outside
+    # ``run_case``, and on nextcloud the fixture seed alone is dozens of
+    # remote writes.
+    target_wall: dict[str, float] = field(default_factory=dict)
 
     def _say(self, line: str) -> None:
         if self.stream:
@@ -644,11 +649,22 @@ class Report:
             self.passed += 1
             self._say(f"ok   [{target}] {case_id}")
 
+    def note_target_wall(self, target: str, seconds: float) -> None:
+        """Add a target's whole-run wall time.
+
+        Args:
+            target (str): target id.
+            seconds (float): wall time for opening, running and cleaning it up.
+        """
+        self.target_wall[target] = self.target_wall.get(target, 0.0) + seconds
+
     def absorb(self, other: "Report") -> None:
         self.passed += other.passed
         self.failed += other.failed
         self.failures.extend(other.failures)
         self.samples.extend(other.samples)
+        for target, seconds in other.target_wall.items():
+            self.note_target_wall(target, seconds)
         for line in other.held:
             print(line)
 
@@ -669,16 +685,20 @@ class Report:
         """
         if not self.samples:
             return ""
+        # ``wall`` is the whole target, ``in cases`` is only what the cases
+        # spent inside it. The gap between them is setup and teardown.
         out = ["", "=== profile: per target ==="]
-        out.append(f"{'target':<22} {'cases':>6} {'total':>9} {'p50':>8} "
-                   f"{'p90':>8} {'max':>9}")
+        out.append(f"{'target':<22} {'cases':>6} {'wall':>9} {'in cases':>9} "
+                   f"{'p50':>8} {'p90':>8} {'max':>9}")
         by_target: dict[str, list[float]] = {}
         for target, _case_id, elapsed, _verb in self.samples:
             by_target.setdefault(target, []).append(elapsed)
         for target, raw in sorted(by_target.items(),
                                   key=lambda kv: -sum(kv[1])):
             ordered = sorted(raw)
-            out.append(f"{target:<22} {len(raw):>6} {_secs(sum(raw)):>9} "
+            wall = self.target_wall.get(target, sum(raw))
+            out.append(f"{target:<22} {len(raw):>6} {_secs(wall):>9} "
+                       f"{_secs(sum(raw)):>9} "
                        f"{_secs(_at(ordered, 0.5)):>8} "
                        f"{_secs(_at(ordered, 0.9)):>8} "
                        f"{_secs(ordered[-1]):>9}")

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -619,8 +619,21 @@ def scenario_verb(case: dict) -> str:
     return ""
 
 
+# A leading `NAME=value` assignment, where the value may be quoted or a
+# parenthesised array. Splitting on whitespace instead cut `v='a b'` in half
+# and recorded the fragment as the command.
+_LEADING_ASSIGN = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|\"[^\"]*\"|\([^)]*\)|\S*)\s*")
+_LEADING_SEP = re.compile(r"^(?:;|&&|\|\||&)\s*")
+
+
 def command_verb(command: str) -> str:
-    """First real word of a command, skipping leading VAR=value assignments.
+    """Name the command a line runs, for grouping the profile.
+
+    Not a shell parser, and it does not need to be: this only labels a row,
+    so the cost of a wrong guess is a mislabelled row rather than a wrong
+    measurement. It does handle the two shapes the corpus actually uses,
+    a quoted assignment and a leading separator.
 
     Args:
         command (str): the case's shell line.
@@ -628,11 +641,14 @@ def command_verb(command: str) -> str:
     Returns:
         str: the command name, or "?" when the line has none.
     """
-    for word in command.strip().split():
-        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", word):
-            continue
-        return word.rsplit("/", 1)[-1]
-    return "?"
+    rest = command.strip()
+    while rest:
+        match = _LEADING_ASSIGN.match(rest) or _LEADING_SEP.match(rest)
+        if match is None or match.end() == 0:
+            break
+        rest = rest[match.end():]
+    words = rest.split()
+    return words[0].rsplit("/", 1)[-1] if words else "?"
 
 
 @dataclass

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import re
 import subprocess
 import tempfile
 import time
@@ -572,21 +573,111 @@ def compare(case: dict,
     return diffs
 
 
+def _secs(value: float) -> str:
+    return f"{value:.1f}s" if value >= 1 else f"{value * 1000:.0f}ms"
+
+
+def _at(ordered: list[float], quantile: float) -> float:
+    index = round(quantile * (len(ordered) - 1))
+    return ordered[min(len(ordered) - 1, max(0, index))]
+
+
+def command_verb(command: str) -> str:
+    """First real word of a command, skipping leading VAR=value assignments.
+
+    Args:
+        command (str): the case's shell line.
+
+    Returns:
+        str: the command name, or "?" when the line has none.
+    """
+    for word in command.strip().split():
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", word):
+            continue
+        return word.rsplit("/", 1)[-1]
+    return "?"
+
+
 @dataclass
 class Report:
     passed: int = 0
     failed: int = 0
     failures: list[str] = field(default_factory=list)
+    stream: bool = True
+    held: list[str] = field(default_factory=list)
+    samples: list[tuple[str, str, float, str]] = field(default_factory=list)
 
-    def record(self, target: str, case_id: str, diffs: list[str]) -> None:
+    def _say(self, line: str) -> None:
+        if self.stream:
+            print(line)
+        else:
+            self.held.append(line)
+
+    def record(self,
+               target: str,
+               case_id: str,
+               diffs: list[str],
+               elapsed: float = 0.0,
+               command: str = "") -> None:
+        self.samples.append((target, case_id, elapsed, command_verb(command)))
         if diffs:
             self.failed += 1
             joined = "; ".join(diffs)
             self.failures.append(f"[{target}] {case_id}: {joined}")
-            print(f"FAIL [{target}] {case_id}: {joined}")
+            self._say(f"FAIL [{target}] {case_id}: {joined}")
         else:
             self.passed += 1
-            print(f"ok   [{target}] {case_id}")
+            self._say(f"ok   [{target}] {case_id}")
+
+    def absorb(self, other: "Report") -> None:
+        self.passed += other.passed
+        self.failed += other.failed
+        self.failures.extend(other.failures)
+        self.samples.extend(other.samples)
+        for line in other.held:
+            print(line)
 
     def summary(self) -> str:
         return f"{self.passed} passed, {self.failed} failed"
+
+    def profile(self, top: int = 15) -> str:
+        """Where the battery's wall clock goes.
+
+        Local timings do not carry to CI, so this reports from inside the
+        CI job itself.
+
+        Args:
+            top (int): how many rows each ranked section prints.
+
+        Returns:
+            str: the formatted profile, empty when nothing was recorded.
+        """
+        if not self.samples:
+            return ""
+        out = ["", "=== profile: per target ==="]
+        out.append(f"{'target':<22} {'cases':>6} {'total':>9} {'p50':>8} "
+                   f"{'p90':>8} {'max':>9}")
+        by_target: dict[str, list[float]] = {}
+        for target, _case_id, elapsed, _verb in self.samples:
+            by_target.setdefault(target, []).append(elapsed)
+        for target, raw in sorted(by_target.items(),
+                                  key=lambda kv: -sum(kv[1])):
+            ordered = sorted(raw)
+            out.append(f"{target:<22} {len(raw):>6} {_secs(sum(raw)):>9} "
+                       f"{_secs(_at(ordered, 0.5)):>8} "
+                       f"{_secs(_at(ordered, 0.9)):>8} "
+                       f"{_secs(ordered[-1]):>9}")
+        out += ["", f"=== profile: {top} slowest cases ==="]
+        for target, case_id, elapsed, _verb in sorted(
+                self.samples, key=lambda s: -s[2])[:top]:
+            out.append(f"  {_secs(elapsed):>9}  [{target}] {case_id}")
+        out += ["", f"=== profile: {top} costliest commands ==="]
+        by_verb: dict[str, list[float]] = {}
+        for _target, _case_id, elapsed, verb in self.samples:
+            by_verb.setdefault(verb, []).append(elapsed)
+        for verb, times in sorted(by_verb.items(),
+                                  key=lambda kv: -sum(kv[1]))[:top]:
+            mean = sum(times) / len(times)
+            out.append(f"  {_secs(sum(times)):>9}  x{len(times):<5} "
+                       f"mean {_secs(mean):>8}  {verb}")
+        return "\n".join(out)

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -597,6 +597,9 @@ def _at(ordered: list[float], quantile: float) -> float:
     return ordered[min(len(ordered) - 1, max(0, index))]
 
 
+SCENARIO_VERB = "scenario"
+
+
 def scenario_verb(case: dict) -> str:
     """Name the command a case runs, scenario cases included.
 
@@ -604,18 +607,26 @@ def scenario_verb(case: dict) -> str:
     scenario steps, so reading the field straight off it labelled every one
     of them as unknown.
 
+    Such a case is charged as ``scenario``, not as its first step. The
+    interval is the whole case, and a scenario spends it on out-of-band
+    remote writes and more than one invocation, so billing it to the first
+    verb made ``cat`` and ``find`` carry time no ``cat`` or ``find`` spent.
+    A row of its own says what the time is; the slowest-cases table above it
+    is where an expensive one is named.
+
     Args:
         case (dict): the case being recorded.
 
     Returns:
-        str: the command line to take a verb from, or "" when it has none.
+        str: the command line to take a verb from, "scenario" for a scenario
+            case, or "" when it has neither.
     """
     command = case.get("command")
     if isinstance(command, str):
         return command
     for step in case.get("scenario") or []:
         if isinstance(step, dict) and isinstance(step.get("command"), str):
-            return step["command"]
+            return SCENARIO_VERB
     return ""
 
 

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -78,6 +78,8 @@ async def run_target(target: dict, cases: list[dict], root: Path,
                      report: harness.Report | None,
                      emit: list[dict] | None) -> None:
     selected = [c for c in cases if target["id"] in c["targets"]]
+    lifecycle = 0.0
+    started = time.monotonic()
     ws, cleanup = await adapters.open_target(target)
     try:
         for mount in target["mounts"]:
@@ -108,6 +110,7 @@ async def run_target(target: dict, cases: list[dict], root: Path,
         # per case worth its time. The reasons double as the tell that a
         # refusal came from the policy layer rather than from the
         # command itself.
+        lifecycle += time.monotonic() - started
         reasons = harness.rule_reasons({
             "profiles": target.get("profiles"),
             "sessions": target.get("sessions"),
@@ -121,7 +124,11 @@ async def run_target(target: dict, cases: list[dict], root: Path,
             _emit_or_record(emit, report, target["id"], bound, exit_code, out,
                             err, elapsed, check_out, notes)
     finally:
+        started = time.monotonic()
         await cleanup()
+        lifecycle += time.monotonic() - started
+        if report is not None:
+            report.record_lifecycle(target["id"], lifecycle)
     for case in selected:
         if "consistency" in case:
             await run_consistency_case(target, case, report, emit)
@@ -201,11 +208,7 @@ async def main() -> None:
     # itself.
     if args.target_jobs == 1:
         for target in eligible:
-            started = time.monotonic()
             await run_target(target, cases, root, report, emit)
-            if report is not None:
-                report.note_target_wall(target["id"],
-                                        time.monotonic() - started)
     else:
         semaphore = asyncio.Semaphore(args.target_jobs)
         lane_locks: dict[str, asyncio.Lock] = {}
@@ -215,17 +218,11 @@ async def main() -> None:
         async def run_one(target: dict, lane: str) -> None:
             slot_report, slot_emit = slots[target["id"]]
             async with lane_locks[lane], semaphore:
-                started = time.monotonic()
                 try:
                     await run_target(target, cases, root, slot_report,
                                      slot_emit)
                 except Exception as exc:  # reported once every target is done
                     errors.append(exc)
-                finally:
-                    if slot_report is not None:
-                        slot_report.note_target_wall(
-                            target["id"],
-                            time.monotonic() - started)
 
         tasks = []
         for target in eligible:

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -209,11 +209,16 @@ async def main() -> None:
     else:
         semaphore = asyncio.Semaphore(args.target_jobs)
         lane_locks: dict[str, asyncio.Lock] = {}
-        slots: dict[str, tuple[harness.Report | None, list[dict] | None]] = {}
+        # One slot per invocation, not per target id. `--target x --target x`
+        # is two runs, and keying by id made both of them write the second
+        # slot and then merged that slot twice, so two runs reported as four.
+        slots: list[tuple[harness.Report | None, list[dict] | None]] = []
         errors: list[BaseException] = []
 
-        async def run_one(target: dict, lane: str) -> None:
-            slot_report, slot_emit = slots[target["id"]]
+        async def run_one(
+                target: dict, lane: str,
+                slot: tuple[harness.Report | None, list[dict] | None]) -> None:
+            slot_report, slot_emit = slot
             async with lane_locks[lane], semaphore:
                 started = time.monotonic()
                 try:
@@ -229,19 +234,19 @@ async def main() -> None:
 
         tasks = []
         for target in eligible:
-            slots[target["id"]] = (
+            slot = (
                 None if report is None else harness.Report(stream=False),
                 None if emit is None else [],
             )
+            slots.append(slot)
             lane = target.get("service") or f"solo:{target['id']}"
             lane_locks.setdefault(lane, asyncio.Lock())
-            tasks.append(asyncio.create_task(run_one(target, lane)))
+            tasks.append(asyncio.create_task(run_one(target, lane, slot)))
         if tasks:
             await asyncio.gather(*tasks)
         # Merged in declared target order, so a concurrent run prints what a
         # serial run printed.
-        for target in eligible:
-            slot_report, slot_emit = slots[target["id"]]
+        for slot_report, slot_emit in slots:
             if report is not None and slot_report is not None:
                 report.absorb(slot_report)
             if emit is not None and slot_emit is not None:

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -193,41 +193,51 @@ async def main() -> None:
     if args.target_jobs < 1:
         print("--target-jobs takes an integer >= 1", file=sys.stderr)
         sys.exit(2)
-    semaphore = asyncio.Semaphore(args.target_jobs)
-    lane_locks: dict[str, asyncio.Lock] = {}
-    slots: dict[str, tuple[harness.Report | None, list[dict] | None]] = {}
-    errors: list[BaseException] = []
 
-    async def run_one(target: dict, lane: str) -> None:
-        slot_report, slot_emit = slots[target["id"]]
-        async with lane_locks[lane], semaphore:
-            try:
-                await run_target(target, cases, root, slot_report, slot_emit)
-            except Exception as exc:  # reported after every target finishes
-                errors.append(exc)
+    # One worker means the old loop, unchanged. The lane scheduler below
+    # cannot stand in for it: a target waiting on a busy lane lets a later
+    # one from another lane take the worker first, and with `s3` carrying
+    # three targets and `gws` four, the default run would quietly reorder
+    # itself.
+    if args.target_jobs == 1:
+        for target in eligible:
+            await run_target(target, cases, root, report, emit)
+    else:
+        semaphore = asyncio.Semaphore(args.target_jobs)
+        lane_locks: dict[str, asyncio.Lock] = {}
+        slots: dict[str, tuple[harness.Report | None, list[dict] | None]] = {}
+        errors: list[BaseException] = []
 
-    tasks = []
-    for target in eligible:
-        slots[target["id"]] = (
-            None if report is None else harness.Report(
-                stream=args.target_jobs <= 1),
-            None if emit is None else [],
-        )
-        lane = target.get("service") or f"solo:{target['id']}"
-        lane_locks.setdefault(lane, asyncio.Lock())
-        tasks.append(asyncio.create_task(run_one(target, lane)))
-    if tasks:
-        await asyncio.gather(*tasks)
-    # Merged in declared target order, so a concurrent run prints what a
-    # serial run printed.
-    for target in eligible:
-        slot_report, slot_emit = slots[target["id"]]
-        if report is not None and slot_report is not None:
-            report.absorb(slot_report)
-        if emit is not None and slot_emit is not None:
-            emit.extend(slot_emit)
-    if errors:
-        raise errors[0]
+        async def run_one(target: dict, lane: str) -> None:
+            slot_report, slot_emit = slots[target["id"]]
+            async with lane_locks[lane], semaphore:
+                try:
+                    await run_target(target, cases, root, slot_report,
+                                     slot_emit)
+                except Exception as exc:  # reported once every target is done
+                    errors.append(exc)
+
+        tasks = []
+        for target in eligible:
+            slots[target["id"]] = (
+                None if report is None else harness.Report(stream=False),
+                None if emit is None else [],
+            )
+            lane = target.get("service") or f"solo:{target['id']}"
+            lane_locks.setdefault(lane, asyncio.Lock())
+            tasks.append(asyncio.create_task(run_one(target, lane)))
+        if tasks:
+            await asyncio.gather(*tasks)
+        # Merged in declared target order, so a concurrent run prints what a
+        # serial run printed.
+        for target in eligible:
+            slot_report, slot_emit = slots[target["id"]]
+            if report is not None and slot_report is not None:
+                report.absorb(slot_report)
+            if emit is not None and slot_emit is not None:
+                emit.extend(slot_emit)
+        if errors:
+            raise errors[0]
 
     # A skip is one line on stderr and exit 0, so a facet whose service
     # never came up (or whose env var got renamed in the workflow)

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -51,7 +51,7 @@ def _emit_or_record(emit: list[dict] | None,
         report.record(
             target_id, case["id"],
             harness.compare(case, exit_code, out, err, elapsed, check_out,
-                            notes))
+                            notes), elapsed, case.get("command", ""))
 
 
 async def run_consistency_case(target: dict, case: dict,
@@ -132,6 +132,11 @@ async def main() -> None:
     # services it knowingly does not provision. Anything skipping outside
     # this list is a broken job, which is the whole point of --strict.
     parser.add_argument("--allow-skip", dest="allow_skip", default="")
+    parser.add_argument("--target-jobs",
+                        dest="target_jobs",
+                        type=int,
+                        default=1)
+    parser.add_argument("--profile", action="store_true")
     args = parser.parse_args()
 
     root = harness.integ_root()
@@ -156,6 +161,7 @@ async def main() -> None:
     ran = 0
     allow_skip = harness.parse_allow_skip(services, args.allow_skip)
     env_skipped: list[str] = []
+    eligible: list[dict] = []
     for target_id in selected:
         target = manifest[target_id]
         if HOST not in target["hosts"]:
@@ -171,8 +177,51 @@ async def main() -> None:
             if target.get("service") not in allow_skip:
                 env_skipped.append(f"{target_id} ({', '.join(missing)})")
             continue
-        await run_target(target, cases, root, report, emit)
+        eligible.append(target)
         ran += 1
+
+    # Targets own separate workspaces, so they overlap safely -- except when
+    # two speak to the SAME fake (cli-gh and github, cli-ntn and notion,
+    # qdrant and qdrant-window). Those share a lane and stay sequential; the
+    # rest are bound only by the overall width.
+    if args.target_jobs < 1:
+        print("--target-jobs takes an integer >= 1", file=sys.stderr)
+        sys.exit(2)
+    semaphore = asyncio.Semaphore(args.target_jobs)
+    lane_locks: dict[str, asyncio.Lock] = {}
+    slots: dict[str, tuple[harness.Report | None, list[dict] | None]] = {}
+    errors: list[BaseException] = []
+
+    async def run_one(target: dict, lane: str) -> None:
+        slot_report, slot_emit = slots[target["id"]]
+        async with lane_locks[lane], semaphore:
+            try:
+                await run_target(target, cases, root, slot_report, slot_emit)
+            except Exception as exc:  # reported after every target finishes
+                errors.append(exc)
+
+    tasks = []
+    for target in eligible:
+        slots[target["id"]] = (
+            None if report is None else harness.Report(
+                stream=args.target_jobs <= 1),
+            None if emit is None else [],
+        )
+        lane = target.get("service") or f"solo:{target['id']}"
+        lane_locks.setdefault(lane, asyncio.Lock())
+        tasks.append(asyncio.create_task(run_one(target, lane)))
+    if tasks:
+        await asyncio.gather(*tasks)
+    # Merged in declared target order, so a concurrent run prints what a
+    # serial run printed.
+    for target in eligible:
+        slot_report, slot_emit = slots[target["id"]]
+        if report is not None and slot_report is not None:
+            report.absorb(slot_report)
+        if emit is not None and slot_emit is not None:
+            emit.extend(slot_emit)
+    if errors:
+        raise errors[0]
 
     # A skip is one line on stderr and exit 0, so a facet whose service
     # never came up (or whose env var got renamed in the workflow)
@@ -197,6 +246,8 @@ async def main() -> None:
         Path(args.emit).write_text(json.dumps(emit))
         return
     assert report is not None
+    if args.profile:
+        print(report.profile())
     print(f"\n{report.summary()}")
     if report.failed:
         sys.exit(1)

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -52,7 +52,7 @@ def _emit_or_record(emit: list[dict] | None,
         report.record(
             target_id, case["id"],
             harness.compare(case, exit_code, out, err, elapsed, check_out,
-                            notes), elapsed, case.get("command", ""))
+                            notes), elapsed, harness.scenario_verb(case))
 
 
 async def run_consistency_case(target: dict, case: dict,

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -38,7 +38,8 @@ def _emit_or_record(emit: list[dict] | None,
                     err: str,
                     elapsed: float,
                     check_out: str | None = None,
-                    notes: list[str] | None = None) -> None:
+                    notes: list[str] | None = None,
+                    sample: float | None = None) -> None:
     if emit is not None:
         emit.append({
             "target": target_id,
@@ -49,10 +50,17 @@ def _emit_or_record(emit: list[dict] | None,
             "check": check_out,
         })
     elif report is not None:
+        # Two durations, deliberately. ``elapsed`` is the command alone and is
+        # what a case's ``expect.elapsed`` bounds are asserted against, so it
+        # cannot grow. ``sample`` is the whole case, which for the 34 cases
+        # carrying a ``check`` includes a second backend read the command-only
+        # figure left out; without it that work fell into the wall-minus-cases
+        # gap and read as setup.
         report.record(
             target_id, case["id"],
             harness.compare(case, exit_code, out, err, elapsed, check_out,
-                            notes), elapsed, harness.scenario_verb(case))
+                            notes), elapsed if sample is None else sample,
+            harness.scenario_verb(case))
 
 
 async def run_consistency_case(target: dict, case: dict,
@@ -116,10 +124,21 @@ async def run_target(target: dict, cases: list[dict], root: Path,
             if "consistency" in case:
                 continue
             bound = harness.bind_mount(case, primary)
+            started = time.monotonic()
             ran = await harness.run_case(ws, bound, reasons)
+            whole = time.monotonic() - started
             exit_code, out, err, elapsed, check_out, notes = ran
-            _emit_or_record(emit, report, target["id"], bound, exit_code, out,
-                            err, elapsed, check_out, notes)
+            _emit_or_record(emit,
+                            report,
+                            target["id"],
+                            bound,
+                            exit_code,
+                            out,
+                            err,
+                            elapsed,
+                            check_out,
+                            notes,
+                            sample=whole)
     finally:
         await cleanup()
     for case in selected:

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -201,7 +201,11 @@ async def main() -> None:
     # itself.
     if args.target_jobs == 1:
         for target in eligible:
+            started = time.monotonic()
             await run_target(target, cases, root, report, emit)
+            if report is not None:
+                report.note_target_wall(target["id"],
+                                        time.monotonic() - started)
     else:
         semaphore = asyncio.Semaphore(args.target_jobs)
         lane_locks: dict[str, asyncio.Lock] = {}
@@ -211,11 +215,17 @@ async def main() -> None:
         async def run_one(target: dict, lane: str) -> None:
             slot_report, slot_emit = slots[target["id"]]
             async with lane_locks[lane], semaphore:
+                started = time.monotonic()
                 try:
                     await run_target(target, cases, root, slot_report,
                                      slot_emit)
                 except Exception as exc:  # reported once every target is done
                     errors.append(exc)
+                finally:
+                    if slot_report is not None:
+                        slot_report.note_target_wall(
+                            target["id"],
+                            time.monotonic() - started)
 
         tasks = []
         for target in eligible:

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -78,8 +78,6 @@ async def run_target(target: dict, cases: list[dict], root: Path,
                      report: harness.Report | None,
                      emit: list[dict] | None) -> None:
     selected = [c for c in cases if target["id"] in c["targets"]]
-    lifecycle = 0.0
-    started = time.monotonic()
     ws, cleanup = await adapters.open_target(target)
     try:
         for mount in target["mounts"]:
@@ -110,7 +108,6 @@ async def run_target(target: dict, cases: list[dict], root: Path,
         # per case worth its time. The reasons double as the tell that a
         # refusal came from the policy layer rather than from the
         # command itself.
-        lifecycle += time.monotonic() - started
         reasons = harness.rule_reasons({
             "profiles": target.get("profiles"),
             "sessions": target.get("sessions"),
@@ -124,11 +121,7 @@ async def run_target(target: dict, cases: list[dict], root: Path,
             _emit_or_record(emit, report, target["id"], bound, exit_code, out,
                             err, elapsed, check_out, notes)
     finally:
-        started = time.monotonic()
         await cleanup()
-        lifecycle += time.monotonic() - started
-        if report is not None:
-            report.record_lifecycle(target["id"], lifecycle)
     for case in selected:
         if "consistency" in case:
             await run_consistency_case(target, case, report, emit)
@@ -208,7 +201,11 @@ async def main() -> None:
     # itself.
     if args.target_jobs == 1:
         for target in eligible:
+            started = time.monotonic()
             await run_target(target, cases, root, report, emit)
+            if report is not None:
+                report.note_target_wall(target["id"],
+                                        time.monotonic() - started)
     else:
         semaphore = asyncio.Semaphore(args.target_jobs)
         lane_locks: dict[str, asyncio.Lock] = {}
@@ -218,11 +215,17 @@ async def main() -> None:
         async def run_one(target: dict, lane: str) -> None:
             slot_report, slot_emit = slots[target["id"]]
             async with lane_locks[lane], semaphore:
+                started = time.monotonic()
                 try:
                     await run_target(target, cases, root, slot_report,
                                      slot_emit)
                 except Exception as exc:  # reported once every target is done
                     errors.append(exc)
+                finally:
+                    if slot_report is not None:
+                        slot_report.note_target_wall(
+                            target["id"],
+                            time.monotonic() - started)
 
         tasks = []
         for target in eligible:

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -16,6 +16,7 @@ import argparse
 import asyncio
 import json
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -60,10 +61,15 @@ async def run_consistency_case(target: dict, case: dict,
     policy = ConsistencyPolicy(case["consistency"])
     read_ws, mutate, cleanup = await adapters.open_consistency(target, policy)
     try:
+        started = time.monotonic()
         exit_code, out = await harness.run_scenario(read_ws, mutate,
                                                     case["scenario"])
+        # Measured, not zero: a consistency scenario on s3 or gridfs runs
+        # several remote mutations, and recording it as free dragged the
+        # profile's totals and percentiles down.
+        elapsed = time.monotonic() - started
         _emit_or_record(emit, report, target["id"], case, exit_code, out, "",
-                        0.0)
+                        elapsed)
     finally:
         await cleanup()
 

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -721,25 +721,113 @@ export function compare(
   return diffs
 }
 
+export interface Sample {
+  target: string
+  id: string
+  elapsed: number
+  verb: string
+}
+
+// The first real word of a command, ignoring leading `VAR=value` assignments.
+// Only groups the profile, so a wrong guess costs a mislabeled row.
+export function commandVerb(command: string): string {
+  for (const word of command.trim().split(/\s+/)) {
+    if (word.length === 0) continue
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(word)) continue
+    return word.replace(/^.*\//, '')
+  }
+  return '?'
+}
+
 export class Report {
   passed = 0
   failed = 0
   failures: string[] = []
+  // Held rather than printed when the run is concurrent, so lines can be
+  // replayed in target order and a parallel run reads like a serial one.
+  readonly held: string[] = []
+  readonly samples: Sample[] = []
 
-  record(target: string, caseId: string, diffs: string[]): void {
+  constructor(readonly stream: boolean = true) {}
+
+  private say(line: string): void {
+    if (this.stream) process.stdout.write(line)
+    else this.held.push(line)
+  }
+
+  record(target: string, caseId: string, diffs: string[], elapsed = 0, command = ''): void {
+    this.samples.push({ target, id: caseId, elapsed, verb: commandVerb(command) })
     if (diffs.length) {
       this.failed++
       const joined = diffs.join('; ')
       this.failures.push(`[${target}] ${caseId}: ${joined}`)
-      process.stdout.write(`FAIL [${target}] ${caseId}: ${joined}\n`)
+      this.say(`FAIL [${target}] ${caseId}: ${joined}\n`)
     } else {
       this.passed++
-      process.stdout.write(`ok   [${target}] ${caseId}\n`)
+      this.say(`ok   [${target}] ${caseId}\n`)
     }
+  }
+
+  absorb(other: Report): void {
+    this.passed += other.passed
+    this.failed += other.failed
+    this.failures.push(...other.failures)
+    this.samples.push(...other.samples)
+    for (const line of other.held) process.stdout.write(line)
   }
 
   summary(): string {
     return `${String(this.passed)} passed, ${String(this.failed)} failed`
+  }
+
+  // Where the battery's wall clock goes. Local timings do not carry to CI
+  // (docker on macOS is far slower per request), so this reports from inside
+  // the CI job itself.
+  profile(top = 15): string {
+    if (this.samples.length === 0) return ''
+    const secs = (n: number): string => (n >= 1 ? `${n.toFixed(1)}s` : `${(n * 1000).toFixed(0)}ms`)
+    const at = (sorted: number[], q: number): number =>
+      sorted[Math.min(sorted.length - 1, Math.max(0, Math.round(q * (sorted.length - 1))))]
+    const byTarget = new Map<string, number[]>()
+    for (const s of this.samples) {
+      const bucket = byTarget.get(s.target)
+      if (bucket === undefined) byTarget.set(s.target, [s.elapsed])
+      else bucket.push(s.elapsed)
+    }
+    const out: string[] = ['', '=== profile: per target ===']
+    out.push(
+      ['target'.padEnd(22), 'cases'.padStart(6), 'total'.padStart(9), 'p50'.padStart(8),
+        'p90'.padStart(8), 'max'.padStart(9)].join(' '),
+    )
+    const total = (xs: number[]): number => xs.reduce((a, b) => a + b, 0)
+    for (const [target, raw] of [...byTarget.entries()].sort((a, b) => total(b[1]) - total(a[1]))) {
+      const sorted = [...raw].sort((a, b) => a - b)
+      out.push(
+        [target.padEnd(22), String(raw.length).padStart(6), secs(total(raw)).padStart(9),
+          secs(at(sorted, 0.5)).padStart(8), secs(at(sorted, 0.9)).padStart(8),
+          secs(sorted[sorted.length - 1]).padStart(9)].join(' '),
+      )
+    }
+    out.push('', `=== profile: ${String(top)} slowest cases ===`)
+    for (const s of [...this.samples].sort((a, b) => b.elapsed - a.elapsed).slice(0, top)) {
+      out.push(`  ${secs(s.elapsed).padStart(9)}  [${s.target}] ${s.id}`)
+    }
+    out.push('', `=== profile: ${String(top)} costliest commands ===`)
+    const byVerb = new Map<string, { total: number; n: number }>()
+    for (const s of this.samples) {
+      const v = byVerb.get(s.verb) ?? { total: 0, n: 0 }
+      v.total += s.elapsed
+      v.n += 1
+      byVerb.set(s.verb, v)
+    }
+    const ranked = [...byVerb.entries()].sort((a, b) => b[1].total - a[1].total).slice(0, top)
+    for (const [verb, v] of ranked) {
+      out.push(
+        `  ${secs(v.total).padStart(9)}  x${String(v.n).padEnd(5)} ` +
+          `mean ${secs(v.total / v.n).padStart(8)}  ${verb}`,
+      )
+    }
+    return out.join('\n')
   }
 }
 

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -747,10 +747,9 @@ export class Report {
   // replayed in target order and a parallel run reads like a serial one.
   readonly held: string[] = []
   readonly samples: Sample[] = []
-  // Wall time for the whole target, which the per-case samples cannot see:
-  // opening it, seeding fixtures and cleaning up all sit outside `runCase`,
-  // and on nextcloud the fixture seed alone is dozens of remote writes.
-  readonly targetWall = new Map<string, number>()
+  // Opening, seeding and closing a target: outside every case, so the
+  // samples above cannot see it.
+  readonly lifecycle: { target: string; elapsed: number }[] = []
 
   constructor(readonly stream: boolean = true) {}
 
@@ -772,8 +771,8 @@ export class Report {
     }
   }
 
-  noteTargetWall(target: string, seconds: number): void {
-    this.targetWall.set(target, (this.targetWall.get(target) ?? 0) + seconds)
+  recordLifecycle(target: string, elapsed: number): void {
+    this.lifecycle.push({ target, elapsed })
   }
 
   absorb(other: Report): void {
@@ -781,7 +780,7 @@ export class Report {
     this.failed += other.failed
     this.failures.push(...other.failures)
     this.samples.push(...other.samples)
-    for (const [target, seconds] of other.targetWall) this.noteTargetWall(target, seconds)
+    this.lifecycle.push(...other.lifecycle)
     for (const line of other.held) process.stdout.write(line)
   }
 
@@ -803,16 +802,19 @@ export class Report {
       if (bucket === undefined) byTarget.set(s.target, [s.elapsed])
       else bucket.push(s.elapsed)
     }
-    // `wall` is the whole target, `cases` is only what the cases spent inside
-    // it. The gap between them is setup and teardown: opening the target,
-    // seeding its fixtures, hydrating sessions, and cleaning up.
+    // Setup is not free and is not in any case: seeding a fixture onto a
+    // remote target is a mkdir and a tee per file. Reported beside the case
+    // time so the row accounts for the target's whole wall clock.
+    const setup = new Map<string, number>()
+    for (const l of this.lifecycle) setup.set(l.target, (setup.get(l.target) ?? 0) + l.elapsed)
     const out: string[] = ['', '=== profile: per target ===']
     out.push(
       [
         'target'.padEnd(22),
         'cases'.padStart(6),
-        'wall'.padStart(9),
-        'in cases'.padStart(9),
+        'in_case'.padStart(9),
+        'setup'.padStart(8),
+        'total'.padStart(9),
         'p50'.padStart(8),
         'p90'.padStart(8),
         'max'.padStart(9),
@@ -825,8 +827,9 @@ export class Report {
         [
           target.padEnd(22),
           String(raw.length).padStart(6),
-          secs(this.targetWall.get(target) ?? total(raw)).padStart(9),
           secs(total(raw)).padStart(9),
+          secs(setup.get(target) ?? 0).padStart(8),
+          secs(total(raw) + (setup.get(target) ?? 0)).padStart(9),
           secs(at(sorted, 0.5)).padStart(8),
           secs(at(sorted, 0.9)).padStart(8),
           secs(sorted[sorted.length - 1]).padStart(9),

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -730,13 +730,21 @@ export interface Sample {
 
 // The first real word of a command, ignoring leading `VAR=value` assignments.
 // Only groups the profile, so a wrong guess costs a mislabeled row.
+// A leading `NAME=value` assignment, where the value may be quoted or a
+// parenthesised array. Splitting on whitespace instead cut `v='a b'` in half
+// and recorded the fragment as the command.
+const LEADING_ASSIGN = /^[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|"[^"]*"|\([^)]*\)|\S*)\s*/
+const LEADING_SEP = /^(?:;|&&|\|\||&)\s*/
+
 export function commandVerb(command: string): string {
-  for (const word of command.trim().split(/\s+/)) {
-    if (word.length === 0) continue
-    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(word)) continue
-    return word.replace(/^.*\//, '')
+  let rest = command.trim()
+  for (;;) {
+    const match = LEADING_ASSIGN.exec(rest) ?? LEADING_SEP.exec(rest)
+    if (match === null || match[0].length === 0) break
+    rest = rest.slice(match[0].length)
   }
-  return '?'
+  const first = rest.split(/\s+/).filter((w) => w.length > 0)[0]
+  return first === undefined ? '?' : first.replace(/^.*\//, '')
 }
 
 // A consistency case carries no `command`: its commands live in the scenario

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -747,6 +747,10 @@ export class Report {
   // replayed in target order and a parallel run reads like a serial one.
   readonly held: string[] = []
   readonly samples: Sample[] = []
+  // Wall time for the whole target, which the per-case samples cannot see:
+  // opening it, seeding fixtures and cleaning up all sit outside `runCase`,
+  // and on nextcloud the fixture seed alone is dozens of remote writes.
+  readonly targetWall = new Map<string, number>()
 
   constructor(readonly stream: boolean = true) {}
 
@@ -768,11 +772,16 @@ export class Report {
     }
   }
 
+  noteTargetWall(target: string, seconds: number): void {
+    this.targetWall.set(target, (this.targetWall.get(target) ?? 0) + seconds)
+  }
+
   absorb(other: Report): void {
     this.passed += other.passed
     this.failed += other.failed
     this.failures.push(...other.failures)
     this.samples.push(...other.samples)
+    for (const [target, seconds] of other.targetWall) this.noteTargetWall(target, seconds)
     for (const line of other.held) process.stdout.write(line)
   }
 
@@ -794,12 +803,16 @@ export class Report {
       if (bucket === undefined) byTarget.set(s.target, [s.elapsed])
       else bucket.push(s.elapsed)
     }
+    // `wall` is the whole target, `cases` is only what the cases spent inside
+    // it. The gap between them is setup and teardown: opening the target,
+    // seeding its fixtures, hydrating sessions, and cleaning up.
     const out: string[] = ['', '=== profile: per target ===']
     out.push(
       [
         'target'.padEnd(22),
         'cases'.padStart(6),
-        'total'.padStart(9),
+        'wall'.padStart(9),
+        'in cases'.padStart(9),
         'p50'.padStart(8),
         'p90'.padStart(8),
         'max'.padStart(9),
@@ -812,6 +825,7 @@ export class Report {
         [
           target.padEnd(22),
           String(raw.length).padStart(6),
+          secs(this.targetWall.get(target) ?? total(raw)).padStart(9),
           secs(total(raw)).padStart(9),
           secs(at(sorted, 0.5)).padStart(8),
           secs(at(sorted, 0.9)).padStart(8),

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -735,11 +735,15 @@ export interface Sample {
 // and recorded the fragment as the command.
 const LEADING_ASSIGN = /^[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|"[^"]*"|\([^)]*\)|\S*)\s*/
 const LEADING_SEP = /^(?:;|&&|\|\||&)\s*/
+// `out=$(cat <<END` is the command `cat`, but LEADING_ASSIGN ends at the space
+// and leaves `<<END` as the first word. Tried before it, so its `\S*` arm
+// never gets to swallow `$(cat`.
+const LEADING_CMDSUB = /^(?:[A-Za-z_][A-Za-z0-9_]*=)?\$\(\s*/
 
 export function commandVerb(command: string): string {
   let rest = command.trim()
   for (;;) {
-    const match = LEADING_ASSIGN.exec(rest) ?? LEADING_SEP.exec(rest)
+    const match = LEADING_CMDSUB.exec(rest) ?? LEADING_ASSIGN.exec(rest) ?? LEADING_SEP.exec(rest)
     if (match === null || match[0].length === 0) break
     rest = rest.slice(match[0].length)
   }
@@ -838,7 +842,13 @@ export class Report {
       ].join(' '),
     )
     const total = (xs: number[]): number => xs.reduce((a, b) => a + b, 0)
-    for (const [target, raw] of [...byTarget.entries()].sort((a, b) => total(b[1]) - total(a[1]))) {
+    // Ranked on wall, the column this table exists to show. Ranking on the
+    // case total instead buried a target whose cost is setup: 100s of setup
+    // and 1s of cases sorted below a target with 2s of cases.
+    const wallOf = (t: string, raw: number[]): number => this.targetWall.get(t) ?? total(raw)
+    for (const [target, raw] of [...byTarget.entries()].sort(
+      (a, b) => wallOf(b[0], b[1]) - wallOf(a[0], a[1]),
+    )) {
       const sorted = [...raw].sort((a, b) => a - b)
       out.push(
         [

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -739,11 +739,21 @@ const LEADING_SEP = /^(?:;|&&|\|\||&)\s*/
 // and leaves `<<END` as the first word. Tried before it, so its `\S*` arm
 // never gets to swallow `$(cat`.
 const LEADING_CMDSUB = /^(?:[A-Za-z_][A-Za-z0-9_]*=)?\$\(\s*/
+// A subshell or brace group is a wrapper, not the command: `(cd d && grep x)`
+// was recorded as `(cd`. Stripping the delimiter re-enters the loop, so
+// `((echo a); echo b)` peels both. It does NOT make the row `grep`: knowing
+// that `cd` is a prelude is shell semantics, and this labels a row rather
+// than parsing a line.
+const LEADING_GROUP = /^[({]\s*/
 
 export function commandVerb(command: string): string {
   let rest = command.trim()
   for (;;) {
-    const match = LEADING_CMDSUB.exec(rest) ?? LEADING_ASSIGN.exec(rest) ?? LEADING_SEP.exec(rest)
+    const match =
+      LEADING_CMDSUB.exec(rest) ??
+      LEADING_GROUP.exec(rest) ??
+      LEADING_ASSIGN.exec(rest) ??
+      LEADING_SEP.exec(rest)
     if (match === null || match[0].length === 0) break
     rest = rest.slice(match[0].length)
   }

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -796,16 +796,27 @@ export class Report {
     }
     const out: string[] = ['', '=== profile: per target ===']
     out.push(
-      ['target'.padEnd(22), 'cases'.padStart(6), 'total'.padStart(9), 'p50'.padStart(8),
-        'p90'.padStart(8), 'max'.padStart(9)].join(' '),
+      [
+        'target'.padEnd(22),
+        'cases'.padStart(6),
+        'total'.padStart(9),
+        'p50'.padStart(8),
+        'p90'.padStart(8),
+        'max'.padStart(9),
+      ].join(' '),
     )
     const total = (xs: number[]): number => xs.reduce((a, b) => a + b, 0)
     for (const [target, raw] of [...byTarget.entries()].sort((a, b) => total(b[1]) - total(a[1]))) {
       const sorted = [...raw].sort((a, b) => a - b)
       out.push(
-        [target.padEnd(22), String(raw.length).padStart(6), secs(total(raw)).padStart(9),
-          secs(at(sorted, 0.5)).padStart(8), secs(at(sorted, 0.9)).padStart(8),
-          secs(sorted[sorted.length - 1]).padStart(9)].join(' '),
+        [
+          target.padEnd(22),
+          String(raw.length).padStart(6),
+          secs(total(raw)).padStart(9),
+          secs(at(sorted, 0.5)).padStart(8),
+          secs(at(sorted, 0.9)).padStart(8),
+          secs(sorted[sorted.length - 1]).padStart(9),
+        ].join(' '),
       )
     }
     out.push('', `=== profile: ${String(top)} slowest cases ===`)

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -747,9 +747,10 @@ export class Report {
   // replayed in target order and a parallel run reads like a serial one.
   readonly held: string[] = []
   readonly samples: Sample[] = []
-  // Opening, seeding and closing a target: outside every case, so the
-  // samples above cannot see it.
-  readonly lifecycle: { target: string; elapsed: number }[] = []
+  // Wall time for the whole target, which the per-case samples cannot see:
+  // opening it, seeding fixtures and cleaning up all sit outside `runCase`,
+  // and on nextcloud the fixture seed alone is dozens of remote writes.
+  readonly targetWall = new Map<string, number>()
 
   constructor(readonly stream: boolean = true) {}
 
@@ -771,8 +772,8 @@ export class Report {
     }
   }
 
-  recordLifecycle(target: string, elapsed: number): void {
-    this.lifecycle.push({ target, elapsed })
+  noteTargetWall(target: string, seconds: number): void {
+    this.targetWall.set(target, (this.targetWall.get(target) ?? 0) + seconds)
   }
 
   absorb(other: Report): void {
@@ -780,7 +781,7 @@ export class Report {
     this.failed += other.failed
     this.failures.push(...other.failures)
     this.samples.push(...other.samples)
-    this.lifecycle.push(...other.lifecycle)
+    for (const [target, seconds] of other.targetWall) this.noteTargetWall(target, seconds)
     for (const line of other.held) process.stdout.write(line)
   }
 
@@ -802,19 +803,16 @@ export class Report {
       if (bucket === undefined) byTarget.set(s.target, [s.elapsed])
       else bucket.push(s.elapsed)
     }
-    // Setup is not free and is not in any case: seeding a fixture onto a
-    // remote target is a mkdir and a tee per file. Reported beside the case
-    // time so the row accounts for the target's whole wall clock.
-    const setup = new Map<string, number>()
-    for (const l of this.lifecycle) setup.set(l.target, (setup.get(l.target) ?? 0) + l.elapsed)
+    // `wall` is the whole target, `cases` is only what the cases spent inside
+    // it. The gap between them is setup and teardown: opening the target,
+    // seeding its fixtures, hydrating sessions, and cleaning up.
     const out: string[] = ['', '=== profile: per target ===']
     out.push(
       [
         'target'.padEnd(22),
         'cases'.padStart(6),
-        'in_case'.padStart(9),
-        'setup'.padStart(8),
-        'total'.padStart(9),
+        'wall'.padStart(9),
+        'in cases'.padStart(9),
         'p50'.padStart(8),
         'p90'.padStart(8),
         'max'.padStart(9),
@@ -827,9 +825,8 @@ export class Report {
         [
           target.padEnd(22),
           String(raw.length).padStart(6),
+          secs(this.targetWall.get(target) ?? total(raw)).padStart(9),
           secs(total(raw)).padStart(9),
-          secs(setup.get(target) ?? 0).padStart(8),
-          secs(total(raw) + (setup.get(target) ?? 0)).padStart(9),
           secs(at(sorted, 0.5)).padStart(8),
           secs(at(sorted, 0.9)).padStart(8),
           secs(sorted[sorted.length - 1]).padStart(9),

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -739,6 +739,17 @@ export function commandVerb(command: string): string {
   return '?'
 }
 
+// A consistency case carries no `command`: its commands live in the scenario
+// steps. Reading the field straight off it handed `commandVerb` undefined,
+// which threw on `.trim()` and took the whole battery down.
+export function scenarioVerb(c: Case): string {
+  if (typeof c.command === 'string') return c.command
+  for (const step of c.scenario ?? []) {
+    if ('command' in step) return step.command
+  }
+  return ''
+}
+
 export class Report {
   passed = 0
   failed = 0

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -764,10 +764,17 @@ export function commandVerb(command: string): string {
 // A consistency case carries no `command`: its commands live in the scenario
 // steps. Reading the field straight off it handed `commandVerb` undefined,
 // which threw on `.trim()` and took the whole battery down.
+export const SCENARIO_VERB = 'scenario'
+
+// A scenario case is charged as `scenario`, not as its first step. The
+// interval is the whole case, and a scenario spends it on out-of-band remote
+// writes and more than one invocation, so billing it to the first verb made
+// `cat` and `find` carry time no `cat` or `find` spent. A row of its own says
+// what the time is; the slowest-cases table above it names an expensive one.
 export function scenarioVerb(c: Case): string {
   if (typeof c.command === 'string') return c.command
   for (const step of c.scenario ?? []) {
-    if ('command' in step) return step.command
+    if ('command' in step) return SCENARIO_VERB
   }
   return ''
 }

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -214,8 +214,7 @@ async function main(): Promise<void> {
   const services = loadServices(root)
   const cases = loadCases(root)
 
-  const { targets, emit: emitPath, facet, strict, allowSkip, targetJobs, profile } =
-    parseArgs()
+  const { targets, emit: emitPath, facet, strict, allowSkip, targetJobs, profile } = parseArgs()
   // Targets are grouped into facets so CI can run one backend family per job; a
   // target with no facet belongs to "core", which the shared battery runs.
   let ids: string[]

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -153,7 +153,15 @@ async function runTarget(
       if (!c.targets.includes(target.id)) continue
       if (c.consistency !== undefined) continue
       const bound = bindMount(c, target.mounts[0].path)
+      const caseStarted = performance.now()
       const { exitCode, out, err, elapsed, checkOut, notes } = await runCase(ws, bound, reasons)
+      // Two durations, deliberately. `elapsed` is the command alone and is what
+      // a case's `expect.elapsed` bounds are asserted against, so it cannot
+      // grow. `whole` is the whole case, which for the 34 cases carrying a
+      // `check` includes a second backend read the command-only figure left
+      // out; without it that work fell into the wall-minus-cases gap and read
+      // as setup.
+      const whole = (performance.now() - caseStarted) / 1000
       if (emit !== null) {
         emit.push({
           target: target.id,
@@ -168,7 +176,7 @@ async function runTarget(
           target.id,
           bound.id,
           compare(bound, exitCode, out, err, elapsed, checkOut, notes),
-          elapsed,
+          whole,
           bound.command,
         )
       }

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -298,14 +298,17 @@ async function main(): Promise<void> {
       const next = waiters.shift()
       if (next !== undefined) next()
     }
-    const slots = new Map<string, { report: Report | null; emit: EmitRow[] | null }>()
+    // One slot per invocation, not per target id. `--target x --target x` is
+    // two runs, and keying by id made the merge below read the second slot
+    // twice and drop the first.
+    const slots: { report: Report | null; emit: EmitRow[] | null }[] = []
     const chain: Promise<void>[] = []
     for (const target of eligible) {
       const slot = {
         report: report === null ? null : new Report(false),
         emit: emit === null ? null : ([] as EmitRow[]),
       }
-      slots.set(target.id, slot)
+      slots.push(slot)
       const lane = target.service ?? `solo:${target.id}`
       const prev = lanes.get(lane) ?? Promise.resolve()
       const next = prev.then(async () => {
@@ -326,9 +329,7 @@ async function main(): Promise<void> {
     await Promise.all(chain)
     // Merged in declared target order, so a concurrent run prints what a serial
     // run printed.
-    for (const target of eligible) {
-      const slot = slots.get(target.id)
-      if (slot === undefined) continue
+    for (const slot of slots) {
       if (report !== null && slot.report !== null) report.absorb(slot.report)
       if (emit !== null && slot.emit !== null) emit.push(...slot.emit)
     }

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -51,12 +51,16 @@ function parseArgs(): {
   facet: string | undefined
   strict: boolean
   allowSkip: string
+  targetJobs: number
+  profile: boolean
 } {
   const targets: string[] = []
   let emit: string | undefined
   let facet: string | undefined
   let strict = false
   let allowSkip = ''
+  let targetJobs = 1
+  let profile = false
   const argv = process.argv.slice(2)
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--target' && i + 1 < argv.length) targets.push(argv[++i])
@@ -64,8 +68,17 @@ function parseArgs(): {
     else if (argv[i] === '--emit' && i + 1 < argv.length) emit = argv[++i]
     else if (argv[i] === '--strict') strict = true
     else if (argv[i] === '--allow-skip' && i + 1 < argv.length) allowSkip = argv[++i]
+    else if (argv[i] === '--profile') profile = true
+    else if (argv[i] === '--target-jobs' && i + 1 < argv.length) {
+      const n = Number(argv[++i])
+      if (!Number.isInteger(n) || n < 1) {
+        process.stderr.write('--target-jobs takes an integer >= 1\n')
+        process.exit(2)
+      }
+      targetJobs = n
+    }
   }
-  return { targets, emit, facet, strict, allowSkip }
+  return { targets, emit, facet, strict, allowSkip, targetJobs, profile }
 }
 
 async function runTarget(
@@ -151,6 +164,8 @@ async function runTarget(
           target.id,
           bound.id,
           compare(bound, exitCode, out, err, elapsed, checkOut, notes),
+          elapsed,
+          bound.command,
         )
       }
     }
@@ -194,7 +209,8 @@ async function main(): Promise<void> {
   const services = loadServices(root)
   const cases = loadCases(root)
 
-  const { targets, emit: emitPath, facet, strict, allowSkip } = parseArgs()
+  const { targets, emit: emitPath, facet, strict, allowSkip, targetJobs, profile } =
+    parseArgs()
   // Targets are grouped into facets so CI can run one backend family per job; a
   // target with no facet belongs to "core", which the shared battery runs.
   let ids: string[]
@@ -216,6 +232,7 @@ async function main(): Promise<void> {
   // broken job, which is the whole point of --strict.
   const allowed = parseAllowSkip(services, allowSkip)
   const envSkipped: string[] = []
+  const eligible: Target[] = []
   for (const id of ids) {
     const target = manifest.get(id)
     if (!target) throw new Error(`unknown target: ${id}`)
@@ -235,9 +252,60 @@ async function main(): Promise<void> {
       }
       continue
     }
-    await runTarget(target, cases, root, report, emit)
+    eligible.push(target)
     ran += 1
   }
+
+  // Targets own separate workspaces, so they overlap safely -- except when two
+  // speak to the SAME fake (cli-gh and github, cli-ntn and notion, qdrant and
+  // qdrant-window). Those share a lane and stay sequential; the rest are bound
+  // only by the overall width.
+  const lanes = new Map<string, Promise<void>>()
+  const errors: unknown[] = []
+  const waiters: (() => void)[] = []
+  let active = 0
+  const acquire = async (): Promise<void> => {
+    if (active >= targetJobs) await new Promise<void>((resolve) => waiters.push(resolve))
+    active += 1
+  }
+  const release = (): void => {
+    active -= 1
+    const next = waiters.shift()
+    if (next !== undefined) next()
+  }
+  const slots = new Map<string, { report: Report | null; emit: EmitRow[] | null }>()
+  const chain: Promise<void>[] = []
+  for (const target of eligible) {
+    const slot = {
+      report: report === null ? null : new Report(targetJobs <= 1),
+      emit: emit === null ? null : ([] as EmitRow[]),
+    }
+    slots.set(target.id, slot)
+    const lane = target.service ?? `solo:${target.id}`
+    const prev = lanes.get(lane) ?? Promise.resolve()
+    const next = prev.then(async () => {
+      await acquire()
+      try {
+        await runTarget(target, cases, root, slot.report, slot.emit)
+      } catch (err) {
+        errors.push(err)
+      } finally {
+        release()
+      }
+    })
+    lanes.set(lane, next)
+    chain.push(next)
+  }
+  await Promise.all(chain)
+  // Merged in declared target order, so a concurrent run prints what a serial
+  // run printed.
+  for (const target of eligible) {
+    const slot = slots.get(target.id)
+    if (slot === undefined) continue
+    if (report !== null && slot.report !== null) report.absorb(slot.report)
+    if (emit !== null && slot.emit !== null) emit.push(...slot.emit)
+  }
+  if (errors.length > 0) throw errors[0]
 
   // A skip is one line on stderr and exit 0, so a facet whose service
   // never came up (or whose env var got renamed in the workflow) reports
@@ -264,6 +332,7 @@ async function main(): Promise<void> {
     return
   }
   if (report === null) return
+  if (profile) process.stdout.write(`${report.profile()}\n`)
   process.stdout.write(`\n${report.summary()}\n`)
   if (report.failed) process.exit(1)
 }

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -103,8 +103,6 @@ async function runTarget(
   if (declaresProfiles && !PROFILE_OPENERS.includes(target.mounts[0].resource)) {
     throw new Error(`target ${target.id}: profiles ride ${PROFILE_OPENERS.join(', ')} mounts`)
   }
-  let lifecycle = 0
-  let started = performance.now()
   const { ws, cleanup } = await ADAPTERS[target.mounts[0].resource](target)
   try {
     // A target's declared environment. A CLI whose spec reads a variable
@@ -146,7 +144,6 @@ async function runTarget(
     // `explain` to predict, and only there is the extra dry run per case
     // worth its time. The reasons double as the tell that a refusal came
     // from the policy layer rather than from the command itself.
-    lifecycle += (performance.now() - started) / 1000
     const reasons = ruleReasons({ profiles: target.profiles, sessions: target.sessions })
     for (const c of cases) {
       if (!c.targets.includes(target.id)) continue
@@ -173,10 +170,7 @@ async function runTarget(
       }
     }
   } finally {
-    started = performance.now()
     await cleanup()
-    lifecycle += (performance.now() - started) / 1000
-    report?.recordLifecycle(target.id, lifecycle)
   }
   const scenarios = cases.filter(
     (c) => c.targets.includes(target.id) && c.consistency !== undefined && c.scenario !== undefined,
@@ -276,7 +270,9 @@ async function main(): Promise<void> {
   // and `gws` four, the default run would quietly reorder itself.
   if (targetJobs <= 1) {
     for (const target of eligible) {
+      const started = performance.now()
       await runTarget(target, cases, root, report, emit)
+      report?.noteTargetWall(target.id, (performance.now() - started) / 1000)
     }
   } else {
     const lanes = new Map<string, Promise<void>>()

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -264,52 +264,62 @@ async function main(): Promise<void> {
   // speak to the SAME fake (cli-gh and github, cli-ntn and notion, qdrant and
   // qdrant-window). Those share a lane and stay sequential; the rest are bound
   // only by the overall width.
-  const lanes = new Map<string, Promise<void>>()
-  const errors: unknown[] = []
-  const waiters: (() => void)[] = []
-  let active = 0
-  const acquire = async (): Promise<void> => {
-    if (active >= targetJobs) await new Promise<void>((resolve) => waiters.push(resolve))
-    active += 1
-  }
-  const release = (): void => {
-    active -= 1
-    const next = waiters.shift()
-    if (next !== undefined) next()
-  }
-  const slots = new Map<string, { report: Report | null; emit: EmitRow[] | null }>()
-  const chain: Promise<void>[] = []
-  for (const target of eligible) {
-    const slot = {
-      report: report === null ? null : new Report(targetJobs <= 1),
-      emit: emit === null ? null : ([] as EmitRow[]),
+  // One worker means the old loop, unchanged. The lane scheduler below cannot
+  // stand in for it: a target waiting on a busy lane lets a later one from
+  // another lane take the worker first, and with `s3` carrying three targets
+  // and `gws` four, the default run would quietly reorder itself.
+  if (targetJobs <= 1) {
+    for (const target of eligible) {
+      await runTarget(target, cases, root, report, emit)
     }
-    slots.set(target.id, slot)
-    const lane = target.service ?? `solo:${target.id}`
-    const prev = lanes.get(lane) ?? Promise.resolve()
-    const next = prev.then(async () => {
-      await acquire()
-      try {
-        await runTarget(target, cases, root, slot.report, slot.emit)
-      } catch (err) {
-        errors.push(err)
-      } finally {
-        release()
+  } else {
+    const lanes = new Map<string, Promise<void>>()
+    const errors: unknown[] = []
+    const waiters: (() => void)[] = []
+    let active = 0
+    const acquire = async (): Promise<void> => {
+      if (active >= targetJobs) await new Promise<void>((resolve) => waiters.push(resolve))
+      active += 1
+    }
+    const release = (): void => {
+      active -= 1
+      const next = waiters.shift()
+      if (next !== undefined) next()
+    }
+    const slots = new Map<string, { report: Report | null; emit: EmitRow[] | null }>()
+    const chain: Promise<void>[] = []
+    for (const target of eligible) {
+      const slot = {
+        report: report === null ? null : new Report(false),
+        emit: emit === null ? null : ([] as EmitRow[]),
       }
-    })
-    lanes.set(lane, next)
-    chain.push(next)
+      slots.set(target.id, slot)
+      const lane = target.service ?? `solo:${target.id}`
+      const prev = lanes.get(lane) ?? Promise.resolve()
+      const next = prev.then(async () => {
+        await acquire()
+        try {
+          await runTarget(target, cases, root, slot.report, slot.emit)
+        } catch (err) {
+          errors.push(err)
+        } finally {
+          release()
+        }
+      })
+      lanes.set(lane, next)
+      chain.push(next)
+    }
+    await Promise.all(chain)
+    // Merged in declared target order, so a concurrent run prints what a serial
+    // run printed.
+    for (const target of eligible) {
+      const slot = slots.get(target.id)
+      if (slot === undefined) continue
+      if (report !== null && slot.report !== null) report.absorb(slot.report)
+      if (emit !== null && slot.emit !== null) emit.push(...slot.emit)
+    }
+    if (errors.length > 0) throw errors[0]
   }
-  await Promise.all(chain)
-  // Merged in declared target order, so a concurrent run prints what a serial
-  // run printed.
-  for (const target of eligible) {
-    const slot = slots.get(target.id)
-    if (slot === undefined) continue
-    if (report !== null && slot.report !== null) report.absorb(slot.report)
-    if (emit !== null && slot.emit !== null) emit.push(...slot.emit)
-  }
-  if (errors.length > 0) throw errors[0]
 
   // A skip is one line on stderr and exit 0, so a facet whose service
   // never came up (or whose env var got renamed in the workflow) reports

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -19,6 +19,7 @@ import { ADAPTERS, openConsistency } from './adapters.ts'
 import type { Case, Target } from './harness.ts'
 import {
   Report,
+  bindMount,
   compare,
   integRoot,
   loadCases,
@@ -26,10 +27,10 @@ import {
   loadTargets,
   missingEnv,
   parseAllowSkip,
-  bindMount,
   ruleReasons,
   runCase,
   runScenario,
+  scenarioVerb,
   seedFixture,
   seedMountRoot,
 } from './harness.ts'
@@ -200,7 +201,13 @@ async function runTarget(
       if (emit !== null) {
         emit.push({ target: target.id, id: c.id, exit: exitCode, stdout: out, stderr: '' })
       } else if (report !== null) {
-        report.record(target.id, c.id, compare(c, exitCode, out, '', elapsed), elapsed, c.command)
+        report.record(
+          target.id,
+          c.id,
+          compare(c, exitCode, out, '', elapsed),
+          elapsed,
+          scenarioVerb(c),
+        )
       }
     } finally {
       await opened.cleanup()
@@ -300,11 +307,13 @@ async function main(): Promise<void> {
       const prev = lanes.get(lane) ?? Promise.resolve()
       const next = prev.then(async () => {
         await acquire()
+        const started = performance.now()
         try {
           await runTarget(target, cases, root, slot.report, slot.emit)
         } catch (err) {
           errors.push(err)
         } finally {
+          slot.report?.noteTargetWall(target.id, (performance.now() - started) / 1000)
           release()
         }
       })

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -103,6 +103,8 @@ async function runTarget(
   if (declaresProfiles && !PROFILE_OPENERS.includes(target.mounts[0].resource)) {
     throw new Error(`target ${target.id}: profiles ride ${PROFILE_OPENERS.join(', ')} mounts`)
   }
+  let lifecycle = 0
+  let started = performance.now()
   const { ws, cleanup } = await ADAPTERS[target.mounts[0].resource](target)
   try {
     // A target's declared environment. A CLI whose spec reads a variable
@@ -144,6 +146,7 @@ async function runTarget(
     // `explain` to predict, and only there is the extra dry run per case
     // worth its time. The reasons double as the tell that a refusal came
     // from the policy layer rather than from the command itself.
+    lifecycle += (performance.now() - started) / 1000
     const reasons = ruleReasons({ profiles: target.profiles, sessions: target.sessions })
     for (const c of cases) {
       if (!c.targets.includes(target.id)) continue
@@ -170,7 +173,10 @@ async function runTarget(
       }
     }
   } finally {
+    started = performance.now()
     await cleanup()
+    lifecycle += (performance.now() - started) / 1000
+    report?.recordLifecycle(target.id, lifecycle)
   }
   const scenarios = cases.filter(
     (c) => c.targets.includes(target.id) && c.consistency !== undefined && c.scenario !== undefined,
@@ -270,9 +276,7 @@ async function main(): Promise<void> {
   // and `gws` four, the default run would quietly reorder itself.
   if (targetJobs <= 1) {
     for (const target of eligible) {
-      const started = performance.now()
       await runTarget(target, cases, root, report, emit)
-      report?.noteTargetWall(target.id, (performance.now() - started) / 1000)
     }
   } else {
     const lanes = new Map<string, Promise<void>>()

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -191,11 +191,16 @@ async function runTarget(
       // every workspace a case can run against, or a consistency scenario would
       // silently run under a different one.
       opened.ws.env = { ...opened.ws.env, ...(target.env ?? {}) }
+      const started = performance.now()
       const { exitCode, out } = await runScenario(opened.ws, opened.mutate, c.scenario)
+      // Measured, not zero: a consistency scenario on s3 or gridfs runs
+      // several remote mutations, and recording it as free dragged the
+      // profile's totals and percentiles down.
+      const elapsed = (performance.now() - started) / 1000
       if (emit !== null) {
         emit.push({ target: target.id, id: c.id, exit: exitCode, stdout: out, stderr: '' })
       } else if (report !== null) {
-        report.record(target.id, c.id, compare(c, exitCode, out, '', 0))
+        report.record(target.id, c.id, compare(c, exitCode, out, '', elapsed), elapsed, c.command)
       }
     } finally {
       await opened.cleanup()

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -270,7 +270,9 @@ async function main(): Promise<void> {
   // and `gws` four, the default run would quietly reorder itself.
   if (targetJobs <= 1) {
     for (const target of eligible) {
+      const started = performance.now()
       await runTarget(target, cases, root, report, emit)
+      report?.noteTargetWall(target.id, (performance.now() - started) / 1000)
     }
   } else {
     const lanes = new Map<string, Promise<void>>()

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -70,8 +70,11 @@ function parseArgs(): {
     else if (argv[i] === '--strict') strict = true
     else if (argv[i] === '--allow-skip' && i + 1 < argv.length) allowSkip = argv[++i]
     else if (argv[i] === '--profile') profile = true
-    else if (argv[i] === '--target-jobs' && i + 1 < argv.length) {
-      const n = Number(argv[++i])
+    // Recognised before its operand is checked: gated on `i + 1 < argv.length`
+    // a trailing `--target-jobs` fell through every arm and ran serially in
+    // silence, where the argparse runner refuses the same line.
+    else if (argv[i] === '--target-jobs') {
+      const n = i + 1 < argv.length ? Number(argv[++i]) : Number.NaN
       if (!Number.isInteger(n) || n < 1) {
         process.stderr.write('--target-jobs takes an integer >= 1\n')
         process.exit(2)


### PR DESCRIPTION
Runs the declarative integ battery's targets concurrently, and reports where
its time actually goes.

## Concurrency

`--target-jobs N` runs targets in parallel. Targets own separate workspaces, so
they overlap safely, except when two speak to the same fake (`cli-gh` and
`github`, `cli-ntn` and `notion`, `qdrant` and `qdrant-window`). Those share a
lane and stay sequential; the rest are bound only by the overall width.

The default stays **strictly serial**, on the old loop. The lane scheduler
cannot stand in for it: a target waiting on a busy lane lets a later one from
another lane take the worker first, and with `s3` carrying three targets and
`gws` four, the default run would quietly reorder itself.

Each invocation gets its own result slot. Keyed by target id, `--target x
--target x --target-jobs 2` made both tasks write the second slot and merged it
twice, reporting 11700 cases where a serial run reports 5850.

## Profile

`--profile` prints three tables: per target, the slowest cases, and the
costliest commands. Several things had to be right for those numbers to mean
anything, and each one was wrong first:

- **Ranked by wall time**, the column the table is about. Ranking by summed
  case time buried a target whose cost is setup.
- **`wall` beside `in cases`**, because the gap between them is setup and
  teardown, and that is often where the time is.
- **A scenario is charged to itself**, not to its first step. A consistency
  case runs out-of-band remote writes and more than one invocation. Billing
  that to the first verb made `cat` and `find` carry time neither spent: on s3
  against local moto, `cat` read 63% costlier than it was and `find` 49%.
- **The sample is the whole case**, not the command alone. `run_case` freezes
  `elapsed` before awaiting `stat_check`, so the 34 cases carrying a `check`
  contributed a sample missing it, and that work fell into the setup gap.
  `elapsed` is still the command alone, because three cases assert
  `expect.elapsed` bounds against it.
- **Commands are named, not guessed at.** `out=$(cat ...)` used to label the
  row with a filename, and `(cd d && grep x)` with `(cd`. Rows whose verb is
  not a command name went from 254 corpus lines to 64, and 47 of those 64 are
  `[` and `[[`, which are the test builtin and already right.

Both hosts return identical verbs for all 5043 command lines in the corpus, and
pick the same percentile index.

## Scope

The typescript runner's option parser is **not** here. It grew out of one bug
in this PR's own new option and turned into an argparse-parity project, so it
moved to #952. What stays is the narrow fix: `--target-jobs` is recognised
before its operand is checked, so a trailing one is refused rather than running
serially without a word.
