### PR TITLE
fix(dropbox): stop stat and du laundering a listing 5xx into a false ENOENT

### DIFF
--- a/python/mirage/core/dropbox/stat.py
+++ b/python/mirage/core/dropbox/stat.py
@@ -95,10 +95,15 @@ async def stat(
                          resource_path=mount_key(parent_virtual, prefix)),
                 index=index,
             )
-        except (FileNotFoundError, DropboxApiError) as exc:
-            # Parent listing failed (missing dir surfaces as a 409 from
-            # the API): fall through to enoent, mirroring the TS stat.
-            logger.debug("stat populate failed for %s: %s", virtual, exc)
+        except FileNotFoundError as exc:
+            # readdir already maps a genuinely missing path to ENOENT, so
+            # catch only that. A non-409 DropboxApiError (a 5xx/429 while
+            # listing the parent) was previously swallowed here and
+            # re-answered as a destructively actionable false ENOENT; it now
+            # surfaces. NotADirectoryError (a path under a file) was never in
+            # this catch and already propagated.
+            logger.debug("stat found no parent listing for %s: %s", virtual,
+                         exc)
         result = await index.get(virtual_key)
         if result.entry is None:
             raise enoent(virtual)

--- a/python/tests/core/dropbox/du/test_size.py
+++ b/python/tests/core/dropbox/du/test_size.py
@@ -18,7 +18,7 @@ import pytest
 
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.core.dropbox.client import DropboxTokenManager
+from mirage.core.dropbox.client import DropboxApiError, DropboxTokenManager
 from mirage.core.dropbox.du import size
 from mirage.resource.dropbox.config import DropboxConfig
 from mirage.types import PathSpec
@@ -61,6 +61,10 @@ async def _fake_list(_tm, path):
     return _TREE[path]
 
 
+async def _rpc_500(_tm, _endpoint, _body):
+    raise DropboxApiError("boom", 500)
+
+
 @pytest.fixture
 def accessor():
     config = DropboxConfig(client_id="c", client_secret="s", refresh_token="r")
@@ -90,3 +94,15 @@ async def test_size_missing_path_is_zero(accessor, index):
             PathSpec(resource_path="ghost", virtual="/ghost", directory="/"),
             index)
     assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_size_propagates_server_error(accessor, index):
+    # A 5xx is not absence: du must surface it, not silently under-count
+    # (mirrors du/walk.py's `except FileNotFoundError`).
+    with patch("mirage.core.dropbox.api.dropbox_rpc", new=_rpc_500):
+        with pytest.raises(DropboxApiError):
+            await size(
+                accessor,
+                PathSpec(resource_path="data", virtual="/data", directory="/"),
+                index)

--- a/python/tests/core/dropbox/test_stat.py
+++ b/python/tests/core/dropbox/test_stat.py
@@ -12,23 +12,70 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
-from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.core.dropbox.client import DropboxApiError, DropboxTokenManager
+from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.read import read
 from mirage.core.dropbox.readdir import readdir
 from mirage.core.dropbox.stat import stat
-from mirage.resource.dropbox.config import DropboxConfig
 from mirage.types import ContentType, FileType, PathSpec
+from mirage.utils.key_prefix import mount_key
+from tests.core.dropbox.conftest import FakeDropboxRpc
+
+# The default seam for this file is the JSON-RPC transport
+# (`mirage.core.dropbox.api.dropbox_rpc`): `list_folder`, `get_metadata`
+# and the token refresh all funnel through it, so one FakeDropboxRpc patch
+# makes stat hermetic with no live api.dropboxapi.com call and no token to
+# seed. The two error-propagation tests that assert "the collaborator
+# raised X" patch the collaborator directly instead, since the transport
+# fake only ever raises a 409.
+RPC = "mirage.core.dropbox.api.dropbox_rpc"
+
+FILE_ENTRY = {
+    ".tag": "file",
+    "id": "id:a",
+    "name": "a.txt",
+    "path_display": "/a.txt",
+    "size": 5,
+    "server_modified": "2026-04-01T00:00:00Z",
+}
+
+FOLDER_ENTRY = {
+    ".tag": "folder",
+    "id": "id:docs",
+    "name": "docs",
+    "path_display": "/docs",
+}
 
 
-def make_accessor() -> DropboxAccessor:
-    config = DropboxConfig(client_id="c", client_secret="s", refresh_token="r")
-    return DropboxAccessor(config, DropboxTokenManager(config))
+# Stateless transport fakes for the error-path tests. They capture nothing
+# from a test body, so they live at module scope (a nested function is for
+# closures only).
+async def _meta_500(_tm, _endpoint, _body):
+    raise DropboxApiError("boom", 500)
+
+
+async def _all_absent(_tm, _endpoint, _body):
+    raise DropboxApiError("nf", 409, "path/not_found/...")
+
+
+async def _list_500(_tm, endpoint, _body):
+    if endpoint == "/files/list_folder":
+        raise DropboxApiError("boom", 500)
+    raise AssertionError(f"unexpected endpoint {endpoint}")
+
+
+async def _under_file(_tm, endpoint, body):
+    if endpoint == "/files/list_folder":
+        raise DropboxApiError("nf", 409, "path/not_folder/...")
+    if endpoint == "/files/get_metadata":
+        if body["path"] == "/a.txt":
+            return {".tag": "file", "name": "a.txt"}
+        raise DropboxApiError("nf", 409, "path/not_found/...")
+    raise AssertionError(f"unexpected endpoint {endpoint}")
 
 
 @pytest.fixture
@@ -37,55 +84,252 @@ def index():
 
 
 @pytest.mark.asyncio
-async def test_stat_mount_root_is_directory(index):
-    out = await stat(make_accessor(),
-                     PathSpec(resource_path="", virtual="/", directory="/"),
-                     index)
+async def test_stat_mount_root_is_directory(dropbox_accessor, index):
+    rpc = FakeDropboxRpc()
+    with patch(RPC, new=rpc):
+        out = await stat(
+            dropbox_accessor,
+            PathSpec(resource_path="", virtual="/", directory="/"), index)
     assert out.type == FileType.DIRECTORY
     assert out.name == "/"
+    assert rpc.list_requests == 0
 
 
 @pytest.mark.asyncio
-async def test_stat_populates_from_parent_listing(index):
-    listing = [{
-        ".tag": "file",
-        "id": "id:1",
-        "name": "note.txt",
-        "path_display": "/note.txt",
-        "size": 5,
-        "server_modified": "2026-04-01T00:00:00Z",
-    }]
-    with patch("mirage.core.dropbox.readdir.list_folder",
-               new_callable=AsyncMock,
-               return_value=listing):
-        out = await stat(
-            make_accessor(),
-            PathSpec(resource_path="note.txt",
-                     virtual="/note.txt",
-                     directory="/"), index)
+async def test_stat_null_index_file_from_api(dropbox_accessor):
+    # No index: stat resolves directly through get_metadata
+    # (unlink/rmdir classification and walk fallbacks take this path).
+    rpc = FakeDropboxRpc(metadata=FILE_ENTRY)
+    with patch(RPC, new=rpc):
+        out = await stat(dropbox_accessor, PathSpec.from_str_path("/a.txt"))
+    assert out.type == FileType.FILE
+    assert out.name == "a.txt"
     assert out.size == 5
     assert out.content == ContentType.TEXT
-    assert out.extra["dropbox_id"] == "id:1"
+    assert out.modified == "2026-04-01T00:00:00Z"
+    assert out.fingerprint == "2026-04-01T00:00:00Z"
+    assert out.extra["dropbox_id"] == "id:a"
+    assert out.extra["resource_type"] == "dropbox/file"
 
 
 @pytest.mark.asyncio
-async def test_stat_missing_maps_api_error_to_enoent(index):
-    with patch("mirage.core.dropbox.readdir.list_folder",
-               new_callable=AsyncMock,
-               side_effect=DropboxApiError("not found", 409)):
-        with pytest.raises(FileNotFoundError):
+async def test_stat_null_index_folder_from_api(dropbox_accessor):
+    rpc = FakeDropboxRpc(metadata=FOLDER_ENTRY)
+    with patch(RPC, new=rpc):
+        out = await stat(dropbox_accessor, PathSpec.from_str_path("/docs"))
+    assert out.type == FileType.DIRECTORY
+    assert out.name == "docs"
+    assert out.size is None
+    assert out.extra["dropbox_id"] == "id:docs"
+
+
+@pytest.mark.asyncio
+async def test_stat_null_index_missing_is_enoent(dropbox_accessor):
+    rpc = FakeDropboxRpc(metadata=None)
+    with patch(RPC, new=rpc):
+        with pytest.raises(FileNotFoundError) as excinfo:
+            await stat(dropbox_accessor, PathSpec.from_str_path("/ghost.txt"))
+    assert str(excinfo.value) == "/ghost.txt"
+
+
+@pytest.mark.asyncio
+async def test_stat_null_index_non_409_propagates(dropbox_accessor):
+    # A rate-limit or server error is not absence: it must surface, not
+    # collapse into ENOENT.
+    with patch(RPC, new=_meta_500):
+        with pytest.raises(DropboxApiError) as excinfo:
+            await stat(dropbox_accessor, PathSpec.from_str_path("/a.txt"))
+    assert excinfo.value.status == 500
+
+
+_FALLBACK_CASES = [
+    ({
+        ".tag": "file",
+        "id": "id:x",
+        "name": "f.txt",
+        "client_modified": "2026-01-02T00:00:00Z",
+        "size": 3,
+    }, "id:x", 3, "2026-01-02T00:00:00Z", "2026-01-02T00:00:00Z"),
+    ({
+        ".tag": "file",
+        "id": "id:x",
+        "name": "f.txt",
+        "size": 3,
+    }, "id:x", 3, "", None),
+    ({
+        ".tag": "file",
+        "name": "f.txt",
+        "path_display": "/d/f.txt",
+        "size": 3,
+    }, "/d/f.txt", 3, "", None),
+    ({
+        ".tag": "file",
+        "name": "f.txt",
+        "size": 3,
+    }, "f.txt", 3, "", None),
+    ({
+        ".tag": "file",
+        "id": "id:x",
+        "name": "f.txt",
+    }, "id:x", None, "", None),
+    ({
+        ".tag": "file",
+        "id": "id:x",
+        "name": "f.txt",
+        "size": "big",
+    }, "id:x", None, "", None),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entry, dropbox_id, size, modified, fingerprint",
+                         _FALLBACK_CASES)
+async def test_stat_entry_field_fallbacks(dropbox_accessor, entry, dropbox_id,
+                                          size, modified, fingerprint):
+    # _stat_from_entry's fallbacks: server_modified→client_modified→"",
+    # id→path_display→name, and a non-int/absent size renders as None
+    # (the unknown-size machinery, never a fabricated number).
+    rpc = FakeDropboxRpc(metadata=entry)
+    with patch(RPC, new=rpc):
+        out = await stat(dropbox_accessor, PathSpec.from_str_path("/f.txt"))
+    assert out.extra["dropbox_id"] == dropbox_id
+    assert out.size == size
+    assert out.modified == modified
+    assert out.fingerprint == fingerprint
+
+
+@pytest.mark.asyncio
+async def test_stat_populates_from_parent_listing(dropbox_accessor, index):
+    rpc = FakeDropboxRpc(entries=[FILE_ENTRY])
+    with patch(RPC, new=rpc):
+        out = await stat(
+            dropbox_accessor,
+            PathSpec(resource_path="a.txt", virtual="/a.txt", directory="/"),
+            index)
+    assert out.type == FileType.FILE
+    assert out.name == "a.txt"
+    assert out.size == 5
+    assert out.content == ContentType.TEXT
+    assert out.modified == "2026-04-01T00:00:00Z"
+    assert out.fingerprint == "2026-04-01T00:00:00Z"
+    assert out.extra["dropbox_id"] == "id:a"
+    assert out.extra["resource_type"] == "dropbox/file"
+    assert rpc.list_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_stat_serves_index_hit_without_second_call(
+        dropbox_accessor, index):
+    # The reason the index exists: once a parent listing populates it, a
+    # stat of any sibling serves from cache. `metadata=None` makes a stray
+    # get_metadata blow up as a 409, so a single list request proves both
+    # the file and the folder came from the index.
+    rpc = FakeDropboxRpc(entries=[FOLDER_ENTRY, FILE_ENTRY], metadata=None)
+    with patch(RPC, new=rpc):
+        file_out = await stat(
+            dropbox_accessor,
+            PathSpec(resource_path="a.txt", virtual="/a.txt", directory="/"),
+            index)
+        dir_out = await stat(
+            dropbox_accessor,
+            PathSpec(resource_path="docs", virtual="/docs", directory="/"),
+            index)
+    assert file_out.type == FileType.FILE
+    assert dir_out.type == FileType.DIRECTORY
+    assert dir_out.extra["dropbox_id"] == "id:docs"
+    assert rpc.list_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_stat_miss_after_populate_is_enoent(dropbox_accessor, index):
+    # The parent lists cleanly but does not contain the child: stat's own
+    # re-check-then-ENOENT, distinct from readdir's 409 mapping.
+    other = {
+        ".tag": "file",
+        "id": "id:o",
+        "name": "other.txt",
+        "path_display": "/other.txt",
+        "size": 1,
+    }
+    rpc = FakeDropboxRpc(entries=[other])
+    with patch(RPC, new=rpc):
+        with pytest.raises(FileNotFoundError) as excinfo:
             await stat(
-                make_accessor(),
+                dropbox_accessor,
+                PathSpec(resource_path="note.txt",
+                         virtual="/note.txt",
+                         directory="/"), index)
+    assert str(excinfo.value) == "/note.txt"
+    assert rpc.list_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_stat_under_mount_prefix(dropbox_accessor, index):
+    # Every other test runs on an unprefixed mount; this pins the prefix
+    # arithmetic (virtual_key and the parent's resource_path).
+    rpc = FakeDropboxRpc(entries=[FILE_ENTRY])
+    with patch(RPC, new=rpc):
+        out = await stat(
+            dropbox_accessor,
+            PathSpec(virtual="/dropbox/a.txt",
+                     directory="/dropbox",
+                     resource_path=mount_key("/dropbox/a.txt", "/dropbox")),
+            index)
+    assert out.type == FileType.FILE
+    assert out.name == "a.txt"
+    assert out.size == 5
+
+
+@pytest.mark.asyncio
+async def test_stat_failed_populate_is_enoent(dropbox_accessor, index):
+    # A genuinely missing parent (409 on the listing and on every ancestor
+    # probe) surfaces as ENOENT through readdir; stat swallows that and
+    # answers its own ENOENT naming the child, not the parent.
+    with patch(RPC, new=_all_absent):
+        with pytest.raises(FileNotFoundError) as excinfo:
+            await stat(
+                dropbox_accessor,
                 PathSpec(resource_path="ghost/missing.txt",
                          virtual="/ghost/missing.txt",
                          directory="/ghost"), index)
+    assert str(excinfo.value) == "/ghost/missing.txt"
 
 
 @pytest.mark.asyncio
-async def test_stat_size_matches_read_for_every_file(index):
+async def test_stat_populate_server_error_propagates(dropbox_accessor, index):
+    # A 5xx/429 while listing the parent is not absence: readdir re-raises
+    # it, and stat must let it surface rather than collapse it into a
+    # (destructively actionable) false ENOENT.
+    with patch(RPC, new=_list_500):
+        with pytest.raises(DropboxApiError) as excinfo:
+            await stat(
+                dropbox_accessor,
+                PathSpec(resource_path="ghost/missing.txt",
+                         virtual="/ghost/missing.txt",
+                         directory="/ghost"), index)
+    assert excinfo.value.status == 500
+
+
+@pytest.mark.asyncio
+async def test_stat_enotdir_from_populate_propagates(dropbox_accessor, index):
+    # A path under a file is ENOTDIR, not ENOENT: readdir's ancestor walk
+    # classifies it, and stat must let NotADirectoryError escape.
+    with patch(RPC, new=_under_file):
+        with pytest.raises(NotADirectoryError):
+            await stat(
+                dropbox_accessor,
+                PathSpec(resource_path="a.txt/x",
+                         virtual="/a.txt/x",
+                         directory="/a.txt"), index)
+
+
+@pytest.mark.asyncio
+async def test_stat_size_matches_read_for_every_file(dropbox_accessor, index):
     # The fskit invariant behind SIZES_ALWAYS_KNOWN: the size stat serves
     # from the listing must equal the byte length a read delivers, 0-byte
-    # files included.
+    # files included. Listings go through the transport seam; the content
+    # channel (dropbox_download) does not pass through dropbox_rpc, so it
+    # keeps its own download seam.
     contents = {
         "/a.txt": b"hello",
         "/empty.txt": b"",
@@ -126,33 +370,37 @@ async def test_stat_size_matches_read_for_every_file(index):
         }],
     }
 
-    async def _list(_tm, path, **_kw):
-        return tree[path]
+    async def _rpc(_tm, endpoint, body):
+        if endpoint == "/files/list_folder":
+            return {
+                "entries": tree[body["path"]],
+                "cursor": "c",
+                "has_more": False,
+            }
+        raise AssertionError(f"unexpected endpoint {endpoint}")
 
     async def _download(_tm, path, _range=None):
         return contents[path]
 
-    accessor = make_accessor()
     files: list[str] = []
-    with patch("mirage.core.dropbox.readdir.list_folder",
-               side_effect=_list), \
+    with patch(RPC, new=_rpc), \
          patch("mirage.core.dropbox.read.dropbox_download",
                side_effect=_download):
         stack = ["/"]
         while stack:
             current = stack.pop()
-            listing = await readdir(accessor, PathSpec.from_str_path(current),
-                                    index)
+            listing = await readdir(dropbox_accessor,
+                                    PathSpec.from_str_path(current), index)
             for child in listing:
                 trimmed = child.rstrip("/")
-                info = await stat(accessor, PathSpec.from_str_path(trimmed),
-                                  index)
+                info = await stat(dropbox_accessor,
+                                  PathSpec.from_str_path(trimmed), index)
                 if info.type == FileType.DIRECTORY:
                     stack.append(trimmed)
                     continue
                 assert info.size is not None, trimmed
-                body = await read(accessor, PathSpec.from_str_path(trimmed),
-                                  index)
+                body = await read(dropbox_accessor,
+                                  PathSpec.from_str_path(trimmed), index)
                 assert info.size == len(body), trimmed
                 files.append(trimmed)
     assert sorted(files) == ["/a.txt", "/docs/b.bin", "/empty.txt"]

--- a/typescript/packages/core/src/core/dropbox/du/du.test.ts
+++ b/typescript/packages/core/src/core/dropbox/du/du.test.ts
@@ -29,7 +29,8 @@ vi.mock('../stat.ts', async () => {
 
 import { DropboxAccessor } from '../../../accessor/dropbox.ts'
 import { FileStat, FileType, PathSpec } from '../../../types.ts'
-import type { DropboxTokenManager } from '../client.ts'
+import { enoent } from '../../../utils/errors.ts'
+import { DropboxApiError, type DropboxTokenManager } from '../client.ts'
 import { size, entries } from './index.ts'
 import * as readdirMod from '../readdir.ts'
 import * as statMod from '../stat.ts'
@@ -43,7 +44,7 @@ function makeAccessor(): DropboxAccessor {
 function mockTree(tree: Record<string, string[]>): void {
   vi.mocked(readdirMod.readdir).mockImplementation((_accessor, spec) => {
     const children = tree[spec.virtual]
-    if (children === undefined) return Promise.reject(new Error(`ENOENT: ${spec.virtual}`))
+    if (children === undefined) return Promise.reject(enoent(spec.virtual))
     return Promise.resolve(children)
   })
 }
@@ -51,7 +52,7 @@ function mockTree(tree: Record<string, string[]>): void {
 function mockStats(stats: Record<string, { size?: number }>): void {
   vi.mocked(statMod.stat).mockImplementation((_accessor, spec) => {
     const entry = stats[spec.virtual]
-    if (entry === undefined) return Promise.reject(new Error(`ENOENT: ${spec.virtual}`))
+    if (entry === undefined) return Promise.reject(enoent(spec.virtual))
     const name = spec.virtual.split('/').pop() ?? ''
     return Promise.resolve(
       new FileStat({
@@ -138,5 +139,13 @@ describe('dropbox core du', () => {
     mockTree(TREE)
     mockStats({})
     expect(await size(makeAccessor(), ROOT)).toBe(0)
+  })
+
+  it('propagates a 5xx instead of under-counting the total', async () => {
+    // A server error is not absence: swallowing it (the old bare catch)
+    // silently reported a wrong total. Only ENOENT counts as zero.
+    mockTree(TREE)
+    vi.mocked(statMod.stat).mockRejectedValue(new DropboxApiError('boom', 500))
+    await expect(size(makeAccessor(), ROOT)).rejects.toMatchObject({ status: 500 })
   })
 })

--- a/typescript/packages/core/src/core/dropbox/du/walk.ts
+++ b/typescript/packages/core/src/core/dropbox/du/walk.ts
@@ -17,6 +17,7 @@ import type { DropboxAccessor } from '../../../accessor/dropbox.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { FileType, PathSpec, type FileStat } from '../../../types.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
+import { isEnoent } from '../../../utils/errors.ts'
 import { readdir } from '../readdir.ts'
 import { stat } from '../stat.ts'
 
@@ -29,7 +30,11 @@ export async function walkSize(
   let s: FileStat
   try {
     s = await stat(accessor, path, index)
-  } catch {
+  } catch (err) {
+    // Absence counts as 0; a 5xx/429 or ENOTDIR is not absence and must
+    // surface (mirrors du/walk.py's `except FileNotFoundError`), rather
+    // than silently under-reporting the total.
+    if (!isEnoent(err)) throw err
     return 0
   }
   if (s.type !== FileType.DIRECTORY) {
@@ -45,7 +50,8 @@ export async function walkSize(
   let children: string[]
   try {
     children = await readdir(accessor, path, index)
-  } catch {
+  } catch (err) {
+    if (!isEnoent(err)) throw err
     return 0
   }
   let total = 0

--- a/typescript/packages/core/src/core/dropbox/stat.test.ts
+++ b/typescript/packages/core/src/core/dropbox/stat.test.ts
@@ -1,0 +1,384 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mountKey } from '../../utils/key_prefix.ts'
+import { describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './client.ts'
+
+// One stable seam: the JSON-RPC transport. listFolder, getMetadata and the
+// token refresh all funnel through dropboxRpc, so mocking it makes stat
+// hermetic (no live api.dropboxapi.com call, no token to seed) and drives
+// readdir's real error mapping end to end; an unexpected endpoint throws
+// loudly instead of leaking a live call.
+vi.mock('./client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./client.ts')
+  return { ...actual, dropboxRpc: vi.fn(), dropboxDownload: vi.fn() }
+})
+
+import { DropboxAccessor } from '../../accessor/dropbox.ts'
+import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
+import { FileType, PathSpec } from '../../types.ts'
+import * as client from './client.ts'
+import { DropboxApiError, type DropboxTokenManager } from './client.ts'
+import type { DropboxEntry } from './api.ts'
+import { stat } from './stat.ts'
+import { read } from './read.ts'
+import { readdir } from './readdir.ts'
+import { FakeDropboxRpc } from './_test_util.ts'
+
+const STUB_TM = {} as DropboxTokenManager
+
+function makeAccessor(): DropboxAccessor {
+  return new DropboxAccessor({ tokenManager: STUB_TM })
+}
+
+const FILE_ENTRY: DropboxEntry = {
+  '.tag': 'file',
+  id: 'id:a',
+  name: 'a.txt',
+  path_display: '/a.txt',
+  size: 5,
+  server_modified: '2026-04-01T00:00:00Z',
+}
+
+const FOLDER_ENTRY: DropboxEntry = {
+  '.tag': 'folder',
+  id: 'id:docs',
+  name: 'docs',
+  path_display: '/docs',
+}
+
+describe('dropbox stat', () => {
+  it('is a directory at the mount root with no I/O', async () => {
+    const fake = new FakeDropboxRpc()
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    const out = await stat(
+      makeAccessor(),
+      new PathSpec({ resourcePath: '', virtual: '/', directory: '/' }),
+      new RAMIndexCacheStore(),
+    )
+    expect(out.type).toBe(FileType.DIRECTORY)
+    expect(out.name).toBe('/')
+    expect(fake.listRequests).toBe(0)
+  })
+
+  it('resolves a file directly through get_metadata without an index', async () => {
+    // No index: stat resolves through get_metadata (unlink/rmdir
+    // classification and the wired find core take this path).
+    const fake = new FakeDropboxRpc({ metadata: FILE_ENTRY })
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    const out = await stat(makeAccessor(), PathSpec.fromStrPath('/a.txt'))
+    expect(out.type).toBe(FileType.TEXT)
+    expect(out.name).toBe('a.txt')
+    expect(out.size).toBe(5)
+    expect(out.modified).toBe('2026-04-01T00:00:00Z')
+    expect(out.fingerprint).toBe('2026-04-01T00:00:00Z')
+    expect(out.extra.dropbox_id).toBe('id:a')
+    expect(out.extra.resource_type).toBe('dropbox/file')
+  })
+
+  it('resolves a folder directly through get_metadata without an index', async () => {
+    const fake = new FakeDropboxRpc({ metadata: FOLDER_ENTRY })
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    const out = await stat(makeAccessor(), PathSpec.fromStrPath('/docs'))
+    expect(out.type).toBe(FileType.DIRECTORY)
+    expect(out.name).toBe('docs')
+    expect(out.size).toBeNull()
+    expect(out.extra.dropbox_id).toBe('id:docs')
+  })
+
+  it('maps a 409 to ENOENT without an index', async () => {
+    const fake = new FakeDropboxRpc({ metadata: null })
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    await expect(stat(makeAccessor(), PathSpec.fromStrPath('/ghost.txt'))).rejects.toMatchObject({
+      code: 'ENOENT',
+      virtualPath: '/ghost.txt',
+    })
+  })
+
+  it('propagates a non-409 error without an index', async () => {
+    // A rate-limit or server error is not absence: it must surface.
+    vi.mocked(client.dropboxRpc).mockRejectedValue(new DropboxApiError('boom', 500))
+    await expect(stat(makeAccessor(), PathSpec.fromStrPath('/a.txt'))).rejects.toMatchObject({
+      status: 500,
+    })
+  })
+
+  // statFromEntry fallbacks: server_modified→client_modified→'',
+  // id→path_display→name, and a non-number/absent size renders as null (the
+  // unknown-size machinery, never a fabricated number).
+  const fallbackCases: [DropboxEntry, string, number | null, string, string | null][] = [
+    [
+      {
+        '.tag': 'file',
+        id: 'id:x',
+        name: 'f.txt',
+        client_modified: '2026-01-02T00:00:00Z',
+        size: 3,
+      },
+      'id:x',
+      3,
+      '2026-01-02T00:00:00Z',
+      '2026-01-02T00:00:00Z',
+    ],
+    [{ '.tag': 'file', id: 'id:x', name: 'f.txt', size: 3 }, 'id:x', 3, '', null],
+    [{ '.tag': 'file', name: 'f.txt', path_display: '/d/f.txt', size: 3 }, '/d/f.txt', 3, '', null],
+    [{ '.tag': 'file', name: 'f.txt', size: 3 }, 'f.txt', 3, '', null],
+    [{ '.tag': 'file', id: 'id:x', name: 'f.txt' }, 'id:x', null, '', null],
+    // size is typed number, but the wire is untyped JSON; a non-number
+    // from the API must render as null, not a fabricated size.
+    [
+      { '.tag': 'file', id: 'id:x', name: 'f.txt', size: 'big' as unknown as number },
+      'id:x',
+      null,
+      '',
+      null,
+    ],
+  ]
+  it.each(fallbackCases)(
+    'renders entry field fallbacks (%#)',
+    async (entry, dropboxId, size, modified, fingerprint) => {
+      const fake = new FakeDropboxRpc({ metadata: entry })
+      vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+      const out = await stat(makeAccessor(), PathSpec.fromStrPath('/f.txt'))
+      expect(out.extra.dropbox_id).toBe(dropboxId)
+      expect(out.size).toBe(size)
+      expect(out.modified).toBe(modified)
+      expect(out.fingerprint).toBe(fingerprint)
+    },
+  )
+
+  it('populates from the parent listing on an index miss', async () => {
+    const fake = new FakeDropboxRpc({ entries: [FILE_ENTRY] })
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    const out = await stat(
+      makeAccessor(),
+      new PathSpec({ resourcePath: 'a.txt', virtual: '/a.txt', directory: '/' }),
+      new RAMIndexCacheStore(),
+    )
+    expect(out.type).toBe(FileType.TEXT)
+    expect(out.name).toBe('a.txt')
+    expect(out.size).toBe(5)
+    expect(out.modified).toBe('2026-04-01T00:00:00Z')
+    expect(out.fingerprint).toBe('2026-04-01T00:00:00Z')
+    expect(out.extra.dropbox_id).toBe('id:a')
+    expect(out.extra.resource_type).toBe('dropbox/file')
+    expect(fake.listRequests).toBe(1)
+  })
+
+  it('serves an index hit without a second listing', async () => {
+    // Once a parent listing populates the index, a stat of any sibling
+    // serves from cache. metadata:null makes a stray get_metadata blow up
+    // as a 409, so a single list request proves both came from the index.
+    const fake = new FakeDropboxRpc({ entries: [FOLDER_ENTRY, FILE_ENTRY], metadata: null })
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    const index = new RAMIndexCacheStore()
+    const accessor = makeAccessor()
+    const fileOut = await stat(
+      accessor,
+      new PathSpec({ resourcePath: 'a.txt', virtual: '/a.txt', directory: '/' }),
+      index,
+    )
+    const dirOut = await stat(
+      accessor,
+      new PathSpec({ resourcePath: 'docs', virtual: '/docs', directory: '/' }),
+      index,
+    )
+    expect(fileOut.type).toBe(FileType.TEXT)
+    expect(dirOut.type).toBe(FileType.DIRECTORY)
+    expect(dirOut.extra.dropbox_id).toBe('id:docs')
+    expect(fake.listRequests).toBe(1)
+  })
+
+  it('reports ENOENT when the parent lists but omits the child', async () => {
+    // The parent lists cleanly without the child: stat's own
+    // re-check-then-ENOENT, distinct from readdir's 409 mapping.
+    const other: DropboxEntry = {
+      '.tag': 'file',
+      id: 'id:o',
+      name: 'other.txt',
+      path_display: '/other.txt',
+      size: 1,
+    }
+    const fake = new FakeDropboxRpc({ entries: [other] })
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    await expect(
+      stat(
+        makeAccessor(),
+        new PathSpec({ resourcePath: 'note.txt', virtual: '/note.txt', directory: '/' }),
+        new RAMIndexCacheStore(),
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT', virtualPath: '/note.txt' })
+    expect(fake.listRequests).toBe(1)
+  })
+
+  it('honors the mount prefix on an index miss', async () => {
+    const fake = new FakeDropboxRpc({ entries: [FILE_ENTRY] })
+    vi.mocked(client.dropboxRpc).mockImplementation(fake.handle)
+    const out = await stat(
+      makeAccessor(),
+      new PathSpec({
+        virtual: '/dropbox/a.txt',
+        directory: '/dropbox',
+        resourcePath: mountKey('/dropbox/a.txt', '/dropbox'),
+      }),
+      new RAMIndexCacheStore(),
+    )
+    expect(out.type).toBe(FileType.TEXT)
+    expect(out.name).toBe('a.txt')
+    expect(out.size).toBe(5)
+  })
+
+  it('reports ENOENT when the parent is genuinely missing', async () => {
+    // 409 on the listing and on every ancestor probe: readdir reports
+    // ENOENT, and stat answers its own ENOENT naming the child.
+    vi.mocked(client.dropboxRpc).mockImplementation(() =>
+      Promise.reject(new DropboxApiError('nf', 409, 'path/not_found/...')),
+    )
+    await expect(
+      stat(
+        makeAccessor(),
+        new PathSpec({
+          resourcePath: 'ghost/missing.txt',
+          virtual: '/ghost/missing.txt',
+          directory: '/ghost',
+        }),
+        new RAMIndexCacheStore(),
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT', virtualPath: '/ghost/missing.txt' })
+  })
+
+  it('propagates a 5xx from the parent listing instead of ENOENT', async () => {
+    // A 5xx/429 while listing the parent is not absence: readdir re-raises
+    // it and stat must let it surface, never collapse it into a
+    // (destructively actionable) false ENOENT.
+    vi.mocked(client.dropboxRpc).mockImplementation((_tm, endpoint) => {
+      if (endpoint === '/files/list_folder') return Promise.reject(new DropboxApiError('boom', 500))
+      throw new Error(`unexpected endpoint ${endpoint}`)
+    })
+    await expect(
+      stat(
+        makeAccessor(),
+        new PathSpec({
+          resourcePath: 'ghost/missing.txt',
+          virtual: '/ghost/missing.txt',
+          directory: '/ghost',
+        }),
+        new RAMIndexCacheStore(),
+      ),
+    ).rejects.toMatchObject({ status: 500 })
+  })
+
+  it('propagates ENOTDIR for a path under a file', async () => {
+    // A path under a file is ENOTDIR, not ENOENT: readdir's ancestor walk
+    // classifies it and stat must let it escape.
+    vi.mocked(client.dropboxRpc).mockImplementation((_tm, endpoint, body) => {
+      if (endpoint === '/files/list_folder') {
+        return Promise.reject(new DropboxApiError('nf', 409, 'path/not_folder/...'))
+      }
+      if (endpoint === '/files/get_metadata') {
+        if ((body as { path?: string }).path === '/a.txt') {
+          return Promise.resolve({ '.tag': 'file', name: 'a.txt' })
+        }
+        return Promise.reject(new DropboxApiError('nf', 409, 'path/not_found/...'))
+      }
+      throw new Error(`unexpected endpoint ${endpoint}`)
+    })
+    await expect(
+      stat(
+        makeAccessor(),
+        new PathSpec({ resourcePath: 'a.txt/x', virtual: '/a.txt/x', directory: '/a.txt' }),
+        new RAMIndexCacheStore(),
+      ),
+    ).rejects.toMatchObject({ code: 'ENOTDIR' })
+  })
+
+  it('serves a size for every listed file that matches its read length', async () => {
+    // The fskit invariant behind SIZES_ALWAYS_KNOWN: the size stat serves
+    // from the listing must equal the byte length a read delivers, 0-byte
+    // files included. Listings go through the transport seam; the content
+    // channel (dropboxDownload) does not, so it keeps its own seam.
+    const tree: Record<string, DropboxEntry[]> = {
+      '': [
+        { '.tag': 'folder', id: 'id:docs', name: 'docs', path_display: '/docs' },
+        {
+          '.tag': 'file',
+          id: 'id:a',
+          name: 'a.txt',
+          path_display: '/a.txt',
+          size: 5,
+          server_modified: '2026-04-01T00:00:00Z',
+        },
+        {
+          '.tag': 'file',
+          id: 'id:empty',
+          name: 'empty.txt',
+          path_display: '/empty.txt',
+          size: 0,
+          server_modified: '2026-04-01T00:00:00Z',
+        },
+      ],
+      '/docs': [
+        {
+          '.tag': 'file',
+          id: 'id:b',
+          name: 'b.bin',
+          path_display: '/docs/b.bin',
+          size: 3,
+          server_modified: '2026-04-01T00:00:00Z',
+        },
+      ],
+    }
+    const contents: Record<string, Uint8Array> = {
+      '/a.txt': new Uint8Array([104, 101, 108, 108, 111]),
+      '/empty.txt': new Uint8Array([]),
+      '/docs/b.bin': new Uint8Array([97, 98, 99]),
+    }
+    vi.mocked(client.dropboxRpc).mockImplementation((_tm, endpoint, body) => {
+      if (endpoint === '/files/list_folder') {
+        const p = (body as { path: string }).path
+        return Promise.resolve({ entries: tree[p], cursor: 'c', has_more: false })
+      }
+      throw new Error(`unexpected endpoint ${endpoint}`)
+    })
+    vi.mocked(client.dropboxDownload).mockImplementation((_tm, path) => {
+      const data = contents[path]
+      if (data === undefined) throw new Error(`no content for ${path}`)
+      return Promise.resolve(data)
+    })
+
+    const accessor = makeAccessor()
+    const index = new RAMIndexCacheStore()
+    const files: string[] = []
+    const stack = ['/']
+    while (stack.length > 0) {
+      const current = stack.pop()
+      if (current === undefined) break
+      const listing = await readdir(accessor, PathSpec.fromStrPath(current), index)
+      for (const child of listing) {
+        const trimmed = child.replace(/\/$/, '')
+        const info = await stat(accessor, PathSpec.fromStrPath(trimmed), index)
+        if (info.type === FileType.DIRECTORY) {
+          stack.push(trimmed)
+          continue
+        }
+        expect(info.size).not.toBeNull()
+        const bytes = await read(accessor, PathSpec.fromStrPath(trimmed), index)
+        expect(info.size).toBe(bytes.length)
+        files.push(trimmed)
+      }
+    }
+    expect(files.sort()).toEqual(['/a.txt', '/docs/b.bin', '/empty.txt'])
+  })
+})

--- a/typescript/packages/core/src/core/dropbox/stat.ts
+++ b/typescript/packages/core/src/core/dropbox/stat.ts
@@ -20,7 +20,7 @@ import { DropboxApiError } from './client.ts'
 import { getMetadata, type DropboxEntry } from './api.ts'
 import { dropboxPathOf } from './paths.ts'
 import { readdir as coreReaddir } from './readdir.ts'
-import { enoent } from '../../utils/errors.ts'
+import { enoent, isEnoent } from '../../utils/errors.ts'
 import { guessType } from '../../utils/filetype.ts'
 
 function statFromEntry(entry: DropboxEntry): FileStat {
@@ -88,8 +88,12 @@ export async function stat(
         }),
         index,
       )
-    } catch {
-      // parent listing failed — fall through
+    } catch (err) {
+      // readdir already maps a genuinely missing path to ENOENT; a listing
+      // that fails any other way — ENOTDIR under a file, or a 5xx/429 from
+      // the API — is not absence and must surface, never read back as a
+      // (destructively actionable) false ENOENT.
+      if (!isEnoent(err)) throw err
     }
     result = await index.get(virtualKey)
     if (result.entry === undefined || result.entry === null) {


### PR DESCRIPTION
## Why

`stat()`'s index-miss path populates the parent listing through `readdir` and
caught `(FileNotFoundError, DropboxApiError)`. `readdir` already maps a genuinely
missing path to ENOENT, so the only `DropboxApiError` that reaches `stat` is a
**non-409** — a 5xx or 429 while listing the parent. It was swallowed and
re-answered as ENOENT. A false ENOENT is the one an agent acts on destructively,
and it is exactly what `MISS_ERRORS` warns against: a transport error is not
absence.

Two twins carried the same bug:

- `stat.ts` had a bare `catch {}` that swallowed *everything*, ENOTDIR included,
  so a path under a file read back as "missing" on the TS side.
- `du/walk.ts` had the same bare `catch {}` one layer up, swallowing the very
  5xx `stat` should surface — so TS `du` silently under-counted a subtree it
  could not read, where Python `du` (which catches only `FileNotFoundError`)
  fails loud per the `du` contract.

And the tests reached `api.dropboxapi.com` on every run: the missing-path test
mocked only `readdir.list_folder`; when that 409'd, readdir's ancestor walk
called the unmocked `get_metadata` and hit the network. In most environments
Dropbox rejected the fake creds with a tolerated `DropboxApiError` (a false
green); under a TLS-intercepting egress proxy it surfaced as an uncaught SSL
error and a deterministic failure.

## What changed

- **Source (py + ts).** Narrow the populate catch to ENOENT only
  (`except FileNotFoundError` / `if (!isEnoent(err)) throw err`). In Python this
  changes only the 5xx path — `NotADirectoryError` was never in the tuple, so
  ENOTDIR already propagated; the TS twin swallowed both, so both now surface.
  Narrow the two `catch {}` in `du/walk.ts` the same way, mirroring
  `du/walk.py`, so TS `du` stops under-counting an unreadable subtree.
- **Tests, one seam.** Rework `test_stat` and add `stat.test.ts` (dropbox had
  none) around a single stable seam — the JSON-RPC transport (`dropbox_rpc` /
  `dropboxRpc`) via the shared `FakeDropboxRpc`, with the **real** `readdir`.
  `list_folder`, `get_metadata` and the token refresh all funnel through that
  one function, so the suite cannot touch the network and an unexpected endpoint
  fails loudly. readdir's error mapping is deterministic, so ENOENT / 5xx /
  ENOTDIR are driven end to end.
- **Coverage.** Add the untested `NULL_INDEX` `_stat_from_api` path (file,
  folder, 409→ENOENT, non-409 propagates), the index-hit caching contract,
  populate-then-still-absent ENOENT, the 5xx and ENOTDIR propagation that pin
  the fix, mount-prefix arithmetic, and the `_stat_from_entry` field fallbacks.
  Give `du.test.ts` realistic coded errors and pin `du`'s 5xx propagation in
  both languages. Drop the dead token seed and the local `make_accessor` for the
  conftest `dropbox_accessor` fixture.

## Verification

- python: `uv run pytest tests/core/dropbox` — all green (`test_stat` 4 → 19),
  no live network; pre-commit (format, ruff, isort, PathSpec) clean.
- typescript: `vitest run src/core/dropbox` — 72 passed; new `stat.test.ts` and
  the du 5xx pin included; `tsc --noEmit` and prettier clean on the changed
  files.
- Every new propagation test fails against the pre-fix source, so it pins the
  behaviour rather than restating it.

## Deliberate divergence

py and ts mirror in coverage and seam. One pre-existing structural divergence
the tests reflect rather than introduce: TS `FileType` is one flattened enum, so
`stat` renders a file's `type` as `guessType(name)` (e.g. `text`), while Python
carries `type=FILE` + a separate `content`; each language's assertions match its
own shape.