### PR TITLE
ci(pre-commit): cache hook environments across runs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,6 +24,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Every run reinstalls all hook environments from scratch (~35s) because
+      # nothing persists ~/.cache/pre-commit between runs. Hook envs are keyed
+      # by the tool revs pinned in the config and by the interpreter, so the
+      # config hash is a sufficient key; a rev bump reinstalls only the hook it
+      # touched, which is why the prefix restore-key is safe to reuse.
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-py3.12-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-py3.12-
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
## What

Add an `actions/cache` step for `~/.cache/pre-commit` in the Pre-commit workflow.

## Why

The job currently reinstalls **every** hook environment on every run — nothing persists the cache between runs. Measured on three recent `main` runs, that cold install is **~35s** of wall time in the job before any hook does real work.

## How

Cache `~/.cache/pre-commit` keyed on the hash of `.pre-commit-config.yaml`, with a prefix `restore-keys` so a single `rev:` bump reinstalls only the hook it touched and reuses the rest. Hook environments are keyed by their pinned tool revs plus the interpreter, so the config hash is a sufficient cache key.

## Scope note

This is the low-risk, no-source-churn item split out from the CI wall-clock work (#886). It does not touch any file contents or the hook set. The pre-commit job has ~18m of slack behind Integ, so this is a **runner-cost** win, not a developer-wait win — kept separate so it doesn't perturb the wall-clock A/B measurements.