### PR TITLE
perf(lint): replace flake8 and autoflake with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,19 +61,6 @@ repos:
         name: Upgrade Python syntax
         args: [--py38-plus]
 
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.3.1
-    hooks:
-      - id: autoflake
-        name: Remove unused imports and variables
-        args: [
-          --remove-all-unused-imports,
-          --remove-unused-variables,
-          --remove-duplicate-keys,
-          --ignore-init-module-imports,
-          --in-place,
-        ]
-
   - repo: https://github.com/google/yapf
     rev: v0.43.0
     hooks:
@@ -100,19 +87,11 @@ repos:
               python/mirage/utils/generated/.*
           )$
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.3.0
-    hooks:
-      - id: flake8
-        name: Check PEP8
-        args: [--toml-config=python/pyproject.toml]
-        additional_dependencies: [Flake8-pyproject]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.3
     hooks:
       - id: ruff
-        name: Ruff formatting
+        name: Lint and remove unused imports
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/executablebooks/mdformat

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
     rev: v0.14.3
     hooks:
       - id: ruff
-        name: Lint and remove unused imports
+        name: Lint and fix Python
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/executablebooks/mdformat

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -269,11 +269,31 @@ dev = [
     "lz4>=4.4.5",
 ]
 
-[tool.flake8]
-exclude = ["mirage/commands/remote/grpc/proto/command_pb2.py", "mirage/commands/remote/grpc/proto/command_pb2_grpc.py"]
-per-file-ignores = [
-    "python/mirage/resource/*/prompt.py:E501",
+[tool.ruff]
+# 79 to match the yapf and isort defaults this repo formats with; ruff's own
+# default is 88, which would disagree with the formatter on every wrapped line.
+line-length = 79
+exclude = [
+    "mirage/commands/remote/grpc/proto/command_pb2.py",
+    "mirage/commands/remote/grpc/proto/command_pb2_grpc.py",
 ]
+
+[tool.ruff.lint]
+# E/W/F is what flake8 enforced; F alone (ruff's default) is what autoflake
+# removed. Deliberately NOT here: `I` and `UP`. Ruff's isort emits one name
+# per line with a trailing comma and cannot produce isort's default grid
+# style, so enabling it would reformat every wrapped import in the repo; and
+# `UP` at this project's py311 floor is stricter than the configured
+# `pyupgrade --py38-plus`, so it would land 168 modernizations. Both are real
+# changes that belong in their own PR, not smuggled into a tooling swap.
+select = ["E", "W", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+"mirage/resource/*/prompt.py" = ["E501"]
+# ruff measures E501 in display columns, so an East Asian character counts as
+# two; flake8 counted characters. These two lines are prose fixtures in CJK
+# that flake8 passed and ruff would not.
+"tests/utils/test_sanitize.py" = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -269,32 +269,6 @@ dev = [
     "lz4>=4.4.5",
 ]
 
-[tool.ruff]
-# 79 to match the yapf and isort defaults this repo formats with; ruff's own
-# default is 88, which would disagree with the formatter on every wrapped line.
-line-length = 79
-exclude = [
-    "mirage/commands/remote/grpc/proto/command_pb2.py",
-    "mirage/commands/remote/grpc/proto/command_pb2_grpc.py",
-]
-
-[tool.ruff.lint]
-# E/W/F is what flake8 enforced; F alone (ruff's default) is what autoflake
-# removed. Deliberately NOT here: `I` and `UP`. Ruff's isort emits one name
-# per line with a trailing comma and cannot produce isort's default grid
-# style, so enabling it would reformat every wrapped import in the repo; and
-# `UP` at this project's py311 floor is stricter than the configured
-# `pyupgrade --py38-plus`, so it would land 168 modernizations. Both are real
-# changes that belong in their own PR, not smuggled into a tooling swap.
-select = ["E", "W", "F"]
-
-[tool.ruff.lint.per-file-ignores]
-"mirage/resource/*/prompt.py" = ["E501"]
-# ruff measures E501 in display columns, so an East Asian character counts as
-# two; flake8 counted characters. These two lines are prose fixtures in CJK
-# that flake8 passed and ruff would not.
-"tests/utils/test_sanitize.py" = ["E501"]
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q --import-mode=importlib"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,27 @@
+# Match the yapf and isort defaults. Ruff's default of 88 would disagree with
+# the formatter on wrapped lines.
+line-length = 79
+target-version = "py311"
+force-exclude = true
+exclude = [
+    "python/mirage/commands/remote/grpc/proto/command_pb2.py",
+    "python/mirage/commands/remote/grpc/proto/command_pb2_grpc.py",
+]
+
+[lint]
+# Match the E/W/F rules enforced by flake8. Import sorting and syntax upgrades
+# remain with isort and pyupgrade because their Ruff equivalents produce
+# broader source changes under this repository's current configuration.
+select = ["E", "W", "F"]
+# Match autoflake's unused-variable cleanup without enabling every unsafe Ruff
+# fix. F601 duplicate keys remain errors but are corrected manually.
+extend-safe-fixes = ["F841"]
+# Ruff does not implement E125; Yapf owns indentation checks in this hook stack.
+# Keep existing suppressions valid instead of warning about an unknown code.
+external = ["E125"]
+
+[lint.per-file-ignores]
+"python/mirage/resource/*/prompt.py" = ["E501"]
+# Ruff measures E501 in display columns, so East Asian characters count as two.
+# These CJK prose fixtures passed flake8's character-based measurement.
+"python/tests/utils/test_sanitize.py" = ["E501"]


### PR DESCRIPTION
Removes the flake8 and autoflake hooks. The Ruff hook already runs on every
Python change; it now owns E/W/F linting and the safe fixes this repository
expects.

## Why

Both removed hooks start isolated Python environments and scan the same files
Ruff already scans. Measured over all tracked Python files on an idle machine:

| tool | wall time |
|---|---:|
| flake8 | 5.75-6.35s |
| autoflake | 6.1s |
| Ruff | 0.04-0.06s |

Ruff remains in the hook stack, so this removes roughly 12 seconds rather than
adding another pass.

## Behavior

- E/W/F rules apply from one repository-root `ruff.toml`, including `scripts/`
  and `integ/` Python files.
- `target-version = "py311"` preserves the package floor formerly inferred
  from `python/pyproject.toml`.
- F401 remains safely fixable. F841 is promoted explicitly to a safe fix, so an
  unused assignment becomes its side-effecting expression just as before.
- F601 duplicate dictionary keys remain blocking errors, but Ruff 0.14.3 does
  not fix them. They now require manual correction instead of autoflake deleting
  the earlier entries. This is the intentional behavior change in this PR.
- Existing generated-file exclusions are forced even when Ruff receives an
  explicit filename.
- Yapf still owns indentation rules Ruff does not implement, including E125.

## Deliberately unchanged

isort and pyupgrade stay. Enabling Ruff's `I` rules would rewrite hundreds of
imports, while `UP` at the Python 3.11 floor would introduce a separate syntax
modernization. Those changes do not belong in this performance-only PR.

## Verification

- Ruff 0.14.3: full repository check passes and proposes no source changes.
- pyupgrade, Yapf, isort, Ruff, YAML, TOML, whitespace, and line-ending hooks
  pass over the full repository.
- Focused probes confirm root-level E501 enforcement, F841 fixing with side
  effects preserved, and F601 blocking without mutation.
- Structured review: no accepted or actionable findings remain.
