### PR TITLE
fix(ci): run the monty-runtime example serially

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -155,7 +155,6 @@ jobs:
           independent=(
             integ/truth/python/ram.json
             integ/truth/python/ram_vfs.json
-            integ/truth/python/ram_python.json
             integ/truth/python/disk.json
             integ/truth/python/disk_vfs.json
             integ/truth/watch_delta.json
@@ -169,6 +168,12 @@ jobs:
             | xargs -P 4 -I{} python3 integ/check_example.py {} --variant python \
             || bad=1
           variant integ/truth/python/ram_vfs.json python_utf8_off
+
+          # ram_python boots the monty language runtime. Four of those loading
+          # at once on a 4 vCPU runner crashed it with SIGABRT (exit -6) in
+          # https://github.com/strukto-ai/mirage/actions/runs/33043622744 while
+          # every other example passed, so it runs on its own.
+          run integ/truth/python/ram_python.json
 
           # These four share one redis server, so they stay serial: running
           # them together would have them racing on the same keyspace.


### PR DESCRIPTION
Fixes a flake I introduced in #918.

## What happened

#918 made the independent example checks run four at a time via `xargs -P 4`.
One of them, `ram_python`, boots the **monty language runtime**, and four
runtimes loading at once on a 4 vCPU runner crashed it:

```
FAIL: integ/truth/python/ram_python.json [python]
  exit -6, expected 0
```

`exit -6` is SIGABRT - a crash, not an output mismatch. Every other example in
the same batch passed, in
[run 33043622744](https://github.com/strukto-ai/mirage/actions/runs/33043622744).

## Why it needs fixing rather than watching

main has been green across two runs since #918 merged, so this is
**intermittent**. That makes it worse to leave alone than a deterministic
failure: it will surface on unrelated PRs and cost someone an afternoon
before anyone connects it back to a CI change.

## The fix

`ram_python` moves to the serial section, beside the redis examples already
there for their own reason. The other ten stay parallel, so #918s 63s to 38s
improvement is preserved apart from this single check - the cost is roughly
one example back on the critical path.
