### PR TITLE
fix(core): route dropbox and google TS clients through apiRequest

### DIFF
--- a/typescript/packages/core/src/core/api/client.test.ts
+++ b/typescript/packages/core/src/core/api/client.test.ts
@@ -223,7 +223,9 @@ describe('apiRequest', () => {
     const response = jsonResponse({ ok: true })
     const drain = vi.spyOn(response, 'arrayBuffer')
     const fakeFetch: typeof fetch = () => Promise.resolve(response)
-    expect(await apiRequest('POST', TARGET, { errorOf, fetchFn: fakeFetch, read: 'none' })).toBeNull()
+    expect(
+      await apiRequest('POST', TARGET, { errorOf, fetchFn: fakeFetch, read: 'none' }),
+    ).toBeNull()
     expect(drain).toHaveBeenCalledTimes(1)
   })
 

--- a/typescript/packages/core/src/core/api/client.test.ts
+++ b/typescript/packages/core/src/core/api/client.test.ts
@@ -219,6 +219,27 @@ describe('apiRequest', () => {
     ).toBe('https://api.test/monitor/1')
   })
 
+  it('drains the body on read none so the connection is released', async () => {
+    const response = jsonResponse({ ok: true })
+    const drain = vi.spyOn(response, 'arrayBuffer')
+    const fakeFetch: typeof fetch = () => Promise.resolve(response)
+    expect(await apiRequest('POST', TARGET, { errorOf, fetchFn: fakeFetch, read: 'none' })).toBeNull()
+    expect(drain).toHaveBeenCalledTimes(1)
+  })
+
+  it('drains the body on read location while returning the header', async () => {
+    const response = new Response('ignored', {
+      status: 202,
+      headers: { Location: 'https://api.test/monitor/1' },
+    })
+    const drain = vi.spyOn(response, 'arrayBuffer')
+    const fakeFetch: typeof fetch = () => Promise.resolve(response)
+    expect(
+      await apiRequest('POST', TARGET, { errorOf, fetchFn: fakeFetch, read: 'location' }),
+    ).toBe('https://api.test/monitor/1')
+    expect(drain).toHaveBeenCalledTimes(1)
+  })
+
   it('a raw body is sent as-is', async () => {
     let sentBody: BodyInit | null | undefined
     const fakeFetch: typeof fetch = (_url, init) => {

--- a/typescript/packages/core/src/core/api/client.ts
+++ b/typescript/packages/core/src/core/api/client.ts
@@ -183,8 +183,18 @@ export async function apiRequest(
     }
     if (response.status >= 400) throw options.errorOf(response, await response.text())
     const read = options.read ?? 'json'
-    if (read === 'none') return null
-    if (read === 'location') return response.headers.get('Location')
+    // The reads that do not consume the body still have to release it, or
+    // Node/undici holds the connection until GC; python's api_request drains
+    // it the same way when its `async with` response context exits.
+    if (read === 'none') {
+      await response.arrayBuffer()
+      return null
+    }
+    if (read === 'location') {
+      const location = response.headers.get('Location')
+      await response.arrayBuffer()
+      return location
+    }
     if (read === 'bytes') {
       const data = new Uint8Array(await response.arrayBuffer())
       return windowOf(data, response.status, options.window)

--- a/typescript/packages/core/src/core/dropbox/client.ts
+++ b/typescript/packages/core/src/core/dropbox/client.ts
@@ -18,9 +18,10 @@ import {
   DROPBOX_TOKEN_URL,
   TOKEN_BUFFER_SECONDS,
 } from './constants.ts'
+import { apiRequest } from '../api/client.ts'
 import { TokenManager as OAuthTokenManager } from '../api/oauth.ts'
 import { rstripSlash } from '../../utils/slash.ts'
-import { rangeHeader, windowOf, type ByteWindow } from '../../utils/ranges.ts'
+import { type ByteWindow } from '../../utils/ranges.ts'
 
 export interface DropboxConfig {
   clientId: string
@@ -69,16 +70,12 @@ async function refreshAccessToken(config: DropboxConfig): Promise<[string, numbe
   if (config.clientSecret !== undefined && config.clientSecret !== '') {
     body.set('client_secret', config.clientSecret)
   }
-  const r = await fetch(tokenUrlOf(config), {
-    method: 'POST',
+  const data = (await apiRequest('POST', tokenUrlOf(config), {
+    errorOf: (r, text) =>
+      new DropboxApiError(`Dropbox token refresh → ${String(r.status)} ${text}`, r.status),
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
-  })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new DropboxApiError(`Dropbox token refresh → ${String(r.status)} ${text}`, r.status)
-  }
-  const data = (await r.json()) as { access_token: string; expires_in: number }
+  })) as { access_token: string; expires_in: number }
   return [data.access_token, data.expires_in]
 }
 
@@ -120,21 +117,16 @@ export async function dropboxRpc(
   body: unknown,
 ): Promise<unknown> {
   const headers = await dropboxAuthHeaders(tm)
-  const url = `${tm.apiBase}${endpoint}`
-  const r = await fetch(url, {
-    method: 'POST',
+  return apiRequest('POST', `${tm.apiBase}${endpoint}`, {
+    errorOf: (r, text) =>
+      new DropboxApiError(
+        `Dropbox POST ${endpoint} → ${String(r.status)} ${text}`,
+        r.status,
+        summaryOf(text),
+      ),
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    json: body,
   })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new DropboxApiError(
-      `Dropbox POST ${endpoint} → ${String(r.status)} ${text}`,
-      r.status,
-      summaryOf(text),
-    )
-  }
-  return r.json()
 }
 
 export async function dropboxUpload(
@@ -143,25 +135,21 @@ export async function dropboxUpload(
   data: Uint8Array,
 ): Promise<void> {
   const headers = await dropboxAuthHeaders(tm)
-  const url = `${tm.contentBase}/files/upload`
-  const r = await fetch(url, {
-    method: 'POST',
+  await apiRequest('POST', `${tm.contentBase}/files/upload`, {
+    errorOf: (r, text) =>
+      new DropboxApiError(
+        `Dropbox upload ${path} → ${String(r.status)} ${text}`,
+        r.status,
+        summaryOf(text),
+      ),
     headers: {
       ...headers,
       'Dropbox-API-Arg': JSON.stringify({ path, mode: 'overwrite', mute: true }),
       'Content-Type': 'application/octet-stream',
     },
     body: data as unknown as BodyInit,
+    read: 'none',
   })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new DropboxApiError(
-      `Dropbox upload ${path} → ${String(r.status)} ${text}`,
-      r.status,
-      summaryOf(text),
-    )
-  }
-  await r.arrayBuffer()
 }
 
 export async function dropboxDownload(
@@ -170,20 +158,14 @@ export async function dropboxDownload(
   window?: ByteWindow,
 ): Promise<Uint8Array> {
   const headers = await dropboxAuthHeaders(tm)
-  const url = `${tm.contentBase}/files/download`
-  const sent: Record<string, string> = {
-    ...headers,
-    'Dropbox-API-Arg': JSON.stringify({ path }),
-  }
-  const range = window === undefined ? null : rangeHeader(window.offset, window.size)
-  if (range !== null) sent.Range = range
-  const r = await fetch(url, { method: 'POST', headers: sent })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new DropboxApiError(`Dropbox download ${path} → ${String(r.status)} ${text}`, r.status)
-  }
-  const buf = await r.arrayBuffer()
-  return windowOf(new Uint8Array(buf), r.status, window)
+  const data = await apiRequest('POST', `${tm.contentBase}/files/download`, {
+    errorOf: (r, text) =>
+      new DropboxApiError(`Dropbox download ${path} → ${String(r.status)} ${text}`, r.status),
+    headers: { ...headers, 'Dropbox-API-Arg': JSON.stringify({ path }) },
+    read: 'bytes',
+    window,
+  })
+  return data as Uint8Array
 }
 
 export async function* dropboxDownloadStream(

--- a/typescript/packages/core/src/core/google/client.test.ts
+++ b/typescript/packages/core/src/core/google/client.test.ts
@@ -125,7 +125,7 @@ describe('TokenManager.refreshFn delegation', () => {
       ok: true,
       status: 200,
       json: () => Promise.resolve({ access_token: 'direct-tok', expires_in: 3600 }),
-      text: () => Promise.resolve(''),
+      text: () => Promise.resolve(JSON.stringify({ access_token: 'direct-tok', expires_in: 3600 })),
     } as unknown as Response) as unknown as typeof fetch
     globalThis.fetch = fakeFetch
     const tm = new TokenManager({ clientId: 'id', clientSecret: 's', refreshToken: 'rt' })

--- a/typescript/packages/core/src/core/google/client.ts
+++ b/typescript/packages/core/src/core/google/client.ts
@@ -25,8 +25,9 @@ import {
   TOKEN_BUFFER_SECONDS,
   TOKEN_URL,
 } from './constants.ts'
+import { apiRequest } from '../api/client.ts'
 import { TokenManager as OAuthTokenManager } from '../api/oauth.ts'
-import { rangeHeader, windowOf, type ByteWindow } from '../../utils/ranges.ts'
+import { type ByteWindow } from '../../utils/ranges.ts'
 
 export function tokenUrl(config: GoogleConfig): string {
   return config.apiBase !== undefined ? `${config.apiBase}/token` : TOKEN_URL
@@ -90,16 +91,12 @@ export async function refreshAccessToken(config: GoogleConfig): Promise<[string,
   if (config.clientSecret !== undefined && config.clientSecret !== '') {
     body.set('client_secret', config.clientSecret)
   }
-  const r = await fetch(tokenUrl(config), {
-    method: 'POST',
+  const data = (await apiRequest('POST', tokenUrl(config), {
+    errorOf: (r, text) =>
+      new GoogleApiError(`Google token refresh → ${String(r.status)} ${text}`, r.status),
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
-  })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new GoogleApiError(`Google token refresh → ${String(r.status)} ${text}`, r.status)
-  }
-  const data = (await r.json()) as { access_token: string; expires_in: number }
+  })) as { access_token: string; expires_in: number }
   return [data.access_token, data.expires_in]
 }
 
@@ -125,39 +122,26 @@ export async function googleHeaders(tm: TokenManager): Promise<Record<string, st
   return { Authorization: `Bearer ${token}` }
 }
 
-function buildUrl(url: string, params?: Record<string, string | number>): string {
-  if (params === undefined) return url
-  const u = new URL(url)
-  for (const [k, v] of Object.entries(params)) u.searchParams.set(k, String(v))
-  return u.toString()
-}
-
 export async function googleGet(
   tm: TokenManager,
   url: string,
   params?: Record<string, string | number>,
 ): Promise<unknown> {
-  const headers = await googleHeaders(tm)
-  const r = await fetch(buildUrl(url, params), { headers })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new GoogleApiError(`Google GET ${url} → ${String(r.status)} ${text}`, r.status)
-  }
-  return r.json()
+  return apiRequest('GET', url, {
+    errorOf: (r, text) =>
+      new GoogleApiError(`Google GET ${url} → ${String(r.status)} ${text}`, r.status),
+    headers: await googleHeaders(tm),
+    params,
+  })
 }
 
 export async function googlePost(tm: TokenManager, url: string, json: unknown): Promise<unknown> {
-  const headers = await googleHeaders(tm)
-  const r = await fetch(url, {
-    method: 'POST',
-    headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify(json),
+  return apiRequest('POST', url, {
+    errorOf: (r, text) =>
+      new GoogleApiError(`Google POST ${url} → ${String(r.status)} ${text}`, r.status),
+    headers: { ...(await googleHeaders(tm)), 'Content-Type': 'application/json' },
+    json,
   })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new GoogleApiError(`Google POST ${url} → ${String(r.status)} ${text}`, r.status)
-  }
-  return r.json()
 }
 
 export async function googlePatch(
@@ -166,18 +150,13 @@ export async function googlePatch(
   json: unknown,
   params?: Record<string, string>,
 ): Promise<unknown> {
-  const headers = await googleHeaders(tm)
-  const full = params !== undefined ? `${url}?${new URLSearchParams(params).toString()}` : url
-  const r = await fetch(full, {
-    method: 'PATCH',
-    headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify(json),
+  return apiRequest('PATCH', url, {
+    errorOf: (r, text) =>
+      new GoogleApiError(`Google PATCH ${url} → ${String(r.status)} ${text}`, r.status),
+    headers: { ...(await googleHeaders(tm)), 'Content-Type': 'application/json' },
+    params,
+    json,
   })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new GoogleApiError(`Google PATCH ${url} → ${String(r.status)} ${text}`, r.status)
-  }
-  return r.json()
 }
 
 // Raw byte payloads (upload endpoints).
@@ -189,27 +168,22 @@ export async function googleSendBytes(
   contentType: string,
   params?: Record<string, string>,
 ): Promise<unknown> {
-  const headers = await googleHeaders(tm)
-  const full = params !== undefined ? `${url}?${new URLSearchParams(params).toString()}` : url
-  const r = await fetch(full, {
-    method,
-    headers: { ...headers, 'Content-Type': contentType },
+  return apiRequest(method, url, {
+    errorOf: (r, text) =>
+      new GoogleApiError(`Google ${method} ${url} → ${String(r.status)} ${text}`, r.status),
+    headers: { ...(await googleHeaders(tm)), 'Content-Type': contentType },
+    params,
     body: data as unknown as BodyInit,
   })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new GoogleApiError(`Google ${method} ${url} → ${String(r.status)} ${text}`, r.status)
-  }
-  return r.json()
 }
 
 export async function googleDelete(tm: TokenManager, url: string): Promise<void> {
-  const headers = await googleHeaders(tm)
-  const r = await fetch(url, { method: 'DELETE', headers })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new GoogleApiError(`Google DELETE ${url} → ${String(r.status)} ${text}`, r.status)
-  }
+  await apiRequest('DELETE', url, {
+    errorOf: (r, text) =>
+      new GoogleApiError(`Google DELETE ${url} → ${String(r.status)} ${text}`, r.status),
+    headers: await googleHeaders(tm),
+    read: 'none',
+  })
 }
 
 export async function googleGetBytes(
@@ -217,16 +191,14 @@ export async function googleGetBytes(
   url: string,
   window?: ByteWindow,
 ): Promise<Uint8Array> {
-  const headers = await googleHeaders(tm)
-  const range = window === undefined ? null : rangeHeader(window.offset, window.size)
-  if (range !== null) headers.Range = range
-  const r = await fetch(url, { headers, redirect: 'follow' })
-  if (!r.ok) {
-    const text = await r.text().catch(() => '')
-    throw new GoogleApiError(`Google GET ${url} → ${String(r.status)} ${text}`, r.status)
-  }
-  const buf = await r.arrayBuffer()
-  return windowOf(new Uint8Array(buf), r.status, window)
+  const data = await apiRequest('GET', url, {
+    errorOf: (r, text) =>
+      new GoogleApiError(`Google GET ${url} → ${String(r.status)} ${text}`, r.status),
+    headers: await googleHeaders(tm),
+    read: 'bytes',
+    window,
+  })
+  return data as Uint8Array
 }
 
 export async function* googleGetStream(tm: TokenManager, url: string): AsyncIterable<Uint8Array> {


### PR DESCRIPTION
## What

The TypeScript Dropbox and Google clients made raw `fetch()` calls with no abort or timeout seam and no shared error mapping, while their Python twins route every call through the shared `api_request` layer. This routes the TS non-stream calls through the TS twin `apiRequest`, so both languages share one transport.

## Parity mapping

Each routed TS call now passes what its Python twin passes to `api_request`.

Dropbox (`python/mirage/core/dropbox/client.py`):
- `refreshAccessToken` matches `api_request("POST", ..., data=form)`
- `dropboxRpc` matches `json_body=body`
- `dropboxUpload` matches `data=data, read="none"`
- `dropboxDownload` matches `read="bytes", window=`

Google (`python/mirage/core/google/client.py`):
- `refreshAccessToken` matches `data=form`
- `googleGet` matches `params=`
- `googlePost` matches `json_body=`
- `googlePatch` matches `params=, json_body=`
- `googleSendBytes` matches `params=, data=`
- `googleDelete` matches `read="none"`
- `googleGetBytes` matches `read="bytes", window=`

No retry policy or explicit timeout is added, matching Python, which passes neither for these calls. `apiRequest` does not auto-set a JSON Content-Type, so the three JSON-body calls set `application/json` themselves, matching the header aiohttp sets for `json=`.

## Streaming stays raw fetch

`dropboxDownloadStream` stays a raw fetch because the Python twin `dropbox_download_stream` also bypasses `api_request` with raw aiohttp. `googleGetStream` stays raw because `core/google` has no stream twin in Python. Both match the box precedent, where `boxGetStream` is also raw.

## Shared layer: release the body on non-consuming reads

Routing the Dropbox upload through `read: 'none'` surfaced a gap in the TS `apiRequest`: the reads that do not consume the body (`none`, `location`) returned without draining it, so Node/undici held the connection until GC. The python twin `api_request` releases the body via its `async with` response context. `apiRequest` now drains the body for those two reads before returning, which also restores the drain the upload path had before it moved to `read: 'none'`. Covered by new tests in `api/client.test.ts`. Python already releases the body this way, so no Python change is needed.

## Follow-up

The buffered whole-body read (`read="bytes"` in both languages, used by `googleGetBytes` and `dropboxDownload`) loads the entire body into memory with no size cap. This is pre-existing and identical across Python and TypeScript, so it is left as is here and tracked in #962.

## Verification

- prettier and eslint clean
- vitest: packages/core and packages/browser pass, including the dropbox, google, and api client tests
- `tsc --noEmit` clean on packages/core
- The packages/node `native_sed` failures are a pre-existing macOS BSD sed vs GNU host differential and are green on Linux CI; they are unrelated to this change
