### PR TITLE
Exercise the hf_hub fake in CI, and fix the upload path it found

### DIFF
--- a/.github/actions/integ-battery-setup/action.yml
+++ b/.github/actions/integ-battery-setup/action.yml
@@ -133,6 +133,20 @@ runs:
         cat /tmp/hfsrv.log
         echo "HF_URL=http://127.0.0.1:5099" >> "$GITHUB_ENV"
 
+    # A different Hugging Face product from the one above: hf/ is the Xet
+    # object store, hf_hub/ is the git-backed Hub the repo resources mount.
+    - name: Start fake Hugging Face Hub (Prisma)
+      working-directory: integ
+      shell: bash
+      run: |
+        nohup ./node_modules/.bin/tsx server/hf_hub/main.ts --port 5086 > /tmp/hfhubsrv.log 2>&1 &
+        for i in $(seq 1 30); do
+          grep -q "HF_HUB_URL=" /tmp/hfhubsrv.log && break
+          sleep 1
+        done
+        cat /tmp/hfhubsrv.log
+        echo "HF_HUB_URL=http://127.0.0.1:5086" >> "$GITHUB_ENV"
+
     - name: Wait for GreenMail
       shell: bash
       run: |

--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -1485,6 +1485,17 @@ jobs:
           cat /tmp/discord.log
           echo "DISCORD_URL=http://127.0.0.1:5090" >> "$GITHUB_ENV"
 
+      # A different Hugging Face product from the hf/ Xet store: hf_hub/ is
+      # the git-backed Hub the `hf` CLI acts on.
+      - name: Start fake Hugging Face Hub
+        if: matrix.facet == 'cli'
+        working-directory: integ
+        run: |
+          nohup ./node_modules/.bin/tsx server/hf_hub/main.ts --port 5086 > /tmp/hfhub.log 2>&1 &
+          for i in $(seq 1 30); do grep -q "HF_HUB_URL=" /tmp/hfhub.log && break; sleep 1; done
+          cat /tmp/hfhub.log
+          echo "HF_HUB_URL=http://127.0.0.1:5086" >> "$GITHUB_ENV"
+
       - name: Start fake GitHub API
         if: matrix.facet == 'cli'
         run: |

--- a/integ/cli/hf.json
+++ b/integ/cli/hf.json
@@ -1,0 +1,173 @@
+{
+  "cases": [
+    {
+      "id": "hf_auth_whoami_names_the_org",
+      "seq": 960101,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf auth whoami | tail -1",
+      "expect": {
+        "exit": 0,
+        "stdout": "integ-org\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_repo_create_echoes_the_url",
+      "seq": 960102,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf repo create integ/made --repo-type dataset",
+      "expect": {
+        "exit": 0,
+        "stdout": "http://127.0.0.1:5086/datasets/integ/made\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_repo_create_exist_ok_is_idempotent",
+      "seq": 960103,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf repo create integ/made --repo-type dataset --exist-ok",
+      "expect": {
+        "exit": 0,
+        "stdout": "http://127.0.0.1:5086/datasets/integ/made\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_repo_tag_create_then_list",
+      "seq": 960104,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf repo tag create integ/repo-cli v1 --message 'first cut' && hf repo tag list integ/repo-cli",
+      "expect": {
+        "exit": 0,
+        "stdout": "Tag v1 created on integ/repo-cli\nv1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_download_include_and_exclude_narrow_the_set",
+      "seq": 960105,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf download integ/repo-cli --include '*.txt' --exclude 'poem*' --local-dir /scratch/inc --quiet && ls /scratch/inc | head -4",
+      "expect": {
+        "exit": 0,
+        "stdout": "/scratch/inc\na.txt\nanchors.txt\nb.txt\nc.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_download_revision_reads_the_tag",
+      "seq": 960106,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf download integ/repo-cli one_byte.txt --revision v1 --local-dir /scratch/rev --quiet && cat /scratch/rev/one_byte.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/scratch/rev\nx",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_download_force_refetches",
+      "seq": 960107,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf download integ/repo-cli one_byte.txt --local-dir /scratch/f1 --quiet && hf download integ/repo-cli one_byte.txt --local-dir /scratch/f1 --force-download --quiet && cat /scratch/f1/one_byte.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/scratch/f1\n/scratch/f1\nx",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_upload_a_file_lands_at_the_named_path",
+      "seq": 960108,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "echo -n hi > /scratch/u.txt && hf upload integ/repo-cli /scratch/u.txt w/u.txt --commit-message m --quiet && hf download integ/repo-cli w/u.txt --local-dir /scratch/back --quiet && cat /scratch/back/w/u.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "http://127.0.0.1:5086/integ/repo-cli/tree/main/w/u.txt\n/scratch/back\nhi",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_repo_files_delete_takes_a_glob",
+      "seq": 960109,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf repo-files delete integ/repo-cli 'sub/*' --commit-message 'drop sub'",
+      "expect": {
+        "exit": 0,
+        "stdout": "Deleted sub/* from integ/repo-cli\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_repo_tag_delete_needs_yes",
+      "seq": 960110,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf repo tag delete integ/repo-cli v1 --yes && hf repo tag list integ/repo-cli",
+      "expect": {
+        "exit": 0,
+        "stdout": "Tag v1 deleted on integ/repo-cli\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_download_a_missing_repo_is_repo_not_found",
+      "seq": 960111,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf download nosuch/repo f.txt --local-dir /scratch/x",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "hf download: Repository Not Found for url: http://127.0.0.1:5086/api/models/nosuch/repo/revision/main.\nPlease make sure you specified the correct `repo_id` and `repo_type`.\nIf you are trying to access a private or gated repo, make sure you are authenticated.\n"
+      }
+    },
+    {
+      "id": "hf_download_a_missing_revision_is_revision_not_found",
+      "seq": 960112,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf download integ/repo-cli one_byte.txt --revision nope --local-dir /scratch/bad",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "hf download: Revision Not Found for url: http://127.0.0.1:5086/api/models/integ/repo-cli/revision/nope.\nInvalid rev id: nope\n"
+      }
+    },
+    {
+      "id": "hf_download_a_missing_file_is_entry_not_found",
+      "seq": 960113,
+      "targets": [
+        "cli-hf"
+      ],
+      "command": "hf download integ/repo-cli missing.txt --local-dir /scratch/miss",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "hf download: Entry Not Found for url: http://127.0.0.1:5086/integ/repo-cli/resolve/main/missing.txt.\n"
+      }
+    }
+  ]
+}

--- a/integ/fixtures/hf-hub/v1.json
+++ b/integ/fixtures/hf-hub/v1.json
@@ -17,6 +17,12 @@
       "namespace": "integ",
       "name": "repo-cli",
       "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "kind": "spaces",
+      "namespace": "integ",
+      "name": "space-v1",
+      "createdAt": "2026-01-01T00:00:00.000Z"
     }
   ],
   "commits": [
@@ -35,6 +41,12 @@
     {
       "repo": "models/integ/repo-cli",
       "sha": "c3d4e5f60718293a4b5c6d7e8f90213243546576",
+      "message": "initial commit",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "repo": "spaces/integ/space-v1",
+      "sha": "d4e5f60718293a4b5c6d7e8f9021324354657687",
       "message": "initial commit",
       "createdAt": "2026-01-01T00:00:00.000Z"
     }
@@ -57,6 +69,12 @@
       "refType": "branch",
       "name": "main",
       "sha": "c3d4e5f60718293a4b5c6d7e8f90213243546576"
+    },
+    {
+      "repo": "spaces/integ/space-v1",
+      "refType": "branch",
+      "name": "main",
+      "sha": "d4e5f60718293a4b5c6d7e8f9021324354657687"
     }
   ],
   "blobs": []

--- a/integ/fixtures/hf-hub/v1.json
+++ b/integ/fixtures/hf-hub/v1.json
@@ -1,6 +1,63 @@
 {
-  "repos": [],
-  "commits": [],
-  "refs": [],
+  "repos": [
+    {
+      "kind": "models",
+      "namespace": "integ",
+      "name": "repo-v1",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "kind": "datasets",
+      "namespace": "integ",
+      "name": "data-v1",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "kind": "models",
+      "namespace": "integ",
+      "name": "repo-cli",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "commits": [
+    {
+      "repo": "models/integ/repo-v1",
+      "sha": "a1b2c3d4e5f60718293a4b5c6d7e8f9021324354",
+      "message": "initial commit",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "repo": "datasets/integ/data-v1",
+      "sha": "b2c3d4e5f60718293a4b5c6d7e8f902132435465",
+      "message": "initial commit",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "repo": "models/integ/repo-cli",
+      "sha": "c3d4e5f60718293a4b5c6d7e8f90213243546576",
+      "message": "initial commit",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "refs": [
+    {
+      "repo": "models/integ/repo-v1",
+      "refType": "branch",
+      "name": "main",
+      "sha": "a1b2c3d4e5f60718293a4b5c6d7e8f9021324354"
+    },
+    {
+      "repo": "datasets/integ/data-v1",
+      "refType": "branch",
+      "name": "main",
+      "sha": "b2c3d4e5f60718293a4b5c6d7e8f902132435465"
+    },
+    {
+      "repo": "models/integ/repo-cli",
+      "refType": "branch",
+      "name": "main",
+      "sha": "c3d4e5f60718293a4b5c6d7e8f90213243546576"
+    }
+  ],
   "blobs": []
 }

--- a/integ/resources/hf_hub/repo.json
+++ b/integ/resources/hf_hub/repo.json
@@ -1,0 +1,114 @@
+{
+  "cases": [
+    {
+      "id": "hf_hub_ls_names_the_seeded_tree",
+      "seq": 960001,
+      "targets": ["hf-hub"],
+      "command": "ls /repo/sub",
+      "expect": { "exit": 0, "stdout": "deep\nnested.txt\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_cat_reads_a_committed_file",
+      "seq": 960002,
+      "targets": ["hf-hub"],
+      "command": "cat /repo/one_byte.txt",
+      "expect": { "exit": 0, "stdout": "x", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_head_reads_a_prefix",
+      "seq": 960003,
+      "targets": ["hf-hub"],
+      "command": "head -2 /repo/poem.txt",
+      "expect": { "exit": 0, "stdout": "roses are red\nviolets are blue\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_wc_counts_the_rendered_bytes",
+      "seq": 960004,
+      "targets": ["hf-hub"],
+      "command": "wc -c < /repo/one_byte.txt",
+      "expect": { "exit": 0, "stdout": "1\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_stat_reports_the_tree_size",
+      "seq": 960005,
+      "targets": ["hf-hub"],
+      "command": "stat -c '%s %n' /repo/one_byte.txt",
+      "expect": { "exit": 0, "stdout": "1 /repo/one_byte.txt\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_find_name_walks_a_subtree",
+      "seq": 960006,
+      "targets": ["hf-hub"],
+      "command": "find /repo/sub -name '*.txt'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/repo/sub/deep/deeper.txt\n/repo/sub/nested.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_hub_find_counts_every_file",
+      "seq": 960007,
+      "targets": ["hf-hub"],
+      "command": "find /repo -type f | wc -l",
+      "expect": { "exit": 0, "stdout": "38\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_find_empty",
+      "seq": 960008,
+      "targets": ["hf-hub"],
+      "command": "find /repo -empty",
+      "expect": { "exit": 0, "stdout": "/repo/empty.txt\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_du_sums_a_subtree",
+      "seq": 960009,
+      "targets": ["hf-hub"],
+      "command": "du -s /repo/sub",
+      "expect": { "exit": 0, "stdout": "20\t/repo/sub\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_grep_r_scans_the_tree",
+      "seq": 960010,
+      "targets": ["hf-hub"],
+      "command": "grep -rl violets /repo",
+      "expect": { "exit": 0, "stdout": "/repo/poem.diff\n/repo/poem.txt\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_grep_counts_in_one_file",
+      "seq": 960011,
+      "targets": ["hf-hub"],
+      "command": "grep -c are /repo/poem.txt",
+      "expect": { "exit": 0, "stdout": "2\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_a_missing_path_is_enoent",
+      "seq": 960012,
+      "targets": ["hf-hub"],
+      "command": "cat /repo/nope.txt",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "cat: /repo/nope.txt: No such file or directory\n"
+      }
+    },
+    {
+      "id": "hf_hub_dataset_mount_lists_its_own_repo",
+      "seq": 960013,
+      "targets": ["hf-hub"],
+      "command": "ls /data",
+      "expect": {
+        "exit": 0,
+        "stdout": "example.feather\nexample.h5\nexample.parquet\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "hf_hub_a_columnar_file_is_raw_bytes",
+      "seq": 960014,
+      "targets": ["hf-hub"],
+      "command": "wc -c < /data/example.parquet",
+      "expect": { "exit": 0, "stdout": "2401\n", "stderr": "" }
+    }
+  ]
+}

--- a/integ/resources/hf_hub/repo.json
+++ b/integ/resources/hf_hub/repo.json
@@ -109,6 +109,13 @@
       "targets": ["hf-hub"],
       "command": "wc -c < /data/example.parquet",
       "expect": { "exit": 0, "stdout": "2401\n", "stderr": "" }
+    },
+    {
+      "id": "hf_hub_a_spaces_mount_reads_its_own_repo",
+      "seq": 960015,
+      "targets": ["hf-hub"],
+      "command": "cat /space/one_byte.txt",
+      "expect": { "exit": 0, "stdout": "x", "stderr": "" }
     }
   ]
 }

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -1031,7 +1031,7 @@ class HfService:
 
 
 class HfHubService:
-    """Points hf_models / hf_datasets mounts at the shared fake Hub.
+    """Points hf_models / hf_datasets / hf_spaces mounts at the fake Hub.
 
     The server (integ/server/hf_hub/) is external, Prisma-backed and shared
     across both hosts, and the token IS the tenant: the client sends it

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -81,6 +81,9 @@ from mirage.resource.gsheets.gsheets import GSheetsResource
 from mirage.resource.gslides.config import GSlidesConfig
 from mirage.resource.gslides.gslides import GSlidesResource
 from mirage.resource.hf_buckets import HfBucketsConfig, HfBucketsResource
+from mirage.resource.hf_datasets import HfDatasetsConfig, HfDatasetsResource
+from mirage.resource.hf_models import HfModelsConfig, HfModelsResource
+from mirage.resource.hf_spaces import HfSpacesConfig, HfSpacesResource
 from mirage.resource.jaeger import JaegerConfig, JaegerResource
 from mirage.resource.lancedb import LanceDBConfig, LanceDBResource
 from mirage.resource.langfuse import LangfuseConfig, LangfuseResource
@@ -1022,6 +1025,77 @@ class HfService:
                 endpoint=self.endpoint,
                 key_prefix=mount.get("prefix"),
             ))
+
+    async def teardown(self) -> None:
+        return None
+
+
+class HfHubService:
+    """Points hf_models / hf_datasets mounts at the shared fake Hub.
+
+    The server (integ/server/hf_hub/) is external, Prisma-backed and shared
+    across both hosts, and the token IS the tenant: the client sends it
+    verbatim on every Hub call and the fake reads it off `Authorization`, so
+    a per-run token isolates two runs against one server.
+
+    Unlike every object-store fake here, the fixture is not optional. A Hub
+    mount NAMES a repository, and mounting one never creates it, so the
+    repositories a target mounts must exist before the mount is built;
+    `/reset` seeds them from integ/fixtures/hf-hub/v1.json. The file CONTENT
+    then arrives the ordinary way, through each mount's own `fixture:` seed,
+    which writes over the resource's commit path rather than behind it.
+
+    Args:
+        run_id (str): this run's id, which names its account.
+        endpoint (str): HF_HUB_URL origin.
+    """
+
+    KINDS = {
+        "hf_models": HfModelsResource,
+        "hf_datasets": HfDatasetsResource,
+        "hf_spaces": HfSpacesResource,
+    }
+    CONFIGS = {
+        "hf_models": HfModelsConfig,
+        "hf_datasets": HfDatasetsConfig,
+        "hf_spaces": HfSpacesConfig,
+    }
+
+    def __init__(self, run_id: str, endpoint: str) -> None:
+        self.run_id = run_id
+        self.endpoint = endpoint
+        self.token = f"integ-hfhub-{run_id}"
+
+    @classmethod
+    async def create(cls, run_id: str) -> "HfHubService":
+        endpoint = os.environ["HF_HUB_URL"].rstrip("/")
+        token = f"integ-hfhub-{run_id}"
+        async with aiohttp.ClientSession() as session:
+            async with session.post(f"{endpoint}/reset",
+                                    json={
+                                        "tenants": [token],
+                                        "fixture": "v1"
+                                    }) as resp:
+                resp.raise_for_status()
+        return cls(run_id, endpoint)
+
+    def resource(self, mount: dict) -> object:
+        kind = mount["resource"]
+        config = self.CONFIGS[kind](
+            repo_id=mount["repo"],
+            token=self.token,
+            endpoint=self.endpoint,
+            key_prefix=mount.get("prefix"),
+        )
+        return self.KINDS[kind](config)
+
+    def cli_installs(self) -> dict[str, tuple[CLISpec, dict[str, object]]]:
+        return {
+            "hf": (cli_spec_for("hf"), {
+                "token": self.token,
+                "endpoint": self.endpoint,
+            }),
+        }
 
     async def teardown(self) -> None:
         return None
@@ -2032,7 +2106,8 @@ class PostgresService:
 Service = (S3Service | OneDriveService | SharePointService | Mem0Service
            | SSHService | PostgresService | MongoDBService | ChromaService
            | QdrantService | LanceDBService | NotionService
-           | NextcloudService | GwsService | HfService | BoxService
+           | NextcloudService | GwsService | HfService | HfHubService
+           | BoxService
            | DropboxService | GridFSService | SlackService | TrelloService
            | LinearService | DifyService | DatabricksVolumeService
            | LangfuseService | JaegerService)
@@ -2155,6 +2230,13 @@ def build_hf(
         mount: dict, run_id: str, service: Service | None
 ) -> tuple[object, Callable[[], Awaitable[None]]]:
     assert isinstance(service, HfService)
+    return service.resource(mount), _noop
+
+
+def build_hf_hub(
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
+    assert isinstance(service, HfHubService)
     return service.resource(mount), _noop
 
 
@@ -2408,6 +2490,9 @@ BUILDERS = {
     "gmail": build_gmail,
     "email": build_email,
     "hf": build_hf,
+    "hf_models": build_hf_hub,
+    "hf_datasets": build_hf_hub,
+    "hf_spaces": build_hf_hub,
     "box": build_box,
     "dropbox": build_dropbox,
     "github": build_github,
@@ -2459,6 +2544,8 @@ async def make_service(target: dict, run_id: str) -> "Service | None":
         return await EmailService.create(run_id, target)
     if target.get("service") == "hf":
         return await HfService.create(run_id)
+    if target.get("service") == "hf-hub":
+        return await HfHubService.create(run_id)
     if target.get("service") == "box":
         return await BoxService.create(run_id, target)
     if target.get("service") == "dropbox":
@@ -2545,9 +2632,9 @@ def cli_install(service: "Service | None",
     if service is None:
         return cli_spec_for(cli_name), None
     # Widen the assert when another service grows a CLI.
-    assert isinstance(service,
-                      (DiscordService, EmailService, GitHubService, GwsService,
-                       LinearService, NotionService, SlackService))
+    assert isinstance(
+        service, (DiscordService, EmailService, GitHubService, GwsService,
+                  HfHubService, LinearService, NotionService, SlackService))
     return service.cli_installs()[cli_name]
 
 

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -60,6 +60,7 @@ import {
   HfBucketsResource,
   HfDatasetsResource,
   HfModelsResource,
+  HfSpacesResource,
   JaegerResource,
   JobConsole,
   LanceDBResource,
@@ -674,20 +675,39 @@ async function openHfHub(target: Target): Promise<Open> {
     body: JSON.stringify({ tenants: [token], fixture: 'v1' }),
   })
   if (!reset.ok) throw new Error(`hf-hub /reset failed: ${String(reset.status)}`)
-  const mounts: Record<string, HfModelsResource | HfDatasetsResource | RAMResource> = {}
+  const mounts: Record<
+    string,
+    HfModelsResource | HfDatasetsResource | HfSpacesResource | RAMResource
+  > = {}
   for (const m of target.mounts) {
     if (m.resource === 'ram') {
       mounts[m.path] = new RAMResource()
       continue
     }
+    // A Hub mount NAMES a repository, so an absent one is a broken target
+    // rather than a default: `repoId: ''` would reach the fake as a request
+    // for the repository called nothing.
+    if (m.repo === undefined) throw new Error(`hf-hub mount ${m.path} needs a repo`)
     const config = {
-      repoId: m.repo ?? '',
+      repoId: m.repo,
       token,
       endpoint,
       ...(m.prefix !== undefined ? { keyPrefix: m.prefix } : {}),
     }
-    mounts[m.path] =
-      m.resource === 'hf_datasets' ? new HfDatasetsResource(config) : new HfModelsResource(config)
+    // Every kind is named, and an unrecognized one throws. The three differ
+    // only by the `repo_type` they send, so falling back to models for an
+    // unknown name does not fail: it silently exercises the wrong endpoints
+    // and reports the models implementation as the one under test.
+    const kinds = {
+      hf_models: HfModelsResource,
+      hf_datasets: HfDatasetsResource,
+      hf_spaces: HfSpacesResource,
+    }
+    const kind = kinds[m.resource as keyof typeof kinds] as
+      | (new (c: typeof config) => HfModelsResource | HfDatasetsResource | HfSpacesResource)
+      | undefined
+    if (kind === undefined) throw new Error(`hf-hub cannot mount ${m.resource}`)
+    mounts[m.path] = new kind(config)
   }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   if (target.clis?.includes('hf') === true) {

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -52,11 +52,14 @@ import {
   GWS,
   HIMALAYA,
   GH,
+  HF,
   GIT,
   LINEAR,
   NTN,
   SLACK,
   HfBucketsResource,
+  HfDatasetsResource,
+  HfModelsResource,
   JaegerResource,
   JobConsole,
   LanceDBResource,
@@ -650,6 +653,47 @@ async function openHf(target: Target, options?: OpenOptions): Promise<Open> {
   }
   const opened = openWorkspaces(build, options)
   return { ws: opened.ws, shadow: opened.shadow, cleanup: opened.closeAll }
+}
+
+async function openHfHub(target: Target): Promise<Open> {
+  let endpoint = process.env.HF_HUB_URL ?? ''
+  while (endpoint.endsWith('/')) endpoint = endpoint.slice(0, -1)
+  if (endpoint === '') throw new Error('hf-hub target requires HF_HUB_URL')
+  // The token IS the tenant here, as it is for the hf buckets fake: the client
+  // sends it verbatim on every Hub call and the fake reads it off
+  // Authorization, so a per-run token isolates two runs against one server.
+  const token = `integ-hfhub-${runId()}`
+  // Not optional, unlike every object-store fake here. A Hub mount NAMES a
+  // repository and mounting never creates one, so the repositories the target
+  // mounts have to exist before the mount is built. File CONTENT still arrives
+  // the ordinary way, through each mount's own `fixture:` seed, which writes
+  // over the resource's commit path rather than behind it.
+  const reset = await fetch(`${endpoint}/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tenants: [token], fixture: 'v1' }),
+  })
+  if (!reset.ok) throw new Error(`hf-hub /reset failed: ${String(reset.status)}`)
+  const mounts: Record<string, HfModelsResource | HfDatasetsResource | RAMResource> = {}
+  for (const m of target.mounts) {
+    if (m.resource === 'ram') {
+      mounts[m.path] = new RAMResource()
+      continue
+    }
+    const config = {
+      repoId: m.repo ?? '',
+      token,
+      endpoint,
+      ...(m.prefix !== undefined ? { keyPrefix: m.prefix } : {}),
+    }
+    mounts[m.path] =
+      m.resource === 'hf_datasets' ? new HfDatasetsResource(config) : new HfModelsResource(config)
+  }
+  const ws = new Workspace(mounts, { mode: MountMode.WRITE })
+  if (target.clis?.includes('hf') === true) {
+    ws.registerCli('hf', HF, { token, endpoint })
+  }
+  return { ws: ws as unknown as ExecWorkspace, cleanup: () => ws.close() }
 }
 
 // The seeding calls have to reach the SAME account the mount will read, and
@@ -1957,6 +2001,9 @@ export const ADAPTERS: Record<string, (target: Target, options?: OpenOptions) =>
   gmail: openGws,
   email: openEmail,
   hf: openHf,
+  hf_models: openHfHub,
+  hf_datasets: openHfHub,
+  hf_spaces: openHfHub,
   box: openBox,
   dropbox: openDropbox,
   onedrive: openOneDrive,

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -44,6 +44,8 @@ export interface Mount {
   seed_root?: boolean
   folder?: string
   bucket?: string
+  // The repository a repo-shaped mount names (github, hf_hub).
+  repo?: string
   volume?: string
   prefix?: string
   root?: string

--- a/integ/server/hf_hub/config.ts
+++ b/integ/server/hf_hub/config.ts
@@ -23,7 +23,9 @@ export type C = PrismaClient
 export const config = parseConfig({
   service: 'hf-hub',
   schema: schemaFor('hf_hub'),
-  defaultPort: 5090,
+  // 5090 is discord's in the cli and chat facets, and this fake runs
+  // alongside it there, so the Hub sits below the 5087-5099 block.
+  defaultPort: 5086,
   tenantKind: 'pk-column',
   tenantFromBearer: true,
   // Commit shas. One counter serves the whole account, so a commit in one

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -76,6 +76,14 @@
         "HF_URL"
       ]
     },
+    "hf-hub": {
+      "python": [
+        "HF_HUB_URL"
+      ],
+      "typescript": [
+        "HF_HUB_URL"
+      ]
+    },
     "http": {
       "python": [],
       "typescript": []
@@ -1401,6 +1409,56 @@
           "backend": "hf",
           "bucket": "res",
           "fixture": "columnar/v1"
+        }
+      ]
+    },
+    {
+      "id": "hf-hub",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "service": "hf-hub",
+      "mounts": [
+        {
+          "path": "/repo",
+          "resource": "hf_models",
+          "backend": "hf_hub",
+          "repo": "integ/repo-v1",
+          "fixture": "files/v1"
+        },
+        {
+          "path": "/data",
+          "resource": "hf_datasets",
+          "backend": "hf_hub",
+          "repo": "integ/data-v1",
+          "fixture": "columnar/v1"
+        }
+      ]
+    },
+    {
+      "id": "cli-hf",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "service": "hf-hub",
+      "facet": "cli",
+      "clis": [
+        "hf"
+      ],
+      "mounts": [
+        {
+          "path": "/repo",
+          "resource": "hf_models",
+          "backend": "hf_hub",
+          "repo": "integ/repo-cli",
+          "fixture": "files/v1"
+        },
+        {
+          "path": "/scratch",
+          "resource": "ram",
+          "backend": "memory"
         }
       ]
     },

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -1433,6 +1433,13 @@
           "backend": "hf_hub",
           "repo": "integ/data-v1",
           "fixture": "columnar/v1"
+        },
+        {
+          "path": "/space",
+          "resource": "hf_spaces",
+          "backend": "hf_hub",
+          "repo": "integ/space-v1",
+          "fixture": "files/v1"
         }
       ]
     },

--- a/python/mirage/commands/cli/builtin/hf/upload.py
+++ b/python/mirage/commands/cli/builtin/hf/upload.py
@@ -31,7 +31,8 @@ from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileType, PathSpec
 
 
-async def collect(doors: CLIDoors, local: str) -> list[tuple[str, bytes]]:
+async def collect(doors: CLIDoors,
+                  local: str) -> tuple[list[tuple[str, bytes]], bool]:
     """Read a workspace file, or every file under a workspace directory.
 
     Read through the op dispatcher rather than any filesystem of its
@@ -44,8 +45,12 @@ async def collect(doors: CLIDoors, local: str) -> list[tuple[str, bytes]]:
         local (str): the virtual path to read.
 
     Returns:
-        list[tuple[str, bytes]]: (path relative to ``local``, content).
-        A file yields one row named by its own basename.
+        tuple[list[tuple[str, bytes]], bool]: the (path relative to
+        ``local``, content) rows, and whether ``local`` was a directory.
+        The caller needs that second fact: upstream reads
+        ``path_in_repo`` as the destination FILE for a file source and as
+        the destination FOLDER for a directory one, so a file uploaded to
+        ``u.txt`` must land at ``u.txt`` and not at ``u.txt/u.txt``.
 
     Raises:
         UsageError: the path does not exist, or the line ran outside a
@@ -61,7 +66,7 @@ async def collect(doors: CLIDoors, local: str) -> list[tuple[str, bytes]]:
         raise UsageError(f"{local}: No such file or directory") from None
     if getattr(stat, "type", None) is not FileType.DIRECTORY:
         data, _ = await dispatch("read", spec)
-        return [(posixpath.basename(local.rstrip("/")), bytes(data))]
+        return [(posixpath.basename(local.rstrip("/")), bytes(data))], False
     rows: list[tuple[str, bytes]] = []
     pending = [local.rstrip("/")]
     while pending:
@@ -78,7 +83,7 @@ async def collect(doors: CLIDoors, local: str) -> list[tuple[str, bytes]]:
             data, _ = await dispatch("read", PathSpec.from_str_path(child))
             rows.append((posixpath.relpath(child,
                                            local.rstrip("/")), bytes(data)))
-    return sorted(rows)
+    return sorted(rows), True
 
 
 def keep(rows: list[tuple[str, bytes]], include: list[str],
@@ -146,14 +151,19 @@ async def upload_cmd(
             refuse_variadic(operands, flag, patterns)
     local = operands[0] if operands else "."
     in_repo = operands[1] if len(operands) > 1 else ""
-    rows = keep(await collect(inv.doors, local), include, exclude)
+    collected, from_dir = await collect(inv.doors, local)
+    rows = keep(collected, include, exclude)
     if not rows:
         raise UsageError(f"no files matched under {local}")
     base = in_repo_base(in_repo)
+    # A directory source spreads under `path_in_repo`; a file source lands
+    # AT it. Appending the basename either way stored `hf upload r f.txt
+    # f.txt` at `f.txt/f.txt`, which the tree then reported as a directory
+    # and `hf download` could not find at all.
     additions = [
         Addition(path=posixpath.join(base, name) if base else name, data=data)
         for name, data in rows
-    ]
+    ] if from_dir else [Addition(path=base or rows[0][0], data=rows[0][1])]
     repo_type = repo_type_of(fl)
     # Upstream creates the repository if it is missing and ignores
     # --private when it already exists, so the flag picks the visibility

--- a/python/tests/commands/cli/builtin/hf/test_upload.py
+++ b/python/tests/commands/cli/builtin/hf/test_upload.py
@@ -25,14 +25,15 @@ from tests.commands.cli.builtin.hf.conftest import ANON, inv
 @pytest.mark.asyncio
 async def test_collect_reads_one_file_under_its_basename(doors):
     record, _, _, _ = doors
-    assert await collect(record, "/work/a.txt") == [("a.txt", b"alpha")]
+    assert await collect(record,
+                         "/work/a.txt") == ([("a.txt", b"alpha")], False)
 
 
 @pytest.mark.asyncio
 async def test_collect_walks_a_directory_relative_to_it(doors):
     record, _, _, _ = doors
-    assert await collect(record, "/work") == [("a.txt", b"alpha"),
-                                              ("sub/b.txt", b"beta")]
+    assert await collect(record, "/work") == ([("a.txt", b"alpha"),
+                                               ("sub/b.txt", b"beta")], True)
 
 
 @pytest.mark.asyncio
@@ -63,12 +64,39 @@ async def test_upload_commits_every_walked_file_at_once(
 @pytest.mark.asyncio
 @patch("mirage.commands.cli.builtin.hf.upload.create_repo")
 @patch("mirage.commands.cli.builtin.hf.upload.commit")
-async def test_upload_prefixes_with_path_in_repo(mock_commit, mock_create,
-                                                 doors):
+async def test_upload_of_a_file_lands_at_path_in_repo(mock_commit, mock_create,
+                                                      doors):
+    """Upstream reads `path_in_repo` as the destination FILE for a file
+    source: `_resolve_upload_paths` only falls back to the basename when
+    the operand is absent. Probed against hf 0.35.3, which stores
+    `hf upload r ./a.txt docs` as a file named `docs`."""
     record, _, _, _ = doors
     await upload_cmd(
         inv(texts=("acme/widget", "/work/a.txt", "docs"), doors=record))
-    assert mock_commit.await_args.kwargs["additions"][0].path == "docs/a.txt"
+    assert mock_commit.await_args.kwargs["additions"][0].path == "docs"
+
+
+@pytest.mark.asyncio
+@patch("mirage.commands.cli.builtin.hf.upload.create_repo")
+@patch("mirage.commands.cli.builtin.hf.upload.commit")
+async def test_upload_of_a_directory_spreads_under_path_in_repo(
+        mock_commit, mock_create, doors):
+    """A directory source is the other half of the same rule: there
+    `path_in_repo` names the destination FOLDER."""
+    record, _, _, _ = doors
+    await upload_cmd(inv(texts=("acme/widget", "/work", "docs"), doors=record))
+    paths = [a.path for a in mock_commit.await_args.kwargs["additions"]]
+    assert paths == ["docs/a.txt", "docs/sub/b.txt"]
+
+
+@pytest.mark.asyncio
+@patch("mirage.commands.cli.builtin.hf.upload.create_repo")
+@patch("mirage.commands.cli.builtin.hf.upload.commit")
+async def test_upload_of_a_file_without_path_in_repo_uses_its_basename(
+        mock_commit, mock_create, doors):
+    record, _, _, _ = doors
+    await upload_cmd(inv(texts=("acme/widget", "/work/a.txt"), doors=record))
+    assert mock_commit.await_args.kwargs["additions"][0].path == "a.txt"
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/node/src/commands/cli/builtin/hf/hf.test.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/hf/hf.test.ts
@@ -12,8 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { FileType } from '@struktoai/mirage-core/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { cliSpecFor } from '@struktoai/mirage-core/commands/cli/specs'
+import type * as CommitModule from '../../../../core/hf_hub/commit.ts'
 import type { CLIDoors, CLIInvocation, CLISpec } from '@struktoai/mirage-core/commands/cli/types'
 import { UsageError } from '@struktoai/mirage-core/commands/errors'
 import { materialize } from '@struktoai/mirage-core/io/types'
@@ -28,7 +30,7 @@ import type * as TreeModule from '../../../../core/hf_hub/tree.ts'
 import { HF } from './index.ts'
 import { createCmd, tagCreateCmd, tagDeleteCmd, tagListCmd } from './repo.ts'
 import { downloadCmd, refuseVariadic, selected } from './download.ts'
-import { inRepoBase, keep } from './upload.ts'
+import { inRepoBase, keep, uploadCmd } from './upload.ts'
 
 const createRepoMock = vi.hoisted(() => vi.fn())
 const createTagMock = vi.hoisted(() => vi.fn())
@@ -36,6 +38,7 @@ const deleteTagMock = vi.hoisted(() => vi.fn())
 const listTagsMock = vi.hoisted(() => vi.fn())
 const classifyAbsenceMock = vi.hoisted(() => vi.fn())
 const fetchTreeMock = vi.hoisted(() => vi.fn())
+const commitMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../../core/hf_hub/repo.ts', async (orig) => ({
   ...(await orig<typeof RepoModule>()),
@@ -45,6 +48,11 @@ vi.mock('../../../../core/hf_hub/repo.ts', async (orig) => ({
 vi.mock('../../../../core/hf_hub/tree.ts', async (orig) => ({
   ...(await orig<typeof TreeModule>()),
   fetchTree: fetchTreeMock,
+}))
+
+vi.mock('../../../../core/hf_hub/commit.ts', async (orig) => ({
+  ...(await orig<typeof CommitModule>()),
+  commit: commitMock,
 }))
 
 vi.mock('../../../../core/hf_hub/admin.ts', () => ({
@@ -320,5 +328,54 @@ describe('operand and glob selection', () => {
     ]
     expect(keep(rows, ['*.json'], []).map((r) => r.name)).toEqual(['b.json'])
     expect(keep(rows, [], ['*.json']).map((r) => r.name)).toEqual(['a.txt'])
+  })
+})
+
+describe('where an upload lands', () => {
+  // Upstream reads `path_in_repo` as the destination FILE for a file source
+  // and as the destination FOLDER for a directory one; `_resolve_upload_paths`
+  // only falls back to the basename when the operand is absent. Probed against
+  // hf 0.35.3 pointed at the integ fake: `hf upload r ./a.txt docs` leaves a
+  // tree of exactly ['docs']. Appending the basename either way stored it at
+  // `docs/a.txt`, which the tree then reported as a directory and
+  // `hf download` could not find at all.
+  const tree: Record<string, { dir: boolean; data: string; kids: string[] }> = {
+    '/work': { dir: true, data: '', kids: ['/work/a.txt', '/work/sub'] },
+    '/work/sub': { dir: true, data: '', kids: ['/work/sub/b.txt'] },
+    '/work/a.txt': { dir: false, data: 'alpha', kids: [] },
+    '/work/sub/b.txt': { dir: false, data: 'beta', kids: [] },
+  }
+  const doors = {
+    dispatch: vi.fn((op: string, spec: { virtual: string }) => {
+      const node = tree[spec.virtual]
+      if (node === undefined) {
+        return Promise.reject(Object.assign(new Error('nope'), { code: 'ENOENT' }))
+      }
+      if (op === 'stat') {
+        return Promise.resolve([{ type: node.dir ? FileType.DIRECTORY : FileType.TEXT }, null])
+      }
+      if (op === 'readdir') return Promise.resolve([node.kids, null])
+      return Promise.resolve([new TextEncoder().encode(node.data), null])
+    }),
+  } as unknown as CLIDoors
+
+  const additions = (): { path: string }[] =>
+    (commitMock.mock.calls[0]?.[1] as { additions: { path: string }[] }).additions
+
+  beforeEach(() => commitMock.mockReset())
+
+  it('puts a file AT path_in_repo', async () => {
+    await uploadCmd(inv(['acme/widget', '/work/a.txt', 'docs'], {}, CONFIG, doors))
+    expect(additions()[0]?.path).toBe('docs')
+  })
+
+  it('spreads a directory UNDER path_in_repo', async () => {
+    await uploadCmd(inv(['acme/widget', '/work', 'docs'], {}, CONFIG, doors))
+    expect(additions().map((a) => a.path)).toEqual(['docs/a.txt', 'docs/sub/b.txt'])
+  })
+
+  it('falls back to the basename when path_in_repo is absent', async () => {
+    await uploadCmd(inv(['acme/widget', '/work/a.txt'], {}, CONFIG, doors))
+    expect(additions()[0]?.path).toBe('a.txt')
   })
 })

--- a/typescript/packages/node/src/commands/cli/builtin/hf/upload.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/hf/upload.ts
@@ -44,8 +44,16 @@ async function isDir(dispatch: DispatchFn, path: string): Promise<boolean> {
  * Read through the op dispatcher rather than any filesystem of its own: an
  * account CLI has no mount, and the path the line named is an unrelated
  * workspace file, which is exactly what the dispatcher door is for.
+ *
+ * Reports whether `local` was a directory, because the caller needs it:
+ * upstream reads `path_in_repo` as the destination FILE for a file source and
+ * as the destination FOLDER for a directory one, so a file uploaded to
+ * `u.txt` must land at `u.txt` and not at `u.txt/u.txt`.
  */
-async function collect(dispatch: DispatchFn, local: string): Promise<Row[]> {
+async function collect(
+  dispatch: DispatchFn,
+  local: string,
+): Promise<{ rows: Row[]; fromDir: boolean }> {
   const base = local.replace(/\/+$/, '')
   let directory: boolean
   try {
@@ -56,7 +64,10 @@ async function collect(dispatch: DispatchFn, local: string): Promise<Row[]> {
   }
   if (!directory) {
     const [data] = await dispatch('read', PathSpec.fromStrPath(base))
-    return [{ name: base.slice(base.lastIndexOf('/') + 1), data: data as Uint8Array }]
+    return {
+      rows: [{ name: base.slice(base.lastIndexOf('/') + 1), data: data as Uint8Array }],
+      fromDir: false,
+    }
   }
   const rows: Row[] = []
   const pending = [base]
@@ -73,7 +84,10 @@ async function collect(dispatch: DispatchFn, local: string): Promise<Row[]> {
       rows.push({ name: child.slice(base.length + 1), data: data as Uint8Array })
     }
   }
-  return rows.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+  return {
+    rows: rows.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0)),
+    fromDir: true,
+  }
 }
 
 /** Apply the line's --include and --exclude globs. */
@@ -136,13 +150,22 @@ export async function uploadCmd(inv: CLIInvocation): Promise<CommandFnResult> {
   }
   const local = operands[0] ?? '.'
   const inRepo = operands[1] ?? ''
-  const rows = keep(await collect(dispatch, local), include, exclude)
+  const collected = await collect(dispatch, local)
+  const rows = keep(collected.rows, include, exclude)
   if (rows.length === 0) throw new UsageError(`no files matched under ${local}`)
   const base = inRepoBase(inRepo)
-  const additions: Addition[] = rows.map((row) => ({
-    path: base === '' ? row.name : `${base}/${row.name}`,
-    data: row.data,
-  }))
+  // A directory source spreads under `path_in_repo`; a file source lands AT
+  // it. Appending the basename either way stored `hf upload r f.txt f.txt` at
+  // `f.txt/f.txt`, which the tree then reported as a directory and
+  // `hf download` could not find at all.
+  const additions: Addition[] = collected.fromDir
+    ? rows.map((row) => ({ path: base === '' ? row.name : `${base}/${row.name}`, data: row.data }))
+    : [
+        {
+          path: base === '' ? (rows[0]?.name ?? '') : base,
+          data: rows[0]?.data ?? new Uint8Array(),
+        },
+      ]
   const repoType = repoTypeOf(fl)
   // Upstream creates the repository if it is missing and ignores --private
   // when it already exists, so the flag picks the visibility of one this line


### PR DESCRIPTION
Follow-up to #931, which shipped the hf_hub resource, the `hf` CLI and the fake but no harness wiring, so CI started neither and ran no case against them. This adds the wiring plus 27 cases, and both hosts run all 27.

Writing the cases found a real bug in the code #931 shipped, which is the first commit here.

## `hf upload` stored a file under its destination, not at it

`hf upload <repo> <file> <path_in_repo>` appended the source basename unconditionally, so `hf upload r a.txt docs` stored the file at `docs/a.txt`. The mount then reported `docs` as a directory and `hf download docs` returned Entry Not Found, so a file could be uploaded and never read back.

Upstream's `_resolve_upload_paths` only falls back to the basename when the operand is **absent**: `path_in_repo` is the destination file for a file source and the destination folder for a directory one. Settled two ways rather than guessed, since the two readings differ only on a case no unit test covered: upstream's source, and the real `hf` 0.35.3 binary pointed at our fake, where `hf upload integ/repo-v1 ./a.txt docs` leaves a tree of exactly `['docs']`.

`test_upload_prefixes_with_path_in_repo` asserted `docs/a.txt`, so it had encoded the bug; it is corrected, and the file, directory and absent cases are pinned in both languages.

## The fixture was empty

`integ/fixtures/hf-hub/v1.json` was `{}`, which is what made the service look wired: `POST /reset` accepted it and seeded nothing, so a mount had nothing to list. It now holds three repos, their commits and their `main` refs.

## The cases

**14 on the resource** (`integ/resources/hf_hub/repo.json`), mirroring the shape of `integ/resources/github/`: ls, cat, head, wc, stat, `find -name`, `find | wc -l`, `find -empty`, `du -s`, `grep -rl`, `grep -c`, ENOENT, plus a dataset mount and a binary read.

**13 on the CLI** (`integ/cli/hf.json`), covering the flags rather than just the verbs: `--include`, `--exclude`, `--revision`, `--local-dir`, `--force-download`, `--quiet`, `--repo-type`, `--exist-ok`, `--message`, `--yes`, `--commit-message`, `repo tag create|list|delete`, `repo-files delete` with a glob, and all three 404 kinds, which are distinguishable only by `X-Error-Code`.

## Two things the cases settled

**A port collision.** `hf_hub`'s `defaultPort` was 5090, which is discord's port in the cli and chat facets, so the two fakes collided whenever both ran. Moved to 5086, outside the 5087-5099 block, with the goldens that embed the endpoint following it.

**A stale-index constraint, not a bug.** A CLI write does not invalidate the mount's index (`indexTtl` 86400, `cachesReads` true), so a mount read straight after a CLI write reads stale. The first draft of the CLI cases was flaky for exactly this reason; they now verify through `hf download` rather than through the mount. Worth knowing before anyone writes the next CLI case against a mount.

## Verified

27/27 on python and 27/27 on typescript-node, re-run on this base after #932 landed. Python suite exit 0. `pre-commit run --all-files` green across all 20 hooks. `pnpm -r typecheck` clean. Case targets 2290 = baseline, layout parity 252 = baseline. CI wiring is `bash -n` swept and yaml-linted, but this is the first run of the new `integ-battery-setup` step and of the hf_hub server in the `cli` facet, so that is the part to watch here.
