### PR TITLE
refactor(observe): own op timing in the record path

### DIFF
--- a/python/mirage/core/box/write.py
+++ b/python/mirage/core/box/write.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.box import BoxAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.box.api import upload_file_version, upload_new_file
 from mirage.core.box.resolve import path_parts, resolve_item, resolve_parent_id
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -29,7 +27,7 @@ async def write_bytes(accessor: BoxAccessor, path: PathSpec,
     if not parts:
         raise IsADirectoryError(path.virtual)
     tm = accessor.token_manager
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     existing = await resolve_item(accessor, parts)
     if existing is not None and existing.get("type") == "file":
         # Overwrite uploads a new version under the same id, keeping Box's
@@ -40,5 +38,5 @@ async def write_bytes(accessor: BoxAccessor, path: PathSpec,
         if parent_id is None:
             raise enoent(path.virtual)
         await upload_new_file(tm, parent_id, parts[-1], data)
-    record("write", path.resource_path, "box", len(data), start_ms)
+    record("write", path.resource_path, "box", len(data), timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/databricks_volume/read.py
+++ b/python/mirage/core/databricks_volume/read.py
@@ -13,14 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-import time
 from urllib.parse import quote
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.databricks_volume.errors import is_not_found
 from mirage.core.databricks_volume.path import backend_path
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.ranges import range_header, slice_window
@@ -86,9 +85,9 @@ async def read_bytes(
 ) -> bytes:
     virtual = path.virtual
     remote_path = backend_path(accessor.config, path)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     if size == 0:
-        record("read", virtual, "databricks_volume", 0, start_ms)
+        record("read", virtual, "databricks_volume", 0, timer)
         return b""
     try:
         data = await asyncio.to_thread(
@@ -111,5 +110,5 @@ async def read_bytes(
     # gave room for. A short answer is what EOF looks like and is kept.
     if size is not None and len(data) > size:
         data = slice_window(data, offset, size)
-    record("read", virtual, "databricks_volume", len(data), start_ms)
+    record("read", virtual, "databricks_volume", len(data), timer)
     return data

--- a/python/mirage/core/databricks_volume/unlink.py
+++ b/python/mirage/core/databricks_volume/unlink.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-import time
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.context import invalidate_after_unlink
@@ -21,7 +20,7 @@ from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.databricks_volume.errors import is_not_found
 from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.stat import stat
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import FileType, PathSpec
 from mirage.utils.errors import enoent
 
@@ -42,12 +41,12 @@ async def unlink(
     if file_stat.type == FileType.DIRECTORY:
         raise IsADirectoryError(path.virtual)
     remote_path = backend_path(accessor.config, path)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         await asyncio.to_thread(_delete_file_sync, accessor, remote_path)
     except Exception as exc:
         if is_not_found(exc):
             raise enoent(path) from exc
         raise
-    record("unlink", path.virtual, "databricks_volume", 0, start_ms)
+    record("unlink", path.virtual, "databricks_volume", 0, timer)
     await invalidate_after_unlink(path)

--- a/python/mirage/core/databricks_volume/write.py
+++ b/python/mirage/core/databricks_volume/write.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-import time
 from io import BytesIO
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
@@ -23,7 +22,7 @@ from mirage.core.databricks_volume._helpers import (is_directory_metadata,
                                                     parent_path)
 from mirage.core.databricks_volume.errors import is_not_found
 from mirage.core.databricks_volume.path import backend_path
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -67,7 +66,7 @@ async def write_bytes(
     parent = parent_path(path)
     remote_parent = backend_path(accessor.config, parent)
     remote_path = backend_path(accessor.config, path)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     # TODO native async client calling HTTP API as databricks sdk is sync
     await asyncio.to_thread(
         _ensure_parent_directory_sync,
@@ -82,5 +81,5 @@ async def write_bytes(
         if is_not_found(exc):
             raise enoent(path) from exc
         raise
-    record("write", path.virtual, "databricks_volume", len(data), start_ms)
+    record("write", path.virtual, "databricks_volume", len(data), timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/disk/append.py
+++ b/python/mirage/core/disk/append.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
 from pathlib import Path
 
 import aiofiles
@@ -20,7 +19,7 @@ import aiofiles
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.disk.errors import disk_errors
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
@@ -35,10 +34,10 @@ async def append_bytes(accessor: DiskAccessor, path_spec: PathSpec,
                        data: bytes) -> None:
     path = path_spec.mount_path
     root = accessor.root
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = _resolve(root, path)
     with disk_errors(path_spec.virtual):
         async with aiofiles.open(p, "ab") as f:
             await f.write(data)
-    record("append", path, "disk", len(data), start_ms)
+    record("append", path, "disk", len(data), timer)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/disk/create.py
+++ b/python/mirage/core/disk/create.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
 from pathlib import Path
 
 import aiofiles
@@ -21,7 +20,7 @@ import aiofiles.os
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.disk.errors import disk_errors
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
@@ -34,10 +33,10 @@ def _resolve(root: Path, path: str) -> Path:
 
 async def create(accessor: DiskAccessor, path_spec: PathSpec) -> None:
     path = path_spec.mount_path
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = _resolve(accessor.root, path)
     with disk_errors(path_spec.virtual):
         async with aiofiles.open(p, "wb") as f:
             await f.write(b"")
-    record("create", path, "disk", 0, start_ms)
+    record("create", path, "disk", 0, timer)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/disk/read.py
+++ b/python/mirage/core/disk/read.py
@@ -12,14 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
 from pathlib import Path
 
 import aiofiles
 
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
@@ -36,14 +35,14 @@ async def read_bytes(accessor: DiskAccessor,
     virtual = path_spec.virtual
     path = path_spec.mount_path
     root = accessor.root
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = _resolve(root, path)
     try:
         async with aiofiles.open(p, "rb") as f:
             data = await f.read()
     except FileNotFoundError as exc:
         raise FileNotFoundError(virtual) from exc
-    record("read", path, "disk", len(data), start_ms)
+    record("read", path, "disk", len(data), timer)
     return data
 
 
@@ -64,7 +63,7 @@ async def read_range(accessor: DiskAccessor,
     virtual = path_spec.virtual
     path = path_spec.mount_path
     root = accessor.root
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = _resolve(root, path)
     try:
         async with aiofiles.open(p, "rb") as f:
@@ -72,5 +71,5 @@ async def read_range(accessor: DiskAccessor,
             data = await (f.read() if size is None else f.read(size))
     except FileNotFoundError as exc:
         raise FileNotFoundError(virtual) from exc
-    record("read", path, "disk", len(data), start_ms)
+    record("read", path, "disk", len(data), timer)
     return data

--- a/python/mirage/core/disk/truncate.py
+++ b/python/mirage/core/disk/truncate.py
@@ -12,14 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
 from pathlib import Path
 
 import aiofiles
 
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.context import invalidate_after_write
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
@@ -33,7 +32,7 @@ def _resolve(root: Path, path: str) -> Path:
 async def truncate(accessor: DiskAccessor, path_spec: PathSpec,
                    length: int) -> None:
     path = path_spec.mount_path
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = _resolve(accessor.root, path)
     try:
         async with aiofiles.open(p, "rb") as f:
@@ -43,5 +42,5 @@ async def truncate(accessor: DiskAccessor, path_spec: PathSpec,
     result = data[:length].ljust(length, b"\0")
     async with aiofiles.open(p, "wb") as f:
         await f.write(result)
-    record("truncate", path, "disk", 0, start_ms)
+    record("truncate", path, "disk", 0, timer)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/disk/write.py
+++ b/python/mirage/core/disk/write.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
 from pathlib import Path
 
 import aiofiles
@@ -20,7 +19,7 @@ import aiofiles
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.disk.errors import disk_errors
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
@@ -35,10 +34,10 @@ async def write_bytes(accessor: DiskAccessor, path_spec: PathSpec,
                       data: bytes) -> None:
     path = path_spec.mount_path
     root = accessor.root
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = _resolve(root, path)
     with disk_errors(path_spec.virtual):
         async with aiofiles.open(p, "wb") as f:
             await f.write(data)
-    record("write", path, "disk", len(data), start_ms)
+    record("write", path, "disk", len(data), timer)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/dropbox/copy.py
+++ b/python/mirage/core/dropbox/copy.py
@@ -12,14 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.context import invalidate_after_write, invalidate_ancestors
 from mirage.core.dropbox.api import copy_path, delete_path, get_metadata
 from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.paths import dropbox_path_of
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -36,7 +34,7 @@ async def copy(accessor: DropboxAccessor, src: PathSpec,
     """
     from_path = dropbox_path_of(accessor, src)
     to_path = dropbox_path_of(accessor, dst)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         await copy_path(accessor.token_manager, from_path, to_path)
     except DropboxApiError as exc:
@@ -49,6 +47,6 @@ async def copy(accessor: DropboxAccessor, src: PathSpec,
             raise
         await delete_path(accessor.token_manager, to_path)
         await copy_path(accessor.token_manager, from_path, to_path)
-    record("copy", src.virtual, "dropbox", 0, start_ms)
+    record("copy", src.virtual, "dropbox", 0, timer)
     await invalidate_after_write(dst)
     await invalidate_ancestors(dst)

--- a/python/mirage/core/dropbox/mkdir.py
+++ b/python/mirage/core/dropbox/mkdir.py
@@ -12,14 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.context import invalidate_after_write, invalidate_ancestors
 from mirage.core.dropbox.api import create_folder, get_metadata
 from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.paths import dropbox_path_of
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -63,13 +61,13 @@ async def mkdir(accessor: DropboxAccessor,
         if (parent != accessor.root_path
                 and await _metadata_tag(accessor, parent) != "folder"):
             raise enoent(path.virtual)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         await create_folder(accessor.token_manager, api_path)
     except DropboxApiError as exc:
         if exc.summary.startswith("path/conflict"):
             raise FileExistsError(path.virtual) from exc
         raise
-    record("mkdir", path.virtual, "dropbox", 0, start_ms)
+    record("mkdir", path.virtual, "dropbox", 0, timer)
     await invalidate_after_write(path)
     await invalidate_ancestors(path)

--- a/python/mirage/core/dropbox/rename.py
+++ b/python/mirage/core/dropbox/rename.py
@@ -12,15 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.context import invalidate_ancestors, invalidate_subtree
 from mirage.core.dropbox.api import (delete_path, get_metadata, list_folder,
                                      move_path)
 from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.paths import dropbox_path_of
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -41,7 +39,7 @@ async def rename(accessor: DropboxAccessor, src: PathSpec,
     """
     from_path = dropbox_path_of(accessor, src)
     to_path = dropbox_path_of(accessor, dst)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         await move_path(accessor.token_manager, from_path, to_path)
     except DropboxApiError as exc:
@@ -58,7 +56,7 @@ async def rename(accessor: DropboxAccessor, src: PathSpec,
                 raise
         await delete_path(accessor.token_manager, to_path)
         await move_path(accessor.token_manager, from_path, to_path)
-    record("rename", src.virtual, "dropbox", 0, start_ms)
+    record("rename", src.virtual, "dropbox", 0, timer)
     await invalidate_subtree(src)
     await invalidate_ancestors(src)
     await invalidate_subtree(dst)

--- a/python/mirage/core/dropbox/rm.py
+++ b/python/mirage/core/dropbox/rm.py
@@ -12,14 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.context import invalidate_ancestors, invalidate_subtree
 from mirage.core.dropbox.api import delete_path
 from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.paths import dropbox_path_of
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -27,13 +25,13 @@ from mirage.utils.errors import enoent
 async def rm_r(accessor: DropboxAccessor, path: PathSpec) -> None:
     # delete_v2 removes folders recursively, so rm -r maps to one call.
     api_path = dropbox_path_of(accessor, path)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         await delete_path(accessor.token_manager, api_path)
     except DropboxApiError as exc:
         if exc.status == 409:
             raise enoent(path.virtual) from exc
         raise
-    record("rm_r", path.virtual, "dropbox", 0, start_ms)
+    record("rm_r", path.virtual, "dropbox", 0, timer)
     await invalidate_subtree(path)
     await invalidate_ancestors(path)

--- a/python/mirage/core/dropbox/rmdir.py
+++ b/python/mirage/core/dropbox/rmdir.py
@@ -12,15 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.dropbox.api import delete_path, get_metadata, list_folder
 from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.paths import dropbox_path_of
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotdir, enotempty
 
@@ -52,8 +50,8 @@ async def rmdir(accessor: DropboxAccessor,
     children = await list_folder(accessor.token_manager, api_path, limit=1)
     if children:
         raise enotempty(path)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     await delete_path(accessor.token_manager, api_path)
-    record("rmdir", path.virtual, "dropbox", 0, start_ms)
+    record("rmdir", path.virtual, "dropbox", 0, timer)
     await invalidate_after_unlink(path)
     await invalidate_ancestors(path)

--- a/python/mirage/core/dropbox/unlink.py
+++ b/python/mirage/core/dropbox/unlink.py
@@ -12,14 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.context import invalidate_after_unlink, invalidate_ancestors
 from mirage.core.dropbox.api import delete_path, get_metadata
 from mirage.core.dropbox.client import DropboxApiError
 from mirage.core.dropbox.paths import dropbox_path_of
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import eisdir, enoent
 
@@ -34,8 +32,8 @@ async def unlink(accessor: DropboxAccessor, path: PathSpec) -> None:
         raise
     if entry.get(".tag") == "folder":
         raise eisdir(path.virtual)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     await delete_path(accessor.token_manager, api_path)
-    record("unlink", path.virtual, "dropbox", 0, start_ms)
+    record("unlink", path.virtual, "dropbox", 0, timer)
     await invalidate_after_unlink(path)
     await invalidate_ancestors(path)

--- a/python/mirage/core/dropbox/write.py
+++ b/python/mirage/core/dropbox/write.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.context import invalidate_after_write, invalidate_ancestors
 from mirage.core.dropbox.client import dropbox_upload
 from mirage.core.dropbox.paths import dropbox_path_of
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
@@ -32,9 +30,9 @@ async def write_bytes(accessor: DropboxAccessor, path: PathSpec,
         path (PathSpec): target path.
         data (bytes): file content.
     """
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     await dropbox_upload(accessor.token_manager,
                          dropbox_path_of(accessor, path), data)
-    record("write", path.virtual, "dropbox", len(data), start_ms)
+    record("write", path.virtual, "dropbox", len(data), timer)
     await invalidate_after_write(path)
     await invalidate_ancestors(path)

--- a/python/mirage/core/gdrive/read.py
+++ b/python/mirage/core/gdrive/read.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import posixpath
-import time
 from functools import partial
 
 from mirage.accessor.gdrive import GDriveAccessor
@@ -28,7 +27,8 @@ from mirage.core.google.client import TokenManager
 from mirage.core.google.drive import download_file
 from mirage.core.gsheets.read import read_spreadsheet
 from mirage.core.gslides.read import read_presentation
-from mirage.observe.context import active_recorder, record, revision_for
+from mirage.observe.context import (active_recorder, record, revision_for,
+                                    start_op)
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
@@ -64,7 +64,7 @@ async def read_file_versioned(token_manager: TokenManager,
     """
     pinned = revision_for(virtual)
     window = window_for(offset, size)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     fingerprint = None
     revision = pinned
     if pinned:
@@ -79,7 +79,7 @@ async def read_file_versioned(token_manager: TokenManager,
            label,
            "gdrive",
            len(data),
-           start_ms,
+           timer,
            fingerprint=fingerprint,
            revision=revision)
     return data

--- a/python/mirage/core/gdrive/write.py
+++ b/python/mirage/core/gdrive/write.py
@@ -13,14 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import posixpath
-import time
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.gdrive.resolve import (eacces_on_denied, resolve_key,
                                         resolve_parent)
 from mirage.core.google.drive import update_file_content, upload_file
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import eisdir
 
@@ -32,7 +31,7 @@ async def write_bytes(accessor: GDriveAccessor, path: PathSpec,
     key = path.resource_path
     if not key:
         raise eisdir(virtual)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     token_manager = accessor.token_manager
     node = await resolve_key(accessor, key)
     if node is not None and node.is_folder:
@@ -47,5 +46,5 @@ async def write_bytes(accessor: GDriveAccessor, path: PathSpec,
         parent_id, _ = await resolve_parent(accessor, path)
         await upload_file(token_manager, posixpath.basename(key), parent_id,
                           data)
-    record("write", key, "gdrive", len(data), start_ms)
+    record("write", key, "gdrive", len(data), timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/gridfs/read.py
+++ b/python/mirage/core/gridfs/read.py
@@ -12,15 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from bson import ObjectId
 from gridfs.errors import NoFile
 
 from mirage.accessor.gridfs import GridFSAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.gridfs.client import _key, bucket, latest_file
-from mirage.observe.context import record, revision_for
+from mirage.observe.context import record, revision_for, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -43,7 +41,7 @@ async def read_bytes(accessor: GridFSAccessor,
     path = path_spec.mount_path
     config = accessor.config
     key = _key(path, config)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     pinned_revision = revision_for(virtual)
     if pinned_revision is not None:
         file_id = ObjectId(pinned_revision)
@@ -67,7 +65,7 @@ async def read_bytes(accessor: GridFSAccessor,
            path,
            "gridfs",
            len(data),
-           start_ms,
+           timer,
            fingerprint=revision,
            revision=revision)
     return data

--- a/python/mirage/core/hf_buckets/read.py
+++ b/python/mirage/core/hf_buckets/read.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from opendal.exceptions import NotFound
 
 from mirage.accessor.hf_buckets import HfBucketsAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -31,7 +29,7 @@ async def read_bytes(accessor: HfBucketsAccessor,
     raw = path.mount_path
     key = raw.lstrip("/")
     op = accessor.operator()
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         if offset or size is not None:
             async with await op.open(key, "rb") as f:
@@ -43,5 +41,5 @@ async def read_bytes(accessor: HfBucketsAccessor,
             data = bytes(await op.read(key))
     except NotFound as exc:
         raise enoent(path) from exc
-    record("read", raw, accessor.RESOURCE_NAME, len(data), start_ms)
+    record("read", raw, accessor.RESOURCE_NAME, len(data), timer)
     return data

--- a/python/mirage/core/hf_hub/read.py
+++ b/python/mirage/core/hf_hub/read.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.hf_hub import HfHubAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
 from mirage.core.hf_hub.client import hub_bytes, resolve_url
 from mirage.core.hf_hub.lookup import key_of, lookup
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import eisdir, enoent
 from mirage.utils.key_prefix import mount_prefix_of
@@ -84,7 +82,7 @@ async def read_bytes(accessor: HfHubAccessor,
                       accessor.revision, accessor.repo_path(raw))
     window = ByteWindow(offset=offset,
                         size=size) if offset or size is not None else None
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     data = await hub_bytes(accessor.token, url, window, session=accessor.pool)
-    record("read", raw, accessor.RESOURCE_NAME, len(data), start_ms)
+    record("read", raw, accessor.RESOURCE_NAME, len(data), timer)
     return data

--- a/python/mirage/core/msgraph/drive_ops.py
+++ b/python/mirage/core/msgraph/drive_ops.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import posixpath
-import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, replace
 from functools import partial
@@ -35,7 +34,7 @@ from mirage.core.msgraph.client import (GraphError, graph_delete, graph_get,
                                         upload_chunk)
 from mirage.core.msgraph.config import MsGraphConfig
 from mirage.observe.context import (active_recorder, record, record_stream,
-                                    revision_for)
+                                    revision_for, start_op)
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent, listing_error
 from mirage.utils.filetype import guess_type
@@ -349,7 +348,7 @@ async def read_item(config: MsGraphConfig,
                     session: SessionArg = None) -> bytes:
     pinned = revision_for(virtual)
     window = window_for(offset, size)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     fingerprint = None
     revision = pinned
     try:
@@ -386,7 +385,7 @@ async def read_item(config: MsGraphConfig,
            label,
            backend,
            len(data),
-           start_ms,
+           timer,
            fingerprint=fingerprint,
            revision=revision)
     return data

--- a/python/mirage/core/nextcloud/create.py
+++ b/python/mirage/core/nextcloud/create.py
@@ -1,15 +1,13 @@
-import time
-
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.context import invalidate_after_write
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
 async def create(accessor: NextcloudAccessor, path: PathSpec) -> None:
     key = path.mount_path.lstrip("/")
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     op = accessor.operator()
     await op.write(key, b"")
-    record("create", path.virtual, "nextcloud", 0, start_ms)
+    record("create", path.virtual, "nextcloud", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/nextcloud/read.py
+++ b/python/mirage/core/nextcloud/read.py
@@ -1,10 +1,8 @@
-import time
-
 from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -17,7 +15,7 @@ async def read_bytes(accessor: NextcloudAccessor,
     raw = path.mount_path
     key = raw.lstrip("/")
     op = accessor.operator()
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         if offset or size is not None:
             async with await op.open(key, "rb") as f:
@@ -29,5 +27,5 @@ async def read_bytes(accessor: NextcloudAccessor,
             data = bytes(await op.read(key))
     except NotFound as exc:
         raise enoent(path) from exc
-    record("read", raw, "nextcloud", len(data), start_ms)
+    record("read", raw, "nextcloud", len(data), timer)
     return data

--- a/python/mirage/core/nextcloud/truncate.py
+++ b/python/mirage/core/nextcloud/truncate.py
@@ -1,17 +1,15 @@
-import time
-
 from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.context import invalidate_after_write
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
 async def truncate(accessor: NextcloudAccessor, path: PathSpec,
                    length: int) -> None:
     key = path.mount_path.lstrip("/")
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     op = accessor.operator()
     try:
         data = bytes(await op.read(key))
@@ -19,5 +17,5 @@ async def truncate(accessor: NextcloudAccessor, path: PathSpec,
         data = b""
     result = data[:length].ljust(length, b"\0")
     await op.write(key, result)
-    record("truncate", path.virtual, "nextcloud", 0, start_ms)
+    record("truncate", path.virtual, "nextcloud", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/nextcloud/unlink.py
+++ b/python/mirage/core/nextcloud/unlink.py
@@ -1,10 +1,8 @@
-import time
-
 from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.context import invalidate_after_unlink
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -13,10 +11,10 @@ async def unlink(accessor: NextcloudAccessor, path: PathSpec) -> None:
     raw = path.mount_path
     key = raw.lstrip("/")
     op = accessor.operator()
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         await op.delete(key)
     except NotFound as exc:
         raise enoent(path) from exc
-    record("unlink", path.virtual, "nextcloud", 0, start_ms)
+    record("unlink", path.virtual, "nextcloud", 0, timer)
     await invalidate_after_unlink(path)

--- a/python/mirage/core/nextcloud/write.py
+++ b/python/mirage/core/nextcloud/write.py
@@ -1,11 +1,9 @@
-import time
-
 from opendal.exceptions import NotFound
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -17,10 +15,10 @@ async def write_bytes(accessor: NextcloudAccessor,
     raw = path.mount_path
     key = raw.lstrip("/")
     op = accessor.operator()
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         await op.write(key, data)
     except NotFound as exc:
         raise enoent(path) from exc
-    record("write", path.virtual, "nextcloud", len(data), start_ms)
+    record("write", path.virtual, "nextcloud", len(data), timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/object_store/write.py
+++ b/python/mirage/core/object_store/write.py
@@ -12,12 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.cache.context import invalidate_after_write, invalidate_ancestors
 from mirage.core.object_store.driver import (A, C, MkdirFn, ObjectStoreDriver,
                                              PathFn, TruncateFn, WriteFn)
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils import key_prefix as kp
 from mirage.utils.errors import enoent
@@ -57,10 +55,10 @@ def make_write_bytes(driver: ObjectStoreDriver[A, C]) -> WriteFn[A]:
                           data: bytes) -> None:
         path = path_spec.mount_path
         key = kp.apply(driver.key_prefix_of(accessor), path)
-        start_ms = int(time.monotonic() * 1000)
+        timer = start_op()
         async with driver.connect(accessor) as conn:
             await _put(driver, conn, key, data, path_spec)
-        record("write", path, driver.resource, len(data), start_ms)
+        record("write", path, driver.resource, len(data), timer)
         await invalidate_after_write(path_spec)
         # A put materializes every missing level of the key at once, so
         # the listings above the immediate parent gained entries too.
@@ -79,10 +77,10 @@ def make_create(driver: ObjectStoreDriver[A, C]) -> PathFn[A]:
     async def create(accessor: A, path_spec: PathSpec) -> None:
         path = path_spec.mount_path
         key = kp.apply(driver.key_prefix_of(accessor), path)
-        start_ms = int(time.monotonic() * 1000)
+        timer = start_op()
         async with driver.connect(accessor) as conn:
             await _put(driver, conn, key, b"", path_spec)
-        record("create", path, driver.resource, 0, start_ms)
+        record("create", path, driver.resource, 0, timer)
         await invalidate_after_write(path_spec)
         # An empty put materializes missing parents exactly like write.
         await invalidate_ancestors(path_spec)
@@ -100,14 +98,14 @@ def make_truncate(driver: ObjectStoreDriver[A, C]) -> TruncateFn[A]:
     async def truncate(accessor: A, path_spec: PathSpec, length: int) -> None:
         path = path_spec.mount_path
         key = kp.apply(driver.key_prefix_of(accessor), path)
-        start_ms = int(time.monotonic() * 1000)
+        timer = start_op()
         async with driver.connect(accessor) as conn:
             data = await driver.get(conn, key)
             if data is None:
                 data = b""
             result = data[:length].ljust(length, b"\0")
             await _put(driver, conn, key, result, path_spec)
-        record("truncate", path, driver.resource, 0, start_ms)
+        record("truncate", path, driver.resource, 0, timer)
         await invalidate_after_write(path_spec)
         # Truncating a missing key creates it, parents included.
         await invalidate_ancestors(path_spec)

--- a/python/mirage/core/onedrive/create.py
+++ b/python/mirage/core/onedrive/create.py
@@ -12,19 +12,17 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.onedrive.client import graph_put_bytes, item_url, split_path
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
 async def create(accessor: OneDriveAccessor, path: PathSpec) -> None:
     _, stripped = split_path(path)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     url = item_url(accessor.config, "/" + stripped, action="/content")
     await graph_put_bytes(accessor.config, url, b"", session=accessor.pool)
-    record("create", stripped, "onedrive", 0, start_ms)
+    record("create", stripped, "onedrive", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/onedrive/write.py
+++ b/python/mirage/core/onedrive/write.py
@@ -12,14 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.msgraph.drive_ops import (SIMPLE_UPLOAD_MAX,
                                            upload_session_write)
 from mirage.core.onedrive.client import graph_put_bytes, item_url, split_path
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
@@ -27,7 +25,7 @@ async def write_bytes(accessor: OneDriveAccessor, path: PathSpec,
                       data: bytes) -> None:
     prefix, stripped = split_path(path)
     config = accessor.config
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     if len(data) <= SIMPLE_UPLOAD_MAX:
         url = item_url(config, "/" + stripped, action="/content")
         await graph_put_bytes(config, url, data, session=accessor.pool)
@@ -39,5 +37,5 @@ async def write_bytes(accessor: OneDriveAccessor, path: PathSpec,
                                    session_url,
                                    data,
                                    session=accessor.pool)
-    record("write", stripped, "onedrive", len(data), start_ms)
+    record("write", stripped, "onedrive", len(data), timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/ram/append.py
+++ b/python/mirage/core/ram/append.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.ram.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
@@ -27,7 +25,7 @@ async def append_bytes(accessor: RAMAccessor, path_spec: PathSpec,
                        data: bytes) -> None:
     path = path_spec.mount_path
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = norm(path)
     check_dest_parents(store, path_spec, p)
     if p in store.files:
@@ -35,5 +33,5 @@ async def append_bytes(accessor: RAMAccessor, path_spec: PathSpec,
     else:
         store.files[p] = data
     store.modified[p] = now_iso()
-    record("append", path, "ram", len(data), start_ms)
+    record("append", path, "ram", len(data), timer)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/ram/create.py
+++ b/python/mirage/core/ram/create.py
@@ -12,23 +12,21 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.ram.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
 
 async def create(accessor: RAMAccessor, path: PathSpec) -> None:
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = norm(path.mount_path)
     check_dest_parents(store, path, p)
     store.files[p] = b""
     store.modified[p] = now_iso()
-    record("create", path.mount_path, "ram", 0, start_ms)
+    record("create", path.mount_path, "ram", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/ram/read.py
+++ b/python/mirage/core/ram/read.py
@@ -12,11 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.path import norm
@@ -44,14 +42,14 @@ async def read_bytes(accessor: RAMAccessor,
     virtual = path_spec.virtual
     path = path_spec.mount_path
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     key = norm(path)
     if key not in store.files:
         raise enoent(virtual)
     data = store.files[key]
     if offset or size is not None:
         data = slice_window(data, offset, size)
-    record("read", path, "ram", len(data), start_ms)
+    record("read", path, "ram", len(data), timer)
     return data
 
 

--- a/python/mirage/core/ram/truncate.py
+++ b/python/mirage/core/ram/truncate.py
@@ -12,19 +12,17 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.timeutil import now_iso
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
 
 async def truncate(accessor: RAMAccessor, path: PathSpec, length: int) -> None:
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = norm(path.mount_path)
     if p in store.files:
         data = store.files[p]
@@ -32,5 +30,5 @@ async def truncate(accessor: RAMAccessor, path: PathSpec, length: int) -> None:
         data = b""
     store.files[p] = data[:length].ljust(length, b"\0")
     store.modified[p] = now_iso()
-    record("truncate", path.mount_path, "ram", 0, start_ms)
+    record("truncate", path.mount_path, "ram", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/ram/write.py
+++ b/python/mirage/core/ram/write.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.ram.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
@@ -27,10 +25,10 @@ async def write_bytes(accessor: RAMAccessor, path_spec: PathSpec,
                       data: bytes) -> None:
     path = path_spec.mount_path
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = norm(path)
     check_dest_parents(store, path_spec, p)
     store.files[p] = data
     store.modified[p] = now_iso()
-    record("write", path, "ram", len(data), start_ms)
+    record("write", path, "ram", len(data), timer)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/redis/append.py
+++ b/python/mirage/core/redis/append.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.redis.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
@@ -30,7 +28,7 @@ async def append_bytes(
 ) -> None:
     path = path_spec.mount_path
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = norm(path)
     await check_dest_parents(store, path_spec, p)
     existing = await store.get_file(p)
@@ -39,5 +37,5 @@ async def append_bytes(
     else:
         await store.set_file(p, data)
     await store.set_modified(p, now_iso())
-    record("append", path, "redis", len(data), start_ms)
+    record("append", path, "redis", len(data), timer)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/redis/create.py
+++ b/python/mirage/core/redis/create.py
@@ -12,23 +12,21 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.redis.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
 
 async def create(accessor: RedisAccessor, path: PathSpec) -> None:
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = norm(path.mount_path)
     await check_dest_parents(store, path, p)
     await store.set_file(p, b"")
     await store.set_modified(p, now_iso())
-    record("create", path.mount_path, "redis", 0, start_ms)
+    record("create", path.mount_path, "redis", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/redis/read.py
+++ b/python/mirage/core/redis/read.py
@@ -12,11 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.path import norm
@@ -39,7 +37,7 @@ async def read_bytes(accessor: RedisAccessor,
     virtual = path_spec.virtual
     path = path_spec.mount_path
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     key = norm(path)
     if offset or size is not None:
         data = await store.get_file_range(key, offset, size)
@@ -47,7 +45,7 @@ async def read_bytes(accessor: RedisAccessor,
         data = await store.get_file(key)
     if data is None:
         raise enoent(virtual)
-    record("read", path, "redis", len(data), start_ms)
+    record("read", path, "redis", len(data), timer)
     return data
 
 

--- a/python/mirage/core/redis/truncate.py
+++ b/python/mirage/core/redis/truncate.py
@@ -12,12 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.timeutil import now_iso
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
@@ -25,12 +23,12 @@ from mirage.utils.path import norm
 async def truncate(accessor: RedisAccessor, path: PathSpec,
                    length: int) -> None:
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = norm(path.mount_path)
     data = await store.get_file(p)
     if data is None:
         data = b""
     await store.set_file(p, data[:length].ljust(length, b"\0"))
     await store.set_modified(p, now_iso())
-    record("truncate", path.mount_path, "redis", 0, start_ms)
+    record("truncate", path.mount_path, "redis", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/redis/write.py
+++ b/python/mirage/core/redis/write.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.redis.dest import check_dest_parents
 from mirage.core.timeutil import now_iso
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.path import norm
 
@@ -30,10 +28,10 @@ async def write_bytes(
 ) -> None:
     path = path_spec.mount_path
     store = accessor.store
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     p = norm(path)
     await check_dest_parents(store, path_spec, p)
     await store.set_file(p, data)
     await store.set_modified(p, now_iso())
-    record("write", path, "redis", len(data), start_ms)
+    record("write", path, "redis", len(data), timer)
     await invalidate_after_write(path_spec)

--- a/python/mirage/core/s3/read.py
+++ b/python/mirage/core/s3/read.py
@@ -12,14 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
 from typing import Any
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.s3.client import (_client_kwargs, _key, async_session,
                                    closing_body)
-from mirage.observe.context import record, revision_for
+from mirage.observe.context import record, revision_for, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.ranges import range_header
@@ -75,7 +74,7 @@ async def read_bytes(accessor: S3Accessor,
     # client rather than the request.
     client = await accessor.cached_client(
         lambda: async_session(config).client(**_client_kwargs(config)))
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         resp = await client.get_object(**kwargs)
         async with closing_body(resp["Body"]) as body:
@@ -85,7 +84,7 @@ async def read_bytes(accessor: S3Accessor,
                path,
                "s3",
                len(data),
-               start_ms,
+               timer,
                fingerprint=fingerprint,
                revision=revision)
         return data

--- a/python/mirage/core/sharepoint/create.py
+++ b/python/mirage/core/sharepoint/create.py
@@ -1,10 +1,8 @@
-import time
-
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.sharepoint.client import graph_put_bytes, item_url, split_path
 from mirage.core.sharepoint.resolve import resolve
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -12,7 +10,7 @@ from mirage.utils.errors import enoent
 async def create(accessor: SharePointAccessor, path: PathSpec) -> None:
     virtual = path.virtual if isinstance(path, PathSpec) else path
     _, stripped = split_path(path)
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     resolved = await resolve(accessor, path)
     if resolved.drive_id is None or resolved.item_path is None:
         raise enoent(virtual)
@@ -21,5 +19,5 @@ async def create(accessor: SharePointAccessor, path: PathSpec) -> None:
                    resolved.item_path,
                    action="/content")
     await graph_put_bytes(accessor.config, url, b"", session=accessor.pool)
-    record("create", stripped, "sharepoint", 0, start_ms)
+    record("create", stripped, "sharepoint", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/sharepoint/write.py
+++ b/python/mirage/core/sharepoint/write.py
@@ -1,12 +1,10 @@
-import time
-
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.msgraph.drive_ops import (SIMPLE_UPLOAD_MAX,
                                            upload_session_write)
 from mirage.core.sharepoint.client import graph_put_bytes, item_url, split_path
 from mirage.core.sharepoint.resolve import resolve
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -21,7 +19,7 @@ async def write_bytes(accessor: SharePointAccessor, path: PathSpec,
     config = accessor.config
     drive_id = resolved.drive_id
     item_p = resolved.item_path
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     if len(data) <= SIMPLE_UPLOAD_MAX:
         url = item_url(config, drive_id, item_p, action="/content")
         await graph_put_bytes(config, url, data, session=accessor.pool)
@@ -34,5 +32,5 @@ async def write_bytes(accessor: SharePointAccessor, path: PathSpec,
                                    session_url,
                                    data,
                                    session=accessor.pool)
-    record("write", stripped, "sharepoint", len(data), start_ms)
+    record("write", stripped, "sharepoint", len(data), timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/ssh/create.py
+++ b/python/mirage/core/ssh/create.py
@@ -12,20 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.ssh.client import _abs
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
 async def create(accessor: SSHAccessor, path: PathSpec) -> None:
     config = accessor.config
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     sftp = await accessor.sftp()
     async with sftp.open(_abs(config, path.mount_path), "wb"):
         pass
-    record("create", path.mount_path, "ssh", 0, start_ms)
+    record("create", path.mount_path, "ssh", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/ssh/read.py
+++ b/python/mirage/core/ssh/read.py
@@ -12,14 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 import asyncssh
 
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.ssh.client import _abs
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -33,7 +31,7 @@ async def read_bytes(accessor: SSHAccessor,
     path = path_spec.mount_path
     config = accessor.config
     sftp = await accessor.sftp()
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     try:
         remote_path = _abs(config, path)
         async with sftp.open(remote_path, "rb") as f:
@@ -41,7 +39,7 @@ async def read_bytes(accessor: SSHAccessor,
                 await f.seek(offset)
             raw = await f.read(size if size is not None else -1)
         data = raw if isinstance(raw, bytes) else raw.encode()
-        record("read", path, "ssh", len(data), start_ms)
+        record("read", path, "ssh", len(data), timer)
         return data
     except asyncssh.SFTPNoSuchFile:
         raise enoent(virtual)

--- a/python/mirage/core/ssh/truncate.py
+++ b/python/mirage/core/ssh/truncate.py
@@ -12,12 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.ssh.client import _abs
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
@@ -25,8 +23,8 @@ async def truncate(accessor: SSHAccessor,
                    path: PathSpec,
                    length: int = 0) -> None:
     config = accessor.config
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     sftp = await accessor.sftp()
     await sftp.truncate(_abs(config, path.mount_path), length)
-    record("truncate", path.mount_path, "ssh", 0, start_ms)
+    record("truncate", path.mount_path, "ssh", 0, timer)
     await invalidate_after_write(path)

--- a/python/mirage/core/ssh/write.py
+++ b/python/mirage/core/ssh/write.py
@@ -12,12 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.ssh.client import _abs
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 
 
@@ -26,9 +24,9 @@ async def write_bytes(accessor: SSHAccessor, path_spec: PathSpec,
     path = path_spec.mount_path
     config = accessor.config
     sftp = await accessor.sftp()
-    start_ms = int(time.monotonic() * 1000)
+    timer = start_op()
     remote_path = _abs(config, path)
     async with sftp.open(remote_path, "wb") as f:
         await f.write(data)
-    record("write", path, "ssh", len(data), start_ms)
+    record("write", path, "ssh", len(data), timer)
     await invalidate_after_write(path_spec)

--- a/python/mirage/observe/context.py
+++ b/python/mirage/observe/context.py
@@ -177,11 +177,79 @@ def _virtual(path: str, prefix: str) -> str:
     return prefix + path
 
 
+class OpTimer:
+    """A running stopwatch for one op, owned by the record path.
+
+    Opened where the backend work begins and read once when the op
+    finishes, so an op module hands this around instead of reading a
+    clock of its own. The wall-clock stamp the record carries is taken
+    at finish time, not here.
+    """
+
+    __slots__ = ("_start_ms", )
+
+    def __init__(self) -> None:
+        self._start_ms = int(time.monotonic() * 1000)
+
+    @property
+    def elapsed_ms(self) -> int:
+        """Milliseconds elapsed since the timer was opened."""
+        return int(time.monotonic() * 1000) - self._start_ms
+
+
+def start_op() -> OpTimer:
+    """Open the record path's stopwatch for one op.
+
+    Returns:
+        OpTimer: a running timer, to hand to :func:`record` or
+        :func:`finish_record` when the op completes.
+    """
+    return OpTimer()
+
+
+def finish_record(op: str,
+                  path: str,
+                  source: str,
+                  nbytes: int,
+                  timer: OpTimer,
+                  fingerprint: str | None = None,
+                  revision: str | None = None) -> OpRecord:
+    """Close ``timer`` and build the finished record.
+
+    The one place an op's duration and wall-clock stamp are read, shared
+    by the recorder sink (:func:`record`) and by the ``Ops`` facade's own
+    ledger, so the two cannot disagree about what a duration measures.
+
+    Args:
+        op (str): Operation name ("read", "write").
+        path (str): The path to name the record with, as it should be
+            stored (callers that need mount prefixing apply it first).
+        source (str): Resource name ("s3", "ram", "disk").
+        nbytes (int): Bytes transferred.
+        timer (OpTimer): the timer opened when the op started.
+        fingerprint (str | None): Content-derived identifier returned by
+            the backend (ETag, md5). Used for drift detection at replay.
+        revision (str | None): Stable revision handle returned by the
+            backend (S3 ``VersionId``, Drive ``revisionId``, Git SHA).
+    """
+    elapsed = timer.elapsed_ms
+    return OpRecord(
+        op=op,
+        path=path,
+        source=source,
+        bytes=nbytes,
+        timestamp=int(time.time() * 1000),
+        duration_ms=elapsed,
+        fingerprint=fingerprint,
+        revision=revision,
+    )
+
+
 def record(op: str,
            path: str,
            source: str,
            nbytes: int,
-           start_ms: int,
+           timer: OpTimer,
            fingerprint: str | None = None,
            revision: str | None = None) -> None:
     """Record a byte transfer event. No-op if no recording context is active.
@@ -191,7 +259,8 @@ def record(op: str,
         path (str): Resource-relative path.
         source (str): Resource name ("s3", "ram", "disk").
         nbytes (int): Bytes transferred.
-        start_ms (int): Monotonic start time in milliseconds.
+        timer (OpTimer): the timer opened by :func:`start_op` when the
+            op started.
         fingerprint (str | None): Content-derived identifier returned by
             the backend (ETag, md5). Used for drift detection at replay.
         revision (str | None): Stable revision handle returned by the
@@ -201,19 +270,15 @@ def record(op: str,
     rec = _recorder.get()
     if rec is None:
         return
-    elapsed = int(time.monotonic() * 1000) - start_ms
     prefix = rec.mount_prefix
     rec.sink.append(
-        OpRecord(
-            op=op,
-            path=_virtual(path, prefix),
-            source=source,
-            bytes=nbytes,
-            timestamp=int(time.time() * 1000),
-            duration_ms=elapsed,
-            fingerprint=fingerprint,
-            revision=revision,
-        ))
+        finish_record(op,
+                      _virtual(path, prefix),
+                      source,
+                      nbytes,
+                      timer,
+                      fingerprint=fingerprint,
+                      revision=revision))
 
 
 def record_stream(op: str,

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -14,11 +14,11 @@
 
 import asyncio
 import errno
-import time
 from typing import Any
 
 from mirage.io import OpReport
 from mirage.observe import OpRecord
+from mirage.observe.context import OpTimer, finish_record, start_op
 from mirage.ops.config import NO_FOLLOW_OPS, NamespaceLinks, OpsMount
 from mirage.runtime.types import DispatchFn
 from mirage.types import FileStat, FileType, MountMode, PathSpec
@@ -128,15 +128,13 @@ class Ops:
         self._mounts = [m for m in self._mounts if m.prefix != norm]
 
     def _record(self, op: str, path: str, source: str, nbytes: int,
-                start_ms: int) -> None:
-        elapsed = int(time.monotonic() * 1000) - start_ms
-        rec = OpRecord(
-            op=op,
-            path=path,
-            source=source.value if hasattr(source, 'value') else str(source),
-            bytes=nbytes,
-            timestamp=int(time.time() * 1000),
-            duration_ms=elapsed,
+                timer: OpTimer) -> None:
+        rec = finish_record(
+            op,
+            path,
+            source.value if hasattr(source, 'value') else str(source),
+            nbytes,
+            timer,
         )
         self.records.append(rec)
         if self._observer is not None:
@@ -190,7 +188,7 @@ class Ops:
             path (str): the virtual path.
             **kwargs: op arguments, by the op function's names.
         """
-        start = int(time.monotonic() * 1000)
+        timer = start_op()
         if (self._links is not None and op not in NO_FOLLOW_OPS
                 and not kwargs.get("nofollow")):
             path = self._links.follow(path)
@@ -210,16 +208,16 @@ class Ops:
             # never defined leaves the transfer on the books.
             if report.completed and owner is not None:
                 self._record_op(op, path, owner, report.source, report.bytes,
-                                None, kwargs, start)
+                                None, kwargs, timer)
             raise
         if owner is not None:
             self._record_op(op, path, owner, report.source, report.bytes,
-                            result, kwargs, start)
+                            result, kwargs, timer)
         return result
 
     def _record_op(self, op: str, path: str, owner: OpsMount,
                    source: str | None, moved: int | None, result: Any,
-                   kwargs: dict[str, Any], start: int) -> None:
+                   kwargs: dict[str, Any], timer: OpTimer) -> None:
         """Record one op from the door's report of who served it.
 
         The door names the server when it was not the owning mount (a
@@ -238,11 +236,11 @@ class Ops:
                 measure the result.
             result (Any): what the op returned, None when withheld.
             kwargs (dict[str, Any]): the op's arguments.
-            start (int): monotonic start stamp, in milliseconds.
+            timer (OpTimer): the stopwatch opened when the op started.
         """
         nbytes = (moved if moved is not None else self._payload_bytes(
             result, kwargs))
-        self._record(op, path, source or owner.resource_type, nbytes, start)
+        self._record(op, path, source or owner.resource_type, nbytes, timer)
 
     async def read(self,
                    path: str,

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -27,7 +27,7 @@ from mirage.commands.builtin.utils.limit import apply_op_limit
 from mirage.context import (get_current_session, hidden_paths_intersect,
                             path_allowed)
 from mirage.io import IOResult, OpReport
-from mirage.observe.context import record
+from mirage.observe.context import record, start_op
 from mirage.observe.record import OpRecord
 from mirage.ops.config import NO_FOLLOW_OPS, STAMP_WRITE_OPS
 from mirage.ops.namespace_view import (merge_readdir, namespace_listing,
@@ -615,7 +615,7 @@ class Dispatcher:
             report (OpReport | None): the caller's report, stamped when
                 the answer is in hand.
         """
-        start = int(time.monotonic() * 1000)
+        timer = start_op()
         mount = self._namespace.try_mount_for(path.virtual)
         owner = mount.prefix if mount is not None else None
         policies = self._namespace.registry.policies
@@ -670,7 +670,7 @@ class Dispatcher:
             target = found
             result = found
         record(op, path.virtual, ResourceName.RAM.value,
-               len(target.encode("utf-8")), start)
+               len(target.encode("utf-8")), timer)
         _memory_answered(report)
         bound = await post_ops_gate(policies, op, path, write, owner or "",
                                     result)
@@ -830,13 +830,13 @@ class Dispatcher:
             path (PathSpec): target path.
             kwargs (dict[str, Any]): the requested attribute fields.
         """
-        start = int(time.monotonic() * 1000)
+        timer = start_op()
         overlay = {
             key: value
             for key in SETATTR_KEYS if (value := kwargs.get(key)) is not None
         }
         await self._write_overlay(path.virtual, overlay)
-        record("setattr", path.virtual, ResourceName.RAM.value, 0, start)
+        record("setattr", path.virtual, ResourceName.RAM.value, 0, timer)
         return overlay
 
     async def _write_overlay(self, virtual: str, fields: dict[str,

--- a/python/tests/observe/test_context.py
+++ b/python/tests/observe/test_context.py
@@ -16,7 +16,7 @@ import pytest
 
 from mirage.observe.context import (RecordingScope, push_mount_prefix,
                                     push_revisions, record, record_stream,
-                                    reset_revisions, revision_for,
+                                    reset_revisions, revision_for, start_op,
                                     with_mount_prefix, with_revisions)
 
 
@@ -40,13 +40,13 @@ class ClosingIterator:
 
 
 def test_record_no_context():
-    record("read", "/a.txt", "s3", 100, 0)
+    record("read", "/a.txt", "s3", 100, start_op())
 
 
 def test_recording_scope_collects_records():
     scope = RecordingScope()
     records = scope.records
-    record("read", "/a.txt", "s3", 100, 0)
+    record("read", "/a.txt", "s3", 100, start_op())
     scope.close()
     assert len(records) == 1
     assert records[0].op == "read"
@@ -56,17 +56,17 @@ def test_recording_scope_collects_records():
 def test_record_after_stop_is_noop():
     scope = RecordingScope()
     records = scope.records
-    record("read", "/a.txt", "s3", 100, 0)
+    record("read", "/a.txt", "s3", 100, start_op())
     scope.close()
-    record("read", "/b.txt", "s3", 200, 0)
+    record("read", "/b.txt", "s3", 200, start_op())
     assert len(records) == 1
 
 
 def test_multiple_records():
     scope = RecordingScope()
     records = scope.records
-    record("read", "/a.txt", "s3", 100, 0)
-    record("write", "/b.txt", "ram", 50, 0)
+    record("read", "/a.txt", "s3", 100, start_op())
+    record("write", "/b.txt", "ram", 50, start_op())
     scope.close()
     assert len(records) == 2
     assert records[0].source == "s3"
@@ -77,7 +77,7 @@ def test_record_with_virtual_prefix():
     scope = RecordingScope()
     records = scope.records
     push_mount_prefix("/s3")
-    record("read", "/data/file.json", "s3", 100, 0)
+    record("read", "/data/file.json", "s3", 100, start_op())
     push_mount_prefix("")
     scope.close()
     assert records[0].path == "/s3/data/file.json"
@@ -86,7 +86,7 @@ def test_record_with_virtual_prefix():
 def test_record_without_prefix():
     scope = RecordingScope()
     records = scope.records
-    record("read", "/data/file.json", "s3", 100, 0)
+    record("read", "/data/file.json", "s3", 100, start_op())
     scope.close()
     assert records[0].path == "/data/file.json"
 
@@ -95,7 +95,7 @@ def test_record_prefix_already_applied():
     scope = RecordingScope()
     records = scope.records
     push_mount_prefix("/s3")
-    record("read", "/s3/data/file.json", "s3", 100, 0)
+    record("read", "/s3/data/file.json", "s3", 100, start_op())
     push_mount_prefix("")
     scope.close()
     assert records[0].path == "/s3/data/file.json"
@@ -107,7 +107,7 @@ def test_record_prefixes_name_sharing_prefix_leading_text():
     scope = RecordingScope()
     records = scope.records
     push_mount_prefix("/s3")
-    record("read", "/s3-report.txt", "s3", 1, 0)
+    record("read", "/s3-report.txt", "s3", 1, start_op())
     push_mount_prefix("")
     scope.close()
     assert records[0].path == "/s3/s3-report.txt"
@@ -146,7 +146,7 @@ async def test_with_revisions_close_propagates_to_source():
 def test_record_carries_fingerprint_when_passed():
     scope = RecordingScope()
     records = scope.records
-    record("read", "/s3/x", "s3", 10, 0, fingerprint="abc")
+    record("read", "/s3/x", "s3", 10, start_op(), fingerprint="abc")
     scope.close()
     assert records[0].fingerprint == "abc"
     assert records[0].revision is None
@@ -155,7 +155,7 @@ def test_record_carries_fingerprint_when_passed():
 def test_record_carries_revision_when_passed():
     scope = RecordingScope()
     records = scope.records
-    record("read", "/s3/x", "s3", 10, 0, revision="v1")
+    record("read", "/s3/x", "s3", 10, start_op(), revision="v1")
     scope.close()
     assert records[0].revision == "v1"
     assert records[0].fingerprint is None
@@ -164,7 +164,13 @@ def test_record_carries_revision_when_passed():
 def test_record_carries_both_when_passed():
     scope = RecordingScope()
     records = scope.records
-    record("read", "/s3/x", "s3", 10, 0, fingerprint="abc", revision="v1")
+    record("read",
+           "/s3/x",
+           "s3",
+           10,
+           start_op(),
+           fingerprint="abc",
+           revision="v1")
     scope.close()
     assert records[0].fingerprint == "abc"
     assert records[0].revision == "v1"
@@ -173,7 +179,7 @@ def test_record_carries_both_when_passed():
 def test_record_fingerprint_default_is_none():
     scope = RecordingScope()
     records = scope.records
-    record("read", "/s3/x", "s3", 10, 0)
+    record("read", "/s3/x", "s3", 10, start_op())
     scope.close()
     assert records[0].fingerprint is None
     assert records[0].revision is None
@@ -235,11 +241,11 @@ def test_revision_for_with_none_context():
 
 def test_nested_scope_close_restores_outer():
     outer = RecordingScope()
-    record("read", "/a", "s3", 1, 0)
+    record("read", "/a", "s3", 1, start_op())
     inner = RecordingScope()
-    record("read", "/b", "s3", 1, 0)
+    record("read", "/b", "s3", 1, start_op())
     inner.close()
-    record("read", "/c", "s3", 1, 0)
+    record("read", "/c", "s3", 1, start_op())
     outer.close()
     assert [r.path for r in outer.records] == ["/a", "/c"]
     assert [r.path for r in inner.records] == ["/b"]
@@ -248,7 +254,7 @@ def test_nested_scope_close_restores_outer():
 def test_inactive_scope_joins_enclosing():
     outer = RecordingScope()
     joined = RecordingScope(active=False)
-    record("read", "/a", "s3", 1, 0)
+    record("read", "/a", "s3", 1, start_op())
     joined.close()
     outer.close()
     assert [r.path for r in outer.records] == ["/a"]

--- a/python/tests/runtime/test_vfs.py
+++ b/python/tests/runtime/test_vfs.py
@@ -14,13 +14,12 @@
 
 import asyncio
 import threading
-import time
 
 import pytest
 
 from mirage.context import (get_current_session, reset_current_session,
                             set_current_session)
-from mirage.observe.context import RecordingScope, record
+from mirage.observe.context import RecordingScope, record, start_op
 from mirage.runtime.errors import CrossMountError
 from mirage.runtime.resolver import PrefixResolver
 from mirage.runtime.types import VFSEntry, VFSStat
@@ -425,7 +424,7 @@ class LedgerDispatch(RecordingDispatch):
     """Emits an op event inside the dispatched op, like a backend core."""
 
     async def __call__(self, op, path, **kwargs):
-        record(op, path.virtual, "ram", 7, int(time.monotonic() * 1000))
+        record(op, path.virtual, "ram", 7, start_op())
         return await super().__call__(op, path, **kwargs)
 
 

--- a/typescript/packages/browser/src/core/opfs/append.ts
+++ b/typescript/packages/browser/src/core/opfs/append.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import type { OPFSAccessor } from '../../accessor/opfs.ts'
@@ -24,7 +24,7 @@ export async function appendBytes(
   data: Uint8Array,
 ): Promise<void> {
   const root = accessor.rootHandle
-  const start = performance.now()
+  const timer = startOp()
   const virtual = p.mountPath
   let handle: FileSystemFileHandle
   try {
@@ -40,5 +40,5 @@ export async function appendBytes(
   const writable = await handle.createWritable()
   await writable.write(toWritableChunk(merged))
   await writable.close()
-  record('append', virtual, ResourceName.OPFS, data.byteLength, start)
+  record('append', virtual, ResourceName.OPFS, data.byteLength, timer)
 }

--- a/typescript/packages/browser/src/core/opfs/read.ts
+++ b/typescript/packages/browser/src/core/opfs/read.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { eisdir, enoent } from '@struktoai/mirage-core/utils/errors'
@@ -43,7 +43,7 @@ export async function read(
   const offset = options?.offset ?? 0
   const size = options?.size ?? null
   const root = accessor.rootHandle
-  const start = performance.now()
+  const timer = startOp()
   const virtual = path.mountPath
   let handle: FileSystemFileHandle
   try {
@@ -59,6 +59,6 @@ export async function read(
       ? file
       : file.slice(offset, size === null ? undefined : offset + size)
   const bytes = new Uint8Array(await window.arrayBuffer())
-  record('read', virtual, ResourceName.OPFS, bytes.byteLength, start)
+  record('read', virtual, ResourceName.OPFS, bytes.byteLength, timer)
   return bytes
 }

--- a/typescript/packages/browser/src/core/opfs/truncate.ts
+++ b/typescript/packages/browser/src/core/opfs/truncate.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import type { OPFSAccessor } from '../../accessor/opfs.ts'
@@ -23,7 +23,7 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const root = accessor.rootHandle
   const virtual = path.mountPath
   let handle: FileSystemFileHandle
@@ -49,5 +49,5 @@ export async function truncate(
   const writable = await handle.createWritable()
   await writable.write(toWritableChunk(out))
   await writable.close()
-  record('truncate', virtual, ResourceName.OPFS, 0, start)
+  record('truncate', virtual, ResourceName.OPFS, 0, timer)
 }

--- a/typescript/packages/browser/src/core/opfs/write.ts
+++ b/typescript/packages/browser/src/core/opfs/write.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import type { OPFSAccessor } from '../../accessor/opfs.ts'
@@ -24,7 +24,7 @@ export async function writeBytes(
   data: Uint8Array,
 ): Promise<void> {
   const root = accessor.rootHandle
-  const start = performance.now()
+  const timer = startOp()
   const virtual = p.mountPath
   let handle: FileSystemFileHandle
   try {
@@ -35,5 +35,5 @@ export async function writeBytes(
   const writable = await handle.createWritable()
   await writable.write(toWritableChunk(data))
   await writable.close()
-  record('write', virtual, ResourceName.OPFS, data.byteLength, start)
+  record('write', virtual, ResourceName.OPFS, data.byteLength, timer)
 }

--- a/typescript/packages/core/src/core/databricks_volume/read.ts
+++ b/typescript/packages/core/src/core/databricks_volume/read.ts
@@ -14,7 +14,7 @@
 
 import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import { dbxFetch } from './client.ts'
 import { isNotFound, notFoundError } from './errors.ts'
@@ -34,11 +34,11 @@ export async function readBytes(
 ): Promise<Uint8Array> {
   const virtual = path.virtual
   const remotePath = backendPath(accessor.config, path)
-  const startMs = performance.now()
+  const timer = startOp()
   const offset = options.offset ?? 0
   const size = options.size ?? null
   if (size === 0) {
-    record('read', virtual, ResourceName.DATABRICKS_VOLUME, 0, startMs)
+    record('read', virtual, ResourceName.DATABRICKS_VOLUME, 0, timer)
     return new Uint8Array(0)
   }
   const range = rangeHeader(offset, size)
@@ -52,6 +52,6 @@ export async function readBytes(
     throw exc
   }
   const data = windowIfUnranged(new Uint8Array(await r.arrayBuffer()), r.status, offset, size)
-  record('read', virtual, ResourceName.DATABRICKS_VOLUME, data.byteLength, startMs)
+  record('read', virtual, ResourceName.DATABRICKS_VOLUME, data.byteLength, timer)
   return data
 }

--- a/typescript/packages/core/src/core/databricks_volume/unlink.ts
+++ b/typescript/packages/core/src/core/databricks_volume/unlink.ts
@@ -15,7 +15,7 @@
 import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import { FileType, ResourceName, type PathSpec } from '../../types.ts'
 import { dbxFetch } from './client.ts'
 import { ensurePathSpec } from './_helpers.ts'
@@ -34,13 +34,13 @@ export async function unlink(
     throw isADirectoryError(p.virtual)
   }
   const remotePath = backendPath(accessor.config, p)
-  const startMs = performance.now()
+  const timer = startOp()
   try {
     await dbxFetch(accessor, 'DELETE', 'files', remotePath)
   } catch (exc) {
     if (isNotFound(exc)) throw notFoundError(p.virtual)
     throw exc
   }
-  record('unlink', p.virtual, ResourceName.DATABRICKS_VOLUME, 0, startMs)
+  record('unlink', p.virtual, ResourceName.DATABRICKS_VOLUME, 0, timer)
   await invalidateAfterUnlink(p)
 }

--- a/typescript/packages/core/src/core/databricks_volume/write.ts
+++ b/typescript/packages/core/src/core/databricks_volume/write.ts
@@ -15,7 +15,7 @@
 import { invalidateAfterWrite } from '../../cache/context.ts'
 import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import { dbxFetch } from './client.ts'
 import { ensurePathSpec, parentPath } from './_helpers.ts'
@@ -51,7 +51,7 @@ export async function writeBytes(
   const p = ensurePathSpec(path)
   const remoteParent = backendPath(accessor.config, parentPath(p))
   const remotePath = backendPath(accessor.config, p)
-  const startMs = performance.now()
+  const timer = startOp()
   await ensureParentDirectory(accessor, remoteParent, p.virtual)
   try {
     await dbxFetch(accessor, 'PUT', 'files', remotePath, {
@@ -63,6 +63,6 @@ export async function writeBytes(
     if (isNotFound(exc)) throw notFoundError(p.virtual)
     throw exc
   }
-  record('write', p.virtual, ResourceName.DATABRICKS_VOLUME, data.byteLength, startMs)
+  record('write', p.virtual, ResourceName.DATABRICKS_VOLUME, data.byteLength, timer)
   await invalidateAfterWrite(p)
 }

--- a/typescript/packages/core/src/core/dropbox/copy.ts
+++ b/typescript/packages/core/src/core/dropbox/copy.ts
@@ -14,7 +14,7 @@
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
 import { DropboxApiError } from './client.ts'
@@ -27,7 +27,7 @@ import { dropboxPathOf } from './paths.ts'
 export async function copy(accessor: DropboxAccessor, src: PathSpec, dst: PathSpec): Promise<void> {
   const from = dropboxPathOf(accessor, src)
   const to = dropboxPathOf(accessor, dst)
-  const startMs = performance.now()
+  const timer = startOp()
   try {
     await copyPath(accessor.tokenManager, from, to)
   } catch (err) {
@@ -39,7 +39,7 @@ export async function copy(accessor: DropboxAccessor, src: PathSpec, dst: PathSp
     await deletePath(accessor.tokenManager, to)
     await copyPath(accessor.tokenManager, from, to)
   }
-  record('copy', src.virtual, 'dropbox', 0, startMs)
+  record('copy', src.virtual, 'dropbox', 0, timer)
   await invalidateAfterWrite(dst)
   await invalidateAncestors(dst)
 }

--- a/typescript/packages/core/src/core/dropbox/mkdir.ts
+++ b/typescript/packages/core/src/core/dropbox/mkdir.ts
@@ -14,7 +14,7 @@
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { eexist, enoent } from '../../utils/errors.ts'
 import { DropboxApiError } from './client.ts'
@@ -60,7 +60,7 @@ export async function mkdir(
       throw enoent(path.virtual)
     }
   }
-  const startMs = performance.now()
+  const timer = startOp()
   try {
     await createFolder(accessor.tokenManager, apiPath)
   } catch (err) {
@@ -69,7 +69,7 @@ export async function mkdir(
     }
     throw err
   }
-  record('mkdir', path.virtual, 'dropbox', 0, startMs)
+  record('mkdir', path.virtual, 'dropbox', 0, timer)
   await invalidateAfterWrite(path)
   await invalidateAncestors(path)
 }

--- a/typescript/packages/core/src/core/dropbox/rename.ts
+++ b/typescript/packages/core/src/core/dropbox/rename.ts
@@ -14,7 +14,7 @@
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
 import { invalidateSubtree } from '../../cache/context.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
 import { DropboxApiError } from './client.ts'
@@ -34,7 +34,7 @@ export async function rename(
 ): Promise<void> {
   const from = dropboxPathOf(accessor, src)
   const to = dropboxPathOf(accessor, dst)
-  const startMs = performance.now()
+  const timer = startOp()
   try {
     await movePath(accessor.tokenManager, from, to)
   } catch (err) {
@@ -49,7 +49,7 @@ export async function rename(
     await deletePath(accessor.tokenManager, to)
     await movePath(accessor.tokenManager, from, to)
   }
-  record('rename', src.virtual, 'dropbox', 0, startMs)
+  record('rename', src.virtual, 'dropbox', 0, timer)
   await invalidateSubtree(src)
   await invalidateAncestors(src)
   await invalidateSubtree(dst)

--- a/typescript/packages/core/src/core/dropbox/rm.ts
+++ b/typescript/packages/core/src/core/dropbox/rm.ts
@@ -14,7 +14,7 @@
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
 import { invalidateSubtree } from '../../cache/context.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
 import { DropboxApiError } from './client.ts'
@@ -25,14 +25,14 @@ import { dropboxPathOf } from './paths.ts'
 // delete_v2 removes folders recursively, so rm -r maps to one call.
 export async function rmR(accessor: DropboxAccessor, path: PathSpec): Promise<void> {
   const apiPath = dropboxPathOf(accessor, path)
-  const startMs = performance.now()
+  const timer = startOp()
   try {
     await deletePath(accessor.tokenManager, apiPath)
   } catch (err) {
     if (err instanceof DropboxApiError && err.status === 409) throw enoent(path.virtual)
     throw err
   }
-  record('rm_r', path.virtual, 'dropbox', 0, startMs)
+  record('rm_r', path.virtual, 'dropbox', 0, timer)
   await invalidateSubtree(path)
   await invalidateAncestors(path)
 }

--- a/typescript/packages/core/src/core/dropbox/rmdir.ts
+++ b/typescript/packages/core/src/core/dropbox/rmdir.ts
@@ -14,7 +14,7 @@
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
 import { invalidateAfterUnlink } from '../../cache/context.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent, enotdir, enotempty } from '../../utils/errors.ts'
 import { DropboxApiError } from './client.ts'
@@ -37,9 +37,9 @@ export async function rmdir(accessor: DropboxAccessor, path: PathSpec): Promise<
   if (tag !== 'folder') throw enotdir(path.virtual)
   const children = await listFolder(accessor.tokenManager, apiPath, { limit: 1 })
   if (children.length > 0) throw enotempty(path.virtual)
-  const startMs = performance.now()
+  const timer = startOp()
   await deletePath(accessor.tokenManager, apiPath)
-  record('rmdir', path.virtual, 'dropbox', 0, startMs)
+  record('rmdir', path.virtual, 'dropbox', 0, timer)
   await invalidateAfterUnlink(path)
   await invalidateAncestors(path)
 }

--- a/typescript/packages/core/src/core/dropbox/unlink.ts
+++ b/typescript/packages/core/src/core/dropbox/unlink.ts
@@ -14,7 +14,7 @@
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
 import { invalidateAfterUnlink } from '../../cache/context.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { eisdir, enoent } from '../../utils/errors.ts'
 import { DropboxApiError } from './client.ts'
@@ -32,9 +32,9 @@ export async function unlink(accessor: DropboxAccessor, path: PathSpec): Promise
     throw err
   }
   if (tag === 'folder') throw eisdir(path.virtual)
-  const startMs = performance.now()
+  const timer = startOp()
   await deletePath(accessor.tokenManager, apiPath)
-  record('unlink', path.virtual, 'dropbox', 0, startMs)
+  record('unlink', path.virtual, 'dropbox', 0, timer)
   await invalidateAfterUnlink(path)
   await invalidateAncestors(path)
 }

--- a/typescript/packages/core/src/core/dropbox/write.ts
+++ b/typescript/packages/core/src/core/dropbox/write.ts
@@ -14,7 +14,7 @@
 
 import type { DropboxAccessor } from '../../accessor/dropbox.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { dropboxUpload } from './client.ts'
 import { invalidateAncestors } from '../../cache/context.ts'
@@ -27,9 +27,9 @@ export async function write(
   path: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
-  const startMs = performance.now()
+  const timer = startOp()
   await dropboxUpload(accessor.tokenManager, dropboxPathOf(accessor, path), data)
-  record('write', path.virtual, 'dropbox', data.byteLength, startMs)
+  record('write', path.virtual, 'dropbox', data.byteLength, timer)
   await invalidateAfterWrite(path)
   await invalidateAncestors(path)
 }

--- a/typescript/packages/core/src/core/gdrive/read.ts
+++ b/typescript/packages/core/src/core/gdrive/read.ts
@@ -17,7 +17,7 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { entryOrWarm } from '../../cache/index/warm.ts'
 import { PathSpec } from '../../types.ts'
-import { record, recordingActive, revisionFor } from '../../observe/context.ts'
+import { record, recordingActive, revisionFor, startOp } from '../../observe/context.ts'
 import { readDoc } from '../gdocs/read.ts'
 import { downloadFile } from '../google/drive.ts'
 import { captureFileMetadata, downloadRevision } from './versions.ts'
@@ -43,7 +43,7 @@ export async function readFileVersioned(
 ): Promise<Uint8Array> {
   const pinned = revisionFor(virtual)
   const window = windowFor(offset, size)
-  const startMs = performance.now()
+  const timer = startOp()
   let fingerprint: string | null = null
   let revision: string | null = pinned
   let data: Uint8Array
@@ -55,7 +55,7 @@ export async function readFileVersioned(
   } else {
     data = await downloadFile(tm, fileId, window)
   }
-  record('read', label, 'gdrive', data.length, startMs, { fingerprint, revision })
+  record('read', label, 'gdrive', data.length, timer, { fingerprint, revision })
   return data
 }
 

--- a/typescript/packages/core/src/core/msgraph/drive.ts
+++ b/typescript/packages/core/src/core/msgraph/drive.ts
@@ -16,7 +16,13 @@ import { invalidateAfterWrite } from '../../cache/context.ts'
 import { IndexEntry, ResourceType } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { buildTree, emitStartPath, keep, type PredNode } from '../../commands/builtin/find_eval.ts'
-import { record, recordingActive, recordStream, revisionFor } from '../../observe/context.ts'
+import {
+  record,
+  recordStream,
+  recordingActive,
+  revisionFor,
+  startOp,
+} from '../../observe/context.ts'
 import type { FindOptions } from '../../resource/base.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { enoent, listingError } from '../../utils/errors.ts'
@@ -347,7 +353,7 @@ export async function readItem(
 ): Promise<Uint8Array> {
   const pinned = revisionFor(virtual)
   const window = windowFor(offset, size)
-  const startMs = performance.now()
+  const timer = startOp()
   let fingerprint: string | null = null
   let revision: string | null = pinned
   try {
@@ -368,7 +374,7 @@ export async function readItem(
     } else {
       data = await graphGetBytes(config, loc.item('/content'), window)
     }
-    record('read', label, backend, data.length, startMs, { fingerprint, revision })
+    record('read', label, backend, data.length, timer, { fingerprint, revision })
     return data
   } catch (error) {
     if (error instanceof GraphError && error.status === 404) throw enoent(virtual)

--- a/typescript/packages/core/src/core/object_store/write.ts
+++ b/typescript/packages/core/src/core/object_store/write.ts
@@ -14,7 +14,7 @@
 
 import type { Accessor } from '../../accessor/base.ts'
 import { invalidateAfterWrite, invalidateAncestors } from '../../cache/context.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
 import * as kp from '../../utils/key_prefix.ts'
@@ -43,14 +43,14 @@ async function put<A extends Accessor, C>(
 export function makeWriteBytes<A extends Accessor, C>(driver: ObjectStoreDriver<A, C>): WriteFn<A> {
   return async function writeBytes(accessor, path, data) {
     const key = kp.apply(driver.keyPrefixOf(accessor), path.mountPath)
-    const start = performance.now()
+    const timer = startOp()
     const { conn, close } = await driver.connect(accessor)
     try {
       await put(driver, conn, key, data, path)
     } finally {
       await close()
     }
-    record('write', path.virtual, driver.resource, data.byteLength, start)
+    record('write', path.virtual, driver.resource, data.byteLength, timer)
     await invalidateAfterWrite(path)
     // A put materializes every missing level of the key at once, so the
     // listings above the immediate parent gained entries too.
@@ -62,14 +62,14 @@ export function makeWriteBytes<A extends Accessor, C>(driver: ObjectStoreDriver<
 export function makeCreate<A extends Accessor, C>(driver: ObjectStoreDriver<A, C>): PathFn<A> {
   return async function create(accessor, path) {
     const key = kp.apply(driver.keyPrefixOf(accessor), path.mountPath)
-    const start = performance.now()
+    const timer = startOp()
     const { conn, close } = await driver.connect(accessor)
     try {
       await put(driver, conn, key, new Uint8Array(0), path)
     } finally {
       await close()
     }
-    record('create', path.virtual, driver.resource, 0, start)
+    record('create', path.virtual, driver.resource, 0, timer)
     await invalidateAfterWrite(path)
     // An empty put materializes missing parents exactly like write.
     await invalidateAncestors(path)
@@ -82,7 +82,7 @@ export function makeTruncate<A extends Accessor, C>(
 ): TruncateFn<A> {
   return async function truncate(accessor, path, length) {
     const key = kp.apply(driver.keyPrefixOf(accessor), path.mountPath)
-    const start = performance.now()
+    const timer = startOp()
     const { conn, close } = await driver.connect(accessor)
     try {
       const data = (await driver.get(conn, key)) ?? new Uint8Array(0)
@@ -93,7 +93,7 @@ export function makeTruncate<A extends Accessor, C>(
     } finally {
       await close()
     }
-    record('truncate', path.virtual, driver.resource, 0, start)
+    record('truncate', path.virtual, driver.resource, 0, timer)
     await invalidateAfterWrite(path)
     // Truncating a missing key creates it, parents included.
     await invalidateAncestors(path)

--- a/typescript/packages/core/src/core/onedrive/index.ts
+++ b/typescript/packages/core/src/core/onedrive/index.ts
@@ -21,7 +21,7 @@ import {
 } from '../../cache/context.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { startBasename } from '../../commands/builtin/find_eval.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { FindOptions } from '../../resource/base.ts'
 import { FileStat, FileType, type PathSpec } from '../../types.ts'
 import { enoent, enotempty } from '../../utils/errors.ts'
@@ -163,9 +163,9 @@ export async function write(
   path: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
-  const startMs = performance.now()
+  const timer = startOp()
   await writeItem(accessor.config, accessor.loc(path.resourcePath), data)
-  record('write', path.resourcePath, 'onedrive', data.length, startMs)
+  record('write', path.resourcePath, 'onedrive', data.length, timer)
   await invalidateAfterWrite(path)
 }
 

--- a/typescript/packages/core/src/core/ram/append.ts
+++ b/typescript/packages/core/src/core/ram/append.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { RAMAccessor } from '../../accessor/ram.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import { norm, nowIso } from './utils.ts'
@@ -24,7 +24,7 @@ export async function appendBytes(
   path: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   checkDestParents(accessor, path, p)
   const existing = accessor.store.files.get(p)
@@ -37,7 +37,7 @@ export async function appendBytes(
     accessor.store.files.set(p, data)
   }
   accessor.store.modified.set(p, nowIso())
-  record('append', p, ResourceName.RAM, data.byteLength, start)
+  record('append', p, ResourceName.RAM, data.byteLength, timer)
   await invalidateAfterWrite(path)
   return Promise.resolve()
 }

--- a/typescript/packages/core/src/core/ram/create.ts
+++ b/typescript/packages/core/src/core/ram/create.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { RAMAccessor } from '../../accessor/ram.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import { norm, nowIso } from './utils.ts'
@@ -23,12 +23,12 @@ export async function create(accessor: RAMAccessor, path: PathSpec): Promise<voi
   // Not a delegation to writeBytes: that recorded the op as 'write',
   // so a guest creating a file and one writing one were the same row
   // in the ledger.
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   checkDestParents(accessor, path, p)
   accessor.store.files.set(p, new Uint8Array())
   accessor.store.modified.set(p, nowIso())
-  record('create', p, ResourceName.RAM, 0, start)
+  record('create', p, ResourceName.RAM, 0, timer)
   await invalidateAfterWrite(path)
   return Promise.resolve()
 }

--- a/typescript/packages/core/src/core/ram/read.ts
+++ b/typescript/packages/core/src/core/ram/read.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { RAMAccessor } from '../../accessor/ram.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import { norm } from './utils.ts'
@@ -41,13 +41,13 @@ export function read(
 ): Promise<Uint8Array> {
   const offset = options?.offset ?? 0
   const size = options?.size ?? null
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   const whole = accessor.store.files.get(p)
   if (whole === undefined) {
     throw enoent(path)
   }
   const data = offset === 0 && size === null ? whole : sliceWindow(whole, offset, size)
-  record('read', p, ResourceName.RAM, data.byteLength, start)
+  record('read', p, ResourceName.RAM, data.byteLength, timer)
   return Promise.resolve(data)
 }

--- a/typescript/packages/core/src/core/ram/truncate.ts
+++ b/typescript/packages/core/src/core/ram/truncate.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { RAMAccessor } from '../../accessor/ram.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import { norm, nowIso } from './utils.ts'
@@ -23,14 +23,14 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   const existing = accessor.store.files.get(p) ?? new Uint8Array()
   const out = new Uint8Array(length)
   out.set(existing.subarray(0, Math.min(existing.byteLength, length)))
   accessor.store.files.set(p, out)
   accessor.store.modified.set(p, nowIso())
-  record('truncate', p, ResourceName.RAM, 0, start)
+  record('truncate', p, ResourceName.RAM, 0, timer)
   await invalidateAfterWrite(path)
   return Promise.resolve()
 }

--- a/typescript/packages/core/src/core/ram/write.ts
+++ b/typescript/packages/core/src/core/ram/write.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { RAMAccessor } from '../../accessor/ram.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import { norm, nowIso } from './utils.ts'
@@ -24,12 +24,12 @@ export async function writeBytes(
   path: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   checkDestParents(accessor, path, p)
   accessor.store.files.set(p, data)
   accessor.store.modified.set(p, nowIso())
-  record('write', p, ResourceName.RAM, data.byteLength, start)
+  record('write', p, ResourceName.RAM, data.byteLength, timer)
   await invalidateAfterWrite(path)
   return Promise.resolve()
 }

--- a/typescript/packages/core/src/core/s3/read.ts
+++ b/typescript/packages/core/src/core/s3/read.ts
@@ -14,7 +14,7 @@
 
 import { mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { record, revisionFor } from '../../observe/context.ts'
+import { record, revisionFor, startOp } from '../../observe/context.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
 import { createS3Client, isNotFoundError, loadS3Module, s3Key, streamToBuffer } from './client.ts'
@@ -66,7 +66,7 @@ export async function read(
   }
   const range = rangeHeader(options.offset ?? 0, options.size ?? null)
   if (range !== null) input.Range = range
-  const startMs = performance.now()
+  const timer = startOp()
   try {
     const resp = (await (
       client as unknown as {
@@ -82,7 +82,7 @@ export async function read(
     // Naming the virtual path rather than rawPath keeps the record exact
     // without consulting the active mount prefix; record() leaves an
     // already-prefixed path alone.
-    record('read', virtual, ResourceName.S3, bytes.byteLength, startMs, {
+    record('read', virtual, ResourceName.S3, bytes.byteLength, timer, {
       fingerprint,
       revision,
     })

--- a/typescript/packages/core/src/core/sharepoint/index.ts
+++ b/typescript/packages/core/src/core/sharepoint/index.ts
@@ -29,7 +29,7 @@ import {
   type FindEntry,
   type PredNode,
 } from '../../commands/builtin/find_eval.ts'
-import { record } from '../../observe/context.ts'
+import { record, startOp } from '../../observe/context.ts'
 import type { FindOptions } from '../../resource/base.ts'
 import { FileStat, FileType, type PathSpec } from '../../types.ts'
 import { enoent, enotempty } from '../../utils/errors.ts'
@@ -225,9 +225,9 @@ export async function write(
   data: Uint8Array,
 ): Promise<void> {
   const resolved = await resolvedItem(accessor, path)
-  const startMs = performance.now()
+  const timer = startOp()
   await writeItem(accessor.config, accessor.loc(resolved, path.resourcePath), data)
-  record('write', path.resourcePath, 'sharepoint', data.length, startMs)
+  record('write', path.resourcePath, 'sharepoint', data.length, timer)
   await invalidateAfterWrite(path)
 }
 

--- a/typescript/packages/core/src/observe/context.test.ts
+++ b/typescript/packages/core/src/observe/context.test.ts
@@ -21,17 +21,18 @@ import {
   runWithRecording,
   runWithRevisions,
   runWithMountPrefix,
+  startOp,
   withMountPrefix,
 } from './context.ts'
 
 describe('runWithRecording / record / runWithMountPrefix', () => {
   it('record outside recording scope is a no-op', () => {
-    record('read', '/a.txt', 's3', 100, 0)
+    record('read', '/a.txt', 's3', 100, startOp())
   })
 
   it('captures a single record within scope', async () => {
     const [, records] = await runWithRecording(async () => {
-      record('read', '/a.txt', 's3', 100, 0)
+      record('read', '/a.txt', 's3', 100, startOp())
     })
     expect(records).toHaveLength(1)
     expect(records[0]?.op).toBe('read')
@@ -40,16 +41,16 @@ describe('runWithRecording / record / runWithMountPrefix', () => {
 
   it('records after scope ends are dropped', async () => {
     const [, records] = await runWithRecording(async () => {
-      record('read', '/a.txt', 's3', 100, 0)
+      record('read', '/a.txt', 's3', 100, startOp())
     })
-    record('read', '/b.txt', 's3', 200, 0)
+    record('read', '/b.txt', 's3', 200, startOp())
     expect(records).toHaveLength(1)
   })
 
   it('captures multiple records with correct sources', async () => {
     const [, records] = await runWithRecording(async () => {
-      record('read', '/a.txt', 's3', 100, 0)
-      record('write', '/b.txt', 'ram', 50, 0)
+      record('read', '/a.txt', 's3', 100, startOp())
+      record('write', '/b.txt', 'ram', 50, startOp())
     })
     expect(records).toHaveLength(2)
     expect(records[0]?.source).toBe('s3')
@@ -59,7 +60,7 @@ describe('runWithRecording / record / runWithMountPrefix', () => {
   it('prepends virtual prefix when path lacks it', async () => {
     const [, records] = await runWithRecording(() =>
       runWithMountPrefix('/s3', async () => {
-        record('read', '/data/file.json', 's3', 100, 0)
+        record('read', '/data/file.json', 's3', 100, startOp())
       }),
     )
     expect(records[0]?.path).toBe('/s3/data/file.json')
@@ -67,7 +68,7 @@ describe('runWithRecording / record / runWithMountPrefix', () => {
 
   it('leaves path unchanged when prefix is empty', async () => {
     const [, records] = await runWithRecording(async () => {
-      record('read', '/data/file.json', 's3', 100, 0)
+      record('read', '/data/file.json', 's3', 100, startOp())
     })
     expect(records[0]?.path).toBe('/data/file.json')
   })
@@ -75,7 +76,7 @@ describe('runWithRecording / record / runWithMountPrefix', () => {
   it('does not double-apply prefix when path already has it', async () => {
     const [, records] = await runWithRecording(() =>
       runWithMountPrefix('/s3', async () => {
-        record('read', '/s3/data/file.json', 's3', 100, 0)
+        record('read', '/s3/data/file.json', 's3', 100, startOp())
       }),
     )
     expect(records[0]?.path).toBe('/s3/data/file.json')
@@ -86,7 +87,7 @@ describe('runWithRecording / record / runWithMountPrefix', () => {
   it('prefixes a filename that merely shares the prefix leading text', async () => {
     const [, records] = await runWithRecording(() =>
       runWithMountPrefix('/s3', async () => {
-        record('read', '/s3-report.txt', 's3', 1, 0)
+        record('read', '/s3-report.txt', 's3', 1, startOp())
       }),
     )
     expect(records[0]?.path).toBe('/s3/s3-report.txt')
@@ -96,9 +97,9 @@ describe('runWithRecording / record / runWithMountPrefix', () => {
     const [, records] = await runWithRecording(() =>
       runWithMountPrefix('/s3', async () => {
         await runWithMountPrefix('/db', async () => {
-          record('read', '/a.txt', 'postgres', 1, 0)
+          record('read', '/a.txt', 'postgres', 1, startOp())
         })
-        record('read', '/b.txt', 's3', 1, 0)
+        record('read', '/b.txt', 's3', 1, startOp())
       }),
     )
     expect(records.map((r) => r.path)).toEqual(['/db/a.txt', '/s3/b.txt'])
@@ -114,7 +115,7 @@ describe('runWithRecording / record / runWithMountPrefix', () => {
       await runWithMountPrefix(prefix, async () => {
         gate[key] = true
         while (!gate[other]) await new Promise((r) => setTimeout(r, 0))
-        record('read', file, key, 1, 0)
+        record('read', file, key, 1, startOp())
       })
     }
     const [, records] = await runWithRecording(async () => {
@@ -128,7 +129,7 @@ describe('runWithRecording / record / runWithMountPrefix', () => {
 
   it('withMountPrefix carries the prefix into a stream consumed after the scope', async () => {
     const lazy = async function* (): AsyncGenerator<Uint8Array> {
-      record('read', '/a.txt', 's3', 3, 0)
+      record('read', '/a.txt', 's3', 3, startOp())
       yield new Uint8Array([1, 2, 3])
     }
     const [, records] = await runWithRecording(async () => {
@@ -142,7 +143,7 @@ describe('runWithRecording / record / runWithMountPrefix', () => {
 describe('OpRecord: fingerprint + revision', () => {
   it('record() persists fingerprint and revision on the OpRecord', async () => {
     const [, records] = await runWithRecording(async () => {
-      record('read', '/a.txt', 's3', 100, performance.now(), {
+      record('read', '/a.txt', 's3', 100, startOp(), {
         fingerprint: 'abc',
         revision: 'v1',
       })
@@ -154,7 +155,7 @@ describe('OpRecord: fingerprint + revision', () => {
 
   it('record() defaults fingerprint and revision to null', async () => {
     const [, records] = await runWithRecording(async () => {
-      record('read', '/a.txt', 's3', 100, performance.now())
+      record('read', '/a.txt', 's3', 100, startOp())
     })
     expect(records[0]?.fingerprint).toBeNull()
     expect(records[0]?.revision).toBeNull()

--- a/typescript/packages/core/src/observe/context.ts
+++ b/typescript/packages/core/src/observe/context.ts
@@ -91,28 +91,77 @@ export interface RecordOptions {
   revision?: string | null
 }
 
+/**
+ * A running stopwatch for one op, owned by the record path.
+ *
+ * Opened where the backend work begins and read once when the op
+ * finishes, so an op module hands this around instead of reading a
+ * clock of its own. The wall-clock stamp the record carries is taken at
+ * finish time, not here. Mirrors python's `OpTimer`.
+ */
+export class OpTimer {
+  private readonly startMs: number
+
+  constructor() {
+    this.startMs = performance.now()
+  }
+
+  /** Milliseconds elapsed since the timer was opened. */
+  get elapsedMs(): number {
+    return Math.floor(performance.now() - this.startMs)
+  }
+}
+
+/**
+ * Open the record path's stopwatch for one op. Hand the timer to
+ * {@link record} or {@link finishRecord} when the op completes.
+ */
+export function startOp(): OpTimer {
+  return new OpTimer()
+}
+
+/**
+ * Close `timer` and build the finished record.
+ *
+ * The one place an op's duration and wall-clock stamp are read, shared
+ * by the recorder sink ({@link record}) and by the `Ops` facade's own
+ * ledger, so the two cannot disagree about what a duration measures.
+ * `path` is stored as given: a caller that needs mount prefixing
+ * applies it first.
+ */
+export function finishRecord(
+  op: string,
+  path: string,
+  source: string,
+  nbytes: number,
+  timer: OpTimer,
+  options: RecordOptions = {},
+): OpRecord {
+  const elapsed = timer.elapsedMs
+  return new OpRecord({
+    op,
+    path,
+    source,
+    bytes: nbytes,
+    timestamp: Date.now(),
+    durationMs: elapsed,
+    fingerprint: options.fingerprint ?? null,
+    revision: options.revision ?? null,
+  })
+}
+
 export function record(
   op: string,
   path: string,
   source: string,
   nbytes: number,
-  startMs: number,
+  timer: OpTimer,
   options: RecordOptions = {},
 ): void {
   const state = storage.getStore()
   if (state === undefined) return
-  const elapsed = Math.floor(performance.now() - startMs)
   state.records.push(
-    new OpRecord({
-      op,
-      path: applyPrefix(state.mountPrefix, path),
-      source,
-      bytes: nbytes,
-      timestamp: Date.now(),
-      durationMs: elapsed,
-      fingerprint: options.fingerprint ?? null,
-      revision: options.revision ?? null,
-    }),
+    finishRecord(op, applyPrefix(state.mountPrefix, path), source, nbytes, timer, options),
   )
 }
 

--- a/typescript/packages/core/src/observe/context_fallback.test.ts
+++ b/typescript/packages/core/src/observe/context_fallback.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it, vi } from 'vitest'
-import { record, revisionFor, runWithRecording, runWithRevisions } from './context.ts'
+import { record, revisionFor, runWithRecording, runWithRevisions, startOp } from './context.ts'
 import type * as asyncContextModule from '../utils/async_context.ts'
 
 // The browser-runtime branch under node's test runner: the real
@@ -75,7 +75,7 @@ describe('recording on the fallback storage', () => {
     const [, records] = await runWithRecording(async () => {
       release()
       await first
-      record('read', '/x', 'test', 3, performance.now())
+      record('read', '/x', 'test', 3, startOp())
     })
     expect(records).toHaveLength(1)
     expect(records[0]?.path).toBe('/x')

--- a/typescript/packages/core/src/ops/ops.ts
+++ b/typescript/packages/core/src/ops/ops.ts
@@ -13,7 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { OpReport } from '../io/types.ts'
-import { OpRecord } from '../observe/record.ts'
+import type { OpRecord } from '../observe/record.ts'
+import { finishRecord, type OpTimer, startOp } from '../observe/context.ts'
 import { NO_FOLLOW_OPS, type NamespaceLinks } from './config.ts'
 import type { OpKwargs } from './registry.ts'
 import type { FileStat, SetAttrFields } from '../types.ts'
@@ -107,16 +108,9 @@ export class Ops {
     path: string,
     source: string,
     bytes: number,
-    startMs: number,
+    timer: OpTimer,
   ): Promise<void> {
-    const rec = new OpRecord({
-      op,
-      path,
-      source,
-      bytes,
-      timestamp: Date.now(),
-      durationMs: Date.now() - startMs,
-    })
+    const rec = finishRecord(op, path, source, bytes, timer)
     this.records.push(rec)
     if (this.sink !== null) await this.sink(rec)
   }
@@ -136,7 +130,7 @@ export class Ops {
     args: readonly unknown[] = [],
     kwargs: OpKwargs = {},
   ): Promise<unknown> {
-    const start = Date.now()
+    const timer = startOp()
     // `nofollow` is the caller's AT_SYMLINK_NOFOLLOW and suppresses
     // both follows, so an op meant for a link entry itself (chmod -h, a
     // guest's lchown) still records the link's own path.
@@ -156,12 +150,12 @@ export class Ops {
       // completion, so even a foreign error the door never defined
       // leaves the transfer on the books.
       if (report.completed && owner !== null) {
-        await this.recordOp(op, followed, owner, report.source, report.bytes, null, args, start)
+        await this.recordOp(op, followed, owner, report.source, report.bytes, null, args, timer)
       }
       throw err
     }
     if (owner !== null) {
-      await this.recordOp(op, followed, owner, report.source, report.bytes, result, args, start)
+      await this.recordOp(op, followed, owner, report.source, report.bytes, result, args, timer)
     }
     return result
   }
@@ -183,9 +177,9 @@ export class Ops {
     moved: number | null,
     result: unknown,
     args: readonly unknown[],
-    start: number,
+    timer: OpTimer,
   ): Promise<void> {
-    await this.record(op, path, source ?? owner.kind, moved ?? payloadBytes(result, args), start)
+    await this.record(op, path, source ?? owner.kind, moved ?? payloadBytes(result, args), timer)
   }
 
   // `raw` skips the filetype cascade: an explicit null filetype stops

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -33,7 +33,7 @@ import { Policies, PolicyDenied, postOpsGate, preOpsGate } from '../../policy/in
 import { PolicyError } from '../../policy/errors.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import { normDir, rstripSlash } from '../../utils/slash.ts'
-import { record, runWithMountPrefix, runWithRevisions } from '../../observe/context.ts'
+import { record, runWithMountPrefix, runWithRevisions, startOp } from '../../observe/context.ts'
 import type { OpRecord } from '../../observe/record.ts'
 import type { OpsRegistry } from '../../ops/registry.ts'
 import { type OpKwargs } from '../../ops/registry.ts'
@@ -682,7 +682,7 @@ export class Dispatcher {
     kwargs: OpKwargs,
     report: OpReport | undefined,
   ): Promise<string | FileStat | null> {
-    const start = performance.now()
+    const timer = startOp()
     const mount = this.namespace.tryMountFor(path.virtual)
     const owner = mount?.prefix ?? null
     const write = POLICY_WRITE_OPS.has(opName)
@@ -732,7 +732,7 @@ export class Dispatcher {
       path.virtual,
       ResourceName.RAM,
       new TextEncoder().encode(target).byteLength,
-      start,
+      timer,
     )
     memoryAnswered(report)
     const bound = await postOpsGate(this.policies, opName, path, write, owner ?? '', result)
@@ -924,14 +924,14 @@ export class Dispatcher {
     p: PathSpec,
     kwargs: OpKwargs,
   ): Promise<Record<string, number | string>> {
-    const start = performance.now()
+    const timer = startOp()
     const overlay: Record<string, number | string> = {}
     for (const key of SETATTR_KEYS) {
       const value = kwargs[key]
       if (value !== undefined && value !== null) overlay[key] = value as number | string
     }
     await this.writeOverlay(p.virtual, overlay)
-    record('setattr', p.virtual, ResourceName.RAM, 0, start)
+    record('setattr', p.virtual, ResourceName.RAM, 0, timer)
     return overlay
   }
 

--- a/typescript/packages/core/src/workspace/snapshot_drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot_drift.test.ts
@@ -18,7 +18,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { Accessor } from '../accessor/base.ts'
-import { record, revisionFor, runWithRecording } from '../observe/context.ts'
+import { record, revisionFor, runWithRecording, startOp } from '../observe/context.ts'
 import { type OpKwargs, OpsRegistry, type RegisteredOp } from '../ops/registry.ts'
 import { BaseResource, type Resource } from '../resource/base.ts'
 import { createShellParser, type ShellParser } from '../shell/parse.ts'
@@ -128,14 +128,14 @@ const readOp: RegisteredOp = {
       const history = acc.versionedHistory.get(scope.virtual)
       const pinnedBytes = history?.get(pinned)
       if (pinnedBytes !== undefined) {
-        record('read', scope.virtual, 'fake-remote', pinnedBytes.byteLength, performance.now(), {
+        record('read', scope.virtual, 'fake-remote', pinnedBytes.byteLength, startOp(), {
           fingerprint: entry.fingerprint,
           revision: pinned,
         })
         return Promise.resolve(pinnedBytes)
       }
     }
-    record('read', scope.virtual, 'fake-remote', entry.bytes.byteLength, performance.now(), {
+    record('read', scope.virtual, 'fake-remote', entry.bytes.byteLength, startOp(), {
       fingerprint: entry.fingerprint,
       revision: entry.revision,
     })

--- a/typescript/packages/node/src/core/disk/append.ts
+++ b/typescript/packages/node/src/core/disk/append.ts
@@ -15,7 +15,7 @@
 import type { DiskAccessor } from '../../accessor/disk.ts'
 import { appendFile } from 'node:fs/promises'
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { diskError } from './errors.ts'
@@ -26,7 +26,7 @@ export async function appendBytes(
   p: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const virtual = p.mountPath
   const full = resolveSafe(accessor.root, virtual)
   try {
@@ -34,6 +34,6 @@ export async function appendBytes(
   } catch (err) {
     throw diskError(err, p)
   }
-  record('append', virtual, ResourceName.DISK, data.byteLength, start)
+  record('append', virtual, ResourceName.DISK, data.byteLength, timer)
   await invalidateAfterWrite(p)
 }

--- a/typescript/packages/node/src/core/disk/read.ts
+++ b/typescript/packages/node/src/core/disk/read.ts
@@ -14,7 +14,7 @@
 
 import type { DiskAccessor } from '../../accessor/disk.ts'
 import { open, readFile } from 'node:fs/promises'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
@@ -23,7 +23,7 @@ import { resolveSafe } from './utils.ts'
 const CHUNK = 1 << 20
 
 export async function read(accessor: DiskAccessor, path: PathSpec): Promise<Uint8Array> {
-  const start = performance.now()
+  const timer = startOp()
   const virtual = path.mountPath
   const full = resolveSafe(accessor.root, virtual)
   let data: Buffer
@@ -35,7 +35,7 @@ export async function read(accessor: DiskAccessor, path: PathSpec): Promise<Uint
     }
     throw err
   }
-  record('read', virtual, ResourceName.DISK, data.byteLength, start)
+  record('read', virtual, ResourceName.DISK, data.byteLength, timer)
   return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
 }
 
@@ -59,7 +59,7 @@ export async function readRange(
   offset: number,
   size: number | null,
 ): Promise<Uint8Array> {
-  const start = performance.now()
+  const timer = startOp()
   const virtual = path.mountPath
   const full = resolveSafe(accessor.root, virtual)
   let handle
@@ -76,7 +76,7 @@ export async function readRange(
       const buf = Buffer.allocUnsafe(size)
       const { bytesRead } = await handle.read(buf, 0, size, offset)
       const out = new Uint8Array(buf.buffer, buf.byteOffset, bytesRead)
-      record('read', virtual, ResourceName.DISK, bytesRead, start)
+      record('read', virtual, ResourceName.DISK, bytesRead, timer)
       return out
     }
     const parts: Buffer[] = []
@@ -91,7 +91,7 @@ export async function readRange(
       at += bytesRead
     }
     const joined = Buffer.concat(parts, total)
-    record('read', virtual, ResourceName.DISK, total, start)
+    record('read', virtual, ResourceName.DISK, total, timer)
     return new Uint8Array(joined.buffer, joined.byteOffset, joined.byteLength)
   } finally {
     await handle.close()

--- a/typescript/packages/node/src/core/disk/truncate.ts
+++ b/typescript/packages/node/src/core/disk/truncate.ts
@@ -15,7 +15,7 @@
 import type { DiskAccessor } from '../../accessor/disk.ts'
 import { readFile, writeFile } from 'node:fs/promises'
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { resolveSafe } from './utils.ts'
@@ -25,7 +25,7 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const full = resolveSafe(accessor.root, path.mountPath)
   let data: Buffer
   try {
@@ -40,6 +40,6 @@ export async function truncate(
   const out = new Uint8Array(length)
   out.set(data.subarray(0, Math.min(data.byteLength, length)))
   await writeFile(full, out)
-  record('truncate', path.mountPath, ResourceName.DISK, 0, start)
+  record('truncate', path.mountPath, ResourceName.DISK, 0, timer)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/node/src/core/disk/write.ts
+++ b/typescript/packages/node/src/core/disk/write.ts
@@ -15,7 +15,7 @@
 import type { DiskAccessor } from '../../accessor/disk.ts'
 import { writeFile } from 'node:fs/promises'
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { diskError } from './errors.ts'
@@ -26,7 +26,7 @@ export async function writeBytes(
   p: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const virtual = p.mountPath
   const full = resolveSafe(accessor.root, virtual)
   // A write is not `mkdir -p`: GNU reports ENOENT on a missing parent
@@ -37,6 +37,6 @@ export async function writeBytes(
   } catch (err) {
     throw diskError(err, p)
   }
-  record('write', virtual, ResourceName.DISK, data.byteLength, start)
+  record('write', virtual, ResourceName.DISK, data.byteLength, timer)
   await invalidateAfterWrite(p)
 }

--- a/typescript/packages/node/src/core/gridfs/read.ts
+++ b/typescript/packages/node/src/core/gridfs/read.ts
@@ -14,7 +14,7 @@
 
 import type { ObjectId } from 'mongodb'
 import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
-import { record, revisionFor } from '@struktoai/mirage-core/observe/context'
+import { record, revisionFor, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
@@ -113,11 +113,11 @@ export async function read(
   const virtual = path.virtual
   const raw = rawPathOf(path)
   const key = gridfsKey(raw, accessor.config)
-  const startMs = performance.now()
+  const timer = startOp()
   const fileId = await resolveFileId(accessor, path, key)
   const bytes = await downloadBytes(accessor, path, fileId, options)
   const revision = fileId.toString()
-  record('read', virtual, ResourceName.GRIDFS, bytes.byteLength, startMs, {
+  record('read', virtual, ResourceName.GRIDFS, bytes.byteLength, timer, {
     fingerprint: revision,
     revision,
   })

--- a/typescript/packages/node/src/core/hf/read.ts
+++ b/typescript/packages/node/src/core/hf/read.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
 import type { HfAccessor } from '../../accessor/hf.ts'
@@ -43,7 +43,7 @@ export async function read(
     readOptions.offset ??= 0n
     readOptions.size = BigInt(options.size)
   }
-  const startMs = performance.now()
+  const timer = startOp()
   const windowed = readOptions.offset !== undefined || readOptions.size !== undefined
   let data: Buffer
   try {
@@ -59,6 +59,6 @@ export async function read(
     data = Buffer.from(sliceWindow(new Uint8Array(whole), 0, options.size ?? null))
   }
   const bytes = new Uint8Array(data)
-  record('read', virtual, accessor.resourceName, bytes.byteLength, startMs)
+  record('read', virtual, accessor.resourceName, bytes.byteLength, timer)
   return bytes
 }

--- a/typescript/packages/node/src/core/hf_hub/read.ts
+++ b/typescript/packages/node/src/core/hf_hub/read.ts
@@ -14,7 +14,7 @@
 
 import type { IndexEntry } from '@struktoai/mirage-core/cache/index/config'
 import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { eisdir, enoent } from '@struktoai/mirage-core/utils/errors'
 import { mountPrefixOf } from '@struktoai/mirage-core/utils/key_prefix'
@@ -71,8 +71,8 @@ export async function read(
   const window: ByteWindow | undefined = hasWindow
     ? { offset: options.offset ?? 0, size: options.size ?? null }
     : undefined
-  const start = Date.now()
+  const timer = startOp()
   const data = await hubBytes(accessor.token, url, window)
-  record('read', raw, accessor.resourceName, data.length, start)
+  record('read', raw, accessor.resourceName, data.length, timer)
   return data
 }

--- a/typescript/packages/node/src/core/nextcloud/read.ts
+++ b/typescript/packages/node/src/core/nextcloud/read.ts
@@ -1,5 +1,5 @@
 import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
@@ -27,7 +27,7 @@ export async function read(
     readOptions.offset ??= 0n
     readOptions.size = BigInt(options.size)
   }
-  const startMs = performance.now()
+  const timer = startOp()
   try {
     const windowed = readOptions.offset !== undefined || readOptions.size !== undefined
     // OpenDAL's node binding refuses to return fewer bytes than the range
@@ -46,7 +46,7 @@ export async function read(
       data = Buffer.from(sliceWindow(new Uint8Array(whole), 0, options.size ?? null))
     }
     const bytes = new Uint8Array(data)
-    record('read', path.virtual, ResourceName.NEXTCLOUD, bytes.byteLength, startMs)
+    record('read', path.virtual, ResourceName.NEXTCLOUD, bytes.byteLength, timer)
     return bytes
   } catch (error) {
     if (isNotFound(error)) throw enoent(path)

--- a/typescript/packages/node/src/core/nextcloud/truncate.ts
+++ b/typescript/packages/node/src/core/nextcloud/truncate.ts
@@ -1,5 +1,5 @@
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import type { NextcloudAccessor } from '../../accessor/nextcloud.ts'
@@ -10,7 +10,7 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const op = await accessor.operator()
   const key = nextcloudKey(path)
   let current: Buffer
@@ -23,6 +23,6 @@ export async function truncate(
   const next = Buffer.alloc(length)
   current.copy(next, 0, 0, Math.min(current.byteLength, length))
   await op.write(key, next)
-  record('truncate', path.virtual, ResourceName.NEXTCLOUD, 0, start)
+  record('truncate', path.virtual, ResourceName.NEXTCLOUD, 0, timer)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/node/src/core/nextcloud/unlink.ts
+++ b/typescript/packages/node/src/core/nextcloud/unlink.ts
@@ -1,5 +1,5 @@
 import { invalidateAfterUnlink } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
@@ -8,13 +8,13 @@ import { isNotFound, nextcloudKey } from './util.ts'
 
 export async function unlink(accessor: NextcloudAccessor, path: PathSpec): Promise<void> {
   const op = await accessor.operator()
-  const startMs = performance.now()
+  const timer = startOp()
   try {
     await op.delete(nextcloudKey(path))
   } catch (error) {
     if (isNotFound(error)) throw enoent(path)
     throw error
   }
-  record('unlink', path.virtual, ResourceName.NEXTCLOUD, 0, startMs)
+  record('unlink', path.virtual, ResourceName.NEXTCLOUD, 0, timer)
   await invalidateAfterUnlink(path)
 }

--- a/typescript/packages/node/src/core/nextcloud/write.ts
+++ b/typescript/packages/node/src/core/nextcloud/write.ts
@@ -1,6 +1,6 @@
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
 import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
@@ -13,7 +13,7 @@ export async function write(
   data: Uint8Array,
   _index?: IndexCacheStore,
 ): Promise<void> {
-  const startMs = performance.now()
+  const timer = startOp()
   try {
     const op = await accessor.operator()
     await op.write(nextcloudKey(path), Buffer.from(data))
@@ -21,6 +21,6 @@ export async function write(
     if (isNotFound(error)) throw enoent(path)
     throw error
   }
-  record('write', path.virtual, ResourceName.NEXTCLOUD, data.byteLength, startMs)
+  record('write', path.virtual, ResourceName.NEXTCLOUD, data.byteLength, timer)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/node/src/core/redis/append.ts
+++ b/typescript/packages/node/src/core/redis/append.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import type { RedisAccessor } from '../../accessor/redis.ts'
@@ -25,7 +25,7 @@ export async function appendBytes(
   path: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   const store = accessor.store
   await checkDestParents(store, path, p)
@@ -39,6 +39,6 @@ export async function appendBytes(
     await store.setFile(p, data)
   }
   await store.setModified(p, nowIso())
-  record('append', p, ResourceName.REDIS, data.byteLength, start)
+  record('append', p, ResourceName.REDIS, data.byteLength, timer)
   await invalidateAfterWrite(p)
 }

--- a/typescript/packages/node/src/core/redis/create.ts
+++ b/typescript/packages/node/src/core/redis/create.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import type { RedisAccessor } from '../../accessor/redis.ts'
@@ -21,12 +21,12 @@ import { checkDestParents } from './dest.ts'
 import { norm, nowIso } from './utils.ts'
 
 export async function create(accessor: RedisAccessor, path: PathSpec): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   const store = accessor.store
   await checkDestParents(store, path, p)
   await store.setFile(p, new Uint8Array(0))
   await store.setModified(p, nowIso())
-  record('create', p, ResourceName.REDIS, 0, start)
+  record('create', p, ResourceName.REDIS, 0, timer)
   await invalidateAfterWrite(path)
 }

--- a/typescript/packages/node/src/core/redis/read.ts
+++ b/typescript/packages/node/src/core/redis/read.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { IndexCacheStore } from '@struktoai/mirage-core/cache/index/store'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import { enoent } from '@struktoai/mirage-core/utils/errors'
@@ -37,7 +37,7 @@ export async function read(
 ): Promise<Uint8Array> {
   const offset = options?.offset ?? 0
   const size = options?.size ?? null
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   const data =
     offset !== 0 || size !== null
@@ -46,6 +46,6 @@ export async function read(
   if (data === null) {
     throw enoent(path)
   }
-  record('read', p, ResourceName.REDIS, data.byteLength, start)
+  record('read', p, ResourceName.REDIS, data.byteLength, timer)
   return data
 }

--- a/typescript/packages/node/src/core/redis/truncate.ts
+++ b/typescript/packages/node/src/core/redis/truncate.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import type { RedisAccessor } from '../../accessor/redis.ts'
@@ -24,7 +24,7 @@ export async function truncate(
   path: PathSpec,
   length: number,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   const store = accessor.store
   const existing = await store.getFile(p)
@@ -34,6 +34,6 @@ export async function truncate(
   out.set(data.subarray(0, copyLen), 0)
   await store.setFile(p, out)
   await store.setModified(p, nowIso())
-  record('truncate', p, ResourceName.REDIS, 0, start)
+  record('truncate', p, ResourceName.REDIS, 0, timer)
   await invalidateAfterWrite(p)
 }

--- a/typescript/packages/node/src/core/redis/write.ts
+++ b/typescript/packages/node/src/core/redis/write.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import type { RedisAccessor } from '../../accessor/redis.ts'
@@ -25,12 +25,12 @@ export async function writeBytes(
   path: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const p = norm(path.mountPath)
   const store = accessor.store
   await checkDestParents(store, path, p)
   await store.setFile(p, data)
   await store.setModified(p, nowIso())
-  record('write', p, ResourceName.REDIS, data.byteLength, start)
+  record('write', p, ResourceName.REDIS, data.byteLength, timer)
   await invalidateAfterWrite(p)
 }

--- a/typescript/packages/node/src/core/ssh/write.ts
+++ b/typescript/packages/node/src/core/ssh/write.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { invalidateAfterWrite } from '@struktoai/mirage-core/cache/context'
-import { record } from '@struktoai/mirage-core/observe/context'
+import { record, startOp } from '@struktoai/mirage-core/observe/context'
 import { ResourceName } from '@struktoai/mirage-core/types'
 import type { PathSpec } from '@struktoai/mirage-core/types'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
@@ -24,7 +24,7 @@ export async function writeBytes(
   p: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
-  const start = performance.now()
+  const timer = startOp()
   const sftp = await accessor.sftp()
   const virtual = stripPrefix(p)
   const remote = joinRoot(accessor.config.root ?? '/', virtual)
@@ -34,6 +34,6 @@ export async function writeBytes(
       else resolveFn()
     })
   })
-  record('write', virtual, ResourceName.SSH, data.byteLength, start)
+  record('write', virtual, ResourceName.SSH, data.byteLength, timer)
   await invalidateAfterWrite(p)
 }


### PR DESCRIPTION
## Why

Time was read ambiently across the codebase. Around 45 Python modules under `mirage/core/<backend>/` repeated the same stopwatch line before their backend call and handed the result to `observe.context.record`, and `Ops` kept a second timing path of its own. TypeScript mirrored both. One number had roughly eighty definitions, so op latency meant slightly different things in different places.

## What

The stopwatch now belongs to observe/context, the one consumer of the number.

- `observe/context` gains `OpTimer` and `start_op` / `startOp`. A call site opens the timer where the backend work begins.
- `finish_record` / `finishRecord` is the single place an op's duration and wall-clock stamp are read. `Ops` builds its record through it too, so the facade's ledger and the recorder sink cannot disagree about what a duration measures.
- `record` takes the timer instead of a start stamp. Call sites stop reading a clock and mostly drop their `time` import.

Converted 53 sites in Python and 48 in TypeScript.

## Intent

- This is the enabling step, not the destination: every op's duration now sits behind one owner (`start_op` / `finish_record`).
- With that single seam, later work can change how time is read in one place instead of across ~80 call sites:
  - an injectable clock for deterministic tests
  - seeded or frozen time
  - a lint rule that keeps new call sites off the ambient clock
- Concretely, a follow-up swaps the clock source at `start_op` alone, and every call site inherits it:

```python
# now: the timer reads the clock itself
def start_op() -> OpTimer:
    return OpTimer()  # OpTimer() reads time.monotonic()

# follow-up (not this PR): source the clock from one seam
def start_op() -> OpTimer:
    return OpTimer(clock=current_clock())  # injected, frozen or seeded under test
```

- None of that ships here. This PR only moves who reads the clock.

## No output change

OpRecord fields, duration semantics, wall stamps, bytes and fingerprints are untouched. Each timed interval starts and ends exactly where it did (s3 excludes client acquisition, disk includes path resolution), so durations keep their per-site meaning. Streaming records are unaffected.

One deliberate change: TypeScript `Ops` measured with `Date.now()` while `record` used `performance.now()`. Folding the two puts `Ops` on the monotonic clock, matching Python's `Ops` and `record` in both languages. Same field, same units, better source.

## Verification

CI. The diff is wide but shallow (drop `import time`, open a timer, pass it) with no behavior to cover. Existing tests that call `record` directly were updated for the new signature; no assertions changed.


Part of #970 (item 1).
