### PR TITLE
Record branch history when a ref moves in the github fake

### DIFF
--- a/integ/prisma/github.prisma
+++ b/integ/prisma/github.prisma
@@ -81,6 +81,10 @@ model GithubBranch {
   tenant String
   repo   String
   name   String
+  // Where the ref points, as a commit sha, empty for a branch that carries
+  // only its synthesized root. A ref IS this pointer: which commits a branch
+  // has is the chain reachable from here, never a column on the commits.
+  headSha String @default("")
   seq    Int
 
   repository GithubRepo @relation(fields: [tenant, repo], references: [tenant, fullName])
@@ -117,14 +121,21 @@ model GithubSubmodule {
   @@index([tenant, repo])
 }
 
+// A commit is immutable and belongs to no branch: it is reached by walking
+// parents back from a ref's head, which is why one commit can sit on many
+// branches at once and why abandoning one costs nothing but the pointer.
 model GithubCommit {
   pk            Int    @id @default(autoincrement())
   tenant        String
   repo          String
-  branch        String
   // Derived from the content rather than stored by the fixture, so a mirror of
-  // a fixture answers the same sha twice.
+  // a fixture answers the same sha twice. Content-addressed in the git sense:
+  // the tree, the people, the message and the PARENT decide it, never a
+  // position, so a sha can never be reproduced by a later commit taking a
+  // freed slot.
   sha           String
+  // The first parent, empty at the start of a chain (the synthesized root).
+  parentSha     String @default("")
   message       String
   authorLogin   String
   date          String
@@ -142,16 +153,12 @@ model GithubCommit {
   // address, and a date is the caller's to pin.
   authorJson    String @default("")
   committerJson String @default("")
-  // Whether a ref update has taken this commit onto its branch. A plumbing
-  // commit is parked on the default branch at creation and moves with the
-  // first ref that names it; once attached, a further ref copies it, because
-  // a git commit is reachable from many refs and stays on each history.
-  attached      Boolean @default(false)
   seq           Int
 
   repository GithubRepo @relation(fields: [tenant, repo], references: [tenant, fullName])
 
-  @@index([tenant, repo, branch])
+  @@index([tenant, repo])
+  @@index([tenant, repo, sha])
 }
 
 model GithubIssue {

--- a/integ/prisma/github.prisma
+++ b/integ/prisma/github.prisma
@@ -142,6 +142,11 @@ model GithubCommit {
   // address, and a date is the caller's to pin.
   authorJson    String @default("")
   committerJson String @default("")
+  // Whether a ref update has taken this commit onto its branch. A plumbing
+  // commit is parked on the default branch at creation and moves with the
+  // first ref that names it; once attached, a further ref copies it, because
+  // a git commit is reachable from many refs and stays on each history.
+  attached      Boolean @default(false)
   seq           Int
 
   repository GithubRepo @relation(fields: [tenant, repo], references: [tenant, fullName])

--- a/integ/server/github/contents.ts
+++ b/integ/server/github/contents.ts
@@ -31,6 +31,7 @@ import {
   branchNames,
   commitList,
   directoriesOf,
+  stageTree,
   submodulesOf,
   treeItems,
   treeOf,
@@ -126,21 +127,23 @@ export async function recordCommit(
   const authorJson = personJson(people.author)
   const committerJson = personJson(people.committer)
   const parentSha = parent ?? (await visibleHeadOf(db, tenant, repo, branch))
-  // A plumbing commit names its tree, and a /contents commit is the tree the
-  // write just produced, fingerprinted the way the synthesized root is. Both
-  // have to be in the sha or the address is not the content's: two writes of
-  // different bytes under one message onto one parent would otherwise be one
-  // commit, which is what a reset freeing a slot used to expose.
-  const state =
+  // EVERY commit names a tree, so every commit is a snapshot that can be read
+  // back on its own. A plumbing commit names the one its caller staged; a
+  // /contents commit stages the tree its own write just produced, which is why
+  // this reads the branch AFTER the write has landed. Without it a commit born
+  // here recorded no tree at all, and the only way to see its files was to read
+  // whatever its branch happened to hold later, which is a different answer the
+  // moment the branch moves.
+  //
+  // The tree is in the sha for the same reason git puts it there: two writes of
+  // different bytes under one message onto one parent are two commits, and
+  // addressing them by message and parent alone made them one.
+  const stored =
     tree === ''
-      ? [...(await treeOfBranch(db, tenant, repo, branch)).entries()]
-          .map(([p, d]): [string, string] => [p, blobSha(d)])
-          .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-          .map(([p, b]) => `${p}:${b}`)
-          .join('\0')
+      ? await stageTree(db, tenant, repo, await treeOfBranch(db, tenant, repo, branch))
       : tree
   const sha = commitSha(
-    [repo.fullName, parentSha, state, authorJson, committerJson, message].join('\0'),
+    [repo.fullName, parentSha, stored, authorJson, committerJson, message].join('\0'),
   )
   await db.githubCommit.create({
     data: {
@@ -152,7 +155,7 @@ export async function recordCommit(
       authorLogin: '',
       date: '',
       filesJson: JSON.stringify(paths),
-      treeSha: tree,
+      treeSha: stored,
       authorJson,
       committerJson,
       seq,

--- a/integ/server/github/contents.ts
+++ b/integ/server/github/contents.ts
@@ -117,12 +117,15 @@ export async function recordCommit(
   },
 ): Promise<{ sha: string; message: string }> {
   const seq = await nextCommitSeq(db, tenant, repo.fullName, branch)
-  // A plumbing commit's sha also covers its tree: a ref update can move a
-  // commit off this branch, which frees its sequence, and a later commit
-  // reusing the sequence and the message would otherwise reproduce the sha
-  // for a different tree. A /contents commit has no tree and cannot move, so
-  // its derivation is unchanged and the goldens keep their shas.
-  const salt = tree === '' ? '' : `${tree}:`
+  const authorJson = personJson(people.author)
+  const committerJson = personJson(people.committer)
+  // A plumbing commit's sha also covers its tree and its people: a ref update
+  // can move a commit off this branch, which frees its sequence, and a later
+  // commit reusing the sequence and the message would otherwise reproduce the
+  // sha for a different tree or a different author, both of which git tells
+  // apart. A /contents commit has no tree and cannot move, so its derivation
+  // is unchanged and the goldens keep their shas.
+  const salt = tree === '' ? '' : `${tree}:${authorJson}:${committerJson}:`
   const sha = commitSha(`${repo.fullName}@${branch}:${String(seq)}:${salt}${message}`)
   await db.githubCommit.create({
     data: {
@@ -135,8 +138,8 @@ export async function recordCommit(
       date: '',
       filesJson: JSON.stringify(paths),
       treeSha: tree,
-      authorJson: personJson(people.author),
-      committerJson: personJson(people.committer),
+      authorJson,
+      committerJson,
       seq,
     },
   })

--- a/integ/server/github/contents.ts
+++ b/integ/server/github/contents.ts
@@ -31,6 +31,7 @@ import {
   branchNames,
   commitList,
   directoriesOf,
+  headOf,
   submodulesOf,
   treeItems,
   treeOf,
@@ -85,14 +86,9 @@ function dirJson(files: Tree, at: string): JsonValue[] | null {
   return [...entries.keys()].sort().map((k) => entries.get(k) as JsonValue)
 }
 
-export async function nextCommitSeq(
-  db: Client,
-  tenant: string,
-  repo: string,
-  branch: string,
-): Promise<number> {
+async function nextCommitSeq(db: Client, tenant: string, repo: string): Promise<number> {
   const rows = await db.githubCommit.findMany({
-    where: { tenant, repo, branch },
+    where: { tenant, repo },
     orderBy: { seq: 'desc' },
     take: 1,
   })
@@ -100,9 +96,17 @@ export async function nextCommitSeq(
   return top === undefined ? 0 : top.seq + 1
 }
 
-// Append a commit for a write to one branch. Its sha is derived from the
-// position in the branch's history, which is what makes a replayed fixture
-// answer the same shas.
+// Record one commit. Its sha is content-addressed the way git's is: the
+// parent, the tree, the people and the message decide it, and nothing about
+// where it sits does. That is the whole reason a sha cannot be reproduced by a
+// later commit landing in a freed slot, which is what a position-derived sha
+// allowed every time a move or a reset released one. `seq` survives only as
+// insertion order for a stable listing; no identity or history reads it.
+//
+// `advance` moves the branch's ref onto the new commit, which is what a
+// /contents write does: the write IS the ref update. A plumbing commit passes
+// false and is born dangling, reachable by sha but on no branch until a ref
+// update points at it.
 export async function recordCommit(
   db: Client,
   tenant: string,
@@ -115,24 +119,35 @@ export async function recordCommit(
     author: null,
     committer: null,
   },
+  parent: string | null = null,
+  advance = true,
 ): Promise<{ sha: string; message: string }> {
-  const seq = await nextCommitSeq(db, tenant, repo.fullName, branch)
+  const seq = await nextCommitSeq(db, tenant, repo.fullName)
   const authorJson = personJson(people.author)
   const committerJson = personJson(people.committer)
-  // A plumbing commit's sha also covers its tree and its people: a ref update
-  // can move a commit off this branch, which frees its sequence, and a later
-  // commit reusing the sequence and the message would otherwise reproduce the
-  // sha for a different tree or a different author, both of which git tells
-  // apart. A /contents commit has no tree and cannot move, so its derivation
-  // is unchanged and the goldens keep their shas.
-  const salt = tree === '' ? '' : `${tree}:${authorJson}:${committerJson}:`
-  const sha = commitSha(`${repo.fullName}@${branch}:${String(seq)}:${salt}${message}`)
+  const parentSha = parent ?? (await headOf(db, tenant, repo, branch))
+  // A plumbing commit names its tree, and a /contents commit is the tree the
+  // write just produced, fingerprinted the way the synthesized root is. Both
+  // have to be in the sha or the address is not the content's: two writes of
+  // different bytes under one message onto one parent would otherwise be one
+  // commit, which is what a reset freeing a slot used to expose.
+  const state =
+    tree === ''
+      ? [...(await treeOfBranch(db, tenant, repo, branch)).entries()]
+          .map(([p, d]): [string, string] => [p, blobSha(d)])
+          .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+          .map(([p, b]) => `${p}:${b}`)
+          .join('\0')
+      : tree
+  const sha = commitSha(
+    [repo.fullName, parentSha, state, authorJson, committerJson, message].join('\0'),
+  )
   await db.githubCommit.create({
     data: {
       tenant,
       repo: repo.fullName,
-      branch,
       sha,
+      parentSha,
       message,
       authorLogin: '',
       date: '',
@@ -140,13 +155,15 @@ export async function recordCommit(
       treeSha: tree,
       authorJson,
       committerJson,
-      // A /contents write moves its ref the moment it lands, so its commit is
-      // attached history from birth; only a plumbing commit (tree present)
-      // parks and waits for a ref update to claim it.
-      attached: tree === '',
       seq,
     },
   })
+  if (advance) {
+    await db.githubBranch.updateMany({
+      where: { tenant, repo: repo.fullName, name: branch },
+      data: { headSha: sha },
+    })
+  }
   return { sha, message }
 }
 

--- a/integ/server/github/contents.ts
+++ b/integ/server/github/contents.ts
@@ -31,11 +31,11 @@ import {
   branchNames,
   commitList,
   directoriesOf,
-  headOf,
   submodulesOf,
   treeItems,
   treeOf,
   treeOfBranch,
+  visibleHeadOf,
 } from './store.ts'
 import type { RepoRow, Tree } from './store.ts'
 import { authedRoute, everywhere, fail, jsonBodyOf, param, route, str, withRepo } from './http.ts'
@@ -125,7 +125,7 @@ export async function recordCommit(
   const seq = await nextCommitSeq(db, tenant, repo.fullName)
   const authorJson = personJson(people.author)
   const committerJson = personJson(people.committer)
-  const parentSha = parent ?? (await headOf(db, tenant, repo, branch))
+  const parentSha = parent ?? (await visibleHeadOf(db, tenant, repo, branch))
   // A plumbing commit names its tree, and a /contents commit is the tree the
   // write just produced, fingerprinted the way the synthesized root is. Both
   // have to be in the sha or the address is not the content's: two writes of

--- a/integ/server/github/contents.ts
+++ b/integ/server/github/contents.ts
@@ -117,7 +117,13 @@ export async function recordCommit(
   },
 ): Promise<{ sha: string; message: string }> {
   const seq = await nextCommitSeq(db, tenant, repo.fullName, branch)
-  const sha = commitSha(`${repo.fullName}@${branch}:${String(seq)}:${message}`)
+  // A plumbing commit's sha also covers its tree: a ref update can move a
+  // commit off this branch, which frees its sequence, and a later commit
+  // reusing the sequence and the message would otherwise reproduce the sha
+  // for a different tree. A /contents commit has no tree and cannot move, so
+  // its derivation is unchanged and the goldens keep their shas.
+  const salt = tree === '' ? '' : `${tree}:`
+  const sha = commitSha(`${repo.fullName}@${branch}:${String(seq)}:${salt}${message}`)
   await db.githubCommit.create({
     data: {
       tenant,

--- a/integ/server/github/contents.ts
+++ b/integ/server/github/contents.ts
@@ -140,6 +140,10 @@ export async function recordCommit(
       treeSha: tree,
       authorJson,
       committerJson,
+      // A /contents write moves its ref the moment it lands, so its commit is
+      // attached history from birth; only a plumbing commit (tree present)
+      // parks and waits for a ref update to claim it.
+      attached: tree === '',
       seq,
     },
   })

--- a/integ/server/github/contents.ts
+++ b/integ/server/github/contents.ts
@@ -85,7 +85,7 @@ function dirJson(files: Tree, at: string): JsonValue[] | null {
   return [...entries.keys()].sort().map((k) => entries.get(k) as JsonValue)
 }
 
-async function nextCommitSeq(
+export async function nextCommitSeq(
   db: Client,
   tenant: string,
   repo: string,

--- a/integ/server/github/git.ts
+++ b/integ/server/github/git.ts
@@ -190,9 +190,14 @@ const createRef = withRepo(async (ctx, repo) => {
 // Moving a branch is what makes a staged tree visible, and it is also what
 // puts the commit on that branch's history: `POST /git/commits` parks the row
 // on the default branch (which is where the touched set is computed, and what
-// a golden that never moves a ref records), so a ref pointed anywhere else has
-// to take the row with it. A move, not a copy, because a row belongs to one
-// branch's history and a dangling commit was never on the default branch's.
+// a golden that never moves a ref records), so the first ref pointed at it
+// takes the row along, because a dangling commit was never on the default
+// branch's history. Once a ref has attached it, a further ref copies it
+// instead: a git commit is reachable from many refs and stays on each
+// history. Pointing a branch below its own head is a forced update, refused
+// as the vendor refuses it unless the body says `force`, and the discarded
+// commits leave the branch (deliberate divergence: their rows are deleted, so
+// a discarded sha stops resolving, where the vendor keeps dangling commits).
 const updateRef = withRepo(async (ctx, repo) => {
   const ref = param(ctx, 'ref').replace(/^\/+|\/+$/g, '')
   const name = ref.startsWith('heads/') ? ref.slice('heads/'.length) : ''
@@ -200,14 +205,25 @@ const updateRef = withRepo(async (ctx, repo) => {
   if (name === '' || !names.includes(name)) return fail(422, 'Reference does not exist')
   const body = jsonBodyOf(ctx)
   const sha = str(body, 'sha')
-  const commit = await ctx.db.githubCommit.findFirst({
-    where: { tenant: ctx.tenant, repo: repo.fullName, sha },
-  })
+  // The row already on this branch wins when copies exist, so a same-branch
+  // update reasons about its own history rather than another ref's copy.
+  const commit =
+    (await ctx.db.githubCommit.findFirst({
+      where: { tenant: ctx.tenant, repo: repo.fullName, sha, branch: name },
+    })) ??
+    (await ctx.db.githubCommit.findFirst({
+      where: { tenant: ctx.tenant, repo: repo.fullName, sha },
+    }))
   if (commit === null || commit.treeSha === '') {
     return fail(422, 'Invalid request.\n\n"sha" is invalid.')
   }
   const staged = await stagedTree(ctx.db, ctx.tenant, repo, commit.treeSha)
   if (staged === null) return fail(422, 'Invalid request.\n\n"sha" is invalid.')
+  // Refused before anything is written, so a refused update changes nothing.
+  const head = (await commitList(ctx.db, ctx.tenant, repo, name))[0]?.sha ?? ''
+  if (commit.branch === name && sha !== head && body.force !== true) {
+    return fail(422, 'Update is not a fast forward')
+  }
   await ctx.db.githubFile.deleteMany({
     where: { tenant: ctx.tenant, repo: repo.fullName, branch: name },
   })
@@ -216,7 +232,41 @@ const updateRef = withRepo(async (ctx, repo) => {
   }
   if (commit.branch !== name) {
     const seq = await nextCommitSeq(ctx.db, ctx.tenant, repo.fullName, name)
-    await ctx.db.githubCommit.update({ where: { pk: commit.pk }, data: { branch: name, seq } })
+    if (commit.attached) {
+      // Already on some branch's history by a ref's choice, so this ref gets
+      // a copy: a git commit is reachable from many refs at once.
+      await ctx.db.githubCommit.create({
+        data: {
+          tenant: ctx.tenant,
+          repo: repo.fullName,
+          branch: name,
+          sha: commit.sha,
+          message: commit.message,
+          authorLogin: commit.authorLogin,
+          date: commit.date,
+          filesJson: commit.filesJson,
+          treeSha: commit.treeSha,
+          authorJson: commit.authorJson,
+          committerJson: commit.committerJson,
+          attached: true,
+          seq,
+        },
+      })
+    } else {
+      await ctx.db.githubCommit.update({
+        where: { pk: commit.pk },
+        data: { branch: name, seq, attached: true },
+      })
+    }
+  } else {
+    if (sha !== head) {
+      await ctx.db.githubCommit.deleteMany({
+        where: { tenant: ctx.tenant, repo: repo.fullName, branch: name, seq: { gt: commit.seq } },
+      })
+    }
+    if (!commit.attached) {
+      await ctx.db.githubCommit.update({ where: { pk: commit.pk }, data: { attached: true } })
+    }
   }
   return { status: 200, body: { ref: `refs/${ref}`, object: { sha, type: 'commit' } } }
 })

--- a/integ/server/github/git.ts
+++ b/integ/server/github/git.ts
@@ -16,10 +16,20 @@ import type { Ctx, JsonValue, KitRoute } from '../kit/typescript/index.ts'
 import { API_PREFIXES } from './config.ts'
 import type { C } from './config.ts'
 import { INVALID_PERSON, blobSha, bodyPerson, commitPeople, personJson, treeSha } from './wire.ts'
-import { addBranch, branchFor, branchNames, commitList, treeOfBranch } from './store.ts'
+import type { CommitRow } from './wire.ts'
+import {
+  addBranch,
+  branchFor,
+  branchNames,
+  commitList,
+  commitsBySha,
+  headOf,
+  reaches,
+  treeOfBranch,
+} from './store.ts'
 import type { RepoRow, Tree } from './store.ts'
 import { authedRoute, everywhere, fail, jsonBodyOf, param, route, str, withRepo } from './http.ts'
-import { nextCommitSeq, recordCommit, writeFile } from './contents.ts'
+import { recordCommit, writeFile } from './contents.ts'
 
 async function blobBySha(
   db: C,
@@ -111,6 +121,13 @@ const createTree = withRepo(async (ctx, repo) => {
 // The touched set is computed against the DEFAULT branch, which is what the
 // python fake did and what a golden records, even when the commit is later
 // pointed at another branch.
+//
+// The commit is born dangling: it advances no ref, because in git creating a
+// commit and moving a branch onto it are two steps, and a client that stages
+// several before touching any ref depends on that. `parents` is read from the
+// body as the API states it (first parent only, which is all a linear fake
+// needs); absent, the default branch's head stands in, which is the base the
+// touched set above is computed against.
 const createCommit = withRepo(async (ctx, repo) => {
   const body = jsonBodyOf(ctx)
   const tree = str(body, 'tree')
@@ -129,6 +146,9 @@ const createCommit = withRepo(async (ctx, repo) => {
   if (author === INVALID_PERSON) return fail(422, 'Invalid request.\n\n"author" is invalid.')
   const committer = bodyPerson(body, 'committer')
   if (committer === INVALID_PERSON) return fail(422, 'Invalid request.\n\n"committer" is invalid.')
+  const parents = body.parents
+  const stated = Array.isArray(parents) && typeof parents[0] === 'string' ? parents[0] : null
+  const parent = stated ?? (await headOf(ctx.db, ctx.tenant, repo, repo.defaultBranch))
   const commit = await recordCommit(
     ctx.db,
     ctx.tenant,
@@ -138,6 +158,8 @@ const createCommit = withRepo(async (ctx, repo) => {
     repo.defaultBranch,
     tree,
     { author, committer },
+    parent,
+    false,
   )
   const people = commitPeople({
     authorJson: personJson(author),
@@ -149,9 +171,10 @@ const createCommit = withRepo(async (ctx, repo) => {
   }
 })
 
-// A branch starts as a copy of whatever the base sha resolves to, which is what
-// a branch is: another name for one commit and every file reachable from it.
-// Its own history starts there, so the two do not share future commits.
+// A branch starts as another name for whatever the base sha resolves to, which
+// is what a branch is: one pointer and every file reachable from it. It takes
+// the base's head, so the two SHARE the history behind that point and diverge
+// only in what each is pointed at next.
 const createRef = withRepo(async (ctx, repo) => {
   const body = jsonBodyOf(ctx)
   const ref = str(body, 'ref').replace(/^\/+|\/+$/g, '')
@@ -165,6 +188,13 @@ const createRef = withRepo(async (ctx, repo) => {
   // Recorded before the files are copied, because a branch off an empty
   // repository copies none and would otherwise not exist at all.
   await addBranch(ctx.db, ctx.tenant, repo.fullName, name)
+  const baseHead = await headOf(ctx.db, ctx.tenant, repo, base)
+  if (baseHead !== '') {
+    await ctx.db.githubBranch.updateMany({
+      where: { tenant: ctx.tenant, repo: repo.fullName, name },
+      data: { headSha: baseHead },
+    })
+  }
   const files = await treeOfBranch(ctx.db, ctx.tenant, repo, base)
   let seq = 0
   for (const [path, data] of files) {
@@ -187,17 +217,15 @@ const createRef = withRepo(async (ctx, repo) => {
   }
 })
 
-// Moving a branch is what makes a staged tree visible, and it is also what
-// puts the commit on that branch's history: `POST /git/commits` parks the row
-// on the default branch (which is where the touched set is computed, and what
-// a golden that never moves a ref records), so the first ref pointed at it
-// takes the row along, because a dangling commit was never on the default
-// branch's history. Once a ref has attached it, a further ref copies it
-// instead: a git commit is reachable from many refs and stays on each
-// history. Pointing a branch below its own head is a forced update, refused
-// as the vendor refuses it unless the body says `force`, and the discarded
-// commits leave the branch (deliberate divergence: their rows are deleted, so
-// a discarded sha stops resolving, where the vendor keeps dangling commits).
+// Moving a branch is a pointer write, which is all a ref has ever been. The
+// commits a branch has are the ones reachable from that pointer, so this
+// function neither owns nor rewrites any commit row: pointing a second ref at
+// one commit shares it, pointing a ref backwards abandons the commits above
+// (they stay resolvable by sha, dangling, exactly as the vendor keeps them),
+// and neither case needs a rule of its own. A move that would abandon
+// anything is refused unless the body says `force`, and the test is exact:
+// a fast forward is one where the branch's current head is still reachable by
+// walking first parents back from the requested commit.
 const updateRef = withRepo(async (ctx, repo) => {
   const ref = param(ctx, 'ref').replace(/^\/+|\/+$/g, '')
   const name = ref.startsWith('heads/') ? ref.slice('heads/'.length) : ''
@@ -205,151 +233,66 @@ const updateRef = withRepo(async (ctx, repo) => {
   if (name === '' || !names.includes(name)) return fail(422, 'Reference does not exist')
   const body = jsonBodyOf(ctx)
   const sha = str(body, 'sha')
-  // The row already on this branch wins when copies exist, so a same-branch
-  // update reasons about its own history rather than another ref's copy.
-  const commit =
-    (await ctx.db.githubCommit.findFirst({
-      where: { tenant: ctx.tenant, repo: repo.fullName, sha, branch: name },
-    })) ??
-    (await ctx.db.githubCommit.findFirst({
-      where: { tenant: ctx.tenant, repo: repo.fullName, sha },
-    }))
+  const commit = await ctx.db.githubCommit.findFirst({
+    where: { tenant: ctx.tenant, repo: repo.fullName, sha },
+  })
   if (commit === null || commit.treeSha === '') {
     return fail(422, 'Invalid request.\n\n"sha" is invalid.')
   }
   const staged = await stagedTree(ctx.db, ctx.tenant, repo, commit.treeSha)
   if (staged === null) return fail(422, 'Invalid request.\n\n"sha" is invalid.')
   // Refused before anything is written, so a refused update changes nothing.
-  // Only ATTACHED rows count as the ref's position: a parked commit was never
-  // where the ref pointed, so attaching one is always a fast forward, however
-  // many others are parked beside it. On the branch itself, a fast forward
-  // therefore means the attached head; for a commit held by another branch,
-  // creation order stands in for ancestry (a commit created later can never
-  // be an ancestor of an earlier one), so the branch's attached rows with a
-  // higher pk are exactly the commits a reset would discard. The proxy is
-  // conservative, not exact: the fake records no parent relationships
-  // (`POST /git/commits` ignores `parents`), so a divergent sibling created
-  // after everything on the branch reads as a fast forward and is appended,
-  // which is the permissive answer every cross-branch update gave before the
-  // guard existed. Exact ancestry would need the parent DAG the model does
-  // not keep.
-  const attachedHead = await ctx.db.githubCommit.findFirst({
-    where: { tenant: ctx.tenant, repo: repo.fullName, branch: name, attached: true },
-    orderBy: { seq: 'desc' },
-  })
-  const refHead = attachedHead?.sha ?? ''
-  const newer =
-    commit.branch === name
-      ? 0
-      : await ctx.db.githubCommit.count({
-          where: {
-            tenant: ctx.tenant,
-            repo: repo.fullName,
-            branch: name,
-            attached: true,
-            pk: { gt: commit.pk },
-          },
-        })
-  const fastForward = commit.branch === name ? !commit.attached || sha === refHead : newer === 0
-  if (!fastForward && body.force !== true) {
+  const head = await headOf(ctx.db, ctx.tenant, repo, name)
+  const byId = await commitsBySha(ctx.db, ctx.tenant, repo)
+  if (!reaches(sha, head, byId) && body.force !== true) {
     return fail(422, 'Update is not a fast forward')
   }
+  await ctx.db.githubBranch.updateMany({
+    where: { tenant: ctx.tenant, repo: repo.fullName, name },
+    data: { headSha: sha },
+  })
   await ctx.db.githubFile.deleteMany({
     where: { tenant: ctx.tenant, repo: repo.fullName, branch: name },
   })
   for (const [path, data] of staged) {
     await writeFile(ctx.db, ctx.tenant, repo, name, path, data)
   }
-  if (commit.branch !== name) {
-    if (newer > 0) {
-      await ctx.db.githubCommit.deleteMany({
-        where: {
-          tenant: ctx.tenant,
-          repo: repo.fullName,
-          branch: name,
-          attached: true,
-          pk: { gt: commit.pk },
-        },
-      })
-    }
-    const seq = await nextCommitSeq(ctx.db, ctx.tenant, repo.fullName, name)
-    if (commit.attached) {
-      // Already on some branch's history by a ref's choice, so this ref gets
-      // a copy: a git commit is reachable from many refs at once.
-      await ctx.db.githubCommit.create({
-        data: {
-          tenant: ctx.tenant,
-          repo: repo.fullName,
-          branch: name,
-          sha: commit.sha,
-          message: commit.message,
-          authorLogin: commit.authorLogin,
-          date: commit.date,
-          filesJson: commit.filesJson,
-          treeSha: commit.treeSha,
-          authorJson: commit.authorJson,
-          committerJson: commit.committerJson,
-          attached: true,
-          seq,
-        },
-      })
-    } else {
-      await ctx.db.githubCommit.update({
-        where: { pk: commit.pk },
-        data: { branch: name, seq, attached: true },
-      })
-    }
-  } else if (commit.attached) {
-    // A forced reset discards only what the ref owned: parked and seeded
-    // rows were never attached, so they survive for a ref that still wants
-    // them.
-    if (sha !== refHead) {
-      await ctx.db.githubCommit.deleteMany({
-        where: {
-          tenant: ctx.tenant,
-          repo: repo.fullName,
-          branch: name,
-          attached: true,
-          seq: { gt: commit.seq },
-        },
-      })
-    }
-  } else {
-    // Attaching a parked commit tops the branch, so the ref reports the
-    // commit it was just pointed at.
-    const seq = await nextCommitSeq(ctx.db, ctx.tenant, repo.fullName, name)
-    await ctx.db.githubCommit.update({
-      where: { pk: commit.pk },
-      data: { attached: true, seq },
-    })
-  }
   return { status: 200, body: { ref: `refs/${ref}`, object: { sha, type: 'commit' } } }
 })
 
-// Looked up in each branch's history rather than in the commit table, because
-// the root commit is synthesized from the tree and never stored: a caller
-// resolving a ref and then asking for that commit would 404 on the one commit
-// every repository has. Every branch, not just the default one, because a ref
-// update moves a commit's row onto the branch it named. A commit that named no
-// tree of its own points at the whole-tree sha, which is what a write through
-// /contents produces.
+// An object is resolved by sha, not by finding a branch that still lists it:
+// a commit created but not yet pointed at, and a commit a reset abandoned,
+// are both real objects the vendor still answers for. Only the synthesized
+// root has to be searched for, because it is derived from a branch's content
+// rather than stored, and a caller resolving a ref on a fresh repository asks
+// for exactly that one. A commit that named no tree of its own points at the
+// whole-tree sha, which is what a write through /contents produces.
 const gitCommit = withRepo(async (ctx, repo) => {
   const sha = param(ctx, 'sha')
-  for (const branch of await branchNames(ctx.db, ctx.tenant, repo)) {
-    const history = await commitList(ctx.db, ctx.tenant, repo, branch)
-    const row = history.find((c) => c.sha === sha)
-    if (row === undefined) continue
-    return {
-      status: 200,
-      body: {
-        sha,
-        message: row.message,
-        tree: { sha: row.treeSha === '' ? treeSha('') : row.treeSha },
-        ...(commitPeople(row) ?? {}),
-      },
+  const stored = (await ctx.db.githubCommit.findFirst({
+    where: { tenant: ctx.tenant, repo: repo.fullName, sha },
+  })) as CommitRow | null
+  let row = stored
+  if (row === null) {
+    for (const branch of await branchNames(ctx.db, ctx.tenant, repo)) {
+      const history = await commitList(ctx.db, ctx.tenant, repo, branch)
+      const hit = history.find((c) => c.sha === sha)
+      if (hit !== undefined) {
+        row = hit
+        break
+      }
     }
   }
-  return fail(404, 'Not Found')
+  if (row === null) return fail(404, 'Not Found')
+  return {
+    status: 200,
+    body: {
+      sha,
+      message: row.message,
+      tree: { sha: row.treeSha === '' ? treeSha('') : row.treeSha },
+      ...(commitPeople(row) ?? {}),
+    },
+  }
 })
 
 async function headSha(ctx: Ctx<C>, repo: RepoRow, branch: string): Promise<string> {

--- a/integ/server/github/git.ts
+++ b/integ/server/github/git.ts
@@ -220,8 +220,19 @@ const updateRef = withRepo(async (ctx, repo) => {
   const staged = await stagedTree(ctx.db, ctx.tenant, repo, commit.treeSha)
   if (staged === null) return fail(422, 'Invalid request.\n\n"sha" is invalid.')
   // Refused before anything is written, so a refused update changes nothing.
+  // On the branch itself, a fast forward means the head; for a commit held by
+  // another branch, creation order stands in for ancestry (a commit created
+  // later can never be an ancestor of an earlier one), so the branch's rows
+  // with a higher pk are exactly the commits a reset would discard.
   const head = (await commitList(ctx.db, ctx.tenant, repo, name))[0]?.sha ?? ''
-  if (commit.branch === name && sha !== head && body.force !== true) {
+  const newer =
+    commit.branch === name
+      ? 0
+      : await ctx.db.githubCommit.count({
+          where: { tenant: ctx.tenant, repo: repo.fullName, branch: name, pk: { gt: commit.pk } },
+        })
+  const fastForward = commit.branch === name ? sha === head : newer === 0
+  if (!fastForward && body.force !== true) {
     return fail(422, 'Update is not a fast forward')
   }
   await ctx.db.githubFile.deleteMany({
@@ -231,6 +242,11 @@ const updateRef = withRepo(async (ctx, repo) => {
     await writeFile(ctx.db, ctx.tenant, repo, name, path, data)
   }
   if (commit.branch !== name) {
+    if (newer > 0) {
+      await ctx.db.githubCommit.deleteMany({
+        where: { tenant: ctx.tenant, repo: repo.fullName, branch: name, pk: { gt: commit.pk } },
+      })
+    }
     const seq = await nextCommitSeq(ctx.db, ctx.tenant, repo.fullName, name)
     if (commit.attached) {
       // Already on some branch's history by a ref's choice, so this ref gets

--- a/integ/server/github/git.ts
+++ b/integ/server/github/git.ts
@@ -26,6 +26,7 @@ import {
   headOf,
   reaches,
   treeOfBranch,
+  visibleHeadOf,
 } from './store.ts'
 import type { RepoRow, Tree } from './store.ts'
 import { authedRoute, everywhere, fail, jsonBodyOf, param, route, str, withRepo } from './http.ts'
@@ -146,9 +147,16 @@ const createCommit = withRepo(async (ctx, repo) => {
   if (author === INVALID_PERSON) return fail(422, 'Invalid request.\n\n"author" is invalid.')
   const committer = bodyPerson(body, 'committer')
   if (committer === INVALID_PERSON) return fail(422, 'Invalid request.\n\n"committer" is invalid.')
+  // A present `parents` is the caller's answer even when it is empty: `[]` is
+  // how the API spells a root commit, and re-parenting one onto the branch
+  // head would change both its sha and its ancestry. Only an ABSENT field
+  // falls back to where the default branch currently points.
   const parents = body.parents
-  const stated = Array.isArray(parents) && typeof parents[0] === 'string' ? parents[0] : null
-  const parent = stated ?? (await headOf(ctx.db, ctx.tenant, repo, repo.defaultBranch))
+  const parent = Array.isArray(parents)
+    ? typeof parents[0] === 'string'
+      ? parents[0]
+      : ''
+    : await visibleHeadOf(ctx.db, ctx.tenant, repo, repo.defaultBranch)
   const commit = await recordCommit(
     ctx.db,
     ctx.tenant,
@@ -264,7 +272,7 @@ const updateRef = withRepo(async (ctx, repo) => {
   const staged = await stagedTree(ctx.db, ctx.tenant, repo, commit.treeSha)
   if (staged === null) return fail(422, 'Invalid request.\n\n"sha" is invalid.')
   // Refused before anything is written, so a refused update changes nothing.
-  const head = await headOf(ctx.db, ctx.tenant, repo, name)
+  const head = await visibleHeadOf(ctx.db, ctx.tenant, repo, name)
   const byId = await commitsBySha(ctx.db, ctx.tenant, repo)
   if (!reaches(sha, head, byId) && body.force !== true) {
     return fail(422, 'Update is not a fast forward')

--- a/integ/server/github/git.ts
+++ b/integ/server/github/git.ts
@@ -25,10 +25,12 @@ import {
   commitsBySha,
   headOf,
   reaches,
+  stageTree,
+  stagedTree,
   treeOfBranch,
   visibleHeadOf,
 } from './store.ts'
-import type { RepoRow, Tree } from './store.ts'
+import type { RepoRow } from './store.ts'
 import { authedRoute, everywhere, fail, jsonBodyOf, param, route, str, withRepo } from './http.ts'
 import { recordCommit, writeFile } from './contents.ts'
 
@@ -43,25 +45,6 @@ async function blobBySha(
     for (const data of files.values()) if (blobSha(data) === sha) return data
   }
   return null
-}
-
-// Scoped to the repository, not just the tenant. A staged sha is unique per
-// tenant, so a bare lookup accepted a tree staged in repository A while the
-// caller was operating on repository B, and committing it copied A's files
-// into B. The fake this replaces held `repo.trees` per repository, so a foreign
-// sha was simply not found there.
-async function stagedTree(db: C, tenant: string, repo: RepoRow, sha: string): Promise<Tree | null> {
-  const tree = await db.githubStagedTree.findFirst({
-    where: { tenant, repo: repo.fullName, sha },
-  })
-  if (tree === null) return null
-  const rows = await db.githubStagedEntry.findMany({
-    where: { tenant, treeSha: sha },
-    orderBy: { seq: 'asc' },
-  })
-  const out: Tree = new Map()
-  for (const r of rows) out.set(r.path, Buffer.from(r.data))
-  return out
 }
 
 // Build a tree from a base plus the caller's entries. A null sha is git's
@@ -102,21 +85,10 @@ const createTree = withRepo(async (ctx, repo) => {
       files.set(path, blob)
     }
   }
-  const count = await ctx.db.githubStagedTree.count({
-    where: { tenant: ctx.tenant, repo: repo.fullName },
-  })
-  const sha = treeSha(`${repo.fullName}:${String(count)}`)
-  await ctx.db.githubStagedTree.create({
-    data: { tenant: ctx.tenant, repo: repo.fullName, sha, seq: count },
-  })
-  let seq = 0
-  for (const [path, data] of files) {
-    await ctx.db.githubStagedEntry.create({
-      data: { tenant: ctx.tenant, treeSha: sha, path, data: new Uint8Array(data), seq },
-    })
-    seq += 1
+  return {
+    status: 201,
+    body: { sha: await stageTree(ctx.db, ctx.tenant, repo, files), tree: [] },
   }
-  return { status: 201, body: { sha, tree: [] } }
 })
 
 // The touched set is computed against the DEFAULT branch, which is what the
@@ -205,15 +177,16 @@ const createRef = withRepo(async (ctx, repo) => {
       : ((await ctx.db.githubCommit.findFirst({
           where: { tenant: ctx.tenant, repo: repo.fullName, sha: asked },
         })) as CommitRow | null)
-  // A plumbing commit carries its own tree, so the branch is populated from it.
-  // A /contents commit does not (its bytes are the branch's file rows), so it
-  // falls back to the branch that holds it, which is where those rows are.
-  const staged =
-    object === null || object.treeSha === ''
-      ? null
-      : await stagedTree(ctx.db, ctx.tenant, repo, object.treeSha)
-  const base = staged !== null ? null : await branchFor(ctx.db, ctx.tenant, repo, asked)
-  if (staged === null && base === null) return fail(422, 'Object does not exist')
+  // A commit carries its own tree, so the branch is populated from the commit
+  // that was named rather than from a branch that happens to hold it. Those are
+  // different answers whenever that branch has moved on since, and reading the
+  // branch reported the newer files under the older sha.
+  const staged = object === null ? null : await stagedTree(ctx.db, ctx.tenant, repo, object.treeSha)
+  if (object !== null && staged === null) return fail(422, 'Object does not exist')
+  // Only a sha no commit row answers for is resolved as a ref, which is how a
+  // branch name, HEAD, the empty string and the synthesized root all arrive.
+  const base = object !== null ? null : await branchFor(ctx.db, ctx.tenant, repo, asked)
+  if (object === null && base === null) return fail(422, 'Object does not exist')
   // Recorded before the files are copied, because a branch off an empty
   // repository copies none and would otherwise not exist at all.
   await addBranch(ctx.db, ctx.tenant, repo.fullName, name)
@@ -266,9 +239,10 @@ const updateRef = withRepo(async (ctx, repo) => {
   const commit = await ctx.db.githubCommit.findFirst({
     where: { tenant: ctx.tenant, repo: repo.fullName, sha },
   })
-  if (commit === null || commit.treeSha === '') {
-    return fail(422, 'Invalid request.\n\n"sha" is invalid.')
-  }
+  if (commit === null) return fail(422, 'Invalid request.\n\n"sha" is invalid.')
+  // Every commit records a tree, so the ref is restored to the snapshot the
+  // named commit took. A commit written through /contents used to record none,
+  // and was refused here as though it were not a commit at all.
   const staged = await stagedTree(ctx.db, ctx.tenant, repo, commit.treeSha)
   if (staged === null) return fail(422, 'Invalid request.\n\n"sha" is invalid.')
   // Refused before anything is written, so a refused update changes nothing.
@@ -295,8 +269,8 @@ const updateRef = withRepo(async (ctx, repo) => {
 // are both real objects the vendor still answers for. Only the synthesized
 // root has to be searched for, because it is derived from a branch's content
 // rather than stored, and a caller resolving a ref on a fresh repository asks
-// for exactly that one. A commit that named no tree of its own points at the
-// whole-tree sha, which is what a write through /contents produces.
+// for exactly that one. It is also the only row that names no tree, which is
+// why the whole-tree sha still stands in for one here.
 const gitCommit = withRepo(async (ctx, repo) => {
   const sha = param(ctx, 'sha')
   const stored = (await ctx.db.githubCommit.findFirst({

--- a/integ/server/github/git.ts
+++ b/integ/server/github/git.ts
@@ -171,10 +171,17 @@ const createCommit = withRepo(async (ctx, repo) => {
   }
 })
 
-// A branch starts as another name for whatever the base sha resolves to, which
-// is what a branch is: one pointer and every file reachable from it. It takes
-// the base's head, so the two SHARE the history behind that point and diverge
-// only in what each is pointed at next.
+// A branch starts as another name for whatever the base resolves to, which is
+// what a branch is: one pointer and every file reachable from it. It takes
+// that point as its head, so it SHARES the history behind it and diverges only
+// in what each ref is pointed at next.
+//
+// The base is resolved as a COMMIT OBJECT first and only then as a ref,
+// because those are two different questions and only the second one needs a
+// branch to already contain the commit. A client that commits and then creates
+// the branch at that sha is naming an object no ref has reached yet, and
+// asking which existing branch holds it answers "none" for a commit that is
+// perfectly real.
 const createRef = withRepo(async (ctx, repo) => {
   const body = jsonBodyOf(ctx)
   const ref = str(body, 'ref').replace(/^\/+|\/+$/g, '')
@@ -183,19 +190,34 @@ const createRef = withRepo(async (ctx, repo) => {
   if (name === '') return fail(422, 'Invalid request.\n\n"ref" is invalid.')
   const names = await branchNames(ctx.db, ctx.tenant, repo)
   if (names.includes(name)) return fail(422, 'Reference already exists')
-  const base = await branchFor(ctx.db, ctx.tenant, repo, str(body, 'sha'))
-  if (base === null) return fail(422, 'Object does not exist')
+  const asked = str(body, 'sha')
+  const object =
+    asked === ''
+      ? null
+      : ((await ctx.db.githubCommit.findFirst({
+          where: { tenant: ctx.tenant, repo: repo.fullName, sha: asked },
+        })) as CommitRow | null)
+  // A plumbing commit carries its own tree, so the branch is populated from it.
+  // A /contents commit does not (its bytes are the branch's file rows), so it
+  // falls back to the branch that holds it, which is where those rows are.
+  const staged =
+    object === null || object.treeSha === ''
+      ? null
+      : await stagedTree(ctx.db, ctx.tenant, repo, object.treeSha)
+  const base = staged !== null ? null : await branchFor(ctx.db, ctx.tenant, repo, asked)
+  if (staged === null && base === null) return fail(422, 'Object does not exist')
   // Recorded before the files are copied, because a branch off an empty
   // repository copies none and would otherwise not exist at all.
   await addBranch(ctx.db, ctx.tenant, repo.fullName, name)
-  const baseHead = await headOf(ctx.db, ctx.tenant, repo, base)
-  if (baseHead !== '') {
+  const startAt =
+    object !== null ? object.sha : base === null ? '' : await headOf(ctx.db, ctx.tenant, repo, base)
+  if (startAt !== '') {
     await ctx.db.githubBranch.updateMany({
       where: { tenant: ctx.tenant, repo: repo.fullName, name },
-      data: { headSha: baseHead },
+      data: { headSha: startAt },
     })
   }
-  const files = await treeOfBranch(ctx.db, ctx.tenant, repo, base)
+  const files = staged ?? (await treeOfBranch(ctx.db, ctx.tenant, repo, base ?? repo.defaultBranch))
   let seq = 0
   for (const [path, data] of files) {
     await ctx.db.githubFile.create({

--- a/integ/server/github/git.ts
+++ b/integ/server/github/git.ts
@@ -19,7 +19,7 @@ import { INVALID_PERSON, blobSha, bodyPerson, commitPeople, personJson, treeSha 
 import { addBranch, branchFor, branchNames, commitList, treeOfBranch } from './store.ts'
 import type { RepoRow, Tree } from './store.ts'
 import { authedRoute, everywhere, fail, jsonBodyOf, param, route, str, withRepo } from './http.ts'
-import { recordCommit, writeFile } from './contents.ts'
+import { nextCommitSeq, recordCommit, writeFile } from './contents.ts'
 
 async function blobBySha(
   db: C,
@@ -187,7 +187,12 @@ const createRef = withRepo(async (ctx, repo) => {
   }
 })
 
-// Moving a branch is what makes a staged tree visible.
+// Moving a branch is what makes a staged tree visible, and it is also what
+// puts the commit on that branch's history: `POST /git/commits` parks the row
+// on the default branch (which is where the touched set is computed, and what
+// a golden that never moves a ref records), so a ref pointed anywhere else has
+// to take the row with it. A move, not a copy, because a row belongs to one
+// branch's history and a dangling commit was never on the default branch's.
 const updateRef = withRepo(async (ctx, repo) => {
   const ref = param(ctx, 'ref').replace(/^\/+|\/+$/g, '')
   const name = ref.startsWith('heads/') ? ref.slice('heads/'.length) : ''
@@ -209,28 +214,37 @@ const updateRef = withRepo(async (ctx, repo) => {
   for (const [path, data] of staged) {
     await writeFile(ctx.db, ctx.tenant, repo, name, path, data)
   }
+  if (commit.branch !== name) {
+    const seq = await nextCommitSeq(ctx.db, ctx.tenant, repo.fullName, name)
+    await ctx.db.githubCommit.update({ where: { pk: commit.pk }, data: { branch: name, seq } })
+  }
   return { status: 200, body: { ref: `refs/${ref}`, object: { sha, type: 'commit' } } }
 })
 
-// Looked up in the default branch's history rather than in the commit table,
-// because the root commit is synthesized from the tree and never stored: a
-// caller resolving a ref and then asking for that commit would 404 on the one
-// commit every repository has. A commit that named no tree of its own points
-// at the whole-tree sha, which is what a write through /contents produces.
+// Looked up in each branch's history rather than in the commit table, because
+// the root commit is synthesized from the tree and never stored: a caller
+// resolving a ref and then asking for that commit would 404 on the one commit
+// every repository has. Every branch, not just the default one, because a ref
+// update moves a commit's row onto the branch it named. A commit that named no
+// tree of its own points at the whole-tree sha, which is what a write through
+// /contents produces.
 const gitCommit = withRepo(async (ctx, repo) => {
   const sha = param(ctx, 'sha')
-  const history = await commitList(ctx.db, ctx.tenant, repo, repo.defaultBranch)
-  const row = history.find((c) => c.sha === sha)
-  if (row === undefined) return fail(404, 'Not Found')
-  return {
-    status: 200,
-    body: {
-      sha,
-      message: row.message,
-      tree: { sha: row.treeSha === '' ? treeSha('') : row.treeSha },
-      ...(commitPeople(row) ?? {}),
-    },
+  for (const branch of await branchNames(ctx.db, ctx.tenant, repo)) {
+    const history = await commitList(ctx.db, ctx.tenant, repo, branch)
+    const row = history.find((c) => c.sha === sha)
+    if (row === undefined) continue
+    return {
+      status: 200,
+      body: {
+        sha,
+        message: row.message,
+        tree: { sha: row.treeSha === '' ? treeSha('') : row.treeSha },
+        ...(commitPeople(row) ?? {}),
+      },
+    }
   }
+  return fail(404, 'Not Found')
 })
 
 async function headSha(ctx: Ctx<C>, repo: RepoRow, branch: string): Promise<string> {

--- a/integ/server/github/git.ts
+++ b/integ/server/github/git.ts
@@ -220,18 +220,37 @@ const updateRef = withRepo(async (ctx, repo) => {
   const staged = await stagedTree(ctx.db, ctx.tenant, repo, commit.treeSha)
   if (staged === null) return fail(422, 'Invalid request.\n\n"sha" is invalid.')
   // Refused before anything is written, so a refused update changes nothing.
-  // On the branch itself, a fast forward means the head; for a commit held by
-  // another branch, creation order stands in for ancestry (a commit created
-  // later can never be an ancestor of an earlier one), so the branch's rows
-  // with a higher pk are exactly the commits a reset would discard.
-  const head = (await commitList(ctx.db, ctx.tenant, repo, name))[0]?.sha ?? ''
+  // Only ATTACHED rows count as the ref's position: a parked commit was never
+  // where the ref pointed, so attaching one is always a fast forward, however
+  // many others are parked beside it. On the branch itself, a fast forward
+  // therefore means the attached head; for a commit held by another branch,
+  // creation order stands in for ancestry (a commit created later can never
+  // be an ancestor of an earlier one), so the branch's attached rows with a
+  // higher pk are exactly the commits a reset would discard. The proxy is
+  // conservative, not exact: the fake records no parent relationships
+  // (`POST /git/commits` ignores `parents`), so a divergent sibling created
+  // after everything on the branch reads as a fast forward and is appended,
+  // which is the permissive answer every cross-branch update gave before the
+  // guard existed. Exact ancestry would need the parent DAG the model does
+  // not keep.
+  const attachedHead = await ctx.db.githubCommit.findFirst({
+    where: { tenant: ctx.tenant, repo: repo.fullName, branch: name, attached: true },
+    orderBy: { seq: 'desc' },
+  })
+  const refHead = attachedHead?.sha ?? ''
   const newer =
     commit.branch === name
       ? 0
       : await ctx.db.githubCommit.count({
-          where: { tenant: ctx.tenant, repo: repo.fullName, branch: name, pk: { gt: commit.pk } },
+          where: {
+            tenant: ctx.tenant,
+            repo: repo.fullName,
+            branch: name,
+            attached: true,
+            pk: { gt: commit.pk },
+          },
         })
-  const fastForward = commit.branch === name ? sha === head : newer === 0
+  const fastForward = commit.branch === name ? !commit.attached || sha === refHead : newer === 0
   if (!fastForward && body.force !== true) {
     return fail(422, 'Update is not a fast forward')
   }
@@ -244,7 +263,13 @@ const updateRef = withRepo(async (ctx, repo) => {
   if (commit.branch !== name) {
     if (newer > 0) {
       await ctx.db.githubCommit.deleteMany({
-        where: { tenant: ctx.tenant, repo: repo.fullName, branch: name, pk: { gt: commit.pk } },
+        where: {
+          tenant: ctx.tenant,
+          repo: repo.fullName,
+          branch: name,
+          attached: true,
+          pk: { gt: commit.pk },
+        },
       })
     }
     const seq = await nextCommitSeq(ctx.db, ctx.tenant, repo.fullName, name)
@@ -274,15 +299,29 @@ const updateRef = withRepo(async (ctx, repo) => {
         data: { branch: name, seq, attached: true },
       })
     }
-  } else {
-    if (sha !== head) {
+  } else if (commit.attached) {
+    // A forced reset discards only what the ref owned: parked and seeded
+    // rows were never attached, so they survive for a ref that still wants
+    // them.
+    if (sha !== refHead) {
       await ctx.db.githubCommit.deleteMany({
-        where: { tenant: ctx.tenant, repo: repo.fullName, branch: name, seq: { gt: commit.seq } },
+        where: {
+          tenant: ctx.tenant,
+          repo: repo.fullName,
+          branch: name,
+          attached: true,
+          seq: { gt: commit.seq },
+        },
       })
     }
-    if (!commit.attached) {
-      await ctx.db.githubCommit.update({ where: { pk: commit.pk }, data: { attached: true } })
-    }
+  } else {
+    // Attaching a parked commit tops the branch, so the ref reports the
+    // commit it was just pointed at.
+    const seq = await nextCommitSeq(ctx.db, ctx.tenant, repo.fullName, name)
+    await ctx.db.githubCommit.update({
+      where: { pk: commit.pk },
+      data: { attached: true, seq },
+    })
   }
   return { status: 200, body: { ref: `refs/${ref}`, object: { sha, type: 'commit' } } }
 })

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -472,6 +472,59 @@ async function main(): Promise<void> {
     const trunkRef2 = await get(`${at}/repos/${REPO}/git/ref/heads/${trunk}`)
     eq('and the ref reports the advance', field(field(trunkRef2, 'object'), 'sha'), shaTh)
 
+    // ---- a /contents write advanced its ref the moment it landed, so it is
+    // attached history: a backward PATCH past it is forced, and forcing
+    // discards it like any other commit the reset abandons.
+    const tF = await stage(at, 'tasks/fourteen.md', '# fourteen\n')
+    const fourteen = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add task fourteen',
+      tree: tF,
+    })
+    const shaF = String(field(fourteen.body, 'sha') ?? '')
+    await post(`${at}/repos/${REPO}/git/refs`, { ref: 'refs/heads/task-5', sha: '' })
+    await fetch(`${at}/repos/${REPO}/git/refs/heads/task-5`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaF }),
+    })
+    const put = await fetch(`${at}/repos/${REPO}/contents/tasks/fifteen.md`, {
+      method: 'PUT',
+      headers: HEADERS,
+      body: JSON.stringify({
+        message: 'Add fifteen via contents',
+        content: Buffer.from('# fifteen\n').toString('base64'),
+        branch: 'task-5',
+      }),
+    })
+    check('a contents write lands on the branch', put.status === 201, String(put.status))
+    const pastSoft = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-5`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaF }),
+    })
+    check(
+      'a backward PATCH past a contents commit is refused without force',
+      pastSoft.status === 422,
+      String(pastSoft.status),
+    )
+    const pastForced = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-5`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaF, force: true }),
+    })
+    check('and lands when forced', pastForced.status === 200, String(pastForced.status))
+    const pastRef = await get(`${at}/repos/${REPO}/git/ref/heads/task-5`)
+    eq('the ref reports the reset commit', field(field(pastRef, 'object'), 'sha'), shaF)
+    const pastList = await get(`${at}/repos/${REPO}/commits?sha=task-5`)
+    check(
+      'and the contents commit left the history',
+      Array.isArray(pastList) &&
+        !pastList.some(
+          (c) => String(field(field(c, 'commit'), 'message')) === 'Add fifteen via contents',
+        ),
+      'Add fifteen via contents',
+    )
+
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {
     fake.child.kill('SIGTERM')

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -430,6 +430,48 @@ async function main(): Promise<void> {
       String(field((Array.isArray(donorList) ? donorList[0] : null) ?? null, 'sha')),
     )
 
+    // ---- a client may prepare several commits before touching any ref, and
+    // attaching one of the parked ones is a fast forward: the others were
+    // never the ref's position, so they must not make the update forced.
+    const repoInfo = await get(`${at}/repos/${REPO}`)
+    const trunk = String(field(repoInfo, 'default_branch'))
+    const tw = await stage(at, 'tasks/twelve.md', '# twelve\n')
+    const twelve = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add task twelve',
+      tree: tw,
+    })
+    const shaTw = String(field(twelve.body, 'sha') ?? '')
+    const th = await stage(at, 'tasks/thirteen.md', '# thirteen\n')
+    const thirteen = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add task thirteen',
+      tree: th,
+    })
+    const shaTh = String(field(thirteen.body, 'sha') ?? '')
+    const parked1 = await fetch(`${at}/repos/${REPO}/git/refs/heads/${trunk}`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaTw }),
+    })
+    check(
+      'attaching a parked commit needs no force with another parked above',
+      parked1.status === 200,
+      String(parked1.status),
+    )
+    const trunkRef1 = await get(`${at}/repos/${REPO}/git/ref/heads/${trunk}`)
+    eq('and the ref reports it', field(field(trunkRef1, 'object'), 'sha'), shaTw)
+    const parked2 = await fetch(`${at}/repos/${REPO}/git/refs/heads/${trunk}`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaTh }),
+    })
+    check(
+      'attaching the second parked commit advances',
+      parked2.status === 200,
+      String(parked2.status),
+    )
+    const trunkRef2 = await get(`${at}/repos/${REPO}/git/ref/heads/${trunk}`)
+    eq('and the ref reports the advance', field(field(trunkRef2, 'object'), 'sha'), shaTh)
+
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {
     fake.child.kill('SIGTERM')

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -353,6 +353,83 @@ async function main(): Promise<void> {
       sha8,
     )
 
+    // ---- two commits telling the same tree and message apart only by their
+    // author are two commits, even when a move freed the first one's sequence.
+    const t9 = await stage(at, 'tasks/nine.md', '# nine\n')
+    const nineA = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add task nine',
+      tree: t9,
+      author: AUTHOR,
+    })
+    const sha9a = String(field(nineA.body, 'sha') ?? '')
+    await post(`${at}/repos/${REPO}/git/refs`, { ref: 'refs/heads/task-3', sha: '' })
+    await fetch(`${at}/repos/${REPO}/git/refs/heads/task-3`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: sha9a }),
+    })
+    const nineB = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add task nine',
+      tree: t9,
+      author: { name: 'Sam Iyer', email: 'sam@example.com', date: '2025-09-06T10:00:00+08:00' },
+    })
+    check(
+      'a same-tree same-message commit by another author gets its own sha',
+      String(field(nineB.body, 'sha')) !== sha9a,
+      sha9a,
+    )
+
+    // ---- a reset is a reset even when the requested commit's row lives on
+    // another branch: it is older than the branch's commits, so the update is
+    // not a fast forward, and forcing it discards the newer commits without
+    // taking anything from the branch that holds the requested one.
+    const tK = await stage(at, 'tasks/ten.md', '# ten\n')
+    const ten = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add task ten',
+      tree: tK,
+    })
+    const shaK = String(field(ten.body, 'sha') ?? '')
+    await post(`${at}/repos/${REPO}/git/refs`, { ref: 'refs/heads/task-4', sha: '' })
+    await fetch(`${at}/repos/${REPO}/git/refs/heads/task-4`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaK }),
+    })
+    const crossSoft = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-4`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: sha6 }),
+    })
+    check(
+      'a cross-branch backward update without force is refused',
+      crossSoft.status === 422,
+      String(crossSoft.status),
+    )
+    const crossForced = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-4`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: sha6, force: true }),
+    })
+    check('and lands when forced', crossForced.status === 200, String(crossForced.status))
+    const crossRef = await get(`${at}/repos/${REPO}/git/ref/heads/task-4`)
+    eq(
+      'the head is the requested commit after the reset',
+      field(field(crossRef, 'object'), 'sha'),
+      sha6,
+    )
+    const crossList = await get(`${at}/repos/${REPO}/commits?sha=task-4`)
+    check(
+      'the newer commit left the reset branch',
+      Array.isArray(crossList) && !crossList.some((c) => String(field(c, 'sha')) === shaK),
+      shaK,
+    )
+    const donorList = await get(`${at}/repos/${REPO}/commits?sha=task-1`)
+    check(
+      'and the branch holding the commit keeps it',
+      Array.isArray(donorList) && String(field(donorList[0] ?? null, 'sha')) === sha6,
+      String(field((Array.isArray(donorList) ? donorList[0] : null) ?? null, 'sha')),
+    )
+
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {
     fake.child.kill('SIGTERM')

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -782,6 +782,78 @@ async function main(): Promise<void> {
       String(forcedOver.status),
     )
 
+    // ---- a commit created with `parents: []` IS a root, so a branch standing
+    // on it stands on nothing further. The synthesized root is the floor for a
+    // chain that never reaches one of its own, not a parent stapled under
+    // every history.
+    const rootedList = await get(`${at}/repos/${REPO}/commits?sha=${trunk}`)
+    check(
+      'a stored root commit is the end of its branch history',
+      Array.isArray(rootedList) &&
+        rootedList.length === 1 &&
+        String(field(rootedList[0] ?? null, 'sha')) === shaRootish,
+      String(Array.isArray(rootedList) ? rootedList.length : -1),
+    )
+
+    // ---- a commit written through /contents is an object like any other, so
+    // a ref can be pointed at it. It reached the branch by advancing the ref,
+    // which is the one thing that used to make it unnameable: it carried no
+    // staged tree, and the ref endpoint read a missing tree as a missing
+    // commit.
+    await post(`${at}/repos/${REPO}/git/refs`, { ref: 'refs/heads/task-8', sha: '' })
+    const c1 = await fetch(`${at}/repos/${REPO}/contents/tasks/first.md`, {
+      method: 'PUT',
+      headers: HEADERS,
+      body: JSON.stringify({
+        message: 'Add the first file',
+        content: Buffer.from('# first\n').toString('base64'),
+        branch: 'task-8',
+      }),
+    })
+    const shaC1 = String(field(field((await c1.json()) as JsonValue, 'commit'), 'sha') ?? '')
+    check('a contents write records a commit', shaC1 !== '', shaC1)
+    const selfMove = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-8`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaC1 }),
+    })
+    check(
+      'a ref can be moved onto a contents commit',
+      selfMove.status === 200,
+      String(selfMove.status),
+    )
+
+    // ---- and that commit is a SNAPSHOT: a branch created at it carries the
+    // files it recorded, not whatever the branch it came from holds now.
+    const c2 = await fetch(`${at}/repos/${REPO}/contents/tasks/second.md`, {
+      method: 'PUT',
+      headers: HEADERS,
+      body: JSON.stringify({
+        message: 'Add the second file',
+        content: Buffer.from('# second\n').toString('base64'),
+        branch: 'task-8',
+      }),
+    })
+    check('the branch advances past it', c2.status === 201, String(c2.status))
+    const snap = await post(`${at}/repos/${REPO}/git/refs`, {
+      ref: 'refs/heads/task-8-snap',
+      sha: shaC1,
+    })
+    check('a ref can be created at the older one', snap.status === 201, String(snap.status))
+    eq('and reports it', field(field(snap.body, 'object'), 'sha'), shaC1)
+    const kept = await fetch(`${at}/repos/${REPO}/contents/tasks/first.md?ref=task-8-snap`, {
+      headers: HEADERS,
+    })
+    check(
+      'the snapshot carries what that commit recorded',
+      kept.status === 200,
+      String(kept.status),
+    )
+    const later = await fetch(`${at}/repos/${REPO}/contents/tasks/second.md?ref=task-8-snap`, {
+      headers: HEADERS,
+    })
+    check('and not what the branch gained afterwards', later.status === 404, String(later.status))
+
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {
     fake.child.kill('SIGTERM')

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -701,6 +701,87 @@ async function main(): Promise<void> {
     })
     check("and carries that commit's tree", bornFile.status === 200, String(bornFile.status))
 
+    // ---- a seeded branch carries files and no stored commit, and the ref
+    // endpoint answers for it with a synthesized root. That root is the ref's
+    // position, so it is what a first update is judged against: a commit that
+    // does not build on it would discard the seeded tree, which is a reset.
+    const reseed = await fetch(`${at}/reset`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ tenants: [TENANT], fixture: 'v1' }),
+    })
+    check('the fixture is seeded again', reseed.status === 200, String(reseed.status))
+    const seededRoot = String(
+      field(field(await get(`${at}/repos/${REPO}/git/ref/heads/${trunk}`), 'object'), 'sha'),
+    )
+    check('a seeded branch answers with a root commit', seededRoot !== '', seededRoot)
+
+    // A commit that states no parent at all is a root commit, which is what an
+    // empty `parents` means: it is not the absent field, and it must not be
+    // quietly re-parented onto the branch head.
+    const tR = await stage(at, 'tasks/rootish.md', '# rootish\n')
+    const rootish = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'A root commit',
+      tree: tR,
+      parents: [],
+    })
+    const shaRootish = String(field(rootish.body, 'sha') ?? '')
+    const implied = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'A root commit',
+      tree: tR,
+    })
+    check(
+      'an empty parents list is not the same commit as an absent one',
+      String(field(implied.body, 'sha')) !== shaRootish,
+      `${shaRootish} vs ${String(field(implied.body, 'sha'))}`,
+    )
+
+    const overwrite = await fetch(`${at}/repos/${REPO}/git/refs/heads/${trunk}`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaRootish }),
+    })
+    check(
+      'a commit that does not build on the seeded root is refused',
+      overwrite.status === 422,
+      String(overwrite.status),
+    )
+    const keptRef = await get(`${at}/repos/${REPO}/git/ref/heads/${trunk}`)
+    eq(
+      'and the branch still answers with its root',
+      field(field(keptRef, 'object'), 'sha'),
+      seededRoot,
+    )
+
+    // The same update, from a commit that DOES build on that root, is an
+    // ordinary advance: this is the flow every client takes on a fresh repo.
+    const onRoot = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Built on the seeded root',
+      tree: tR,
+      parents: [seededRoot],
+    })
+    const shaOnRoot = String(field(onRoot.body, 'sha') ?? '')
+    const advanced = await fetch(`${at}/repos/${REPO}/git/refs/heads/${trunk}`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaOnRoot }),
+    })
+    check(
+      'a commit built on the root advances unforced',
+      advanced.status === 200,
+      String(advanced.status),
+    )
+    const forcedOver = await fetch(`${at}/repos/${REPO}/git/refs/heads/${trunk}`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaRootish, force: true }),
+    })
+    check(
+      'and the refused one lands when forced',
+      forcedOver.status === 200,
+      String(forcedOver.status),
+    )
+
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {
     fake.child.kill('SIGTERM')

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -225,6 +225,60 @@ async function main(): Promise<void> {
       date: '2026-01-01T00:00:00Z',
     })
 
+    // ---- pointing a ref at a commit is what puts it on that branch's
+    // history: a client that builds history stages a tree, creates the
+    // commit, and PATCHes the ref, and the branch's commit list has to grow
+    // by exactly that commit. The move is a move, not a copy: a commit a ref
+    // took to a branch does not stay on the default branch's history.
+    const mainBefore = await get(`${at}/repos/${REPO}/commits`)
+    const mainCount = Array.isArray(mainBefore) ? mainBefore.length : 0
+    const made6 = await post(`${at}/repos/${REPO}/git/refs`, {
+      ref: 'refs/heads/task-1',
+      sha: '',
+    })
+    check('a branch is created', made6.status === 201, String(made6.status))
+    const branchBefore = await get(`${at}/repos/${REPO}/commits?sha=task-1`)
+    const branchCount = Array.isArray(branchBefore) ? branchBefore.length : 0
+    const t6 = await stage(at, 'tasks/six.md', '# six\n')
+    const six = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add task six',
+      tree: t6,
+      author: AUTHOR,
+    })
+    const sha6 = String(field(six.body, 'sha') ?? '')
+    const moved = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-1`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: sha6 }),
+    })
+    check('the ref moves', moved.status === 200, String(moved.status))
+    const branchAfter = await get(`${at}/repos/${REPO}/commits?sha=task-1`)
+    const rows = Array.isArray(branchAfter) ? branchAfter : []
+    check(
+      'the branch history grows by one',
+      rows.length === branchCount + 1,
+      `got ${String(rows.length)} want ${String(branchCount + 1)}`,
+    )
+    check('and its head is the commit the ref took', String(field(rows[0] ?? null, 'sha')) === sha6)
+    eq(
+      'with the message the commit stated',
+      field(field(rows[0] ?? null, 'commit'), 'message'),
+      'Add task six',
+    )
+    eq(
+      'and the author it stated',
+      field(field(field(rows[0] ?? null, 'commit'), 'author'), 'date'),
+      AUTHOR.date,
+    )
+    const mainAfter = await get(`${at}/repos/${REPO}/commits`)
+    check(
+      'the default branch does not keep it',
+      Array.isArray(mainAfter) && mainAfter.length === mainCount,
+      `got ${String(Array.isArray(mainAfter) ? mainAfter.length : -1)} want ${String(mainCount)}`,
+    )
+    const read6 = await get(`${at}/repos/${REPO}/git/commits/${sha6}`)
+    eq('GET /git/commits/:sha still answers after the move', field(read6, 'sha'), sha6)
+
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {
     fake.child.kill('SIGTERM')

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -279,6 +279,80 @@ async function main(): Promise<void> {
     const read6 = await get(`${at}/repos/${REPO}/git/commits/${sha6}`)
     eq('GET /git/commits/:sha still answers after the move', field(read6, 'sha'), sha6)
 
+    // ---- the moved commit freed its sequence on the default branch, so a
+    // later commit reusing that sequence AND the message must still get its
+    // own sha, or a ref update resolving the sha publishes the wrong tree.
+    const t7 = await stage(at, 'tasks/seven.md', '# seven\n')
+    const seven = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add task six',
+      tree: t7,
+    })
+    check(
+      'a same-message commit after the move gets its own sha',
+      String(field(seven.body, 'sha')) !== sha6,
+      sha6,
+    )
+
+    // ---- a second ref pointing at the same commit shares it: git commits
+    // are reachable from many refs, so attaching one to another branch copies
+    // it onto that history rather than stealing it from the first.
+    await post(`${at}/repos/${REPO}/git/refs`, { ref: 'refs/heads/task-2', sha: '' })
+    const shared = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-2`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: sha6 }),
+    })
+    check('a second ref takes the same commit', shared.status === 200, String(shared.status))
+    const firstList = await get(`${at}/repos/${REPO}/commits?sha=task-1`)
+    check(
+      'the first branch keeps it',
+      Array.isArray(firstList) && String(field(firstList[0] ?? null, 'sha')) === sha6,
+      String(field((Array.isArray(firstList) ? firstList[0] : null) ?? null, 'sha')),
+    )
+    const secondList = await get(`${at}/repos/${REPO}/commits?sha=task-2`)
+    check(
+      'and the second branch gains it',
+      Array.isArray(secondList) && String(field(secondList[0] ?? null, 'sha')) === sha6,
+      String(field((Array.isArray(secondList) ? secondList[0] : null) ?? null, 'sha')),
+    )
+
+    // ---- resetting a branch to an older commit is a forced update: refused
+    // without `force`, and with it the requested commit becomes the head and
+    // the discarded one leaves the branch's history.
+    const t8 = await stage(at, 'tasks/eight.md', '# eight\n')
+    const eight = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add task eight',
+      tree: t8,
+    })
+    const sha8 = String(field(eight.body, 'sha') ?? '')
+    await fetch(`${at}/repos/${REPO}/git/refs/heads/task-1`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: sha8 }),
+    })
+    const soft = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-1`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: sha6 }),
+    })
+    check('a backward update without force is refused', soft.status === 422, String(soft.status))
+    const heldRef = await get(`${at}/repos/${REPO}/git/ref/heads/task-1`)
+    eq('and the head is unchanged', field(field(heldRef, 'object'), 'sha'), sha8)
+    const forced = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-1`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: sha6, force: true }),
+    })
+    check('a forced backward update lands', forced.status === 200, String(forced.status))
+    const resetRef = await get(`${at}/repos/${REPO}/git/ref/heads/task-1`)
+    eq('the head is the requested commit', field(field(resetRef, 'object'), 'sha'), sha6)
+    const resetList = await get(`${at}/repos/${REPO}/commits?sha=task-1`)
+    check(
+      'and the discarded commit left the history',
+      Array.isArray(resetList) && !resetList.some((c) => String(field(c, 'sha')) === sha8),
+      sha8,
+    )
+
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {
     fake.child.kill('SIGTERM')

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -668,6 +668,39 @@ async function main(): Promise<void> {
     })
     check('and lands when forced', staleForced.status === 200, String(staleForced.status))
 
+    // ---- a branch can be created directly at a commit no ref names yet,
+    // which is the two-step a client takes when it builds a branch from
+    // scratch: commit, then point a new ref at it. The branch starts at that
+    // commit and carries its tree, rather than inheriting some other ref's.
+    const tN = await stage(at, 'tasks/newbranch.md', '# new branch\n')
+    const newborn = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Commit for a branch that does not exist yet',
+      tree: tN,
+    })
+    const shaN = String(field(newborn.body, 'sha') ?? '')
+    const atCommit = await post(`${at}/repos/${REPO}/git/refs`, {
+      ref: 'refs/heads/task-7',
+      sha: shaN,
+    })
+    check(
+      'a ref can be created at a dangling commit',
+      atCommit.status === 201,
+      String(atCommit.status),
+    )
+    eq('and the new ref reports that commit', field(field(atCommit.body, 'object'), 'sha'), shaN)
+    const bornRef = await get(`${at}/repos/${REPO}/git/ref/heads/task-7`)
+    eq('which survives a re-read', field(field(bornRef, 'object'), 'sha'), shaN)
+    const bornList = await get(`${at}/repos/${REPO}/commits?sha=task-7`)
+    check(
+      'the branch history starts at that commit',
+      Array.isArray(bornList) && String(field(bornList[0] ?? null, 'sha')) === shaN,
+      String(field((Array.isArray(bornList) ? bornList[0] : null) ?? null, 'sha')),
+    )
+    const bornFile = await fetch(`${at}/repos/${REPO}/contents/tasks/newbranch.md?ref=task-7`, {
+      headers: HEADERS,
+    })
+    check("and carries that commit's tree", bornFile.status === 200, String(bornFile.status))
+
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {
     fake.child.kill('SIGTERM')

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -147,7 +147,25 @@ async function main(): Promise<void> {
     eq('GET /git/commits/:sha reports the author', field(read, 'author'), AUTHOR)
     eq('and the committer', field(read, 'committer'), AUTHOR)
 
-    // ---- the list endpoint, which is what "most recent commits" reads
+    // ---- a commit exists before any ref names it, and until one does it is
+    // on no branch's history, which is what "dangling" means: readable by sha,
+    // absent from every list.
+    const beforeAttach = await get(`${at}/repos/${REPO}/commits`)
+    check(
+      'a commit no ref names is not on a branch',
+      Array.isArray(beforeAttach) && !beforeAttach.some((c) => String(field(c, 'sha')) === sha),
+      sha,
+    )
+
+    // ---- the list endpoint, which is what "most recent commits" reads, once
+    // the ref has been pointed at the commit
+    const trunk = String(field(await get(`${at}/repos/${REPO}`), 'default_branch'))
+    const attach = await fetch(`${at}/repos/${REPO}/git/refs/heads/${trunk}`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha }),
+    })
+    check('the default ref takes the commit', attach.status === 200, String(attach.status))
     const listed = await get(`${at}/repos/${REPO}/commits`)
     const top = Array.isArray(listed) ? (listed[0] ?? null) : null
     eq('the commit list carries the author', field(field(top, 'commit'), 'author'), AUTHOR)
@@ -323,13 +341,19 @@ async function main(): Promise<void> {
     const eight = await post(`${at}/repos/${REPO}/git/commits`, {
       message: 'Add task eight',
       tree: t8,
+      parents: [sha6],
     })
     const sha8 = String(field(eight.body, 'sha') ?? '')
-    await fetch(`${at}/repos/${REPO}/git/refs/heads/task-1`, {
+    const advance = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-1`, {
       method: 'PATCH',
       headers: HEADERS,
       body: JSON.stringify({ sha: sha8 }),
     })
+    check(
+      'a commit stating its parent advances the ref unforced',
+      advance.status === 200,
+      String(advance.status),
+    )
     const soft = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-1`, {
       method: 'PATCH',
       headers: HEADERS,
@@ -352,6 +376,10 @@ async function main(): Promise<void> {
       Array.isArray(resetList) && !resetList.some((c) => String(field(c, 'sha')) === sha8),
       sha8,
     )
+    // Abandoned, not destroyed: nothing points at it, and it still answers,
+    // which is what the vendor does with a dangling commit.
+    const dangling = await get(`${at}/repos/${REPO}/git/commits/${sha8}`)
+    eq('the abandoned commit is still readable by sha', field(dangling, 'sha'), sha8)
 
     // ---- two commits telling the same tree and message apart only by their
     // author are two commits, even when a move freed the first one's sequence.
@@ -430,21 +458,24 @@ async function main(): Promise<void> {
       String(field((Array.isArray(donorList) ? donorList[0] : null) ?? null, 'sha')),
     )
 
-    // ---- a client may prepare several commits before touching any ref, and
-    // attaching one of the parked ones is a fast forward: the others were
-    // never the ref's position, so they must not make the update forced.
-    const repoInfo = await get(`${at}/repos/${REPO}`)
-    const trunk = String(field(repoInfo, 'default_branch'))
+    // ---- a client may prepare several commits before touching any ref. Each
+    // states the one it builds on, so the two form a chain and attaching them
+    // in turn is an ordinary fast forward, however long the ref sat still.
+    const trunkHead = String(
+      field(field(await get(`${at}/repos/${REPO}/git/ref/heads/${trunk}`), 'object'), 'sha'),
+    )
     const tw = await stage(at, 'tasks/twelve.md', '# twelve\n')
     const twelve = await post(`${at}/repos/${REPO}/git/commits`, {
       message: 'Add task twelve',
       tree: tw,
+      parents: [trunkHead],
     })
     const shaTw = String(field(twelve.body, 'sha') ?? '')
     const th = await stage(at, 'tasks/thirteen.md', '# thirteen\n')
     const thirteen = await post(`${at}/repos/${REPO}/git/commits`, {
       message: 'Add task thirteen',
       tree: th,
+      parents: [shaTw],
     })
     const shaTh = String(field(thirteen.body, 'sha') ?? '')
     const parked1 = await fetch(`${at}/repos/${REPO}/git/refs/heads/${trunk}`, {
@@ -453,7 +484,7 @@ async function main(): Promise<void> {
       body: JSON.stringify({ sha: shaTw }),
     })
     check(
-      'attaching a parked commit needs no force with another parked above',
+      'attaching a prepared commit needs no force with another prepared above',
       parked1.status === 200,
       String(parked1.status),
     )
@@ -465,12 +496,44 @@ async function main(): Promise<void> {
       body: JSON.stringify({ sha: shaTh }),
     })
     check(
-      'attaching the second parked commit advances',
+      'attaching the second prepared commit advances',
       parked2.status === 200,
       String(parked2.status),
     )
     const trunkRef2 = await get(`${at}/repos/${REPO}/git/ref/heads/${trunk}`)
     eq('and the ref reports the advance', field(field(trunkRef2, 'object'), 'sha'), shaTh)
+    const wholeChain = await get(`${at}/repos/${REPO}/commits`)
+    check(
+      'the branch lists the whole chain it was walked onto',
+      Array.isArray(wholeChain) &&
+        wholeChain.some((c) => String(field(c, 'sha')) === shaTh) &&
+        wholeChain.some((c) => String(field(c, 'sha')) === shaTw),
+      String(Array.isArray(wholeChain) ? wholeChain.length : -1),
+    )
+
+    // ---- a commit that does NOT build on the head is a divergence, not an
+    // advance, so pointing the ref at it is forced even though it is the
+    // newest thing in the repository. This is the difference stated parents
+    // buy: order of creation is not ancestry.
+    const ts = await stage(at, 'tasks/sibling.md', '# sibling\n')
+    const sibling = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Add a sibling',
+      tree: ts,
+      parents: [shaTw],
+    })
+    const shaSib = String(field(sibling.body, 'sha') ?? '')
+    const diverge = await fetch(`${at}/repos/${REPO}/git/refs/heads/${trunk}`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaSib }),
+    })
+    check('a divergent sibling is refused unforced', diverge.status === 422, String(diverge.status))
+    const forcedSib = await fetch(`${at}/repos/${REPO}/git/refs/heads/${trunk}`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaSib, force: true }),
+    })
+    check('and lands when forced', forcedSib.status === 200, String(forcedSib.status))
 
     // ---- a /contents write advanced its ref the moment it landed, so it is
     // attached history: a backward PATCH past it is forced, and forcing
@@ -524,6 +587,86 @@ async function main(): Promise<void> {
         ),
       'Add fifteen via contents',
     )
+
+    // ---- a /contents write after a forced reset cannot reproduce the sha of
+    // the commit the reset abandoned: the address covers the bytes, so the
+    // same message on the same parent with different content is a different
+    // commit.
+    await post(`${at}/repos/${REPO}/git/refs`, { ref: 'refs/heads/task-6', sha: '' })
+    const base6 = String(
+      field(field(await get(`${at}/repos/${REPO}/git/ref/heads/task-6`), 'object'), 'sha'),
+    )
+    const w1 = await fetch(`${at}/repos/${REPO}/contents/tasks/reused.md`, {
+      method: 'PUT',
+      headers: HEADERS,
+      body: JSON.stringify({
+        message: 'One message',
+        content: Buffer.from('first\n').toString('base64'),
+        branch: 'task-6',
+      }),
+    })
+    const firstSha = String(field(field(await w1.json(), 'commit'), 'sha'))
+    if (base6 !== '') {
+      await fetch(`${at}/repos/${REPO}/git/refs/heads/task-6`, {
+        method: 'PATCH',
+        headers: HEADERS,
+        body: JSON.stringify({ sha: base6, force: true }),
+      })
+    }
+    const w2 = await fetch(`${at}/repos/${REPO}/contents/tasks/reused.md`, {
+      method: 'PUT',
+      headers: HEADERS,
+      body: JSON.stringify({
+        message: 'One message',
+        content: Buffer.from('second, different bytes\n').toString('base64'),
+        branch: 'task-6',
+      }),
+    })
+    const secondSha = String(field(field(await w2.json(), 'commit'), 'sha'))
+    check(
+      'a contents commit after a reset cannot reuse an abandoned sha',
+      firstSha !== secondSha && secondSha !== '',
+      `${firstSha} vs ${secondSha}`,
+    )
+
+    // ---- a commit prepared before the branch moved on is stale: the ref has
+    // advanced through /contents since, so pointing back at it is a reset and
+    // needs force, whatever order the two were created in.
+    const tStale = await stage(at, 'tasks/stale.md', '# stale\n')
+    const staleHead = String(
+      field(field(await get(`${at}/repos/${REPO}/git/ref/heads/task-6`), 'object'), 'sha'),
+    )
+    const stale = await post(`${at}/repos/${REPO}/git/commits`, {
+      message: 'Prepared before the write',
+      tree: tStale,
+      parents: [staleHead],
+    })
+    const shaStale = String(field(stale.body, 'sha') ?? '')
+    await fetch(`${at}/repos/${REPO}/contents/tasks/after.md`, {
+      method: 'PUT',
+      headers: HEADERS,
+      body: JSON.stringify({
+        message: 'Written after the commit was prepared',
+        content: Buffer.from('after\n').toString('base64'),
+        branch: 'task-6',
+      }),
+    })
+    const staleSoft = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-6`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaStale }),
+    })
+    check(
+      'a stale prepared commit is refused once a contents write moved the ref',
+      staleSoft.status === 422,
+      String(staleSoft.status),
+    )
+    const staleForced = await fetch(`${at}/repos/${REPO}/git/refs/heads/task-6`, {
+      method: 'PATCH',
+      headers: HEADERS,
+      body: JSON.stringify({ sha: shaStale, force: true }),
+    })
+    check('and lands when forced', staleForced.status === 200, String(staleForced.status))
 
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {

--- a/integ/server/github/store.ts
+++ b/integ/server/github/store.ts
@@ -182,10 +182,67 @@ export async function treeOf(
   return branch === null ? null : await treeOfBranch(db, tenant, repo, branch)
 }
 
-// One branch's commits, newest first, with a synthetic root derived from the
-// branch's CONTENT rather than the repository's name, so that a mirror of a
-// repository has the same root sha as its source. Two branches differ here
-// exactly when their trees differ.
+// Every commit in one repository, keyed by sha, for walking a chain without a
+// query per hop.
+export async function commitsBySha(
+  db: C,
+  tenant: string,
+  repo: RepoRow,
+): Promise<Map<string, CommitRow>> {
+  const rows = (await db.githubCommit.findMany({
+    where: { ...scope(tenant), repo: repo.fullName },
+    orderBy: { seq: 'asc' },
+  })) as CommitRow[]
+  const out = new Map<string, CommitRow>()
+  for (const row of rows) out.set(row.sha, row)
+  return out
+}
+
+// Walk first parents from a sha, newest first. Bounded by the map's size
+// because a chain cannot visit a commit twice: `seen` is what stops a cycle,
+// which a hand-built parent can always describe.
+export function chainFrom(head: string, byId: Map<string, CommitRow>): CommitRow[] {
+  const out: CommitRow[] = []
+  const seen = new Set<string>()
+  let at = head
+  while (at !== '' && !seen.has(at)) {
+    seen.add(at)
+    const row = byId.get(at)
+    if (row === undefined) break
+    out.push(row)
+    at = row.parentSha
+  }
+  return out
+}
+
+// Whether `ancestor` is reachable from `head` by first parents, which is the
+// exact question a fast-forward asks. The empty sha is every commit's
+// ancestor, since that is where a chain ends.
+export function reaches(head: string, ancestor: string, byId: Map<string, CommitRow>): boolean {
+  if (ancestor === '') return true
+  if (head === ancestor) return true
+  return chainFrom(head, byId).some((c) => c.sha === ancestor)
+}
+
+export async function headOf(
+  db: C,
+  tenant: string,
+  repo: RepoRow,
+  branch: string,
+): Promise<string> {
+  const row = await db.githubBranch.findFirst({
+    where: { ...scope(tenant), repo: repo.fullName, name: branch },
+  })
+  return row?.headSha ?? ''
+}
+
+// One branch's commits, newest first: the chain its ref points at, then a
+// synthetic root derived from the branch's CONTENT rather than the
+// repository's name, so that a mirror of a repository has the same root sha as
+// its source. Two branches differ in that root exactly when their trees
+// differ. The chain is walked rather than filtered by a column, so a commit
+// two refs share is on both lists and a commit a reset abandoned is on
+// neither, without either case being written down anywhere.
 export async function commitList(
   db: C,
   tenant: string,
@@ -194,11 +251,9 @@ export async function commitList(
 ): Promise<CommitRow[]> {
   const tree = await treeOfBranch(db, tenant, repo, branch)
   const pairs: Array<[string, string]> = [...tree.entries()].map(([p, d]) => [p, blobSha(d)])
-  const written = (await db.githubCommit.findMany({
-    where: { ...scope(tenant), repo: repo.fullName, branch },
-    orderBy: { seq: 'asc' },
-  })) as CommitRow[]
-  return [...[...written].reverse(), rootCommit(pairs)]
+  const head = await headOf(db, tenant, repo, branch)
+  const walked = head === '' ? [] : chainFrom(head, await commitsBySha(db, tenant, repo))
+  return [...walked, rootCommit(pairs)]
 }
 
 export function directoriesOf(files: Tree): Set<string> {

--- a/integ/server/github/store.ts
+++ b/integ/server/github/store.ts
@@ -145,6 +145,70 @@ export async function treeOfBranch(
   return out
 }
 
+// A tree's bytes, as `path:blob` pairs in path order. This is the tree's whole
+// identity, so it is what both the sha and any equality test are derived from.
+export function treeFingerprint(files: Tree): string {
+  return [...files.entries()]
+    .map(([p, d]): [string, string] => [p, blobSha(d)])
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([p, b]) => `${p}:${b}`)
+    .join('\0')
+}
+
+// Scoped to the repository, not just the tenant. A staged sha is unique per
+// tenant, so a bare lookup accepted a tree staged in repository A while the
+// caller was operating on repository B, and committing it copied A's files
+// into B. The fake this replaces held `repo.trees` per repository, so a foreign
+// sha was simply not found there.
+export async function stagedTree(
+  db: C,
+  tenant: string,
+  repo: RepoRow,
+  sha: string,
+): Promise<Tree | null> {
+  const tree = await db.githubStagedTree.findFirst({
+    where: { tenant, repo: repo.fullName, sha },
+  })
+  if (tree === null) return null
+  const rows = await db.githubStagedEntry.findMany({
+    where: { tenant, treeSha: sha },
+    orderBy: { seq: 'asc' },
+  })
+  const out: Tree = new Map()
+  for (const r of rows) out.set(r.path, Buffer.from(r.data))
+  return out
+}
+
+// Store one tree and answer its sha. The sha is the CONTENT's, the way git's
+// is, so staging the same bytes twice is one object rather than two, and no id
+// can be reproduced by a later tree landing in a slot a delete freed. The
+// repository name is in the hash because the table's uniqueness is per tenant
+// while every reader scopes by repository: without it two repositories holding
+// the same file would collide on insert, and the second would be handed the
+// first's rows.
+export async function stageTree(
+  db: C,
+  tenant: string,
+  repo: RepoRow,
+  files: Tree,
+): Promise<string> {
+  const sha = treeSha(`${repo.fullName}\0${treeFingerprint(files)}`)
+  const already = await db.githubStagedTree.findFirst({
+    where: { tenant, repo: repo.fullName, sha },
+  })
+  if (already !== null) return sha
+  const count = await db.githubStagedTree.count({ where: { tenant, repo: repo.fullName } })
+  await db.githubStagedTree.create({ data: { tenant, repo: repo.fullName, sha, seq: count } })
+  let seq = 0
+  for (const [path, data] of files) {
+    await db.githubStagedEntry.create({
+      data: { tenant, treeSha: sha, path, data: new Uint8Array(data), seq },
+    })
+    seq += 1
+  }
+  return sha
+}
+
 // A ref is a branch name, HEAD, the empty string, or a commit sha belonging to
 // one branch's history. A fully qualified spelling names the same branch: tool
 // schemas advertise `refs/heads/main` and the live API accepts it on every
@@ -263,23 +327,31 @@ export async function headOf(
   return row?.headSha ?? ''
 }
 
-// One branch's commits, newest first: the chain its ref points at, then a
-// synthetic root derived from the branch's CONTENT rather than the
+// One branch's commits, newest first: the chain its ref points at, and under
+// it a synthetic root derived from the branch's CONTENT rather than the
 // repository's name, so that a mirror of a repository has the same root sha as
 // its source. Two branches differ in that root exactly when their trees
 // differ. The chain is walked rather than filtered by a column, so a commit
 // two refs share is on both lists and a commit a reset abandoned is on
 // neither, without either case being written down anywhere.
+//
+// That synthetic root is the floor for a chain that does not reach one of its
+// own, not a parent stapled under every history. A chain ENDING at a stored
+// commit with no parent already has its root, and appending a second one would
+// report a fabricated ancestor beneath a commit the caller created with
+// `parents: []` precisely to say it has none.
 export async function commitList(
   db: C,
   tenant: string,
   repo: RepoRow,
   branch: string,
 ): Promise<CommitRow[]> {
-  const tree = await treeOfBranch(db, tenant, repo, branch)
-  const pairs: Array<[string, string]> = [...tree.entries()].map(([p, d]) => [p, blobSha(d)])
   const head = await headOf(db, tenant, repo, branch)
   const walked = head === '' ? [] : chainFrom(head, await commitsBySha(db, tenant, repo))
+  const last = walked[walked.length - 1]
+  if (last !== undefined && last.parentSha === '') return walked
+  const tree = await treeOfBranch(db, tenant, repo, branch)
+  const pairs: Array<[string, string]> = [...tree.entries()].map(([p, d]) => [p, blobSha(d)])
   return [...walked, rootCommit(pairs)]
 }
 

--- a/integ/server/github/store.ts
+++ b/integ/server/github/store.ts
@@ -220,8 +220,35 @@ export function chainFrom(head: string, byId: Map<string, CommitRow>): CommitRow
 // ancestor, since that is where a chain ends.
 export function reaches(head: string, ancestor: string, byId: Map<string, CommitRow>): boolean {
   if (ancestor === '') return true
-  if (head === ancestor) return true
-  return chainFrom(head, byId).some((c) => c.sha === ancestor)
+  // Walked as POINTERS rather than as rows, because the sha being looked for
+  // may be one no row carries: a synthesized root is derived from a branch's
+  // content and stored nowhere, yet it is what the ref endpoint answers with
+  // and therefore what a commit on a seeded branch states as its parent.
+  const seen = new Set<string>()
+  let at = head
+  while (at !== '' && !seen.has(at)) {
+    if (at === ancestor) return true
+    seen.add(at)
+    at = byId.get(at)?.parentSha ?? ''
+  }
+  return false
+}
+
+// Where a ref answers it points, which is the stored head once anything has
+// been committed and the synthesized root before that. A seeded branch carries
+// files and no commit row, so its root is the only position it has, and both
+// the fast-forward test and a new commit's default parent have to use it or
+// they are reasoning about a ref the API never described.
+export async function visibleHeadOf(
+  db: C,
+  tenant: string,
+  repo: RepoRow,
+  branch: string,
+): Promise<string> {
+  const stored = await headOf(db, tenant, repo, branch)
+  if (stored !== '') return stored
+  const tree = await treeOfBranch(db, tenant, repo, branch)
+  return rootCommit([...tree.entries()].map(([p, d]): [string, string] => [p, blobSha(d)])).sha
 }
 
 export async function headOf(

--- a/integ/server/github/wire.ts
+++ b/integ/server/github/wire.ts
@@ -126,6 +126,7 @@ export function commitFiles(paths: string[], status = 'added'): JsonValue {
 
 export interface CommitRow {
   sha: string
+  parentSha: string
   message: string
   authorLogin: string
   date: string
@@ -175,6 +176,7 @@ export function rootCommit(tree: Array<[string, string]>): CommitRow {
   const sorted = [...tree].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
   return {
     sha: commitSha(`root\0${sorted.map(([p, b]) => `${p}:${b}`).join('\0')}`),
+    parentSha: '',
     message: 'Initial commit',
     authorLogin: 'mirage',
     date: ROOT_COMMIT_DATE,


### PR DESCRIPTION
PATCH /git/refs/heads/<b> rewrote the branch's files from the staged tree but never attached the commit to the branch, so a client that built history through POST /git/trees + POST /git/commits + PATCH /git/refs saw the branch's commit list stay at the synthetic root ("Initial commit", 1970-01-01) while the files changed.

- updateRef now moves the GithubCommit row onto the branch the ref names, at the branch's next seq. POST /git/commits still parks the row on the default branch at creation (the touched set is computed there and a selftest check reads /commits right after create), so the ref update takes it along: a move, not a copy, since a row is one branch's history entry.
- GET /git/commits/:sha searches every branch's history instead of only the default branch, so a moved commit still resolves.
- nextCommitSeq is exported from contents.ts for the ref path.
- selftest grows 18 to 26 checks covering the full plumbing flow: branch history grows by one with the stated sha/message/author date, the default branch does not keep the commit, and the commit stays readable after the move.