### PR TITLE
docs: document OrcaRouter as an OpenAI-compatible provider for the agent examples

### DIFF
--- a/docs/python/agents/openai-agents.mdx
+++ b/docs/python/agents/openai-agents.mdx
@@ -54,6 +54,8 @@ client = MirageSandboxClient(ws)
 agent = SandboxAgent(name="...", model="gpt-5.5", instructions=ws.file_prompt)
 ```
 
+Any of these examples can also run against an OpenAI-compatible gateway. Point the OpenAI SDK at it with `OPENAI_BASE_URL` and `OPENAI_API_KEY`, then name a model the gateway serves in the `Agent` — for example, with [OrcaRouter](https://www.orcarouter.ai) as the gateway, use `model="orcarouter/auto"`, its adaptive-routing entry that picks the best model per request and fails over automatically.
+
 ## Exports
 
 | Symbol | Purpose |

--- a/docs/typescript/agents/openai.mdx
+++ b/docs/typescript/agents/openai.mdx
@@ -54,6 +54,17 @@ await run(agent, "Create /hello.txt with 'hi from mirage' and cat it.")
 
 The examples also support OpenAI-compatible providers. Set `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `OPENAI_MODEL`; a custom base URL defaults to Chat Completions, uses `mirageExecuteTool`, and disables OpenAI tracing so the third-party key stays with that provider. Set `OPENAI_API=responses` when a compatible endpoint implements the Responses API and the examples will use OpenAI's hosted shell and editor tools instead.
 
+For example, the same examples run against [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible gateway that fronts many models behind one endpoint with adaptive routing and automatic failover:
+
+```bash
+export OPENAI_BASE_URL=https://api.orcarouter.ai/v1
+export OPENAI_API_KEY=sk-orca-...
+export OPENAI_MODEL=orcarouter/auto
+node examples/typescript/agents/openai/ram_agent.ts
+```
+
+`orcarouter/auto` is OrcaRouter's adaptive-routing entry: it picks the best model for each request and fails over automatically when one provider degrades.
+
 ## Exports
 
 | Symbol | Purpose |


### PR DESCRIPTION
The Mirage agent examples already run against any OpenAI-compatible provider, and with a concrete base URL + model name they become one `export` away from OrcaRouter — no code changes. These two pages show users how.

Mirage describes itself as **a Unified Virtual File System for AI Agents**, and its agent integrations (OpenAI Agents SDK in Python and TypeScript, Vercel AI SDK, etc.) are provider-agnostic: they hand the model call to the OpenAI SDK, which already honors `OPENAI_BASE_URL`. The TypeScript OpenAI page documents this pattern for OpenAI-compatible providers in general. This PR names the first concrete example so a Mirage user who wants adaptive routing, automatic failover, and zero-markup inference can get it without treating OrcaRouter as an anonymous custom base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means Mirage users can use that stack directly. The Python and TypeScript examples just set `OPENAI_BASE_URL=https://api.orcarouter.ai/v1`, `OPENAI_API_KEY`, and `OPENAI_MODEL=orcarouter/auto` (OrcaRouter's adaptive-routing entry, which picks the best model per request and fails over automatically).

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Changes:
- `docs/typescript/agents/openai.mdx` — worked example with the three env vars plus a note on what `orcarouter/auto` does.
- `docs/python/agents/openai-agents.mdx` — gateway paragraph showing the same pattern for the Python examples.

Verified: the docs' exact `orcarouter/auto` model id is served by `GET https://api.orcarouter.ai/v1/models` and a `POST /chat/completions` with `model=orcarouter/auto` returns 200. Both `.mdx` pages pass `scripts/check_docs_frontmatter.py` (276 pages parse), and the diff is clean of trailing whitespace / missing-EOF issues.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
