### PR TITLE
Fix orphaned $var expansion in redirect targets and forward record through the daemon

### DIFF
--- a/integ/bash/redirect/vartarget.json
+++ b/integ/bash/redirect/vartarget.json
@@ -1,0 +1,132 @@
+{
+  "cases": [
+    {
+      "id": "rv_second_var_suffix",
+      "seq": 603220,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "c=aa; id=1; mkdir -p /data/rv/$c && echo hi > /data/rv/$c/$id.json && cat /data/rv/aa/1.json && find /data/rv -type f",
+      "expect": {
+        "exit": 0,
+        "stdout": "hi\n/data/rv/aa/1.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rv_three_vars_no_suffix",
+      "seq": 603221,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "a=x; b=y; c=z; mkdir -p /data/rv/w/$a/$b && echo hi > /data/rv/w/$a/$b/$c && cat /data/rv/w/x/y/z",
+      "expect": {
+        "exit": 0,
+        "stdout": "hi\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rv_heredoc_target",
+      "seq": 603222,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "c=cc; id=2; mkdir -p /data/rv/$c && cat > /data/rv/$c/$id.json <<EOF\nbody\nEOF\ncat /data/rv/cc/2.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "body\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rv_word_and_assignment",
+      "seq": 603223,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "c=bb; id=9; p=/api/$c/$id.json; echo $p; echo /api/$c/$id.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "/api/bb/9.json\n/api/bb/9.json\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/python/mirage/server/routers/execute.py
+++ b/python/mirage/server/routers/execute.py
@@ -33,6 +33,7 @@ class ExecuteRequest(BaseModel):
     agent_id: str | None = None
     cwd: str | None = None
     runtime: str | None = None
+    record: bool = True
 
 
 class BackgroundResponse(BaseModel):
@@ -53,6 +54,7 @@ def _build_execute_kwargs(req: ExecuteRequest,
     kwargs: dict[str, Any] = {
         "command": req.command,
         "provision": req.provision,
+        "record": req.record,
     }
     if req.session_id is not None:
         kwargs["session_id"] = req.session_id

--- a/python/mirage/shell/parse.py
+++ b/python/mirage/shell/parse.py
@@ -183,6 +183,87 @@ def find_unterminated_backtick(command: str) -> str | None:
     return command[opened:] if opened is not None else None
 
 
+_NAME_CONT = frozenset(
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_")
+_DIGITS = frozenset(b"0123456789")
+
+
+def _orphaned_dollar_offsets(root: tree_sitter.Node, data: bytes) -> list[int]:
+    """Byte offsets of literal ``$`` tokens cut off from their name.
+
+    tree-sitter-bash 0.25.1 stops lexing a later unbraced expansion in a
+    word when a name-terminating character follows it, so
+    ``> /api/$c/$id.json`` parses as ``/api/$c/$`` plus a sibling word
+    ``id.json``: the ``$`` lands in the tree as a literal token and the
+    expansion is gone. A literal ``$`` directly followed by a name
+    character is a shape no correct bash lex produces (bash would have
+    read an expansion), so each one marks a mis-parse. The ``$`` opening
+    a simple_expansion is that expansion's own token and is skipped.
+
+    Args:
+        root (tree_sitter.Node): root of the parsed tree.
+        data (bytes): the source the tree was parsed from.
+    """
+    offsets: list[int] = []
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        for child in node.children:
+            if (not child.is_named and child.type == "$"
+                    and node.type != "simple_expansion"
+                    and data[child.end_byte:child.end_byte + 1]
+                    and data[child.end_byte] in _NAME_CONT):
+                offsets.append(child.start_byte)
+            stack.append(child)
+    return offsets
+
+
+def _rebrace_dollar(data: bytes, offset: int) -> bytes:
+    """Rewrite the expansion at ``offset`` into its braced spelling.
+
+    ``$id.json`` becomes ``${id}.json``, which says the same thing and
+    is the spelling the grammar reads correctly. Bash reads a single
+    digit after ``$`` as one positional parameter, so ``$12`` rebraces
+    as ``${1}2``.
+
+    Args:
+        data (bytes): shell source holding the orphaned ``$``.
+        offset (int): byte offset of the ``$``.
+    """
+    end = offset + 1
+    if data[end] in _DIGITS:
+        end += 1
+    else:
+        while end < len(data) and data[end] in _NAME_CONT:
+            end += 1
+    return data[:offset] + b"${" + data[offset + 1:end] + b"}" + data[end:]
+
+
+def _repair_orphaned_dollars(root: tree_sitter.Node,
+                             data: bytes) -> tree_sitter.Node:
+    """Rebrace mis-lexed expansions and reparse until none remain.
+
+    Every rebrace consumes one bare ``$`` and never writes a new one,
+    so the loop is bounded by the count of ``$`` bytes. A retry that
+    parses worse than what it replaces is discarded.
+
+    Args:
+        root (tree_sitter.Node): tree parsed from ``data``.
+        data (bytes): the source ``root`` was parsed from.
+    """
+    for _ in range(data.count(b"$")):
+        offsets = _orphaned_dollar_offsets(root, data)
+        if not offsets:
+            break
+        for offset in sorted(offsets, reverse=True):
+            data = _rebrace_dollar(data, offset)
+        retried = TS_PARSER.parse(data).root_node
+        if retried.has_error:
+            break
+        root = retried
+    return root
+
+
 def parse(command: str) -> tree_sitter.Node:
     """Parse a shell command string into a tree-sitter AST.
 
@@ -195,6 +276,12 @@ def parse(command: str) -> tree_sitter.Node:
     only if it parses cleanly. Commands that parse today are untouched,
     so no working command's byte offsets move.
 
+    A later unbraced ``$var`` followed by a name-terminating character
+    is mis-lexed by the grammar, leaving a literal ``$`` token behind
+    (see _orphaned_dollar_offsets); those expansions are rebraced and
+    the line reparsed, so the returned tree can spell ``$id`` as
+    ``${id}``.
+
     Args:
         command (str): shell source to parse.
 
@@ -204,25 +291,31 @@ def parse(command: str) -> tree_sitter.Node:
     """
     data = strip_line_continuation(command).encode()
     root = TS_PARSER.parse(data).root_node
-    if not root.has_error:
-        return root
-    # Sitting inside an ERROR is not evidence that an opener is broken:
-    # tree-sitter's error region swallows neighbouring tokens, so a valid
-    # `((i++))` next to a bad opener reports as errored too. Splitting it
-    # would silently turn arithmetic into a subshell running `i++`, which
-    # is a wrong parse rather than a rejected one. Each opener is judged
-    # on its own span instead, in byte space throughout, because the
-    # offsets tree-sitter reports are byte offsets.
-    offsets = [
-        offset for offset in set(_failed_arith_openers(root))
-        if not _is_arithmetic(data, offset)
-    ]
-    if not offsets:
-        return root
-    for offset in sorted(offsets, reverse=True):
-        data = data[:offset + 1] + b" " + data[offset + 1:]
-    retried = TS_PARSER.parse(data).root_node
-    return root if retried.has_error else retried
+    if root.has_error:
+        # Sitting inside an ERROR is not evidence that an opener is
+        # broken: tree-sitter's error region swallows neighbouring
+        # tokens, so a valid `((i++))` next to a bad opener reports as
+        # errored too. Splitting it would silently turn arithmetic into
+        # a subshell running `i++`, which is a wrong parse rather than a
+        # rejected one. Each opener is judged on its own span instead,
+        # in byte space throughout, because the offsets tree-sitter
+        # reports are byte offsets.
+        offsets = [
+            offset for offset in set(_failed_arith_openers(root))
+            if not _is_arithmetic(data, offset)
+        ]
+        if offsets:
+            retried_data = data
+            for offset in sorted(offsets, reverse=True):
+                retried_data = (retried_data[:offset + 1] + b" " +
+                                retried_data[offset + 1:])
+            retried = TS_PARSER.parse(retried_data).root_node
+            if not retried.has_error:
+                root = retried
+                data = retried_data
+    if b"$" in data:
+        root = _repair_orphaned_dollars(root, data)
+    return root
 
 
 _BASH_KEYWORDS = frozenset({

--- a/python/tests/server/test_execute_router.py
+++ b/python/tests/server/test_execute_router.py
@@ -105,6 +105,36 @@ async def test_execute_passes_runtime_through():
 
 
 @pytest.mark.asyncio
+async def test_execute_record_false_leaves_no_history_entry():
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://test") as client:
+        wid = await _create_workspace(client)
+        r = await client.post(
+            f"/v1/workspaces/{wid}/execute",
+            json={"command": "echo recorded"},
+        )
+        assert r.status_code == 200, r.text
+        r = await client.post(
+            f"/v1/workspaces/{wid}/execute",
+            json={
+                "command": "echo hidden",
+                "record": False
+            },
+        )
+        assert r.status_code == 200, r.text
+        r = await client.post(
+            f"/v1/workspaces/{wid}/execute",
+            json={"command": "history"},
+        )
+        assert r.status_code == 200, r.text
+        out = r.json()["stdout"]
+        assert "echo recorded" in out
+        assert "echo hidden" not in out
+
+
+@pytest.mark.asyncio
 async def test_execute_sync_records_a_job_in_done_state():
     app = build_app(idle_grace_seconds=10.0)
     transport = ASGITransport(app=app)

--- a/python/tests/shell/test_parse.py
+++ b/python/tests/shell/test_parse.py
@@ -351,3 +351,49 @@ def test_find_unterminated_backtick_flags_open_region(command):
     ])
 def test_find_unterminated_backtick_accepts_balanced(command):
     assert find_unterminated_backtick(command) is None
+
+
+# tree-sitter-bash 0.25.1 drops a later unbraced `$var` out of its word
+# when the name is cut short by a name-terminating character: the `$`
+# stays behind as a literal token and the rest splits into a sibling
+# word (`/api/$c/$id.json` -> `/api/$c/$` + `id.json`). parse() rebraces
+# the orphaned expansion and reparses, so consumers see one whole word.
+@pytest.mark.parametrize(("command", "target"), [
+    ("echo hi > /api/$c/$id.json", "/api/$c/${id}.json"),
+    ("echo hi > /api/$c/$id-x", "/api/$c/${id}-x"),
+    ("echo hi > /w/$a/$b/$c", "/w/$a/${b}/$c"),
+    ("echo hi > ${a}.$b.json", "${a}.${b}.json"),
+    ("echo hi > /w/$c/$1.json", "/w/$c/${1}.json"),
+])
+def test_redirect_target_later_unbraced_var_stays_one_word(command, target):
+    node = parse(command).named_children[0]
+    assert node.type == NT.REDIRECTED_STATEMENT
+    _, redirects = get_redirects(node)
+    assert len(redirects) == 1
+    assert redirects[0].target == target
+
+
+def test_word_later_unbraced_var_stays_one_argument():
+    cmd = parse("echo /api/$c/$id.json").named_children[0]
+    parts = get_parts(cmd)
+    assert [get_text(p) for p in parts] == ["echo", "/api/$c/${id}.json"]
+
+
+def test_assignment_later_unbraced_var_stays_one_assignment():
+    # The broken parse split this into an assignment holding
+    # `p=/api/$c/$` plus a command named `id.json`.
+    node = parse("p=/api/$c/$id.json").named_children[0]
+    assert node.type == NT.VARIABLE_ASSIGNMENT
+    assert get_text(node) == "p=/api/$c/${id}.json"
+
+
+@pytest.mark.parametrize(
+    ("command", "words"),
+    [
+        # A `$` bash keeps literal is left alone: no name character follows.
+        ("echo a$ b", ["echo", "a$", "b"]),
+        ("echo $", ["echo", "$"]),
+    ])
+def test_literal_dollar_words_stay_untouched(command, words):
+    cmd = parse(command).named_children[0]
+    assert [get_text(p) for p in get_parts(cmd)] == words

--- a/python/tests/workspace/expand/test_redirects.py
+++ b/python/tests/workspace/expand/test_redirects.py
@@ -243,3 +243,49 @@ async def test_herestring_single_quoted_body_into_redirect():
     ws = await _workspace_at("/data")
     await ws.execute("cat <<< 'hi' > /data/HS")
     assert await _stdout(ws, "cat /data/HS") == "hi\n"
+
+
+# tree-sitter-bash 0.25.1 splits a later unbraced `$var` out of a word
+# when a name-terminating character follows it, so `> /api/$c/$id.json`
+# used to write a file literally named `$` under /api/<c>. parse()
+# repairs the tree; these pin the end-to-end behavior.
+
+
+@pytest.mark.asyncio
+async def test_redirect_second_unbraced_var_with_suffix():
+    ws = await _workspace_at("/data")
+    await ws.execute("c=aa; id=1; mkdir -p /api/$c")
+    io = await ws.execute("echo hi > /api/$c/$id.json")
+    assert io.exit_code == 0
+    assert await _stdout(ws, "cat /api/aa/1.json") == "hi\n"
+    assert await _stdout(ws, "find /api -type f") == "/api/aa/1.json\n"
+
+
+@pytest.mark.asyncio
+async def test_heredoc_into_second_unbraced_var_target():
+    ws = await _workspace_at("/data")
+    await ws.execute("c=aa; id=1; mkdir -p /api/$c")
+    await ws.execute("cat > /api/$c/$id.json <<EOF\nbody\nEOF")
+    assert await _stdout(ws, "cat /api/aa/1.json") == "body\n"
+
+
+@pytest.mark.asyncio
+async def test_redirect_three_unbraced_vars_no_suffix():
+    ws = await _workspace_at("/data")
+    await ws.execute("a=x; b=y; c=z; mkdir -p /w/$a/$b")
+    await ws.execute("echo hi > /w/$a/$b/$c")
+    assert await _stdout(ws, "cat /w/x/y/z") == "hi\n"
+
+
+@pytest.mark.asyncio
+async def test_word_second_unbraced_var_stays_one_argument():
+    ws = await _workspace_at("/data")
+    assert await _stdout(
+        ws, "c=aa; id=1; echo /api/$c/$id.json") == "/api/aa/1.json\n"
+
+
+@pytest.mark.asyncio
+async def test_assignment_second_unbraced_var_stays_assignment():
+    ws = await _workspace_at("/data")
+    assert await _stdout(
+        ws, "c=aa; id=1; p=/api/$c/$id.json; echo $p") == "/api/aa/1.json\n"

--- a/typescript/packages/cli/src/e2e.test.ts
+++ b/typescript/packages/cli/src/e2e.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { spawn } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -226,6 +226,34 @@ describe('mirage CLI end-to-end', () => {
     expect(result.stdout.trim()).toBe('json-out')
 
     await runCli(env, ['workspace', 'delete', 'exec-json'])
+  }, 30000)
+
+  it('execute record=false over HTTP leaves no history entry', async () => {
+    const cfgPath = writeRamConfig(tmp, 'record-cfg.yaml')
+    await runCli(env, ['workspace', 'create', cfgPath, '--id', 'record-ws'])
+
+    await runCli(env, ['execute', '-w', 'record-ws', '-c', 'echo recorded'])
+    // The CLI has no record flag; the option rides the HTTP body, so an
+    // unrecorded run is what a harness does directly against the daemon.
+    const token = readFileSync(join(tmp, 'auth_token'), 'utf-8').trim()
+    const base = env.MIRAGE_DAEMON_URL ?? ''
+    const res = await fetch(`${base}/v1/workspaces/record-ws/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ command: 'echo hidden', record: false }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { stdout: string; exitCode: number }
+    expect(body.exitCode).toBe(0)
+    expect(body.stdout).toBe('hidden\n')
+
+    const history = (await runCli(env, ['execute', '-w', 'record-ws', '-c', 'history'])) as {
+      stdout: string
+    }
+    expect(history.stdout).toContain('echo recorded')
+    expect(history.stdout).not.toContain('echo hidden')
+
+    await runCli(env, ['workspace', 'delete', 'record-ws'])
   }, 30000)
 
   it('execute consumes piped stdin', async () => {

--- a/typescript/packages/core/src/shell/parse.test.ts
+++ b/typescript/packages/core/src/shell/parse.test.ts
@@ -15,6 +15,7 @@
 import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { beforeAll, describe, expect, it } from 'vitest'
+import { getParts, getRedirects, getText } from './helpers.ts'
 import {
   createShellParser,
   findSyntaxError,
@@ -22,6 +23,7 @@ import {
   stripLineContinuation,
   type ShellParser,
 } from './parse.ts'
+import type { TSNodeLike } from './types.ts'
 
 const require = createRequire(import.meta.url)
 const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
@@ -197,6 +199,49 @@ describe('(( reparse: subshell that immediately opens a subshell', () => {
 
   it('still reports an unrelated syntax error', () => {
     expect(parser.parse('if then').hasError).toBe(true)
+  })
+})
+
+// tree-sitter-bash 0.25.1 drops a later unbraced `$var` out of its word
+// when the name is cut short by a name-terminating character: the `$`
+// stays behind as a literal token and the rest splits into a sibling
+// word (`/api/$c/$id.json` -> `/api/$c/$` + `id.json`). parse() rebraces
+// the orphaned expansion and reparses, so consumers see one whole word.
+describe('$ reparse: later unbraced var cut off from its name', () => {
+  it.each([
+    ['echo hi > /api/$c/$id.json', '/api/$c/${id}.json'],
+    ['echo hi > /api/$c/$id-x', '/api/$c/${id}-x'],
+    ['echo hi > /w/$a/$b/$c', '/w/$a/${b}/$c'],
+    ['echo hi > ${a}.$b.json', '${a}.${b}.json'],
+    ['echo hi > /w/$c/$1.json', '/w/$c/${1}.json'],
+  ])('keeps the redirect target of %j one word', (command, target) => {
+    const statement = parser.parse(command).children[0] as TSNodeLike
+    expect(statement.type).toBe('redirected_statement')
+    const [, redirects] = getRedirects(statement)
+    expect(redirects).toHaveLength(1)
+    expect(redirects[0]?.target).toBe(target)
+  })
+
+  it('keeps a bare word one argument', () => {
+    const command = parser.parse('echo /api/$c/$id.json').children[0] as TSNodeLike
+    expect(getParts(command).map((p) => getText(p))).toEqual(['echo', '/api/$c/${id}.json'])
+  })
+
+  it('keeps an assignment one assignment', () => {
+    // The broken parse split this into an assignment holding
+    // `p=/api/$c/$` plus a command named `id.json`.
+    const node = parser.parse('p=/api/$c/$id.json').namedChildren[0]
+    expect(node?.type).toBe('variable_assignment')
+    expect(getText(node as TSNodeLike)).toBe('p=/api/$c/${id}.json')
+  })
+
+  it.each([
+    // A `$` bash keeps literal is left alone: no name character follows.
+    ['echo a$ b', ['echo', 'a$', 'b']],
+    ['echo $', ['echo', '$']],
+  ])('leaves the literal dollar in %j untouched', (command, words) => {
+    const node = parser.parse(command).children[0] as TSNodeLike
+    expect(getParts(node).map((p) => getText(p))).toEqual(words)
   })
 })
 

--- a/typescript/packages/core/src/shell/parse.ts
+++ b/typescript/packages/core/src/shell/parse.ts
@@ -161,6 +161,81 @@ export function findUnterminatedBacktick(command: string): string | null {
   return opened !== null ? command.slice(opened) : null
 }
 
+const NAME_CONT = /[A-Za-z0-9_]/
+const DIGIT = /[0-9]/
+
+/**
+ * Offsets of literal `$` tokens cut off from their variable name.
+ *
+ * tree-sitter-bash 0.25.1 stops lexing a later unbraced expansion in a
+ * word when a name-terminating character follows it, so
+ * `> /api/$c/$id.json` parses as `/api/$c/$` plus a sibling word
+ * `id.json`: the `$` lands in the tree as a literal token and the
+ * expansion is gone. A literal `$` directly followed by a name
+ * character is a shape no correct bash lex produces (bash would have
+ * read an expansion), so each one marks a mis-parse. The `$` opening a
+ * simple_expansion is that expansion's own token and is skipped.
+ */
+function orphanedDollarOffsets(root: Node, text: string): number[] {
+  const offsets: number[] = []
+  const stack: Node[] = [root]
+  for (;;) {
+    const node = stack.pop()
+    if (node === undefined) break
+    for (const child of node.children) {
+      if (
+        !child.isNamed &&
+        child.type === '$' &&
+        node.type !== 'simple_expansion' &&
+        NAME_CONT.test(text[child.endIndex] ?? '')
+      ) {
+        offsets.push(child.startIndex)
+      }
+      stack.push(child)
+    }
+  }
+  return offsets
+}
+
+/**
+ * Rewrite the expansion at `offset` into its braced spelling.
+ *
+ * `$id.json` becomes `${id}.json`, which says the same thing and is the
+ * spelling the grammar reads correctly. Bash reads a single digit after
+ * `$` as one positional parameter, so `$12` rebraces as `${1}2`.
+ */
+function rebraceDollar(text: string, offset: number): string {
+  let end = offset + 1
+  if (DIGIT.test(text[end] ?? '')) {
+    end += 1
+  } else {
+    while (end < text.length && NAME_CONT.test(text[end] ?? '')) end += 1
+  }
+  return `${text.slice(0, offset)}\${${text.slice(offset + 1, end)}}${text.slice(end)}`
+}
+
+/**
+ * Rebrace mis-lexed expansions and reparse until none remain.
+ *
+ * Every rebrace consumes one bare `$` and never writes a new one, so
+ * the loop is bounded by the count of `$` characters. A retry that
+ * parses worse than what it replaces is discarded.
+ */
+function repairOrphanedDollars(parser: Parser, root: Node, text: string): Node {
+  const bound = text.split('$').length - 1
+  for (let i = 0; i < bound; i += 1) {
+    const offsets = orphanedDollarOffsets(root, text)
+    if (offsets.length === 0) break
+    for (const offset of offsets.sort((a, b) => b - a)) {
+      text = rebraceDollar(text, offset)
+    }
+    const retried = parser.parse(text)
+    if (retried === null || retried.rootNode.hasError) break
+    root = retried.rootNode
+  }
+  return root
+}
+
 // `Parser.init` boots one wasm module for the whole process, so two callers
 // that start at the same time used to race it: the second read the language
 // out of a half-built module and threw "Incompatible language version 0".
@@ -191,6 +266,12 @@ export async function createShellParser(config: ShellParserConfig): Promise<Shel
      * only openers that already sit inside an error and keeping the
      * retry only if it parses cleanly. Commands that parse today are
      * untouched, so no working command's offsets move.
+     *
+     * A later unbraced `$var` followed by a name-terminating character
+     * is mis-lexed by the grammar, leaving a literal `$` token behind
+     * (see orphanedDollarOffsets); those expansions are rebraced and
+     * the line reparsed, so the returned tree can spell `$id` as
+     * `${id}`.
      */
     parse(command: string): Node {
       const source = stripLineContinuation(command)
@@ -198,25 +279,34 @@ export async function createShellParser(config: ShellParserConfig): Promise<Shel
       if (tree === null) {
         throw new Error('shell parse returned null')
       }
-      const root = tree.rootNode
-      if (!root.hasError) return root
-      // Sitting inside an ERROR is not evidence that an opener is
-      // broken: tree-sitter's error region swallows neighbouring tokens,
-      // so a valid `((i++))` next to a bad opener reports as errored
-      // too. Splitting it would silently turn arithmetic into a subshell
-      // running `i++`, which is a wrong parse rather than a rejected
-      // one. Each opener is judged on its own span instead.
-      const offsets = [...new Set(failedArithOpeners(root))].filter(
-        (o) => !isArithmetic(parser, source, o),
-      )
-      if (offsets.length === 0) return root
+      let root = tree.rootNode
       let text = source
-      for (const offset of offsets.sort((a, b) => b - a)) {
-        text = `${text.slice(0, offset + 1)} ${text.slice(offset + 1)}`
+      if (root.hasError) {
+        // Sitting inside an ERROR is not evidence that an opener is
+        // broken: tree-sitter's error region swallows neighbouring tokens,
+        // so a valid `((i++))` next to a bad opener reports as errored
+        // too. Splitting it would silently turn arithmetic into a subshell
+        // running `i++`, which is a wrong parse rather than a rejected
+        // one. Each opener is judged on its own span instead.
+        const offsets = [...new Set(failedArithOpeners(root))].filter(
+          (o) => !isArithmetic(parser, source, o),
+        )
+        if (offsets.length > 0) {
+          let split = source
+          for (const offset of offsets.sort((a, b) => b - a)) {
+            split = `${split.slice(0, offset + 1)} ${split.slice(offset + 1)}`
+          }
+          const retried = parser.parse(split)
+          if (retried !== null && !retried.rootNode.hasError) {
+            root = retried.rootNode
+            text = split
+          }
+        }
       }
-      const retried = parser.parse(text)
-      if (retried === null) return root
-      return retried.rootNode.hasError ? root : retried.rootNode
+      if (text.includes('$')) {
+        root = repairOrphanedDollars(parser, root, text)
+      }
+      return root
     },
   }
 }

--- a/typescript/packages/core/src/workspace/expand/redirects.test.ts
+++ b/typescript/packages/core/src/workspace/expand/redirects.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { makeIntegrationWS, run, runResult } from '../fixtures/integration_fixture.ts'
+import { makeIntegrationWS, run, runExit, runResult } from '../fixtures/integration_fixture.ts'
 
 describe('heredoc body expansion', () => {
   it('expands braced vars and command substitutions', async () => {
@@ -248,6 +248,64 @@ describe('quoted redirect targets', () => {
     try {
       await ws.execute("cat <<< 'hi' > /data/HS")
       expect(await run(ws, 'cat /data/HS')).toBe('hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+})
+
+// tree-sitter-bash 0.25.1 splits a later unbraced `$var` out of a word
+// when a name-terminating character follows it, so `> /api/$c/$id.json`
+// used to write a file literally named `$` under /api/<c>. parse()
+// repairs the tree; these pin the end-to-end behavior.
+describe('later unbraced var in a redirect target', () => {
+  it('writes the fully expanded path', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      await ws.execute('c=aa; id=1; mkdir -p /api/$c')
+      expect(await runExit(ws, 'echo hi > /api/$c/$id.json')).toBe(0)
+      expect(await run(ws, 'cat /api/aa/1.json')).toBe('hi\n')
+      expect(await run(ws, 'find /api -type f')).toBe('/api/aa/1.json\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('delivers a heredoc into the fully expanded path', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      await ws.execute('c=aa; id=1; mkdir -p /api/$c')
+      await ws.execute('cat > /api/$c/$id.json <<EOF\nbody\nEOF')
+      expect(await run(ws, 'cat /api/aa/1.json')).toBe('body\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('expands three suffixless vars in one target', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      await ws.execute('a=x; b=y; c=z; mkdir -p /w/$a/$b')
+      await ws.execute('echo hi > /w/$a/$b/$c')
+      expect(await run(ws, 'cat /w/x/y/z')).toBe('hi\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('keeps a bare word one argument', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'c=aa; id=1; echo /api/$c/$id.json')).toBe('/api/aa/1.json\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('keeps an assignment one assignment', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'c=aa; id=1; p=/api/$c/$id.json; echo $p')).toBe('/api/aa/1.json\n')
     } finally {
       await ws.close()
     }

--- a/typescript/packages/server/src/routers/execute.test.ts
+++ b/typescript/packages/server/src/routers/execute.test.ts
@@ -95,6 +95,31 @@ describe('execute router', () => {
     await app.close()
   })
 
+  it('honors record=false by leaving no history entry', async () => {
+    const app = buildApp()
+    await createWs(app, 'erec')
+    await app.inject({
+      method: 'POST',
+      url: '/v1/workspaces/erec/execute',
+      payload: { command: 'echo recorded' },
+    })
+    await app.inject({
+      method: 'POST',
+      url: '/v1/workspaces/erec/execute',
+      payload: { command: 'echo hidden', record: false },
+    })
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/workspaces/erec/execute',
+      payload: { command: 'history' },
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json<{ stdout: string }>()
+    expect(body.stdout).toContain('echo recorded')
+    expect(body.stdout).not.toContain('echo hidden')
+    await app.close()
+  })
+
   it('POST /v1/jobs/:id/wait accepts an empty body', async () => {
     const app = buildApp()
     await createWs(app, 'ewait')

--- a/typescript/packages/server/src/routers/execute.ts
+++ b/typescript/packages/server/src/routers/execute.ts
@@ -35,6 +35,7 @@ interface ExecuteBody {
   cwd?: string
   runtime?: string
   stdinBase64?: string
+  record?: boolean
 }
 
 interface ExecuteQuery {
@@ -58,6 +59,7 @@ export function registerExecuteRoutes(app: FastifyInstance, deps: ExecuteRoutesD
           ...(body.agentId !== undefined ? { agentId: body.agentId } : {}),
           ...(body.cwd !== undefined ? { cwd: body.cwd } : {}),
           ...(body.runtime !== undefined ? { runtime: body.runtime } : {}),
+          ...(body.record !== undefined ? { record: body.record } : {}),
           ...(body.provision === true ? { provision: true as const } : {}),
           ...(body.stdinBase64 !== undefined
             ? { stdin: new Uint8Array(Buffer.from(body.stdinBase64, 'base64')) }


### PR DESCRIPTION
## Summary
- tree-sitter-bash 0.25.1 orphans a later unbraced `$var` when a name-terminating character follows it, so `echo hi > /api/$c/$id.json` wrote a file literally named `$` (bare words, for lists, arrays and assignments split the same way). `parse()` now rebraces the orphaned expansion (`$id` -> `${id}`) and reparses, in both languages.
- The daemon's execute route dropped `ExecuteOptions.record`, so an unrecorded run was unreachable over HTTP. Both routes now forward it.

## Test plan
- New parse-level and workspace tests for the repair (py + ts), including literal-dollar guards.
- New route tests: `record: false` leaves no history entry (py + ts), plus a CLI e2e over a live daemon.
- New integ corpus `integ/bash/redirect/vartarget.json`; ram+disk battery green on both hosts (5808 each).
- Full pytest, core/server/cli vitest, `pnpm -r typecheck`, pre-commit all green.