### PR TITLE
perf(ci): run independent example checks concurrently and rebalance pytest workers

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -110,7 +110,13 @@ jobs:
           for path in "${redis_serial[@]}"; do
             ignore_args+=("--ignore=$path")
           done
-          uv run pytest -n 4 --dist loadscope "${ignore_args[@]}"
+          # worksteal, not loadscope. Measured as sibling jobs at one commit,
+          # n=4 each: worksteal 398s median with a 13s spread, loadscope 420s
+          # with a 91s spread. loadscope pins a module to one worker, so a
+          # heavy module leaves the others idle and the run time depends on
+          # which worker drew it; worksteal rebalances, which is why its tail
+          # is 58s better even though the medians are close.
+          uv run pytest -n 4 --dist worksteal "${ignore_args[@]}"
           uv run pytest "${redis_serial[@]}"
 
       # Each truth file owns the command it was captured against, so this
@@ -133,22 +139,34 @@ jobs:
           variant() {
             python3 integ/check_example.py "$1" --variant "$2" || bad=1
           }
-          run integ/truth/python/ram.json
-          run integ/truth/python/ram_vfs.json
+          # Each check is its own process against its own workspace, so the
+          # ram/disk-backed ones are independent and run concurrently. xargs
+          # exits 123 when any invocation failed, which is what marks the step
+          # bad; -I{} keeps one check per invocation so all of them still run.
+          independent=(
+            integ/truth/python/ram.json
+            integ/truth/python/ram_vfs.json
+            integ/truth/python/ram_python.json
+            integ/truth/python/disk.json
+            integ/truth/python/disk_vfs.json
+            integ/truth/watch_delta.json
+            integ/truth/permissions.json
+            integ/truth/python/custom_command.json
+            integ/truth/custom_resource.json
+            integ/truth/python/filetype.json
+            integ/truth/version_branching.json
+          )
+          printf '%s\n' "${independent[@]}" \
+            | xargs -P 4 -I{} python3 integ/check_example.py {} --variant python \
+            || bad=1
           variant integ/truth/python/ram_vfs.json python_utf8_off
-          run integ/truth/python/ram_python.json
-          run integ/truth/python/disk.json
-          run integ/truth/python/disk_vfs.json
-          run integ/truth/watch_delta.json
-          run integ/truth/permissions.json
-          run integ/truth/python/custom_command.json
-          run integ/truth/custom_resource.json
-          run integ/truth/python/filetype.json
+
+          # These four share one redis server, so they stay serial: running
+          # them together would have them racing on the same keyspace.
           run integ/truth/python/redis.json
           run integ/truth/python/redis_index.json
           run integ/truth/python/redis_cache.json
           run integ/truth/python/redis_vfs.json
-          run integ/truth/version_branching.json
           exit $bad
 
       - name: Sync Python dependencies for camel


### PR DESCRIPTION
Part of #886. Two measured changes to the `test` job in `test_python.yml`.
No test is removed, skipped, or weakened; both changes only schedule the same
work differently.

## 1. Example checks run concurrently

16 checks ran one after another at roughly 4s each. Each is its own process
against its own workspace, so the 11 backed by ram/disk are independent.
The four redis-backed ones **stay serial** on purpose: they share one server
and would race on the same keyspace.

**Measured on CI: 63s to 38s.**

`xargs` exits 123 when any invocation fails, which is what sets `bad`, and
`-I{}` keeps one check per invocation so every check still runs even after one
fails, preserving the previous behaviour of reporting all failures rather than
stopping at the first.

## 2. pytest uses `--dist worksteal`

Measured as **sibling jobs at the same commit** on real runners, n=4 per config:

| config | samples | median | spread |
|---|---|---|---|
| **worksteal** | 397, 397, 398, 410 | **398s** | **13s** |
| loadscope (current) | 377, 384, 456, 468 | 420s | 91s |
| worksteal `-n 8` | 388, 415, 459, 469 | 437s | 81s |
| loadfile | 457, 472, 472, 510 | 472s | 53s |

The medians are close (−22s). The real argument is the **tail**: loadscope is
bimodal with a 91s spread, because it pins a whole module to one worker and the
run time then depends on which worker drew the heavy one. worksteal rebalances,
giving a 13s spread and a p90 about 58s better. That makes the job predictable,
which is what a developer waiting on CI actually experiences.

`-n 8` is also included above and is worse than `-n 4`, confirming the 4 vCPU
runner is already saturated. Not proposing it.

## Method note

An earlier local benchmark of these same options produced the opposite ranking
and was wrong: run sequentially on a laptop while load varied, the *same*
config measured 445s and 206s. Everything above was re-measured as concurrent
sibling jobs so arms share hardware class and queue conditions.