### PR TITLE
docs: credit upstream CLI projects and licenses

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -180,11 +180,11 @@
           {
             "group": "CLIs",
             "pages": [
+              "home/setup/clis",
               {
                 "group": "CLIs",
                 "icon": "terminal",
                 "pages": [
-                  "home/setup/clis",
                   "home/setup/cli/himalaya",
                   "home/setup/cli/gws",
                   "home/setup/cli/slack",
@@ -368,12 +368,12 @@
           {
             "group": "CLIs",
             "pages": [
+              "python/cli/index",
+              "python/cli/custom",
               {
                 "group": "CLIs",
                 "icon": "terminal",
                 "pages": [
-                  "python/cli/index",
-                  "python/cli/custom",
                   "python/cli/himalaya",
                   "python/cli/gws",
                   "python/cli/slack",
@@ -563,12 +563,12 @@
           {
             "group": "CLIs",
             "pages": [
+              "typescript/cli/index",
+              "typescript/cli/custom",
               {
                 "group": "CLIs",
                 "icon": "terminal",
                 "pages": [
-                  "typescript/cli/index",
-                  "typescript/cli/custom",
                   "typescript/cli/himalaya",
                   "typescript/cli/gws",
                   "typescript/cli/slack",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -180,16 +180,22 @@
           {
             "group": "CLIs",
             "pages": [
-              "home/setup/clis",
-              "home/setup/cli/himalaya",
-              "home/setup/cli/gws",
-              "home/setup/cli/slack",
-              "home/setup/cli/discord",
-              "home/setup/cli/ntn",
-              "home/setup/cli/linear",
-              "home/setup/cli/gh",
-                "home/setup/cli/hf",
-              "home/setup/cli/git"
+              {
+                "group": "CLIs",
+                "icon": "terminal",
+                "pages": [
+                  "home/setup/clis",
+                  "home/setup/cli/himalaya",
+                  "home/setup/cli/gws",
+                  "home/setup/cli/slack",
+                  "home/setup/cli/discord",
+                  "home/setup/cli/ntn",
+                  "home/setup/cli/linear",
+                  "home/setup/cli/gh",
+                  "home/setup/cli/hf",
+                  "home/setup/cli/git"
+                ]
+              }
             ]
           },
           {
@@ -362,17 +368,23 @@
           {
             "group": "CLIs",
             "pages": [
-              "python/cli/index",
-              "python/cli/custom",
-              "python/cli/himalaya",
-              "python/cli/gws",
-              "python/cli/slack",
-              "python/cli/discord",
-              "python/cli/ntn",
-              "python/cli/linear",
-              "python/cli/gh",
-                "python/cli/hf",
-              "python/cli/git"
+              {
+                "group": "CLIs",
+                "icon": "terminal",
+                "pages": [
+                  "python/cli/index",
+                  "python/cli/custom",
+                  "python/cli/himalaya",
+                  "python/cli/gws",
+                  "python/cli/slack",
+                  "python/cli/discord",
+                  "python/cli/ntn",
+                  "python/cli/linear",
+                  "python/cli/gh",
+                  "python/cli/hf",
+                  "python/cli/git"
+                ]
+              }
             ]
           },
           {
@@ -551,17 +563,23 @@
           {
             "group": "CLIs",
             "pages": [
-              "typescript/cli/index",
-              "typescript/cli/custom",
-              "typescript/cli/himalaya",
-              "typescript/cli/gws",
-              "typescript/cli/slack",
-              "typescript/cli/discord",
-              "typescript/cli/ntn",
-              "typescript/cli/linear",
-              "typescript/cli/gh",
-                "typescript/cli/hf",
-              "typescript/cli/git"
+              {
+                "group": "CLIs",
+                "icon": "terminal",
+                "pages": [
+                  "typescript/cli/index",
+                  "typescript/cli/custom",
+                  "typescript/cli/himalaya",
+                  "typescript/cli/gws",
+                  "typescript/cli/slack",
+                  "typescript/cli/discord",
+                  "typescript/cli/ntn",
+                  "typescript/cli/linear",
+                  "typescript/cli/gh",
+                  "typescript/cli/hf",
+                  "typescript/cli/git"
+                ]
+              }
             ]
           },
           {

--- a/docs/home/setup/clis.mdx
+++ b/docs/home/setup/clis.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-icon: terminal
+icon: circle-info
 description: Set up Mirage CLIs with Python or TypeScript.
 ---
 

--- a/docs/python/cli/discord.mdx
+++ b/docs/python/cli/discord.mdx
@@ -6,8 +6,8 @@ icon: discord
 
 Mirage's built-in Discord REST API client follows the Discord action
 vocabulary from the upstream
-[OpenClaw](https://github.com/openclaw/openclaw) project. Install it on the
-workspace and the whole tree is discoverable with `discord --help`.
+[OpenClaw](https://github.com/openclaw/openclaw) project. The Mirage command
+tree is discoverable with `discord --help`.
 
 **Licenses:** OpenClaw uses the
 [MIT License](https://github.com/openclaw/openclaw/blob/main/LICENSE); Mirage's

--- a/docs/python/cli/discord.mdx
+++ b/docs/python/cli/discord.mdx
@@ -4,8 +4,15 @@ description: "Discord REST API client speaking the OpenClaw Discord action vocab
 icon: discord
 ---
 
-Discord REST API client speaking the OpenClaw Discord action vocabulary. Install it on the workspace and the whole tree is
-discoverable with `discord --help`.
+Mirage's built-in Discord REST API client follows the Discord action
+vocabulary from the upstream
+[OpenClaw](https://github.com/openclaw/openclaw) project. Install it on the
+workspace and the whole tree is discoverable with `discord --help`.
+
+**Licenses:** OpenClaw uses the
+[MIT License](https://github.com/openclaw/openclaw/blob/main/LICENSE); Mirage's
+independent Discord implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 
@@ -25,7 +32,7 @@ install rides the `clis:` section; see the [CLI overview](/python/cli/index).
 
 ## Verbs
 
-The verbs follow the OpenClaw Discord action vocabulary (bare verbs:
+The verbs follow that OpenClaw Discord action vocabulary (bare verbs:
 `send`, `read`, `edit`, `delete`, `react`, `search`, `thread-create`,
 `poll`); `members` and `server-info` are mirage extensions. IDs are
 Discord snowflakes, discoverable from the mounted tree

--- a/docs/python/cli/gh.mdx
+++ b/docs/python/cli/gh.mdx
@@ -4,11 +4,17 @@ description: "Act on GitHub in the official CLI's vocabulary, alongside a github
 icon: github
 ---
 
-Act on GitHub in the official [CLI](https://cli.github.com)'s vocabulary.
-A repository is a tree, so mirage already reads one as files: the
+Mirage's built-in `gh` implementation uses the vocabulary of the official
+[`cli/cli`](https://github.com/cli/cli) project. A repository is a tree, so
+mirage already reads one as files: the
 [`github` mount](/python/setup/github) is the read half, and `ls`, `cat`
 and `grep` are how an agent explores it. `gh` is the write half, plus the
 account-level operations a filesystem has no shape for.
+
+**Licenses:** The upstream `cli/cli` project uses the
+[MIT License](https://github.com/cli/cli/blob/trunk/LICENSE); Mirage's
+independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -8,7 +8,7 @@ Mirage's built-in `git` implementation reads and changes a repository on any
 mount, following the vocabulary of the upstream
 [Git source](https://github.com/git/git). Unlike the account CLIs, `git` needs
 no credentials and takes no config: it is a program tree with nothing to
-authenticate to, so installing it is one line.
+authenticate to.
 
 **Licenses:** The upstream Git source uses
 [GPLv2](https://github.com/git/git/blob/master/COPYING). Mirage does not

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -4,10 +4,10 @@ description: "Read and change a git repository that lives on any mount, in git's
 icon: git-alt
 ---
 
-Mirage's built-in `git` implementation reads and changes a repository on any
-mount, following the vocabulary of the upstream
-[Git source](https://github.com/git/git). Unlike the account CLIs, `git` needs
-no credentials and takes no config: it is a program tree with nothing to
+Mirage's built-in `git` is an independent implementation that follows the
+command-line interface of upstream [Git](https://github.com/git/git). It reads
+and changes a repository on any mount. Unlike the account CLIs, `git` needs no
+credentials and takes no config: it is a program tree with nothing to
 authenticate to.
 
 **Licenses:** The upstream Git source uses

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -4,10 +4,16 @@ description: "Read and change a git repository that lives on any mount, in git's
 icon: git-alt
 ---
 
-Read and change a git repository that lives on any mount, in git's own
-vocabulary. Unlike the account CLIs, `git` needs no credentials and takes
-no config: it is a program tree with nothing to authenticate to, so
-installing it is one line.
+Mirage's built-in `git` implementation reads and changes a repository on any
+mount, following the vocabulary of the upstream
+[Git source](https://github.com/git/git). Unlike the account CLIs, `git` needs
+no credentials and takes no config: it is a program tree with nothing to
+authenticate to, so installing it is one line.
+
+**Licenses:** The upstream Git source uses
+[GPLv2](https://github.com/git/git/blob/master/COPYING). Mirage does not
+distribute that source; its independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 

--- a/docs/python/cli/gws.mdx
+++ b/docs/python/cli/gws.mdx
@@ -6,8 +6,8 @@ icon: google
 
 Mirage's built-in Google Workspace API client follows the command surface of
 the upstream [googleworkspace/cli](https://github.com/googleworkspace/cli)
-project, with Discovery passthroughs plus ergonomic helpers. Install it on the
-workspace and the whole tree is discoverable with `gws --help`.
+project, with Discovery passthroughs plus ergonomic helpers. The Mirage command
+tree is discoverable with `gws --help`.
 
 **Licenses:** The upstream project uses
 [Apache-2.0](https://github.com/googleworkspace/cli/blob/main/LICENSE); Mirage's

--- a/docs/python/cli/gws.mdx
+++ b/docs/python/cli/gws.mdx
@@ -4,8 +4,15 @@ description: "Google Workspace API client: Discovery passthroughs plus ergonomic
 icon: google
 ---
 
-Google Workspace API client: Discovery passthroughs plus ergonomic helpers. Install it on the workspace and the whole tree is
-discoverable with `gws --help`.
+Mirage's built-in Google Workspace API client follows the command surface of
+the upstream [googleworkspace/cli](https://github.com/googleworkspace/cli)
+project, with Discovery passthroughs plus ergonomic helpers. Install it on the
+workspace and the whole tree is discoverable with `gws --help`.
+
+**Licenses:** The upstream project uses
+[Apache-2.0](https://github.com/googleworkspace/cli/blob/main/LICENSE); Mirage's
+independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 
@@ -25,10 +32,8 @@ install rides the `clis:` section; see the [CLI overview](/python/cli/index).
 
 ## Verbs
 
-The syntax mirrors the official
-[Google Workspace CLI](https://github.com/googleworkspace/cli): one
-passthrough leaf per Discovery method, plus hand-written helpers under
-each service.
+The syntax mirrors the upstream Google Workspace CLI: one passthrough leaf per
+Discovery method, plus hand-written helpers under each service.
 
 ```bash
 gws <service> <resource> <method> [--params JSON] [--json JSON]   # API passthrough

--- a/docs/python/cli/hf.mdx
+++ b/docs/python/cli/hf.mdx
@@ -13,6 +13,11 @@ a tree, so mirage already reads one as files: the
 `cat` and `grep` are how an agent explores one without downloading it. `hf` is
 the write half.
 
+**Licenses:** The upstream `huggingface_hub` project uses
+[Apache-2.0](https://github.com/huggingface/huggingface_hub/blob/main/LICENSE);
+Mirage's independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
+
 ## The three tiers
 
 A Hub write is a **commit**, and a POSIX write cannot say where a commit ends,

--- a/docs/python/cli/himalaya.mdx
+++ b/docs/python/cli/himalaya.mdx
@@ -5,8 +5,8 @@ icon: envelope
 ---
 
 Mirage's built-in IMAP/SMTP mail client follows the vocabulary of the original
-[pimalaya/himalaya](https://github.com/pimalaya/himalaya) project. Install it
-on the workspace and the whole tree is discoverable with `himalaya --help`.
+[pimalaya/himalaya](https://github.com/pimalaya/himalaya) project. The Mirage
+command tree is discoverable with `himalaya --help`.
 
 **Licenses:** `pimalaya/himalaya` is dual-licensed under
 [Apache-2.0](https://github.com/pimalaya/himalaya/blob/master/LICENSE-APACHE) or

--- a/docs/python/cli/himalaya.mdx
+++ b/docs/python/cli/himalaya.mdx
@@ -4,8 +4,15 @@ description: "IMAP/SMTP mail client following the pimalaya/himalaya vocabulary."
 icon: envelope
 ---
 
-IMAP/SMTP mail client following the pimalaya/himalaya vocabulary. Install it on the workspace and the whole tree is
-discoverable with `himalaya --help`.
+Mirage's built-in IMAP/SMTP mail client follows the vocabulary of the original
+[pimalaya/himalaya](https://github.com/pimalaya/himalaya) project. Install it
+on the workspace and the whole tree is discoverable with `himalaya --help`.
+
+**Licenses:** `pimalaya/himalaya` is dual-licensed under
+[Apache-2.0](https://github.com/pimalaya/himalaya/blob/master/LICENSE-APACHE) or
+[MIT](https://github.com/pimalaya/himalaya/blob/master/LICENSE-MIT); Mirage's
+independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 

--- a/docs/python/cli/index.mdx
+++ b/docs/python/cli/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: "Install typed command-line programs beside your mounts and let agents act on services by name."
-icon: terminal
+icon: circle-info
 ---
 
 Mounts make a service readable as files; CLIs make it actionable as a

--- a/docs/python/cli/linear.mdx
+++ b/docs/python/cli/linear.mdx
@@ -4,8 +4,16 @@ description: "Linear GraphQL API client with the noun/verb grammar of the mount 
 icon: /images/linear-logo.svg
 ---
 
-Linear GraphQL API client with the noun/verb grammar of the mount commands. Install it on the workspace and the whole tree is
-discoverable with `linear --help`.
+Mirage's built-in client for Linear's
+[GraphQL API](https://linear.app/developers/graphql) has a Mirage-native
+noun/verb command grammar partly inspired by
+[schpet/linear-cli](https://github.com/schpet/linear-cli). Install it on the
+workspace and the whole tree is discoverable with `linear --help`.
+
+**Licenses:** `schpet/linear-cli` uses the
+[ISC License](https://github.com/schpet/linear-cli/blob/main/LICENSE); Mirage's
+independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 
@@ -25,10 +33,11 @@ install rides the `clis:` section; see the [CLI overview](/python/cli/index).
 
 ## Verbs
 
-The grammar keeps the noun/verb structure the mount commands spoke
-(`linear issue create`, `linear team list`). Issues are addressed by a
-positional key or ID (`linear issue get ENG-42`); every command emits
-normalized JSON, so output pipes straight into `jq`.
+The shared shape is `linear issue ...` and noun groups such as `team`, `user`,
+`project`, and `document`. Mirage keeps the exact command tree from its former
+mount commands (`linear issue create`, `linear team list`). Issues are
+addressed by a positional key or ID (`linear issue get ENG-42`); every command
+emits normalized JSON, so output pipes straight into `jq`.
 
 ### Reads
 

--- a/docs/python/cli/linear.mdx
+++ b/docs/python/cli/linear.mdx
@@ -7,8 +7,8 @@ icon: /images/linear-logo.svg
 Mirage's built-in client for Linear's
 [GraphQL API](https://linear.app/developers/graphql) has a Mirage-native
 noun/verb command grammar partly inspired by
-[schpet/linear-cli](https://github.com/schpet/linear-cli). Install it on the
-workspace and the whole tree is discoverable with `linear --help`.
+[schpet/linear-cli](https://github.com/schpet/linear-cli). The Mirage command
+tree is discoverable with `linear --help`.
 
 **Licenses:** `schpet/linear-cli` uses the
 [ISC License](https://github.com/schpet/linear-cli/blob/main/LICENSE); Mirage's

--- a/docs/python/cli/ntn.mdx
+++ b/docs/python/cli/ntn.mdx
@@ -5,8 +5,8 @@ icon: /images/notion-logo.svg
 ---
 
 Mirage's built-in Notion API client follows the grammar of Notion's official
-[`ntn` CLI](https://www.npmjs.com/package/ntn). Install it on the workspace and
-the whole tree is discoverable with `ntn --help` or `man ntn`.
+[`ntn` CLI](https://www.npmjs.com/package/ntn). The Mirage command tree is
+discoverable with `ntn --help` or `man ntn`.
 
 **Licenses:** The official `ntn` package declares the
 [MIT License](https://www.npmjs.com/package/ntn); Mirage's independent

--- a/docs/python/cli/ntn.mdx
+++ b/docs/python/cli/ntn.mdx
@@ -4,8 +4,14 @@ description: "Notion API client following the official Notion CLI grammar."
 icon: /images/notion-logo.svg
 ---
 
-Notion API client following the official Notion CLI grammar. Install it on the workspace and the whole tree is
-discoverable with `ntn --help` or `man ntn`.
+Mirage's built-in Notion API client follows the grammar of Notion's official
+[`ntn` CLI](https://www.npmjs.com/package/ntn). Install it on the workspace and
+the whole tree is discoverable with `ntn --help` or `man ntn`.
+
+**Licenses:** The official `ntn` package declares the
+[MIT License](https://www.npmjs.com/package/ntn); Mirage's independent
+implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 

--- a/docs/python/cli/slack.mdx
+++ b/docs/python/cli/slack.mdx
@@ -4,8 +4,15 @@ description: "Slack Web API client speaking the OpenClaw Slack action vocabulary
 icon: slack
 ---
 
-Slack Web API client speaking the OpenClaw Slack action vocabulary. Install it on the workspace and the whole tree is
-discoverable with `slack --help`.
+Mirage's built-in Slack Web API client follows the Slack action vocabulary
+from the upstream [OpenClaw](https://github.com/openclaw/openclaw) project.
+Install it on the workspace and the whole tree is discoverable with
+`slack --help`.
+
+**Licenses:** OpenClaw uses the
+[MIT License](https://github.com/openclaw/openclaw/blob/main/LICENSE); Mirage's
+independent Slack implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 
@@ -25,7 +32,7 @@ install rides the `clis:` section; see the [CLI overview](/python/cli/index).
 
 ## Verbs
 
-The verbs follow the OpenClaw Slack action vocabulary (kebab verbs:
+The verbs follow that OpenClaw Slack action vocabulary (kebab verbs:
 `send-message`, `read-messages`, `pin-message`, `list-pins`,
 `member-info`, `emoji-list`); `search` and `list-members` are mirage
 extensions. Search needs a user token (`search_token`), the rest run on

--- a/docs/python/cli/slack.mdx
+++ b/docs/python/cli/slack.mdx
@@ -6,8 +6,7 @@ icon: slack
 
 Mirage's built-in Slack Web API client follows the Slack action vocabulary
 from the upstream [OpenClaw](https://github.com/openclaw/openclaw) project.
-Install it on the workspace and the whole tree is discoverable with
-`slack --help`.
+The Mirage command tree is discoverable with `slack --help`.
 
 **Licenses:** OpenClaw uses the
 [MIT License](https://github.com/openclaw/openclaw/blob/main/LICENSE); Mirage's

--- a/docs/python/resource/github.mdx
+++ b/docs/python/resource/github.mdx
@@ -3,8 +3,9 @@ title: GitHub
 description: Mount a GitHub repository as a read-only Mirage filesystem for agents to list, read, search, and inspect code.
 icon: github
 ---
-The GitHub resource mounts a GitHub repository as a read-only virtual
-filesystem.
+The GitHub resource uses GitHub's [REST API](https://docs.github.com/en/rest)
+to mount a repository as a read-only virtual filesystem. It does not imitate
+another CLI.
 
 For token setup, see [GitHub Setup](/python/setup/github).
 

--- a/docs/python/setup/github.mdx
+++ b/docs/python/setup/github.mdx
@@ -4,6 +4,9 @@ icon: github
 description: Set up the GitHub resource in Python.
 ---
 
+`GitHubResource` exposes a repository through GitHub's
+[REST API](https://docs.github.com/en/rest); it does not imitate another CLI.
+
 ## Dependencies
 
 No additional dependencies - uses `aiohttp` (included).

--- a/docs/python/watch.mdx
+++ b/docs/python/watch.mdx
@@ -1,7 +1,7 @@
 ---
-title: Watch
+title: Overview
 description: Subscribe to external file changes on any mount. Events arrive only after Mirage has invalidated its caches, so reacting to a change always reads fresh content.
-icon: bell
+icon: circle-info
 ---
 
 ## What It Does

--- a/docs/typescript/cli/discord.mdx
+++ b/docs/typescript/cli/discord.mdx
@@ -6,8 +6,8 @@ icon: discord
 
 Mirage's built-in Discord REST API client follows the Discord action
 vocabulary from the upstream
-[OpenClaw](https://github.com/openclaw/openclaw) project. Install it on the
-workspace and the whole tree is discoverable with `discord --help`.
+[OpenClaw](https://github.com/openclaw/openclaw) project. The Mirage command
+tree is discoverable with `discord --help`.
 
 **Licenses:** OpenClaw uses the
 [MIT License](https://github.com/openclaw/openclaw/blob/main/LICENSE); Mirage's

--- a/docs/typescript/cli/discord.mdx
+++ b/docs/typescript/cli/discord.mdx
@@ -4,8 +4,15 @@ description: "Discord REST API client speaking the OpenClaw Discord action vocab
 icon: discord
 ---
 
-Discord REST API client speaking the OpenClaw Discord action vocabulary. Install it on the workspace and the whole tree is
-discoverable with `discord --help`.
+Mirage's built-in Discord REST API client follows the Discord action
+vocabulary from the upstream
+[OpenClaw](https://github.com/openclaw/openclaw) project. Install it on the
+workspace and the whole tree is discoverable with `discord --help`.
+
+**Licenses:** OpenClaw uses the
+[MIT License](https://github.com/openclaw/openclaw/blob/main/LICENSE); Mirage's
+independent Discord implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 
@@ -23,7 +30,7 @@ install rides the `clis:` section; see the [CLI overview](/typescript/cli/index)
 
 ## Verbs
 
-The verbs follow the OpenClaw Discord action vocabulary (bare verbs:
+The verbs follow that OpenClaw Discord action vocabulary (bare verbs:
 `send`, `read`, `edit`, `delete`, `react`, `search`, `thread-create`,
 `poll`); `members` and `server-info` are mirage extensions. IDs are
 Discord snowflakes, discoverable from the mounted tree

--- a/docs/typescript/cli/gh.mdx
+++ b/docs/typescript/cli/gh.mdx
@@ -4,11 +4,17 @@ description: "Act on GitHub in the official CLI's vocabulary, alongside a github
 icon: github
 ---
 
-Act on GitHub in the official [CLI](https://cli.github.com)'s vocabulary.
-A repository is a tree, so mirage already reads one as files: the
+Mirage's built-in `gh` implementation uses the vocabulary of the official
+[`cli/cli`](https://github.com/cli/cli) project. A repository is a tree, so
+mirage already reads one as files: the
 [`github` mount](/typescript/setup/github) is the read half, and `ls`,
 `cat` and `grep` are how an agent explores it. `gh` is the write half,
 plus the account-level operations a filesystem has no shape for.
+
+**Licenses:** The upstream `cli/cli` project uses the
+[MIT License](https://github.com/cli/cli/blob/trunk/LICENSE); Mirage's
+independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -8,7 +8,7 @@ Mirage's built-in `git` implementation reads and changes a repository on any
 mount, following the vocabulary of the upstream
 [Git source](https://github.com/git/git). Unlike the account CLIs, `git` needs
 no credentials and takes no config: it is a program tree with nothing to
-authenticate to, so installing it is one line.
+authenticate to.
 
 **Licenses:** The upstream Git source uses
 [GPLv2](https://github.com/git/git/blob/master/COPYING). Mirage does not

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -4,10 +4,10 @@ description: "Read and change a git repository that lives on any mount, in git's
 icon: git-alt
 ---
 
-Mirage's built-in `git` implementation reads and changes a repository on any
-mount, following the vocabulary of the upstream
-[Git source](https://github.com/git/git). Unlike the account CLIs, `git` needs
-no credentials and takes no config: it is a program tree with nothing to
+Mirage's built-in `git` is an independent implementation that follows the
+command-line interface of upstream [Git](https://github.com/git/git). It reads
+and changes a repository on any mount. Unlike the account CLIs, `git` needs no
+credentials and takes no config: it is a program tree with nothing to
 authenticate to.
 
 **Licenses:** The upstream Git source uses

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -4,10 +4,16 @@ description: "Read and change a git repository that lives on any mount, in git's
 icon: git-alt
 ---
 
-Read and change a git repository that lives on any mount, in git's own
-vocabulary. Unlike the account CLIs, `git` needs no credentials and takes
-no config: it is a program tree with nothing to authenticate to, so
-installing it is one line.
+Mirage's built-in `git` implementation reads and changes a repository on any
+mount, following the vocabulary of the upstream
+[Git source](https://github.com/git/git). Unlike the account CLIs, `git` needs
+no credentials and takes no config: it is a program tree with nothing to
+authenticate to, so installing it is one line.
+
+**Licenses:** The upstream Git source uses
+[GPLv2](https://github.com/git/git/blob/master/COPYING). Mirage does not
+distribute that source; its independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 

--- a/docs/typescript/cli/gws.mdx
+++ b/docs/typescript/cli/gws.mdx
@@ -6,8 +6,8 @@ icon: google
 
 Mirage's built-in Google Workspace API client follows the command surface of
 the upstream [googleworkspace/cli](https://github.com/googleworkspace/cli)
-project, with Discovery passthroughs plus ergonomic helpers. Install it on the
-workspace and the whole tree is discoverable with `gws --help`.
+project, with Discovery passthroughs plus ergonomic helpers. The Mirage command
+tree is discoverable with `gws --help`.
 
 **Licenses:** The upstream project uses
 [Apache-2.0](https://github.com/googleworkspace/cli/blob/main/LICENSE); Mirage's

--- a/docs/typescript/cli/gws.mdx
+++ b/docs/typescript/cli/gws.mdx
@@ -4,8 +4,15 @@ description: "Google Workspace API client: Discovery passthroughs plus ergonomic
 icon: google
 ---
 
-Google Workspace API client: Discovery passthroughs plus ergonomic helpers. Install it on the workspace and the whole tree is
-discoverable with `gws --help`.
+Mirage's built-in Google Workspace API client follows the command surface of
+the upstream [googleworkspace/cli](https://github.com/googleworkspace/cli)
+project, with Discovery passthroughs plus ergonomic helpers. Install it on the
+workspace and the whole tree is discoverable with `gws --help`.
+
+**Licenses:** The upstream project uses
+[Apache-2.0](https://github.com/googleworkspace/cli/blob/main/LICENSE); Mirage's
+independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 
@@ -23,10 +30,8 @@ install rides the `clis:` section; see the [CLI overview](/typescript/cli/index)
 
 ## Verbs
 
-The syntax mirrors the official
-[Google Workspace CLI](https://github.com/googleworkspace/cli): one
-passthrough leaf per Discovery method, plus hand-written helpers under
-each service.
+The syntax mirrors the upstream Google Workspace CLI: one passthrough leaf per
+Discovery method, plus hand-written helpers under each service.
 
 ```bash
 gws <service> <resource> <method> [--params JSON] [--json JSON]   # API passthrough

--- a/docs/typescript/cli/hf.mdx
+++ b/docs/typescript/cli/hf.mdx
@@ -13,6 +13,11 @@ a tree, so mirage already reads one as files: the
 `cat` and `grep` are how an agent explores one without downloading it. `hf` is
 the write half.
 
+**Licenses:** The upstream `huggingface_hub` project uses
+[Apache-2.0](https://github.com/huggingface/huggingface_hub/blob/main/LICENSE);
+Mirage's independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
+
 ## The three tiers
 
 A Hub write is a **commit**, and a POSIX write cannot say where a commit ends,

--- a/docs/typescript/cli/himalaya.mdx
+++ b/docs/typescript/cli/himalaya.mdx
@@ -5,8 +5,8 @@ icon: envelope
 ---
 
 Mirage's built-in IMAP/SMTP mail client follows the vocabulary of the original
-[pimalaya/himalaya](https://github.com/pimalaya/himalaya) project. Install it
-on the workspace and the whole tree is discoverable with `himalaya --help`.
+[pimalaya/himalaya](https://github.com/pimalaya/himalaya) project. The Mirage
+command tree is discoverable with `himalaya --help`.
 
 **Licenses:** `pimalaya/himalaya` is dual-licensed under
 [Apache-2.0](https://github.com/pimalaya/himalaya/blob/master/LICENSE-APACHE) or

--- a/docs/typescript/cli/himalaya.mdx
+++ b/docs/typescript/cli/himalaya.mdx
@@ -4,8 +4,15 @@ description: "IMAP/SMTP mail client following the pimalaya/himalaya vocabulary."
 icon: envelope
 ---
 
-IMAP/SMTP mail client following the pimalaya/himalaya vocabulary. Install it on the workspace and the whole tree is
-discoverable with `himalaya --help`.
+Mirage's built-in IMAP/SMTP mail client follows the vocabulary of the original
+[pimalaya/himalaya](https://github.com/pimalaya/himalaya) project. Install it
+on the workspace and the whole tree is discoverable with `himalaya --help`.
+
+**Licenses:** `pimalaya/himalaya` is dual-licensed under
+[Apache-2.0](https://github.com/pimalaya/himalaya/blob/master/LICENSE-APACHE) or
+[MIT](https://github.com/pimalaya/himalaya/blob/master/LICENSE-MIT); Mirage's
+independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 

--- a/docs/typescript/cli/index.mdx
+++ b/docs/typescript/cli/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: "Install typed command-line programs beside your mounts and let agents act on services by name from Node."
-icon: terminal
+icon: circle-info
 ---
 
 Mounts make a service readable as files; CLIs make it actionable as a

--- a/docs/typescript/cli/linear.mdx
+++ b/docs/typescript/cli/linear.mdx
@@ -4,8 +4,16 @@ description: "Linear GraphQL API client with the noun/verb grammar of the mount 
 icon: /images/linear-logo.svg
 ---
 
-Linear GraphQL API client with the noun/verb grammar of the mount commands. Install it on the workspace and the whole tree is
-discoverable with `linear --help`.
+Mirage's built-in client for Linear's
+[GraphQL API](https://linear.app/developers/graphql) has a Mirage-native
+noun/verb command grammar partly inspired by
+[schpet/linear-cli](https://github.com/schpet/linear-cli). Install it on the
+workspace and the whole tree is discoverable with `linear --help`.
+
+**Licenses:** `schpet/linear-cli` uses the
+[ISC License](https://github.com/schpet/linear-cli/blob/main/LICENSE); Mirage's
+independent implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 
@@ -23,10 +31,11 @@ install rides the `clis:` section; see the [CLI overview](/typescript/cli/index)
 
 ## Verbs
 
-The grammar keeps the noun/verb structure the mount commands spoke
-(`linear issue create`, `linear team list`). Issues are addressed by a
-positional key or ID (`linear issue get ENG-42`); every command emits
-normalized JSON, so output pipes straight into `jq`.
+The shared shape is `linear issue ...` and noun groups such as `team`, `user`,
+`project`, and `document`. Mirage keeps the exact command tree from its former
+mount commands (`linear issue create`, `linear team list`). Issues are
+addressed by a positional key or ID (`linear issue get ENG-42`); every command
+emits normalized JSON, so output pipes straight into `jq`.
 
 ### Reads
 

--- a/docs/typescript/cli/linear.mdx
+++ b/docs/typescript/cli/linear.mdx
@@ -7,8 +7,8 @@ icon: /images/linear-logo.svg
 Mirage's built-in client for Linear's
 [GraphQL API](https://linear.app/developers/graphql) has a Mirage-native
 noun/verb command grammar partly inspired by
-[schpet/linear-cli](https://github.com/schpet/linear-cli). Install it on the
-workspace and the whole tree is discoverable with `linear --help`.
+[schpet/linear-cli](https://github.com/schpet/linear-cli). The Mirage command
+tree is discoverable with `linear --help`.
 
 **Licenses:** `schpet/linear-cli` uses the
 [ISC License](https://github.com/schpet/linear-cli/blob/main/LICENSE); Mirage's

--- a/docs/typescript/cli/ntn.mdx
+++ b/docs/typescript/cli/ntn.mdx
@@ -5,8 +5,8 @@ icon: /images/notion-logo.svg
 ---
 
 Mirage's built-in Notion API client follows the grammar of Notion's official
-[`ntn` CLI](https://www.npmjs.com/package/ntn). Install it on the workspace and
-the whole tree is discoverable with `ntn --help` or `man ntn`.
+[`ntn` CLI](https://www.npmjs.com/package/ntn). The Mirage command tree is
+discoverable with `ntn --help` or `man ntn`.
 
 **Licenses:** The official `ntn` package declares the
 [MIT License](https://www.npmjs.com/package/ntn); Mirage's independent

--- a/docs/typescript/cli/ntn.mdx
+++ b/docs/typescript/cli/ntn.mdx
@@ -4,8 +4,14 @@ description: "Notion API client following the official Notion CLI grammar."
 icon: /images/notion-logo.svg
 ---
 
-Notion API client following the official Notion CLI grammar. Install it on the workspace and the whole tree is
-discoverable with `ntn --help` or `man ntn`.
+Mirage's built-in Notion API client follows the grammar of Notion's official
+[`ntn` CLI](https://www.npmjs.com/package/ntn). Install it on the workspace and
+the whole tree is discoverable with `ntn --help` or `man ntn`.
+
+**Licenses:** The official `ntn` package declares the
+[MIT License](https://www.npmjs.com/package/ntn); Mirage's independent
+implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 

--- a/docs/typescript/cli/slack.mdx
+++ b/docs/typescript/cli/slack.mdx
@@ -6,8 +6,7 @@ icon: slack
 
 Mirage's built-in Slack Web API client follows the Slack action vocabulary
 from the upstream [OpenClaw](https://github.com/openclaw/openclaw) project.
-Install it on the workspace and the whole tree is discoverable with
-`slack --help`.
+The Mirage command tree is discoverable with `slack --help`.
 
 **Licenses:** OpenClaw uses the
 [MIT License](https://github.com/openclaw/openclaw/blob/main/LICENSE); Mirage's

--- a/docs/typescript/cli/slack.mdx
+++ b/docs/typescript/cli/slack.mdx
@@ -4,8 +4,15 @@ description: "Slack Web API client speaking the OpenClaw Slack action vocabulary
 icon: slack
 ---
 
-Slack Web API client speaking the OpenClaw Slack action vocabulary. Install it on the workspace and the whole tree is
-discoverable with `slack --help`.
+Mirage's built-in Slack Web API client follows the Slack action vocabulary
+from the upstream [OpenClaw](https://github.com/openclaw/openclaw) project.
+Install it on the workspace and the whole tree is discoverable with
+`slack --help`.
+
+**Licenses:** OpenClaw uses the
+[MIT License](https://github.com/openclaw/openclaw/blob/main/LICENSE); Mirage's
+independent Slack implementation uses
+[Apache-2.0](https://github.com/strukto-ai/mirage/blob/main/LICENSE).
 
 ## Install
 
@@ -23,7 +30,7 @@ install rides the `clis:` section; see the [CLI overview](/typescript/cli/index)
 
 ## Verbs
 
-The verbs follow the OpenClaw Slack action vocabulary (kebab verbs:
+The verbs follow that OpenClaw Slack action vocabulary (kebab verbs:
 `send-message`, `read-messages`, `pin-message`, `list-pins`,
 `member-info`, `emoji-list`); `search` and `list-members` are mirage
 extensions. Search needs a user token (`search_token`), the rest run on

--- a/docs/typescript/setup/github.mdx
+++ b/docs/typescript/setup/github.mdx
@@ -4,7 +4,9 @@ icon: github
 description: Mount a GitHub repository as a Mirage filesystem from Node or the browser.
 ---
 
-`GitHubResource` exposes a single repository at a ref as a read-only filesystem. Reads stream blobs through the GitHub API.
+`GitHubResource` exposes a single repository at a ref as a read-only
+filesystem. Reads stream blobs through GitHub's
+[REST API](https://docs.github.com/en/rest); it does not imitate another CLI.
 
 Setup steps for the personal access token live at [GitHub Credentials](/home/setup/github).
 

--- a/docs/typescript/watch.mdx
+++ b/docs/typescript/watch.mdx
@@ -1,7 +1,7 @@
 ---
-title: Watch
+title: Overview
 description: Subscribe to external file changes on any TypeScript mount. Mirage invalidates its caches before every event is delivered.
-icon: bell
+icon: circle-info
 ---
 
 ## What It Does


### PR DESCRIPTION
## Summary

- link each compatibility CLI to its upstream project or API
- document upstream licenses alongside Mirage Apache-2.0 implementation license
- distinguish OpenClaw-inspired Slack and Discord vocabularies, schpet-inspired Linear shape, and Mirage-native GitHub resource behavior

## Validation

- git diff --check
- python3 scripts/check_docs_frontmatter.py (276 pages)