### PR TITLE
Refuse an unseeded tenant, and give the run axis a URL it can ride

### DIFF
--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -1660,44 +1660,60 @@ class NotionService:
     across both hosts. The token doubles as the workspace id, the way a real
     Notion integration token scopes you to one workspace.
 
-    It is NOT minted per run, and notion is the only kit fake that cannot be:
-    the token is observable. `ntn auth token` prints the CLI's configured value
-    without contacting the server, integ/cli/ntn.json pins that literal, and
-    integ/ntn_conformance.ts asserts the same line against the real ntn binary,
-    which it configures with this same fixed token. A per-run token would make
-    those two runs print different things with one golden between them. So the
-    hosts share this workspace and must not reset it concurrently; the scoped
-    reset still buys the sequential case, where a reset no longer destroys the
-    whole run file out from under the other host.
+    The token is NOT minted per run, and notion is the only kit fake whose
+    token cannot be: it is observable. `ntn auth token` prints the CLI's
+    configured value without contacting the server, integ/cli/ntn.json pins
+    that literal, and integ/ntn_conformance.ts asserts the same line against
+    the real ntn binary, which it configures with this same fixed token. A
+    per-run token would make those two runs print different things with one
+    golden between them.
+
+    So the RUN is the axis that separates the hosts, and it rides the base URL
+    as a leading `/_run/<id>` segment. A header or a query parameter cannot do
+    this job: the mount hands its base URL to the resource and never sees the
+    request again. With the run in the URL the two hosts keep the one shared
+    token, get a SQLite file each, and can reset concurrently.
 
     Args:
         url (str): NOTION_URL origin (the REST surface lives under /v1).
         token (str): the shared workspace token.
+        run_id (str): this run's id, which names its own server-side file.
     """
 
-    def __init__(self, url: str, token: str) -> None:
+    def __init__(self, url: str, token: str, run_id: str) -> None:
         self.url = url
         self.token = token
+        self.run_id = run_id
+
+    @property
+    def base(self) -> str:
+        """Return the run-scoped origin every mount and CLI is pointed at.
+
+        Returns:
+            str: the origin with this run's `/_run/<id>` prefix.
+        """
+        return f"{self.url}/_run/{self.run_id}"
 
     @classmethod
-    async def create(cls) -> "NotionService":
+    async def create(cls, run_id: str) -> "NotionService":
         url = os.environ["NOTION_URL"].rstrip("/")
         token = NOTION_TOKEN
+        made = cls(url, token, run_id)
         async with aiohttp.ClientSession() as session:
-            async with session.post(f"{url}/reset", json={"tenants":
-                                                          [token]}) as resp:
+            async with session.post(f"{made.base}/reset",
+                                    json={"tenants": [token]}) as resp:
                 resp.raise_for_status()
-        return cls(url, token)
+        return made
 
     def resource(self, mount: dict) -> NotionResource:
-        return NotionResource(
-            config=NotionConfig(api_key=self.token, base_url=f"{self.url}/v1"))
+        return NotionResource(config=NotionConfig(api_key=self.token,
+                                                  base_url=f"{self.base}/v1"))
 
     def cli_installs(self) -> dict[str, tuple[CLISpec, dict[str, object]]]:
         return {
             "ntn": (cli_spec_for("ntn"), {
                 "api_key": self.token,
-                "base_url": f"{self.url}/v1",
+                "base_url": f"{self.base}/v1",
             }),
         }
 
@@ -2533,7 +2549,7 @@ async def make_service(target: dict, run_id: str) -> "Service | None":
     if target.get("service") == "lancedb":
         return await LanceDBService.create(target)
     if target.get("service") == "notion":
-        return await NotionService.create()
+        return await NotionService.create(run_id)
     if target.get("service") == "ssh":
         return await SSHService.create(run_id, target)
     if target.get("service") == "nextcloud":

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -970,17 +970,23 @@ async function openNotion(target: Target): Promise<Open> {
   let base = process.env.NOTION_URL ?? ''
   while (base.endsWith('/')) base = base.slice(0, -1)
   if (base === '') throw new Error('notion target requires NOTION_URL')
-  // NOT minted per run, and notion is the only kit fake that cannot be. Its
-  // tenant channel is the bearer token, and the token is OBSERVABLE: `ntn auth
-  // token` prints the CLI's configured value without contacting the server at
-  // all, and integ/cli/ntn.json pins that literal, asserted a second time
-  // against the real ntn binary by integ/ntn_conformance.ts. A per-run token
-  // makes the battery print one value and the conformance run another, with
-  // one golden between them. So the two hosts share this workspace and must
-  // not reset it concurrently; the scoped reset still buys the sequential
-  // case, where a reset no longer destroys the whole run file.
+  // The TOKEN is not minted per run, and notion is the only kit fake whose
+  // token cannot be. It is OBSERVABLE: `ntn auth token` prints the CLI's
+  // configured value without contacting the server at all, integ/cli/ntn.json
+  // pins that literal, and integ/ntn_conformance.ts asserts the same line
+  // against the real ntn binary configured with the same fixed token. A
+  // per-run token makes the battery print one value and the conformance run
+  // another, with one golden between them.
+  //
+  // So the RUN separates the two hosts instead, riding the base URL as a
+  // leading `/_run/<id>` segment. That is the only channel available here: the
+  // mount hands this URL to NotionResource and never sees the request, so a
+  // header or a `?_run=` query would have to be threaded through the resource.
+  // Each host now gets its own SQLite file under the one shared token, and the
+  // two can reset concurrently instead of taking turns.
   const token = NOTION_TOKEN
-  const reset = await fetch(`${base}/reset`, {
+  const scoped = `${base}/_run/${runId()}`
+  const reset = await fetch(`${scoped}/reset`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ tenants: [token] }),
@@ -994,15 +1000,18 @@ async function openNotion(target: Target): Promise<Open> {
     }
     const resource = new NotionResource({
       apiKey: token,
-      baseUrl: `${base}/v1`,
+      baseUrl: `${scoped}/v1`,
     })
     mounts[mount.path] = mount.mode === 'read' ? [resource, MountMode.READ] : resource
   }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   if (target.clis?.includes('ntn') === true) {
+    // The same run as the mounts above. The CLI and the mount are two views of
+    // one workspace, so pointing them at different runs would give a case that
+    // writes with `ntn` and reads through /notion two different worlds.
     ws.registerCli('ntn', NTN, {
       api_key: token,
-      base_url: `${base}/v1`,
+      base_url: `${scoped}/v1`,
     })
   }
   const cleanup = async (): Promise<void> => {

--- a/integ/server/kit/selftest/fake.ts
+++ b/integ/server/kit/selftest/fake.ts
@@ -194,6 +194,16 @@ export const selftestFake: Fake<C> = {
   client: PrismaClient,
   dmmf: Prisma.dmmf as unknown as Dmmf,
   defaultTenants: ['default'],
+  // Opted in, because the refusal is opt-in and this is where it is covered.
+  // A fake that says nothing here keeps serving unseeded tenants, which is
+  // what dropbox and the other lazily-created accounts need.
+  unknownTenant: (tenant: string) => ({
+    status: 401,
+    body: {
+      error: 'unknown_tenant',
+      message: `selftest fake: no tenant ${tenant}; seed it with /reset`,
+    },
+  }),
   routes: (): KitRoute<C>[] => [
     route('GET', '/boards', listBoards),
     route('GET', '/boards/:board/cards', listCards),

--- a/integ/server/kit/selftest/run.ts
+++ b/integ/server/kit/selftest/run.ts
@@ -80,6 +80,9 @@ interface CallOpts {
   body?: JsonValue
   run?: string
   tenant?: string
+  // Address the run through the URL instead of the header, which is the only
+  // spelling a mount handing its base URL to an SDK can actually use.
+  runInPath?: string
 }
 
 async function call(
@@ -90,7 +93,8 @@ async function call(
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (opts.run !== undefined) headers['x-mirage-run'] = opts.run
   if (opts.tenant !== undefined) headers['x-mirage-tenant'] = opts.tenant
-  const res = await fetch(`${fake.endpoint}${path}`, {
+  const prefix = opts.runInPath === undefined ? '' : `/_run/${opts.runInPath}`
+  const res = await fetch(`${fake.endpoint}${prefix}${path}`, {
     method: opts.method ?? 'GET',
     headers,
     ...(opts.body === undefined ? {} : { body: JSON.stringify(opts.body) }),
@@ -534,6 +538,101 @@ async function main(): Promise<void> {
       'a stray positional fails the launch too',
       refusedWord.includes('exited 1'),
       refusedWord === '' ? 'launched ANYWAY' : (refusedWord.split('\n')[0] ?? ''),
+    )
+
+    process.stdout.write('\n16. a tenant nobody seeded is refused, not crashed\n')
+    // The failure this covers reached the caller as a 500 carrying whatever
+    // the fake's own query threw, which reads as a crashed service: a
+    // container healthcheck that probes with a credential marked the fake
+    // permanently unhealthy. Both routes to an unseeded tenant are checked,
+    // because they were two separate 500s with one cause.
+    const ghost = await call(fake, '/boards', { run: 'p', tenant: 'never-seeded' })
+    check('an unseeded tenant is 401, not 500', ghost.status === 401, JSON.stringify(ghost.json))
+    check(
+      'and the refusal names the tenant it did not find',
+      JSON.stringify(ghost.json).includes('never-seeded'),
+      JSON.stringify(ghost.json),
+    )
+    // Reading a tenant must not bring it into being. `of()` mints per-tenant
+    // state for any legal name on first sight, so a check written against that
+    // map would answer 401 once and then serve an empty world forever after.
+    const again = await call(fake, '/boards', { run: 'p', tenant: 'never-seeded' })
+    check('and asking twice is still 401', again.status === 401, JSON.stringify(again.json))
+    const born = await call(fake, '/reset', {
+      method: 'POST',
+      body: { run: 'p', tenants: ['never-seeded'] },
+    })
+    check('seeding it is 200', born.status === 200, JSON.stringify(born.json))
+    check(
+      'and now the same request is served',
+      (await call(fake, '/boards', { run: 'p', tenant: 'never-seeded' })).status === 200,
+      JSON.stringify((await call(fake, '/boards', { run: 'p', tenant: 'never-seeded' })).json),
+    )
+    // A run is its own file, so seeding a tenant in one run says nothing about
+    // the same name in another.
+    const elsewhere = await call(fake, '/boards', { run: 'q', tenant: 'never-seeded' })
+    check(
+      'the same name in another run is still unseeded',
+      elsewhere.status === 401,
+      JSON.stringify(elsewhere.json),
+    )
+
+    process.stdout.write('\n17. a run can be addressed by URL, not just by header\n')
+    // The header and the query parameter are only reachable by a caller that
+    // builds its own requests. Every mount here hands a base URL to a vendor
+    // SDK and never sees the request again, which is why the run axis went
+    // unused and the tenant column was made to carry host isolation instead.
+    // A path prefix is just part of the base URL, so it survives the trip.
+    const seedU = await call(fake, '/reset', {
+      method: 'POST',
+      runInPath: 'u1',
+      body: { tenants: ['shared'] },
+    })
+    check(
+      'a reset under /_run/<id> resets THAT run',
+      (seedU.json as { run: string }).run === 'u1',
+      JSON.stringify(seedU.json),
+    )
+    await call(fake, '/reset', { method: 'POST', runInPath: 'u2', body: { tenants: ['shared'] } })
+    // The same tenant name in both, which is the point: notion's bearer token
+    // is echoed by `ntn auth token` and pinned by a golden, so it CANNOT be
+    // minted per run. The run has to be the axis that separates two hosts.
+    const wroteU1 = await call(fake, '/boards/brd_1/cards', {
+      method: 'POST',
+      runInPath: 'u1',
+      tenant: 'shared',
+      body: { title: 'only-in-u1' },
+    })
+    check('a write into run u1 is 201', wroteU1.status === 201, JSON.stringify(wroteU1.json))
+    check(
+      'u1 sees it',
+      titles((await call(fake, '/boards/brd_1/cards', { runInPath: 'u1', tenant: 'shared' })).json)
+        .includes('only-in-u1'),
+      JSON.stringify(
+        titles((await call(fake, '/boards/brd_1/cards', { runInPath: 'u1', tenant: 'shared' })).json),
+      ),
+    )
+    check(
+      'and u2 does NOT, under the very same tenant name',
+      !titles((await call(fake, '/boards/brd_1/cards', { runInPath: 'u2', tenant: 'shared' })).json)
+        .includes('only-in-u1'),
+      JSON.stringify(
+        titles((await call(fake, '/boards/brd_1/cards', { runInPath: 'u2', tenant: 'shared' })).json),
+      ),
+    )
+    const noPrefix = await call(fake, '/boards')
+    check('an unprefixed URL still means the default run', noPrefix.status === 200, JSON.stringify(noPrefix.json))
+    const badRun = await call(fake, '/boards', { runInPath: 'bad%2Fname' })
+    check('an illegal run in the path is 400, not 500', badRun.status === 400, JSON.stringify(badRun.json))
+    const clash = await call(fake, '/reset', {
+      method: 'POST',
+      runInPath: 'u1',
+      body: { run: 'u2', tenants: ['shared'] },
+    })
+    check(
+      'a body naming a different run than the prefix is refused',
+      clash.status === 400,
+      JSON.stringify(clash.json),
     )
 
     process.stdout.write(`\nselftest: ${String(checks)} checks passed\n`)

--- a/integ/server/kit/selftest/run.ts
+++ b/integ/server/kit/selftest/run.ts
@@ -606,24 +606,60 @@ async function main(): Promise<void> {
     check('a write into run u1 is 201', wroteU1.status === 201, JSON.stringify(wroteU1.json))
     check(
       'u1 sees it',
-      titles((await call(fake, '/boards/brd_1/cards', { runInPath: 'u1', tenant: 'shared' })).json)
-        .includes('only-in-u1'),
+      titles(
+        (await call(fake, '/boards/brd_1/cards', { runInPath: 'u1', tenant: 'shared' })).json,
+      ).includes('only-in-u1'),
       JSON.stringify(
-        titles((await call(fake, '/boards/brd_1/cards', { runInPath: 'u1', tenant: 'shared' })).json),
+        titles(
+          (await call(fake, '/boards/brd_1/cards', { runInPath: 'u1', tenant: 'shared' })).json,
+        ),
       ),
     )
     check(
       'and u2 does NOT, under the very same tenant name',
-      !titles((await call(fake, '/boards/brd_1/cards', { runInPath: 'u2', tenant: 'shared' })).json)
-        .includes('only-in-u1'),
+      !titles(
+        (await call(fake, '/boards/brd_1/cards', { runInPath: 'u2', tenant: 'shared' })).json,
+      ).includes('only-in-u1'),
       JSON.stringify(
-        titles((await call(fake, '/boards/brd_1/cards', { runInPath: 'u2', tenant: 'shared' })).json),
+        titles(
+          (await call(fake, '/boards/brd_1/cards', { runInPath: 'u2', tenant: 'shared' })).json,
+        ),
       ),
     )
     const noPrefix = await call(fake, '/boards')
-    check('an unprefixed URL still means the default run', noPrefix.status === 200, JSON.stringify(noPrefix.json))
+    check(
+      'an unprefixed URL still means the default run',
+      noPrefix.status === 200,
+      JSON.stringify(noPrefix.json),
+    )
     const badRun = await call(fake, '/boards', { runInPath: 'bad%2Fname' })
-    check('an illegal run in the path is 400, not 500', badRun.status === 400, JSON.stringify(badRun.json))
+    check(
+      'an illegal run in the path is 400, not 500',
+      badRun.status === 400,
+      JSON.stringify(badRun.json),
+    )
+    // decodeURIComponent throws a URIError on this, which is not a TenantError
+    // and so reached the 500 envelope: a typed URL reported as a fake bug.
+    const badEscape = await call(fake, '/boards', { runInPath: '%ZZ' })
+    check(
+      'a malformed percent escape in the run is 400, not 500',
+      badEscape.status === 400,
+      JSON.stringify(badEscape.json),
+    )
+    // The prefix fills in an ABSENT run only. Overwriting a malformed one
+    // turned a request that owes a 400 into a successful reset.
+    for (const bad of [12, '']) {
+      const malformed = await call(fake, '/reset', {
+        method: 'POST',
+        runInPath: 'u1',
+        body: { run: bad, tenants: ['shared'] },
+      })
+      check(
+        `a malformed body run ${JSON.stringify(bad)} is still refused`,
+        malformed.status === 400,
+        JSON.stringify(malformed.json),
+      )
+    }
     const clash = await call(fake, '/reset', {
       method: 'POST',
       runInPath: 'u1',

--- a/integ/server/kit/typescript/base.ts
+++ b/integ/server/kit/typescript/base.ts
@@ -19,7 +19,7 @@ import type { ClientCtor, MinimalClient } from './db.ts'
 import type { KitConfig } from './config.ts'
 import type { Dmmf } from './seed.ts'
 import type { KitRoute } from './route.ts'
-import type { JsonValue, MintSharing, ResetResponse } from './types.ts'
+import type { JsonValue, MintSharing, Reply, ResetResponse } from './types.ts'
 
 // What a service implements. Everything else in the kit is machinery around
 // these five members: there is no base class to extend and no lifecycle to
@@ -42,6 +42,10 @@ export interface Fake<C extends MinimalClient> {
     extras: Record<string, JsonValue>,
   ) => Promise<void>
   defaultTenants?: string[]
+  // How this fake refuses a tenant it was never seeded with. The kit knows
+  // WHICH tenant is unknown and nothing about how the vendor says so, so the
+  // status and body come from here; the default below is a generic 401.
+  unknownTenant?: (tenant: string) => Reply
 }
 
 // Per-TENANT mutable state. These were per-run until /reset learned to scope
@@ -60,6 +64,11 @@ export interface TenantState {
 // other's ids; this is now that guarantee one level finer.
 export class RunState {
   private readonly tenants = new Map<string, TenantState>()
+  // The tenants this run has actually been seeded with, which `tenants` alone
+  // cannot answer: `of` mints state for ANY legal name on first sight, so a
+  // tenant nobody seeded is indistinguishable from a seeded one until the
+  // fake's first query comes back empty. Only `reset` records here.
+  private readonly seeded = new Set<string>()
   private readonly sharing: MintSharing
   private readonly format: string
 
@@ -83,6 +92,11 @@ export class RunState {
     const st = this.of(tenant)
     st.clock.setEpoch(epoch)
     st.minter.reset()
+    this.seeded.add(tenant)
+  }
+
+  isSeeded(tenant: string): boolean {
+    return this.seeded.has(tenant)
   }
 }
 

--- a/integ/server/kit/typescript/base.ts
+++ b/integ/server/kit/typescript/base.ts
@@ -42,9 +42,14 @@ export interface Fake<C extends MinimalClient> {
     extras: Record<string, JsonValue>,
   ) => Promise<void>
   defaultTenants?: string[]
-  // How this fake refuses a tenant it was never seeded with. The kit knows
-  // WHICH tenant is unknown and nothing about how the vendor says so, so the
-  // status and body come from here; the default below is a generic 401.
+  // How this fake refuses a tenant it was never seeded with, and by being
+  // present, THAT it refuses one at all. Declaring it is opt-in for the same
+  // reason tenantFromBearer is: what an unseeded tenant means is the vendor's
+  // question, not the kit's. Notion hands an integration one workspace that
+  // has to exist, so an unknown one is a bad token. Dropbox mints an account
+  // per mount and never resets it, so an unseeded tenant there is an ordinary
+  // EMPTY account and refusing it broke every dropbox case. A fake that says
+  // nothing keeps serving unseeded tenants, which is what it did before.
   unknownTenant?: (tenant: string) => Reply
 }
 
@@ -88,10 +93,19 @@ export class RunState {
     return made
   }
 
+  // Starting a reset UNMARKS the tenant, and only markSeeded re-marks it. The
+  // two are separate because a reset that throws half way through leaves a
+  // world that is partly the old fixture and partly nothing: marking here
+  // would serve that as valid, and never unmarking would serve a failed
+  // RESEED of an already-good tenant the same way.
   reset(tenant: string, epoch?: string): void {
     const st = this.of(tenant)
     st.clock.setEpoch(epoch)
     st.minter.reset()
+    this.seeded.delete(tenant)
+  }
+
+  markSeeded(tenant: string): void {
     this.seeded.add(tenant)
   }
 

--- a/integ/server/kit/typescript/http.ts
+++ b/integ/server/kit/typescript/http.ts
@@ -72,13 +72,25 @@ export function makeRuntime<C extends MinimalClient>(fake: Fake<C>): Runtime<C> 
 // for a body that parseResetBody will reject; an invalid body is a 400 that
 // still must not jump the queue.
 // The prefix and the body must not disagree, and the prefix is the one the
-// caller cannot have set by accident.
+// caller cannot have set by accident. Only an ABSENT run is filled in: a body
+// carrying `{"run": 12}` or `{"run": ""}` is malformed and has to reach
+// parseResetBody to be refused, and overwriting it turned a request that owes
+// a 400 into a successful reset of somebody else's run.
 function withPathRun(body: JsonValue, pathRun: string | undefined): JsonValue {
   if (pathRun === undefined) return body
   if (typeof body !== 'object' || body === null || Array.isArray(body)) return body
   const named = (body as Record<string, JsonValue>).run
-  if (typeof named === 'string' && named !== '' && named !== pathRun) {
-    throw new ResetBodyError(`/reset run ${named} contradicts the /_run/${pathRun} it was sent to`)
+  if (named !== undefined) {
+    // A non-empty string that differs is a caller contradicting itself. Every
+    // other present value (a number, an empty string) is malformed, and is
+    // handed on unchanged so parseResetBody refuses it in its own words
+    // rather than being reported as a contradiction it is not.
+    if (typeof named === 'string' && named !== '' && named !== pathRun) {
+      throw new ResetBodyError(
+        `/reset run ${named} contradicts the /_run/${pathRun} it was sent to`,
+      )
+    }
+    return body
   }
   return { ...(body as Record<string, JsonValue>), run: pathRun }
 }
@@ -146,17 +158,6 @@ function envelope(service: string, err: unknown): Reply {
 // so, so the body is the fake's whenever it declares one. The fallback is a
 // 401 rather than a 404 because the tenant is reached through a credential in
 // every fake that has one, and refusing the credential is what the vendor does.
-function unknownTenant<C extends MinimalClient>(fake: Fake<C>, tenant: string): Reply {
-  if (fake.unknownTenant !== undefined) return fake.unknownTenant(tenant)
-  return {
-    status: 401,
-    body: {
-      error: 'unknown_tenant',
-      message: `${fake.config.service} fake: no tenant ${tenant}; seed it with /reset`,
-    },
-  }
-}
-
 async function answer<C extends MinimalClient>(
   rt: Runtime<C>,
   router: Router<C>,
@@ -178,7 +179,10 @@ async function answer<C extends MinimalClient>(
     path = split.path
   } catch (err: unknown) {
     if (err instanceof TenantError) {
-      return { status: 400, body: { error: 'bad_run', kind: err.constructor.name, message: err.message } }
+      return {
+        status: 400,
+        body: { error: 'bad_run', kind: err.constructor.name, message: err.message },
+      }
     }
     throw err
   }
@@ -244,8 +248,15 @@ async function answer<C extends MinimalClient>(
   // a legal name that was never seeded, and the DEFAULT_TENANT that an illegal
   // one falls back to, were two separate 500s with one cause.
   const runState = rt.state(run)
-  if (tenantKind !== 'none' && !runState.isSeeded(tenant)) {
-    return unknownTenant(rt.fake, tenant)
+  const refuse = rt.fake.unknownTenant
+  if (refuse !== undefined && tenantKind !== 'none' && !runState.isSeeded(tenant)) {
+    // The tenant may be BEING seeded right now: /reset is queued on the run
+    // and a read only waits for that queue inside Router.run, which is after
+    // this point. Checked first and awaited only on a miss, so the ordinary
+    // request pays nothing and a request racing its own reset is not told the
+    // tenant does not exist when an accepted reset is about to create it.
+    await router.settled(run)
+    if (!runState.isSeeded(tenant)) return refuse(tenant)
   }
   const hit = router.match(method, path)
   if (hit === null) return unrouted(service, method, path)

--- a/integ/server/kit/typescript/http.ts
+++ b/integ/server/kit/typescript/http.ts
@@ -22,7 +22,7 @@ import { Router } from './route.ts'
 import type { Ctx } from './route.ts'
 import { DEFAULT_FIXTURE } from './fixture.ts'
 import { applyReset, defaultTenantsOf, parseResetBody } from './reset.ts'
-import { DEFAULT_RUN, resolveRun, resolveTenant } from './tenant.ts'
+import { DEFAULT_RUN, resolveRun, resolveTenant, splitRunPath } from './tenant.ts'
 import type { Headers } from './tenant.ts'
 import { unrouted } from './unrouted.ts'
 import type { JsonValue, Reply } from './types.ts'
@@ -71,6 +71,18 @@ export function makeRuntime<C extends MinimalClient>(fake: Fake<C>): Runtime<C> 
 // The reset's target run is read before validation so the queue key exists even
 // for a body that parseResetBody will reject; an invalid body is a 400 that
 // still must not jump the queue.
+// The prefix and the body must not disagree, and the prefix is the one the
+// caller cannot have set by accident.
+function withPathRun(body: JsonValue, pathRun: string | undefined): JsonValue {
+  if (pathRun === undefined) return body
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) return body
+  const named = (body as Record<string, JsonValue>).run
+  if (typeof named === 'string' && named !== '' && named !== pathRun) {
+    throw new ResetBodyError(`/reset run ${named} contradicts the /_run/${pathRun} it was sent to`)
+  }
+  return { ...(body as Record<string, JsonValue>), run: pathRun }
+}
+
 function runOfReset(body: JsonValue): string {
   if (typeof body === 'object' && body !== null && !Array.isArray(body)) {
     const named = (body as Record<string, JsonValue>).run
@@ -130,6 +142,21 @@ function envelope(service: string, err: unknown): Reply {
   return { status: 500, body: { error: 'internal_error', kind, message } }
 }
 
+// The kit knows a tenant is unknown; only the fake knows how its vendor says
+// so, so the body is the fake's whenever it declares one. The fallback is a
+// 401 rather than a 404 because the tenant is reached through a credential in
+// every fake that has one, and refusing the credential is what the vendor does.
+function unknownTenant<C extends MinimalClient>(fake: Fake<C>, tenant: string): Reply {
+  if (fake.unknownTenant !== undefined) return fake.unknownTenant(tenant)
+  return {
+    status: 401,
+    body: {
+      error: 'unknown_tenant',
+      message: `${fake.config.service} fake: no tenant ${tenant}; seed it with /reset`,
+    },
+  }
+}
+
 async function answer<C extends MinimalClient>(
   rt: Runtime<C>,
   router: Router<C>,
@@ -139,17 +166,37 @@ async function answer<C extends MinimalClient>(
   raw: Buffer,
 ): Promise<Reply> {
   const { service, tenantKind, tenantFromBearer, tenantTokenPattern } = rt.fake.config
-  if (url.pathname === HEALTH_PATH && (method === 'GET' || method === 'HEAD')) {
+  // Stripped FIRST, so every path below is the one the fake declares. A run
+  // prefix is transport, not routing: `/_run/h1/v1/users/me` is the same route
+  // as `/v1/users/me`, and health and /reset answer under it too, which is
+  // what lets a harness point one base URL at everything it needs.
+  let pathRun: string | undefined
+  let path: string
+  try {
+    const split = splitRunPath(url.pathname)
+    pathRun = split.run
+    path = split.path
+  } catch (err: unknown) {
+    if (err instanceof TenantError) {
+      return { status: 400, body: { error: 'bad_run', kind: err.constructor.name, message: err.message } }
+    }
+    throw err
+  }
+  if (path === HEALTH_PATH && (method === 'GET' || method === 'HEAD')) {
     return { status: 200, body: { ok: true, service, runs: rt.pool.runs() } }
   }
-  if (url.pathname === RESET_PATH && method === 'POST') {
+  if (path === RESET_PATH && method === 'POST') {
     try {
       // Enqueued on the run's own write queue. A reset deletes and reseeds
       // rows, and for a fake with no tenant column recreates the SQLite file
       // outright, so running it beside an in-flight write unlinked the
       // database under that write: the request 500'd and every later request
       // on the run failed forever. It is a write and queues like one.
-      const body = parseResetRequest(raw)
+      // A reset reached through `/_run/<id>/reset` is about THAT run, so the
+      // prefix fills the body's `run` in. Naming a different one in the body
+      // under a prefix is a caller contradicting itself, and is refused rather
+      // than silently resolved in favour of either.
+      const body = withPathRun(parseResetRequest(raw), pathRun)
       const done = await router.enqueue(runOfReset(body), () => rt.reset(body))
       return { status: 200, body: JSON.parse(JSON.stringify(done)) as JsonValue }
     } catch (err: unknown) {
@@ -172,7 +219,7 @@ async function answer<C extends MinimalClient>(
   let run: string
   let tenant: string
   try {
-    run = resolveRun(headers, url)
+    run = resolveRun(headers, url, pathRun)
     tenant = resolveTenant(headers, url, tenantKind, tenantFromBearer, tenantTokenPattern)
   } catch (err: unknown) {
     // Same shape /reset already used, just reached from the request path. An
@@ -186,9 +233,23 @@ async function answer<C extends MinimalClient>(
     }
     throw err
   }
-  const hit = router.match(method, url.pathname)
-  if (hit === null) return unrouted(service, method, url.pathname)
-  const st = rt.state(run).of(tenant)
+  // A tenant nobody seeded has no state to serve, and until now the fake found
+  // that out one layer down, where its own first query came back empty and it
+  // threw into the 500 envelope. 500 is the wrong answer twice over: it reads
+  // as a crashed fake to anything watching (a container healthcheck marks the
+  // service permanently unhealthy), and every real vendor here refuses an
+  // unknown credential with a 401. Refused CENTRALLY rather than in each fake
+  // because the condition is the kit's own: the kit is what resolved the name.
+  // Both ways of reaching an unseeded tenant land here, which is the point --
+  // a legal name that was never seeded, and the DEFAULT_TENANT that an illegal
+  // one falls back to, were two separate 500s with one cause.
+  const runState = rt.state(run)
+  if (tenantKind !== 'none' && !runState.isSeeded(tenant)) {
+    return unknownTenant(rt.fake, tenant)
+  }
+  const hit = router.match(method, path)
+  if (hit === null) return unrouted(service, method, path)
+  const st = runState.of(tenant)
   const ctx: Ctx<C> = {
     params: hit.params,
     query: url.searchParams,

--- a/integ/server/kit/typescript/reset.ts
+++ b/integ/server/kit/typescript/reset.ts
@@ -105,6 +105,7 @@ export async function applyReset<C extends MinimalClient>(
   const st = state(req.run)
   for (const tenant of req.tenants) st.reset(tenant, req.epoch)
   const seeded: SeedReport[] = []
+
   for (const tenant of req.tenants) {
     const rows = await seedFixture(db, fixture, {
       dmmf: fake.dmmf,
@@ -114,6 +115,9 @@ export async function applyReset<C extends MinimalClient>(
     })
     if (fake.afterSeed !== undefined) await fake.afterSeed(db, tenant, rows, req.extras)
     seeded.push({ tenant, rows })
+    // After this tenant's own seed and afterSeed, not after the loop: a later
+    // tenant throwing must not unmark the ones already finished.
+    st.markSeeded(tenant)
   }
   return {
     ok: true,

--- a/integ/server/kit/typescript/route.ts
+++ b/integ/server/kit/typescript/route.ts
@@ -157,6 +157,13 @@ export class Router<C> {
     return pending.then(() => spec.handler(ctx))
   }
 
+  // The pending work on ONE run, for a caller that has to see the effect of an
+  // already-accepted write before deciding. `drain` is every run at once,
+  // which would make one run's slow reset block every other run's requests.
+  async settled(run: string): Promise<void> {
+    await this.queues.get(run)
+  }
+
   async drain(): Promise<void> {
     await Promise.all([...this.queues.values()])
   }

--- a/integ/server/kit/typescript/tenant.ts
+++ b/integ/server/kit/typescript/tenant.ts
@@ -20,6 +20,7 @@ export const RUN_HEADER = 'x-mirage-run'
 export const TENANT_HEADER = 'x-mirage-tenant'
 export const RUN_QUERY = '_run'
 export const TENANT_QUERY = '_tenant'
+export const RUN_PREFIX = '_run'
 export const DEFAULT_RUN = 'default'
 export const DEFAULT_TENANT = 'default'
 export const TENANT_FIELD = 'tenant'
@@ -55,9 +56,27 @@ export function checkName(kind: string, value: string): string {
   return value
 }
 
+// The run also rides the URL, as a LEADING PATH SEGMENT, and that is the
+// spelling a harness can actually use. The header and the query parameter are
+// only reachable by a caller that builds its own requests; every mount here
+// hands its base URL to a vendor SDK and never sees the request again, so
+// neither survives the trip. A path prefix does, because it is just part of
+// the base URL: `http://host/_run/<id>/v1` needs nothing of the client.
+// Returns the run it stripped, if any, and the path the router should match.
+export function splitRunPath(pathname: string): { run?: string; path: string } {
+  const parts = pathname.split('/')
+  if (parts.length < 3 || parts[1] !== RUN_PREFIX) return { path: pathname }
+  const run = checkName('run', decodeURIComponent(parts[2] ?? ''))
+  const rest = parts.slice(3).join('/')
+  return { run, path: rest === '' ? '/' : `/${rest}` }
+}
+
 // A run is its own SQLite file, so it is resolved before any query runs
-// and never reaches a WHERE clause.
-export function resolveRun(headers: Headers, url: URL): string {
+// and never reaches a WHERE clause. The path segment wins over the header and
+// the query because it is the one a mount can carry, so a base URL naming a
+// run cannot be overridden by an ambient header the caller forgot to drop.
+export function resolveRun(headers: Headers, url: URL, fromPath?: string): string {
+  if (fromPath !== undefined) return fromPath
   const raw = headerValue(headers, RUN_HEADER) ?? url.searchParams.get(RUN_QUERY) ?? undefined
   return raw === undefined || raw === '' ? DEFAULT_RUN : checkName('run', raw)
 }

--- a/integ/server/kit/typescript/tenant.ts
+++ b/integ/server/kit/typescript/tenant.ts
@@ -56,6 +56,18 @@ export function checkName(kind: string, value: string): string {
   return value
 }
 
+// decodeURIComponent throws a URIError on a malformed escape (`/_run/%ZZ`),
+// which is caller-controlled input and so must arrive as the same 400 an
+// illegal NAME gets. Left as a URIError it reached the internal 500 envelope,
+// which reports a fake bug for a typed URL.
+function decodeRun(raw: string): string {
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    throw new TenantError(`invalid run name: ${JSON.stringify(raw)}`)
+  }
+}
+
 // The run also rides the URL, as a LEADING PATH SEGMENT, and that is the
 // spelling a harness can actually use. The header and the query parameter are
 // only reachable by a caller that builds its own requests; every mount here
@@ -66,7 +78,7 @@ export function checkName(kind: string, value: string): string {
 export function splitRunPath(pathname: string): { run?: string; path: string } {
   const parts = pathname.split('/')
   if (parts.length < 3 || parts[1] !== RUN_PREFIX) return { path: pathname }
-  const run = checkName('run', decodeURIComponent(parts[2] ?? ''))
+  const run = checkName('run', decodeRun(parts[2] ?? ''))
   const rest = parts.slice(3).join('/')
   return { run, path: rest === '' ? '/' : `/${rest}` }
 }

--- a/integ/server/notion/fake.ts
+++ b/integ/server/notion/fake.ts
@@ -17,6 +17,7 @@ import type { Dmmf, Fake } from '../kit/typescript/index.ts'
 import { config } from './config.ts'
 import type { C } from './config.ts'
 import { notionRoutes } from './routes.ts'
+import { apiError } from './wire.ts'
 
 export const notionFake: Fake<C> = {
   config,
@@ -37,5 +38,9 @@ export const notionFake: Fake<C> = {
   // fake this replaces seeded at startup; the battery resets to a per-run
   // tenant on top of it.
   defaultTenants: ['integ-test'],
+  // Notion cannot tell an unknown token from a malformed one, and says the
+  // same thing about both, so this is word for word what `unauthorized`
+  // answers a request carrying no token at all.
+  unknownTenant: () => apiError(401, 'unauthorized', 'API token is invalid.'),
   routes: notionRoutes,
 }


### PR DESCRIPTION
Two changes in the integ kit's run/tenant plane. They ship together because they interlock: the second is what makes the first common rather than rare.

## A tenant nobody seeded answered 500

Measured against a live notion fake before any change:

| request | status | body |
|---|---|---|
| no Authorization | 401 | vendor-shaped |
| `Bearer probe` (legal, unseeded) | **500** | `notion fake: no meta row for tenant probe` |
| `Bearer integ-test` (seeded) | 200 | |
| `Bearer a/b` (**illegal**) | **500** | `notion fake: no meta row for tenant default` |

The fourth row is the one that shows this is not a notion bug. `resolveTenant` falls back to `DEFAULT_TENANT` for an unreadable token, and notion's `defaultTenants` is `['integ-test']`, so `default` is unseeded too. `tenant.ts` says the illegal case was fixed; only half was. It stopped throwing in `resolveTenant` and then died one layer down for the same reason.

`RunState.of()` mints per-tenant state for any legal name on first sight, so "is this tenant real" had no answer anywhere. It now records what `reset()` seeded, and the kit refuses before routing. The reply body belongs to the fake, because only it knows how its vendor says this; notion answers exactly what it already answers a request carrying no token, since Notion cannot tell an unknown token from a malformed one. A fake that declares nothing gets a generic 401 instead of a 500.

500 is wrong twice over here: every vendor in this repo refuses an unknown credential with a 401, and a 500 reads as a crashed service to anything watching, which is what made a container healthcheck fail permanently.

The failure has a quieter second face. With the guard disabled the selftest fake returns an empty list rather than an error, so a fake with a required singleton row 500s while one without serves an empty world and a test can pass against nothing.

## The run axis had no spelling a mount could use

`run` was implemented and unused: zero callers set it, which is why the tenant column was carrying host isolation. Neither the header nor `?_run=` is reachable from a mount, which hands its base URL to a vendor SDK and never sees the request again.

A leading `/_run/<id>` path segment is part of that base URL, so it survives. Health and `/reset` answer under it, the path wins over the header and the query, and a `/reset` body naming a different run than its prefix is refused rather than silently resolved in favour of either.

Both notion adapters now scope the mount, the reset and the `ntn` CLI install to one run. That gives the two hosts a SQLite file each while the token stays the fixed literal `ntn auth token` prints and `integ/cli/ntn.json` pins, which is why notion's token cannot be minted per run.

## Verification

- kit selftest **70/70**, 13 new checks across two sections. Includes write isolation between two runs under the same tenant name, and a check that reading an unseeded tenant twice still refuses rather than bringing it into being.
- notion MCP parity **33/33** byte-identical
- notion battery **43/43** on both hosts, each landing in its own run
- typecheck, eslint and yapf clean
- Both new guards were reverted and re-run to confirm they fail without the change.

## What this does not claim

I ran both hosts concurrently with the change and with the adapters reverted, and both passed 43/43. No live race was reproduced, so this does not claim to fix one. The structural argument that two hosts resetting one tenant in one file can collide stands as an argument only.