### PR TITLE
perf(integ): cut three fixed costs from the integ workflow

### DIFF
--- a/integ/server/notion/mcp.ts
+++ b/integ/server/notion/mcp.ts
@@ -161,11 +161,17 @@ export async function startMockMcpServer(): Promise<{
         server,
         port: address.port,
         close: async () => {
-          await new Promise<void>((ok) =>
+          // `close` only stops new connections and then WAITS for the open
+          // ones, and the MCP client's keep-alive socket is still open by
+          // then, so the wait ran to node's 300s `requestTimeout` and every
+          // teardown cost five idle minutes. Destroy the sockets too; the
+          // callback fires once they are gone.
+          await new Promise<void>((ok) => {
             server.close(() => {
               ok()
-            }),
-          )
+            })
+            server.closeAllConnections()
+          })
           await rest.close()
         },
       })

--- a/python/mirage/accessor/pool.py
+++ b/python/mirage/accessor/pool.py
@@ -1,0 +1,164 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import logging
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _Entry:
+    """One open client and the context manager that releases it.
+
+    The context manager itself, not an AsyncExitStack wrapping it: a stack
+    pops each callback BEFORE invoking it, so once an exit raises or is
+    cancelled that callback is gone and a later attempt silently does
+    nothing. Holding the manager means `__aexit__` can actually be called
+    again, which is what makes a failed release retryable rather than merely
+    remembered.
+
+    Args:
+        client (Any): the open client.
+        manager (AbstractAsyncContextManager): releases the client on exit.
+    """
+    client: Any
+    manager: AbstractAsyncContextManager[Any]
+
+
+class LoopClientCache:
+    """One open client per event loop, opened once and released exactly once.
+
+    A client that costs real time to build is worth keeping, but keeping it
+    turns its lifetime into this object's problem: whatever used to close at
+    the end of every operation no longer does. The whole point of this class
+    is that "opened" and "released" cannot drift apart, so the three ways they
+    did are structural here rather than left to each call site:
+
+    - opening is serialized per loop, so two callers that both miss cannot
+      each open a client and have one of them go untracked;
+    - an entry is dropped only after its release has COMPLETED, so an exit
+      that raises or is cancelled leaves the entry retryable rather than
+      unreachable;
+    - a loop that closed still has its client released, from a later loop,
+      rather than forgotten.
+
+    Clients bind to the loop that opened them, so the key is the loop OBJECT.
+    Never `id(loop)`: CPython reuses the address of a collected loop, so a
+    second `asyncio.run()` can hash to a client belonging to the first run's
+    closed loop.
+    """
+
+    def __init__(self, what: str) -> None:
+        """Build an empty cache.
+
+        Args:
+            what (str): what is being cached, for log lines ("s3").
+        """
+        self.what = what
+        self._entries: dict[asyncio.AbstractEventLoop, _Entry] = {}
+        self._locks: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
+
+    async def get(
+        self, factory: Callable[[], AbstractAsyncContextManager[Any]]
+    ) -> Any:
+        """Return this loop's client, opening one when there is none.
+
+        Args:
+            factory (Callable): builds the client context manager. Called
+                only on a miss, so a hit costs one dict lookup.
+
+        Returns:
+            Any: the open client for the running loop.
+        """
+        loop = asyncio.get_running_loop()
+        await self.release_dead()
+        entry = self._entries.get(loop)
+        if entry is not None:
+            return entry.client
+        # `factory()` may suspend (resolving credentials can reach IMDS or
+        # SSO), so without this two callers that both miss would each open a
+        # client and the loser's manager would never be reachable again.
+        # setdefault is atomic because nothing awaits between the read and the
+        # write, so both callers take the same lock.
+        lock = self._locks.setdefault(loop, asyncio.Lock())
+        async with lock:
+            entry = self._entries.get(loop)
+            if entry is not None:
+                return entry.client
+            manager = factory()
+            client = await manager.__aenter__()
+            self._entries[loop] = _Entry(client=client, manager=manager)
+            return client
+
+    async def _release(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Release one entry, forgetting it only once its exit has finished.
+
+        Args:
+            loop (asyncio.AbstractEventLoop): the loop whose client to close.
+        """
+        entry = self._entries.get(loop)
+        if entry is None:
+            return
+        # The pops come AFTER the await on purpose. Clearing first meant a
+        # cancelled or failing shutdown dropped the entry while its client was
+        # still open, and nothing could retry it.
+        await entry.manager.__aexit__(None, None, None)
+        self._entries.pop(loop, None)
+        self._locks.pop(loop, None)
+
+    async def release_dead(self) -> None:
+        """Close the clients whose loop has gone.
+
+        A closing loop does not run the client's context manager, so an entry
+        left behind is an abandoned connection pool. Exiting the manager from
+        a later loop does work, so close it rather than forgetting it.
+        """
+        for loop in [one for one in self._entries if one.is_closed()]:
+            await self._release_logging(loop)
+
+    async def _release_logging(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Release one entry, reporting a failure instead of raising it.
+
+        Args:
+            loop (asyncio.AbstractEventLoop): the loop whose client to close.
+        """
+        try:
+            await self._release(loop)
+        except Exception as exc:
+            # Not fatal to the caller, and not silent either. The entry stays
+            # in the map, so the next `release_dead` or `close` retries it.
+            logger.debug("%s: releasing a client failed, will retry: %s",
+                         self.what, exc)
+
+    async def close(self) -> None:
+        """Close every client this cache opened.
+
+        One failure must not skip the rest, and must not lose the entry that
+        failed: every loop is attempted and anything still open stays in the
+        map for a later attempt.
+        """
+        for loop in list(self._entries):
+            await self._release_logging(loop)
+
+    def open_count(self) -> int:
+        """Return how many clients are currently held.
+
+        Returns:
+            int: number of open clients.
+        """
+        return len(self._entries)

--- a/python/mirage/accessor/pool.py
+++ b/python/mirage/accessor/pool.py
@@ -20,6 +20,9 @@ from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
+ClientManager = AbstractAsyncContextManager[Any]
+ClientFactory = Callable[[], ClientManager]
+
 
 @dataclass(slots=True)
 class _Entry:
@@ -34,10 +37,10 @@ class _Entry:
 
     Args:
         client (Any): the open client.
-        manager (AbstractAsyncContextManager): releases the client on exit.
+        manager (ClientManager): releases the client on exit.
     """
     client: Any
-    manager: AbstractAsyncContextManager[Any]
+    manager: ClientManager
 
 
 class LoopClientCache:
@@ -46,16 +49,18 @@ class LoopClientCache:
     A client that costs real time to build is worth keeping, but keeping it
     turns its lifetime into this object's problem: whatever used to close at
     the end of every operation no longer does. The whole point of this class
-    is that "opened" and "released" cannot drift apart, so the three ways they
-    did are structural here rather than left to each call site:
+    is that "opened" and "released" cannot drift apart, so every way they can
+    is answered structurally here rather than left to each call site:
 
     - opening is serialized per loop, so two callers that both miss cannot
       each open a client and have one of them go untracked;
-    - an entry is dropped only after its release has COMPLETED, so an exit
-      that raises or is cancelled leaves the entry retryable rather than
-      unreachable;
-    - a loop that closed still has its client released, from a later loop,
-      rather than forgotten.
+    - releasing takes ownership of its entry, so of two callers releasing the
+      same client exactly one runs `__aexit__`, and the entry is put back if
+      that exit does not complete;
+    - a loop that closed leaves nothing behind, whether or not it ever got as
+      far as an open client;
+    - `close` reports a failure rather than logging it, so a caller that
+      records "closed" only records it when everything really is.
 
     Clients bind to the loop that opened them, so the key is the loop OBJECT.
     Never `id(loop)`: CPython reuses the address of a collected loop, so a
@@ -73,13 +78,11 @@ class LoopClientCache:
         self._entries: dict[asyncio.AbstractEventLoop, _Entry] = {}
         self._locks: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
 
-    async def get(
-        self, factory: Callable[[], AbstractAsyncContextManager[Any]]
-    ) -> Any:
+    async def get(self, factory: ClientFactory) -> Any:
         """Return this loop's client, opening one when there is none.
 
         Args:
-            factory (Callable): builds the client context manager. Called
+            factory (ClientFactory): builds the client manager. Called
                 only on a miss, so a hit costs one dict lookup.
 
         Returns:
@@ -106,20 +109,35 @@ class LoopClientCache:
             return client
 
     async def _release(self, loop: asyncio.AbstractEventLoop) -> None:
-        """Release one entry, forgetting it only once its exit has finished.
+        """Release one entry, keeping it if its exit does not finish.
 
         Args:
             loop (asyncio.AbstractEventLoop): the loop whose client to close.
         """
-        entry = self._entries.get(loop)
+        # Popping FIRST is what makes a release exclusive. Nothing awaits
+        # between the lookup and the pop, so of two callers sweeping the same
+        # dead loop one holds the entry and the other finds nothing, instead
+        # of both running `__aexit__` on one client. Putting it back on the
+        # way out is what keeps that safe: an exit that raises or is
+        # cancelled leaves the entry retryable rather than unreachable.
+        entry = self._entries.pop(loop, None)
         if entry is None:
             return
-        # The pops come AFTER the await on purpose. Clearing first meant a
-        # cancelled or failing shutdown dropped the entry while its client was
-        # still open, and nothing could retry it.
-        await entry.manager.__aexit__(None, None, None)
-        self._entries.pop(loop, None)
-        self._locks.pop(loop, None)
+        try:
+            await entry.manager.__aexit__(None, None, None)
+        except BaseException:
+            self._entries[loop] = entry
+            raise
+
+    def _drop_dead_locks(self) -> None:
+        """Forget the locks belonging to loops that have gone.
+
+        Swept by liveness rather than at each site that could strand one: a
+        loop whose `__aenter__` raised holds a lock and no entry, so a sweep
+        that only visited entries would pin every such loop object forever.
+        """
+        for loop in [one for one in self._locks if one.is_closed()]:
+            self._locks.pop(loop, None)
 
     async def release_dead(self) -> None:
         """Close the clients whose loop has gone.
@@ -129,31 +147,43 @@ class LoopClientCache:
         a later loop does work, so close it rather than forgetting it.
         """
         for loop in [one for one in self._entries if one.is_closed()]:
-            await self._release_logging(loop)
-
-    async def _release_logging(self, loop: asyncio.AbstractEventLoop) -> None:
-        """Release one entry, reporting a failure instead of raising it.
-
-        Args:
-            loop (asyncio.AbstractEventLoop): the loop whose client to close.
-        """
-        try:
-            await self._release(loop)
-        except Exception as exc:
-            # Not fatal to the caller, and not silent either. The entry stays
-            # in the map, so the next `release_dead` or `close` retries it.
-            logger.debug("%s: releasing a client failed, will retry: %s",
-                         self.what, exc)
+            try:
+                await self._release(loop)
+            except Exception as exc:
+                # Logged rather than raised, and only here: this runs on the
+                # read path, where a stale client that will not close is no
+                # reason to fail the unrelated operation that noticed it. The
+                # entry stays, and `close` is where a failure is reported.
+                logger.debug(
+                    "%s: releasing a dead loop's client failed, "
+                    "will retry: %s", self.what, exc)
+        self._drop_dead_locks()
 
     async def close(self) -> None:
-        """Close every client this cache opened.
+        """Close every client this cache opened, reporting any failure.
 
-        One failure must not skip the rest, and must not lose the entry that
-        failed: every loop is attempted and anything still open stays in the
-        map for a later attempt.
+        Every loop is attempted before anything is raised, so one failure
+        cannot skip the rest, and the entry that failed stays for a later
+        attempt. The failure is then raised rather than logged, because a
+        caller that swallows it goes on to record itself as closed (see
+        `Resource.close`), and a closed resource returns early the next time,
+        so nothing could ever reach the retained entry again.
+
+        Raises:
+            Exception: the first release failure, once all were attempted.
         """
+        failures: list[Exception] = []
         for loop in list(self._entries):
-            await self._release_logging(loop)
+            try:
+                await self._release(loop)
+            except Exception as exc:
+                failures.append(exc)
+        self._drop_dead_locks()
+        for extra in failures[1:]:
+            logger.debug("%s: releasing a client also failed: %s", self.what,
+                         extra)
+        if failures:
+            raise failures[0]
 
     def open_count(self) -> int:
         """Return how many clients are currently held.

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -57,9 +57,9 @@ class S3Accessor(Accessor):
         # CONSTRUCTION: building a client needs the kwargs helpers in
         # mirage.core.s3.client, and that module imports S3Config from here,
         # so constructing one here would be a cycle.
-        self._stacks: dict[int, AsyncExitStack] = {}
-        self._clients: dict[int, Any] = {}
-        self._locks: dict[int, asyncio.Lock] = {}
+        self._stacks: dict[asyncio.AbstractEventLoop, AsyncExitStack] = {}
+        self._clients: dict[asyncio.AbstractEventLoop, Any] = {}
+        self._locks: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
 
     async def cached_client(
             self, factory: Callable[[],
@@ -73,8 +73,13 @@ class S3Accessor(Accessor):
         Returns:
             Any: the open aioboto3 client for the running loop.
         """
-        key = id(asyncio.get_running_loop())
-        live = self._clients.get(key)
+        loop = asyncio.get_running_loop()
+        # Keyed by the loop OBJECT, never by id(loop): CPython reuses the
+        # address of a collected loop, so a second asyncio.run() could hash to
+        # a client bound to the first run's closed loop. Holding the key also
+        # keeps that reuse impossible.
+        self._drop_closed()
+        live = self._clients.get(loop)
         if live is not None:
             return live
         # Opening is serialized per loop. `factory()` may suspend (resolving
@@ -85,19 +90,32 @@ class S3Accessor(Accessor):
         # nothing awaits between the read and the write, so both callers take
         # the same lock. TypeScript's SSH accessor guards the same way with a
         # cached connectPromise.
-        lock = self._locks.setdefault(key, asyncio.Lock())
+        lock = self._locks.setdefault(loop, asyncio.Lock())
         async with lock:
-            live = self._clients.get(key)
+            live = self._clients.get(loop)
             if live is not None:
                 return live
             stack = AsyncExitStack()
             client = await stack.enter_async_context(factory())
-            self._stacks[key] = stack
-            self._clients[key] = client
+            self._stacks[loop] = stack
+            self._clients[loop] = client
             return client
+
+    def _drop_closed(self) -> None:
+        """Forget clients whose loop is gone.
+
+        Their connections went with the loop, so there is nothing left to
+        close; keeping the entries would only grow the map and hand `close`
+        a stack it cannot await.
+        """
+        for dead in [one for one in self._clients if one.is_closed()]:
+            self._clients.pop(dead, None)
+            self._stacks.pop(dead, None)
+            self._locks.pop(dead, None)
 
     async def close(self) -> None:
         """Close every client this accessor opened."""
+        self._drop_closed()
         stacks = list(self._stacks.values())
         self._stacks.clear()
         self._clients.clear()

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -12,17 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import asyncio
-import logging
-from contextlib import AbstractAsyncContextManager, AsyncExitStack
+from contextlib import AbstractAsyncContextManager
 from typing import Any, Callable
 
 from pydantic import BaseModel, ConfigDict, SecretStr, field_validator
 
 from mirage.accessor.base import Accessor
+from mirage.accessor.pool import LoopClientCache
 from mirage.utils import key_prefix as kp
-
-logger = logging.getLogger(__name__)
 
 
 class S3Config(BaseModel):
@@ -51,89 +48,30 @@ class S3Accessor(Accessor):
     def __init__(self, config: S3Config) -> None:
         self.config = config
         # One live client per event loop, the way GridFSAccessor keeps its
-        # motor client, because an aioboto3 client is bound to the loop that
-        # opened it. Opening one costs ~50ms (botocore builds the S3 service
-        # model and a fresh connection pool), so the old client-per-operation
-        # made every op 24x its own cost.
+        # motor client. Opening one costs ~50ms (botocore builds the S3
+        # service model and a fresh connection pool), so the old
+        # client-per-operation made every op 24x its own cost.
         #
-        # The accessor owns the LIFETIME and the driver owns the
-        # CONSTRUCTION: building a client needs the kwargs helpers in
-        # mirage.core.s3.client, and that module imports S3Config from here,
-        # so constructing one here would be a cycle.
-        self._stacks: dict[asyncio.AbstractEventLoop, AsyncExitStack] = {}
-        self._clients: dict[asyncio.AbstractEventLoop, Any] = {}
-        self._locks: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
+        # The cache owns the lifetime and the driver owns the construction:
+        # building a client needs the kwargs helpers in mirage.core.s3.client,
+        # and that module imports S3Config from here, so constructing one here
+        # would be a cycle.
+        self._clients = LoopClientCache("s3")
 
     async def cached_client(
             self, factory: Callable[[],
                                     AbstractAsyncContextManager[Any]]) -> Any:
-        """Return this loop's live client, opening one when there is none.
+        """Return this loop's open client, opening one when there is none.
 
         Args:
-            factory (Callable): builds the client context manager. Called
-                only on a miss, so a hit costs one dict lookup.
+            factory (Callable): builds the client context manager, called
+                only when this loop has no client yet.
 
         Returns:
             Any: the open aioboto3 client for the running loop.
         """
-        loop = asyncio.get_running_loop()
-        # Keyed by the loop OBJECT, never by id(loop): CPython reuses the
-        # address of a collected loop, so a second asyncio.run() could hash to
-        # a client bound to the first run's closed loop. Holding the key also
-        # keeps that reuse impossible.
-        await self._release_closed()
-        live = self._clients.get(loop)
-        if live is not None:
-            return live
-        # Opening is serialized per loop. `factory()` may suspend (resolving
-        # credentials can reach IMDS or SSO), and two callers that both miss
-        # would then each open a client and each store it under this one key,
-        # so the loser's AsyncExitStack becomes unreachable and `close` can
-        # never close its connection pool. setdefault is atomic here because
-        # nothing awaits between the read and the write, so both callers take
-        # the same lock. TypeScript's SSH accessor guards the same way with a
-        # cached connectPromise.
-        lock = self._locks.setdefault(loop, asyncio.Lock())
-        async with lock:
-            live = self._clients.get(loop)
-            if live is not None:
-                return live
-            stack = AsyncExitStack()
-            client = await stack.enter_async_context(factory())
-            self._stacks[loop] = stack
-            self._clients[loop] = client
-            return client
-
-    async def _release_closed(self) -> None:
-        """Close the clients whose loop has gone.
-
-        A closing loop does not run the client's context manager, so dropping
-        the AsyncExitStack without executing it abandons the aiohttp session
-        and its connector and the connection is never released. Running the
-        stack from a LATER loop does work, so close it rather than forgetting
-        it.
-        """
-        for dead in [one for one in self._clients if one.is_closed()]:
-            stack = self._stacks.pop(dead, None)
-            self._clients.pop(dead, None)
-            self._locks.pop(dead, None)
-            if stack is None:
-                continue
-            try:
-                await stack.aclose()
-            except Exception as exc:
-                # Not fatal to the caller's operation, and not silent either:
-                # the transports belonged to a loop that is gone, so the
-                # sockets are reclaimed when the objects are collected.
-                logger.debug(
-                    "s3: closing a client from a closed loop failed: %s", exc)
+        return await self._clients.get(factory)
 
     async def close(self) -> None:
         """Close every client this accessor opened."""
-        await self._release_closed()
-        stacks = list(self._stacks.values())
-        self._stacks.clear()
-        self._clients.clear()
-        self._locks.clear()
-        for stack in stacks:
-            await stack.aclose()
+        await self._clients.close()

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import logging
 from contextlib import AbstractAsyncContextManager, AsyncExitStack
 from typing import Any, Callable
 
@@ -20,6 +21,8 @@ from pydantic import BaseModel, ConfigDict, SecretStr, field_validator
 
 from mirage.accessor.base import Accessor
 from mirage.utils import key_prefix as kp
+
+logger = logging.getLogger(__name__)
 
 
 class S3Config(BaseModel):
@@ -78,7 +81,7 @@ class S3Accessor(Accessor):
         # address of a collected loop, so a second asyncio.run() could hash to
         # a client bound to the first run's closed loop. Holding the key also
         # keeps that reuse impossible.
-        self._drop_closed()
+        await self._release_closed()
         live = self._clients.get(loop)
         if live is not None:
             return live
@@ -101,21 +104,33 @@ class S3Accessor(Accessor):
             self._clients[loop] = client
             return client
 
-    def _drop_closed(self) -> None:
-        """Forget clients whose loop is gone.
+    async def _release_closed(self) -> None:
+        """Close the clients whose loop has gone.
 
-        Their connections went with the loop, so there is nothing left to
-        close; keeping the entries would only grow the map and hand `close`
-        a stack it cannot await.
+        A closing loop does not run the client's context manager, so dropping
+        the AsyncExitStack without executing it abandons the aiohttp session
+        and its connector and the connection is never released. Running the
+        stack from a LATER loop does work, so close it rather than forgetting
+        it.
         """
         for dead in [one for one in self._clients if one.is_closed()]:
+            stack = self._stacks.pop(dead, None)
             self._clients.pop(dead, None)
-            self._stacks.pop(dead, None)
             self._locks.pop(dead, None)
+            if stack is None:
+                continue
+            try:
+                await stack.aclose()
+            except Exception as exc:
+                # Not fatal to the caller's operation, and not silent either:
+                # the transports belonged to a loop that is gone, so the
+                # sockets are reclaimed when the objects are collected.
+                logger.debug(
+                    "s3: closing a client from a closed loop failed: %s", exc)
 
     async def close(self) -> None:
         """Close every client this accessor opened."""
-        self._drop_closed()
+        await self._release_closed()
         stacks = list(self._stacks.values())
         self._stacks.clear()
         self._clients.clear()

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -12,13 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from contextlib import AbstractAsyncContextManager
-from typing import Any, Callable
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, SecretStr, field_validator
 
 from mirage.accessor.base import Accessor
-from mirage.accessor.pool import LoopClientCache
+from mirage.accessor.pool import ClientFactory, LoopClientCache
 from mirage.utils import key_prefix as kp
 
 
@@ -58,13 +57,11 @@ class S3Accessor(Accessor):
         # would be a cycle.
         self._clients = LoopClientCache("s3")
 
-    async def cached_client(
-            self, factory: Callable[[],
-                                    AbstractAsyncContextManager[Any]]) -> Any:
+    async def cached_client(self, factory: ClientFactory) -> Any:
         """Return this loop's open client, opening one when there is none.
 
         Args:
-            factory (Callable): builds the client context manager, called
+            factory (ClientFactory): builds the client manager, called
                 only when this loop has no client yet.
 
         Returns:

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -12,6 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
+from contextlib import AbstractAsyncContextManager, AsyncExitStack
+from typing import Any, Callable
+
 from pydantic import BaseModel, ConfigDict, SecretStr, field_validator
 
 from mirage.accessor.base import Accessor
@@ -43,3 +47,45 @@ class S3Accessor(Accessor):
 
     def __init__(self, config: S3Config) -> None:
         self.config = config
+        # One live client per event loop, the way GridFSAccessor keeps its
+        # motor client, because an aioboto3 client is bound to the loop that
+        # opened it. Opening one costs ~50ms (botocore builds the S3 service
+        # model and a fresh connection pool), so the old client-per-operation
+        # made every op 24x its own cost.
+        #
+        # The accessor owns the LIFETIME and the driver owns the
+        # CONSTRUCTION: building a client needs the kwargs helpers in
+        # mirage.core.s3.client, and that module imports S3Config from here,
+        # so constructing one here would be a cycle.
+        self._stacks: dict[int, AsyncExitStack] = {}
+        self._clients: dict[int, Any] = {}
+
+    async def cached_client(
+            self, factory: Callable[[],
+                                    AbstractAsyncContextManager[Any]]) -> Any:
+        """Return this loop's live client, opening one when there is none.
+
+        Args:
+            factory (Callable): builds the client context manager. Called
+                only on a miss, so a hit costs one dict lookup.
+
+        Returns:
+            Any: the open aioboto3 client for the running loop.
+        """
+        key = id(asyncio.get_running_loop())
+        live = self._clients.get(key)
+        if live is not None:
+            return live
+        stack = AsyncExitStack()
+        client = await stack.enter_async_context(factory())
+        self._stacks[key] = stack
+        self._clients[key] = client
+        return client
+
+    async def close(self) -> None:
+        """Close every client this accessor opened."""
+        stacks = list(self._stacks.values())
+        self._stacks.clear()
+        self._clients.clear()
+        for stack in stacks:
+            await stack.aclose()

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -59,6 +59,7 @@ class S3Accessor(Accessor):
         # so constructing one here would be a cycle.
         self._stacks: dict[int, AsyncExitStack] = {}
         self._clients: dict[int, Any] = {}
+        self._locks: dict[int, asyncio.Lock] = {}
 
     async def cached_client(
             self, factory: Callable[[],
@@ -76,16 +77,30 @@ class S3Accessor(Accessor):
         live = self._clients.get(key)
         if live is not None:
             return live
-        stack = AsyncExitStack()
-        client = await stack.enter_async_context(factory())
-        self._stacks[key] = stack
-        self._clients[key] = client
-        return client
+        # Opening is serialized per loop. `factory()` may suspend (resolving
+        # credentials can reach IMDS or SSO), and two callers that both miss
+        # would then each open a client and each store it under this one key,
+        # so the loser's AsyncExitStack becomes unreachable and `close` can
+        # never close its connection pool. setdefault is atomic here because
+        # nothing awaits between the read and the write, so both callers take
+        # the same lock. TypeScript's SSH accessor guards the same way with a
+        # cached connectPromise.
+        lock = self._locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            live = self._clients.get(key)
+            if live is not None:
+                return live
+            stack = AsyncExitStack()
+            client = await stack.enter_async_context(factory())
+            self._stacks[key] = stack
+            self._clients[key] = client
+            return client
 
     async def close(self) -> None:
         """Close every client this accessor opened."""
         stacks = list(self._stacks.values())
         self._stacks.clear()
         self._clients.clear()
+        self._locks.clear()
         for stack in stacks:
             await stack.aclose()

--- a/python/mirage/core/s3/client.py
+++ b/python/mirage/core/s3/client.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import AsyncIterator
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any
 
 import aioboto3
@@ -75,3 +77,30 @@ def _client_kwargs(config: S3Config) -> dict[str, Any]:
 
 def async_session(config: S3Config) -> aioboto3.Session:
     return aioboto3.Session(profile_name=config.aws_profile or None)
+
+
+@asynccontextmanager
+async def closing_body(body: Any) -> AsyncIterator[Any]:
+    """Yield a streaming body and release it however that body can be released.
+
+    The client outlives a single operation now that it is cached on the
+    accessor, so a read that raises or is cancelled before EOF no longer has
+    its connection reclaimed by the client closing. Each caller has to hand
+    the pool slot back itself, or a few transport failures exhaust the pool
+    and every later operation blocks waiting for a connection.
+
+    Args:
+        body (Any): the response body, which may be an async context manager
+            or may only offer a plain ``close``.
+
+    Yields:
+        Any: the same body, released on exit.
+    """
+    async with AsyncExitStack() as stack:
+        if hasattr(body, "__aenter__") and hasattr(body, "__aexit__"):
+            await stack.enter_async_context(body)
+        else:
+            close = getattr(body, "close", None)
+            if close is not None:
+                stack.callback(close)
+        yield body

--- a/python/mirage/core/s3/driver.py
+++ b/python/mirage/core/s3/driver.py
@@ -20,7 +20,8 @@ from typing import Any
 from mirage.accessor.s3 import S3Accessor, S3Config
 from mirage.core.object_store.driver import (ChildEntry, ObjectMeta,
                                              ObjectStoreDriver, TreeEntry)
-from mirage.core.s3.client import _client_kwargs, async_session, is_not_found
+from mirage.core.s3.client import (_client_kwargs, async_session, closing_body,
+                                   is_not_found)
 from mirage.core.s3.constants import SCOPE_ERROR
 from mirage.core.timeutil import to_iso_z
 
@@ -127,7 +128,8 @@ async def _get(conn: S3Conn, key: str) -> bytes | None:
         if is_not_found(exc):
             return None
         raise
-    data: bytes = await resp["Body"].read()
+    async with closing_body(resp["Body"]) as body:
+        data: bytes = await body.read()
     return data
 
 

--- a/python/mirage/core/s3/driver.py
+++ b/python/mirage/core/s3/driver.py
@@ -45,9 +45,13 @@ def _key_prefix_of(accessor: S3Accessor) -> str:
 
 @asynccontextmanager
 async def _connect(accessor: S3Accessor) -> AsyncIterator[S3Conn]:
-    session = async_session(accessor.config)
-    async with session.client(**_client_kwargs(accessor.config)) as client:
-        yield S3Conn(client=client, config=accessor.config)
+    # The client lives on the accessor and is closed with it, which is what
+    # the driver contract means by "a store holding a live client on its
+    # accessor". Opening one per operation cost ~49ms against ~2ms for a
+    # reused one, so a battery of small ops paid the client, not the request.
+    client = await accessor.cached_client(lambda: async_session(
+        accessor.config).client(**_client_kwargs(accessor.config)))
+    yield S3Conn(client=client, config=accessor.config)
 
 
 async def _list_children(conn: S3Conn, pfx: str) -> AsyncIterator[ChildEntry]:

--- a/python/mirage/core/s3/read.py
+++ b/python/mirage/core/s3/read.py
@@ -17,7 +17,8 @@ from typing import Any
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.s3.client import _client_kwargs, _key, async_session
+from mirage.core.s3.client import (_client_kwargs, _key, async_session,
+                                   closing_body)
 from mirage.observe.context import record, revision_for
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
@@ -77,7 +78,8 @@ async def read_bytes(accessor: S3Accessor,
     start_ms = int(time.monotonic() * 1000)
     try:
         resp = await client.get_object(**kwargs)
-        data = await resp["Body"].read()
+        async with closing_body(resp["Body"]) as body:
+            data = await body.read()
         fingerprint, revision = _fp_rev_from_response(resp)
         record("read",
                path,

--- a/python/mirage/core/s3/read.py
+++ b/python/mirage/core/s3/read.py
@@ -69,21 +69,24 @@ async def read_bytes(accessor: S3Accessor,
     window = range_header(offset, size)
     if window is not None:
         kwargs["Range"] = window
-    session = async_session(config)
+    # The accessor's cached client, not a fresh one: opening a client costs
+    # ~160ms against ~2ms for a reused one, so a read-heavy battery paid the
+    # client rather than the request.
+    client = await accessor.cached_client(
+        lambda: async_session(config).client(**_client_kwargs(config)))
     start_ms = int(time.monotonic() * 1000)
     try:
-        async with session.client(**_client_kwargs(config)) as client:
-            resp = await client.get_object(**kwargs)
-            data = await resp["Body"].read()
-            fingerprint, revision = _fp_rev_from_response(resp)
-            record("read",
-                   path,
-                   "s3",
-                   len(data),
-                   start_ms,
-                   fingerprint=fingerprint,
-                   revision=revision)
-            return data
+        resp = await client.get_object(**kwargs)
+        data = await resp["Body"].read()
+        fingerprint, revision = _fp_rev_from_response(resp)
+        record("read",
+               path,
+               "s3",
+               len(data),
+               start_ms,
+               fingerprint=fingerprint,
+               revision=revision)
+        return data
     except Exception as exc:
         if (hasattr(exc, "response")
                 and exc.response.get("Error", {}).get("Code") == "NoSuchKey"):

--- a/python/mirage/core/s3/stream.py
+++ b/python/mirage/core/s3/stream.py
@@ -51,36 +51,39 @@ async def read_stream(
     pinned_revision = revision_for(virtual)
     config = accessor.config
     rec = record_stream("read", path, "s3")
-    session = async_session(config)
-    async with session.client(**_client_kwargs(config)) as client:
-        kwargs: dict[str, Any] = {
-            "Bucket": config.bucket,
-            "Key": _key(path, config)
-        }
-        if pinned_revision is not None:
-            kwargs["VersionId"] = pinned_revision
-        try:
-            response = await client.get_object(**kwargs)
-        except Exception as exc:
-            if _is_not_found(exc):
-                raise enoent(virtual) from exc
-            raise
-        if rec is not None:
-            fingerprint, revision = _fp_rev_from_response(response)
-            rec.fingerprint = fingerprint
-            rec.revision = revision
-        body = response["Body"]
-        async with AsyncExitStack() as stack:
-            if hasattr(body, "__aenter__") and hasattr(body, "__aexit__"):
-                await stack.enter_async_context(body)
-            else:
-                close = getattr(body, "close", None)
-                if close is not None:
-                    stack.callback(close)
-            async for chunk in body.iter_chunks(chunk_size):
-                if rec is not None:
-                    rec.bytes += len(chunk)
-                yield chunk
+    # The accessor's cached client, not a fresh one. It outlives this
+    # generator, which is what a stream needs: the body is consumed after
+    # the call that produced it returns.
+    client = await accessor.cached_client(
+        lambda: async_session(config).client(**_client_kwargs(config)))
+    kwargs: dict[str, Any] = {
+        "Bucket": config.bucket,
+        "Key": _key(path, config)
+    }
+    if pinned_revision is not None:
+        kwargs["VersionId"] = pinned_revision
+    try:
+        response = await client.get_object(**kwargs)
+    except Exception as exc:
+        if _is_not_found(exc):
+            raise enoent(virtual) from exc
+        raise
+    if rec is not None:
+        fingerprint, revision = _fp_rev_from_response(response)
+        rec.fingerprint = fingerprint
+        rec.revision = revision
+    body = response["Body"]
+    async with AsyncExitStack() as stack:
+        if hasattr(body, "__aenter__") and hasattr(body, "__aexit__"):
+            await stack.enter_async_context(body)
+        else:
+            close = getattr(body, "close", None)
+            if close is not None:
+                stack.callback(close)
+        async for chunk in body.iter_chunks(chunk_size):
+            if rec is not None:
+                rec.bytes += len(chunk)
+            yield chunk
 
 
 async def range_read(accessor: S3Accessor, path_spec: PathSpec, start: int,

--- a/python/mirage/core/s3/watch.py
+++ b/python/mirage/core/s3/watch.py
@@ -58,36 +58,36 @@ class S3Walk:
         base = (stem + "/") if stem else ""
         files: list[str] = []
         markers: list[str] = []
-        session = async_session(config)
-        async with session.client(**_client_kwargs(config)) as client:
-            paginator = client.get_paginator("list_objects_v2")
-            async for page in paginator.paginate(Bucket=config.bucket,
-                                                 Prefix=stem):
-                for obj in page.get("Contents") or []:
-                    okey = obj["Key"]
-                    if not (okey == stem or okey.startswith(base)):
-                        continue
-                    relative = _strip_prefix(okey, config)
-                    virtual = (prefix.rstrip("/") + "/" +
-                               relative.lstrip("/") if prefix else "/" +
-                               relative.lstrip("/"))
-                    if okey.endswith("/"):
-                        # A directory marker: mirage's own mkdir writes
-                        # one. It carries an ETag and a size, but it is
-                        # not a file, so synth_dirs reports it instead.
-                        markers.append(virtual.rstrip("/"))
-                        continue
-                    files.append(virtual)
-                    last_mod = obj.get("LastModified")
-                    modified = to_iso_z(last_mod) if last_mod else None
-                    size = obj.get("Size")
-                    etag = (obj.get("ETag") or "").strip('"') or None
-                    yield WalkEntry(virtual=virtual,
-                                    is_dir=False,
-                                    fingerprint=stat_fingerprint(
-                                        etag, modified, size),
-                                    size=size,
-                                    modified=modified)
+        client = await self._accessor.cached_client(
+            lambda: async_session(config).client(**_client_kwargs(config)))
+        paginator = client.get_paginator("list_objects_v2")
+        async for page in paginator.paginate(Bucket=config.bucket,
+                                             Prefix=stem):
+            for obj in page.get("Contents") or []:
+                okey = obj["Key"]
+                if not (okey == stem or okey.startswith(base)):
+                    continue
+                relative = _strip_prefix(okey, config)
+                virtual = (prefix.rstrip("/") + "/" +
+                           relative.lstrip("/") if prefix else "/" +
+                           relative.lstrip("/"))
+                if okey.endswith("/"):
+                    # A directory marker: mirage's own mkdir writes
+                    # one. It carries an ETag and a size, but it is
+                    # not a file, so synth_dirs reports it instead.
+                    markers.append(virtual.rstrip("/"))
+                    continue
+                files.append(virtual)
+                last_mod = obj.get("LastModified")
+                modified = to_iso_z(last_mod) if last_mod else None
+                size = obj.get("Size")
+                etag = (obj.get("ETag") or "").strip('"') or None
+                yield WalkEntry(virtual=virtual,
+                                is_dir=False,
+                                fingerprint=stat_fingerprint(
+                                    etag, modified, size),
+                                size=size,
+                                modified=modified)
         for entry in synth_dirs(root.virtual, files, markers):
             yield entry
 

--- a/python/tests/accessor/test_pool.py
+++ b/python/tests/accessor/test_pool.py
@@ -1,0 +1,202 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+import pytest
+
+from mirage.accessor.pool import LoopClientCache
+
+
+class Stub:
+    """A client that records its own open and release.
+
+    A class, not an @asynccontextmanager generator: a generator's `finally`
+    runs when the generator is collected, which reports a released client even
+    when the cache abandoned it, and hides exactly the bug these tests exist
+    to catch.
+
+    Args:
+        opened (list): receives this client's id when it opens.
+        released (list): receives this client's id when it is released.
+        counter (list): single-item id source, so ids are stable.
+        fail_release (bool): raise from __aexit__ once, to model a shutdown
+            that is cancelled or errors.
+        slow_open (bool): suspend inside __aenter__, opening the window two
+            concurrent callers race in.
+    """
+
+    def __init__(self, opened, released, counter, fail_release=False,
+                 slow_open=False) -> None:
+        self.opened = opened
+        self.released = released
+        self.counter = counter
+        self.fail_release = fail_release
+        self.slow_open = slow_open
+        self.ident = -1
+
+    async def __aenter__(self) -> str:
+        if self.slow_open:
+            await asyncio.sleep(0.01)
+        self.ident = self.counter[0]
+        self.counter[0] += 1
+        self.opened.append(self.ident)
+        return f"client-{self.ident}"
+
+    async def __aexit__(self, *exc) -> bool:
+        if self.fail_release:
+            self.fail_release = False
+            raise RuntimeError("release failed")
+        self.released.append(self.ident)
+        return False
+
+
+def _stub(opened, released, counter, **kw):
+    return lambda: Stub(opened, released, counter, **kw)
+
+
+def test_hit_reuses_one_client():
+    opened, released, counter = [], [], [0]
+    cache = LoopClientCache("test")
+
+    async def go():
+        first = await cache.get(_stub(opened, released, counter))
+        second = await cache.get(_stub(opened, released, counter))
+        assert first == second
+        await cache.close()
+
+    asyncio.run(go())
+    assert opened == [0]
+    assert released == [0]
+
+
+def test_concurrent_miss_opens_exactly_one():
+    """Two callers that both miss must not each open a client.
+
+    The loser's stack would be unreachable, so its connection pool could never
+    be closed.
+    """
+    opened, released, counter = [], [], [0]
+    cache = LoopClientCache("test")
+
+    async def go():
+        got = await asyncio.gather(
+            *[cache.get(_stub(opened, released, counter, slow_open=True))
+              for _ in range(5)])
+        assert len(set(got)) == 1
+        await cache.close()
+
+    asyncio.run(go())
+    assert opened == [0]
+    assert released == [0]
+
+
+def test_client_from_a_closed_loop_is_released_not_forgotten():
+    """A closing loop does not run the client's context manager.
+
+    Dropping the entry would abandon the connection pool, so the cache has to
+    release it from the later loop.
+    """
+    opened, released, counter = [], [], [0]
+    cache = LoopClientCache("test")
+
+    async def step():
+        await cache.get(_stub(opened, released, counter))
+
+    for _ in range(3):
+        asyncio.run(step())
+    asyncio.run(cache.close())
+
+    assert opened == [0, 1, 2]
+    assert released == [0, 1, 2]
+    assert cache.open_count() == 0
+
+
+def test_a_failed_release_keeps_the_entry_retryable():
+    """A release that raises must not lose the client.
+
+    Clearing the map first meant a cancelled or failing shutdown dropped an
+    entry whose client was still open, and nothing could retry it.
+    """
+    opened, released, counter = [], [], [0]
+    cache = LoopClientCache("test")
+
+    async def go():
+        await cache.get(_stub(opened, released, counter, fail_release=True))
+        await cache.close()
+        assert cache.open_count() == 1, "a failed release must keep the entry"
+        assert released == []
+        # The manager is held rather than wrapped in an AsyncExitStack, so the
+        # retry really re-invokes __aexit__ instead of finding a spent stack.
+        await cache.close()
+        assert cache.open_count() == 0
+        assert released == [0]
+
+    asyncio.run(go())
+
+
+def test_a_failed_release_does_not_strand_the_other_loops():
+    """One client failing to release must not cost the others theirs.
+
+    The entry that failed stays, and because `release_dead` runs on every
+    `get`, the next operation retries it: all three end up released rather
+    than one failure stranding the rest.
+    """
+    opened, released, counter = [], [], [0]
+    cache = LoopClientCache("test")
+    fail_first = [True]
+
+    async def step():
+        await cache.get(
+            _stub(opened, released, counter, fail_release=fail_first[0]))
+        fail_first[0] = False
+
+    for _ in range(3):
+        asyncio.run(step())
+    asyncio.run(cache.close())
+
+    assert opened == [0, 1, 2]
+    assert sorted(released) == [0, 1, 2], "a failed release stranded a client"
+    assert cache.open_count() == 0
+
+
+def test_key_is_the_loop_object_not_its_id():
+    """Two runs must not share a client because ids collide.
+
+    CPython reuses the address of a collected loop, so keying on `id(loop)`
+    could hand the second run a client bound to the first run's closed loop.
+    """
+    opened, released, counter = [], [], [0]
+    cache = LoopClientCache("test")
+    seen = []
+
+    async def step():
+        seen.append(await cache.get(_stub(opened, released, counter)))
+
+    asyncio.run(step())
+    asyncio.run(step())
+    assert seen[0] != seen[1], "each run needs its own client"
+    asyncio.run(cache.close())
+    assert sorted(released) == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_open_count_reports_live_clients():
+    opened, released, counter = [], [], [0]
+    cache = LoopClientCache("test")
+    assert cache.open_count() == 0
+    await cache.get(_stub(opened, released, counter))
+    assert cache.open_count() == 1
+    await cache.close()
+    assert cache.open_count() == 0

--- a/python/tests/accessor/test_pool.py
+++ b/python/tests/accessor/test_pool.py
@@ -27,23 +27,38 @@ class Stub:
     when the cache abandoned it, and hides exactly the bug these tests exist
     to catch.
 
+    `released` records every __aexit__ that gets past the failure check, so a
+    client closed twice appears twice.
+
     Args:
         opened (list): receives this client's id when it opens.
         released (list): receives this client's id when it is released.
         counter (list): single-item id source, so ids are stable.
         fail_release (bool): raise from __aexit__ once, to model a shutdown
             that is cancelled or errors.
+        always_fail (bool): raise from __aexit__ every time, to model a
+            client that will not close at all.
         slow_open (bool): suspend inside __aenter__, opening the window two
             concurrent callers race in.
+        slow_exit (bool): suspend inside __aexit__, opening the window two
+            concurrent releases of one client race in.
     """
 
-    def __init__(self, opened, released, counter, fail_release=False,
-                 slow_open=False) -> None:
+    def __init__(self,
+                 opened,
+                 released,
+                 counter,
+                 fail_release=False,
+                 slow_open=False,
+                 slow_exit=False,
+                 always_fail=False) -> None:
         self.opened = opened
         self.released = released
         self.counter = counter
         self.fail_release = fail_release
+        self.always_fail = always_fail
         self.slow_open = slow_open
+        self.slow_exit = slow_exit
         self.ident = -1
 
     async def __aenter__(self) -> str:
@@ -55,10 +70,24 @@ class Stub:
         return f"client-{self.ident}"
 
     async def __aexit__(self, *exc) -> bool:
+        if self.always_fail:
+            raise RuntimeError("release failed")
         if self.fail_release:
             self.fail_release = False
             raise RuntimeError("release failed")
         self.released.append(self.ident)
+        if self.slow_exit:
+            await asyncio.sleep(0.01)
+        return False
+
+
+class Boom:
+    """A client whose open fails, the way a credential lookup does."""
+
+    async def __aenter__(self) -> str:
+        raise RuntimeError("no credentials")
+
+    async def __aexit__(self, *exc) -> bool:
         return False
 
 
@@ -91,9 +120,10 @@ def test_concurrent_miss_opens_exactly_one():
     cache = LoopClientCache("test")
 
     async def go():
-        got = await asyncio.gather(
-            *[cache.get(_stub(opened, released, counter, slow_open=True))
-              for _ in range(5)])
+        got = await asyncio.gather(*[
+            cache.get(_stub(opened, released, counter, slow_open=True))
+            for _ in range(5)
+        ])
         assert len(set(got)) == 1
         await cache.close()
 
@@ -123,6 +153,30 @@ def test_client_from_a_closed_loop_is_released_not_forgotten():
     assert cache.open_count() == 0
 
 
+def test_a_dead_loop_is_released_once_under_concurrent_gets():
+    """Two callers sweeping the same dead loop must not both close it.
+
+    `release_dead` runs before the new loop's lock is taken, so concurrent
+    first operations all reach the same stale entry. A release that removed
+    the entry only after awaiting would run `__aexit__` twice on one client.
+    """
+    opened, released, counter = [], [], [0]
+    cache = LoopClientCache("test")
+
+    async def first():
+        await cache.get(_stub(opened, released, counter, slow_exit=True))
+
+    asyncio.run(first())
+
+    async def second():
+        await asyncio.gather(
+            *[cache.get(_stub(opened, released, counter)) for _ in range(4)])
+        await cache.close()
+
+    asyncio.run(second())
+    assert released == [0, 1], "a client was closed more than once"
+
+
 def test_a_failed_release_keeps_the_entry_retryable():
     """A release that raises must not lose the client.
 
@@ -134,7 +188,8 @@ def test_a_failed_release_keeps_the_entry_retryable():
 
     async def go():
         await cache.get(_stub(opened, released, counter, fail_release=True))
-        await cache.close()
+        with pytest.raises(RuntimeError, match="release failed"):
+            await cache.close()
         assert cache.open_count() == 1, "a failed release must keep the entry"
         assert released == []
         # The manager is held rather than wrapped in an AsyncExitStack, so the
@@ -144,6 +199,35 @@ def test_a_failed_release_keeps_the_entry_retryable():
         assert released == [0]
 
     asyncio.run(go())
+
+
+def test_close_reports_a_failed_release_instead_of_logging_it():
+    """A swallowed failure makes the caller record itself as closed.
+
+    `Resource.close` sets `_closed` once this returns and then returns early
+    forever after, so logging here would mean the retained entry is never
+    reachable again: retryable in this class and permanently leaked in the
+    resource above it.
+    """
+    opened, released, counter = [], [], [0]
+    cache = LoopClientCache("test")
+
+    async def bad():
+        await cache.get(_stub(opened, released, counter, always_fail=True))
+
+    async def good():
+        await cache.get(_stub(opened, released, counter))
+
+    asyncio.run(bad())
+    asyncio.run(good())
+
+    with pytest.raises(RuntimeError, match="release failed"):
+        asyncio.run(cache.close())
+
+    # The good one was still released: one failure must not skip the rest, it
+    # must only be reported. The failed one stays for a later attempt.
+    assert released == [1]
+    assert cache.open_count() == 1
 
 
 def test_a_failed_release_does_not_strand_the_other_loops():
@@ -169,6 +253,28 @@ def test_a_failed_release_does_not_strand_the_other_loops():
     assert opened == [0, 1, 2]
     assert sorted(released) == [0, 1, 2], "a failed release stranded a client"
     assert cache.open_count() == 0
+
+
+def test_a_loop_that_failed_to_open_leaves_no_lock_behind():
+    """A failed open registers a lock and nothing else.
+
+    Both sweeps used to visit only the entries, so a credential error across
+    repeated `asyncio.run` calls pinned every closed loop object forever. The
+    locks are swept by liveness instead, which covers a failure at any site
+    rather than only at the one this was found on.
+    """
+    cache = LoopClientCache("test")
+
+    async def step():
+        with pytest.raises(RuntimeError, match="no credentials"):
+            await cache.get(Boom)
+
+    for _ in range(3):
+        asyncio.run(step())
+    asyncio.run(cache.close())
+
+    assert cache.open_count() == 0
+    assert cache._locks == {}, "a closed loop kept its lock"
 
 
 def test_key_is_the_loop_object_not_its_id():

--- a/spec/layout_exceptions.json
+++ b/spec/layout_exceptions.json
@@ -53,6 +53,11 @@
     "_test_util": "The FakeDropboxRpc transport fake shared by rmdir.test.ts and rename.test.ts. TypeScript colocates tests with sources, so a shared test helper lands in the source directory; python keeps the same fake in tests/core/dropbox/conftest.py, which this gate does not scan. core/gdrive carries an identical _test_util.ts, still counted in the baseline rather than excused here."
    }
   },
+  "accessor": {
+   "python_only": {
+    "pool": "One open client per event loop, keyed by the loop object. Only python has the hazard: an aiobotocore client binds to the loop that opened it, and a process runs many loops over its lifetime (every asyncio.run makes one), so a cached client outlives the loop it belongs to and has to be released against a loop that is already closed. Node has one loop and an AWS SDK v3 client that is not bound to it, so S3Accessor there holds config and opens nothing -- there is no lifetime to manage and nothing to mirror."
+   }
+  },
   "runtime/python/monty": {
    "typescript_only": {
     "tree": "The guest's scratch filesystem for unmounted paths. Python needs no twin: its binding hands monty an OSAccess subclass whose base class (pydantic_monty.os_access) already carries this tree, while the JS binding is a bare callback with no tree behind it, so the TypeScript side implements the same semantics itself (message spellings pinned to the python binding's)."

--- a/typescript/packages/node/src/accessor/ssh.ts
+++ b/typescript/packages/node/src/accessor/ssh.ts
@@ -69,6 +69,14 @@ export class SSHAccessor extends Accessor {
     }
     return new Promise<SFTPWrapper>((resolveFn, rejectFn) => {
       c.on('ready', () => {
+        // SFTP is a request/response protocol over small packets, and node
+        // leaves Nagle ON. Paired with Linux's 40ms delayed ACK that stalls
+        // roughly every exchange, which is why the same battery costs 41.8ms
+        // per case on a Linux runner and ~3ms on a BSD-derived stack. ssh2
+        // offers setNoDelay but never calls it; asyncssh sets TCP_NODELAY on
+        // every connection (connection.py), which is the whole reason the
+        // python host was 44x faster against the same server.
+        c.setNoDelay(true)
         c.sftp((err: Error | undefined, sftp: SFTPWrapper) => {
           if (err !== undefined) {
             rejectFn(err)


### PR DESCRIPTION
Three unrelated stalls found by timing every job and battery step of the Integ run on `6761aa0e`. Each was reproduced before being changed.

## 1. notion MCP parity idled for 5 minutes

The step ran **307s** but logged `33/33 cases byte-identical` at 6s. Bisecting the teardown:

```
PROBE restWs.close at 1ms
PROBE mcpWs.close  at 1ms
PROBE rest.close   at 3ms
PROBE mcp.close    at 300831ms   <-- here
```

`server.close()` stops accepting new connections and then waits for the open ones to drain. The MCP client's keep-alive socket is still open, so the wait ran to node's default `requestTimeout` of exactly 300000ms. `closeAllConnections()` destroys them so the callback can fire.

**304s -> 2s**, still 33/33, exit 0.

## 2. s3 opened a new AWS client on every operation

`async with session.client(...)` per op, in the driver's `_connect` and again in `read`, `stream` and `watch`. Measured:

| | per op |
|---|---|
| fresh client | 49.24 ms |
| reused client | 2.07 ms |

23.8x, which matches the observed CI gap (python 217 ms/case vs typescript 11 ms/case against the *same* moto server). End to end through `_connect`: **161.04 ms -> 0.00 ms**.

The driver contract already documents the intended shape: *"a store holding a live client on its accessor yields the accessor itself"*, which is what gridfs does (and it measures 5 ms/case). `S3Accessor` now keeps one live client per event loop, mirroring `GridFSAccessor`. The accessor owns the **lifetime** and the driver owns the **construction**, because `core/s3/client.py` imports `S3Config` from the accessor and constructing there would be a cycle.

Checked for a leak, since `async with` used to close every op: clients go 1 during use -> 0 after close, no unclosed-session warnings.

## 3. ssh never set TCP_NODELAY

The same 2532 cases cost **681s on the typescript host and 15.5s on the python host** in the same run, against the same asyncssh server. Verified that measurement is sound: 2532 distinct timestamps for 2532 cases, so it is not a stdout-buffering artifact.

SFTP is request/response over small packets and node leaves Nagle on. Linux's delayed ACK is 40ms, and the observed **p50 was 41.8ms** which is that signature exactly. `ssh2` exposes `setNoDelay()` but never calls it; `asyncssh` sets `TCP_NODELAY` on every connection (`connection.py:1387`), which is the whole asymmetry.

Verified `setNoDelay(true)` reaches the live socket.

**This one is not reproducible on macOS** where the battery runs in 7.4s either way, so CI is the proof rather than a local number. Locally it is a no-op: 2532 pass before and after.

## Verification

- python: full `pytest` suite exit 0
- typescript: 2616 tests pass, `pnpm -r typecheck` clean, eslint clean
- integ: TS ssh battery 2532/2532, notion parity 33/33
- `pre-commit run --all-files` clean and stable across two passes