### PR TITLE
Give gws the run axis, and stop two hosts sharing one world

### DIFF
--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -534,7 +534,12 @@ class GwsService:
 
     @classmethod
     async def create(cls, run_id: str, target: dict) -> "GwsService":
-        url = os.environ["GWS_URL"].rstrip("/")
+        # Every call below goes to this run's own world. gws keeps per-run
+        # state already; what it lacked was a way for a mount to ask for one,
+        # since a mount hands its base URL to a client and never sees the
+        # request. Scoping the base once covers the reset, the drives and
+        # folders, the seeds and every mount.
+        url = f'{os.environ["GWS_URL"].rstrip("/")}/_run/{run_id}'
         folder_ids: dict[str, str] = {}
         drive_ids: dict[str, str] = {}
         # Native mounts (gdocs/gsheets/gslides) render the modified date

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -1626,6 +1626,12 @@ async function openGws(target: Target): Promise<Open> {
   let base = process.env.GWS_URL ?? ''
   while (base.endsWith('/')) base = base.slice(0, -1)
   if (base === '') throw new Error('gdrive target requires GWS_URL')
+  // Every call below goes to this run's own world. gws keeps per-run state
+  // already; what it lacked was a way for a mount to ask for one, since a
+  // mount hands its base URL to a client and never sees the request. Scoping
+  // the base once covers the reset, the drive and folder creation, the seeds
+  // and every mount, which is what makes this one line rather than sixteen.
+  base = `${base}/_run/${runId()}`
   // Native mounts (gdocs/gsheets/gslides) render the modified date into
   // filenames, so those targets pin the server clock. Secondary calendars
   // and seeded form responses ride the same call rather than being

--- a/integ/server/gws/serve.ts
+++ b/integ/server/gws/serve.ts
@@ -28,6 +28,8 @@ import {
   parseBody,
   parsePort,
   resolveRun,
+  splitRunPath,
+  withPathRun,
   unroutedLine,
 } from '../kit/typescript/index.ts'
 import type {
@@ -126,12 +128,38 @@ async function answer(
   raw: Buffer,
 ): Promise<Reply> {
   const { service } = rt.fake.config
-  if (url.pathname === HEALTH_PATH && (method === 'GET' || method === 'HEAD')) {
+  // The same `/_run/<id>` prefix the kit strips, and gws has to strip it in
+  // its own copy of this flow or the run axis works everywhere except here.
+  // gws already keeps a separate in-memory world per run; what it lacked was
+  // a way for a mount to ASK for one, since a mount hands its base URL to a
+  // client and never sees the request again.
+  let pathRun: string | undefined
+  let path: string
+  try {
+    const split = splitRunPath(url.pathname)
+    pathRun = split.run
+    path = split.path
+    // The URL a HANDLER reads loses the prefix too, exactly as in the kit.
+    // gws handlers pass ctx.url.pathname to unknownRoute (docs/routes.ts and
+    // several branches of sheets/routes.ts), so a scoped request answered
+    // `Unknown route: POST /_run/<random-id>/v1/...`: the harness's run id in
+    // observable output, which no golden can match twice.
+    url.pathname = path
+  } catch (err: unknown) {
+    if (err instanceof TenantError) {
+      return {
+        status: 400,
+        body: { error: 'bad_run', kind: err.constructor.name, message: err.message },
+      }
+    }
+    throw err
+  }
+  if (path === HEALTH_PATH && (method === 'GET' || method === 'HEAD')) {
     return { status: 200, body: { ok: true, service, runs: rt.runs() } }
   }
-  if (url.pathname === RESET_PATH && method === 'POST') {
+  if (path === RESET_PATH && method === 'POST') {
     try {
-      return { status: 200, body: rt.reset(parseBody(raw)) }
+      return { status: 200, body: rt.reset(withPathRun(parseBody(raw), pathRun)) }
     } catch (err: unknown) {
       if (err instanceof ResetBodyError || err instanceof TenantError) {
         return {
@@ -144,7 +172,7 @@ async function answer(
   }
   let run: string
   try {
-    run = resolveRun(headers, url)
+    run = resolveRun(headers, url, pathRun)
   } catch (err: unknown) {
     // A run name the kit refuses is the caller's mistake, and it is the same
     // mistake /reset already answers 400 for. Letting it reach the google 500
@@ -157,10 +185,10 @@ async function answer(
     }
     throw err
   }
-  const hit = router.match(method, url.pathname)
+  const hit = router.match(method, path)
   if (hit === null) {
-    process.stderr.write(`${unroutedLine(service, method, url.pathname)}\n`)
-    return unknownRoute(method, url.pathname)
+    process.stderr.write(`${unroutedLine(service, method, path)}\n`)
+    return unknownRoute(method, path)
   }
   const st = rt.state(run)
   const ctx: Ctx<GwsState> = {

--- a/integ/server/kit/typescript/http.ts
+++ b/integ/server/kit/typescript/http.ts
@@ -21,7 +21,7 @@ import { FixtureError, KitError, ResetBodyError, TenantError } from './errors.ts
 import { Router } from './route.ts'
 import type { Ctx } from './route.ts'
 import { DEFAULT_FIXTURE } from './fixture.ts'
-import { applyReset, defaultTenantsOf, parseResetBody } from './reset.ts'
+import { applyReset, defaultTenantsOf, parseResetBody, withPathRun } from './reset.ts'
 import { DEFAULT_RUN, resolveRun, resolveTenant, splitRunPath } from './tenant.ts'
 import type { Headers } from './tenant.ts'
 import { unrouted } from './unrouted.ts'
@@ -71,30 +71,6 @@ export function makeRuntime<C extends MinimalClient>(fake: Fake<C>): Runtime<C> 
 // The reset's target run is read before validation so the queue key exists even
 // for a body that parseResetBody will reject; an invalid body is a 400 that
 // still must not jump the queue.
-// The prefix and the body must not disagree, and the prefix is the one the
-// caller cannot have set by accident. Only an ABSENT run is filled in: a body
-// carrying `{"run": 12}` or `{"run": ""}` is malformed and has to reach
-// parseResetBody to be refused, and overwriting it turned a request that owes
-// a 400 into a successful reset of somebody else's run.
-function withPathRun(body: JsonValue, pathRun: string | undefined): JsonValue {
-  if (pathRun === undefined) return body
-  if (typeof body !== 'object' || body === null || Array.isArray(body)) return body
-  const named = (body as Record<string, JsonValue>).run
-  if (named !== undefined) {
-    // A non-empty string that differs is a caller contradicting itself. Every
-    // other present value (a number, an empty string) is malformed, and is
-    // handed on unchanged so parseResetBody refuses it in its own words
-    // rather than being reported as a contradiction it is not.
-    if (typeof named === 'string' && named !== '' && named !== pathRun) {
-      throw new ResetBodyError(
-        `/reset run ${named} contradicts the /_run/${pathRun} it was sent to`,
-      )
-    }
-    return body
-  }
-  return { ...(body as Record<string, JsonValue>), run: pathRun }
-}
-
 function runOfReset(body: JsonValue): string {
   if (typeof body === 'object' && body !== null && !Array.isArray(body)) {
     const named = (body as Record<string, JsonValue>).run

--- a/integ/server/kit/typescript/index.ts
+++ b/integ/server/kit/typescript/index.ts
@@ -52,7 +52,7 @@ export { parseRange, rangeHeaderOf, rangeReply } from './range.ts'
 export type { ByteRange } from './range.ts'
 export { Router, compilePath, route } from './route.ts'
 export type { Ctx, KitHandler, KitRoute, Matched } from './route.ts'
-export { applyReset, defaultTenantsOf, parseResetBody } from './reset.ts'
+export { applyReset, defaultTenantsOf, parseResetBody, withPathRun } from './reset.ts'
 export {
   DEFAULT_RUN,
   DEFAULT_TENANT,
@@ -66,6 +66,7 @@ export {
   resolveRun,
   resolveTenant,
   runId,
+  splitRunPath,
   tenantKeyName,
   tenantWhere,
 } from './tenant.ts'

--- a/integ/server/kit/typescript/reset.ts
+++ b/integ/server/kit/typescript/reset.ts
@@ -180,6 +180,31 @@ function templateKey(req: ResetRequest): string {
   return JSON.stringify([req.fixture, req.tenants, req.extras])
 }
 
+// A /reset reached through `/_run/<id>/reset` is about THAT run, so the prefix
+// fills the body's `run` in. A body naming a DIFFERENT one is a caller
+// contradicting itself, and is refused rather than silently resolved in favour
+// of either. Lives here beside the rest of the body handling so gws, which
+// keeps its own copy of the request flow, reaches the same rule.
+export function withPathRun(body: JsonValue, pathRun: string | undefined): JsonValue {
+  if (pathRun === undefined) return body
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) return body
+  const named = (body as Record<string, JsonValue>).run
+  if (named !== undefined) {
+    // A non-empty string that differs is a caller contradicting itself. Every
+    // other present value (a number, an empty string) is malformed, and is
+    // handed on unchanged so parseResetBody refuses it in its own words
+    // rather than being reported as a contradiction it is not. Overwriting it
+    // turned a request that owes a 400 into a reset of somebody else's run.
+    if (typeof named === 'string' && named !== '' && named !== pathRun) {
+      throw new ResetBodyError(
+        `/reset run ${named} contradicts the /_run/${pathRun} it was sent to`,
+      )
+    }
+    return body
+  }
+  return { ...(body as Record<string, JsonValue>), run: pathRun }
+}
+
 export function defaultTenantsOf<C extends MinimalClient>(fake: Fake<C>): string[] {
   return fake.defaultTenants ?? [DEFAULT_TENANT]
 }


### PR DESCRIPTION
Stacked on #946, which is stacked on #945. Review those first.

## The gap

gws keeps its own copy of the kit's request flow, so the `/_run/<id>` prefix added in #945 reached every fake except this one. That is worse than not having the prefix: the run axis appears to work and silently does not, for the one service whose state is a process-wide set of in-memory Maps.

gws already keeps state per run. What it lacked was any way for a mount to *ask* for a run, because a mount hands its base URL to a client and never sees the request again. That is the same reason the header and `?_run=` went unused everywhere else.

## The change

Scoping the adapter's base URL once covers the reset, the drive and folder creation, the seeds and every mount, in both languages. `withPathRun` moves from `http.ts` into `reset.ts` beside the rest of the `/reset` body handling so gws reaches the same rule rather than growing a second spelling of it, and `splitRunPath` is exported alongside it.

## The measurement

This one has the evidence #945 could not produce. Running the TypeScript and python gws batteries **concurrently** against one server:

| | TypeScript | Python |
|---|---|---|
| without run scoping | 2559 passed, **22 failed** | 2445 passed, **136 failed** |
| with run scoping | 2581 passed, 0 failed | 2581 passed, 0 failed |

Sequentially both hosts were already 2581/0 either way, so the failure only appears under the concurrency the harness is moving towards.

## Scope

This is **not** the Prisma migration gws still needs. It is the part of that work that does not have to wait for it: gws still has no tenants, and `/reset` still recreates its Maps rather than deleting rows.

## Verification

- gws battery **2581/2581** on both hosts, sequentially and concurrently
- kit selftest **73/73**
- typecheck, eslint and yapf clean