### PR TITLE
fix(cli): validate custom specs at construction

### DIFF
--- a/python/mirage/commands/cli/compile.py
+++ b/python/mirage/commands/cli/compile.py
@@ -23,15 +23,16 @@ if TYPE_CHECKING:
 def validate_cli(node: "CLISpec") -> None:
     """Validate one CLISpec node at construction time.
 
-    Called from CLISpec.__post_init__, so a structurally invalid node
-    raises ValueError at import time, never at dispatch. Children were
+    Called from CLISpec.__post_init__, so an invalid node raises ValueError
+    at import time, never at dispatch. Children were
     validated by their own construction (a nested literal builds bottom
     up), so each call checks one level: the name is a single word with no
     whitespace, a node takes exactly one of fn, subcommands, or script
-    (a script root stands alone: the program re-parses argv natively),
-    runtime only rides a script, a group declares no positional/rest
-    (its operand is the subcommand word), child names are unique, and
-    only a tree's root may declare config_model or script.
+    (a script root stands alone and takes opaque config: the program
+    re-parses argv natively), runtime only rides a script, every node's
+    inherited CommandSpec grammar compiles, a group declares no
+    positional/rest (its operand is the subcommand word), child names are
+    unique, and only a tree's root may declare config_model or script.
 
     Args:
         node (CLISpec): the freshly constructed node.
@@ -50,6 +51,9 @@ def validate_cli(node: "CLISpec") -> None:
         raise ValueError(
             f"cli {node.name!r}: a script serves the whole program; "
             f"subcommands belong to fn trees")
+    if node.script is not None and node.config_model is not None:
+        raise ValueError(f"cli {node.name!r}: script config is opaque; it "
+                         f"cannot declare config_model")
     if node.runtime is not None and node.script is None:
         raise ValueError(f"cli {node.name!r}: runtime names the entry that "
                          f"runs script; it takes script")
@@ -63,6 +67,7 @@ def validate_cli(node: "CLISpec") -> None:
         raise ValueError(
             f"cli {node.name!r}: a group's operand is its subcommand "
             f"word; positional/rest belong on leaves")
+    compiled = compile_spec(node)
     # Names and aliases share one sibling namespace (argparse refuses a
     # conflicting subparser alias the same way).
     seen: set[str] = set()
@@ -81,7 +86,7 @@ def validate_cli(node: "CLISpec") -> None:
                 f"cli {node.name!r}: subcommand {child.name!r} declares "
                 f"script; only the root of a tree may")
     if node.options and node.subcommands:
-        own = set(compile_spec(node).dest.values())
+        own = set(compiled.dest.values())
         for child in node.subcommands:
             _check_collisions(node.name, own, child, (child.name, ))
 

--- a/python/mirage/commands/cli/types.py
+++ b/python/mirage/commands/cli/types.py
@@ -196,7 +196,10 @@ class CLISpec(CommandSpec):
     """
     name: str = ""
     aliases: tuple[str, ...] = ()
-    fn: Callable[..., Any] | None = None
+    # Any callable is valid, including stateful callable objects whose
+    # class deliberately has no hash. The handler does not affect the
+    # inherited CommandSpec grammar cached by compile_spec.
+    fn: Callable[..., Any] | None = field(default=None, hash=False)
     subcommands: tuple["CLISpec", ...] = ()
     write: bool = False
     usage_style: UsageStyle = UsageStyle.ARGPARSE

--- a/python/mirage/commands/spec/compile.py
+++ b/python/mirage/commands/spec/compile.py
@@ -186,7 +186,7 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
     for opt in spec.options:
         canonical = opt.long if opt.long else opt.short
         if canonical is None:
-            continue
+            raise ValueError("option requires a short or long spelling")
         for spelling in (opt.short, opt.long):
             if spelling is None:
                 continue

--- a/python/mirage/commands/spec/compile.py
+++ b/python/mirage/commands/spec/compile.py
@@ -160,6 +160,7 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
     Args:
         spec (CommandSpec): the declarative spec to compile.
     """
+    seen_spellings: set[str] = set()
     bool_spellings: set[str] = set()
     value_spellings: list[str] = []
     attach_spellings: list[str] = []
@@ -186,6 +187,12 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
         canonical = opt.long if opt.long else opt.short
         if canonical is None:
             continue
+        for spelling in (opt.short, opt.long):
+            if spelling is None:
+                continue
+            if spelling in seen_spellings:
+                raise ValueError(f"duplicate option spelling {spelling!r}")
+            seen_spellings.add(spelling)
         if opt.count and opt.type != "bool":
             raise ValueError(f"option {canonical!r}: count requires a "
                              "boolean flag (type 'bool')")

--- a/python/tests/commands/cli/test_compile.py
+++ b/python/tests/commands/cli/test_compile.py
@@ -123,6 +123,14 @@ def test_leaf_option_grammar_is_validated_at_construction():
                 options=(Option(long="--mode", choices=("a", "b")), ))
 
 
+def test_duplicate_leaf_option_spelling_is_rejected_at_construction():
+    with pytest.raises(ValueError, match="duplicate option spelling"):
+        CLISpec(name="mine",
+                fn=_verb,
+                options=(Option(long="--mode"),
+                         Option(long="--mode", type="str")))
+
+
 def test_ancestor_descendant_option_collision_raises():
     with pytest.raises(ValueError, match="collides with subcommand"):
         CLISpec(name="gws",

--- a/python/tests/commands/cli/test_compile.py
+++ b/python/tests/commands/cli/test_compile.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from dataclasses import dataclass
+
 import pytest
 from pydantic import BaseModel
 
@@ -26,6 +28,14 @@ class _Config(BaseModel):
 
 async def _verb(config, paths, *texts, **flags):
     return None
+
+
+@dataclass
+class _StatefulVerb:
+    calls: int = 0
+
+    async def __call__(self, invocation):
+        self.calls += 1
 
 
 def test_name_must_be_a_single_word():
@@ -121,6 +131,17 @@ def test_leaf_option_grammar_is_validated_at_construction():
         CLISpec(name="mine",
                 fn=_verb,
                 options=(Option(long="--mode", choices=("a", "b")), ))
+
+
+def test_unhashable_callable_handler_is_valid():
+    handler = _StatefulVerb()
+    spec = CLISpec(name="mine", fn=handler)
+    assert spec.fn is handler
+
+
+def test_spellingless_leaf_option_is_rejected_at_construction():
+    with pytest.raises(ValueError, match="requires a short or long spelling"):
+        CLISpec(name="mine", fn=_verb, options=(Option(), ))
 
 
 def test_duplicate_leaf_option_spelling_is_rejected_at_construction():

--- a/python/tests/commands/cli/test_compile.py
+++ b/python/tests/commands/cli/test_compile.py
@@ -69,6 +69,11 @@ def test_script_excludes_subcommands():
                 subcommands=(CLISpec(name="send", fn=_verb), ))
 
 
+def test_script_excludes_config_model():
+    with pytest.raises(ValueError, match="config_model"):
+        CLISpec(name="pager", script=ScriptSource("1"), config_model=_Config)
+
+
 def test_runtime_takes_script():
     with pytest.raises(ValueError, match="it takes script"):
         CLISpec(name="pager", fn=_verb, runtime="monty")
@@ -108,6 +113,14 @@ def test_config_model_is_root_only():
                 subcommands=(CLISpec(name="gmail",
                                      fn=_verb,
                                      config_model=_Config), ))
+
+
+def test_leaf_option_grammar_is_validated_at_construction():
+    with pytest.raises(ValueError,
+                       match="choices and default require a value flag"):
+        CLISpec(name="mine",
+                fn=_verb,
+                options=(Option(long="--mode", choices=("a", "b")), ))
 
 
 def test_ancestor_descendant_option_collision_raises():

--- a/python/tests/commands/spec/test_compile.py
+++ b/python/tests/commands/spec/test_compile.py
@@ -73,6 +73,11 @@ def test_compile_is_cached_per_spec():
     assert compile_spec(spec) is compile_spec(spec)
 
 
+def test_option_requires_a_spelling():
+    with pytest.raises(ValueError, match="requires a short or long spelling"):
+        compile_spec(CommandSpec(options=(Option(), )))
+
+
 @pytest.mark.parametrize("options", (
     (Option(short="-m"), Option(short="-m", type="str")),
     (Option(long="--mode"), Option(long="--mode", type="str")),

--- a/python/tests/commands/spec/test_compile.py
+++ b/python/tests/commands/spec/test_compile.py
@@ -73,6 +73,15 @@ def test_compile_is_cached_per_spec():
     assert compile_spec(spec) is compile_spec(spec)
 
 
+@pytest.mark.parametrize("options", (
+    (Option(short="-m"), Option(short="-m", type="str")),
+    (Option(long="--mode"), Option(long="--mode", type="str")),
+))
+def test_duplicate_option_spellings_are_spec_errors(options):
+    with pytest.raises(ValueError, match="duplicate option spelling"):
+        compile_spec(CommandSpec(options=options))
+
+
 def test_count_choices_required_default_tables():
     spec = CommandSpec(options=(
         Option(short="-v", long="--verbose", count=True),

--- a/typescript/packages/core/src/commands/cli/types.test.ts
+++ b/typescript/packages/core/src/commands/cli/types.test.ts
@@ -132,6 +132,17 @@ describe('CLISpec', () => {
     ).toThrow(/subcommands belong to fn trees/)
   })
 
+  it('script excludes configModel', () => {
+    expect(
+      () =>
+        new CLISpec({
+          name: 'pager',
+          script: new ScriptSource('1'),
+          configModel,
+        }),
+    ).toThrow(/configModel/)
+  })
+
   it('runtime takes script', () => {
     expect(() => new CLISpec({ name: 'pager', fn: verb, runtime: 'monty' })).toThrow(
       /it takes script/,
@@ -190,6 +201,17 @@ describe('CLISpec', () => {
           subcommands: [new CLISpec({ name: 'gmail', fn: verb, configModel })],
         }),
     ).toThrow(/only the root of a tree may/)
+  })
+
+  it('validates leaf option grammar at construction', () => {
+    expect(
+      () =>
+        new CLISpec({
+          name: 'mine',
+          fn: verb,
+          options: [new Option({ long: '--mode', choices: ['a', 'b'] })],
+        }),
+    ).toThrow(/choices and default require a value flag/)
   })
 
   it('rejects an option colliding between a node and a descendant', () => {

--- a/typescript/packages/core/src/commands/cli/types.test.ts
+++ b/typescript/packages/core/src/commands/cli/types.test.ts
@@ -214,6 +214,12 @@ describe('CLISpec', () => {
     ).toThrow(/choices and default require a value flag/)
   })
 
+  it('rejects a spelling-less leaf option at construction', () => {
+    expect(() => new CLISpec({ name: 'mine', fn: verb, options: [new Option()] })).toThrow(
+      /requires a short or long spelling/,
+    )
+  })
+
   it('rejects a duplicate leaf option spelling at construction', () => {
     expect(
       () =>

--- a/typescript/packages/core/src/commands/cli/types.test.ts
+++ b/typescript/packages/core/src/commands/cli/types.test.ts
@@ -214,6 +214,17 @@ describe('CLISpec', () => {
     ).toThrow(/choices and default require a value flag/)
   })
 
+  it('rejects a duplicate leaf option spelling at construction', () => {
+    expect(
+      () =>
+        new CLISpec({
+          name: 'mine',
+          fn: verb,
+          options: [new Option({ long: '--mode' }), new Option({ long: '--mode', type: 'str' })],
+        }),
+    ).toThrow(/duplicate option spelling/)
+  })
+
   it('rejects an option colliding between a node and a descendant', () => {
     expect(
       () =>

--- a/typescript/packages/core/src/commands/cli/types.ts
+++ b/typescript/packages/core/src/commands/cli/types.ts
@@ -148,15 +148,17 @@ export type CLIConfigModel = ZodObject<ZodRawShape> | ((input: Record<string, un
  * identity, behavior, and nesting. A leaf carries `fn`; a group carries
  * `subcommands`; the root of an installable program may carry
  * `configModel` (the zod-backed `normalize*Config` shape resources already
- * use, doubling as the redaction schema). Every level of the tree parses
- * with the ordinary spec machinery because every level is a CommandSpec.
+ * use, doubling as the redaction schema). A script's config is opaque, so a
+ * script cannot declare `configModel`. Every level of the tree parses with
+ * the ordinary spec machinery because every level is a CommandSpec.
  *
  * The constructor validates the node at module-import time: the name must
  * be a single word, a node takes exactly one of `fn`, `subcommands`, or
  * `script` (a script root stands alone: the program re-parses argv
- * natively), a group declares no positional/rest (its operand is the
- * subcommand word), child names must be unique, and only a tree's root may
- * declare `configModel` or `script`.
+ * natively), every node's inherited CommandSpec grammar compiles, a group
+ * declares no positional/rest (its operand is the subcommand word), child
+ * names must be unique, and only a tree's root may declare `configModel` or
+ * `script`.
  */
 export class CLISpec extends CommandSpec {
   readonly name: string
@@ -226,6 +228,9 @@ export class CLISpec extends CommandSpec {
         `cli '${this.name}': a script serves the whole program; subcommands belong to fn trees`,
       )
     }
+    if (this.script !== null && this.configModel !== null) {
+      throw new Error(`cli '${this.name}': script config is opaque; it cannot declare configModel`)
+    }
     if (this.runtime !== null && this.script === null) {
       throw new Error(
         `cli '${this.name}': runtime names the entry that runs script; it takes script`,
@@ -243,6 +248,7 @@ export class CLISpec extends CommandSpec {
           'positional/rest belong on leaves',
       )
     }
+    const compiled = compileSpec(this)
     // Names and aliases share one sibling namespace (argparse refuses a
     // conflicting subparser alias the same way).
     const seen = new Set<string>()
@@ -267,7 +273,7 @@ export class CLISpec extends CommandSpec {
       }
     }
     if (this.options.length > 0 && this.subcommands.length > 0) {
-      const own = new Set(compileSpec(this).dest.values())
+      const own = new Set(compiled.dest.values())
       for (const child of this.subcommands) {
         checkCollisions(this.name, own, child, [child.name])
       }

--- a/typescript/packages/core/src/commands/spec/compile.test.ts
+++ b/typescript/packages/core/src/commands/spec/compile.test.ts
@@ -69,6 +69,14 @@ describe('compileSpec — count/choices/required/default tables', () => {
     const spec = new CommandSpec({ options: [new Option({ short: '-x' })] })
     expect(compileSpec(spec)).toBe(compileSpec(spec))
   })
+
+  it.each([
+    [new Option({ short: '-m' }), new Option({ short: '-m', type: 'str' })],
+    [new Option({ long: '--mode' }), new Option({ long: '--mode', type: 'str' })],
+  ])('rejects duplicate option spellings', (first, second) => {
+    const spec = new CommandSpec({ options: [first, second] })
+    expect(() => compileSpec(spec)).toThrow(/duplicate option spelling/)
+  })
 })
 
 describe('type int validation', () => {

--- a/typescript/packages/core/src/commands/spec/compile.test.ts
+++ b/typescript/packages/core/src/commands/spec/compile.test.ts
@@ -70,6 +70,11 @@ describe('compileSpec — count/choices/required/default tables', () => {
     expect(compileSpec(spec)).toBe(compileSpec(spec))
   })
 
+  it('requires an option spelling', () => {
+    const spec = new CommandSpec({ options: [new Option()] })
+    expect(() => compileSpec(spec)).toThrow(/requires a short or long spelling/)
+  })
+
   it.each([
     [new Option({ short: '-m' }), new Option({ short: '-m', type: 'str' })],
     [new Option({ long: '--mode' }), new Option({ long: '--mode', type: 'str' })],

--- a/typescript/packages/core/src/commands/spec/compile.ts
+++ b/typescript/packages/core/src/commands/spec/compile.ts
@@ -183,7 +183,9 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
 
   for (const opt of spec.options) {
     const canonical = opt.long ?? opt.short
-    if (canonical === null) continue
+    if (canonical === null) {
+      throw new Error('option requires a short or long spelling')
+    }
     for (const spelling of [opt.short, opt.long]) {
       if (spelling === null) continue
       if (seenSpellings.has(spelling)) {

--- a/typescript/packages/core/src/commands/spec/compile.ts
+++ b/typescript/packages/core/src/commands/spec/compile.ts
@@ -158,6 +158,7 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
   const cached = CACHE.get(spec)
   if (cached !== undefined) return cached
 
+  const seenSpellings = new Set<string>()
   const boolSpellings = new Set<string>()
   const valueSpellings: string[] = []
   const attachSpellings: string[] = []
@@ -183,6 +184,13 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
   for (const opt of spec.options) {
     const canonical = opt.long ?? opt.short
     if (canonical === null) continue
+    for (const spelling of [opt.short, opt.long]) {
+      if (spelling === null) continue
+      if (seenSpellings.has(spelling)) {
+        throw new Error(`duplicate option spelling '${spelling}'`)
+      }
+      seenSpellings.add(spelling)
+    }
     if (opt.count && opt.type !== 'bool') {
       throw new Error(`option '${canonical}': count requires a boolean flag (valueKind NONE)`)
     }

--- a/typescript/packages/core/src/commands/spec/types.test.ts
+++ b/typescript/packages/core/src/commands/spec/types.test.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import { compileSpec } from './compile.ts'
 import { CommandSpec, Operand, Option, ParsedArgs } from './types.ts'
 
 describe('ValueType', () => {
@@ -37,11 +38,33 @@ describe('Option', () => {
     const o = new Option()
     expect(Object.isFrozen(o)).toBe(true)
   })
+
+  it('copies and freezes choices', () => {
+    const choices = ['a']
+    const o = new Option({ long: '--mode', type: 'str', choices })
+    choices.push('b')
+
+    expect(o.choices).toEqual(['a'])
+    expect(Object.isFrozen(o.choices)).toBe(true)
+  })
 })
 
 describe('Operand', () => {
   it('defaults type to path', () => {
     expect(new Operand().type).toBe('path')
+  })
+
+  it('copies and freezes conditional flag lists', () => {
+    const providedBy = ['--pattern']
+    const textWhen = ['--args']
+    const operand = new Operand({ providedBy, textWhen })
+    providedBy.push('--file')
+    textWhen.push('--raw-input')
+
+    expect(operand.providedBy).toEqual(['--pattern'])
+    expect(operand.textWhen).toEqual(['--args'])
+    expect(Object.isFrozen(operand.providedBy)).toBe(true)
+    expect(Object.isFrozen(operand.textWhen)).toBe(true)
   })
 })
 
@@ -51,6 +74,23 @@ describe('CommandSpec', () => {
     expect(s.options).toEqual([])
     expect(s.positional).toEqual([])
     expect(s.rest).toBeNull()
+  })
+
+  it('copies and freezes grammar arrays before compilation caches them', () => {
+    const option = new Option({ long: '--mode', type: 'str' })
+    const operand = new Operand({ type: 'str' })
+    const options = [option]
+    const positional = [operand]
+    const spec = new CommandSpec({ options, positional })
+    const compiled = compileSpec(spec)
+    options.push(new Option({ long: '--later' }))
+    positional.push(new Operand({ type: 'path' }))
+
+    expect(spec.options).toEqual([option])
+    expect(spec.positional).toEqual([operand])
+    expect(Object.isFrozen(spec.options)).toBe(true)
+    expect(Object.isFrozen(spec.positional)).toBe(true)
+    expect(compileSpec(spec)).toBe(compiled)
   })
 })
 

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -199,7 +199,7 @@ export class Option {
     this.pair = init.pair ?? false
     this.valueOptional = init.valueOptional ?? false
     this.shortValue = init.shortValue ?? true
-    this.choices = init.choices ?? []
+    this.choices = Object.freeze([...(init.choices ?? [])])
     this.required = init.required ?? false
     this.default = init.default ?? null
     this.metavar = init.metavar ?? null
@@ -267,8 +267,8 @@ export class Operand {
 
   constructor(init: OperandInit = {}) {
     this.type = init.type ?? 'path'
-    this.providedBy = init.providedBy ?? []
-    this.textWhen = init.textWhen ?? []
+    this.providedBy = Object.freeze([...(init.providedBy ?? [])])
+    this.textWhen = Object.freeze([...(init.textWhen ?? [])])
     this.name = init.name ?? ''
     this.required = init.required ?? false
     this.remainder = init.remainder ?? false
@@ -321,8 +321,8 @@ export class CommandSpec {
   // express the second.
 
   constructor(init: CommandSpecInit = {}) {
-    this.options = init.options ?? []
-    this.positional = init.positional ?? []
+    this.options = Object.freeze([...(init.options ?? [])])
+    this.positional = Object.freeze([...(init.positional ?? [])])
     this.rest = init.rest ?? null
     this.ignoreTokens = new Set(init.ignoreTokens ?? [])
     this.description = init.description ?? null


### PR DESCRIPTION
## Summary

- validate every custom CLI node's inherited command grammar during construction
- reject impossible or ambiguous option declarations: missing spellings and duplicate short/long spellings
- reject script-backed CLIs that also declare a config model, because script config is opaque
- keep callable handlers out of Python grammar-cache hashing so stateful, unhashable callable objects remain valid
- defensively freeze TypeScript grammar collections so constructor validation and cached parsing cannot diverge

## Context

First implementation slice for Item 2 of #705. A third-party `CLISpec` should fail at the authoring boundary, before workspace registration or first execution. This PR intentionally does not add the guide, worked example, or generated reference surface.

Python and TypeScript behavior stays mirrored. No shared spec fields or registry APIs are added.

## Validation

- focused Python spec/CLI constructor suites: 40 passed
- focused TypeScript spec/CLI constructor suites: 38 passed
- final-head GitHub checks: 44 passed, 4 intentional platform skips, 0 incomplete or failing
- review findings fixed; 0 unresolved threads
