### PR TITLE
fix(runtime): keep /dev/stderr alive so a python timeout cannot kill the host

### DIFF
--- a/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
@@ -176,6 +176,8 @@ describe('MirageFs', () => {
       stat: (p: string) => { mode: number }
       open: (p: string, flags: string) => unknown
       readFile: (p: string) => Uint8Array
+      createDevice: (dir: string, name: string, i?: unknown, o?: unknown) => unknown
+      chmod: (p: string, m: number) => void
     }
     for (const name of ['stdin', 'stdout', 'stderr']) {
       expect((fs.stat(`/dev/${name}`).mode & 0o170000) === 0o020000).toBe(true)
@@ -189,6 +191,14 @@ describe('MirageFs', () => {
     for (const name of ['stdin', 'stdout', 'stderr']) {
       expect(fs.readFile(`/dev/${name}`).length).toBe(0)
     }
+    // And nothing about a device reaches the journal. pyodide makes one at
+    // runtime (API.capture_stderr calls FS.createDevice) and chmods it right
+    // after; replaying either wrote a device path against the real mount,
+    // which is what failed during teardown.
+    fs.createDevice('/dev', 'probe_dev', undefined, () => true)
+    fs.chmod('/dev/probe_dev', 0o600)
+    const touched = journal.takeMutations().map((m) => m.path)
+    expect(touched.filter((path) => path.includes('probe_dev'))).toEqual([])
   })
 
   it('serves a seeded file to the guest', async () => {

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
@@ -165,6 +165,24 @@ describe('MirageFs', () => {
     return `/m${String(counter)}/`
   }
 
+  // Emscripten's MEMFS makes /dev/stdin, /dev/stdout and /dev/stderr at
+  // startup, and pyodide's own capture reopens /dev/stderr when a run ends.
+  // Mounting mirage's /dev over MEMFS's used to hide them, and that reopen
+  // threw ENOENT out of a callback nobody catches: an unhandled rejection,
+  // which Node turns into a dead process.
+  it('keeps the standard stream devices when it takes over /dev', async () => {
+    await mountPrefix('/dev/')
+    const fs = py.FS as unknown as {
+      stat: (p: string) => { mode: number }
+      open: (p: string, flags: string) => unknown
+    }
+    for (const name of ['stdin', 'stdout', 'stderr']) {
+      expect((fs.stat(`/dev/${name}`).mode & 0o170000) === 0o020000).toBe(true)
+    }
+    // The reopen itself, which is the call that used to throw.
+    expect(fs.open('/dev/stderr', 'w')).toBeTruthy()
+  })
+
   it('serves a seeded file to the guest', async () => {
     const p = prefix()
     store.set(`${p}seed.txt`, enc.encode('ORIGINAL'))

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.test.ts
@@ -175,12 +175,20 @@ describe('MirageFs', () => {
     const fs = py.FS as unknown as {
       stat: (p: string) => { mode: number }
       open: (p: string, flags: string) => unknown
+      readFile: (p: string) => Uint8Array
     }
     for (const name of ['stdin', 'stdout', 'stderr']) {
       expect((fs.stat(`/dev/${name}`).mode & 0o170000) === 0o020000).toBe(true)
     }
     // The reopen itself, which is the call that used to throw.
     expect(fs.open('/dev/stderr', 'w')).toBeTruthy()
+    // And they have to read as empty. A character device here answers with an
+    // endless run of zeroes unless told otherwise, which is /dev/zero's job; a
+    // stream doing the same would hang `open('/dev/stdin').read()` forever
+    // rather than reach EOF.
+    for (const name of ['stdin', 'stdout', 'stderr']) {
+      expect(fs.readFile(`/dev/${name}`).length).toBe(0)
+    }
   })
 
   it('serves a seeded file to the guest', async () => {

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.ts
@@ -48,6 +48,12 @@ const STD_STREAM_RDEV: ReadonlyMap<string, number> = new Map([
   ['stderr', 8],
 ])
 
+// /dev/null's device number. It and the three streams above answer a read with
+// EOF; only /dev/zero hands back an endless run of zeroes, and a stream that
+// did the same would hang `open('/dev/stdin').read()` forever.
+const NULL_RDEV = 0x103
+const EOF_ON_READ_RDEV: ReadonlySet<number> = new Set([NULL_RDEV, ...STD_STREAM_RDEV.values()])
+
 function isCharDevice(mode: number): boolean {
   return (mode & S_IFMT) === S_IFCHR
 }
@@ -179,6 +185,10 @@ export class MirageFs {
     if (this.prefix === '/dev') {
       for (const [name, rdev] of STD_STREAM_RDEV) {
         const path = `/dev/${name}`
+        // A write is swallowed, as it is for every synthetic character device
+        // here. The interpreter's real stderr rides its own capture, not this
+        // node, so nothing that used to be reported is lost: before this the
+        // path did not exist at all and the open raised.
         if (!seed.devices.has(path)) seed.charDevice(path, S_IFCHR | 0o666, rdev)
       }
     }
@@ -366,7 +376,7 @@ export class MirageFs {
   ): number {
     const node = stream.node
     if (isCharDevice(node.mode)) {
-      if (node.rdev === 0x103) return 0
+      if (EOF_ON_READ_RDEV.has(node.rdev)) return 0
       buffer.fill(0, offset, offset + length)
       return length
     }

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.ts
@@ -36,6 +36,18 @@ const ENC = new TextEncoder()
 const S_IFMT = 0o170000
 const S_IFCHR = 0o020000
 
+// Emscripten's MEMFS makes these three at startup and its own stderr capture
+// reopens /dev/stderr when a run ends (`API.restore_stderr`). Mounting mirage's
+// /dev on top hid them, so that reopen raised ENOENT out of a filesystem
+// callback nobody catches, and the unhandled rejection took the process down
+// with it. Recreated here so the interpreter still finds them. rdev matches
+// MEMFS's own numbering.
+const STD_STREAM_RDEV: ReadonlyMap<string, number> = new Map([
+  ['stdin', 6],
+  ['stdout', 7],
+  ['stderr', 8],
+])
+
 function isCharDevice(mode: number): boolean {
   return (mode & S_IFMT) === S_IFCHR
 }
@@ -102,6 +114,7 @@ export class MirageFs {
   private readonly journal: MutationJournal
   private readonly tree: NodeTree
   private readonly mountOf: (path: string) => string | null
+  private readonly prefix: string
   // The file node FS.open just created, whose finalizing chmod is the
   // filesystem's own and not a guest metadata write. Cleared by the
   // first setattr, so it can never outlive the create it belongs to.
@@ -126,6 +139,7 @@ export class MirageFs {
     mountOf: (path: string) => string | null,
   ) {
     this.host = host
+    this.prefix = prefix
     this.errno = errno
     this.journal = journal
     this.mountOf = mountOf
@@ -159,6 +173,15 @@ export class MirageFs {
    *   seed: tree collected from the mounts before the run.
    */
   seed(seed: MirageFsSeed): void {
+    // Only when this shim is what /dev resolves to. The mount's own listing
+    // is untouched: these nodes live in this tree, which is what the
+    // interpreter reads, not what `ls /dev` on the mount reports.
+    if (this.prefix === '/dev') {
+      for (const [name, rdev] of STD_STREAM_RDEV) {
+        const path = `/dev/${name}`
+        if (!seed.devices.has(path)) seed.charDevice(path, S_IFCHR | 0o666, rdev)
+      }
+    }
     this.tree.seed(seed)
   }
 
@@ -231,6 +254,12 @@ export class MirageFs {
     const node = this.tree.makeNode(parent, name, mode)
     node.rdev = rdev
     const path = this.tree.pathOf(node)
+    // A character device is not mount content. pyodide makes one of its own
+    // at runtime -- `API.capture_stderr` calls FS.createDevice, which lands
+    // here as mknod -- and journaling it queued a write of /dev/capture_stderr
+    // against the real mount, which then failed on replay. Devices live in
+    // this tree only.
+    if (isCharDevice(mode)) return node
     if (this.host.isDir(mode)) this.journal.markMkdir(path)
     else {
       // An empty write is what carries a file that is created and never

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.ts
@@ -52,6 +52,23 @@ const STD_STREAM_RDEV: ReadonlyMap<string, number> = new Map([
 // EOF; only /dev/zero hands back an endless run of zeroes, and a stream that
 // did the same would hang `open('/dev/stdin').read()` forever.
 const NULL_RDEV = 0x103
+
+/**
+ * Whether the seed already places a node at this path, by any means.
+ *
+ * Args:
+ *   seed: the tree collected from the mounts before the run.
+ *   path: guest-absolute path to check.
+ */
+function seedHolds(seed: MirageFsSeed, path: string): boolean {
+  return (
+    seed.files.has(path) ||
+    seed.devices.has(path) ||
+    seed.links.has(path) ||
+    seed.unreadable.has(path) ||
+    seed.dirs.includes(path)
+  )
+}
 const EOF_ON_READ_RDEV: ReadonlySet<number> = new Set([NULL_RDEV, ...STD_STREAM_RDEV.values()])
 
 function isCharDevice(mode: number): boolean {
@@ -185,11 +202,16 @@ export class MirageFs {
     if (this.prefix === '/dev') {
       for (const [name, rdev] of STD_STREAM_RDEV) {
         const path = `/dev/${name}`
+        // Only where the mount itself has nothing by that name. `NodeTree.seed`
+        // places devices after files, directories and links, so injecting one
+        // blindly would overwrite a real entry the mount is serving and hand
+        // the guest an empty device instead of its content.
+        if (seedHolds(seed, path)) continue
         // A write is swallowed, as it is for every synthetic character device
         // here. The interpreter's real stderr rides its own capture, not this
         // node, so nothing that used to be reported is lost: before this the
         // path did not exist at all and the open raised.
-        if (!seed.devices.has(path)) seed.charDevice(path, S_IFCHR | 0o666, rdev)
+        seed.charDevice(path, S_IFCHR | 0o666, rdev)
       }
     }
     this.tree.seed(seed)

--- a/typescript/packages/core/src/runtime/python/vfs/vfs.ts
+++ b/typescript/packages/core/src/runtime/python/vfs/vfs.ts
@@ -53,6 +53,8 @@ const STD_STREAM_RDEV: ReadonlyMap<string, number> = new Map([
 // did the same would hang `open('/dev/stdin').read()` forever.
 const NULL_RDEV = 0x103
 
+const EOF_ON_READ_RDEV: ReadonlySet<number> = new Set([NULL_RDEV, ...STD_STREAM_RDEV.values()])
+
 /**
  * Whether the seed already places a node at this path, by any means.
  *
@@ -69,7 +71,6 @@ function seedHolds(seed: MirageFsSeed, path: string): boolean {
     seed.dirs.includes(path)
   )
 }
-const EOF_ON_READ_RDEV: ReadonlySet<number> = new Set([NULL_RDEV, ...STD_STREAM_RDEV.values()])
 
 function isCharDevice(mode: number): boolean {
   return (mode & S_IFMT) === S_IFCHR
@@ -250,7 +251,12 @@ export class MirageFs {
     // a stamp write that changes nothing.
     const finalizing = this.fresh === node
     this.fresh = null
-    const fields = finalizing ? null : changedAttrs(node, attr)
+    // Read before the mode below is applied. A character device is not mount
+    // content, so none of its metadata is a guest write: Emscripten chmods one
+    // right after creating it, and journaling that queued a setattr against
+    // the real mount for a node the mount does not have.
+    const isDevice = isCharDevice(node.mode)
+    const fields = finalizing || isDevice ? null : changedAttrs(node, attr)
     if (attr.mode !== undefined) node.mode = attr.mode
     if (attr.atime !== undefined) node.atime = attr.atime
     if (attr.mtime !== undefined) node.mtime = attr.mtime
@@ -261,7 +267,7 @@ export class MirageFs {
       if (this.host.isLink(node.mode)) fields.nofollow = true
       this.journal.markSetattr(this.tree.pathOf(node), fields)
     }
-    if (attr.size === undefined) return
+    if (attr.size === undefined || isDevice) return
     const old = node.contents ?? new Uint8Array(0)
     const next = new Uint8Array(attr.size)
     next.set(old.subarray(0, Math.min(old.length, attr.size)))
@@ -285,13 +291,13 @@ export class MirageFs {
   private mknod(parent: FSNode, name: string, mode: number, rdev: number): FSNode {
     const node = this.tree.makeNode(parent, name, mode)
     node.rdev = rdev
-    const path = this.tree.pathOf(node)
     // A character device is not mount content. pyodide makes one of its own
     // at runtime -- `API.capture_stderr` calls FS.createDevice, which lands
     // here as mknod -- and journaling it queued a write of /dev/capture_stderr
     // against the real mount, which then failed on replay. Devices live in
     // this tree only.
     if (isCharDevice(mode)) return node
+    const path = this.tree.pathOf(node)
     if (this.host.isDir(mode)) this.journal.markMkdir(path)
     else {
       // An empty write is what carries a file that is created and never

--- a/typescript/packages/core/src/workspace/close_drains_runtimes.test.ts
+++ b/typescript/packages/core/src/workspace/close_drains_runtimes.test.ts
@@ -15,10 +15,14 @@
 import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { beforeAll, describe, expect, it } from 'vitest'
+import { CLISpec } from '../commands/cli/types.ts'
+import { IOResult } from '../io/types.ts'
 import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { createShellParser, type ShellParser } from '../shell/parse.ts'
+import type { FileEvent, PathSpec } from '../types.ts'
 import { MountMode } from '../types.ts'
+import type { WatchRuntime } from '../watch/base.ts'
 import { Workspace } from './workspace/workspace.ts'
 
 const require = createRequire(import.meta.url)
@@ -41,6 +45,32 @@ function build(): Workspace {
   )
 }
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = (): void => undefined
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+class BlockingWatchRuntime implements WatchRuntime {
+  readonly closeStarted = deferred()
+  readonly allowClose = deferred()
+
+  watch(_path: PathSpec | readonly PathSpec[]): AsyncIterable<FileEvent> {
+    throw new Error('not used')
+  }
+
+  notify(_change: FileEvent): Promise<void> {
+    return Promise.resolve()
+  }
+
+  async close(): Promise<void> {
+    this.closeStarted.resolve()
+    await this.allowClose.promise
+  }
+}
+
 describe('Workspace.close', () => {
   // Re-entry is guarded by the in-flight promise rather than by setting
   // `closed` before the first await. A runtime replaying its journal during
@@ -59,6 +89,63 @@ describe('Workspace.close', () => {
     // resources out from under it.
     await expect(ws.execute('echo hi')).rejects.toThrow('Workspace is closed')
     await closing
+  })
+
+  it('refuses public filesystem operations while close is in progress', async () => {
+    const ws = build()
+    const watch = new BlockingWatchRuntime()
+    ws.attachWatchRuntime(watch)
+    const closing = ws.close()
+    await watch.closeStarted.promise
+
+    const attempts = await Promise.allSettled([
+      ws.resolve('/data'),
+      ws.dispatch('readdir', '/data'),
+      ws.stat('/data'),
+      ws.readdir('/data'),
+      ws.fs.stat('/data'),
+    ])
+
+    watch.allowClose.resolve()
+    await closing
+    expect(
+      attempts.map((attempt) =>
+        attempt.status === 'rejected' && attempt.reason instanceof Error
+          ? attempt.reason.message
+          : attempt.status,
+      ),
+    ).toEqual(Array.from({ length: attempts.length }, () => 'Workspace is closed'))
+  })
+
+  it('lets an admitted line finish recursive execution during close', async () => {
+    const ws = build()
+    const watch = new BlockingWatchRuntime()
+    const entered = deferred()
+    const resume = deferred()
+    ws.attachWatchRuntime(watch)
+    ws.registerCli(
+      'pause',
+      new CLISpec({
+        name: 'pause',
+        fn: async () => {
+          entered.resolve()
+          await resume.promise
+          return [null, new IOResult()]
+        },
+      }),
+    )
+
+    const running = ws.execute("pause; eval 'echo hi'")
+    await entered.promise
+    const closing = ws.close()
+    await watch.closeStarted.promise
+    resume.resolve()
+    const result = await running
+    watch.allowClose.resolve()
+    await closing
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdoutText).toBe('hi\n')
   })
 
   it('runs teardown once when two callers race it', async () => {

--- a/typescript/packages/core/src/workspace/close_drains_runtimes.test.ts
+++ b/typescript/packages/core/src/workspace/close_drains_runtimes.test.ts
@@ -14,7 +14,7 @@
 
 import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { beforeAll, describe, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { createShellParser, type ShellParser } from '../shell/parse.ts'
@@ -46,6 +46,17 @@ describe('Workspace.close', () => {
   // `closed` before the first await. A runtime replaying its journal during
   // teardown writes to mounts, so it has to see an open workspace; Python has
   // always ordered it that way and sets its flags once teardown is done.
+  // `closed` is only set once teardown finishes, so that a runtime can still
+  // replay its journal. That would otherwise leave a window where a caller
+  // could start a job after killAll, or add a mount after the close list was
+  // taken, so the public doors check that a close is under way.
+  it('refuses new work as soon as close starts', async () => {
+    const ws = build()
+    const closing = ws.close()
+    expect(() => ws.addMount('/late', new RAMResource())).toThrow('Workspace is closed')
+    await closing
+  })
+
   it('runs teardown once when two callers race it', async () => {
     const ws = build()
     await Promise.all([ws.close(), ws.close(), ws.close()])

--- a/typescript/packages/core/src/workspace/close_drains_runtimes.test.ts
+++ b/typescript/packages/core/src/workspace/close_drains_runtimes.test.ts
@@ -54,6 +54,10 @@ describe('Workspace.close', () => {
     const ws = build()
     const closing = ws.close()
     expect(() => ws.addMount('/late', new RAMResource())).toThrow('Workspace is closed')
+    // The top-level door too: a line that got in here could submit a
+    // background job after killAll had already run, and teardown would close
+    // resources out from under it.
+    await expect(ws.execute('echo hi')).rejects.toThrow('Workspace is closed')
     await closing
   })
 

--- a/typescript/packages/core/src/workspace/close_drains_runtimes.test.ts
+++ b/typescript/packages/core/src/workspace/close_drains_runtimes.test.ts
@@ -1,0 +1,54 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { beforeAll, describe, it } from 'vitest'
+import { OpsRegistry } from '../ops/registry.ts'
+import { RAMResource } from '../resource/ram/ram.ts'
+import { createShellParser, type ShellParser } from '../shell/parse.ts'
+import { MountMode } from '../types.ts'
+import { Workspace } from './workspace/workspace.ts'
+
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
+
+let parser: ShellParser
+
+beforeAll(async () => {
+  parser = await createShellParser({ engineWasm, grammarWasm })
+})
+
+function build(): Workspace {
+  const ram = new RAMResource()
+  const registry = new OpsRegistry()
+  registry.registerResource(ram)
+  return new Workspace(
+    { '/data': ram },
+    { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+  )
+}
+
+describe('Workspace.close', () => {
+  // Re-entry is guarded by the in-flight promise rather than by setting
+  // `closed` before the first await. A runtime replaying its journal during
+  // teardown writes to mounts, so it has to see an open workspace; Python has
+  // always ordered it that way and sets its flags once teardown is done.
+  it('runs teardown once when two callers race it', async () => {
+    const ws = build()
+    await Promise.all([ws.close(), ws.close(), ws.close()])
+    await ws.close()
+  })
+})

--- a/typescript/packages/core/src/workspace/workspace/lifecycle.ts
+++ b/typescript/packages/core/src/workspace/workspace/lifecycle.ts
@@ -38,9 +38,10 @@ export interface CloseDeps {
  * `workspace/lifecycle.py`.
  *
  * Order matters: the watch runtime goes first (it reads mounts), then
- * background jobs, then in-flight cache drains settle, then the state
- * store if this workspace built it, then the runtime closers, and
- * finally every resource not shared with a sibling workspace.
+ * background jobs, then the runtime closers (their journals still write
+ * to mounts), then in-flight cache drains settle, then the state store if
+ * this workspace built it, and finally every resource not shared with a
+ * sibling workspace.
  */
 export async function closeWorkspace(deps: CloseDeps): Promise<void> {
   await deps.watch.detach()
@@ -53,6 +54,19 @@ export async function closeWorkspace(deps: CloseDeps): Promise<void> {
   // that is already gone.
   await deps.jobTable.killAll()
   await deps.jobTable.closeConsoles()
+  // Runtimes next, and before the cache or any resource closes. A runtime
+  // that was interrupted mid-run still has a journal to replay, and that
+  // replay writes to mounts: draining it after the cache had gone made every
+  // one of those writes fail with "Workspace is closed", so a python program
+  // killed by its timeout silently lost its last mutations. Python has always
+  // ordered it this way (`close_async` closes line runtimes before resources).
+  for (const fn of deps.closers.splice(0)) {
+    try {
+      await fn()
+    } catch {
+      // keep tearing down; swallow subsystem-cleanup failures
+    }
+  }
   const drainTasks = [...(deps.cache.drainTasks?.values() ?? [])]
   for (const task of drainTasks) {
     await task
@@ -71,13 +85,6 @@ export async function closeWorkspace(deps: CloseDeps): Promise<void> {
     // nothing else would release, and clear() above connects to it.
     // Mirrors the try/finally pairing in Python's `close_async`.
     await deps.cache.close()
-  }
-  for (const fn of deps.closers.splice(0)) {
-    try {
-      await fn()
-    } catch {
-      // keep tearing down; swallow subsystem-cleanup failures
-    }
   }
   const toClose = new Set<Resource>(deps.openOrder)
   for (const mount of deps.registry.allMounts()) {

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -123,8 +123,8 @@ export class Workspace {
    * finishes. The two differ because `closed` is now set at the end so a
    * runtime can still replay its journal, and that window would otherwise let
    * a caller start a job after `killAll`, or add a mount after the close list
-   * was taken. `resolve` is deliberately not guarded on this: the replay
-   * dispatches through it while teardown is running.
+   * was taken. Internal dispatch and recursive execution stay open until
+   * teardown finishes; their public doors do not.
    */
   private get shuttingDown(): boolean {
     return this.closing !== null || this.closed
@@ -258,7 +258,7 @@ export class Workspace {
     // adopts whatever identity the namespace store holds.
     this.namespace = new Namespace(
       this.registry,
-      (p) => this.resolve(p),
+      (p) => this.resolveInternal(p),
       stores.namespace,
       options.agentId ?? null,
     )
@@ -323,7 +323,10 @@ export class Workspace {
     // the policy gates fire exactly once, at that door. It keeps the
     // ledger, which is its own; the sink is only the observer's copy.
     this.fs = new Ops(
-      this.dispatcher.dispatch,
+      (op, path, args, kwargs, report) => {
+        if (this.shuttingDown) throw new Error('Workspace is closed')
+        return this.dispatcher.dispatch(op, path, args, kwargs, report)
+      },
       async (rec) => {
         await this.observer.logOp(rec, this.agentId ?? '', this.sessionManager.defaultId)
       },
@@ -402,8 +405,9 @@ export class Workspace {
   }
 
   // The sandboxed runtimes' sole data path (quickjs, pyodide, monty).
-  // Routes through `dispatch`, not the raw Ops facade, so sandbox I/O
-  // takes the same path as shell commands — cache read-through on
+  // Routes through the private dispatch continuation, not the raw Ops facade,
+  // so runtime journal replay stays open during close and sandbox I/O takes
+  // the same path as shell commands — cache read-through on
   // reads, post-write invalidation, and mount-mode enforcement narrowed
   // by the current session all come from the Dispatcher. Reads are raw
   // bytes (no filetype rendering), matching the Python WasmVFS.
@@ -411,19 +415,19 @@ export class Workspace {
     return async (op, path, bytes, dst, attrs) => {
       switch (op) {
         case 'read':
-          return (await this.dispatch('read', path)) as Uint8Array
+          return (await this.dispatchInternal('read', path)) as Uint8Array
         case 'write': {
           if (bytes === undefined) throw new Error('write op requires bytes')
           const buf =
             bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes as ArrayLike<number>)
-          await this.dispatch('write', path, [buf])
+          await this.dispatchInternal('write', path, [buf])
           return undefined
         }
         case 'append': {
           if (bytes === undefined) throw new Error('append op requires bytes')
           const buf =
             bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes as ArrayLike<number>)
-          await this.dispatch('append', path, [buf])
+          await this.dispatchInternal('append', path, [buf])
           return undefined
         }
         case 'stat':
@@ -432,32 +436,37 @@ export class Workspace {
           // tiers cannot drift into two translations of one fact.
           // `nofollow` is the only attrs field a stat carries, and it
           // is the caller's lstat; the dispatcher consumes it.
-          return await this.dispatch(
+          return await this.dispatchInternal(
             'stat',
             path,
             [],
             attrs?.nofollow === true ? { nofollow: true } : undefined,
           )
         case 'create':
-          await this.dispatch('create', path)
+          await this.dispatchInternal('create', path)
           return undefined
         case 'truncate':
-          await this.dispatch('truncate', path, [0])
+          await this.dispatchInternal('truncate', path, [0])
           return undefined
         case 'unlink':
-          await this.dispatch('unlink', path)
+          await this.dispatchInternal('unlink', path)
           return undefined
         case 'mkdir':
           // `parents` is pathlib's mkdir(parents=True), riding to the
           // backend op as a kwarg the way python's dispatch carries it.
-          await this.dispatch('mkdir', path, [], attrs?.parents === true ? { parents: true } : {})
+          await this.dispatchInternal(
+            'mkdir',
+            path,
+            [],
+            attrs?.parents === true ? { parents: true } : {},
+          )
           return undefined
         case 'rmdir':
-          await this.dispatch('rmdir', path)
+          await this.dispatchInternal('rmdir', path)
           return undefined
         case 'rename': {
           if (dst === undefined) throw new Error('rename op requires dst')
-          await this.dispatch('rename', path, [PathSpec.fromStrPath(dst)])
+          await this.dispatchInternal('rename', path, [PathSpec.fromStrPath(dst)])
           return undefined
         }
         case 'symlink': {
@@ -465,14 +474,14 @@ export class Workspace {
           // relative or dangling, and resolving it here would record a
           // different link than the guest asked for.
           if (dst === undefined) throw new Error('symlink op requires dst')
-          await this.dispatch('symlink', path, [], { target: dst })
+          await this.dispatchInternal('symlink', path, [], { target: dst })
           return undefined
         }
         case 'readlink':
-          return (await this.dispatch('readlink', path)) as string
+          return (await this.dispatchInternal('readlink', path)) as string
         case 'setattr': {
           if (attrs === undefined) throw new Error('setattr op requires attrs')
-          await this.dispatch('setattr', path, [], attrs as Record<string, unknown>)
+          await this.dispatchInternal('setattr', path, [], attrs as Record<string, unknown>)
           return undefined
         }
         case 'readdir':
@@ -480,7 +489,7 @@ export class Workspace {
           // runtime door (`RuntimeVFS.readdir`) stats each entry and
           // marks the links, so a row is built in one tier and in one
           // shape in both languages.
-          return ((await this.dispatch('readdir', path)) as string[] | null) ?? []
+          return ((await this.dispatchInternal('readdir', path)) as string[] | null) ?? []
       }
     }
   }
@@ -842,9 +851,19 @@ export class Workspace {
     args: readonly unknown[] = [],
     kwargs: OpKwargs = {},
   ): Promise<unknown> {
+    if (this.shuttingDown) throw new Error('Workspace is closed')
+    return this.dispatchInternal(opName, path, args, kwargs)
+  }
+
+  private async dispatchInternal(
+    opName: string,
+    path: string,
+    args: readonly unknown[] = [],
+    kwargs: OpKwargs = {},
+  ): Promise<unknown> {
     // The Dispatcher owns the whole pipeline: pre-dispatch
     // initialization (namespace load, pending drift checks), symlink
-    // follow, resolution (its resolveFn is Workspace.resolve, so lazy
+    // follow, resolution (its resolveFn is resolveInternal, so lazy
     // open and mount grants happen there), cache read-through, mode
     // enforcement, per-op commandLimits on the executing mount,
     // revisions, overlay stat, and post-write invalidation. The same
@@ -859,6 +878,11 @@ export class Workspace {
   }
 
   async resolve(path: string): Promise<[Resource, PathSpec, MountMode]> {
+    if (this.shuttingDown) throw new Error('Workspace is closed')
+    return this.resolveInternal(path)
+  }
+
+  private async resolveInternal(path: string): Promise<[Resource, PathSpec, MountMode]> {
     if (this.closed) {
       throw new Error('Workspace is closed')
     }
@@ -923,7 +947,7 @@ export class Workspace {
       parser: () => this.getShellParser(),
       meta: this.meta,
       drift: this.drift,
-      statFn: (p) => this.dispatch('stat', p),
+      statFn: (p) => this.dispatchInternal('stat', p),
       namespace: this.namespace,
       sessions: this.sessionManager,
       registry: this.registry,
@@ -942,7 +966,7 @@ export class Workspace {
       invalidateAllAfterRemote: () => this.invalidateAllAfterRemote(),
       provision: (cmd) => this.provision(cmd),
       execute: (cmd, opts) =>
-        this.execute(cmd, opts as ExecuteOptions & { provision?: false | undefined }),
+        this.executeInternal(cmd, opts as ExecuteOptions & { provision?: false | undefined }),
     }
   }
 
@@ -965,6 +989,24 @@ export class Workspace {
     // internal dispatch path stays open, which is what the journal replay
     // uses.
     if (this.shuttingDown) throw new Error('Workspace is closed')
+    return this.executeInternal(command, options)
+  }
+
+  private async executeInternal(
+    command: string,
+    options: ExecuteOptions & { provision?: false | undefined },
+  ): Promise<ExecuteResult>
+  private async executeInternal(
+    command: string,
+    options: ExecuteOptions,
+  ): Promise<ExecuteResult | ProvisionResult>
+  private async executeInternal(
+    command: string,
+    options: ExecuteOptions,
+  ): Promise<ExecuteResult | ProvisionResult> {
+    // A line admitted before close may still recurse through eval/source/$(),
+    // but no continuation can start after teardown has finished.
+    if (this.closed) throw new Error('Workspace is closed')
     return executeLine(this.executeEnv(), command, options)
   }
 

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -115,6 +115,20 @@ export class Workspace {
   private closed = false
   private readonly closers: (() => Promise<void>)[] = []
   private closing: Promise<void> | null = null
+
+  /**
+   * Whether no new work should be accepted.
+   *
+   * True from the moment `close()` is called, not from the moment teardown
+   * finishes. The two differ because `closed` is now set at the end so a
+   * runtime can still replay its journal, and that window would otherwise let
+   * a caller start a job after `killAll`, or add a mount after the close list
+   * was taken. `resolve` is deliberately not guarded on this: the replay
+   * dispatches through it while teardown is running.
+   */
+  private get shuttingDown(): boolean {
+    return this.closing !== null || this.closed
+  }
   private readonly watchManager: WatchManager
   private readonly runtimes: Runtimes
   private readonly policyRouter: PolicyRouter
@@ -687,7 +701,7 @@ export class Workspace {
   }
 
   attachWatchRuntime(runtime: WatchRuntime): void {
-    if (this.closed) throw new Error('Workspace is closed')
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     this.watchManager.attach(runtime)
   }
 
@@ -696,12 +710,12 @@ export class Workspace {
   }
 
   watch(path: string | PathSpec | readonly (string | PathSpec)[]): AsyncIterable<FileEvent> {
-    if (this.closed) throw new Error('Workspace is closed')
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     return this.watchManager.watch(path)
   }
 
   async notify(change: FileEvent): Promise<void> {
-    if (this.closed) throw new Error('Workspace is closed')
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     await this.watchManager.notify(change)
   }
 
@@ -710,7 +724,7 @@ export class Workspace {
    * on this workspace's OpsRegistry so dispatch can find them.
    */
   addMount(prefix: string, resource: Resource, mode: MountMode = MountMode.READ): MountEntry {
-    if (this.closed) throw new Error('Workspace is closed')
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     const m = this.registry.mount(prefix, resource, mode)
     this.opsRegistry.registerResource(resource)
     const resourceOps = resource.ops?.()
@@ -727,7 +741,7 @@ export class Workspace {
    * In-flight ops that already resolved their Mount are not interrupted.
    */
   async unmount(prefix: string): Promise<void> {
-    if (this.closed) throw new Error('Workspace is closed')
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     await unmountPrefix(
       {
         registry: this.registry,
@@ -955,7 +969,7 @@ export class Workspace {
    * runtime throws.
    */
   async executePythonRepl(code: string, options: { sessionId?: string } = {}): Promise<EvalResult> {
-    if (this.closed) throw new Error('Workspace is closed')
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     const sessionId = options.sessionId ?? this.sessionManager.defaultId
     const bound = this.runtimes.bindings.python3
     if (bound === undefined || !isEvaluator(bound)) {

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -959,6 +959,12 @@ export class Workspace {
     command: string,
     options: ExecuteOptions = {},
   ): Promise<ExecuteResult | ProvisionResult> {
+    // The top-level door, so it shuts as soon as a close starts. A line that
+    // got in after `jobTable.killAll()` could submit a background job that
+    // teardown then never stops, and resources would close under it. The
+    // internal dispatch path stays open, which is what the journal replay
+    // uses.
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     return executeLine(this.executeEnv(), command, options)
   }
 

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -114,6 +114,7 @@ export class Workspace {
   readonly fs: Ops
   private closed = false
   private readonly closers: (() => Promise<void>)[] = []
+  private closing: Promise<void> | null = null
   private readonly watchManager: WatchManager
   private readonly runtimes: Runtimes
   private readonly policyRouter: PolicyRouter
@@ -1066,7 +1067,16 @@ export class Workspace {
 
   async close(): Promise<void> {
     if (this.closed) return
-    this.closed = true
+    // Re-entry is guarded by the in-flight promise, not by flipping `closed`
+    // up front. A runtime still replaying its journal has to see an open
+    // workspace or its final writes fail, which is how an interrupted python
+    // program used to lose its last mutations. Python guards the same way,
+    // with `_close_lock`, and sets its flags once teardown is done.
+    this.closing ??= this.runClose()
+    await this.closing
+  }
+
+  private async runClose(): Promise<void> {
     await this.scriptPolicy.close()
     await closeWorkspace({
       watch: this.watchManager,
@@ -1080,5 +1090,6 @@ export class Workspace {
       openOrder: this.openOrder,
       sharedResources: this.sharedResources,
     })
+    this.closed = true
   }
 }


### PR DESCRIPTION
## The bug

A python3 run stopped by its timeout could take the whole host process down.

Pyodide reopens `/dev/stderr` when a run ends, through `API.restore_stderr`.
Emscripten's own MEMFS makes `/dev/stdin`, `/dev/stdout` and `/dev/stderr` at
startup, but mirage mounts its `/dev` on top and that mount carries only `null`
and `zero`. So the reopen raises ENOENT out of a filesystem callback, and
nothing catches it.

That matters because mirage installs no `unhandledRejection` handler anywhere,
node ends the process on one, and `timeoutSeconds` is a documented option. A
deployment that sets a python3 timeout can lose its host the first time the
limit is hit.

Traced by instrumenting the shim:

```
MISS  /dev/capture_stderr   <- expected probe, Emscripten catches this one
MKNOD /dev/capture_stderr   <- created fine
MISS  /dev/stderr           <- this is the one that escapes
```

## The fix

The shim recreates the three stream devices when it is what `/dev` resolves to.

This stays inside the shim on purpose. The nodes live in the tree the
interpreter reads, not in the mount, so `ls /dev` answers exactly what it did
before and the integ golden for it (22 targets) is untouched.

## Two smaller faults found on the way

**Close ordering.** `Workspace.close` set `closed` before its first await while
the runtime closers ran later, after the cache had gone. A runtime replaying
its journal saw a closed workspace and every write failed. Re-entry now guards
on the in-flight promise, the flag is set once teardown is done, and the
closers run before the cache and the resources. **Python already did all three**
(`close_async` closes line runtimes before resources and sets its flags last),
so this closes a py/ts divergence in TS's favour.

**Devices journaled as writes.** `MirageFs.mknod` journaled every
non-directory node as a mount write, character devices included. That is why
the original failure named `/dev/capture_stderr`: pyodide creates that device
at runtime and mirage queued a write of it against the real mount.

## On the test

It asserts the reopen directly rather than the crash, because the crash is
timing-dependent. My first attempt drove the timeout path end to end and
**passed with the fix removed**, so it was guarding nothing. I caught that by
deleting the fix on purpose and re-running. The test that shipped fails with
errno 44 without the fix.

## Verification

- core: 751 files, 10179 tests pass on forks **and** on threads.
- prettier, eslint, tsc clean.

## Not addressed here

A run stopped by its timeout still loses the mutations it had journaled, even
for a file it closed itself. Separate defect, wants its own change.

## Why this came up

Found while looking at CI time. Vitest's default forked workers hid it, because
each worker process exits before anyone observes the rejection. It only showed
once I tried worker threads, which are about 25% faster on core. So this also
unblocks that change.
