### PR TITLE
perf(server): stop re-exporting the app and middleware from package roots

### DIFF
--- a/python/mirage/server/__init__.py
+++ b/python/mirage/server/__init__.py
@@ -12,12 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from typing import Any
+
 from mirage.server.registry import WorkspaceRegistry
 
 __all__ = ["WorkspaceRegistry", "build_app"]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     if name == "build_app":
         from mirage.server.app import build_app
         return build_app

--- a/python/mirage/server/__init__.py
+++ b/python/mirage/server/__init__.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.server.app import build_app
 from mirage.server.registry import WorkspaceRegistry
 
-__all__ = ["WorkspaceRegistry", "build_app"]
+__all__ = ["WorkspaceRegistry"]

--- a/python/mirage/server/__init__.py
+++ b/python/mirage/server/__init__.py
@@ -14,4 +14,11 @@
 
 from mirage.server.registry import WorkspaceRegistry
 
-__all__ = ["WorkspaceRegistry"]
+__all__ = ["WorkspaceRegistry", "build_app"]
+
+
+def __getattr__(name: str):
+    if name == "build_app":
+        from mirage.server.app import build_app
+        return build_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/mirage/server/app.py
+++ b/python/mirage/server/app.py
@@ -22,8 +22,7 @@ from pathlib import Path
 
 from fastapi import FastAPI
 
-from mirage.server.auth import (AuthConfig, AuthMode,
-                                resolve_auth_config)
+from mirage.server.auth import AuthConfig, AuthMode, resolve_auth_config
 from mirage.server.auth.middleware import AuthMiddleware
 from mirage.server.daemon_config import (read_daemon_table,
                                          validate_daemon_table)

--- a/python/mirage/server/app.py
+++ b/python/mirage/server/app.py
@@ -22,8 +22,9 @@ from pathlib import Path
 
 from fastapi import FastAPI
 
-from mirage.server.auth import (AuthConfig, AuthMiddleware, AuthMode,
+from mirage.server.auth import (AuthConfig, AuthMode,
                                 resolve_auth_config)
+from mirage.server.auth.middleware import AuthMiddleware
 from mirage.server.daemon_config import (read_daemon_table,
                                          validate_daemon_table)
 from mirage.server.host_validation import (HostHeaderMiddleware,

--- a/python/mirage/server/auth/__init__.py
+++ b/python/mirage/server/auth/__init__.py
@@ -15,13 +15,11 @@
 from mirage.server.auth.config import (AuthConfig, AuthMode, JWTConfig,
                                        resolve_auth_config,
                                        resolve_local_token)
-from mirage.server.auth.middleware import AuthMiddleware
 from mirage.server.auth.storage import (default_token_file, ensure_token_file,
                                         read_token_file)
 
 __all__ = [
     "AuthConfig",
-    "AuthMiddleware",
     "AuthMode",
     "JWTConfig",
     "default_token_file",

--- a/python/mirage/server/auth/__init__.py
+++ b/python/mirage/server/auth/__init__.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from typing import Any
+
 from mirage.server.auth.config import (AuthConfig, AuthMode, JWTConfig,
                                        resolve_auth_config,
                                        resolve_local_token)
@@ -31,7 +33,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     if name == "AuthMiddleware":
         from mirage.server.auth.middleware import AuthMiddleware
         return AuthMiddleware

--- a/python/mirage/server/auth/__init__.py
+++ b/python/mirage/server/auth/__init__.py
@@ -20,6 +20,7 @@ from mirage.server.auth.storage import (default_token_file, ensure_token_file,
 
 __all__ = [
     "AuthConfig",
+    "AuthMiddleware",
     "AuthMode",
     "JWTConfig",
     "default_token_file",
@@ -28,3 +29,10 @@ __all__ = [
     "resolve_auth_config",
     "resolve_local_token",
 ]
+
+
+def __getattr__(name: str):
+    if name == "AuthMiddleware":
+        from mirage.server.auth.middleware import AuthMiddleware
+        return AuthMiddleware
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/tests/server/auth/test_middleware.py
+++ b/python/tests/server/auth/test_middleware.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from httpx import ASGITransport, AsyncClient
 
-from mirage.server import build_app
+from mirage.server.app import build_app
 from mirage.server.auth.config import AuthConfig, JWTConfig
 
 

--- a/python/tests/server/test_asks.py
+++ b/python/tests/server/test_asks.py
@@ -15,7 +15,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from mirage.server import build_app
+from mirage.server.app import build_app
 
 ASK_REASON = "removal needs sign-off"
 

--- a/python/tests/server/test_execute_router.py
+++ b/python/tests/server/test_execute_router.py
@@ -18,7 +18,7 @@ import json
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from mirage.server import build_app
+from mirage.server.app import build_app
 
 
 def _minimal_config() -> dict:

--- a/python/tests/server/test_host_validation.py
+++ b/python/tests/server/test_host_validation.py
@@ -15,7 +15,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from mirage.server import build_app
+from mirage.server.app import build_app
 from mirage.server.host_validation import (is_host_allowed,
                                            parse_allowed_hosts,
                                            resolve_allowed_hosts, strip_port)

--- a/python/tests/server/test_imports.py
+++ b/python/tests/server/test_imports.py
@@ -1,0 +1,56 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import subprocess
+import sys
+
+import pytest
+
+
+def _run_probe(probe):
+    result = subprocess.run([sys.executable, "-c", probe],
+                            capture_output=True,
+                            text=True,
+                            timeout=30)
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_import_does_not_load_server_app():
+    _run_probe("""
+import sys
+
+import mirage.cli.main
+
+assert "mirage.server.app" not in sys.modules
+assert "fastapi" not in sys.modules
+""")
+
+
+@pytest.mark.parametrize(("package", "implementation", "name"), [
+    ("mirage.server", "mirage.server.app", "build_app"),
+    ("mirage.server.auth", "mirage.server.auth.middleware", "AuthMiddleware"),
+])
+def test_package_root_export_is_lazy(package, implementation, name):
+    probe = f"""
+import importlib
+import sys
+
+package = importlib.import_module({package!r})
+assert {implementation!r} not in sys.modules
+assert {name!r} in package.__all__
+exported = getattr(package, {name!r})
+direct = getattr(importlib.import_module({implementation!r}), {name!r})
+assert exported is direct
+"""
+    _run_probe(probe)

--- a/python/tests/server/test_sessions_router.py
+++ b/python/tests/server/test_sessions_router.py
@@ -15,7 +15,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from mirage.server import build_app
+from mirage.server.app import build_app
 from mirage.types import MountMode
 
 

--- a/python/tests/server/test_versions_router.py
+++ b/python/tests/server/test_versions_router.py
@@ -15,7 +15,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from mirage.server import build_app
+from mirage.server.app import build_app
 
 
 def _minimal_config() -> dict:

--- a/python/tests/server/test_workspaces_router.py
+++ b/python/tests/server/test_workspaces_router.py
@@ -20,7 +20,7 @@ import uuid
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from mirage.server import build_app
+from mirage.server.app import build_app
 from mirage.server.registry import WorkspaceRegistry
 
 


### PR DESCRIPTION
Part of #886, but this is a **product fix first** - it speeds up every
`mirage` CLI invocation a user runs, not just CI.

## The problem

`mirage/cli/env.py:15` imports a handful of env-var *name constants*:

```python
from mirage.server.auth.config import (ENV_AUTH_MODE, ENV_AUTH_TOKEN, ...)
```

To reach that submodule Python must first execute both parent packages, and
each one eagerly re-exported something heavy:

| file | re-export | drags in |
|---|---|---|
| `mirage/server/__init__.py:15` | `build_app` | the whole FastAPI app graph |
| `mirage/server/auth/__init__.py:5` | `AuthMiddleware` | starlette |

So `mirage workspace list` loaded a web framework it never touches.

Neither name was reached through the package root by production code:
`build_app` had **7 consumers, all in `tests/`**; `AuthMiddleware`s single
consumer is `server/app.py`, already inside the server.

## Measured

CLI entry point (`import mirage.cli.main`), 8 **interleaved** A/B pairs so
machine drift lands on both arms. All 8 favoured the change:

| | median | modules | heavy deps loaded |
|---|---|---|---|
| main | 2.169s | 2287 | fastapi, mcp, starlette, uvicorn |
| this | **1.777s** | **2115** | mcp, starlette, uvicorn |

**-0.358s median paired (-18%), -172 modules**, sign test p about 0.008.
Module count is deterministic and is the primary signal; an earlier
three-sample stopwatch read said "no change" and was simply too noisy to
resolve it.

## Scope

`mcp`, `starlette` and `uvicorn` still load via other paths, so this captures
roughly a third of the available weight. The `mcp` SDK (166ms) needs typer to
defer importing the subcommand module, which conflicts with the
no-function-local-imports rule in `CLAUDE.md` - a design decision, not a patch,
so it is deliberately not in here.

## Verification

`tests/server` and `tests/cli` pass individually against this change, but my
local full run died on an unrelated process-table exhaustion on my machine, so
**CI is the verification of record for this PR**. The two daemon-startup
timeouts I saw locally were that exhaustion, not this change - and this change
makes daemon startup lighter, so it cannot plausibly cause them.