### PR TITLE
feat(agents): stale-write trackers stamp backend-native identity

### DIFF
--- a/python/mirage/agents/file_version.py
+++ b/python/mirage/agents/file_version.py
@@ -282,8 +282,23 @@ class FileVersionTracker:
         key = self._key(path)
         stamp = Stamp(identity=identity, content_hash=fingerprint(content))
         read_stamp = self._read_versions.get(key)
-        if read_stamp is not None and moved(read_stamp, stamp):
-            raise StaleMirageFileError(path)
+        if read_stamp is not None:
+            changed = moved(read_stamp, stamp)
+            if (changed and identity is None
+                    and read_stamp.content_hash is None
+                    and has_marker(read_stamp.identity)):
+                # A marker-only restamp holds no hash and a rendering
+                # read attaches no markers (a versioned mount with a
+                # registered filetype read, drive's gdoc rendering),
+                # so the ladder above had nothing to compare and
+                # refused a file nobody touched. One live_identity
+                # call restores the marker rung for exactly this
+                # corner; every other shape stays zero extra calls.
+                current = await self._ws.ops.live_identity(path)
+                changed = compare_markers(read_stamp.identity,
+                                          current) is not MarkerMatch.SAME
+            if changed:
+                raise StaleMirageFileError(path)
         self._edit_versions[key] = stamp
         return content
 

--- a/python/mirage/agents/file_version.py
+++ b/python/mirage/agents/file_version.py
@@ -299,10 +299,11 @@ class FileVersionTracker:
         Returns:
             bytes: The stored bytes.
         """
+        if not self._enabled:
+            return await self._ws.ops.read(path)
         content, identity = await self._ws.ops.read_with_identity(path)
-        if self._enabled:
-            self._read_versions[self._key(path)] = Stamp(
-                identity=identity, content_hash=fingerprint(content))
+        self._read_versions[self._key(path)] = Stamp(
+            identity=identity, content_hash=fingerprint(content))
         return content
 
     async def read_for_edit(self, path: str) -> bytes:
@@ -317,9 +318,9 @@ class FileVersionTracker:
         Raises:
             StaleMirageFileError: The file moved since it was last read.
         """
-        content, identity = await self._ws.ops.read_with_identity(path)
         if not self._enabled:
-            return content
+            return await self._ws.ops.read(path)
+        content, identity = await self._ws.ops.read_with_identity(path)
         key = self._key(path)
         stamp = Stamp(identity=identity, content_hash=fingerprint(content))
         read_stamp = self._read_versions.get(key)

--- a/python/mirage/agents/file_version.py
+++ b/python/mirage/agents/file_version.py
@@ -14,7 +14,10 @@
 
 import base64
 import hashlib
+from dataclasses import dataclass
+from enum import Enum
 
+from mirage.ops.types import LiveFileIdentity
 from mirage.workspace.workspace import Workspace
 
 
@@ -39,6 +42,137 @@ def fingerprint(content: bytes) -> str:
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 
+@dataclass(frozen=True, slots=True)
+class Stamp:
+    """What one file looked like the last time the agent saw it.
+
+    Both fields, never one. ``identity`` is what the backend itself
+    said, lifted off the read's own response, so it describes the bytes
+    the agent was handed and not a concurrent writer's. ``content_hash``
+    is the hash of those same bytes, which costs nothing on a path that
+    already holds them and is the only comparator a mount without native
+    markers has. An identity-only stamp would have nothing to say on
+    such a mount, and one taken from a separate call after the read
+    could stamp somebody else's version.
+
+    ``content_hash`` is None in exactly one case: a post-write restamp
+    whose backend answered with a marker. Hashing there would mean
+    re-reading the file just written, which is the download this design
+    exists to remove. The ladder reaches the hash rung from such a stamp
+    only if the backend stopped reporting markers between that write and
+    the next check; it then refuses the write rather than guessing, so a
+    missing baseline costs a spurious refusal in a case that should not
+    happen and never an accepted stale write.
+
+    Args:
+        identity (LiveFileIdentity | None): the backend's own markers
+            for the bytes stamped, None when it reported none.
+        content_hash (str | None): hash of the bytes stamped, None only
+            for the marker-carrying write restamp described above.
+    """
+
+    identity: LiveFileIdentity | None
+    content_hash: str | None
+
+
+class MarkerMatch(Enum):
+    """How two identities compared on the strongest marker they share."""
+
+    SAME = "same"
+    CHANGED = "changed"
+    UNCOMPARABLE = "uncomparable"
+
+
+def compare_markers(stamp: LiveFileIdentity | None,
+                    current: LiveFileIdentity | None) -> MarkerMatch:
+    """Compare a stamped identity against the live one, strongest first.
+
+    A revision is a durable handle and a fingerprint only a change
+    token, so two revisions settle the question and two fingerprints
+    settle it one rung lower. A backend that says the file is gone
+    settles it above both, which is the tracker's old "no current
+    version" answer. Anything else is UNCOMPARABLE and the caller falls
+    back to hashing bytes.
+
+    Args:
+        stamp (LiveFileIdentity | None): identity recorded when the
+            agent last saw the file.
+        current (LiveFileIdentity | None): identity the backend reports
+            now, None when the mount has no identity op.
+
+    Returns:
+        MarkerMatch: SAME, CHANGED, or UNCOMPARABLE.
+    """
+    if current is not None and not current.exists:
+        return MarkerMatch.CHANGED
+    if stamp is None or current is None:
+        return MarkerMatch.UNCOMPARABLE
+    if stamp.revision is not None and current.revision is not None:
+        return (MarkerMatch.SAME
+                if stamp.revision == current.revision else MarkerMatch.CHANGED)
+    if stamp.fingerprint is not None and current.fingerprint is not None:
+        return (MarkerMatch.SAME if stamp.fingerprint == current.fingerprint
+                else MarkerMatch.CHANGED)
+    return MarkerMatch.UNCOMPARABLE
+
+
+def has_marker(identity: LiveFileIdentity | None) -> bool:
+    """Whether an identity carries a marker the ladder can compare.
+
+    Args:
+        identity (LiveFileIdentity | None): the identity to inspect.
+
+    Returns:
+        bool: True when the file is there and the backend named a
+        revision or a fingerprint for it.
+    """
+    return (identity is not None and identity.exists
+            and (identity.revision is not None
+                 or identity.fingerprint is not None))
+
+
+def hash_differs(stamp: Stamp, current_hash: str | None) -> bool:
+    """Whether the hash rung says the file moved.
+
+    A file that is no longer there has moved, and so has one whose
+    stamp never took a baseline: neither can show the bytes are the ones
+    the agent saw, and this rung answers what it was asked rather than
+    guessing in the permissive direction.
+
+    Args:
+        stamp (Stamp): what the agent last saw.
+        current_hash (str | None): hash of the bytes there now, None
+            when the file is gone.
+
+    Returns:
+        bool: True when the write must be refused.
+    """
+    return (stamp.content_hash is None or current_hash is None
+            or stamp.content_hash != current_hash)
+
+
+def moved(stamp: Stamp, current: Stamp) -> bool:
+    """Whether two stamps of one path describe different bytes.
+
+    The whole ladder, for the caller that already holds both the live
+    identity and the live bytes (a ``read_for_edit``, which has just
+    read them) and so owes no ``live_identity`` call of its own.
+
+    Args:
+        stamp (Stamp): what the agent last saw.
+        current (Stamp): what the file holds now.
+
+    Returns:
+        bool: True when the write must be refused.
+    """
+    verdict = compare_markers(stamp.identity, current.identity)
+    if verdict is MarkerMatch.SAME:
+        return False
+    if verdict is MarkerMatch.CHANGED:
+        return True
+    return hash_differs(stamp, current.content_hash)
+
+
 class FileVersionTracker:
     """Refuses a write to a file that moved under the agent.
 
@@ -47,8 +181,16 @@ class FileVersionTracker:
     `read_for_edit` records what it is about to rewrite. A plain write
     is checked against the read stamp, an edit against the edit stamp.
 
-    Stamps cover the rendered bytes, which is what the read tool hands
-    the agent. The TypeScript tracker stamps the stored bytes instead;
+    A check asks the backend for its own identity first and only hashes
+    bytes when that answers nothing, so a mount that knows its versions
+    costs one metadata call per check instead of one full download. The
+    read-side stamp comes from the read's own response
+    (`read_with_identity`), never from a second call: an identity
+    fetched after the read would already be a concurrent writer's, and
+    the write that should have been refused would sail through.
+
+    Hashes cover the rendered bytes, which is what the read tool hands
+    the agent. The TypeScript tracker hashes the stored bytes instead;
     here that would let `edit` search bytes the agent never saw, since
     this side's read tool has always rendered.
 
@@ -61,8 +203,8 @@ class FileVersionTracker:
     def __init__(self, workspace: Workspace, enabled: bool = True) -> None:
         self._ws = workspace
         self._enabled = enabled
-        self._read_versions: dict[str, str] = {}
-        self._edit_versions: dict[str, str] = {}
+        self._read_versions: dict[str, Stamp] = {}
+        self._edit_versions: dict[str, Stamp] = {}
 
     def _key(self, path: str) -> str:
         """The stamp key for a path: one key per file, not per spelling.
@@ -81,27 +223,71 @@ class FileVersionTracker:
         """
         return self._ws.namespace.follow(path)
 
-    async def _current_version(self, path: str) -> str | None:
+    async def _current_hash(self, path: str) -> str | None:
+        """Hash the bytes the file holds now, the ladder's last rung.
+
+        Args:
+            path (str): Virtual path.
+
+        Returns:
+            str | None: the hash, None when nothing is there.
+        """
         if not await self._ws.ops.exists(path):
             return None
         return fingerprint(await self._ws.ops.read(path))
 
-    async def _assert_version(self, path: str, expected: str) -> None:
-        if await self._current_version(path) != expected:
-            raise StaleMirageFileError(path)
+    async def _assert_version(self, path: str, stamp: Stamp) -> None:
+        """Refuse unless the file still holds what the stamp describes.
+
+        One `live_identity` call, then the strongest marker both sides
+        carry. The full re-read only happens when neither side has a
+        marker to compare, which is every mount whose backend has no
+        identity op.
+
+        Args:
+            path (str): Virtual path.
+            stamp (Stamp): what the agent last saw.
+
+        Raises:
+            StaleMirageFileError: The file moved since it was stamped.
+        """
+        current = await self._ws.ops.live_identity(path)
+        verdict = compare_markers(stamp.identity, current)
+        if verdict is MarkerMatch.SAME:
+            return
+        if verdict is MarkerMatch.UNCOMPARABLE and not hash_differs(
+                stamp, await self._current_hash(path)):
+            return
+        raise StaleMirageFileError(path)
 
     async def _record_write(self, path: str, key: str) -> None:
-        # Stamp what a later read will return, not the bytes handed in.
-        # A mount whose read op renders answers with something other than
-        # what was stored, so stamping the input would make the very next
-        # write or edit look stale with nobody having touched the file.
+        """Restamp a path this tracker has just written.
+
+        Stamp what a later read will return, not the bytes handed in. A
+        mount whose read op renders answers with something other than
+        what was stored, so stamping the input would make the very next
+        write or edit look stale with nobody having touched the file.
+        A backend that names its own marker says that much in one
+        metadata call; only a backend that names none has to be read
+        back, and that read is what fills the hash.
+
+        Args:
+            path (str): Virtual path.
+            key (str): The stamp key the write was checked under.
+        """
         if not self._enabled:
             return
-        version = await self._current_version(path)
-        if version is None:
-            self._read_versions.pop(key, None)
+        identity = await self._ws.ops.live_identity(path)
+        if has_marker(identity):
+            self._read_versions[key] = Stamp(identity=identity,
+                                             content_hash=None)
         else:
-            self._read_versions[key] = version
+            content_hash = await self._current_hash(path)
+            if content_hash is None:
+                self._read_versions.pop(key, None)
+            else:
+                self._read_versions[key] = Stamp(identity=identity,
+                                                 content_hash=content_hash)
         self._edit_versions.pop(key, None)
 
     async def read(self, path: str) -> bytes:
@@ -113,9 +299,10 @@ class FileVersionTracker:
         Returns:
             bytes: The stored bytes.
         """
-        content = await self._ws.ops.read(path)
+        content, identity = await self._ws.ops.read_with_identity(path)
         if self._enabled:
-            self._read_versions[self._key(path)] = fingerprint(content)
+            self._read_versions[self._key(path)] = Stamp(
+                identity=identity, content_hash=fingerprint(content))
         return content
 
     async def read_for_edit(self, path: str) -> bytes:
@@ -130,15 +317,15 @@ class FileVersionTracker:
         Raises:
             StaleMirageFileError: The file moved since it was last read.
         """
-        content = await self._ws.ops.read(path)
+        content, identity = await self._ws.ops.read_with_identity(path)
         if not self._enabled:
             return content
         key = self._key(path)
-        version = fingerprint(content)
-        read_version = self._read_versions.get(key)
-        if read_version is not None and read_version != version:
+        stamp = Stamp(identity=identity, content_hash=fingerprint(content))
+        read_stamp = self._read_versions.get(key)
+        if read_stamp is not None and moved(read_stamp, stamp):
             raise StaleMirageFileError(path)
-        self._edit_versions[key] = version
+        self._edit_versions[key] = stamp
         return content
 
     async def write(self, path: str, content: str) -> None:
@@ -153,9 +340,9 @@ class FileVersionTracker:
         """
         key = self._key(path)
         if self._enabled:
-            read_version = self._read_versions.get(key)
-            if read_version is not None:
-                await self._assert_version(path, read_version)
+            read_stamp = self._read_versions.get(key)
+            if read_stamp is not None:
+                await self._assert_version(path, read_stamp)
         await self._ws.ops.write(path, content.encode("utf-8"))
         await self._record_write(path, key)
 
@@ -171,8 +358,8 @@ class FileVersionTracker:
         """
         key = self._key(path)
         if self._enabled:
-            edit_version = self._edit_versions.get(key)
-            if edit_version is not None:
-                await self._assert_version(path, edit_version)
+            edit_stamp = self._edit_versions.get(key)
+            if edit_stamp is not None:
+                await self._assert_version(path, edit_stamp)
         await self._ws.ops.write(path, content.encode("utf-8"))
         await self._record_write(path, key)

--- a/python/mirage/agents/file_version.py
+++ b/python/mirage/agents/file_version.py
@@ -14,9 +14,8 @@
 
 import base64
 import hashlib
-from dataclasses import dataclass
-from enum import Enum
 
+from mirage.agents.types import MarkerMatch, Stamp
 from mirage.ops.types import LiveFileIdentity
 from mirage.workspace.workspace import Workspace
 
@@ -40,47 +39,6 @@ def fingerprint(content: bytes) -> str:
     """
     digest = hashlib.sha256(content).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-
-
-@dataclass(frozen=True, slots=True)
-class Stamp:
-    """What one file looked like the last time the agent saw it.
-
-    Both fields, never one. ``identity`` is what the backend itself
-    said, lifted off the read's own response, so it describes the bytes
-    the agent was handed and not a concurrent writer's. ``content_hash``
-    is the hash of those same bytes, which costs nothing on a path that
-    already holds them and is the only comparator a mount without native
-    markers has. An identity-only stamp would have nothing to say on
-    such a mount, and one taken from a separate call after the read
-    could stamp somebody else's version.
-
-    ``content_hash`` is None in exactly one case: a post-write restamp
-    whose backend answered with a marker. Hashing there would mean
-    re-reading the file just written, which is the download this design
-    exists to remove. The ladder reaches the hash rung from such a stamp
-    only if the backend stopped reporting markers between that write and
-    the next check; it then refuses the write rather than guessing, so a
-    missing baseline costs a spurious refusal in a case that should not
-    happen and never an accepted stale write.
-
-    Args:
-        identity (LiveFileIdentity | None): the backend's own markers
-            for the bytes stamped, None when it reported none.
-        content_hash (str | None): hash of the bytes stamped, None only
-            for the marker-carrying write restamp described above.
-    """
-
-    identity: LiveFileIdentity | None
-    content_hash: str | None
-
-
-class MarkerMatch(Enum):
-    """How two identities compared on the strongest marker they share."""
-
-    SAME = "same"
-    CHANGED = "changed"
-    UNCOMPARABLE = "uncomparable"
 
 
 def compare_markers(stamp: LiveFileIdentity | None,

--- a/python/mirage/agents/types.py
+++ b/python/mirage/agents/types.py
@@ -1,0 +1,59 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+from enum import Enum
+
+from mirage.ops.types import LiveFileIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class Stamp:
+    """What one file looked like the last time the agent saw it.
+
+    Both fields, never one. ``identity`` is what the backend itself
+    said, lifted off the read's own response, so it describes the bytes
+    the agent was handed and not a concurrent writer's. ``content_hash``
+    is the hash of those same bytes, which costs nothing on a path that
+    already holds them and is the only comparator a mount without native
+    markers has. An identity-only stamp would have nothing to say on
+    such a mount, and one taken from a separate call after the read
+    could stamp somebody else's version.
+
+    ``content_hash`` is None in exactly one case: a post-write restamp
+    whose backend answered with a marker. Hashing there would mean
+    re-reading the file just written, which is the download this design
+    exists to remove. The ladder reaches the hash rung from such a stamp
+    only if the backend stopped reporting markers between that write and
+    the next check; it then refuses the write rather than guessing, so a
+    missing baseline costs a spurious refusal in a case that should not
+    happen and never an accepted stale write.
+
+    Args:
+        identity (LiveFileIdentity | None): the backend's own markers
+            for the bytes stamped, None when it reported none.
+        content_hash (str | None): hash of the bytes stamped, None only
+            for the marker-carrying write restamp described above.
+    """
+
+    identity: LiveFileIdentity | None
+    content_hash: str | None
+
+
+class MarkerMatch(Enum):
+    """How two identities compared on the strongest marker they share."""
+
+    SAME = "same"
+    CHANGED = "changed"
+    UNCOMPARABLE = "uncomparable"

--- a/python/scratch/test_live_identity_s3.py
+++ b/python/scratch/test_live_identity_s3.py
@@ -4,7 +4,6 @@ import os
 from mirage import MountMode, Workspace
 from mirage.resource.s3 import S3Config, S3Resource
 
-
 PATH = "/s3/mirage-pr-demo/file.txt"
 
 

--- a/python/scratch/test_live_identity_s3.py
+++ b/python/scratch/test_live_identity_s3.py
@@ -1,0 +1,33 @@
+import asyncio
+import os
+
+from mirage import MountMode, Workspace
+from mirage.resource.s3 import S3Config, S3Resource
+
+
+PATH = "/s3/mirage-pr-demo/file.txt"
+
+
+async def main() -> None:
+    config = S3Config(
+        bucket=os.environ["AWS_S3_BUCKET"],
+        region=os.environ["AWS_DEFAULT_REGION"],
+        aws_profile=os.environ.get("AWS_PROFILE"),
+    )
+    ws = Workspace(
+        {"/s3/": S3Resource(config)},
+        mode=MountMode.WRITE,
+    )
+
+    try:
+        identity = await ws.ops.live_identity(PATH)
+        print("live_identity:", identity)
+
+        data, read_identity = await ws.ops.read_with_identity(PATH)
+        print("content:", data.decode().strip())
+        print("read_identity:", read_identity)
+    finally:
+        await ws.close()
+
+
+asyncio.run(main())

--- a/python/scratch/test_read_for_edit_s3.py
+++ b/python/scratch/test_read_for_edit_s3.py
@@ -7,7 +7,6 @@ from mirage import MountMode, Workspace
 from mirage.agents.file_version import FileVersionTracker, StaleMirageFileError
 from mirage.resource.s3 import S3Config, S3Resource
 
-
 KEY = "mirage-pr-demo/file.txt"
 PATH = f"/s3/{KEY}"
 

--- a/python/scratch/test_read_for_edit_s3.py
+++ b/python/scratch/test_read_for_edit_s3.py
@@ -1,0 +1,71 @@
+import asyncio
+import os
+
+import aioboto3
+
+from mirage import MountMode, Workspace
+from mirage.agents.file_version import FileVersionTracker, StaleMirageFileError
+from mirage.resource.s3 import S3Config, S3Resource
+
+
+KEY = "mirage-pr-demo/file.txt"
+PATH = f"/s3/{KEY}"
+
+
+async def put_outside(
+    session: aioboto3.Session,
+    bucket: str,
+    region: str,
+    content: bytes,
+) -> None:
+    async with session.client("s3", region_name=region) as s3:
+        await s3.put_object(Bucket=bucket, Key=KEY, Body=content)
+
+
+async def main() -> None:
+    bucket = os.environ["AWS_S3_BUCKET"]
+    region = os.environ["AWS_DEFAULT_REGION"]
+    profile = os.environ.get("AWS_PROFILE")
+    session = aioboto3.Session(profile_name=profile)
+
+    await put_outside(session, bucket, region, b"A: original\n")
+
+    resource = S3Resource(
+        S3Config(
+            bucket=bucket,
+            region=region,
+            aws_profile=profile,
+        ))
+    ws = Workspace({"/s3/": resource}, mode=MountMode.WRITE)
+
+    try:
+        tracker = FileVersionTracker(ws)
+
+        first = await tracker.read(PATH)
+        print("1. Agent read and stamped:", first.decode().strip())
+
+        await put_outside(session, bucket, region, b"B: outside change\n")
+        print("2. Outside writer committed: B: outside change")
+
+        try:
+            await tracker.read_for_edit(PATH)
+            print("3. ERROR: stale edit preparation was accepted")
+        except StaleMirageFileError as exc:
+            print("3. PASS: read_for_edit detected the stale baseline")
+            print("  ", exc)
+
+        latest = await tracker.read(PATH)
+        print("4. Agent re-read and stamped:", latest.decode().strip())
+
+        editable = await tracker.read_for_edit(PATH)
+        merged = editable.decode() + "C: agent edit\n"
+        await tracker.write_edit(PATH, merged)
+        print("5. PASS: edit based on the latest version was accepted")
+
+        final = await ws.ops.read(PATH, fresh=True)
+        print("6. Final S3 content:\n" + final.decode(), end="")
+    finally:
+        await ws.close()
+
+
+asyncio.run(main())

--- a/python/scratch/test_stale_write_s3.py
+++ b/python/scratch/test_stale_write_s3.py
@@ -1,0 +1,61 @@
+import asyncio
+import os
+
+import aioboto3
+
+from mirage import MountMode, Workspace
+from mirage.agents.file_version import FileVersionTracker, StaleMirageFileError
+from mirage.resource.s3 import S3Config, S3Resource
+
+
+KEY = "mirage-pr-demo/file.txt"
+PATH = f"/s3/{KEY}"
+
+
+async def main() -> None:
+    bucket = os.environ["AWS_S3_BUCKET"]
+    region = os.environ["AWS_DEFAULT_REGION"]
+    profile = os.environ.get("AWS_PROFILE")
+    config = S3Config(
+        bucket=bucket,
+        region=region,
+        aws_profile=profile,
+    )
+    ws = Workspace(
+        {"/s3/": S3Resource(config)},
+        mode=MountMode.WRITE,
+    )
+
+    try:
+        tracker = FileVersionTracker(ws)
+        content = await tracker.read(PATH)
+        stamped = await ws.ops.live_identity(PATH)
+        print("1. Agent read:", content.decode().strip())
+        print("   Stamped identity:", stamped)
+
+        session = aioboto3.Session(profile_name=profile)
+        async with session.client("s3", region_name=region) as s3:
+            await s3.put_object(
+                Bucket=bucket,
+                Key=KEY,
+                Body=b"outside-writer-version\n",
+            )
+
+        current = await ws.ops.live_identity(PATH)
+        print("2. Outside writer replaced the object")
+        print("   Current identity:", current)
+
+        try:
+            await tracker.write(PATH, "agent-version\n")
+            print("3. ERROR: stale write was accepted")
+        except StaleMirageFileError as exc:
+            print("3. PASS: stale write was refused")
+            print("  ", exc)
+
+        final = await ws.ops.read(PATH, fresh=True)
+        print("4. Final S3 content:", final.decode().strip())
+    finally:
+        await ws.close()
+
+
+asyncio.run(main())

--- a/python/scratch/test_stale_write_s3.py
+++ b/python/scratch/test_stale_write_s3.py
@@ -7,7 +7,6 @@ from mirage import MountMode, Workspace
 from mirage.agents.file_version import FileVersionTracker, StaleMirageFileError
 from mirage.resource.s3 import S3Config, S3Resource
 
-
 KEY = "mirage-pr-demo/file.txt"
 PATH = f"/s3/{KEY}"
 

--- a/python/tests/agents/test_file_version.py
+++ b/python/tests/agents/test_file_version.py
@@ -1,10 +1,11 @@
 import pytest
 
 from mirage import MountMode, RAMResource, Workspace
-from mirage.agents.file_version import (FileVersionTracker, MarkerMatch,
-                                        StaleMirageFileError, Stamp,
-                                        compare_markers, fingerprint)
+from mirage.agents.file_version import (FileVersionTracker,
+                                        StaleMirageFileError, compare_markers,
+                                        fingerprint)
 from mirage.agents.tool_operations import MirageToolOperations
+from mirage.agents.types import MarkerMatch, Stamp
 from mirage.ops.types import LiveFileIdentity
 
 

--- a/python/tests/agents/test_file_version.py
+++ b/python/tests/agents/test_file_version.py
@@ -71,6 +71,7 @@ class _VersionedOps:
         self.with_fingerprint = with_fingerprint
         self.reads = 0
         self.identity_calls = 0
+        self.read_with_identity_calls = 0
 
     async def _identity(self, path):
         if not await self._ops.exists(path):
@@ -91,6 +92,7 @@ class _VersionedOps:
         # The markers ride the read's own response, the way s3 and
         # gridfs lift an ETag and a VersionId off the GET that carried
         # the bytes.
+        self.read_with_identity_calls += 1
         return await self.read(path), await self._identity(path)
 
     async def live_identity(self, path):
@@ -411,3 +413,15 @@ def test_stamp_keeps_both_the_identity_and_the_hash():
     stamp = Stamp(identity=identity, content_hash=fingerprint(b"one"))
     assert stamp.identity is identity
     assert stamp.content_hash == fingerprint(b"one")
+
+
+@pytest.mark.asyncio
+async def test_disabled_tracker_never_asks_for_identity(workspace):
+    versioned = _VersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned, enabled=False)
+    await versioned.ops.write("/a.txt", b"one")
+    assert await tracker.read("/a.txt") == b"one"
+    assert await tracker.read_for_edit("/a.txt") == b"one"
+    await tracker.write("/a.txt", "two")
+    assert versioned.ops.read_with_identity_calls == 0
+    assert versioned.ops.identity_calls == 0

--- a/python/tests/agents/test_file_version.py
+++ b/python/tests/agents/test_file_version.py
@@ -426,3 +426,70 @@ async def test_disabled_tracker_never_asks_for_identity(workspace):
     await tracker.write("/a.txt", "two")
     assert versioned.ops.read_with_identity_calls == 0
     assert versioned.ops.identity_calls == 0
+
+
+class _RenderingVersionedOps:
+    """A versioned mount whose read renders: markers ride live_identity
+    but never the read itself, which is drive's gdoc shape (a registered
+    filetype read on a mount with an identity op)."""
+
+    def __init__(self, ops):
+        self._ops = ops
+        self._marks: dict[str, int] = {}
+        self.identity_calls = 0
+
+    async def _identity(self, path):
+        if not await self._ops.exists(path):
+            return LiveFileIdentity(exists=False,
+                                    revision=None,
+                                    fingerprint=None)
+        return LiveFileIdentity(exists=True,
+                                revision=f"r{self._marks.get(path, 0)}",
+                                fingerprint=None)
+
+    async def read(self, path):
+        return b"rendered:" + await self._ops.read(path)
+
+    async def read_with_identity(self, path, raw=False):
+        return await self.read(path), None
+
+    async def live_identity(self, path):
+        self.identity_calls += 1
+        return await self._identity(path)
+
+    async def write(self, path, data):
+        await self._ops.write(path, data)
+        self._marks[path] = self._marks.get(path, 0) + 1
+
+    async def exists(self, path):
+        return await self._ops.exists(path)
+
+
+class _RenderingVersionedWorkspace:
+
+    def __init__(self, ws):
+        self.ops = _RenderingVersionedOps(ws.ops)
+        self.namespace = ws.namespace
+
+
+@pytest.mark.asyncio
+async def test_edit_after_own_write_survives_a_marker_only_restamp(workspace):
+    # The restamp keeps the marker and no hash; the rendering read hands
+    # back no marker. Without the corner's live_identity call the hash
+    # rung had nothing to compare and refused a file nobody touched.
+    versioned = _RenderingVersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned)
+    await tracker.write("/a.txt", "one")
+    calls = versioned.ops.identity_calls
+    assert await tracker.read_for_edit("/a.txt") == b"rendered:one"
+    assert versioned.ops.identity_calls == calls + 1
+
+
+@pytest.mark.asyncio
+async def test_marker_only_restamp_still_refuses_an_outside_change(workspace):
+    versioned = _RenderingVersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned)
+    await tracker.write("/a.txt", "one")
+    await versioned.ops.write("/a.txt", b"moved underneath")
+    with pytest.raises(StaleMirageFileError):
+        await tracker.read_for_edit("/a.txt")

--- a/python/tests/agents/test_file_version.py
+++ b/python/tests/agents/test_file_version.py
@@ -1,9 +1,11 @@
 import pytest
 
 from mirage import MountMode, RAMResource, Workspace
-from mirage.agents.file_version import (FileVersionTracker,
-                                        StaleMirageFileError, fingerprint)
+from mirage.agents.file_version import (FileVersionTracker, MarkerMatch,
+                                        StaleMirageFileError, Stamp,
+                                        compare_markers, fingerprint)
 from mirage.agents.tool_operations import MirageToolOperations
+from mirage.ops.types import LiveFileIdentity
 
 
 @pytest.fixture
@@ -16,8 +18,10 @@ class _RenderingOps:
 
     Any mount carrying a filetype read op behaves this way: `write`
     stores one thing and `read` hands back the rendering. The tracker
-    reaches the workspace only through these three calls, so this is the
-    whole of the condition.
+    reaches the workspace only through these calls, so this is the whole
+    of the condition. It names no version of its own, so every check
+    falls to the hash rung, which is what a RAM, disk or redis mount
+    does too.
     """
 
     def __init__(self, ops):
@@ -25,6 +29,12 @@ class _RenderingOps:
 
     async def read(self, path):
         return b"rendered:" + await self._ops.read(path)
+
+    async def read_with_identity(self, path, raw=False):
+        return await self.read(path), None
+
+    async def live_identity(self, path):
+        return None
 
     async def write(self, path, data):
         await self._ops.write(path, data)
@@ -37,6 +47,70 @@ class _RenderingWorkspace:
 
     def __init__(self, ws):
         self.ops = _RenderingOps(ws.ops)
+        self.namespace = ws.namespace
+
+
+class _VersionedOps:
+    """A backend that names its own versions, the way s3 and gridfs do.
+
+    Every write bumps the marker, `read_with_identity` hands the marker
+    back with the bytes it just read, and `live_identity` answers from
+    the same table without touching content. `reads` counts full
+    content reads, which is the cost the native path must not pay.
+
+    Args:
+        ops: The real ops facade to store through.
+        with_revision (bool): Report a revision marker.
+        with_fingerprint (bool): Report a fingerprint marker.
+    """
+
+    def __init__(self, ops, with_revision=True, with_fingerprint=True):
+        self._ops = ops
+        self._marks: dict[str, int] = {}
+        self.with_revision = with_revision
+        self.with_fingerprint = with_fingerprint
+        self.reads = 0
+        self.identity_calls = 0
+
+    async def _identity(self, path):
+        if not await self._ops.exists(path):
+            return LiveFileIdentity(exists=False,
+                                    revision=None,
+                                    fingerprint=None)
+        mark = self._marks.get(path, 0)
+        return LiveFileIdentity(
+            exists=True,
+            revision=f"r{mark}" if self.with_revision else None,
+            fingerprint=f"f{mark}" if self.with_fingerprint else None)
+
+    async def read(self, path):
+        self.reads += 1
+        return await self._ops.read(path)
+
+    async def read_with_identity(self, path, raw=False):
+        # The markers ride the read's own response, the way s3 and
+        # gridfs lift an ETag and a VersionId off the GET that carried
+        # the bytes.
+        return await self.read(path), await self._identity(path)
+
+    async def live_identity(self, path):
+        self.identity_calls += 1
+        return await self._identity(path)
+
+    async def write(self, path, data):
+        await self._ops.write(path, data)
+        self._marks[path] = self._marks.get(path, 0) + 1
+
+    async def exists(self, path):
+        return await self._ops.exists(path)
+
+
+class _VersionedWorkspace:
+
+    def __init__(self, ws, with_revision=True, with_fingerprint=True):
+        self.ops = _VersionedOps(ws.ops,
+                                 with_revision=with_revision,
+                                 with_fingerprint=with_fingerprint)
         self.namespace = ws.namespace
 
 
@@ -162,3 +236,178 @@ async def test_edit_tool_without_protection_overwrites(workspace):
     result = await ops.edit("/a.txt", "hello", "goodbye")
     assert result.is_error is False
     assert await workspace.ops.read("/a.txt") == b"goodbye there"
+
+
+def test_compare_markers_takes_the_strongest_shared_rung():
+    both = LiveFileIdentity(exists=True, revision="r1", fingerprint="f1")
+    # A revision outranks a fingerprint: the two disagree here and the
+    # revision is what the verdict follows.
+    moved_revision = LiveFileIdentity(exists=True,
+                                      revision="r2",
+                                      fingerprint="f1")
+    assert compare_markers(both, both) is MarkerMatch.SAME
+    assert compare_markers(both, moved_revision) is MarkerMatch.CHANGED
+    only_fp = LiveFileIdentity(exists=True, revision=None, fingerprint="f1")
+    assert compare_markers(both, only_fp) is MarkerMatch.SAME
+    bare = LiveFileIdentity(exists=True, revision=None, fingerprint=None)
+    assert compare_markers(both, bare) is MarkerMatch.UNCOMPARABLE
+    assert compare_markers(None, both) is MarkerMatch.UNCOMPARABLE
+    gone = LiveFileIdentity(exists=False, revision=None, fingerprint=None)
+    assert compare_markers(both, gone) is MarkerMatch.CHANGED
+    assert compare_markers(None, gone) is MarkerMatch.CHANGED
+
+
+@pytest.mark.asyncio
+async def test_native_markers_refuse_a_stale_write_without_a_re_read(
+        workspace):
+    versioned = _VersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned)
+    await versioned.ops.write("/a.txt", b"one")
+    await tracker.read("/a.txt")
+    reads = versioned.ops.reads
+    await versioned.ops.write("/a.txt", b"moved underneath")
+    with pytest.raises(StaleMirageFileError):
+        await tracker.write("/a.txt", "two")
+    # The refusal came from one metadata call, not from a download.
+    assert versioned.ops.reads == reads
+    assert await workspace.ops.read("/a.txt") == b"moved underneath"
+
+
+@pytest.mark.asyncio
+async def test_native_markers_allow_a_second_write_without_a_re_read(
+        workspace):
+    # The restamp after a write is a marker, so the file the agent just
+    # wrote is never downloaded to prove it is still its own.
+    versioned = _VersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned)
+    await versioned.ops.write("/a.txt", b"one")
+    await tracker.read("/a.txt")
+    reads = versioned.ops.reads
+    await tracker.write("/a.txt", "two")
+    await tracker.write("/a.txt", "three")
+    assert versioned.ops.reads == reads
+    assert await workspace.ops.read("/a.txt") == b"three"
+
+
+@pytest.mark.asyncio
+async def test_a_write_landing_before_the_check_is_refused(workspace):
+    # The blocker this redesign exists for. The stamp is the identity of
+    # the bytes the read itself returned, so a writer that lands after
+    # that read and before the check moves the live marker away from it
+    # and the write is refused. A stamp taken from a second identity
+    # call after the read could have been this writer's version, and the
+    # genuinely stale write would have gone through.
+    versioned = _VersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned)
+    await versioned.ops.write("/a.txt", b"A")
+    await tracker.read("/a.txt")
+    reads = versioned.ops.reads
+    await versioned.ops.write("/a.txt", b"B")
+    assert (await versioned.ops.live_identity("/a.txt")).revision == "r2"
+    with pytest.raises(StaleMirageFileError):
+        await tracker.write("/a.txt", "C")
+    assert versioned.ops.reads == reads
+    assert await workspace.ops.read("/a.txt") == b"B"
+
+
+@pytest.mark.asyncio
+async def test_a_vanished_file_is_stale(workspace):
+    versioned = _VersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned)
+    await versioned.ops.write("/a.txt", b"one")
+    await tracker.read("/a.txt")
+    reads = versioned.ops.reads
+    assert (await workspace.execute("rm /a.txt")).exit_code == 0
+    with pytest.raises(StaleMirageFileError):
+        await tracker.write("/a.txt", "two")
+    assert versioned.ops.reads == reads
+
+
+@pytest.mark.asyncio
+async def test_a_marker_less_mount_uses_the_hash_path(workspace):
+    # A RAM mount registers no identity op, so the facade answers None
+    # end to end and every check is the full re-read it always was.
+    assert await workspace.ops.live_identity("/a.txt") is None
+    tracker = FileVersionTracker(workspace)
+    await workspace.ops.write("/a.txt", b"one")
+    await tracker.read("/a.txt")
+    await tracker.write("/a.txt", "two")
+    await workspace.ops.write("/a.txt", b"moved underneath")
+    with pytest.raises(StaleMirageFileError):
+        await tracker.write("/a.txt", "three")
+
+
+@pytest.mark.asyncio
+async def test_the_fingerprint_rung_decides_when_only_it_is_shared(workspace):
+    versioned = _VersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned)
+    await versioned.ops.write("/a.txt", b"one")
+    await tracker.read("/a.txt")
+    reads = versioned.ops.reads
+    # The stamp carries both markers; the backend now names only the
+    # weaker one, so the check drops to it rather than to a download.
+    versioned.ops.with_revision = False
+    await tracker.write("/a.txt", "two")
+    assert versioned.ops.reads == reads
+    await tracker.read("/a.txt")
+    reads = versioned.ops.reads
+    await versioned.ops.write("/a.txt", b"moved underneath")
+    with pytest.raises(StaleMirageFileError):
+        await tracker.write("/a.txt", "three")
+    assert versioned.ops.reads == reads
+
+
+@pytest.mark.asyncio
+async def test_the_hash_rung_decides_when_the_stamp_has_no_marker(workspace):
+    versioned = _VersionedWorkspace(workspace,
+                                    with_revision=False,
+                                    with_fingerprint=False)
+    tracker = FileVersionTracker(versioned)
+    await versioned.ops.write("/a.txt", b"one")
+    await tracker.read("/a.txt")
+    reads = versioned.ops.reads
+    # Markers appear only after the stamp was taken, so there is no
+    # shared rung and the check falls back to reading the bytes.
+    versioned.ops.with_revision = True
+    versioned.ops.with_fingerprint = True
+    await tracker.write("/a.txt", "two")
+    assert versioned.ops.reads == reads + 1
+
+
+@pytest.mark.asyncio
+async def test_a_marker_only_stamp_refuses_once_the_markers_go_away(workspace):
+    # The one cost of the hash-free write restamp, pinned in the safe
+    # direction: a backend that stops naming versions between a write
+    # and the next check leaves the stamp with nothing to compare, and
+    # the tracker refuses rather than guessing the file is untouched.
+    versioned = _VersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned)
+    await tracker.write("/a.txt", "one")
+    versioned.ops.with_revision = False
+    versioned.ops.with_fingerprint = False
+    with pytest.raises(StaleMirageFileError):
+        await tracker.write("/a.txt", "two")
+
+
+@pytest.mark.asyncio
+async def test_read_for_edit_compares_without_a_second_identity_call(
+        workspace):
+    # The read it just did carries the current identity, so the ladder
+    # runs on what is already in hand.
+    versioned = _VersionedWorkspace(workspace)
+    tracker = FileVersionTracker(versioned)
+    await versioned.ops.write("/a.txt", b"one")
+    await tracker.read("/a.txt")
+    calls = versioned.ops.identity_calls
+    assert await tracker.read_for_edit("/a.txt") == b"one"
+    assert versioned.ops.identity_calls == calls
+    await versioned.ops.write("/a.txt", b"moved underneath")
+    with pytest.raises(StaleMirageFileError):
+        await tracker.read_for_edit("/a.txt")
+
+
+def test_stamp_keeps_both_the_identity_and_the_hash():
+    identity = LiveFileIdentity(exists=True, revision="r1", fingerprint="f1")
+    stamp = Stamp(identity=identity, content_hash=fingerprint(b"one"))
+    assert stamp.identity is identity
+    assert stamp.content_hash == fingerprint(b"one")

--- a/typescript/packages/agents/src/file-version.test.ts
+++ b/typescript/packages/agents/src/file-version.test.ts
@@ -199,7 +199,7 @@ class RenderingVersionedFs {
     if (!(await this.inner.fs.exists(path))) {
       return { exists: false, revision: null, fingerprint: null }
     }
-    return { exists: true, revision: `r${this.marks.get(path) ?? 0}`, fingerprint: null }
+    return { exists: true, revision: `r${String(this.marks.get(path) ?? 0)}`, fingerprint: null }
   }
 
   async readFile(path: string): Promise<Uint8Array> {

--- a/typescript/packages/agents/src/file-version.test.ts
+++ b/typescript/packages/agents/src/file-version.test.ts
@@ -59,6 +59,7 @@ function renderingWs(inner: Workspace): Workspace {
 class VersionedFs {
   reads = 0
   identityCalls = 0
+  readWithIdentityCalls = 0
   withRevision = true
   withFingerprint = true
   private readonly marks = new Map<string, number>()
@@ -85,6 +86,7 @@ class VersionedFs {
   // The markers ride the read's own response, the way s3 and gridfs
   // lift an ETag and a VersionId off the GET that carried the bytes.
   async readFileWithIdentity(path: string): Promise<[Uint8Array, LiveFileIdentity]> {
+    this.readWithIdentityCalls += 1
     return [await this.readFile(path), await this.identity(path)]
   }
 
@@ -170,6 +172,17 @@ describe('FileVersionTracker', () => {
     await ws.fs.writeFile('/a.txt', 'moved underneath')
     await tracker.write('/a.txt', 'two')
     expect(await ws.fs.readFileText('/a.txt')).toBe('two')
+  })
+
+  it('never asks for identity when disabled', async () => {
+    const fs = new VersionedFs(ws)
+    const tracker = new FileVersionTracker(versionedWs(ws, fs), false)
+    await fs.writeFile('/a.txt', 'one')
+    expect((await tracker.read('/a.txt')).toString()).toBe('one')
+    expect((await tracker.readForEdit('/a.txt')).toString()).toBe('one')
+    await tracker.write('/a.txt', 'two')
+    expect(fs.readWithIdentityCalls).toBe(0)
+    expect(fs.identityCalls).toBe(0)
   })
 })
 

--- a/typescript/packages/agents/src/file-version.test.ts
+++ b/typescript/packages/agents/src/file-version.test.ts
@@ -186,6 +186,69 @@ describe('FileVersionTracker', () => {
   })
 })
 
+// A versioned mount whose read renders: markers ride liveIdentity but
+// never the read itself, which is drive's gdoc shape (a registered
+// filetype read on a mount with an identity op).
+class RenderingVersionedFs {
+  identityCalls = 0
+  private readonly marks = new Map<string, number>()
+
+  constructor(private readonly inner: Workspace) {}
+
+  private async identity(path: string): Promise<LiveFileIdentity> {
+    if (!(await this.inner.fs.exists(path))) {
+      return { exists: false, revision: null, fingerprint: null }
+    }
+    return { exists: true, revision: `r${this.marks.get(path) ?? 0}`, fingerprint: null }
+  }
+
+  async readFile(path: string): Promise<Uint8Array> {
+    const raw = await this.inner.fs.readFile(path, { raw: true })
+    return Buffer.concat([Buffer.from('rendered:'), Buffer.from(raw)])
+  }
+
+  async readFileWithIdentity(path: string): Promise<[Uint8Array, null]> {
+    return [await this.readFile(path), null]
+  }
+
+  async liveIdentity(path: string): Promise<LiveFileIdentity> {
+    this.identityCalls += 1
+    return this.identity(path)
+  }
+
+  async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+    await this.inner.fs.writeFile(path, content)
+    this.marks.set(path, (this.marks.get(path) ?? 0) + 1)
+  }
+
+  exists(path: string): Promise<boolean> {
+    return this.inner.fs.exists(path)
+  }
+}
+
+describe('FileVersionTracker on a rendering versioned mount', () => {
+  it('an edit after its own write survives a marker-only restamp', async () => {
+    // The restamp keeps the marker and no hash; the rendering read
+    // hands back no marker. Without the corner's liveIdentity call the
+    // hash rung had nothing to compare and refused a file nobody
+    // touched.
+    const fs = new RenderingVersionedFs(ws)
+    const tracker = new FileVersionTracker(versionedWs(ws, fs as unknown as VersionedFs))
+    await tracker.write('/a.txt', 'one')
+    const calls = fs.identityCalls
+    expect((await tracker.readForEdit('/a.txt')).toString()).toBe('rendered:one')
+    expect(fs.identityCalls).toBe(calls + 1)
+  })
+
+  it('a marker-only restamp still refuses an outside change', async () => {
+    const fs = new RenderingVersionedFs(ws)
+    const tracker = new FileVersionTracker(versionedWs(ws, fs as unknown as VersionedFs))
+    await tracker.write('/a.txt', 'one')
+    await fs.writeFile('/a.txt', 'moved underneath')
+    await expect(tracker.readForEdit('/a.txt')).rejects.toThrow(StaleMirageFileError)
+  })
+})
+
 describe('compareMarkers', () => {
   const both: LiveFileIdentity = { exists: true, revision: 'r1', fingerprint: 'f1' }
 

--- a/typescript/packages/agents/src/file-version.test.ts
+++ b/typescript/packages/agents/src/file-version.test.ts
@@ -14,7 +14,8 @@
 
 import { beforeEach, describe, expect, it } from 'vitest'
 import { MountMode, RAMResource, Workspace } from '@struktoai/mirage-node'
-import { FileVersionTracker, StaleMirageFileError } from './file-version.ts'
+import type { LiveFileIdentity } from '@struktoai/mirage-core/ops/types'
+import { compareMarkers, FileVersionTracker, StaleMirageFileError } from './file-version.ts'
 
 let ws: Workspace
 
@@ -26,21 +27,84 @@ beforeEach(() => {
 // Any mount carrying a filetype read op behaves this way: writeFile
 // stores one thing and readFile hands back the rendering. The tracker
 // reaches the workspace only through these calls, so this is the whole
-// of the condition.
+// of the condition. It names no version of its own, so every check falls
+// to the hash rung, which is what a RAM, disk or redis mount does too.
 function renderingWs(inner: Workspace): Workspace {
   const prefix = new TextEncoder().encode('rendered:')
+  const render = async (path: string): Promise<Uint8Array> => {
+    const stored = await inner.fs.readFile(path, { raw: true })
+    return new Uint8Array([...prefix, ...stored])
+  }
   return {
     fs: {
-      readFile: async (path: string): Promise<Uint8Array> => {
-        const stored = await inner.fs.readFile(path, { raw: true })
-        return new Uint8Array([...prefix, ...stored])
-      },
+      readFile: render,
+      readFileWithIdentity: async (path: string): Promise<[Uint8Array, null]> => [
+        await render(path),
+        null,
+      ],
+      liveIdentity: (): Promise<null> => Promise.resolve(null),
       writeFile: (path: string, content: string | Uint8Array): Promise<void> =>
         inner.fs.writeFile(path, content),
       exists: (path: string): Promise<boolean> => inner.fs.exists(path),
     },
     namespace: inner.namespace,
   } as unknown as Workspace
+}
+
+// A backend that names its own versions, the way s3 and gridfs do.
+// Every write bumps the marker, readFileWithIdentity hands the marker
+// back with the bytes it just read, and liveIdentity answers from the
+// same table without touching content. `reads` counts full content
+// reads, which is the cost the native path must not pay.
+class VersionedFs {
+  reads = 0
+  identityCalls = 0
+  withRevision = true
+  withFingerprint = true
+  private readonly marks = new Map<string, number>()
+
+  constructor(private readonly inner: Workspace) {}
+
+  private async identity(path: string): Promise<LiveFileIdentity> {
+    if (!(await this.inner.fs.exists(path))) {
+      return { exists: false, revision: null, fingerprint: null }
+    }
+    const mark = String(this.marks.get(path) ?? 0)
+    return {
+      exists: true,
+      revision: this.withRevision ? `r${mark}` : null,
+      fingerprint: this.withFingerprint ? `f${mark}` : null,
+    }
+  }
+
+  async readFile(path: string): Promise<Uint8Array> {
+    this.reads += 1
+    return this.inner.fs.readFile(path, { raw: true })
+  }
+
+  // The markers ride the read's own response, the way s3 and gridfs
+  // lift an ETag and a VersionId off the GET that carried the bytes.
+  async readFileWithIdentity(path: string): Promise<[Uint8Array, LiveFileIdentity]> {
+    return [await this.readFile(path), await this.identity(path)]
+  }
+
+  async liveIdentity(path: string): Promise<LiveFileIdentity> {
+    this.identityCalls += 1
+    return this.identity(path)
+  }
+
+  async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+    await this.inner.fs.writeFile(path, content)
+    this.marks.set(path, (this.marks.get(path) ?? 0) + 1)
+  }
+
+  exists(path: string): Promise<boolean> {
+    return this.inner.fs.exists(path)
+  }
+}
+
+function versionedWs(inner: Workspace, fs: VersionedFs): Workspace {
+  return { fs, namespace: inner.namespace } as unknown as Workspace
 }
 
 describe('FileVersionTracker', () => {
@@ -106,5 +170,143 @@ describe('FileVersionTracker', () => {
     await ws.fs.writeFile('/a.txt', 'moved underneath')
     await tracker.write('/a.txt', 'two')
     expect(await ws.fs.readFileText('/a.txt')).toBe('two')
+  })
+})
+
+describe('compareMarkers', () => {
+  const both: LiveFileIdentity = { exists: true, revision: 'r1', fingerprint: 'f1' }
+
+  it('takes the strongest rung the two sides share', () => {
+    // A revision outranks a fingerprint: the two disagree here and the
+    // revision is what the verdict follows.
+    const movedRevision: LiveFileIdentity = { exists: true, revision: 'r2', fingerprint: 'f1' }
+    expect(compareMarkers(both, both)).toBe('same')
+    expect(compareMarkers(both, movedRevision)).toBe('changed')
+    const onlyFingerprint: LiveFileIdentity = { exists: true, revision: null, fingerprint: 'f1' }
+    expect(compareMarkers(both, onlyFingerprint)).toBe('same')
+  })
+
+  it('has nothing to compare without a shared marker', () => {
+    const bare: LiveFileIdentity = { exists: true, revision: null, fingerprint: null }
+    expect(compareMarkers(both, bare)).toBe('uncomparable')
+    expect(compareMarkers(null, both)).toBe('uncomparable')
+  })
+
+  it('reads a file the backend says is gone as changed', () => {
+    const gone: LiveFileIdentity = { exists: false, revision: null, fingerprint: null }
+    expect(compareMarkers(both, gone)).toBe('changed')
+    expect(compareMarkers(null, gone)).toBe('changed')
+  })
+})
+
+describe('FileVersionTracker on a backend that names its versions', () => {
+  let fs: VersionedFs
+  let tracker: FileVersionTracker
+
+  beforeEach(() => {
+    fs = new VersionedFs(ws)
+    tracker = new FileVersionTracker(versionedWs(ws, fs))
+  })
+
+  it('refuses a stale write without a re-read', async () => {
+    await fs.writeFile('/a.txt', 'one')
+    await tracker.read('/a.txt')
+    const reads = fs.reads
+    await fs.writeFile('/a.txt', 'moved underneath')
+    await expect(tracker.write('/a.txt', 'two')).rejects.toThrow(StaleMirageFileError)
+    // The refusal came from one metadata call, not from a download.
+    expect(fs.reads).toBe(reads)
+    expect(await ws.fs.readFileText('/a.txt')).toBe('moved underneath')
+  })
+
+  it('allows a second write without a re-read', async () => {
+    // The restamp after a write is a marker, so the file the agent just
+    // wrote is never downloaded to prove it is still its own.
+    await fs.writeFile('/a.txt', 'one')
+    await tracker.read('/a.txt')
+    const reads = fs.reads
+    await tracker.write('/a.txt', 'two')
+    await tracker.write('/a.txt', 'three')
+    expect(fs.reads).toBe(reads)
+    expect(await ws.fs.readFileText('/a.txt')).toBe('three')
+  })
+
+  it('refuses a write when another one landed before the check', async () => {
+    // The blocker this redesign exists for. The stamp is the identity of
+    // the bytes the read itself returned, so a writer that lands after
+    // that read and before the check moves the live marker away from it
+    // and the write is refused. A stamp taken from a second identity
+    // call after the read could have been this writer's version, and the
+    // genuinely stale write would have gone through.
+    await fs.writeFile('/a.txt', 'A')
+    await tracker.read('/a.txt')
+    const reads = fs.reads
+    await fs.writeFile('/a.txt', 'B')
+    expect((await fs.liveIdentity('/a.txt')).revision).toBe('r2')
+    await expect(tracker.write('/a.txt', 'C')).rejects.toThrow(StaleMirageFileError)
+    expect(fs.reads).toBe(reads)
+    expect(await ws.fs.readFileText('/a.txt')).toBe('B')
+  })
+
+  it('reads a vanished file as stale', async () => {
+    await fs.writeFile('/a.txt', 'one')
+    await tracker.read('/a.txt')
+    const reads = fs.reads
+    expect((await ws.execute('rm /a.txt')).exitCode).toBe(0)
+    await expect(tracker.write('/a.txt', 'two')).rejects.toThrow(StaleMirageFileError)
+    expect(fs.reads).toBe(reads)
+  })
+
+  it('drops to the fingerprint when only it is shared', async () => {
+    await fs.writeFile('/a.txt', 'one')
+    await tracker.read('/a.txt')
+    let reads = fs.reads
+    // The stamp carries both markers; the backend now names only the
+    // weaker one, so the check drops to it rather than to a download.
+    fs.withRevision = false
+    await tracker.write('/a.txt', 'two')
+    expect(fs.reads).toBe(reads)
+    await tracker.read('/a.txt')
+    reads = fs.reads
+    await fs.writeFile('/a.txt', 'moved underneath')
+    await expect(tracker.write('/a.txt', 'three')).rejects.toThrow(StaleMirageFileError)
+    expect(fs.reads).toBe(reads)
+  })
+
+  it('falls to the hash rung when the stamp has no marker', async () => {
+    fs.withRevision = false
+    fs.withFingerprint = false
+    await fs.writeFile('/a.txt', 'one')
+    await tracker.read('/a.txt')
+    const reads = fs.reads
+    // Markers appear only after the stamp was taken, so there is no
+    // shared rung and the check falls back to reading the bytes.
+    fs.withRevision = true
+    fs.withFingerprint = true
+    await tracker.write('/a.txt', 'two')
+    expect(fs.reads).toBe(reads + 1)
+  })
+
+  it('refuses a marker-only stamp once the markers go away', async () => {
+    // The one cost of the hash-free write restamp, pinned in the safe
+    // direction: a backend that stops naming versions between a write
+    // and the next check leaves the stamp with nothing to compare, and
+    // the tracker refuses rather than guessing the file is untouched.
+    await tracker.write('/a.txt', 'one')
+    fs.withRevision = false
+    fs.withFingerprint = false
+    await expect(tracker.write('/a.txt', 'two')).rejects.toThrow(StaleMirageFileError)
+  })
+
+  it('compares a read for edit without a second identity call', async () => {
+    // The read it just did carries the current identity, so the ladder
+    // runs on what is already in hand.
+    await fs.writeFile('/a.txt', 'one')
+    await tracker.read('/a.txt')
+    const calls = fs.identityCalls
+    expect(new TextDecoder().decode(await tracker.readForEdit('/a.txt'))).toBe('one')
+    expect(fs.identityCalls).toBe(calls)
+    await fs.writeFile('/a.txt', 'moved underneath')
+    await expect(tracker.readForEdit('/a.txt')).rejects.toThrow(StaleMirageFileError)
   })
 })

--- a/typescript/packages/agents/src/file-version.ts
+++ b/typescript/packages/agents/src/file-version.ts
@@ -173,18 +173,17 @@ export class FileVersionTracker {
   }
 
   async read(path: string): Promise<Buffer> {
+    if (!this.enabled) return readBuffer(this.ws, path)
     const [bytes, identity] = await this.ws.fs.readFileWithIdentity(path, { raw: true })
     const content = Buffer.from(bytes)
-    if (this.enabled) {
-      this.readVersions.set(this.key(path), { identity, contentHash: fingerprint(content) })
-    }
+    this.readVersions.set(this.key(path), { identity, contentHash: fingerprint(content) })
     return content
   }
 
   async readForEdit(path: string): Promise<Buffer> {
+    if (!this.enabled) return readBuffer(this.ws, path)
     const [bytes, identity] = await this.ws.fs.readFileWithIdentity(path, { raw: true })
     const content = Buffer.from(bytes)
-    if (!this.enabled) return content
     const key = this.key(path)
     const stamp: Stamp = { identity, contentHash: fingerprint(content) }
     const readStamp = this.readVersions.get(key)

--- a/typescript/packages/agents/src/file-version.ts
+++ b/typescript/packages/agents/src/file-version.ts
@@ -161,8 +161,24 @@ export class FileVersionTracker {
     const key = this.key(path)
     const stamp: Stamp = { identity, contentHash: fingerprint(content) }
     const readStamp = this.readVersions.get(key)
-    if (readStamp !== undefined && moved(readStamp, stamp)) {
-      throw new StaleMirageFileError(path)
+    if (readStamp !== undefined) {
+      let changed = moved(readStamp, stamp)
+      if (
+        changed &&
+        identity === null &&
+        readStamp.contentHash === null &&
+        hasMarker(readStamp.identity)
+      ) {
+        // A marker-only restamp holds no hash and a rendering read
+        // attaches no markers (a versioned mount with a registered
+        // filetype read, drive's gdoc rendering), so the ladder above
+        // had nothing to compare and refused a file nobody touched.
+        // One liveIdentity call restores the marker rung for exactly
+        // this corner; every other shape stays zero extra calls.
+        const current = await this.ws.fs.liveIdentity(path)
+        changed = compareMarkers(readStamp.identity, current) !== 'same'
+      }
+      if (changed) throw new StaleMirageFileError(path)
     }
     this.editVersions.set(key, stamp)
     return content

--- a/typescript/packages/agents/src/file-version.ts
+++ b/typescript/packages/agents/src/file-version.ts
@@ -14,6 +14,7 @@
 
 import { createHash } from 'node:crypto'
 import type { LiveFileIdentity } from '@struktoai/mirage-core/ops/types'
+import type { MarkerMatch, Stamp } from './types.ts'
 import type { Workspace } from '@struktoai/mirage-core/workspace/workspace/workspace'
 
 export class StaleMirageFileError extends Error {
@@ -34,33 +35,6 @@ async function readBuffer(ws: Workspace, path: string): Promise<Buffer> {
   const bytes = await ws.fs.readFile(path, { raw: true })
   return Buffer.from(bytes)
 }
-
-// What one file looked like the last time the agent saw it.
-//
-// Both fields, never one. `identity` is what the backend itself said,
-// lifted off the read's own response, so it describes the bytes the
-// agent was handed and not a concurrent writer's. `contentHash` is the
-// hash of those same bytes, which costs nothing on a path that already
-// holds them and is the only comparator a mount without native markers
-// has. An identity-only stamp would have nothing to say on such a
-// mount, and one taken from a separate call after the read could stamp
-// somebody else's version.
-//
-// `contentHash` is null in exactly one case: a post-write restamp whose
-// backend answered with a marker. Hashing there would mean re-reading
-// the file just written, which is the download this design exists to
-// remove. The ladder reaches the hash rung from such a stamp only if the
-// backend stopped reporting markers between that write and the next
-// check; it then refuses the write rather than guessing, so a missing
-// baseline costs a spurious refusal in a case that should not happen and
-// never an accepted stale write. Mirrors python's `Stamp`.
-export interface Stamp {
-  identity: LiveFileIdentity | null
-  contentHash: string | null
-}
-
-// How two identities compared on the strongest marker they share.
-export type MarkerMatch = 'same' | 'changed' | 'uncomparable'
 
 // Compare a stamped identity against the live one, strongest first.
 //

--- a/typescript/packages/agents/src/file-version.ts
+++ b/typescript/packages/agents/src/file-version.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { createHash } from 'node:crypto'
+import type { LiveFileIdentity } from '@struktoai/mirage-core/ops/types'
 import type { Workspace } from '@struktoai/mirage-core/workspace/workspace/workspace'
 
 export class StaleMirageFileError extends Error {
@@ -34,9 +35,89 @@ async function readBuffer(ws: Workspace, path: string): Promise<Buffer> {
   return Buffer.from(bytes)
 }
 
+// What one file looked like the last time the agent saw it.
+//
+// Both fields, never one. `identity` is what the backend itself said,
+// lifted off the read's own response, so it describes the bytes the
+// agent was handed and not a concurrent writer's. `contentHash` is the
+// hash of those same bytes, which costs nothing on a path that already
+// holds them and is the only comparator a mount without native markers
+// has. An identity-only stamp would have nothing to say on such a
+// mount, and one taken from a separate call after the read could stamp
+// somebody else's version.
+//
+// `contentHash` is null in exactly one case: a post-write restamp whose
+// backend answered with a marker. Hashing there would mean re-reading
+// the file just written, which is the download this design exists to
+// remove. The ladder reaches the hash rung from such a stamp only if the
+// backend stopped reporting markers between that write and the next
+// check; it then refuses the write rather than guessing, so a missing
+// baseline costs a spurious refusal in a case that should not happen and
+// never an accepted stale write. Mirrors python's `Stamp`.
+export interface Stamp {
+  identity: LiveFileIdentity | null
+  contentHash: string | null
+}
+
+// How two identities compared on the strongest marker they share.
+export type MarkerMatch = 'same' | 'changed' | 'uncomparable'
+
+// Compare a stamped identity against the live one, strongest first.
+//
+// A revision is a durable handle and a fingerprint only a change token,
+// so two revisions settle the question and two fingerprints settle it
+// one rung lower. A backend that says the file is gone settles it above
+// both, which is the tracker's old "no current version" answer.
+// Anything else is uncomparable and the caller falls back to hashing
+// bytes.
+export function compareMarkers(
+  stamp: LiveFileIdentity | null,
+  current: LiveFileIdentity | null,
+): MarkerMatch {
+  if (current !== null && !current.exists) return 'changed'
+  if (stamp === null || current === null) return 'uncomparable'
+  if (stamp.revision !== null && current.revision !== null) {
+    return stamp.revision === current.revision ? 'same' : 'changed'
+  }
+  if (stamp.fingerprint !== null && current.fingerprint !== null) {
+    return stamp.fingerprint === current.fingerprint ? 'same' : 'changed'
+  }
+  return 'uncomparable'
+}
+
+// Whether an identity carries a marker the ladder can compare.
+function hasMarker(identity: LiveFileIdentity | null): boolean {
+  return (
+    identity !== null &&
+    identity.exists &&
+    (identity.revision !== null || identity.fingerprint !== null)
+  )
+}
+
+// Whether the hash rung says the file moved.
+//
+// A file that is no longer there has moved, and so has one whose stamp
+// never took a baseline: neither can show the bytes are the ones the
+// agent saw, and this rung answers what it was asked rather than
+// guessing in the permissive direction.
+function hashDiffers(stamp: Stamp, currentHash: string | null): boolean {
+  return stamp.contentHash === null || currentHash === null || stamp.contentHash !== currentHash
+}
+
+// Whether two stamps of one path describe different bytes: the whole
+// ladder, for the caller that already holds both the live identity and
+// the live bytes (a `readForEdit`, which has just read them) and so owes
+// no `liveIdentity` call of its own.
+function moved(stamp: Stamp, current: Stamp): boolean {
+  const verdict = compareMarkers(stamp.identity, current.identity)
+  if (verdict === 'same') return false
+  if (verdict === 'changed') return true
+  return hashDiffers(stamp, current.contentHash)
+}
+
 export class FileVersionTracker {
-  private readonly readVersions = new Map<string, string>()
-  private readonly editVersions = new Map<string, string>()
+  private readonly readVersions = new Map<string, Stamp>()
+  private readonly editVersions = new Map<string, Stamp>()
 
   constructor(
     private readonly ws: Workspace,
@@ -53,53 +134,72 @@ export class FileVersionTracker {
     return this.ws.namespace.follow(path)
   }
 
-  private async currentVersion(path: string): Promise<string | null> {
+  // Hash the bytes the file holds now, the ladder's last rung.
+  private async currentHash(path: string): Promise<string | null> {
     if (!(await this.ws.fs.exists(path))) return null
     return fingerprint(await readBuffer(this.ws, path))
   }
 
-  private async assertVersion(path: string, expected: string): Promise<void> {
-    if ((await this.currentVersion(path)) !== expected) {
-      throw new StaleMirageFileError(path)
-    }
+  // Refuse unless the file still holds what the stamp describes: one
+  // liveIdentity call, then the strongest marker both sides carry. The
+  // full re-read only happens when neither side has a marker to compare,
+  // which is every mount whose backend has no identity op.
+  private async assertVersion(path: string, stamp: Stamp): Promise<void> {
+    const current = await this.ws.fs.liveIdentity(path)
+    const verdict = compareMarkers(stamp.identity, current)
+    if (verdict === 'same') return
+    if (verdict === 'uncomparable' && !hashDiffers(stamp, await this.currentHash(path))) return
+    throw new StaleMirageFileError(path)
   }
 
   // Stamp what a later read will return, not the bytes handed in. A
   // mount that does not store writes verbatim answers with something
   // else, so stamping the input would make the very next write or edit
-  // look stale with nobody having touched the file.
+  // look stale with nobody having touched the file. A backend that names
+  // its own marker says that much in one metadata call; only a backend
+  // that names none has to be read back, and that read is what fills the
+  // hash.
   private async recordWrite(path: string, key: string): Promise<void> {
     if (!this.enabled) return
-    const version = await this.currentVersion(path)
-    if (version === null) this.readVersions.delete(key)
-    else this.readVersions.set(key, version)
+    const identity = await this.ws.fs.liveIdentity(path)
+    if (hasMarker(identity)) {
+      this.readVersions.set(key, { identity, contentHash: null })
+    } else {
+      const contentHash = await this.currentHash(path)
+      if (contentHash === null) this.readVersions.delete(key)
+      else this.readVersions.set(key, { identity, contentHash })
+    }
     this.editVersions.delete(key)
   }
 
   async read(path: string): Promise<Buffer> {
-    const content = await readBuffer(this.ws, path)
-    if (this.enabled) this.readVersions.set(this.key(path), fingerprint(content))
+    const [bytes, identity] = await this.ws.fs.readFileWithIdentity(path, { raw: true })
+    const content = Buffer.from(bytes)
+    if (this.enabled) {
+      this.readVersions.set(this.key(path), { identity, contentHash: fingerprint(content) })
+    }
     return content
   }
 
   async readForEdit(path: string): Promise<Buffer> {
-    const content = await readBuffer(this.ws, path)
+    const [bytes, identity] = await this.ws.fs.readFileWithIdentity(path, { raw: true })
+    const content = Buffer.from(bytes)
     if (!this.enabled) return content
     const key = this.key(path)
-    const version = fingerprint(content)
-    const readVersion = this.readVersions.get(key)
-    if (readVersion !== undefined && readVersion !== version) {
+    const stamp: Stamp = { identity, contentHash: fingerprint(content) }
+    const readStamp = this.readVersions.get(key)
+    if (readStamp !== undefined && moved(readStamp, stamp)) {
       throw new StaleMirageFileError(path)
     }
-    this.editVersions.set(key, version)
+    this.editVersions.set(key, stamp)
     return content
   }
 
   async write(path: string, content: string): Promise<void> {
     const key = this.key(path)
     if (this.enabled) {
-      const readVersion = this.readVersions.get(key)
-      if (readVersion !== undefined) await this.assertVersion(path, readVersion)
+      const readStamp = this.readVersions.get(key)
+      if (readStamp !== undefined) await this.assertVersion(path, readStamp)
     }
     await this.ws.fs.writeFile(path, content)
     await this.recordWrite(path, key)
@@ -108,8 +208,8 @@ export class FileVersionTracker {
   async writeEdit(path: string, content: string): Promise<void> {
     const key = this.key(path)
     if (this.enabled) {
-      const editVersion = this.editVersions.get(key)
-      if (editVersion !== undefined) await this.assertVersion(path, editVersion)
+      const editStamp = this.editVersions.get(key)
+      if (editStamp !== undefined) await this.assertVersion(path, editStamp)
     }
     await this.ws.fs.writeFile(path, content)
     await this.recordWrite(path, key)

--- a/typescript/packages/agents/src/types.ts
+++ b/typescript/packages/agents/src/types.ts
@@ -1,0 +1,42 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { LiveFileIdentity } from '@struktoai/mirage-core/ops/types'
+
+// What one file looked like the last time the agent saw it.
+//
+// Both fields, never one. `identity` is what the backend itself said,
+// lifted off the read's own response, so it describes the bytes the
+// agent was handed and not a concurrent writer's. `contentHash` is the
+// hash of those same bytes, which costs nothing on a path that already
+// holds them and is the only comparator a mount without native markers
+// has. An identity-only stamp would have nothing to say on such a
+// mount, and one taken from a separate call after the read could stamp
+// somebody else's version.
+//
+// `contentHash` is null in exactly one case: a post-write restamp whose
+// backend answered with a marker. Hashing there would mean re-reading
+// the file just written, which is the download this design exists to
+// remove. The ladder reaches the hash rung from such a stamp only if the
+// backend stopped reporting markers between that write and the next
+// check; it then refuses the write rather than guessing, so a missing
+// baseline costs a spurious refusal in a case that should not happen and
+// never an accepted stale write. Mirrors python's `Stamp`.
+export interface Stamp {
+  identity: LiveFileIdentity | null
+  contentHash: string | null
+}
+
+// How two identities compared on the strongest marker they share.
+export type MarkerMatch = 'same' | 'changed' | 'uncomparable'


### PR DESCRIPTION
Closes #572. Stacked on #958 (base is `feat/live-identity`); only the tracker diff shows here. After #958 merges, this retargets to `main`.

## What

Both stale-write trackers (`python/mirage/agents/file_version.py`, `typescript/packages/agents/src/file-version.ts` - behind the Pi, MCP/Codex/Grok, OpenCode and Claude Agent SDK adapters) stop re-reading and SHA-256-hashing the whole file around every write.

- The stamp becomes `Stamp(identity, content_hash)`: the identity lifted off the read's own response (`read_with_identity`; TS keeps `{raw: true}`), plus the hash of the bytes in hand (zero extra I/O). Identity-only stamping from a second call would let a concurrent writer's version be stamped - the race is pinned by a regression test in both languages.
- Pre-write check: one `live_identity` call, compared on the strongest shared marker - revision, then fingerprint - falling back to today's re-read+hash only when neither side carries a marker (which is every mount without an identity op, so behavior there is unchanged).
- `read_for_edit` spends zero extra calls: its own read already carries the current identity.
- Write restamps store the returned marker without re-reading what was just written; if markers later vanish the ladder refuses rather than guesses.
- A vanished file (`exists=False`) refuses, matching today. Public method signatures, `StaleMirageFileError` wording, symlink keying and `enabled=False` are untouched; no adapter changes.

## Cost change on marker-carrying backends

Per checked write: one metadata call instead of one full download + hash. Read-side stamping is free (same response).

## Tests

23 python (11 new) + 18 TS (11 new), mirrored: marker fast path with read-call-count proof, the concurrent-writer race, vanished file, marker-less mounts identical to today (rendered/stored divergence cases kept), fingerprint rung, hash rung, marker-only stamp refused once markers vanish.