### PR TITLE
test(ids): fix uuid7 clock-race flake

### DIFF
--- a/python/tests/utils/test_ids.py
+++ b/python/tests/utils/test_ids.py
@@ -41,10 +41,13 @@ def test_uuid7_timestamp_never_runs_ahead_of_the_clock():
     # Minting faster than one id per millisecond must not borrow from
     # the future: these ids are database keys, and a timestamp ahead of
     # the clock is wrong data that never corrects itself.
+    # The clock is read after the mint, never before: a bound taken
+    # first is stale by the millisecond that ticks over between the two
+    # lines, which fails an id that was honest when it was stamped.
     for _ in range(5000):
         uuid7()
-    after_ms = time.time_ns() // 1_000_000
     embedded_ms = uuid.UUID(uuid7()).int >> 80
+    after_ms = time.time_ns() // 1_000_000
     assert embedded_ms <= after_ms
 
 


### PR DESCRIPTION
## Problem

`test_uuid7_timestamp_never_runs_ahead_of_the_clock` fails at random on unrelated PRs (seen on #914, run 33180075213: `assert 1787927302966 <= 1787927302965`).

The test read the upper-bound clock **before** minting the id it asserts on:

```python
after_ms = time.time_ns() // 1_000_000        # clock read first
embedded_ms = uuid.UUID(uuid7()).int >> 80    # id minted second
assert embedded_ms <= after_ms
```

If the millisecond ticked over between those two lines, the embedded timestamp is legitimately 1ms greater than `after_ms` and the assert fails. The invariant is real and worth keeping; only the measurement order was inverted.

## Fix

Mint the id first, then read the clock as its upper bound.

## Scope checked

- The neighbour `test_uuid7_embeds_current_timestamp` already sandwiches correctly (clock -> mint -> clock) and is airtight: `_stamp()` returns `max(now_ms, _last_ms)` and `_last_ms` is always a clock reading taken before `before_ms`. No change.
- TS twin (`typescript/packages/core/src/utils/ids.test.ts`) sandwiches with +/-10ms slop and delegates to the `uuid` package (no hand-rolled counter), so it cannot fail this way. No change.

## Verification

Same harness, only the two lines swapped:

- Race quantified, 20k iterations each: old order **3 violations**, new order **0**.
- Soak 500k iterations, mint-then-read shape: **0 violations**; sandwich shape: **0**.
- `pytest tests/utils/test_ids.py` run **300x** (random ordering on): 0 failures.

A single pass proves nothing for a race; the 20k A/B is the load-bearing evidence, with failures entirely on the old side.