### PR TITLE
fix(parity): trello write guards, fenced revisions, browser ambient fallback

### DIFF
--- a/python/mirage/commands/builtin/trello/trello_card_assign.py
+++ b/python/mirage/commands/builtin/trello/trello_card_assign.py
@@ -18,6 +18,7 @@ from mirage.accessor.trello import TrelloAccessor
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec.types import CommandSpec, FlagView, Option
+from mirage.context import require_mount_writable
 from mirage.core.trello.client import card_assign
 from mirage.core.trello.normalize import normalize_card
 from mirage.io.stream import yield_bytes
@@ -30,7 +31,7 @@ SPEC = CommandSpec(options=(
 ), )
 
 
-@command("trello card assign", resource="trello", spec=SPEC)
+@command("trello card assign", resource="trello", spec=SPEC, write=True)
 async def trello_card_assign(
         accessor: TrelloAccessor, paths: list[PathSpec], texts: list[str],
         opts: CommandOpts) -> tuple[ByteSource | None, IOResult]:
@@ -42,6 +43,9 @@ async def trello_card_assign(
     member_id = fl.as_str("member_id")
     if not member_id:
         raise ValueError("--member_id is required")
+    # A card write is addressed by id, not path, so only the mount-wide
+    # grant can admit it (a write-granting carve-out names no card).
+    require_mount_writable()
     card = await card_assign(config, card_id=card_id, member_id=member_id)
     return yield_bytes(
         json.dumps(normalize_card(card),

--- a/python/mirage/commands/builtin/trello/trello_card_label_add.py
+++ b/python/mirage/commands/builtin/trello/trello_card_label_add.py
@@ -18,6 +18,7 @@ from mirage.accessor.trello import TrelloAccessor
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec.types import CommandSpec, FlagView, Option
+from mirage.context import require_mount_writable
 from mirage.core.trello.client import card_add_label
 from mirage.core.trello.normalize import normalize_card
 from mirage.io.stream import yield_bytes
@@ -30,7 +31,7 @@ SPEC = CommandSpec(options=(
 ), )
 
 
-@command("trello card label", resource="trello", spec=SPEC)
+@command("trello card label", resource="trello", spec=SPEC, write=True)
 async def trello_card_label_add(
         accessor: TrelloAccessor, paths: list[PathSpec], texts: list[str],
         opts: CommandOpts) -> tuple[ByteSource | None, IOResult]:
@@ -42,6 +43,9 @@ async def trello_card_label_add(
     label_id = fl.as_str("label_id")
     if not label_id:
         raise ValueError("--label_id is required")
+    # A card write is addressed by id, not path, so only the mount-wide
+    # grant can admit it (a write-granting carve-out names no card).
+    require_mount_writable()
     card = await card_add_label(config, card_id=card_id, label_id=label_id)
     return yield_bytes(
         json.dumps(normalize_card(card),

--- a/python/mirage/commands/builtin/trello/trello_card_label_remove.py
+++ b/python/mirage/commands/builtin/trello/trello_card_label_remove.py
@@ -18,6 +18,7 @@ from mirage.accessor.trello import TrelloAccessor
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec.types import CommandSpec, FlagView, Option
+from mirage.context import require_mount_writable
 from mirage.core.trello.client import card_remove_label
 from mirage.core.trello.normalize import normalize_card
 from mirage.io.stream import yield_bytes
@@ -30,7 +31,7 @@ SPEC = CommandSpec(options=(
 ), )
 
 
-@command("trello card unlabel", resource="trello", spec=SPEC)
+@command("trello card unlabel", resource="trello", spec=SPEC, write=True)
 async def trello_card_label_remove(
         accessor: TrelloAccessor, paths: list[PathSpec], texts: list[str],
         opts: CommandOpts) -> tuple[ByteSource | None, IOResult]:
@@ -42,6 +43,9 @@ async def trello_card_label_remove(
     label_id = fl.as_str("label_id")
     if not label_id:
         raise ValueError("--label_id is required")
+    # A card write is addressed by id, not path, so only the mount-wide
+    # grant can admit it (a write-granting carve-out names no card).
+    require_mount_writable()
     card = await card_remove_label(config, card_id=card_id, label_id=label_id)
     return yield_bytes(
         json.dumps(normalize_card(card),

--- a/python/mirage/commands/builtin/trello/trello_card_move.py
+++ b/python/mirage/commands/builtin/trello/trello_card_move.py
@@ -18,6 +18,7 @@ from mirage.accessor.trello import TrelloAccessor
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec.types import CommandSpec, FlagView, Option
+from mirage.context import require_mount_writable
 from mirage.core.trello.client import card_move
 from mirage.core.trello.normalize import normalize_card
 from mirage.io.stream import yield_bytes
@@ -30,7 +31,7 @@ SPEC = CommandSpec(options=(
 ), )
 
 
-@command("trello card move", resource="trello", spec=SPEC)
+@command("trello card move", resource="trello", spec=SPEC, write=True)
 async def trello_card_move(
         accessor: TrelloAccessor, paths: list[PathSpec], texts: list[str],
         opts: CommandOpts) -> tuple[ByteSource | None, IOResult]:
@@ -42,6 +43,9 @@ async def trello_card_move(
     list_id = fl.as_str("list_id")
     if not list_id:
         raise ValueError("--list_id is required")
+    # A card write is addressed by id, not path, so only the mount-wide
+    # grant can admit it (a write-granting carve-out names no card).
+    require_mount_writable()
     card = await card_move(config, card_id=card_id, list_id=list_id)
     return yield_bytes(
         json.dumps(normalize_card(card),

--- a/python/mirage/commands/builtin/trello/trello_card_update.py
+++ b/python/mirage/commands/builtin/trello/trello_card_update.py
@@ -20,6 +20,7 @@ from mirage.commands.builtin.trello._input import (file_operand,
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec.types import CommandSpec, FlagView, Option
+from mirage.context import require_mount_writable
 from mirage.core.trello.client import card_update
 from mirage.core.trello.normalize import normalize_card
 from mirage.io.stream import yield_bytes
@@ -36,7 +37,7 @@ SPEC = CommandSpec(options=(
 ), )
 
 
-@command("trello card update", resource="trello", spec=SPEC)
+@command("trello card update", resource="trello", spec=SPEC, write=True)
 async def trello_card_update(
         accessor: TrelloAccessor, paths: list[PathSpec], texts: list[str],
         opts: CommandOpts) -> tuple[ByteSource | None, IOResult]:
@@ -62,6 +63,9 @@ async def trello_card_update(
     if closed_flag is not None:
         closed = closed_flag.lower() in ("true", "1", "yes")
     due = fl.as_str("due")
+    # A card write is addressed by id, not path, so only the mount-wide
+    # grant can admit it (a write-granting carve-out names no card).
+    require_mount_writable()
     card = await card_update(
         config,
         card_id=card_id,

--- a/python/tests/commands/builtin/trello/test_write_guards.py
+++ b/python/tests/commands/builtin/trello/test_write_guards.py
@@ -1,0 +1,123 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.accessor.trello import TrelloAccessor
+from mirage.commands.builtin.trello.trello_card_assign import \
+    trello_card_assign
+from mirage.commands.builtin.trello.trello_card_comment_add import \
+    trello_card_comment_add
+from mirage.commands.builtin.trello.trello_card_comment_update import \
+    trello_card_comment_update
+from mirage.commands.builtin.trello.trello_card_create import \
+    trello_card_create
+from mirage.commands.builtin.trello.trello_card_label_add import \
+    trello_card_label_add
+from mirage.commands.builtin.trello.trello_card_label_remove import \
+    trello_card_label_remove
+from mirage.commands.builtin.trello.trello_card_move import trello_card_move
+from mirage.commands.builtin.trello.trello_card_update import \
+    trello_card_update
+from mirage.commands.config import CommandFn, CommandOpts, RegisteredCommand
+from mirage.context import reset_mount_gate, set_mount_gate
+from mirage.resource.trello.config import TrelloConfig
+from mirage.types import MountMode
+from mirage.utils.errors import ReadOnlyError
+
+_ACCESSOR = TrelloAccessor(TrelloConfig(api_key="k", api_token="t"))
+
+# Every card write, with the flags that pass its own validation, so the
+# refusal below is the guard's and not a missing-flag ValueError. The
+# guard fires before the client, so no case reaches the network.
+CASES = [
+    pytest.param(trello_card_create, {
+        "list_id": "l1",
+        "name": "card"
+    },
+                 id="trello card create"),
+    pytest.param(trello_card_comment_add, {
+        "card_id": "c1",
+        "text": "hi"
+    },
+                 id="trello card comment"),
+    pytest.param(trello_card_comment_update, {
+        "card_id": "c1",
+        "comment_id": "m1",
+        "text": "hi"
+    },
+                 id="trello card comment-update"),
+    pytest.param(trello_card_assign, {
+        "card_id": "c1",
+        "member_id": "u1"
+    },
+                 id="trello card assign"),
+    pytest.param(trello_card_label_add, {
+        "card_id": "c1",
+        "label_id": "g1"
+    },
+                 id="trello card label"),
+    pytest.param(trello_card_label_remove, {
+        "card_id": "c1",
+        "label_id": "g1"
+    },
+                 id="trello card unlabel"),
+    pytest.param(trello_card_move, {
+        "card_id": "c1",
+        "list_id": "l2"
+    },
+                 id="trello card move"),
+    pytest.param(trello_card_update, {
+        "card_id": "c1",
+        "name": "renamed"
+    },
+                 id="trello card update"),
+]
+
+
+def _record(cmd: CommandFn) -> RegisteredCommand:
+    return getattr(cmd, "_registered_commands")[0]
+
+
+@pytest.mark.parametrize("cmd,flags", CASES)
+def test_every_card_write_declares_write(cmd: CommandFn,
+                                         flags: dict[str, str]) -> None:
+    """A card write must register ``write=True``.
+
+    ``Mount.execute_cmd``'s write-command gate keys on the registration
+    flag, so a card write without it runs on a fully read-only mount.
+    The TS twins all declare ``write: true``; five python commands had
+    neither the flag nor the guard.
+    """
+    assert _record(cmd).write is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cmd,flags", CASES)
+async def test_a_read_mount_refuses_an_id_addressed_write(
+        cmd: CommandFn, flags: dict[str, str]) -> None:
+    """Every card write refuses under a READ mount gate.
+
+    An id-addressed write names no path the per-path mode guard could
+    judge, so each handler must call ``require_mount_writable`` itself
+    (the placement the TS twins pin: after its own validation, before
+    the client call). With no session bound the configured mode stands,
+    so a READ gate alone must refuse.
+    """
+    token = set_mount_gate("/trello", MountMode.READ)
+    try:
+        with pytest.raises(ReadOnlyError):
+            await cmd(_ACCESSOR, [], [], CommandOpts(flags=flags))
+    finally:
+        reset_mount_gate(token)

--- a/typescript/packages/core/src/cache/context.ts
+++ b/typescript/packages/core/src/cache/context.ts
@@ -47,9 +47,41 @@ export function runWithCacheManager<T>(
   return Promise.resolve(storage.run({ manager }, fn))
 }
 
-/** Return the active cache manager for the current async context. */
+/**
+ * Return the active cache manager for the current async context.
+ *
+ * Serves the read-through paths, so a wrong manager is worse than
+ * none: a warm hit from another mount's cache is another mount's
+ * bytes, where a miss just reads the backend. On an isolating runtime
+ * one binding is live and answers as bound; on the fallback storage
+ * the manager answers only while every live frame agrees on it, and a
+ * disagreement (overlapping commands on different mounts) reads as no
+ * manager, failing toward the cold read.
+ */
 export function activeCacheManager(): CacheInvalidator | null {
-  return storage.getStore()?.manager ?? null
+  const states = storage.liveStores()
+  const first = states[0]
+  if (first === undefined) return null
+  for (const state of states) {
+    if (state.manager !== first.manager) return null
+  }
+  return first.manager
+}
+
+/**
+ * Every distinct manager bound by a live frame. Invalidation is the
+ * opposite trade from the read side: dropping a live frame's
+ * invalidation serves stale bytes later, while evicting from a mount
+ * the write never touched only costs a refetch, so writes broadcast
+ * where reads abstain.
+ */
+function liveManagers(): CacheInvalidator[] {
+  const managers: CacheInvalidator[] = []
+  for (const state of storage.liveStores()) {
+    const manager = state.manager
+    if (manager !== null && !managers.includes(manager)) managers.push(manager)
+  }
+  return managers
 }
 
 /**
@@ -57,8 +89,7 @@ export function activeCacheManager(): CacheInvalidator | null {
  * site. No-op if no cache manager is active.
  */
 export async function invalidateAfterWrite(path: string | PathSpec): Promise<void> {
-  const manager = storage.getStore()?.manager
-  if (manager !== null && manager !== undefined) {
+  for (const manager of liveManagers()) {
     await manager.invalidateAfterWrite(path)
   }
 }
@@ -68,8 +99,7 @@ export async function invalidateAfterWrite(path: string | PathSpec): Promise<voi
  * site. No-op if no cache manager is active.
  */
 export async function invalidateAfterUnlink(path: string | PathSpec): Promise<void> {
-  const manager = storage.getStore()?.manager
-  if (manager !== null && manager !== undefined) {
+  for (const manager of liveManagers()) {
     await manager.invalidateAfterUnlink(path)
   }
 }
@@ -90,8 +120,7 @@ export async function invalidateAfterUnlink(path: string | PathSpec): Promise<vo
  * is only known to the caches themselves.
  */
 export async function invalidateSubtree(path: string | PathSpec): Promise<void> {
-  const manager = storage.getStore()?.manager
-  if (manager !== null && manager !== undefined) {
+  for (const manager of liveManagers()) {
     await manager.invalidateSubtree(path)
   }
 }

--- a/typescript/packages/core/src/cache/context_fallback.test.ts
+++ b/typescript/packages/core/src/cache/context_fallback.test.ts
@@ -1,0 +1,141 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  type CacheInvalidator,
+  activeCacheManager,
+  invalidateAfterUnlink,
+  invalidateAfterWrite,
+  invalidateSubtree,
+  runWithCacheManager,
+} from './context.ts'
+import type * as asyncContextModule from '../utils/async_context.ts'
+
+// The browser-runtime branch under node's test runner: the real
+// FallbackStorage, no task isolation.
+vi.mock('../utils/async_context.ts', async (importOriginal) => {
+  const real = await importOriginal<typeof asyncContextModule>()
+  return {
+    ...real,
+    asyncContextIsolatesTasks: false,
+    createAsyncContext<T>() {
+      return new real.FallbackStorage<T>()
+    },
+  }
+})
+
+function gate(): [Promise<void>, () => void] {
+  let release!: () => void
+  const held = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return [held, release]
+}
+
+function fakeManager(log: string[], name: string): CacheInvalidator {
+  return {
+    invalidateAfterWrite(path) {
+      log.push(`${name}:write:${typeof path === 'string' ? path : path.virtual}`)
+      return Promise.resolve()
+    },
+    invalidateAfterUnlink(path) {
+      log.push(`${name}:unlink:${typeof path === 'string' ? path : path.virtual}`)
+      return Promise.resolve()
+    },
+    invalidateSubtree(path) {
+      log.push(`${name}:subtree:${typeof path === 'string' ? path : path.virtual}`)
+      return Promise.resolve()
+    },
+    cachedBytes() {
+      return Promise.resolve(null)
+    },
+  }
+}
+
+describe('cache invalidation on the fallback storage', () => {
+  it('a write invalidates every live manager, and only live ones', async () => {
+    // Dropping a live frame's invalidation serves stale bytes later;
+    // evicting a mount the write never touched only costs a refetch.
+    // So writes broadcast.
+    const log: string[] = []
+    const managerA = fakeManager(log, 'a')
+    const managerB = fakeManager(log, 'b')
+    const [hold, release] = gate()
+    const long = runWithCacheManager(managerA, async () => {
+      await hold
+    })
+    const short = runWithCacheManager(managerB, async () => {
+      await invalidateAfterWrite('/m/x')
+      release()
+    })
+    await Promise.all([long, short])
+    expect(log.sort()).toEqual(['a:write:/m/x', 'b:write:/m/x'])
+    log.length = 0
+    await invalidateAfterWrite('/m/x')
+    expect(log).toEqual([])
+  })
+
+  it('an unlink and a subtree drop broadcast the same way', async () => {
+    const log: string[] = []
+    const managerA = fakeManager(log, 'a')
+    const managerB = fakeManager(log, 'b')
+    const [hold, release] = gate()
+    const long = runWithCacheManager(managerA, async () => {
+      await hold
+    })
+    const short = runWithCacheManager(managerB, async () => {
+      await invalidateAfterUnlink('/m/x')
+      await invalidateSubtree('/m/d')
+      release()
+    })
+    await Promise.all([long, short])
+    expect(log.sort()).toEqual([
+      'a:subtree:/m/d',
+      'a:unlink:/m/x',
+      'b:subtree:/m/d',
+      'b:unlink:/m/x',
+    ])
+  })
+
+  it('the read side abstains while two managers disagree', async () => {
+    // A warm hit from another mount's cache is another mount's bytes;
+    // a miss just reads the backend. So reads fail toward the cold
+    // read while the frames disagree, and answer again once one
+    // manager is live — or while every frame agrees (a nested rebind).
+    const log: string[] = []
+    const managerA = fakeManager(log, 'a')
+    const managerB = fakeManager(log, 'b')
+    const [hold, release] = gate()
+    let besideOther: CacheInvalidator | null = managerB
+    let afterOtherSettled: CacheInvalidator | null = null
+    const first = runWithCacheManager(managerB, async () => {
+      await hold
+    })
+    const second = runWithCacheManager(managerA, async () => {
+      besideOther = activeCacheManager()
+      release()
+      await first
+      afterOtherSettled = activeCacheManager()
+      await runWithCacheManager(managerA, () => {
+        expect(activeCacheManager()).toBe(managerA)
+        return Promise.resolve()
+      })
+    })
+    await second
+    expect(besideOther).toBeNull()
+    expect(afterOtherSettled).toBe(managerA)
+    expect(activeCacheManager()).toBeNull()
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -19,6 +19,7 @@ import {
   getCurrentSession,
   getOpPolicies,
   hiddenPathsIntersect,
+  liveSessions,
   mountGateFor,
   pathAllowed,
   readonlyBelow,
@@ -204,11 +205,11 @@ function visibleChildren(entries: string[], parent: PathSpec): string[] {
   })
 }
 
-/** Whether the session's hides make this relocation a reveal. */
+/** Whether any live session's hides make this relocation a reveal. */
 function moveWouldReveal(src: PathSpec, dst: PathSpec): boolean {
-  const sess = getCurrentSession()
-  if (sess === null) return false
-  return moveReveals(sess.hiddenPaths, sess.shownPaths, src.virtual, dst.virtual)
+  return liveSessions().some((sess) =>
+    moveReveals(sess.hiddenPaths, sess.shownPaths, src.virtual, dst.virtual),
+  )
 }
 
 /** Refuse a relocation that would surface a hidden path.

--- a/typescript/packages/core/src/commands/builtin/trello/write_guards.test.ts
+++ b/typescript/packages/core/src/commands/builtin/trello/write_guards.test.ts
@@ -1,0 +1,74 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { TrelloAccessor } from '../../../accessor/trello.ts'
+import { runWithMountGate } from '../../../context/session_context.ts'
+import type { TrelloTransport } from '../../../core/trello/client.ts'
+import { MountMode } from '../../../types.ts'
+import type { CommandOpts, RegisteredCommand } from '../../config.ts'
+import type { FlagValue } from '../../spec/types.ts'
+import { TRELLO_CARD_ASSIGN } from './trello_card_assign.ts'
+import { TRELLO_CARD_COMMENT_ADD } from './trello_card_comment_add.ts'
+import { TRELLO_CARD_COMMENT_UPDATE } from './trello_card_comment_update.ts'
+import { TRELLO_CARD_CREATE } from './trello_card_create.ts'
+import { TRELLO_CARD_LABEL_ADD } from './trello_card_label_add.ts'
+import { TRELLO_CARD_LABEL_REMOVE } from './trello_card_label_remove.ts'
+import { TRELLO_CARD_MOVE } from './trello_card_move.ts'
+import { TRELLO_CARD_UPDATE } from './trello_card_update.ts'
+
+const transport: TrelloTransport = {
+  call() {
+    throw new Error('the transport was reached; the guard did not fire')
+  },
+}
+const accessor = new TrelloAccessor(transport)
+
+// Every card write, with the flags that pass its own validation, so the
+// refusal below is the guard's and not a missing-flag error. The guard
+// fires before the client, so no case reaches the transport.
+const CASES: readonly [readonly RegisteredCommand[], Record<string, FlagValue>][] = [
+  [TRELLO_CARD_CREATE, { list_id: 'l1', name: 'card' }],
+  [TRELLO_CARD_COMMENT_ADD, { card_id: 'c1', text: 'hi' }],
+  [TRELLO_CARD_COMMENT_UPDATE, { card_id: 'c1', comment_id: 'm1', text: 'hi' }],
+  [TRELLO_CARD_ASSIGN, { card_id: 'c1', member_id: 'u1' }],
+  [TRELLO_CARD_LABEL_ADD, { card_id: 'c1', label_id: 'g1' }],
+  [TRELLO_CARD_LABEL_REMOVE, { card_id: 'c1', label_id: 'g1' }],
+  [TRELLO_CARD_MOVE, { card_id: 'c1', list_id: 'l2' }],
+  [TRELLO_CARD_UPDATE, { card_id: 'c1', name: 'renamed' }],
+]
+
+describe('trello card writes hold the mount-wide write grant', () => {
+  for (const [cmds, flags] of CASES) {
+    const rc = cmds[0]
+    if (rc === undefined) throw new Error('command registered nothing')
+    it(`${rc.name} declares write and refuses under a READ gate`, async () => {
+      // Mount.executeCmd's write-command gate keys on the registration
+      // flag, and the in-handler guard covers the id-addressed write a
+      // per-path check cannot judge. Nothing pinned the per-command
+      // wiring before, which is how the Python side drifted to 3 of 8.
+      expect(rc.write).toBe(true)
+      const opts: CommandOpts = {
+        stdin: null,
+        flags,
+        filetypeFns: null,
+        cwd: '/',
+        mountPrefix: '/trello',
+      }
+      await runWithMountGate('/trello', MountMode.READ, async () => {
+        await expect(Promise.resolve(rc.fn(accessor, [], [], opts))).rejects.toThrow(/read-only/)
+      })
+    })
+  }
+})

--- a/typescript/packages/core/src/context/session_context.ts
+++ b/typescript/packages/core/src/context/session_context.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { asyncContextIsolatesTasks, createAsyncContext } from '../utils/async_context.ts'
+import { createAsyncContext } from '../utils/async_context.ts'
 import type { SessionManager } from '../workspace/session/manager.ts'
 import type { Session } from '../workspace/session/session.ts'
 import { stripSlash } from '../utils/slash.ts'
@@ -64,16 +64,37 @@ export function getCurrentSession(): Session | null {
 }
 
 /**
+ * Every session whose binding is live in this context, oldest first.
+ *
+ * On an isolating runtime this is the bound session alone, so a fold
+ * over it computes exactly what `getCurrentSession` implies. On the
+ * fallback storage it is every concurrently bound session, which is
+ * what lets a security predicate merge toward the most restrictive
+ * answer instead of trusting the newest binding: every predicate here
+ * fails open on "no session", so a frame another task shadows or
+ * settles past must keep counting while it is live.
+ */
+export function liveSessions(): Session[] {
+  return sessionStorage.liveStores().map((binding) => binding.session)
+}
+
+/**
  * The bound session, but only when `owner` published it.
  *
  * A session carries one workspace's cwd, env and mount grants, so a
  * second workspace re-entered mid-line must resolve its own session
- * rather than adopt this one.
+ * rather than adopt this one. The owner is the disambiguator, so every
+ * live binding is searched, newest first: on the fallback storage a
+ * concurrent workspace's bind shadowing the newest frame must not hide
+ * this owner's own session.
  */
 export function getCurrentSessionFor(owner: SessionManager): Session | null {
-  const binding = sessionStorage.getStore()
-  if (binding?.owner !== owner) return null
-  return binding.session
+  const bindings = sessionStorage.liveStores()
+  for (let at = bindings.length - 1; at >= 0; at--) {
+    const binding = bindings[at]
+    if (binding?.owner === owner) return binding.session
+  }
+  return null
 }
 
 function normPrefix(mountPrefix: string): string {
@@ -89,12 +110,20 @@ function normPrefix(mountPrefix: string): string {
  * mount sections narrow what the mount already offers and never decide
  * whether it exists. A profile that must not reach a mount hides it, which
  * answers ENOENT rather than a permission error naming something the
- * profile cannot see.
+ * profile cannot see. Folded to the weakest across every live session,
+ * which on an isolating runtime is the bound one alone.
  */
-function sessionMode(mountPrefix: string): MountMode {
-  const sess = getCurrentSession()
-  if (sess?.mountModes == null) return MountMode.EXEC
+function sessionModeOf(sess: Session, mountPrefix: string): MountMode {
+  if (sess.mountModes == null) return MountMode.EXEC
   return sess.mountModes.get(normPrefix(mountPrefix)) ?? MountMode.EXEC
+}
+
+function sessionMode(mountPrefix: string): MountMode {
+  let mode: MountMode = MountMode.EXEC
+  for (const sess of liveSessions()) {
+    mode = weakerMode(mode, sessionModeOf(sess, mountPrefix))
+  }
+  return mode
 }
 
 /**
@@ -106,7 +135,7 @@ function sessionMode(mountPrefix: string): MountMode {
  * nothing, and modes never change what a walk enumerates.
  */
 export function hiddenPathsActive(): boolean {
-  return getCurrentSession()?.hiddenPaths != null
+  return liveSessions().some((sess) => sess.hiddenPaths != null)
 }
 
 /**
@@ -120,8 +149,7 @@ export function hiddenPathsActive(): boolean {
  * force `find` on `/s3` off its native op.
  */
 export function hiddenPathsIntersect(virtual: string): boolean {
-  const sess = getCurrentSession()
-  return sess != null && hidesIntersect(sess.hiddenPaths, virtual)
+  return liveSessions().some((sess) => hidesIntersect(sess.hiddenPaths, virtual))
 }
 
 export const DEFAULT_UMASK = 0o022
@@ -130,10 +158,16 @@ export const DEFAULT_UMASK = 0o022
  * The file-creation mask of the session bound to this context, read by
  * the creators that run inside a command handler (`mkdir`, which cannot
  * be handed the session) the way `pathAllowed` reads the hidden-paths
- * spec. bash's default when no session is bound.
+ * spec. bash's default when no session is bound; ORed across live
+ * sessions otherwise, since a mask can only clear more bits, failing
+ * toward the tighter mode.
  */
 export function sessionUmask(): number {
-  return getCurrentSession()?.umask ?? DEFAULT_UMASK
+  const live = liveSessions()
+  if (live.length === 0) return DEFAULT_UMASK
+  let mask = 0
+  for (const sess of live) mask |= sess.umask
+  return mask
 }
 
 /**
@@ -141,10 +175,14 @@ export function sessionUmask(): number {
  * pathname expansion, which runs in every backend's resolveGlob and so
  * cannot be handed the session: a name starting with `.` is matched
  * only by a pattern that also starts with `.`, unless dotglob relaxes
- * it. False when no session is bound (bash's default).
+ * it. False when no session is bound (bash's default), and unanimous
+ * across live sessions otherwise: dotfiles entering a match set is the
+ * surprising direction, so one session's opt-in must not widen a
+ * concurrent one's expansion.
  */
 export function dotglobActive(): boolean {
-  return getCurrentSession()?.shopts.dotglob === true
+  const live = liveSessions()
+  return live.length > 0 && live.every((sess) => sess.shopts.dotglob === true)
 }
 
 /**
@@ -165,11 +203,13 @@ export function sessionPathAllowed(sess: Session, virtual: string): boolean {
  * ENOENT (EACCES for creates) when it says no, so hiding reads as
  * nonexistence, never as a denial that leaks the name. True when no
  * session is bound. This is how a profile keeps a session away from a
- * mount, since naming mounts only narrows their modes.
+ * mount, since naming mounts only narrows their modes. Every live
+ * session must leave the path visible, so on the fallback storage a
+ * hide stays in force while its command's frame is shadowed, and a
+ * concurrent settle cannot wipe it into visibility.
  */
 export function pathAllowed(virtual: string): boolean {
-  const sess = getCurrentSession()
-  return sess == null || sessionPathAllowed(sess, virtual)
+  return liveSessions().every((sess) => sessionPathAllowed(sess, virtual))
 }
 
 const admissionStorage = createAsyncContext<EntryGate>()
@@ -191,9 +231,28 @@ export function runWithAdmission<T>(gate: EntryGate, fn: () => Promise<T>): Prom
  * The entry gate of the command running in this context, null when no
  * admitted command is bound (a command constructed outside the
  * dispatcher, or a line no gate judged).
+ *
+ * On an isolating runtime one gate is live and answers as bound. On
+ * the fallback storage several commands' gates can be live at once
+ * with nothing to say whose op is asking, so they merge toward
+ * refusal: an entry must pass every live gate's `check`, a rule counts
+ * as granted only when every live gate carries it (a once-grant nodded
+ * for one line must not authorize another's op door), and `scoped` is
+ * true when any live gate scopes, keeping walks off the unfiltered
+ * native fast paths.
  */
 export function getAdmission(): EntryGate | null {
-  return admissionStorage.getStore() ?? null
+  const gates = admissionStorage.liveStores()
+  const first = gates[0]
+  if (first === undefined) return null
+  if (gates.every((gate) => gate === first)) return first
+  return {
+    scoped: gates.some((gate) => gate.scoped),
+    granted: first.granted.filter((rule) => gates.every((gate) => gate.granted.includes(rule))),
+    check(virtual: string): void {
+      for (const gate of gates) gate.check(virtual)
+    },
+  }
 }
 
 /**
@@ -237,23 +296,26 @@ export function runWithSuspendedOpPolicies<T>(fn: () => Promise<T>): Promise<T> 
   return Promise.resolve(opPoliciesStorage.run(null, fn))
 }
 
-/** The policies bound to the running command, null outside one. */
+/**
+ * The policies bound to the running command, null outside one.
+ *
+ * The newest live armed set. On an isolating runtime the live set is
+ * the innermost binding, so a suspension answers null exactly as
+ * bound. On the fallback storage a suspension yields to any
+ * concurrently armed frame, because disarming another command's op
+ * doors is the worse failure: find's delegated `rm` then double-admits
+ * its removal (an over-count, failing closed) instead of a concurrent
+ * command's ops running unguarded.
+ */
 export function getOpPolicies(): Policies | null {
-  return opPoliciesStorage.getStore() ?? null
+  let armed: Policies | null = null
+  for (const policies of opPoliciesStorage.liveStores()) {
+    if (policies !== null) armed = policies
+  }
+  return armed
 }
 
 const mountGateStorage = createAsyncContext<readonly [string, MountMode]>()
-
-// The fallback storage is one global slot, so overlapping commands on
-// different mounts (a pipeline's stages, a background job) would read
-// each other's gate mid-await; every live gate is kept instead, and
-// `mountGateFor` selects among them by the path being judged.
-const liveMountGates: (readonly [string, MountMode])[] = []
-
-function releaseMountGate(gate: readonly [string, MountMode]): void {
-  const at = liveMountGates.indexOf(gate)
-  if (at >= 0) liveMountGates.splice(at, 1)
-}
 
 /**
  * Bind the executing mount's prefix and configured mode for the
@@ -264,31 +326,13 @@ function releaseMountGate(gate: readonly [string, MountMode]): void {
  * a handler mutates: the write-command gate admits a command when any
  * shown subtree grants writes, and this binding is how each individual
  * write is then held to its own region's mode.
- *
- * Where the async context isolates tasks the binding rides it. On the
- * fallback storage (a browser with no AsyncLocalStorage) the gate joins
- * the live list instead, because a permission read off a slot another
- * mount's command can overwrite mid-await would judge a path against
- * the wrong mount.
  */
 export function runWithMountGate<T>(
   prefix: string,
   mode: MountMode,
   fn: () => Promise<T>,
 ): Promise<T> {
-  if (asyncContextIsolatesTasks) {
-    return Promise.resolve(mountGateStorage.run([prefix, mode], fn))
-  }
-  const gate: readonly [string, MountMode] = [prefix, mode]
-  liveMountGates.push(gate)
-  try {
-    return Promise.resolve(fn()).finally(() => {
-      releaseMountGate(gate)
-    })
-  } catch (err) {
-    releaseMountGate(gate)
-    throw err
-  }
+  return Promise.resolve(mountGateStorage.run([prefix, mode], fn))
 }
 
 /**
@@ -296,25 +340,23 @@ export function runWithMountGate<T>(
  * mode], null outside a mount's command (a generic invoked directly in
  * a test, or the scratch tier).
  *
- * Where the async context isolates tasks the binding answers and the
- * path plays no part. On the fallback storage the reader selects among
- * every live gate by the path itself: the longest prefix covering it
- * wins, the way the mount table routes, and two live gates at one
- * prefix (two workspaces sharing a fallback runtime) answer with the
- * weaker mode, failing toward refusal. A path no live gate covers
- * answers null, which is the same inert reading an unbound context
- * gives: the serving mount's own gate is live for the whole run of its
- * handler, so only a path outside every executing mount can miss.
+ * The reader selects among every live gate by the path itself: the
+ * longest prefix covering it wins, the way the mount table routes, and
+ * two live gates at one prefix (two workspaces sharing a fallback
+ * runtime) answer with the weaker mode, failing toward refusal. On an
+ * isolating runtime one binding is live and every caller asks about a
+ * path that mount serves; on the fallback storage (a browser with no
+ * AsyncLocalStorage) overlapping commands on different mounts hold
+ * gates concurrently, and the path is what keeps one from being judged
+ * against the other's. A path no live gate covers answers null, the
+ * same inert reading an unbound context gives.
  */
 export function mountGateFor(virtual: string): readonly [string, MountMode] | null {
-  if (asyncContextIsolatesTasks) {
-    return mountGateStorage.getStore() ?? null
-  }
   const v = normPrefix(virtual)
   let bestLen = -1
   let bestPrefix: string | null = null
   let bestMode: MountMode | null = null
-  for (const [rawPrefix, mode] of liveMountGates) {
+  for (const [rawPrefix, mode] of mountGateStorage.liveStores()) {
     const prefix = normPrefix(rawPrefix)
     if (prefix !== '/' && v !== prefix && !v.startsWith(prefix + '/')) continue
     if (prefix.length > bestLen) {
@@ -352,11 +394,18 @@ export function runWithRedirectPaths<T>(
 /**
  * The redirect targets bound to this command node, empty for any other
  * node or when none are bound.
+ *
+ * The node is the disambiguator, so every live binding is searched,
+ * newest first: on the fallback storage a concurrent statement's bind
+ * shadowing the newest frame must not hide this node's own targets.
  */
 export function redirectPathsFor(node: object): readonly PathSpec[] {
-  const bound = redirectStorage.getStore()
-  if (bound?.[0] !== node) return []
-  return bound[1]
+  const bindings = redirectStorage.liveStores()
+  for (let at = bindings.length - 1; at >= 0; at--) {
+    const bound = bindings[at]
+    if (bound?.[0] === node) return bound[1]
+  }
+  return []
 }
 
 /**
@@ -370,11 +419,13 @@ export function redirectPathsFor(node: object): readonly PathSpec[] {
  * statement whose targets a rule refused never reaches the write at all.
  * So a bound target is one the line was admitted with, and re-deriving a
  * verdict for it from a door that knows neither the line nor the nod it
- * holds can only get it wrong.
+ * holds can only get it wrong. Every live binding counts, because a
+ * target is only ever bound after its own line's door judged it: on the
+ * fallback storage a concurrent statement's frame must not shadow this
+ * one's targets into a re-derived refusal.
  */
 export function redirectTargetJudged(virtual: string): boolean {
-  const bound = redirectStorage.getStore()
-  return bound?.[1].some((p) => p.virtual === virtual) ?? false
+  return redirectStorage.liveStores().some(([, paths]) => paths.some((p) => p.virtual === virtual))
 }
 
 /**
@@ -399,14 +450,15 @@ export function effectiveMountMode(mountPrefix: string, mountMode: MountMode): M
  * repo and writes only the build tree; an equal-depth pair takes the
  * weaker, failing toward refusal. The configured mode stays the
  * strongest answer possible: the document never grants past it.
+ * Folded to the weakest across every live session, which on an
+ * isolating runtime is the bound one alone.
  */
-export function effectivePathMode(
+function pathModeUnder(
+  sess: Session,
   virtual: string,
   mountPrefix: string,
   mountMode: MountMode,
 ): MountMode {
-  const sess = getCurrentSession()
-  if (sess == null) return mountMode
   const prefix = normPrefix(mountPrefix)
   const cap = sess.mountModes?.get(prefix) ?? null
   let bestDepth = cap != null ? anchorDepth(prefix) : null
@@ -423,6 +475,18 @@ export function effectivePathMode(
   }
   if (bestMode == null) return mountMode
   return weakerMode(mountMode, bestMode)
+}
+
+export function effectivePathMode(
+  virtual: string,
+  mountPrefix: string,
+  mountMode: MountMode,
+): MountMode {
+  let mode = mountMode
+  for (const sess of liveSessions()) {
+    mode = weakerMode(mode, pathModeUnder(sess, virtual, mountPrefix, mountMode))
+  }
+  return mode
 }
 
 /**
@@ -448,12 +512,17 @@ function reachesUnder(head: string, prefix: string): boolean {
  * What the whole-mount gates read: a write command stays runnable on a
  * mount whose only writable region is a show entry (the op door then
  * refuses per path), and the interpreters' any-`x` rule counts a show
- * grant the way it counts a whole mount.
+ * grant the way it counts a whole mount. Each live session's strongest
+ * reach is computed on its own, then folded to the weakest across
+ * sessions: a command runs only when every live session would let it.
  */
-export function strongestModeUnder(mountPrefix: string, mountMode: MountMode): MountMode {
-  let best = effectiveMountMode(mountPrefix, mountMode)
-  const sess = getCurrentSession()
-  if (sess?.shownPaths == null) return best
+function strongestUnderSession(
+  sess: Session,
+  mountPrefix: string,
+  mountMode: MountMode,
+): MountMode {
+  let best = weakerMode(mountMode, sessionModeOf(sess, mountPrefix))
+  if (sess.shownPaths == null) return best
   const prefix = normPrefix(mountPrefix)
   for (const entry of sess.shownPaths.entries) {
     if (entry.mode == null) continue
@@ -461,6 +530,14 @@ export function strongestModeUnder(mountPrefix: string, mountMode: MountMode): M
       const reached = weakerMode(mountMode, entry.mode)
       if (MOUNT_MODE_RANK[reached] > MOUNT_MODE_RANK[best]) best = reached
     }
+  }
+  return best
+}
+
+export function strongestModeUnder(mountPrefix: string, mountMode: MountMode): MountMode {
+  let best = mountMode
+  for (const sess of liveSessions()) {
+    best = weakerMode(best, strongestUnderSession(sess, mountPrefix, mountMode))
   }
   return best
 }
@@ -477,15 +554,16 @@ export function strongestModeUnder(mountPrefix: string, mountMode: MountMode): M
  * the operand up front. An exact entry is blamed by its anchor, the
  * row GNU would report the refusal on; a pattern names no single
  * anchor, so the operand itself is blamed whenever the pattern's
- * match space could reach below it, failing toward refusal.
+ * match space could reach below it, failing toward refusal. The first
+ * blame any live session raises answers.
  */
-export function readonlyBelow(
+function readonlyBelowUnder(
+  sess: Session,
   virtual: string,
   mountPrefix: string,
   mountMode: MountMode,
 ): string | null {
-  const sess = getCurrentSession()
-  if (sess?.shownPaths == null) return null
+  if (sess.shownPaths == null) return null
   const v = '/' + virtual.replace(/^\/+|\/+$/g, '')
   for (const entry of sess.shownPaths.entries) {
     if (entry.mode == null) continue
@@ -498,9 +576,21 @@ export function readonlyBelow(
     const anchor = '/' + entry.path.replace(/^\/+|\/+$/g, '')
     const below = v === '/' ? anchor !== '/' : anchor.startsWith(v + '/')
     if (!below) continue
-    if (effectivePathMode(anchor, mountPrefix, mountMode) === MountMode.READ) {
+    if (pathModeUnder(sess, anchor, mountPrefix, mountMode) === MountMode.READ) {
       return anchor
     }
+  }
+  return null
+}
+
+export function readonlyBelow(
+  virtual: string,
+  mountPrefix: string,
+  mountMode: MountMode,
+): string | null {
+  for (const sess of liveSessions()) {
+    const blame = readonlyBelowUnder(sess, virtual, mountPrefix, mountMode)
+    if (blame !== null) return blame
   }
   return null
 }

--- a/typescript/packages/core/src/context/session_context_fallback.test.ts
+++ b/typescript/packages/core/src/context/session_context_fallback.test.ts
@@ -14,65 +14,61 @@
 
 import { describe, expect, it, vi } from 'vitest'
 import {
+  getAdmission,
+  getCurrentSessionFor,
+  getOpPolicies,
   mountGateFor,
+  pathAllowed,
+  redirectPathsFor,
+  redirectTargetJudged,
   requireMountWritable,
+  runWithAdmission,
   runWithMountGate,
+  runWithOpPolicies,
+  runWithRedirectPaths,
   runWithSession,
+  runWithSuspendedOpPolicies,
+  sessionUmask,
 } from './session_context.ts'
-import { MountMode } from '../types.ts'
+import type { EntryGate } from '../types.ts'
+import { MountMode, PathSpec } from '../types.ts'
+import type { CommandRule } from '../policy/types.ts'
+import type { Policies } from '../policy/policies.ts'
+import type { SessionManager } from '../workspace/session/manager.ts'
 import { Session } from '../workspace/session/session.ts'
+import type * as asyncContextModule from '../utils/async_context.ts'
 
-// The browser-runtime branch under node's test runner: the mocked
-// module is the real FallbackStorage shape (one global slot restored
-// when run's promise settles, no task isolation), so these tests pin
-// what the mount gate does where AsyncLocalStorage does not exist.
-vi.mock('../utils/async_context.ts', () => {
-  class SlotStorage<T> {
-    private store: T | undefined
-
-    run<R>(s: T, fn: () => R | Promise<R>): R | Promise<R> {
-      const prev = this.store
-      this.store = s
-      try {
-        const result = fn()
-        if (result instanceof Promise) {
-          return result.finally(() => {
-            this.store = prev
-          })
-        }
-        this.store = prev
-        return result
-      } catch (err) {
-        this.store = prev
-        throw err
-      }
-    }
-
-    getStore(): T | undefined {
-      return this.store
-    }
-  }
+// The browser-runtime branch under node's test runner: the mock forces
+// the real FallbackStorage (no task isolation, one frame stack per
+// storage), so these tests pin what every ambient fact does where
+// AsyncLocalStorage does not exist.
+vi.mock('../utils/async_context.ts', async (importOriginal) => {
+  const real = await importOriginal<typeof asyncContextModule>()
   return {
+    ...real,
     asyncContextIsolatesTasks: false,
-    createAsyncContext<T>(): SlotStorage<T> {
-      return new SlotStorage<T>()
+    createAsyncContext<T>() {
+      return new real.FallbackStorage<T>()
     },
   }
 })
+
+/** A promise released by hand, for holding one run live inside another. */
+function gate(): [Promise<void>, () => void] {
+  let release!: () => void
+  const held = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return [held, release]
+}
 
 describe('the mount gate on the fallback storage', () => {
   it('overlapping commands each answer with their own mounts gate', async () => {
     // The corruption the slot would allow: while B runs, a slot read in
     // A's continuation sees B's gate, and A's protected path is judged
-    // with B's prefix and mode. The live list answers by the path.
-    let releaseA!: () => void
-    const holdA = new Promise<void>((resolve) => {
-      releaseA = resolve
-    })
-    let releaseB!: () => void
-    const holdB = new Promise<void>((resolve) => {
-      releaseB = resolve
-    })
+    // with B's prefix and mode. The live frames answer by the path.
+    const [holdA, releaseA] = gate()
+    const [holdB, releaseB] = gate()
     let gateInA: readonly [string, MountMode] | null = null
     let gateInB: readonly [string, MountMode] | null = null
     const cmdA = runWithMountGate('/a', MountMode.WRITE, async () => {
@@ -141,5 +137,239 @@ describe('the mount gate on the fallback storage', () => {
         }),
       ),
     )
+  })
+})
+
+describe('session predicates on the fallback storage', () => {
+  it('a hide holds while a concurrent session shadows the newest frame', async () => {
+    const hider = new Session({
+      sessionId: 'hider',
+      hiddenPaths: { paths: ['/repo/.env'] },
+    })
+    const other = new Session({ sessionId: 'other' })
+    const [hold, release] = gate()
+    let allowedBesideHider: boolean | undefined
+    const long = runWithSession(hider, async () => {
+      await hold
+    })
+    const short = runWithSession(other, () => {
+      // The hider's frame is not the newest, but its hide must still
+      // count: every live session is folded, most restrictive first.
+      allowedBesideHider = pathAllowed('/repo/.env')
+      release()
+      return Promise.resolve()
+    })
+    await Promise.all([long, short])
+    expect(allowedBesideHider).toBe(false)
+    expect(pathAllowed('/repo/.env')).toBe(true)
+  })
+
+  it('a settle out of order cannot wipe a live hide into visibility', async () => {
+    // The slot's worst failure: the first-bound run settles, restores
+    // its saved (empty) slot, and the still-running hider's predicates
+    // all read "no session", which fails open — the hidden path turns
+    // visible mid-command.
+    const hider = new Session({
+      sessionId: 'hider',
+      hiddenPaths: { paths: ['/repo/.env'] },
+    })
+    const other = new Session({ sessionId: 'other' })
+    const [hold, release] = gate()
+    let seen: boolean | undefined
+    const first = runWithSession(other, async () => {
+      await hold
+    })
+    const second = runWithSession(hider, async () => {
+      release()
+      await first
+      seen = pathAllowed('/repo/.env')
+    })
+    await second
+    expect(seen).toBe(false)
+  })
+
+  it('getCurrentSessionFor answers by owner while another workspace is live', async () => {
+    const ownerA = {} as unknown as SessionManager
+    const ownerB = {} as unknown as SessionManager
+    const sessA = new Session({ sessionId: 'a' })
+    const sessB = new Session({ sessionId: 'b' })
+    const [hold, release] = gate()
+    let forA: Session | null = null
+    let forB: Session | null = null
+    const runA = runWithSession(
+      sessA,
+      async () => {
+        await hold
+      },
+      ownerA,
+    )
+    const runB = runWithSession(
+      sessB,
+      () => {
+        // A's binding is beneath B's own: the owner search must reach
+        // past the newest frame, where the slot read answered null.
+        forA = getCurrentSessionFor(ownerA)
+        forB = getCurrentSessionFor(ownerB)
+        release()
+        return Promise.resolve()
+      },
+      ownerB,
+    )
+    await Promise.all([runA, runB])
+    expect(forA).toBe(sessA)
+    expect(forB).toBe(sessB)
+    expect(getCurrentSessionFor(ownerA)).toBeNull()
+  })
+
+  it('the umask ORs across live sessions, clearing toward the tighter mode', async () => {
+    const loose = new Session({ sessionId: 'loose' })
+    loose.umask = 0o022
+    const tight = new Session({ sessionId: 'tight' })
+    tight.umask = 0o077
+    const [hold, release] = gate()
+    let masked: number | undefined
+    const long = runWithSession(tight, async () => {
+      await hold
+    })
+    const short = runWithSession(loose, () => {
+      masked = sessionUmask()
+      release()
+      return Promise.resolve()
+    })
+    await Promise.all([long, short])
+    expect(masked).toBe(0o077)
+  })
+})
+
+describe('the admission gate on the fallback storage', () => {
+  const ruleShared = { reason: 'shared' } as unknown as CommandRule
+  const ruleAOnly = { reason: 'a-only' } as unknown as CommandRule
+
+  function entryGate(scoped: boolean, granted: readonly CommandRule[], refuse: string): EntryGate {
+    return {
+      scoped,
+      granted,
+      check(virtual: string): void {
+        if (virtual === refuse) throw new Error(`refused: ${virtual}`)
+      },
+    }
+  }
+
+  it('two live gates merge toward refusal', async () => {
+    const gateA = entryGate(true, [ruleShared, ruleAOnly], '/a/secret')
+    const gateB = entryGate(false, [ruleShared], '/b/secret')
+    const [hold, release] = gate()
+    const runA = runWithAdmission(gateA, async () => {
+      await hold
+    })
+    const runB = runWithAdmission(gateB, () => {
+      const seen = getAdmission()
+      release()
+      return Promise.resolve(seen)
+    })
+    const [, merged] = await Promise.all([runA, runB])
+    if (merged === null) throw new Error('no gate answered')
+    const live: EntryGate = merged
+    // An entry must pass every live gate, a walk scopes when any live
+    // gate scopes, and a once-grant counts only when every live gate
+    // carries it: a nod taken for one line must not authorize another.
+    expect(() => {
+      live.check('/a/secret')
+    }).toThrow('refused: /a/secret')
+    expect(() => {
+      live.check('/b/secret')
+    }).toThrow('refused: /b/secret')
+    live.check('/fine')
+    expect(live.scoped).toBe(true)
+    expect(live.granted).toEqual([ruleShared])
+    expect(getAdmission()).toBeNull()
+  })
+
+  it('a lone live gate answers as itself, and survives a concurrent settle', async () => {
+    const gateA = entryGate(true, [ruleAOnly], '/a/secret')
+    const gateB = entryGate(false, [], '/b/secret')
+    const [hold, release] = gate()
+    let after: EntryGate | null = null
+    const first = runWithAdmission(gateB, async () => {
+      await hold
+    })
+    const second = runWithAdmission(gateA, async () => {
+      release()
+      await first
+      after = getAdmission()
+    })
+    await second
+    expect(after).toBe(gateA)
+  })
+})
+
+describe('op policies on the fallback storage', () => {
+  const armed = { wants: () => true } as unknown as Policies
+
+  it('an armed frame survives a concurrent settle', async () => {
+    const [hold, release] = gate()
+    let after: Policies | null = null
+    const first = runWithOpPolicies({ wants: () => true } as unknown as Policies, async () => {
+      await hold
+    })
+    const second = runWithOpPolicies(armed, async () => {
+      release()
+      await first
+      after = getOpPolicies()
+    })
+    await second
+    expect(after).toBe(armed)
+  })
+
+  it('a suspension yields to a concurrently armed frame, and stands alone otherwise', async () => {
+    // Deliberate fallback divergence: with no execution identity, a
+    // suspension that silenced every live frame would disarm a
+    // concurrent command's op doors (failing open), so the delegated
+    // sub-command double-admits instead (failing closed). A lone
+    // suspension still answers null, which is the isolating behavior.
+    const [hold, release] = gate()
+    let besideArmed: Policies | null = null
+    const long = runWithOpPolicies(armed, async () => {
+      await hold
+    })
+    const short = runWithSuspendedOpPolicies(() => {
+      besideArmed = getOpPolicies()
+      release()
+      return Promise.resolve()
+    })
+    await Promise.all([long, short])
+    expect(besideArmed).toBe(armed)
+    await runWithSuspendedOpPolicies(() => {
+      expect(getOpPolicies()).toBeNull()
+      return Promise.resolve()
+    })
+  })
+})
+
+describe('redirect targets on the fallback storage', () => {
+  it('each statement finds its own targets by node while both are live', async () => {
+    const nodeA = {}
+    const nodeB = {}
+    const outA = PathSpec.fromStrPath('/a/out.txt')
+    const outB = PathSpec.fromStrPath('/b/out.txt')
+    const [hold, release] = gate()
+    let pathsInA: readonly PathSpec[] = []
+    let judgedInA = false
+    const runA = runWithRedirectPaths(nodeA, [outA], async () => {
+      await hold
+      pathsInA = redirectPathsFor(nodeA)
+      judgedInA = redirectTargetJudged(outA.virtual)
+    })
+    const runB = runWithRedirectPaths(nodeB, [outB], () => {
+      expect(redirectPathsFor(nodeB)).toEqual([outB])
+      expect(redirectPathsFor(nodeA)).toEqual([outA])
+      release()
+      return Promise.resolve()
+    })
+    await Promise.all([runA, runB])
+    expect(pathsInA).toEqual([outA])
+    expect(judgedInA).toBe(true)
+    expect(redirectTargetJudged(outA.virtual)).toBe(false)
+    expect(redirectPathsFor(nodeA)).toEqual([])
   })
 })

--- a/typescript/packages/core/src/observe/context.ts
+++ b/typescript/packages/core/src/observe/context.ts
@@ -158,11 +158,21 @@ export function runWithRevisions<T>(
 /**
  * Look up the active revision pin for `path`, or null if no pin is
  * installed (or no revisions context is active).
+ *
+ * Every live frame's map is searched, because pins are mount state
+ * threaded through the context only for reach: each bind hands over
+ * the mount's own map, keyed by full virtual path, so a hit is never
+ * another task's different pin — the same mount binds the same map,
+ * and another mount's map cannot hold this path. On the fallback
+ * storage this is what keeps a pinned read pinned while an unpinned
+ * op's frame shadows the newest slot.
  */
 export function revisionFor(path: string): string | null {
-  const map = revisionsStorage.getStore()?.map
-  if (!map) return null
-  return map.get(path) ?? null
+  for (const state of revisionsStorage.liveStores()) {
+    const pin = state.map?.get(path)
+    if (pin !== undefined) return pin
+  }
+  return null
 }
 
 // Backends name the mount-relative path ('/report.json') and a few name the

--- a/typescript/packages/core/src/observe/context_fallback.test.ts
+++ b/typescript/packages/core/src/observe/context_fallback.test.ts
@@ -1,0 +1,84 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it, vi } from 'vitest'
+import { record, revisionFor, runWithRecording, runWithRevisions } from './context.ts'
+import type * as asyncContextModule from '../utils/async_context.ts'
+
+// The browser-runtime branch under node's test runner: the real
+// FallbackStorage, no task isolation.
+vi.mock('../utils/async_context.ts', async (importOriginal) => {
+  const real = await importOriginal<typeof asyncContextModule>()
+  return {
+    ...real,
+    asyncContextIsolatesTasks: false,
+    createAsyncContext<T>() {
+      return new real.FallbackStorage<T>()
+    },
+  }
+})
+
+function gate(): [Promise<void>, () => void] {
+  let release!: () => void
+  const held = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return [held, release]
+}
+
+describe('revision pins on the fallback storage', () => {
+  it('a pinned read stays pinned while an unpinned frame shadows it', async () => {
+    // Pins are mount state handed over per bind, so every live frame's
+    // map is searched: the unpinned op's null frame sits on top and
+    // contributes nothing, and the pinned mount's map answers from
+    // beneath it, where the slot's newest-wins read answered null.
+    const pins = new Map([['/s3/report.json', 'r7']])
+    const [holdPinned, releasePinned] = gate()
+    const [holdNull, releaseNull] = gate()
+    let beneathNull: string | null = null
+    const pinned = runWithRevisions(pins, async () => {
+      await holdPinned
+      beneathNull = revisionFor('/s3/report.json')
+      releaseNull()
+    })
+    const unpinned = runWithRevisions(null, async () => {
+      releasePinned()
+      await holdNull
+    })
+    await Promise.all([pinned, unpinned])
+    expect(beneathNull).toBe('r7')
+    expect(revisionFor('/s3/report.json')).toBeNull()
+  })
+})
+
+describe('recording on the fallback storage', () => {
+  it('a record lands after a concurrent recording settles', async () => {
+    // The slot's restore dropped every record written after a
+    // concurrent line finished: the recorder read as absent and
+    // `record` returned silently. The frame stack keeps the live
+    // line's recorder until its own settle.
+    const [hold, release] = gate()
+    const first = runWithRecording(async () => {
+      await hold
+    })
+    const [, records] = await runWithRecording(async () => {
+      release()
+      await first
+      record('read', '/x', 'test', 3, performance.now())
+    })
+    expect(records).toHaveLength(1)
+    expect(records[0]?.path).toBe('/x')
+    await first
+  })
+})

--- a/typescript/packages/core/src/utils/async_context.test.ts
+++ b/typescript/packages/core/src/utils/async_context.test.ts
@@ -1,0 +1,167 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FallbackStorage, asyncContextIsolatesTasks, createAsyncContext } from './async_context.ts'
+
+describe('the resolved storage on node', () => {
+  it('isolates two overlapping runs, which is what the flag claims', async () => {
+    expect(asyncContextIsolatesTasks).toBe(true)
+    const ctx = createAsyncContext<number>()
+    const reads = await Promise.all([
+      ctx.run(1, async () => {
+        await Promise.resolve()
+        return ctx.getStore()
+      }),
+      ctx.run(2, async () => {
+        await Promise.resolve()
+        return ctx.getStore()
+      }),
+    ])
+    expect(reads).toEqual([1, 2])
+  })
+
+  it('liveStores answers the current task alone', async () => {
+    const ctx = createAsyncContext<string>()
+    expect(ctx.liveStores()).toEqual([])
+    await ctx.run('mine', async () => {
+      await Promise.resolve()
+      expect(ctx.liveStores()).toEqual(['mine'])
+    })
+    expect(ctx.liveStores()).toEqual([])
+  })
+})
+
+describe('the fallback frame stack', () => {
+  it('nested runs answer innermost and unwind outward', async () => {
+    const ctx = new FallbackStorage<string>()
+    await ctx.run('outer', async () => {
+      expect(ctx.getStore()).toBe('outer')
+      await ctx.run('inner', () => {
+        expect(ctx.getStore()).toBe('inner')
+        expect(ctx.liveStores()).toEqual(['outer', 'inner'])
+        return Promise.resolve()
+      })
+      expect(ctx.getStore()).toBe('outer')
+    })
+    expect(ctx.getStore()).toBeUndefined()
+  })
+
+  it('an out-of-order settle neither wipes a live frame nor strands a stale one', async () => {
+    // The single-slot restore this replaces failed both halves: the
+    // first-bound run's settle blind-restored its saved value (wiping
+    // the still-live second binding to undefined), and the second's
+    // settle then restored the first's store into a context where
+    // nothing ran any more.
+    const ctx = new FallbackStorage<string>()
+    let releaseFirst!: () => void
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let seenAfterFirstSettled: string | undefined
+    const first = ctx.run('first', async () => {
+      await holdFirst
+    })
+    const second = ctx.run('second', async () => {
+      releaseFirst()
+      await first
+      seenAfterFirstSettled = ctx.getStore()
+    })
+    await second
+    expect(seenAfterFirstSettled).toBe('second')
+    expect(ctx.getStore()).toBeUndefined()
+    expect(ctx.liveStores()).toEqual([])
+  })
+
+  it('a throwing sync fn and a rejecting promise both drop their frames', async () => {
+    const ctx = new FallbackStorage<string>()
+    expect(() =>
+      ctx.run('sync', () => {
+        throw new Error('boom')
+      }),
+    ).toThrow('boom')
+    expect(ctx.liveStores()).toEqual([])
+    await expect(
+      Promise.resolve(ctx.run('async', () => Promise.reject(new Error('boom')))),
+    ).rejects.toThrow('boom')
+    expect(ctx.liveStores()).toEqual([])
+  })
+
+  it('rebinding one value twice releases one frame per settle', async () => {
+    const ctx = new FallbackStorage<string>()
+    await ctx.run('same', async () => {
+      await ctx.run('same', () => {
+        expect(ctx.liveStores()).toEqual(['same', 'same'])
+        return Promise.resolve()
+      })
+      expect(ctx.liveStores()).toEqual(['same'])
+    })
+    expect(ctx.liveStores()).toEqual([])
+  })
+})
+
+describe('the isolation probe', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('refuses a non-isolating AsyncLocalStorage polyfill on globalThis', async () => {
+    // The bundler-shim shape: right constructor name, single slot. A
+    // constructor-identity check would trust it and disarm every
+    // fallback hardening; the behavioral probe must not.
+    class SlotShim<T> {
+      private store: T | undefined
+
+      run<R>(s: T, fn: () => R | Promise<R>): R | Promise<R> {
+        const prev = this.store
+        this.store = s
+        const result = fn()
+        if (result instanceof Promise) {
+          return result.finally(() => {
+            this.store = prev
+          })
+        }
+        this.store = prev
+        return result
+      }
+
+      getStore(): T | undefined {
+        return this.store
+      }
+    }
+    vi.stubGlobal('AsyncLocalStorage', SlotShim)
+    vi.resetModules()
+    const fresh = await import('./async_context.ts')
+    expect(fresh.asyncContextIsolatesTasks).toBe(false)
+    expect(fresh.createAsyncContext()).toBeInstanceOf(fresh.FallbackStorage)
+  })
+
+  it('refuses a polyfill that throws', async () => {
+    class ThrowingShim {
+      run(): never {
+        throw new Error('not implemented')
+      }
+
+      getStore(): never {
+        throw new Error('not implemented')
+      }
+    }
+    vi.stubGlobal('AsyncLocalStorage', ThrowingShim)
+    vi.resetModules()
+    const fresh = await import('./async_context.ts')
+    expect(fresh.asyncContextIsolatesTasks).toBe(false)
+    expect(fresh.createAsyncContext()).toBeInstanceOf(fresh.FallbackStorage)
+  })
+})

--- a/typescript/packages/core/src/utils/async_context.ts
+++ b/typescript/packages/core/src/utils/async_context.ts
@@ -15,37 +15,94 @@
 export interface AsyncStorage<T> {
   run<R>(store: T, fn: () => R | Promise<R>): R | Promise<R>
   getStore(): T | undefined
+  /**
+   * Every store bound by a live `run`, oldest first.
+   *
+   * On an isolating runtime that is the current task's store alone,
+   * because `AsyncLocalStorage` cannot enumerate other tasks and the
+   * isolated world never needs it to. On the fallback it is the honest
+   * answer the single slot cannot give — all concurrently live
+   * bindings — so a reader can merge conservatively instead of
+   * trusting whichever binding happens to sit in the slot. The array
+   * is a snapshot; it does not track later binds or settles.
+   */
+  liveStores(): readonly T[]
 }
 
-type ALSCtor = new <T>() => AsyncStorage<T>
+interface TaskStorage<T> {
+  run<R>(store: T, fn: () => R | Promise<R>): R | Promise<R>
+  getStore(): T | undefined
+}
 
-class FallbackStorage<T> implements AsyncStorage<T> {
-  private store: T | undefined
+type ALSCtor = new <T>() => TaskStorage<T>
+
+/**
+ * The browser storage: no task isolation, one frame stack per storage.
+ *
+ * `getStore` answers the newest live frame, so a read that interleaves
+ * with another task's bind can still see that task's store — only real
+ * isolation fixes that, which is what `liveStores` exists to route
+ * around. What the stack does fix is the slot's two worse failures: a
+ * settle removes its own frame rather than blind-restoring a saved
+ * value, so an out-of-order settle can neither wipe a binding that is
+ * still live nor strand a stale one after every run has finished.
+ *
+ * Exported for the fallback-mode tests, which mock `createAsyncContext`
+ * with this class so the browser branch runs under node's test runner.
+ */
+export class FallbackStorage<T> implements AsyncStorage<T> {
+  private frames: T[] = []
 
   run<R>(s: T, fn: () => R | Promise<R>): R | Promise<R> {
-    const prev = this.store
-    this.store = s
+    this.frames.push(s)
+    const drop = (): void => {
+      const at = this.frames.lastIndexOf(s)
+      if (at >= 0) this.frames.splice(at, 1)
+    }
     try {
       const result = fn()
       if (result instanceof Promise) {
-        return result.finally(() => {
-          this.store = prev
-        })
+        return result.finally(drop)
       }
-      this.store = prev
+      drop()
       return result
     } catch (err) {
-      this.store = prev
+      drop()
       throw err
     }
   }
 
   getStore(): T | undefined {
-    return this.store
+    return this.frames.length === 0 ? undefined : this.frames[this.frames.length - 1]
+  }
+
+  liveStores(): readonly T[] {
+    return this.frames.slice()
   }
 }
 
-async function resolveCtor(): Promise<ALSCtor> {
+class IsolatedStorage<T> implements AsyncStorage<T> {
+  private readonly tasks: TaskStorage<T>
+
+  constructor(ctor: ALSCtor) {
+    this.tasks = new ctor<T>()
+  }
+
+  run<R>(store: T, fn: () => R | Promise<R>): R | Promise<R> {
+    return this.tasks.run(store, fn)
+  }
+
+  getStore(): T | undefined {
+    return this.tasks.getStore()
+  }
+
+  liveStores(): readonly T[] {
+    const store = this.tasks.getStore()
+    return store === undefined ? [] : [store]
+  }
+}
+
+async function resolveCtor(): Promise<ALSCtor | null> {
   const g = globalThis as unknown as {
     AsyncLocalStorage?: ALSCtor
     process?: { versions?: { node?: string } }
@@ -57,26 +114,56 @@ async function resolveCtor(): Promise<ALSCtor> {
       const mod = (await import(/* @vite-ignore */ modName)) as { AsyncLocalStorage: ALSCtor }
       return mod.AsyncLocalStorage
     } catch {
-      return FallbackStorage as ALSCtor
+      return null
     }
   }
-  return FallbackStorage as ALSCtor
+  return null
 }
 
-const AsyncStorageCtor: ALSCtor = await resolveCtor()
+/**
+ * Whether `ctor` actually isolates overlapping tasks.
+ *
+ * Constructor identity is not proof: a bundler's `AsyncLocalStorage`
+ * shim on `globalThis` is typically a single slot, and trusting it
+ * would disarm every fallback hardening while behaving exactly like
+ * the fallback. So the claim is tested: two runs overlap across a
+ * microtask and each must read back its own store. A ctor that throws
+ * anywhere in the probe is answering the same question.
+ */
+async function isolates(ctor: ALSCtor): Promise<boolean> {
+  try {
+    const probe = new ctor<number>()
+    const reads = await Promise.all([
+      probe.run(1, async () => {
+        await Promise.resolve()
+        return probe.getStore()
+      }),
+      probe.run(2, async () => {
+        await Promise.resolve()
+        return probe.getStore()
+      }),
+    ])
+    return reads[0] === 1 && reads[1] === 2
+  } catch {
+    return false
+  }
+}
+
+const resolved = await resolveCtor()
 
 /**
- * Whether the resolved storage isolates concurrent tasks.
+ * Whether the storage isolates concurrent tasks, verified behaviorally
+ * at module load rather than assumed from where the constructor came
+ * from.
  *
  * `AsyncLocalStorage` gives every task its own store. The fallback is
- * one global slot restored when `run`'s promise settles, so work
- * started beside a still-running scope observes that scope's store;
- * a caller that binds a store for concurrent work has to know which
- * it got.
+ * one frame stack whose top a concurrent task can shadow, so a caller
+ * that binds a store for concurrent work has to know which it got.
  */
-export const asyncContextIsolatesTasks: boolean =
-  (AsyncStorageCtor as unknown) !== (FallbackStorage as unknown)
+export const asyncContextIsolatesTasks: boolean = resolved !== null && (await isolates(resolved))
+
+const verifiedCtor: ALSCtor | null = asyncContextIsolatesTasks ? resolved : null
 
 export function createAsyncContext<T>(): AsyncStorage<T> {
-  return new AsyncStorageCtor<T>()
+  return verifiedCtor === null ? new FallbackStorage<T>() : new IsolatedStorage<T>(verifiedCtor)
 }

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
@@ -13,10 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import { runWithSession } from '../../context/session_context.ts'
+import { revisionFor } from '../../observe/context.ts'
 import { OpsRegistry } from '../../ops/registry.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import { Limit, MountMode, PathSpec } from '../../types.ts'
 import { getTestParser } from '../fixtures/workspace_fixture.ts'
+import { Session } from '../session/session.ts'
 import { Workspace } from '../workspace/workspace.ts'
 
 const ENC = new TextEncoder()
@@ -229,4 +232,52 @@ describe('the node table answers every verb that names a link', () => {
       await ws.close()
     }
   })
+})
+
+describe('the fenced remnant cascade rides the mount revisions', () => {
+  it('a fenced backend op reads the pinned revision', async () => {
+    // fencedCall reruns backend ops outside `dispatch`, and Python's
+    // twin routes them through `Mount.execute_op`, which binds the
+    // mount prefix AND the revision pins. A fenced readdir/stat that
+    // reads unpinned answers from the wrong version of a
+    // revision-pinned mount, so the binding is pinned here through the
+    // one public trigger: an rmdir whose only remnants the session
+    // cannot see.
+    const parser = await getTestParser()
+    const ram = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(ram)
+    const ws = new Workspace(
+      { '/ram': ram },
+      { mode: MountMode.WRITE, ops: registry, shellParserFactory: () => Promise.resolve(parser) },
+    )
+    try {
+      await ws.execute('mkdir /ram/d && echo x > /ram/d/h.txt')
+      // Mounting re-registers the resource's ops (workspace.ts), so the
+      // probe wraps readdir only after construction, or it is clobbered.
+      const original = registry.find('readdir', 'ram')
+      if (original === null) throw new Error('ram readdir op missing')
+      const originalFn = original.fn
+      let seen: string | null | undefined
+      registry.register({
+        ...original,
+        fn: (...args: Parameters<typeof originalFn>) => {
+          seen = revisionFor('/ram/d/h.txt')
+          return originalFn(...args)
+        },
+      })
+      const internals = ws as unknown as {
+        registry: { mountFor(path: string): { revisions: Map<string, string> } }
+      }
+      internals.registry.mountFor('/ram/d').revisions.set('/ram/d/h.txt', 'r1')
+      const sess = new Session({
+        sessionId: 'agent',
+        hiddenPaths: { paths: ['/ram/d/h.txt'] },
+      })
+      await runWithSession(sess, () => ws.dispatch('rmdir', '/ram/d'))
+      expect(seen).toBe('r1')
+    } finally {
+      await ws.close()
+    }
+  }, 30_000)
 })

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -68,6 +68,7 @@ import {
   effectivePathMode,
   getCurrentSession,
   hiddenPathsIntersect,
+  liveSessions,
   pathAllowed,
 } from '../../context/session_context.ts'
 import { moveReveals } from '../../utils/hidden.ts'
@@ -204,13 +205,13 @@ export class Dispatcher {
       // (rmR, the remnant rmdir below); relocating it into view is
       // refused. Only a directory has anything below it to re-anchor,
       // so a file source passes.
-      const sess = getCurrentSession()
-      if (
-        sess !== null &&
-        moveReveals(sess.hiddenPaths, sess.shownPaths, path.virtual, dstArg.virtual) &&
-        (await this.movedSourceIsDir(path))
-      ) {
-        throw eacces(path.virtual)
+      for (const sess of liveSessions()) {
+        if (
+          moveReveals(sess.hiddenPaths, sess.shownPaths, path.virtual, dstArg.virtual) &&
+          (await this.movedSourceIsDir(path))
+        ) {
+          throw eacces(path.virtual)
+        }
       }
     }
     if (this.tableAnswers(opName, path.virtual, kwargs)) {
@@ -509,15 +510,22 @@ export class Dispatcher {
         throw erofsReadOnly(`mount at '${spec.virtual}' is read-only`, spec)
       }
     }
+    // The fence reruns backend ops outside `dispatch`, so the revision
+    // pins have to ride here as on the main path above, or a cascade
+    // read answers from the wrong version of a revision-pinned mount.
+    // Python's twin gets both bindings from `Mount.execute_op`.
+    const mount = this.namespace.mountFor(spec.virtual)
     try {
       return await runWithMountPrefix(rstripSlash(mountPrefix), () =>
-        this.opsRegistry.call(
-          opName,
-          resource.kind,
-          resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-          spec,
-          [],
-          this.indexKwargs(resource),
+        runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, () =>
+          this.opsRegistry.call(
+            opName,
+            resource.kind,
+            resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+            spec,
+            [],
+            this.indexKwargs(resource),
+          ),
         ),
       )
     } finally {

--- a/typescript/packages/core/src/workspace/executor/jobs.ts
+++ b/typescript/packages/core/src/workspace/executor/jobs.ts
@@ -136,12 +136,15 @@ export async function handleBackground(
     //
     // A job runs concurrently with the rest of the line, so the bind is
     // only safe where the async context isolates tasks. On the fallback
-    // storage (a browser with no AsyncLocalStorage) it is one global
-    // slot that would stay set while the foreground continues, showing
-    // the job's fork to the rest of the line. There the job's inner
-    // evals resolve by id instead, which is what they did before
-    // ambient sessions existed: a job that leaks into its own nested
-    // eval is narrower than a job that leaks into the whole line.
+    // storage (a browser with no AsyncLocalStorage) the fork's frame
+    // would stay live beside the foreground's under the same owner and
+    // manager, with nothing to say whose read is whose: newest-wins
+    // reads would hand the fork to the rest of the line, and the
+    // restrictive folds would hold the line to the fork's view. There
+    // the job's inner evals resolve by id instead, which is what they
+    // did before ambient sessions existed: a job that leaks into its
+    // own nested eval is narrower than a job that leaks into the whole
+    // line.
     return asyncContextIsolatesTasks ? runWithSession(bgSession, body) : body()
   }
 


### PR DESCRIPTION
## What

A survey of the ambient-state lane (the eight facts Python carries in ContextVars and TypeScript carries in `utils/async_context.ts` storages) found the lane itself deliberately mirrored — and exactly two observable divergences inside it, plus one structural weakness on the TS browser branch. This PR closes all three; every behavior fix carries a pin that was verified red first.

## Divergence 1 — five trello card writes ran on a read-only mount (Python)

TypeScript wires all 8 trello card writes the same way: `write: true` on the registration plus `requireMountWritable` before the client call. Python had drifted to 3 of 8 — `trello card assign`, `label`, `unlabel`, `move` and `update` carried **neither**, and each miss is its own hole:

- Without `write=True`, `Mount.execute_cmd`'s write-command gate (the `strongest_mode_under` check) never fires, so the command runs on a **fully read-only** trello mount. TS refuses with exit 1.
- Without `require_mount_writable()`, a write-granting show carve-out admits the command, and an id-addressed write names no path the per-path mode guard could judge — so nothing refuses it. TS raises EROFS.

The new pin demonstrated the first hole live: on current main, `trello card assign` under a READ mount gate went all the way to the network (HTTP 401 from api.trello.com).

Nothing had ever pinned the *per-command* wiring in either language — the existing tests cover the `require_mount_writable` helper itself — which is how the drift went unseen. `tests/commands/builtin/trello/test_write_guards.py` and `write_guards.test.ts` now hold all 8 in both languages: the registration flag, and an EROFS refusal under a READ gate with per-command valid flags (the guard fires before the client, so no case touches the network).

## Divergence 2 — the fenced remnant cascade read unpinned (TypeScript)

`Dispatcher.fencedCall` (the rmdir-remnant cascade and `movedSourceIsDir`'s probe) bound `runWithMountPrefix` but not `runWithRevisions`, while the main dispatch path binds both — and Python's twin routes these ops through `Mount.execute_op`, which also binds both. On a revision-pinned mount, a fenced `readdir`/`stat` therefore answered from the wrong version in TS and the pinned one in Python. (`dispatcher.py` even names "the TS `fencedCall`" as its co-designed twin, so this was an oversight, not intent.)

The fix mirrors the main path's binding. The pin drives the one public trigger — an rmdir whose only remnants the session cannot see — through a probe op that records `revisionFor` from inside the cascade; it read `null` before the fix and the pinned revision after.

## Part 3 — the browser fallback now protects all eight facts (TypeScript)

Python's ContextVars isolate concurrent tasks by construction. TS matches that on node via `AsyncLocalStorage`, but the browser fallback was **one mutable slot per storage**: two interleaved executions cross-read each other's binding, and the earlier settle blind-restored a saved value — wiping a binding that was still live or stranding a stale one after every run finished. Only 2 of the 8 facts were hardened against that (the mount gate through a bespoke `liveMountGates` list, the background-job session by declining to bind); the session predicates failed **open** (null session ⇒ path allowed), and admission, policies, redirects, cache manager, revisions and the recorder all rode the slot. On top of that, `asyncContextIsolatesTasks` trusted constructor identity, so a bundler's single-slot `AsyncLocalStorage` shim on `globalThis` would silently disarm even those two hardenings.

The fix generalizes the live-list design that already guarded the mount gate into the storage primitive itself, flag-free:

- **`AsyncStorage.liveStores()`** — every store bound by a live `run`, oldest first. On node it is the current task's store as a singleton, so every fold over it computes exactly today's behavior — node semantics are provably unchanged and the hardened path is unconditional (no `asyncContextIsolatesTasks` forks in readers; its one remaining consumer is the jobs decline-to-bind). On the fallback it is the honest answer the slot could not give.
- **`FallbackStorage` is now a frame stack**: `run` pushes, settle removes its *own* frame (`lastIndexOf`), `getStore` answers the top. The wipe and the stale-leak are structurally gone; the residual cross-read is what the per-fact merges below absorb.
- **A behavioral probe replaces constructor trust**: two overlapping runs across a microtask must each read back their own store, at module load. A shim that fails the probe loses to our own fallback instead of silently disarming it.
- **Per-fact merges, each chosen by failure direction** (each exact on node's singleton):
  - *Sessions* — most-restrictive fold: `pathAllowed` must pass every live session, hidden-path checks trip on any, mode/umask/dotglob fold toward the weaker answer. The fail-open null read is gone. `getCurrentSessionFor` recovers exactly by owner identity, newest first.
  - *Admission* — identical gates pass through; disagreeing live gates merge into a synthetic gate (grants intersect, checks conjoin, scoped unions).
  - *Op policies* — newest live non-null wins: under fallback concurrency a suspension yields to a concurrently armed frame, because double-admitting fails closed while disarming fails open.
  - *Mount gate* — the same longest-prefix/tie-takes-weaker loop as before, now over `liveStores()`; the bespoke `liveMountGates` global, `releaseMountGate`, and both flag forks are deleted.
  - *Redirects* — exact by node key; `redirectTargetJudged` unions over live frames.
  - *Cache* — reads abstain to a cold read while live managers disagree (a wrong warm hit is another mount's bytes); invalidations broadcast to every distinct live manager (a dropped invalidation serves stale bytes, an extra one costs a refetch).
  - *Revisions* — every live frame's map is searched; pins are mount state keyed by full virtual path, so this is exact.
  - *Recorder* — stays top-frame (attribution tier, not security); the frame stack alone fixes its wipe/leak.
- **Two security reads converted to folds**: the dispatcher's rename-reveal check and the adapter's `moveWouldReveal` now consult every live session.

Falsifiability: temporarily reverting `FallbackStorage` to the slot (with a degenerate `liveStores()`) turned 20 of the 26 fallback-mode tests red across all four test files; the frame stack restores 51/51 green. The fallback tests mock `createAsyncContext` to force the browser branch under node's runner, and include the specific old failure shapes: the out-of-order wipe, the hide that a shadowing frame used to lift, the record dropped after a concurrent recording settled, and the pinned revision a null frame used to shadow.

Python needs no change for this part — contextvars isolate, and mirroring inert merge scaffolding into a language that cannot need it would be noise.

## What the survey settled without code

- **Both languages share the ambient design on purpose.** All eight facts have twins (`context/session_context`, `cache/context`, `observe/context` in both trees), with comments cross-referencing each other by name. There is no "explicit language" to align to.
- **The dispatcher's ambient session read is the documented conversion point** (`_session_id()` → `OpsContext.session_id`), stated in `policy/builtin/permissions.py`: from the context object onward the fact travels explicitly. Not a defect.
- **The jobs decline-to-bind stays** even with the frame stack: a background fork's frame beside the foreground's under the same owner is indistinguishable — newest-wins reads would hand the fork's session to the foreground line, folds would hold the line to the fork's view. Declining keeps the foreground exact and is documented in place.
- Python restores two facts by set-prev rather than `ContextVar.reset(token)`; both sit inside `Mount.execute_cmd`'s single `finally`, so there is no observable behavior to fix — declined as churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
