### PR TITLE
fix(runtime): withhold the history view and root anchor from runtimes

### DIFF
--- a/python/mirage/runtime/language.py
+++ b/python/mirage/runtime/language.py
@@ -40,6 +40,15 @@ class LanguageRuntime(Runtime):
     sandboxed interpreter bridges file I/O through the workspace
     dispatch attached here, while a host subprocess only sees the host
     filesystem and keeps the default no-op attach.
+
+    The doors are the data plane (dispatch) and the name plane
+    (resolver), and the list is complete on purpose: there is no
+    session door. A guest reads the frozen ``RunArgs.env`` snapshot; an
+    env write lands on the guest's own copy and dies with the run,
+    never reaching the live session, so guest code can neither trip nor
+    bypass a ``pre_session`` rule. That blindness is a security
+    boundary, not a gap — a runtime that ever needs session state must
+    take a gated ``SessionView``, never a bare session reference.
     """
 
     language: ClassVar[Language]

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -233,7 +233,7 @@ class Workspace:
 
         self._runtimes, self._policy_router = wire_runtime_world(
             self._registry, self.dispatch,
-            PrefixResolver(self._ops.mount_prefixes,
+            PrefixResolver(self._sandbox_visible_mounts,
                            self._namespace.link_names_under), runtimes)
         reject_config_script("policy", policy)
         self._policy = policy
@@ -412,6 +412,29 @@ class Workspace:
     def clis(self) -> dict[str, CLIInstall]:
         """Snapshot of the installed CLIs keyed by head word."""
         return self._registry.clis.items()
+
+    def _sandbox_visible_mounts(self) -> list[str]:
+        """The mount prefixes announced to sandboxed runtimes, read live.
+
+        Two are withheld, and neither is withheld for being ``/``. An
+        explicit root mount is forwarded like any other prefix, and a
+        runtime that cannot serve it refuses on its own (pyodide does,
+        because Emscripten already owns ``/``). What is withheld is the
+        history view, which is a shell surface rather than a place to
+        put files, and the synthetic root anchor, which nobody mounted:
+        the workspace adds it so arg-less commands and root listing
+        have somewhere to resolve, so announcing it as a mount would
+        make every runtime report a claim on a resource the embedder
+        never asked for (TS ``sandboxVisibleMounts``).
+        """
+        prefixes: list[str] = []
+        for entry in self._registry.mounts():
+            if entry.prefix in (HISTORY_PREFIX, HISTORY_PREFIX + "/"):
+                continue
+            if self._implicit_root and entry.prefix == "/":
+                continue
+            prefixes.append(entry.prefix)
+        return prefixes
 
     def add_runtime(self, runtime: Runtime | str) -> Runtime:
         """Append a runtime entry to the workspace's ordered set.

--- a/python/tests/workspace/test_runtime_binding.py
+++ b/python/tests/workspace/test_runtime_binding.py
@@ -23,8 +23,9 @@ from mirage.runtime.mixin import LineExecutorMixin
 from mirage.runtime.policy import DenyResult, RouteResult
 from mirage.runtime.python import LocalRuntime, MontyRuntime
 from mirage.runtime.python.base import PythonRuntime
+from mirage.runtime.resolver import MountResolver
 from mirage.runtime.table import VFSRuntime
-from mirage.runtime.types import RunArgs, RunResult, ScriptSource
+from mirage.runtime.types import DispatchFn, RunArgs, RunResult, ScriptSource
 
 
 @pytest_asyncio.fixture
@@ -546,3 +547,56 @@ async def test_vfs_entry_is_a_pure_routing_marker():
 def test_stage_engines_carry_no_line_door():
     assert not isinstance(MontyRuntime(), LineExecutorMixin)
     assert not hasattr(MontyRuntime(), "run_line")
+
+
+class ResolverProbe(PythonRuntime):
+    name = "resolver-probe"
+    captures = ("probe-run", )
+    resolver: MountResolver | None = None
+
+    def attach(self, dispatch: DispatchFn, resolver: MountResolver) -> None:
+        self.resolver = resolver
+
+    async def run(self, args: RunArgs) -> RunResult:
+        return RunResult(stdout=b"", stderr=None, exit_code=0)
+
+
+@pytest.mark.asyncio
+async def test_attach_withholds_the_history_view_from_runtimes():
+    # The history view is a shell surface, not a place to put files;
+    # announcing it would make a WASI guest preopen /.bash_history.
+    probe = ResolverProbe()
+    ws = Workspace({"/data": RAMResource()}, runtimes=[probe])
+    try:
+        assert probe.resolver is not None
+        prefixes = probe.resolver.prefixes()
+        assert "/data/" in prefixes
+        assert not any("bash_history" in p for p in prefixes)
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_withholds_the_synthetic_root_anchor():
+    # Nobody mounted the anchor; forwarding it would make every
+    # runtime claim a resource the embedder never asked for.
+    probe = ResolverProbe()
+    ws = Workspace({"/data": RAMResource()}, runtimes=[probe])
+    try:
+        assert probe.resolver is not None
+        assert "/" not in probe.resolver.prefixes()
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_forwards_an_explicit_root_mount():
+    # Withheld for being synthetic, never for being `/`: a runtime
+    # that cannot serve the root refuses on its own (pyodide does).
+    probe = ResolverProbe()
+    ws = Workspace({"/": RAMResource()}, runtimes=[probe])
+    try:
+        assert probe.resolver is not None
+        assert "/" in probe.resolver.prefixes()
+    finally:
+        await ws.close()

--- a/typescript/packages/core/src/runtime/language.ts
+++ b/typescript/packages/core/src/runtime/language.ts
@@ -36,6 +36,15 @@ import type { BridgeDispatchFn, RunArgs, RunResult, RuntimeLanguage } from './ty
  * sandboxed interpreter bridges file I/O through the workspace
  * dispatch attached here, while a host subprocess only sees the host
  * filesystem and keeps the default no-op attach.
+ *
+ * The doors are the data plane (dispatch) and the name plane
+ * (resolver), and the list is complete on purpose: there is no
+ * session door. A guest reads the frozen `RunArgs.env` snapshot; an
+ * env write lands on the guest's own copy and dies with the run,
+ * never reaching the live session, so guest code can neither trip nor
+ * bypass a `preSession` rule. That blindness is a security boundary,
+ * not a gap — a runtime that ever needs session state must take a
+ * gated `SessionView`, never a bare session reference.
  */
 export abstract class LanguageRuntime extends Runtime {
   abstract readonly language: RuntimeLanguage

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -19,6 +19,9 @@ import { OpsRegistry } from '../ops/registry.ts'
 import { MountMode, ResourceName, type PathSpec } from '../types.ts'
 import { BaseResource, type Resource } from '../resource/base.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
+import { LanguageRuntime } from '../runtime/language.ts'
+import type { MountResolver } from '../runtime/resolver.ts'
+import type { BridgeDispatchFn, RunArgs, RunResult } from '../runtime/types.ts'
 import { getTestParser } from './fixtures/workspace_fixture.ts'
 import { Workspace } from './workspace/workspace.ts'
 
@@ -482,6 +485,53 @@ describe('rm/rmdir on a mount prefix is refused (Unix-like)', () => {
     await ws.execute('rm /data')
     // The intercept only triggers for recursive forms; mount stays either way
     expect(ws.mounts().some((m) => m.prefix === '/data/')).toBe(true)
+    await ws.close()
+  })
+})
+
+class ResolverProbe extends LanguageRuntime {
+  readonly language = 'python'
+  readonly name = 'resolver-probe'
+  resolver: MountResolver | null = null
+  constructor() {
+    super({ captures: ['probe-run'] })
+  }
+  override attach(_dispatch: BridgeDispatchFn, resolver: MountResolver): void {
+    this.resolver = resolver
+  }
+  run(_args: RunArgs): Promise<RunResult> {
+    return Promise.resolve({ stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 0 })
+  }
+}
+
+describe('runtime-visible mounts', () => {
+  it('attach withholds the history view from runtimes', async () => {
+    // The history view is a shell surface, not a place to put files;
+    // announcing it would make a WASI guest preopen /.bash_history.
+    const probe = new ResolverProbe()
+    const ws = new Workspace({ '/data': new RAMResource() }, { runtimes: [probe] })
+    expect(probe.resolver).not.toBeNull()
+    const prefixes = probe.resolver?.prefixes() ?? []
+    expect(prefixes).toContain('/data/')
+    expect(prefixes.some((p) => p.includes('bash_history'))).toBe(false)
+    await ws.close()
+  })
+
+  it('attach withholds the synthetic root anchor', async () => {
+    // Nobody mounted the anchor; forwarding it would make every
+    // runtime claim a resource the embedder never asked for.
+    const probe = new ResolverProbe()
+    const ws = new Workspace({ '/data': new RAMResource() }, { runtimes: [probe] })
+    expect(probe.resolver?.prefixes() ?? []).not.toContain('/')
+    await ws.close()
+  })
+
+  it('attach forwards an explicit root mount', async () => {
+    // Withheld for being synthetic, never for being `/`: a runtime
+    // that cannot serve the root refuses on its own (pyodide does).
+    const probe = new ResolverProbe()
+    const ws = new Workspace({ '/': new RAMResource() }, { runtimes: [probe] })
+    expect(probe.resolver?.prefixes() ?? []).toContain('/')
     await ws.close()
   })
 })


### PR DESCRIPTION
## What

Python announced the **unfiltered** mount table to sandboxed runtimes; TypeScript filters it (`sandboxVisibleMounts`). This PR ports the filter and pins it in both languages, and writes the runtime tier's session-blindness doctrine down on `LanguageRuntime`.

## The divergence

The workspace hands every `LanguageRuntime` a resolver at `attach` time — the mount prefixes a guest may see (WASI preopens one directory per mount; `RuntimeVFS.prefixes()`/`mount_of` route on them; `PolicyContext.mounts` is stamped from the same resolver).

- **TypeScript** (`workspace.ts` `sandboxVisibleMounts`) withholds two prefixes, neither for being `/`: the **history view** (a shell surface, not a place to put files) and the **synthetic root anchor** (a mount nobody asked for — the workspace adds it so arg-less commands resolve). An explicit root mount is forwarded like any other prefix.
- **Python** passed `self._ops.mount_prefixes` unfiltered, so a WASI guest preopened `/.bash_history` and every runtime reported a claim on the anchor. `PrefixResolver`'s own docstring already promised "a sandbox-filtered list for the runtimes" — the docstring described TS, not Python.

## Changes

- `workspace.py`: new `Workspace._sandbox_visible_mounts()` (live read off the registry, mirroring TS), wired into the one `PrefixResolver` construction. `PolicyContext.mounts` follows the same resolver in both languages, so policies now see the same list too.
- `tests/workspace/test_runtime_binding.py`: a `ResolverProbe` runtime captures the attached resolver; three pins — history withheld, synthetic anchor withheld, **explicit root forwarded** (guards against over-filtering). The two "withholds" pins were verified red against the old wiring.
- `workspace.test.ts`: the same three pins. TS behavior was already correct but had no direct test.
- `language.py` / `language.ts`: doctrine paragraph — the doors are the data plane (dispatch) and the name plane (resolver), and the list is complete on purpose: there is **no session door**. A guest env write lands on the guest's own copy and dies with the run, so guest code can neither trip nor bypass a `pre_session` rule. A runtime that ever needs session state must take a gated `SessionView`.

## What this PR deliberately does not do

This came out of a design review of how state planes reach the runtime tier (D4: "runtimes have no doors record"). The survey falsified the record: `attach(dispatch, resolver)` already **is** the two doors — data plane and name plane — mirrored field-for-field across languages, with `MountResolver` documented as "the name-plane questions a runtime asks" and growth landing as protocol methods fed by injected sources, not signature changes. A `RuntimeDoors` record would additionally have Python-only payload (the session/recorder re-bind exists only where guest calls cross threads; TS has no ambient capture at all), violating the parity it was meant to serve. What the survey *did* surface is this filter divergence, which is the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
