### PR TITLE
Answer hf_fs errors the way the live server answers them

### DIFF
--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -45,6 +45,7 @@ import { hfHubFake } from './fake.ts'
 import { hfHubRoutes } from './routes.ts'
 import {
   FS_INVALID,
+  FS_BUDGET,
   FS_IMAGE_ONLY,
   FS_IMAGE_TOO_LARGE,
   FS_NOT_A_FILE,
@@ -371,14 +372,55 @@ function entriesOf(reply: Reply): FsEntry[] {
   }))
 }
 
+/**
+ * A repository tree, WHOLE.
+ *
+ * The REST arm answers one page and puts the cursor in a `Link` header, the
+ * way the Hub's own API does. Reading only the first page made this fake
+ * quietly disagree with itself on any repository over DEFAULT_LIMIT files:
+ * `ls` showed a prefix and said nothing about the rest, `find` missed
+ * matches, and `stat` reported a file that exists as `missing` because the
+ * recursive tree it searched stopped before reaching it.
+ *
+ * Followed here rather than at each call site because every caller wants the
+ * same thing -- the tree -- and only one of them was even aware there were
+ * pages.
+ *
+ * There is no page cap. One was written, at 200, and it was the same bug a
+ * size larger: a repository past it would have been truncated in silence,
+ * which is the failure this function exists to end rather than to raise the
+ * threshold of. What a cap was reaching for is termination, and termination
+ * is guaranteed by the cursor instead -- a page whose cursor has already
+ * been seen cannot advance, and is the only way a well-formed loop fails to
+ * end. That state means the REST arm on the other side of `callRoute` is
+ * broken, which is this repo's own bug and not a caller's, so it throws
+ * where it is discovered rather than returning a shorter tree that reads
+ * exactly like a complete one.
+ */
 async function treeAt(at: Dispatch, where: Located, recursive: boolean): Promise<Reply> {
   const suffix = where.path === '' ? '' : `/${where.path}`
-  return callRoute(
-    at,
-    'GET',
-    `/api/${where.kind}/${where.id}/tree/main${suffix}`,
-    recursive ? { recursive: 'true' } : {},
-  )
+  const path = `/api/${where.kind}/${where.id}/tree/main${suffix}`
+  const query: Record<string, string> = recursive ? { recursive: 'true' } : {}
+  const first = await callRoute(at, 'GET', path, query)
+  if (!ok(first) || !Array.isArray(first.body)) return first
+  const all = [...first.body]
+  const seen = new Set<string>()
+  let link = (first.headers ?? {}).Link
+  while (link !== undefined) {
+    const cursor = /[?&]cursor=([^&>]+)/.exec(link)?.[1]
+    if (cursor === undefined) break
+    if (seen.has(cursor)) {
+      throw new Error(
+        `mock hf mcp: ${path} handed back cursor ${cursor} twice; the tree route is not advancing`,
+      )
+    }
+    seen.add(cursor)
+    const next = await callRoute(at, 'GET', path, { ...query, cursor: decodeURIComponent(cursor) })
+    if (!ok(next) || !Array.isArray(next.body)) break
+    all.push(...next.body)
+    link = (next.headers ?? {}).Link
+  }
+  return { ...first, body: all, headers: { ...(first.headers ?? {}) } }
 }
 
 // One operation answers twice over: the markdown a reader sees, and the
@@ -562,6 +604,21 @@ function binaryName(path: string): boolean {
 // live server rather than assumed from the other.
 const ATTACH_MAX_BYTES = 8 * 1024 * 1024
 
+// And the same number again, as a budget shared by every attachment in ONE
+// call. The captured schema allows 30 operations, so without this a valid
+// request could ask for 30 x 8MiB and be answered with a quarter of a
+// gigabyte of base64. Upstream documents the cap at hf://README.md and
+// answers HF_FS_ATTACHMENT_BUDGET_EXCEEDED for each attachment it drops.
+//
+// Admission here is in the order the operations were written. Upstream's is
+// not: probed with four images it dropped the FIRST and returned the other
+// three, which is what "attachment admission is best-effort" means when the
+// fetches run in parallel and whichever lands first reserves. Its own advice
+// -- "Split attachments across separate calls when deterministic inclusion is
+// required" -- is an admission that the choice is not promised, so this fake
+// makes the deterministic choice rather than simulating a race.
+const ATTACH_BATCH_BYTES = 8 * 1024 * 1024
+
 // Upstream matches these case-insensitively and by extension alone: "bytes
 // are opaque, are never inspected or altered before MCP encoding".
 const IMAGE_MIME: Record<string, string> = {
@@ -610,7 +667,11 @@ function attachArgs(rest: string[]): number | Refusal {
   return bound
 }
 
-async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> {
+interface Budget {
+  left: number
+}
+
+async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget): Promise<FsOut> {
   if (cmd === 'search') {
     return fsFail(
       FS_INVALID,
@@ -750,6 +811,18 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
           `complete-file limit is ${String(bound)} bytes.`,
       )
     }
+    // Checked against what the BATCH has left, and checked here rather than
+    // after the loop so an over-budget image is released instead of retained:
+    // the cost this cap exists to prevent is the response, and the buffer is
+    // most of it.
+    if (whole.length > budget.left) {
+      return fsFail(
+        FS_BUDGET,
+        `Attachment omitted because the batch exceeds the cumulative response limit of ` +
+          `${String(ATTACH_BATCH_BYTES)} bytes.`,
+      )
+    }
+    budget.left -= whole.length
     return {
       text: attachMarkdown(uri, where.path, mime, whole.length),
       result: { op: 'attach', uri, path: where.path, mime_type: mime, bytes: whole.length },
@@ -851,8 +924,9 @@ async function fsAnswer(at: Dispatch, args: Record<string, JsonValue>): Promise<
   const texts: string[] = []
   const results: JsonValue[] = []
   const images: { mimeType: string; data: string }[] = []
+  const budget: Budget = { left: ATTACH_BATCH_BYTES }
   for (const [i, one] of ops.entries()) {
-    const out = await fsOne(at, String(one.cmd ?? ''), strList(one.args))
+    const out = await fsOne(at, String(one.cmd ?? ''), strList(one.args), budget)
     texts.push(out.text)
     if (out.image !== undefined) images.push(out.image)
     if (out.error === undefined) {

--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -59,6 +59,7 @@ import {
   attachMarkdown,
   fsRecovery,
   fsSuggested,
+  LIST_TRUNCATED,
   listingMarkdown,
   operationsMarkdown,
   searchMarkdown,
@@ -397,7 +398,12 @@ function entriesOf(reply: Reply): FsEntry[] {
  * where it is discovered rather than returning a shorter tree that reads
  * exactly like a complete one.
  */
-async function treeAt(at: Dispatch, where: Located, recursive: boolean): Promise<Reply> {
+async function treeAt(
+  at: Dispatch,
+  where: Located,
+  recursive: boolean,
+  cap = Number.POSITIVE_INFINITY,
+): Promise<Reply> {
   const suffix = where.path === '' ? '' : `/${where.path}`
   const path = `/api/${where.kind}/${where.id}/tree/main${suffix}`
   const query: Record<string, string> = recursive ? { recursive: 'true' } : {}
@@ -418,6 +424,11 @@ async function treeAt(at: Dispatch, where: Located, recursive: boolean): Promise
     const next = await callRoute(at, 'GET', path, { ...query, cursor: decodeURIComponent(cursor) })
     if (!ok(next) || !Array.isArray(next.body)) break
     all.push(...next.body)
+    // Stopped at the caller's ceiling rather than at every page there is.
+    // One row past it is enough to know the listing was cut, and it is what
+    // keeps an arbitrarily large repository from being aggregated whole in
+    // order to throw most of it away.
+    if (all.length > cap) break
     link = (next.headers ?? {}).Link
   }
   return { ...first, body: all, headers: { ...(first.headers ?? {}) } }
@@ -453,6 +464,38 @@ const CAT_MAX_BYTES = 80_000
 interface CatArgs {
   offset: number
   maxBytes: number
+}
+
+// `ls` and `find` are BOUNDED upstream too, and by a documented number
+// rather than by however much the tree turned out to hold: 1,000 entries by
+// default and 10,000 at most. Past it the listing stops and says so, which
+// is why the schema carries `truncated` and `truncation_reason` for these
+// commands as well as for cat.
+const LIST_DEFAULT_LIMIT = 1000
+const LIST_MAX_LIMIT = 10000
+
+function listArgs(cmd: string, rest: string[]): number | Refusal {
+  const bad = (message: string): Refusal => ({ code: FS_INVALID, message })
+  let limit = LIST_DEFAULT_LIMIT
+  for (let i = 0; i < rest.length; i += 2) {
+    const flag = rest[i] ?? ''
+    // The other flags this command advertises -- --recursive, --glob, --sort,
+    // --name, --path, --type -- are still refused by name below, because the
+    // fake has no filtering behind them and a silently ignored flag is worse
+    // than an honest EINVAL.
+    if (flag !== '--limit') return bad(`EINVAL: unexpected argument for ${cmd}: ${flag}`)
+    const raw = rest[i + 1]
+    if (raw === undefined) return bad(`EINVAL: ${flag} needs a value`)
+    if (!/^-?\d+$/.test(raw)) return bad(`EINVAL: ${flag} requires an integer`)
+    const value = Number(raw)
+    // "for this command", because upstream's other listings have their own
+    // ceilings -- search is 1,000 and documentation search 25.
+    if (value < 1 || value > LIST_MAX_LIMIT) {
+      return bad(`EINVAL: limit must be between 1 and ${String(LIST_MAX_LIMIT)} for this command`)
+    }
+    limit = value
+  }
+  return limit
 }
 
 function catArgs(rest: string[]): CatArgs | Refusal {
@@ -682,23 +725,44 @@ async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget):
   const where = locate(uri, cmd)
   if (!('kind' in where)) return fsFail(where.code, where.message)
   const rest = args.slice(1)
-  // Every other command here takes the URI alone. `cat` takes the two flags
-  // its own captured grammar advertises and `attach` the one, and each
-  // refuses the rest itself below.
-  if (cmd !== 'cat' && cmd !== 'attach' && rest.length > 0) {
+  // `stat` is the only command that takes the URI alone; cat, attach, ls and
+  // find each parse their own flags below and refuse the rest by name there.
+  // Listing the exceptions here was a standing trap -- attach and then ls
+  // were each given a flag and then refused it by a guard written when they
+  // had none -- so the condition names the one command that has no grammar
+  // rather than the growing set that does.
+  if (cmd === 'stat' && rest.length > 0) {
     return fsFail(FS_INVALID, `EINVAL: unexpected argument for ${cmd}: ${rest[0] ?? ''}`)
   }
+
   if (cmd === 'ls' || cmd === 'find') {
-    const reply = await treeAt(at, where, cmd === 'find')
+    const limit = listArgs(cmd, rest)
+    if (typeof limit !== 'number') return fsFail(limit.code, limit.message)
+    // One past the limit, so a listing that exactly fills it is not reported
+    // as cut and one that overflows is -- without reading the rest of a tree
+    // whose tail is going to be dropped anyway.
+    const reply = await treeAt(at, where, cmd === 'find', limit)
     if (!ok(reply)) {
       return fsFail(FS_NOT_FOUND, `${where.path} does not exist on "main". URI: ${uri}`)
     }
-    const entries = entriesOf(reply)
+    const found = entriesOf(reply)
+    const truncated = found.length > limit
+    const entries = truncated ? found.slice(0, limit) : found
     return {
-      text: listingMarkdown(cmd, uri, entries),
+      text: listingMarkdown(cmd, uri, entries, truncated),
       result: {
         uri,
         op: cmd,
+        // The schema's own three, and the same vocabulary cat uses -- with
+        // `entry_limit` where cat says `max_bytes`, because that is the enum
+        // value upstream answers for a listing.
+        ...(truncated
+          ? {
+              truncated: true,
+              truncation_reason: 'entry_limit',
+              truncation_message: LIST_TRUNCATED,
+            }
+          : {}),
         // A directory entry carries no `size`, which is the live server's own
         // shape rather than a zero: the schema makes size optional precisely
         // because a Hub directory has none.

--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -374,7 +374,7 @@ function entriesOf(reply: Reply): FsEntry[] {
 }
 
 /**
- * A repository tree, WHOLE.
+ * The pages of a repository tree, in order.
  *
  * The REST arm answers one page and puts the cursor in a `Link` header, the
  * way the Hub's own API does. Reading only the first page made this fake
@@ -384,19 +384,52 @@ function entriesOf(reply: Reply): FsEntry[] {
  * recursive tree it searched stopped before reaching it.
  *
  * Followed here rather than at each call site because every caller wants the
- * same thing -- the tree -- and only one of them was even aware there were
- * pages.
+ * cursor followed, and only one of them was even aware there were pages. A
+ * generator rather than a list because they do not all want the same amount
+ * of it: a caller after ONE row can stop on the page that holds it, where a
+ * function returning the tree would buy the whole repository to throw it away.
  *
- * There is no page cap. One was written, at 200, and it was the same bug a
- * size larger: a repository past it would have been truncated in silence,
- * which is the failure this function exists to end rather than to raise the
- * threshold of. What a cap was reaching for is termination, and termination
- * is guaranteed by the cursor instead -- a page whose cursor has already
- * been seen cannot advance, and is the only way a well-formed loop fails to
- * end. That state means the REST arm on the other side of `callRoute` is
- * broken, which is this repo's own bug and not a caller's, so it throws
- * where it is discovered rather than returning a shorter tree that reads
- * exactly like a complete one.
+ * Termination is the cursor's, not a page cap's. A cap was written, at 200,
+ * and it was the same bug a size larger: a repository past it would have been
+ * truncated in silence, which is the failure this loop exists to end rather
+ * than to raise the threshold of. A page whose cursor has already been seen
+ * cannot advance, and is the only way a well-formed loop fails to end; that
+ * state means the REST arm on the other side of `callRoute` is broken, which
+ * is this repo's own bug and not a caller's, so it throws where it is
+ * discovered rather than handing back a shorter tree that reads exactly like
+ * a complete one.
+ */
+async function* treePages(at: Dispatch, where: Located, recursive: boolean): AsyncGenerator<Reply> {
+  const suffix = where.path === '' ? '' : `/${where.path}`
+  const path = `/api/${where.kind}/${where.id}/tree/main${suffix}`
+  const query: Record<string, string> = recursive ? { recursive: 'true' } : {}
+  const seen = new Set<string>()
+  let page = await callRoute(at, 'GET', path, query)
+  for (;;) {
+    yield page
+    if (!ok(page) || !Array.isArray(page.body)) return
+    const link = (page.headers ?? {}).Link
+    if (link === undefined) return
+    const cursor = /[?&]cursor=([^&>]+)/.exec(link)?.[1]
+    if (cursor === undefined) return
+    if (seen.has(cursor)) {
+      throw new Error(
+        `mock hf mcp: ${path} handed back cursor ${cursor} twice; the tree route is not advancing`,
+      )
+    }
+    seen.add(cursor)
+    page = await callRoute(at, 'GET', path, { ...query, cursor: decodeURIComponent(cursor) })
+  }
+}
+
+/**
+ * A repository tree, up to `cap` rows.
+ *
+ * For the callers that want the rows in hand: `ls` and `find`, which print
+ * them, and the two existence tests, which want one page and read no further.
+ * `cap` is the listing's `--limit` -- paging stops one row past it, which is
+ * enough to report the listing as truncated without holding a tail that is
+ * only going to be dropped.
  */
 async function treeAt(
   at: Dispatch,
@@ -404,34 +437,20 @@ async function treeAt(
   recursive: boolean,
   cap = Number.POSITIVE_INFINITY,
 ): Promise<Reply> {
-  const suffix = where.path === '' ? '' : `/${where.path}`
-  const path = `/api/${where.kind}/${where.id}/tree/main${suffix}`
-  const query: Record<string, string> = recursive ? { recursive: 'true' } : {}
-  const first = await callRoute(at, 'GET', path, query)
-  if (!ok(first) || !Array.isArray(first.body)) return first
-  const all = [...first.body]
-  const seen = new Set<string>()
-  let link = (first.headers ?? {}).Link
-  while (link !== undefined) {
-    const cursor = /[?&]cursor=([^&>]+)/.exec(link)?.[1]
-    if (cursor === undefined) break
-    if (seen.has(cursor)) {
-      throw new Error(
-        `mock hf mcp: ${path} handed back cursor ${cursor} twice; the tree route is not advancing`,
-      )
-    }
-    seen.add(cursor)
-    const next = await callRoute(at, 'GET', path, { ...query, cursor: decodeURIComponent(cursor) })
-    if (!ok(next) || !Array.isArray(next.body)) break
-    all.push(...next.body)
-    // Stopped at the caller's ceiling rather than at every page there is.
-    // One row past it is enough to know the listing was cut, and it is what
-    // keeps an arbitrarily large repository from being aggregated whole in
-    // order to throw most of it away.
+  const all: JsonValue[] = []
+  let head: Reply | undefined
+  for await (const page of treePages(at, where, recursive)) {
+    head ??= page
+    if (!ok(page) || !Array.isArray(page.body)) break
+    all.push(...page.body)
     if (all.length > cap) break
-    link = (next.headers ?? {}).Link
   }
-  return { ...first, body: all, headers: { ...(first.headers ?? {}) } }
+  // `treePages` yields its first reply before testing anything, so `head` is
+  // always set by the time the loop ends.
+  if (head === undefined || !ok(head) || !Array.isArray(head.body)) {
+    return head ?? { status: 502, body: null }
+  }
+  return { ...head, body: all, headers: { ...(head.headers ?? {}) } }
 }
 
 // One operation answers twice over: the markdown a reader sees, and the
@@ -684,8 +703,37 @@ function imageMime(path: string): string | undefined {
 // are the test, and this is the only place that knows it.
 async function isDirectory(at: Dispatch, where: Located): Promise<boolean> {
   if (where.path === '') return false
-  const listed = await treeAt(at, where, false)
+  // One page: the question is whether there is a row, not what the rows are.
+  const listed = await treeAt(at, where, false, 1)
   return ok(listed) && entriesOf(listed).length > 0
+}
+
+/**
+ * The tree row for ONE path, or nothing where the repository has no entry.
+ *
+ * The PARENT directory is listed, not the repository. git names a path's type
+ * and size in the entry its own directory holds, so the parent is the smallest
+ * listing guaranteed to carry the answer, and paging stops on the page the row
+ * is on -- a hit costs one request far more often than it costs the directory.
+ *
+ * `stat` used to walk the whole recursive tree and then search it, which cost
+ * the entire repository to keep a single row; a batch of the 30 operations one
+ * call allows paid that thirty times over.
+ */
+async function rowAt(at: Dispatch, where: Located): Promise<FsEntry | undefined> {
+  const cut = where.path.lastIndexOf('/')
+  const parent = cut === -1 ? '' : where.path.slice(0, cut)
+  for await (const page of treePages(at, { ...where, path: parent }, false)) {
+    const hit = rows(page).find((one) => String(one.path ?? '') === where.path)
+    if (hit === undefined) continue
+    return {
+      type: String(hit.type ?? 'file') === 'directory' ? 'dir' : 'file',
+      path: where.path,
+      size: typeof hit.size === 'number' ? hit.size : 0,
+      lfs: hit.lfs !== undefined,
+    }
+  }
+  return undefined
 }
 
 function attachArgs(rest: string[]): number | Refusal {
@@ -790,7 +838,8 @@ async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget):
       // as opposed to private. This fake is always authenticated as the
       // tenant and does know, so it says so in stat's own vocabulary; that
       // divergence is the one place it prefers the truth it has.
-      const exists = ok(await treeAt(at, { ...where, path: '' }, false))
+      // One page: only the status is read, never the rows.
+      const exists = ok(await treeAt(at, { ...where, path: '' }, false, 1))
       return {
         text: statMarkdown(uri, exists ? 'repo' : 'missing', ''),
         result: exists
@@ -798,33 +847,28 @@ async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget):
           : { uri, op: 'stat', exists: false, type: 'missing', path: '' },
       }
     }
-    const all = entriesOfFull(await treeAt(at, { ...where, path: '' }, true))
-    const hit = all.find((one) => one.full === where.path)
-    if (hit !== undefined) {
+    // One row answers all three of the remaining outcomes: the parent's
+    // listing names the type, and for a file the size, which is every field
+    // stat prints. A row absent from the directory it would have to be in is
+    // what `missing` means -- read from the rows and not from the status,
+    // because the tree route answers 200 with nothing for a path that is not
+    // there, and `ok` alone called every missing file a directory.
+    const row = await rowAt(at, where)
+    if (row === undefined) {
       return {
-        text: statMarkdown(uri, 'file', where.path, hit.entry.size),
-        result: {
-          uri,
-          op: 'stat',
-          exists: true,
-          type: 'file',
-          path: where.path,
-          size: hit.entry.size,
-        },
+        text: statMarkdown(uri, 'missing', where.path),
+        result: { uri, op: 'stat', exists: false, type: 'missing', path: where.path },
       }
     }
-    // Rows, not merely a reply: the tree route answers 200 with nothing for a
-    // path that is not there, so `ok` alone reported every missing file as a
-    // directory that exists.
-    if (await isDirectory(at, where)) {
+    if (row.type === 'dir') {
       return {
         text: statMarkdown(uri, 'dir', where.path),
         result: { uri, op: 'stat', exists: true, type: 'dir', path: where.path },
       }
     }
     return {
-      text: statMarkdown(uri, 'missing', where.path),
-      result: { uri, op: 'stat', exists: false, type: 'missing', path: where.path },
+      text: statMarkdown(uri, 'file', where.path, row.size),
+      result: { uri, op: 'stat', exists: true, type: 'file', path: where.path, size: row.size },
     }
   }
   if (cmd === 'attach') {
@@ -962,25 +1006,6 @@ async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget):
     }
   }
   return fsFail(FS_INVALID, `EINVAL: unknown command: ${cmd}`)
-}
-
-// The recursive listing keeps the FULL path beside the leaf, which `stat`
-// needs and `ls` must not print.
-function entriesOfFull(reply: Reply): { full: string; entry: FsEntry }[] {
-  return rows(reply)
-    .filter((one) => String(one.type ?? '') !== 'directory')
-    .map((one) => ({
-      full: String(one.path ?? ''),
-      entry: {
-        type: 'file',
-        path:
-          String(one.path ?? '')
-            .split('/')
-            .pop() ?? '',
-        size: typeof one.size === 'number' ? one.size : 0,
-        lfs: one.lfs !== undefined,
-      },
-    }))
 }
 
 async function fsAnswer(at: Dispatch, args: Record<string, JsonValue>): Promise<Answer> {

--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -45,13 +45,17 @@ import { hfHubFake } from './fake.ts'
 import { hfHubRoutes } from './routes.ts'
 import {
   FS_INVALID,
+  FS_IMAGE_ONLY,
+  FS_IMAGE_TOO_LARGE,
   FS_NOT_A_FILE,
   FS_NOT_FOUND,
   FS_TEXT_ONLY,
+  FS_UNSUPPORTED_MEDIA,
   catMarkdown,
   type CatBounds,
   detailsMarkdown,
   fsError,
+  attachMarkdown,
   fsRecovery,
   fsSuggested,
   listingMarkdown,
@@ -166,6 +170,8 @@ const PLURAL: Record<string, string> = {
 interface Answer {
   text: string
   structured?: JsonValue
+  // `attach` returns the file itself, as MCP image blocks beside the prose.
+  images?: { mimeType: string; data: string }[]
   // MCP's own flag on the tool result, which the live server sets when EVERY
   // operation in the batch failed and omits the moment one succeeds. Omitted
   // rather than false, because that is what upstream sends and a client may
@@ -310,6 +316,15 @@ interface Refusal {
 // serve, and saying so is more use than pretending the name is invalid.
 const UPSTREAM_KINDS = ['models', 'datasets', 'spaces', 'buckets', 'collections', 'papers']
 
+// `docs` is a root too, and is NOT in the sentence above: `ls hf://docs`
+// answers with entries. That sentence describes what upstream says when it
+// rejects a TYPE; it is not the list of what the server addresses, and
+// reading it as one turned two working URIs into errors. `hf://README.md` is
+// the other -- a root-level page, where the live server documents its own
+// limits. Both are refused below as things this fake does not hold, which is
+// true, rather than as bad names, which is not.
+const UPSTREAM_ROOTS = [...UPSTREAM_KINDS, 'docs', 'README.md']
+
 function locate(uri: string, cmd: string): Located | Refusal {
   const bad = (message: string): Refusal => ({ code: FS_INVALID, message })
   if (!uri.startsWith('hf://')) return bad('EINVAL: URI must start with hf://')
@@ -319,7 +334,7 @@ function locate(uri: string, cmd: string): Located | Refusal {
     .filter((one) => one !== '')
   const kind = parts[0] ?? ''
   if (kind === '') return bad('EINVAL: Missing repository or bucket type in URI.')
-  if (!UPSTREAM_KINDS.includes(kind)) {
+  if (!UPSTREAM_ROOTS.includes(kind)) {
     return bad(`EINVAL: Invalid URI type '${kind}'. Must be one of ${UPSTREAM_KINDS.join(', ')}.`)
   }
   if (!KINDS.includes(kind)) {
@@ -372,6 +387,7 @@ async function treeAt(at: Dispatch, where: Located, recursive: boolean): Promise
 interface FsOut {
   text: string
   result?: Record<string, JsonValue>
+  image?: { mimeType: string; data: string }
   error?: { code: string; message: string }
 }
 
@@ -539,8 +555,63 @@ function binaryName(path: string): boolean {
   return BINARY_SUFFIX.some((suffix) => name.endsWith(suffix))
 }
 
+// `attach` returns a COMPLETE file and cannot truncate one, so its bound is a
+// refusal rather than a cut: 8MiB, which is upstream's documented default and
+// maximum both. Zero is invalid here, where `cat --max-bytes 0` means the
+// maximum -- the two commands genuinely differ, and each was read off the
+// live server rather than assumed from the other.
+const ATTACH_MAX_BYTES = 8 * 1024 * 1024
+
+// Upstream matches these case-insensitively and by extension alone: "bytes
+// are opaque, are never inspected or altered before MCP encoding".
+const IMAGE_MIME: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+}
+
+function imageMime(path: string): string | undefined {
+  const name = path.slice(path.lastIndexOf('/') + 1).toLowerCase()
+  const at = name.lastIndexOf('.')
+  return at === -1 ? undefined : IMAGE_MIME[name.slice(at)]
+}
+
+// Whether a path inside a repository is a DIRECTORY. Rows, not merely a
+// reply: the tree route answers 200 with nothing for a path that is not
+// there, so `ok` alone calls every miss a directory. A directory in git
+// always holds something -- an empty one cannot be committed -- so the rows
+// are the test, and this is the only place that knows it.
+async function isDirectory(at: Dispatch, where: Located): Promise<boolean> {
+  if (where.path === '') return false
+  const listed = await treeAt(at, where, false)
+  return ok(listed) && entriesOf(listed).length > 0
+}
+
+function attachArgs(rest: string[]): number | Refusal {
+  const bad = (message: string): Refusal => ({ code: FS_INVALID, message })
+  let bound = ATTACH_MAX_BYTES
+  for (let i = 0; i < rest.length; i += 2) {
+    const flag = rest[i] ?? ''
+    // Only one flag, where cat has two: `--offset` is meaningless for a file
+    // that arrives whole, and upstream refuses it by name.
+    if (flag !== '--max-bytes') {
+      return bad(`EINVAL: unexpected argument for attach: ${flag}`)
+    }
+    const raw = rest[i + 1]
+    if (raw === undefined) return bad(`EINVAL: ${flag} needs a value`)
+    if (!/^-?\d+$/.test(raw)) return bad(`EINVAL: ${flag} requires an integer`)
+    const value = Number(raw)
+    if (value < 1 || value > ATTACH_MAX_BYTES) {
+      return bad(`EINVAL: attach max_bytes must be between 1 and ${String(ATTACH_MAX_BYTES)}`)
+    }
+    bound = value
+  }
+  return bound
+}
+
 async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> {
-  if (cmd === 'attach' || cmd === 'search') {
+  if (cmd === 'search') {
     return fsFail(
       FS_INVALID,
       `EINVAL: ${cmd} is not served by the mirage hf_hub fake; use ls, cat, stat or find`,
@@ -551,8 +622,9 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
   if (!('kind' in where)) return fsFail(where.code, where.message)
   const rest = args.slice(1)
   // Every other command here takes the URI alone. `cat` takes the two flags
-  // its own captured grammar advertises, and refuses the rest below.
-  if (cmd !== 'cat' && rest.length > 0) {
+  // its own captured grammar advertises and `attach` the one, and each
+  // refuses the rest itself below.
+  if (cmd !== 'cat' && cmd !== 'attach' && rest.length > 0) {
     return fsFail(FS_INVALID, `EINVAL: unexpected argument for ${cmd}: ${rest[0] ?? ''}`)
   }
   if (cmd === 'ls' || cmd === 'find') {
@@ -583,9 +655,22 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
     // `repo` and not `dir` -- the distinction is the whole reason stat is
     // recommended for "an uncertain target type".
     if (where.path === '') {
+      // Looked up, not assumed. Returning `repo` without asking made every
+      // syntactically valid URI a repository that exists -- and on a task
+      // whose Hub starts EMPTY, an agent that stats the repository it is
+      // about to create would be told it is already there.
+      //
+      // Upstream answers HF_FS_ACCESS_DENIED here rather than `missing`,
+      // because anonymously it will not confirm that a repository is absent
+      // as opposed to private. This fake is always authenticated as the
+      // tenant and does know, so it says so in stat's own vocabulary; that
+      // divergence is the one place it prefers the truth it has.
+      const exists = ok(await treeAt(at, { ...where, path: '' }, false))
       return {
-        text: statMarkdown(uri, 'repo', ''),
-        result: { uri, op: 'stat', exists: true, type: 'repo', path: '' },
+        text: statMarkdown(uri, exists ? 'repo' : 'missing', ''),
+        result: exists
+          ? { uri, op: 'stat', exists: true, type: 'repo', path: '' }
+          : { uri, op: 'stat', exists: false, type: 'missing', path: '' },
       }
     }
     const all = entriesOfFull(await treeAt(at, { ...where, path: '' }, true))
@@ -606,8 +691,7 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
     // Rows, not merely a reply: the tree route answers 200 with nothing for a
     // path that is not there, so `ok` alone reported every missing file as a
     // directory that exists.
-    const listed = await treeAt(at, where, false)
-    if (ok(listed) && entriesOf(listed).length > 0) {
+    if (await isDirectory(at, where)) {
       return {
         text: statMarkdown(uri, 'dir', where.path),
         result: { uri, op: 'stat', exists: true, type: 'dir', path: where.path },
@@ -616,6 +700,60 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
     return {
       text: statMarkdown(uri, 'missing', where.path),
       result: { uri, op: 'stat', exists: false, type: 'missing', path: where.path },
+    }
+  }
+  if (cmd === 'attach') {
+    const bound = attachArgs(rest)
+    if (typeof bound !== 'number') return fsFail(bound.code, bound.message)
+    const mime = imageMime(where.path)
+    const name = where.path.slice(where.path.lastIndexOf('/') + 1)
+    const unsupported = (): FsOut =>
+      fsFail(
+        FS_UNSUPPORTED_MEDIA,
+        `Unsupported attachment media: ${name === '' ? where.id : name}. ` +
+          `The file extension is not .jpg, .jpeg, .png, or .webp.`,
+      )
+    if (mime === undefined) {
+      // Three answers, and the classifier is the one `cat` uses read the other
+      // way round. A known binary -- and a DIRECTORY, which has no extension
+      // to match -- is unsupported media; anything else is a file upstream
+      // calls text and sends you to `cat` for.
+      if (where.path === '' || binaryName(where.path) || (await isDirectory(at, where))) {
+        return unsupported()
+      }
+      return fsFail(
+        FS_IMAGE_ONLY,
+        `Refusing to attach known text file: ${name}. Attach returns supported image files only.`,
+      )
+    }
+    const reply = await callRoute(
+      at,
+      'GET',
+      `/${where.kind === 'models' ? '' : `${where.kind}/`}${where.id}/resolve/main/${where.path}`,
+    )
+    if (reply.status !== 200 || !Buffer.isBuffer(reply.body)) {
+      // A name is not a promise of a file. `assets.png` can be a DIRECTORY,
+      // and the extension branch above would have taken it for an image; a
+      // resolve that fails is where the two become distinguishable again.
+      // NOT_FOUND here would assert that something which exists does not,
+      // and a directory is the one thing upstream can be OBSERVED calling
+      // unsupported media -- no repository reachable from here holds a
+      // directory named `*.png` to ask about directly.
+      if (await isDirectory(at, where)) return unsupported()
+      return fsFail(FS_NOT_FOUND, `File does not exist: ${where.path}`)
+    }
+    const whole = reply.body
+    if (whole.length > bound) {
+      return fsFail(
+        FS_IMAGE_TOO_LARGE,
+        `Image is too large to attach: ${where.path} is ${String(whole.length)} bytes; ` +
+          `complete-file limit is ${String(bound)} bytes.`,
+      )
+    }
+    return {
+      text: attachMarkdown(uri, where.path, mime, whole.length),
+      result: { op: 'attach', uri, path: where.path, mime_type: mime, bytes: whole.length },
+      image: { mimeType: mime, data: whole.toString('base64') },
     }
   }
   if (cmd === 'cat') {
@@ -652,8 +790,7 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
       // 200 with no rows for a path that is not there at all, so the rows are
       // the test. A directory in git always holds something; an empty one
       // cannot be committed.
-      const listed = await treeAt(at, where, false)
-      if (ok(listed) && entriesOf(listed).length > 0) {
+      if (await isDirectory(at, where)) {
         return fsFail(FS_NOT_A_FILE, `cat requires a file path, got dir: ${where.path}`)
       }
       return fsFail(FS_NOT_FOUND, `File does not exist: ${where.path}`)
@@ -713,9 +850,11 @@ async function fsAnswer(at: Dispatch, args: Record<string, JsonValue>): Promise<
   const ops = Array.isArray(args.operations) ? args.operations.map((one) => obj(one)) : []
   const texts: string[] = []
   const results: JsonValue[] = []
+  const images: { mimeType: string; data: string }[] = []
   for (const [i, one] of ops.entries()) {
     const out = await fsOne(at, String(one.cmd ?? ''), strList(one.args))
     texts.push(out.text)
+    if (out.image !== undefined) images.push(out.image)
     if (out.error === undefined) {
       results.push({ index: i, status: 'success', result: out.result ?? {} })
       continue
@@ -742,6 +881,9 @@ async function fsAnswer(at: Dispatch, args: Record<string, JsonValue>): Promise<
     text: operationsMarkdown(texts),
     structured: { results },
     ...(failed ? { isError: true } : {}),
+    // One block per attachment, after the prose, which is the order upstream
+    // sends them in: the text names what arrived and the block is what did.
+    ...(images.length > 0 ? { images } : {}),
   }
 }
 
@@ -772,7 +914,14 @@ function buildMcpServer(at: Dispatch, doc: ToolDoc): McpServer {
       obj((req.params.arguments ?? {}) as JsonValue),
     )
     return {
-      content: [{ type: 'text', text: answer.text }],
+      content: [
+        { type: 'text', text: answer.text },
+        ...(answer.images ?? []).map((one) => ({
+          type: 'image' as const,
+          mimeType: one.mimeType,
+          data: one.data,
+        })),
+      ],
       ...(answer.structured === undefined ? {} : { structuredContent: answer.structured }),
       ...(answer.isError === true ? { isError: true } : {}),
     }

--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -45,6 +45,7 @@ import { hfHubFake } from './fake.ts'
 import { hfHubRoutes } from './routes.ts'
 import {
   FS_INVALID,
+  FS_NOT_A_FILE,
   FS_NOT_FOUND,
   FS_TEXT_ONLY,
   catMarkdown,
@@ -52,6 +53,7 @@ import {
   detailsMarkdown,
   fsError,
   fsRecovery,
+  fsSuggested,
   listingMarkdown,
   operationsMarkdown,
   searchMarkdown,
@@ -164,6 +166,11 @@ const PLURAL: Record<string, string> = {
 interface Answer {
   text: string
   structured?: JsonValue
+  // MCP's own flag on the tool result, which the live server sets when EVERY
+  // operation in the batch failed and omits the moment one succeeds. Omitted
+  // rather than false, because that is what upstream sends and a client may
+  // read the key's presence.
+  isError?: boolean
 }
 
 async function whoamiAnswer(at: Dispatch): Promise<Answer> {
@@ -296,20 +303,42 @@ interface Refusal {
   message: string
 }
 
-function locate(uri: string): Located | Refusal {
+// Every root the live server addresses, which is more than this fake holds
+// rows for. The distinction matters in exactly one place: a type that is not
+// on this list is wrong ANYWHERE and earns upstream's own sentence, while one
+// that is on it but missing from KINDS is a real root that this fake does not
+// serve, and saying so is more use than pretending the name is invalid.
+const UPSTREAM_KINDS = ['models', 'datasets', 'spaces', 'buckets', 'collections', 'papers']
+
+function locate(uri: string, cmd: string): Located | Refusal {
   const bad = (message: string): Refusal => ({ code: FS_INVALID, message })
-  if (!uri.startsWith('hf://')) {
-    return bad(`EINVAL: first argument must be an hf:// URI: ${uri}`)
-  }
+  if (!uri.startsWith('hf://')) return bad('EINVAL: URI must start with hf://')
   const parts = uri
     .slice('hf://'.length)
     .split('/')
     .filter((one) => one !== '')
   const kind = parts[0] ?? ''
+  if (kind === '') return bad('EINVAL: Missing repository or bucket type in URI.')
+  if (!UPSTREAM_KINDS.includes(kind)) {
+    return bad(`EINVAL: Invalid URI type '${kind}'. Must be one of ${UPSTREAM_KINDS.join(', ')}.`)
+  }
   if (!KINDS.includes(kind)) {
     return bad(`EINVAL: the mirage hf_hub fake serves ${KINDS.join(', ')} only: ${uri}`)
   }
-  if (parts.length < 3) return bad(`EINVAL: expected hf://${kind}/<namespace>/<name>: ${uri}`)
+  // A URI naming a root or an owner is a NAMESPACE, and asking `cat` for one
+  // is not a malformed argument -- it is a URI that points at the wrong kind
+  // of thing, which is what NOT_A_FILE says. The live server answers that
+  // code here, and an agent branching on the code should not be told it
+  // mistyped a flag. Every other command still gets the fake's own sentence,
+  // because a namespace listing is a thing this fake genuinely cannot do.
+  if (parts.length < 3) {
+    return cmd === 'cat'
+      ? {
+          code: FS_NOT_A_FILE,
+          message: 'cat requires a URI that points to a file path, not a namespace.',
+        }
+      : bad(`EINVAL: expected hf://${kind}/<namespace>/<name>: ${uri}`)
+  }
   return { kind, id: `${parts[1] ?? ''}/${parts[2] ?? ''}`, path: parts.slice(3).join('/') }
 }
 
@@ -518,7 +547,7 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
     )
   }
   const uri = args[0] ?? ''
-  const where = locate(uri)
+  const where = locate(uri, cmd)
   if (!('kind' in where)) return fsFail(where.code, where.message)
   const rest = args.slice(1)
   // Every other command here takes the URI alone. `cat` takes the two flags
@@ -549,14 +578,21 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
     }
   }
   if (cmd === 'stat') {
-    // A path is a file if the repo's recursive tree names it, and a directory
-    // if listing it answers at all. Asked in that order because only the
-    // listing can tell an empty directory from a missing one.
+    // Four outcomes, in the order that can tell them apart. A repository root
+    // is answered first and without a lookup, because upstream calls it
+    // `repo` and not `dir` -- the distinction is the whole reason stat is
+    // recommended for "an uncertain target type".
+    if (where.path === '') {
+      return {
+        text: statMarkdown(uri, 'repo', ''),
+        result: { uri, op: 'stat', exists: true, type: 'repo', path: '' },
+      }
+    }
     const all = entriesOfFull(await treeAt(at, { ...where, path: '' }, true))
     const hit = all.find((one) => one.full === where.path)
     if (hit !== undefined) {
       return {
-        text: statMarkdown(uri, { ...hit.entry, type: 'file' }, where.path),
+        text: statMarkdown(uri, 'file', where.path, hit.entry.size),
         result: {
           uri,
           op: 'stat',
@@ -567,20 +603,30 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
         },
       }
     }
+    // Rows, not merely a reply: the tree route answers 200 with nothing for a
+    // path that is not there, so `ok` alone reported every missing file as a
+    // directory that exists.
     const listed = await treeAt(at, where, false)
-    if (ok(listed)) {
+    if (ok(listed) && entriesOf(listed).length > 0) {
       return {
-        text: statMarkdown(uri, { type: 'dir', path: where.path, size: 0, lfs: false }, where.path),
+        text: statMarkdown(uri, 'dir', where.path),
         result: { uri, op: 'stat', exists: true, type: 'dir', path: where.path },
       }
     }
     return {
-      text: statMarkdown(uri, null, where.path),
-      result: { uri, op: 'stat', exists: false, path: where.path },
+      text: statMarkdown(uri, 'missing', where.path),
+      result: { uri, op: 'stat', exists: false, type: 'missing', path: where.path },
     }
   }
   if (cmd === 'cat') {
-    if (where.path === '') return fsFail(FS_INVALID, `EINVAL: cat needs a file path: ${uri}`)
+    // A repo root is not a malformed argument either -- it is a URI naming a
+    // repository where a file was wanted, and the live server distinguishes
+    // the three by wording alone: this sentence for a repository, the
+    // "not a namespace" one above for a root or an owner, and "got dir"
+    // below for a directory inside a repository.
+    if (where.path === '') {
+      return fsFail(FS_NOT_A_FILE, 'cat requires a URI that points to a file path.')
+    }
     const flags = catArgs(rest)
     if ('code' in flags) return fsFail(flags.code, flags.message)
     if (binaryName(where.path)) {
@@ -597,6 +643,19 @@ async function fsOne(at: Dispatch, cmd: string, args: string[]): Promise<FsOut> 
       `/${where.kind === 'models' ? '' : `${where.kind}/`}${where.id}/resolve/main/${where.path}`,
     )
     if (reply.status !== 200 || !Buffer.isBuffer(reply.body)) {
+      // A path that does not resolve is either missing or a DIRECTORY, and
+      // the live server tells them apart. Only asked on the miss path, so a
+      // read that succeeds still costs one request; and asked of the tree
+      // rather than guessed from the name, because a directory is not
+      // required to look like one.
+      // A listing that ANSWERS is not a directory -- the tree route replies
+      // 200 with no rows for a path that is not there at all, so the rows are
+      // the test. A directory in git always holds something; an empty one
+      // cannot be committed.
+      const listed = await treeAt(at, where, false)
+      if (ok(listed) && entriesOf(listed).length > 0) {
+        return fsFail(FS_NOT_A_FILE, `cat requires a file path, got dir: ${where.path}`)
+      }
       return fsFail(FS_NOT_FOUND, `File does not exist: ${where.path}`)
     }
     // The whole file is fetched and then sliced, because the resolve route
@@ -657,22 +716,33 @@ async function fsAnswer(at: Dispatch, args: Record<string, JsonValue>): Promise<
   for (const [i, one] of ops.entries()) {
     const out = await fsOne(at, String(one.cmd ?? ''), strList(one.args))
     texts.push(out.text)
-    results.push(
-      out.error === undefined
-        ? { index: i, status: 'success', result: out.result ?? {} }
-        : {
-            index: i,
-            status: 'error',
-            error: {
-              code: out.error.code,
-              message: out.error.message,
-              recovery: fsRecovery(out.error.code),
-              retryable: false,
-            },
-          },
-    )
+    if (out.error === undefined) {
+      results.push({ index: i, status: 'success', result: out.result ?? {} })
+      continue
+    }
+    const error: Record<string, JsonValue> = {
+      code: out.error.code,
+      message: out.error.message,
+      recovery: fsRecovery(out.error.code),
+      retryable: false,
+    }
+    // Assigned rather than spread, so the key is absent when there is no
+    // suggestion instead of present and undefined -- which is what upstream
+    // sends, and the difference a client checking `in` would see.
+    const suggested = fsSuggested(out.error.code)
+    if (suggested !== undefined) error.suggestedOperation = suggested
+    results.push({ index: i, status: 'error', error })
   }
-  return { text: operationsMarkdown(texts), structured: { results } }
+  // A batch of nothing is not a batch of failures. The captured schema puts
+  // `minItems: 1` on operations, so this cannot arrive from a conforming
+  // caller, but `every` on an empty array is true and would report a batch
+  // that ran nothing as a batch where everything failed.
+  const failed = ops.length > 0 && ops.every((_, i) => obj(results[i]).status === 'error')
+  return {
+    text: operationsMarkdown(texts),
+    structured: { results },
+    ...(failed ? { isError: true } : {}),
+  }
 }
 
 // ---------------------------------------------------------------- assembly
@@ -704,6 +774,7 @@ function buildMcpServer(at: Dispatch, doc: ToolDoc): McpServer {
     return {
       content: [{ type: 'text', text: answer.text }],
       ...(answer.structured === undefined ? {} : { structuredContent: answer.structured }),
+      ...(answer.isError === true ? { isError: true } : {}),
     }
   })
   return server

--- a/integ/server/hf_hub/render.ts
+++ b/integ/server/hf_hub/render.ts
@@ -268,6 +268,29 @@ export function listingMarkdown(cmd: string, uri: string, rows: FsEntry[]): stri
 // outcome, so a reader never has to infer a field from its absence.
 export type StatKind = 'file' | 'dir' | 'repo' | 'missing'
 
+/**
+ * Captured:
+ *
+ *   # hf_fs attach
+ *
+ *   - URI: `hf://datasets/OWNER/NAME/fig.png`
+ *   - Path: `fig.png`
+ *   - MIME type: `image/png`
+ *   - Bytes: 2104615
+ *
+ * The bytes themselves ride beside this as an MCP image block, not in it.
+ */
+export function attachMarkdown(uri: string, path: string, mime: string, bytes: number): string {
+  return [
+    `# hf_fs attach`,
+    '',
+    `- URI: \`${uri}\``,
+    `- Path: \`${path}\``,
+    `- MIME type: \`${mime}\``,
+    `- Bytes: ${String(bytes)}`,
+  ].join('\n')
+}
+
 export function statMarkdown(uri: string, kind: StatKind, path: string, size?: number): string {
   return [
     `# hf_fs stat`,
@@ -334,6 +357,13 @@ export const FS_NOT_FOUND = 'HF_FS_NOT_FOUND'
 export const FS_INVALID = 'HF_FS_INVALID_ARGUMENT'
 export const FS_TEXT_ONLY = 'HF_FS_TEXT_ONLY'
 export const FS_NOT_A_FILE = 'HF_FS_NOT_A_FILE'
+// `attach`'s own three. It refuses more precisely than `cat` does, because it
+// returns a whole file and cannot truncate: a text file is the wrong KIND of
+// thing (use cat), a non-image binary is unsupported media, and an image over
+// the limit is simply too large.
+export const FS_IMAGE_ONLY = 'HF_FS_IMAGE_ONLY'
+export const FS_UNSUPPORTED_MEDIA = 'HF_FS_UNSUPPORTED_MEDIA'
+export const FS_IMAGE_TOO_LARGE = 'HF_FS_IMAGE_TOO_LARGE'
 
 const RECOVERY: Record<string, string> = {
   [FS_NOT_FOUND]:
@@ -344,6 +374,11 @@ const RECOVERY: Record<string, string> = {
     'Use stat for metadata or ls on the parent directory. Do not use cat for binary or non-UTF-8 content.',
   [FS_NOT_A_FILE]:
     'Use stat to confirm the target is a file, or ls/find to discover a returned file URI.',
+  [FS_IMAGE_ONLY]: 'Use cat to read this text file, or stat for metadata.',
+  [FS_UNSUPPORTED_MEDIA]:
+    'Attach supports only files ending in .jpg, .jpeg, .png, or .webp. Use stat for metadata.',
+  [FS_IMAGE_TOO_LARGE]:
+    'Use stat for metadata. Attach cannot truncate images or exceed its configured complete-file limit.',
 }
 
 // The live server names a DIFFERENT command in the error object when one
@@ -356,6 +391,12 @@ const SUGGESTED: Record<string, string> = {
   [FS_NOT_FOUND]: 'stat',
   [FS_TEXT_ONLY]: 'stat',
   [FS_NOT_A_FILE]: 'stat',
+  [FS_UNSUPPORTED_MEDIA]: 'stat',
+  [FS_IMAGE_TOO_LARGE]: 'stat',
+  // The one that is not `stat`. A text file asked for as an image is not an
+  // uncertain target -- it is a known one, reached with the wrong command,
+  // and upstream names the right command instead of the diagnostic one.
+  [FS_IMAGE_ONLY]: 'cat',
 }
 
 export function fsSuggested(code: string): string | undefined {

--- a/integ/server/hf_hub/render.ts
+++ b/integ/server/hf_hub/render.ts
@@ -261,16 +261,23 @@ export function listingMarkdown(cmd: string, uri: string, rows: FsEntry[]): stri
  *   - Path: `config.json`
  *   - Size: 570 bytes
  */
-export function statMarkdown(uri: string, entry: FsEntry | null, path: string): string {
-  const out = [`# hf_fs stat`, '', `- URI: \`${uri}\``]
-  if (entry === null) {
-    out.push('- Exists: no')
-    return out.join('\n')
-  }
-  out.push('- Exists: yes', `- Type: \`${entry.type === 'dir' ? 'dir' : 'file'}\``)
-  out.push(`- Path: \`${path}\``)
-  if (entry.type !== 'dir') out.push(`- Size: ${humanSize(entry.size)}`)
-  return out.join('\n')
+// The four things a URI can be, which is one more than this renderer used to
+// admit and one more than the fake used to compute. A repository is not a
+// directory upstream, and a path that is not there is `missing` rather than an
+// absent Type line -- both are printed, and both are printed for every
+// outcome, so a reader never has to infer a field from its absence.
+export type StatKind = 'file' | 'dir' | 'repo' | 'missing'
+
+export function statMarkdown(uri: string, kind: StatKind, path: string, size?: number): string {
+  return [
+    `# hf_fs stat`,
+    '',
+    `- URI: \`${uri}\``,
+    `- Exists: ${kind === 'missing' ? 'no' : 'yes'}`,
+    `- Type: \`${kind}\``,
+    `- Path: \`${path}\``,
+    ...(kind === 'file' && size !== undefined ? [`- Size: ${humanSize(size)}`] : []),
+  ].join('\n')
 }
 
 /**
@@ -326,6 +333,7 @@ export function catMarkdown(
 export const FS_NOT_FOUND = 'HF_FS_NOT_FOUND'
 export const FS_INVALID = 'HF_FS_INVALID_ARGUMENT'
 export const FS_TEXT_ONLY = 'HF_FS_TEXT_ONLY'
+export const FS_NOT_A_FILE = 'HF_FS_NOT_A_FILE'
 
 const RECOVERY: Record<string, string> = {
   [FS_NOT_FOUND]:
@@ -334,6 +342,24 @@ const RECOVERY: Record<string, string> = {
     'Correct the URI or flags using the operation grammar and route-specific option guidance.',
   [FS_TEXT_ONLY]:
     'Use stat for metadata or ls on the parent directory. Do not use cat for binary or non-UTF-8 content.',
+  [FS_NOT_A_FILE]:
+    'Use stat to confirm the target is a file, or ls/find to discover a returned file URI.',
+}
+
+// The live server names a DIFFERENT command in the error object when one
+// would help, and names none when nothing would: `stat` answers all three of
+// the codes below -- it reports a missing path, a directory and a binary blob
+// without erroring on any of them -- while a malformed flag or a bad URI is
+// the caller's to fix and gets no suggestion at all. Read off the live
+// server for each code rather than assigned by taste.
+const SUGGESTED: Record<string, string> = {
+  [FS_NOT_FOUND]: 'stat',
+  [FS_TEXT_ONLY]: 'stat',
+  [FS_NOT_A_FILE]: 'stat',
+}
+
+export function fsSuggested(code: string): string | undefined {
+  return SUGGESTED[code]
 }
 
 export function fsRecovery(code: string): string {

--- a/integ/server/hf_hub/render.ts
+++ b/integ/server/hf_hub/render.ts
@@ -364,6 +364,7 @@ export const FS_NOT_A_FILE = 'HF_FS_NOT_A_FILE'
 export const FS_IMAGE_ONLY = 'HF_FS_IMAGE_ONLY'
 export const FS_UNSUPPORTED_MEDIA = 'HF_FS_UNSUPPORTED_MEDIA'
 export const FS_IMAGE_TOO_LARGE = 'HF_FS_IMAGE_TOO_LARGE'
+export const FS_BUDGET = 'HF_FS_ATTACHMENT_BUDGET_EXCEEDED'
 
 const RECOVERY: Record<string, string> = {
   [FS_NOT_FOUND]:
@@ -379,6 +380,10 @@ const RECOVERY: Record<string, string> = {
     'Attach supports only files ending in .jpg, .jpeg, .png, or .webp. Use stat for metadata.',
   [FS_IMAGE_TOO_LARGE]:
     'Use stat for metadata. Attach cannot truncate images or exceed its configured complete-file limit.',
+  // Upstream's own sentence, curly apostrophe included -- it is bytes the
+  // model is charged for, so it is copied rather than tidied.
+  [FS_BUDGET]:
+    'This attachment was omitted because other attachments already reserved the call\u2019s shared 8 MiB payload budget. Retry it in a separate hf_fs call.',
 }
 
 // The live server names a DIFFERENT command in the error object when one
@@ -397,6 +402,9 @@ const SUGGESTED: Record<string, string> = {
   // uncertain target -- it is a known one, reached with the wrong command,
   // and upstream names the right command instead of the diagnostic one.
   [FS_IMAGE_ONLY]: 'cat',
+  // `attach` again: the operation was not wrong, only unlucky in its batch,
+  // so the thing to do is the same thing in a call of its own.
+  [FS_BUDGET]: 'attach',
 }
 
 export function fsSuggested(code: string): string | undefined {

--- a/integ/server/hf_hub/render.ts
+++ b/integ/server/hf_hub/render.ts
@@ -240,13 +240,25 @@ export interface FsEntry {
  * a value only for the entry kinds this fake has none of, so they are rendered
  * empty rather than dropped -- the column count is part of what was captured.
  */
-export function listingMarkdown(cmd: string, uri: string, rows: FsEntry[]): string {
+// What upstream says when a listing stopped at the entry limit, and it says
+// it after the table rather than in the header -- the same placement as
+// cat's resume notice.
+export const LIST_TRUNCATED =
+  'Result truncated after reaching the entry limit. Rerun with a larger --limit, up to 10000.'
+
+export function listingMarkdown(
+  cmd: string,
+  uri: string,
+  rows: FsEntry[],
+  truncated = false,
+): string {
   const out = [`# hf_fs ${cmd}`, '', `URI: \`${uri}\``, '']
   out.push('| Type | Path | URI | Target | Details |', '|---|---|---|---|---|')
   for (const row of rows) {
     const details = row.type === 'dir' ? '' : `${row.lfs ? 'lfs, ' : ''}size=${humanSize(row.size)}`
     out.push(`| ${row.type} | ${escapeCell(row.path)} |  |  | ${details} |`)
   }
+  if (truncated) out.push('', LIST_TRUNCATED)
   return out.join('\n')
 }
 

--- a/integ/server/hf_hub/routes.ts
+++ b/integ/server/hf_hub/routes.ts
@@ -705,11 +705,14 @@ function validateYaml(ctx: Ctx<C>): Reply {
     parsed = yamlLoad(source)
   } catch (err) {
     // The status, the envelope and the `Invalid YAML in README.md: ` prefix are
-    // upstream's. The sentence AFTER the prefix is js-yaml's own and upstream
-    // runs a different build of it -- both render the same `-----^` snippet,
-    // but `license: [` is "deficient indentation" here and "unexpected end of
-    // the stream within a flow collection" there. What decides the upload is
-    // the 400, and that is exact.
+    // upstream's, and so is the parser's sentence for the case that matters:
+    // `license: [` answers "unexpected end of the stream within a flow
+    // collection" on both. What differs is the CURSOR. Upstream reports it at
+    // (2:1) over a two-line snippet and this reports (1:11) over one, because
+    // the block captured above carries no trailing newline and upstream's
+    // parser is fed one -- adding it here moves the cursor into agreement and
+    // the sentence out of it, which is how the two builds are known to differ
+    // at all. What decides the upload is the 400, and that is exact.
     const message = err instanceof Error ? err.message : String(err)
     return cardError(`Invalid YAML in README.md: ${message}`)
   }

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -988,6 +988,40 @@ async function mcpChecks(): Promise<void> {
     check('stat reports existence', stat.includes('- Exists: yes'), stat.slice(0, 200))
     check('stat reports a size', stat.includes('- Size: '), stat.slice(0, 200))
 
+    // A file one level down, which is the case stat reads a PARENT listing
+    // for rather than the repository root. It used to walk the whole recursive
+    // tree to find this row, and paid the repository to keep one entry.
+    const statNested = await text('hf_fs', {
+      operations: [{ cmd: 'stat', args: ['hf://models/integ/card-model/nested/note.txt'] }],
+    })
+    check(
+      'stat finds a file inside a directory, with its size',
+      statNested.includes('- Type: `file`') &&
+        statNested.includes('- Path: `nested/note.txt`') &&
+        /- Size: \d/.test(statNested),
+      statNested.slice(0, 220),
+    )
+    // Absent from a directory that IS there -- the listing consulted has to be
+    // the parent's, and a row missing from it is what `missing` means.
+    const statNestedGone = await text('hf_fs', {
+      operations: [{ cmd: 'stat', args: ['hf://models/integ/card-model/nested/nope.txt'] }],
+    })
+    check(
+      'and calls a name absent from an existing directory missing',
+      statNestedGone.includes('- Type: `missing`') && statNestedGone.includes('- Exists: no'),
+      statNestedGone.slice(0, 220),
+    )
+    // A directory below the root is a `dir` too, which only the parent's
+    // synthesized row can say: git commits no directory object of its own.
+    const statNestedDir = await text('hf_fs', {
+      operations: [{ cmd: 'stat', args: ['hf://models/integ/card-model/assets.png'] }],
+    })
+    check(
+      'and a directory whose name looks like a file is still a dir',
+      statNestedDir.includes('- Type: `dir`'),
+      statNestedDir.slice(0, 220),
+    )
+
     // Both error codes are the live server's own, captured rather than coined,
     // because an agent may branch on the bracketed code.
     const missing = await text('hf_fs', {

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -817,6 +817,72 @@ async function mcpChecks(): Promise<void> {
       ((pagedRows.entries ?? []) as JsonValue[]).length === PAGED,
       String(((pagedRows.entries ?? []) as JsonValue[]).length),
     )
+    // ---- and the listing is bounded, by upstream's number
+    //
+    // 1,000 entries by default and 10,000 at most. The bound matters twice:
+    // it is what upstream answers, and it is what stops an arbitrarily large
+    // repository being aggregated whole in order to throw most of it away.
+    const capped = await call(
+      'hf_fs',
+      ops({ cmd: 'ls', args: ['hf://models/integ/paged-model', '--limit', '10'] }),
+    )
+    const cappedRow = (
+      (((capped.structuredContent ?? {}) as Record<string, JsonValue>).results ?? []) as Record<
+        string,
+        JsonValue
+      >[]
+    )[0]
+    const cappedResult = (cappedRow ?? {}).result as Record<string, JsonValue>
+    eq('--limit bounds the listing', ((cappedResult.entries ?? []) as JsonValue[]).length, 10)
+    eq('and says it was cut', cappedResult.truncated ?? null, true)
+    eq('in the schema own vocabulary', cappedResult.truncation_reason ?? null, 'entry_limit')
+    const cappedText = ((capped.content ?? []) as Record<string, JsonValue>[])
+      .map((one) => String(one.text ?? ''))
+      .join('')
+    check(
+      'and after the table, the way upstream places it',
+      cappedText.includes(
+        'Result truncated after reaching the entry limit. Rerun with a larger --limit, up to 10000.',
+      ),
+      cappedText.slice(-200),
+    )
+    // A listing that FITS is not cut, and says nothing about limits.
+    const uncut = await call(
+      'hf_fs',
+      ops({ cmd: 'ls', args: ['hf://models/integ/paged-model', '--limit', '60'] }),
+    )
+    const uncutResult = (
+      (
+        (((uncut.structuredContent ?? {}) as Record<string, JsonValue>).results ?? []) as Record<
+          string,
+          JsonValue
+        >[]
+      )[0] ?? {}
+    ).result as Record<string, JsonValue>
+    check(
+      'a listing that fits is not marked truncated',
+      !('truncated' in uncutResult),
+      JSON.stringify(Object.keys(uncutResult)),
+    )
+    const badLimit = await call(
+      'hf_fs',
+      ops({ cmd: 'ls', args: ['hf://models/integ/paged-model', '--limit', '20000'] }),
+    )
+    eq(
+      'a limit past the ceiling names the ceiling',
+      errorOf(badLimit).message ?? null,
+      'EINVAL: limit must be between 1 and 10000 for this command',
+    )
+    const otherFlag = await call(
+      'hf_fs',
+      ops({ cmd: 'ls', args: ['hf://models/integ/paged-model', '--sort', 'downloads'] }),
+    )
+    eq(
+      'and a flag the fake has nothing behind is still an honest EINVAL',
+      errorOf(otherFlag).message ?? null,
+      'EINVAL: unexpected argument for ls: --sort',
+    )
+
     const statLate = await text('hf_fs', {
       operations: [{ cmd: 'stat', args: [`hf://models/integ/paged-model/${lastFile}`] }],
     })

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -758,6 +758,134 @@ async function mcpChecks(): Promise<void> {
       JSON.stringify(errorOf(readme).message ?? null),
     )
 
+    // ---- a repository past one page
+    //
+    // The REST arm pages at DEFAULT_LIMIT and puts the cursor in a `Link`
+    // header. Reading only page one made this fake disagree with itself on
+    // any repository bigger than that: `ls` showed a prefix in silence, and
+    // `stat` called a file that exists `missing`, because the recursive tree
+    // it searched stopped before reaching it. 60 files is one page and a
+    // remainder.
+    const PAGED = 60
+    await fetch(`${mcp.rest.endpoint}/api/repos/create`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_TENANT}`,
+        'Content-Type': 'application/json',
+      },
+      // The namespace is the repo's OWNER, which the create route takes from
+      // `organization` and otherwise from the bearer -- and the bearer here
+      // is the default tenant, not `integ`.
+      body: JSON.stringify({ name: 'paged-model', type: 'model', organization: 'integ' }),
+    })
+    const pushedMany = await fetch(
+      `${mcp.rest.endpoint}/api/models/integ/paged-model/commit/main`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${DEFAULT_TENANT}`,
+          'Content-Type': 'application/x-ndjson',
+        },
+        body: [
+          JSON.stringify({ key: 'header', value: { summary: 'more than one page' } }),
+          ...Array.from({ length: PAGED }, (_unused, i) =>
+            JSON.stringify({
+              key: 'file',
+              value: { path: `f${String(i).padStart(3, '0')}.txt`, content: `row ${String(i)}\n` },
+            }),
+          ),
+        ].join('\n'),
+      },
+    )
+    check(
+      'a repository of 60 files is pushed',
+      pushedMany.status === 200,
+      String(pushedMany.status),
+    )
+    const lastFile = `f${String(PAGED - 1).padStart(3, '0')}.txt`
+    const paged = await call('hf_fs', ops({ cmd: 'ls', args: ['hf://models/integ/paged-model'] }))
+    const pagedRows = (
+      (
+        (((paged.structuredContent ?? {}) as Record<string, JsonValue>).results ?? []) as Record<
+          string,
+          JsonValue
+        >[]
+      )[0] ?? {}
+    ).result as Record<string, JsonValue>
+    check(
+      'ls returns every page, not the first',
+      ((pagedRows.entries ?? []) as JsonValue[]).length === PAGED,
+      String(((pagedRows.entries ?? []) as JsonValue[]).length),
+    )
+    const statLate = await text('hf_fs', {
+      operations: [{ cmd: 'stat', args: [`hf://models/integ/paged-model/${lastFile}`] }],
+    })
+    check(
+      'and stat finds a file past the first page',
+      statLate.includes('- Type: `file`') && statLate.includes('- Exists: yes'),
+      statLate.slice(0, 220),
+    )
+
+    // ---- the shared attachment budget
+    //
+    // 8MiB across ONE call, whatever the per-file bound allows. The captured
+    // schema permits 30 operations, so without this a valid request could ask
+    // for 30 x 8MiB. Two 5MiB images are one over.
+    const FIVE_MIB = 5 * 1024 * 1024
+    const bigPng = Buffer.concat([
+      Buffer.from(PNG_1X1, 'base64'),
+      Buffer.alloc(FIVE_MIB, 0),
+    ]).toString('base64')
+    const pushedBig = await fetch(`${mcp.rest.endpoint}/api/models/integ/card-model/commit/main`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_TENANT}`,
+        'Content-Type': 'application/x-ndjson',
+      },
+      body: [
+        JSON.stringify({ key: 'header', value: { summary: 'two large images' } }),
+        JSON.stringify({
+          key: 'file',
+          value: { path: 'figures/big1.png', encoding: 'base64', content: bigPng },
+        }),
+        JSON.stringify({
+          key: 'file',
+          value: { path: 'figures/big2.png', encoding: 'base64', content: bigPng },
+        }),
+      ].join('\n'),
+    })
+    check('two 5MiB images are pushed', pushedBig.status === 200, String(pushedBig.status))
+    const twoBig = await call(
+      'hf_fs',
+      ops(
+        attach('hf://models/integ/card-model/figures/big1.png'),
+        attach('hf://models/integ/card-model/figures/big2.png'),
+      ),
+    )
+    const rowsOf = (out: Record<string, JsonValue>): Record<string, JsonValue>[] =>
+      (((out.structuredContent ?? {}) as Record<string, JsonValue>).results ?? []) as Record<
+        string,
+        JsonValue
+      >[]
+    eq('the first attachment is admitted', (rowsOf(twoBig)[0] ?? {}).status ?? null, 'success')
+    eq(
+      'and the second is dropped on the shared budget',
+      errorOf(twoBig, 1).code ?? null,
+      'HF_FS_ATTACHMENT_BUDGET_EXCEEDED',
+    )
+    eq(
+      'with upstream sentence',
+      errorOf(twoBig, 1).message ?? null,
+      'Attachment omitted because the batch exceeds the cumulative response limit of 8388608 bytes.',
+    )
+    eq('and told to retry it alone', errorOf(twoBig, 1).suggestedOperation ?? null, 'attach')
+    check(
+      'only the admitted image rides along',
+      ((twoBig.content ?? []) as Record<string, JsonValue>[]).filter((one) => one.type === 'image')
+        .length === 1,
+      JSON.stringify(((twoBig.content ?? []) as Record<string, JsonValue>[]).map((o) => o.type)),
+    )
+
     // ---- stat tells four things apart, which is why upstream recommends it
     // for "an uncertain target type". A repository is `repo` and not `dir`,
     // and a path that is not there is `missing` and not a directory -- the

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -62,6 +62,11 @@ function eq(name: string, got: JsonValue, want: JsonValue): void {
   check(name, a === b, a === b ? a : `got ${a} want ${b}`)
 }
 
+// A 1x1 PNG. Written out rather than generated so the bytes in the fixture
+// are the bytes an image decoder accepts, signature included.
+const PNG_1X1 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+
 interface Fake {
   child: ChildProcessByStdio<null, Readable, Readable>
   endpoint: string
@@ -415,6 +420,16 @@ async function mcpChecks(): Promise<void> {
         // `stat` both have to tell a directory from a missing path, and a
         // flat repo cannot prove either.
         JSON.stringify({ key: 'file', value: { path: 'nested/note.txt', content: 'in a dir\n' } }),
+        // A REAL 1x1 PNG, header and all, because attach returns the bytes
+        // untouched and a caller decodes them.
+        JSON.stringify({
+          key: 'file',
+          value: { path: 'figures/fig1.png', encoding: 'base64', content: PNG_1X1 },
+        }),
+        // A DIRECTORY whose name ends in an image extension. Nothing stops a
+        // repository holding one, and it is the one shape where classifying
+        // on the name alone gives the wrong answer.
+        JSON.stringify({ key: 'file', value: { path: 'assets.png/inside.txt', content: 'x\n' } }),
         ...['binary.bin', 'invalid.txt'].map((path) =>
           JSON.stringify({
             key: 'file',
@@ -603,6 +618,145 @@ async function mcpChecks(): Promise<void> {
       ),
     )
     check('but one success clears it', !('isError' in mixed), JSON.stringify(mixed.isError ?? null))
+
+    // ---- attach
+    //
+    // The live server returns a COMPLETE image and cannot truncate one, so
+    // every refusal below is a refusal rather than a cut. All four codes and
+    // all four sentences were read off https://huggingface.co/mcp.
+    const attach = (uri: string, ...rest: string[]): Record<string, unknown> => ({
+      cmd: 'attach',
+      args: [uri, ...rest],
+    })
+    const png = await call('hf_fs', ops(attach('hf://models/integ/card-model/figures/fig1.png')))
+    const blocks = (png.content ?? []) as Record<string, JsonValue>[]
+    check(
+      'attach returns the image beside the prose',
+      blocks.some((one) => one.type === 'image' && one.mimeType === 'image/png'),
+      JSON.stringify(blocks.map((one) => one.type)),
+    )
+    check(
+      'and the bytes are the file, decodable',
+      Buffer.from(String((blocks.find((one) => one.type === 'image') ?? {}).data ?? ''), 'base64')
+        .subarray(0, 8)
+        .toString('hex') === '89504e470d0a1a0a',
+      String((blocks.find((one) => one.type === 'image') ?? {}).data ?? '').slice(0, 24),
+    )
+    const attachText = blocks.map((one) => String(one.text ?? '')).join('')
+    check(
+      'and the prose names the MIME type',
+      attachText.includes('- MIME type: `image/png`'),
+      attachText.slice(0, 240),
+    )
+    check('and a whole-file byte count', attachText.includes('- Bytes: '), attachText.slice(0, 240))
+
+    // A text file is the wrong KIND of thing, and upstream names `cat` for it
+    // rather than the diagnostic `stat` it names everywhere else.
+    const asText = await call('hf_fs', ops(attach('hf://models/integ/card-model/README.md')))
+    eq('attaching text is HF_FS_IMAGE_ONLY', errorOf(asText).code ?? null, 'HF_FS_IMAGE_ONLY')
+    eq(
+      'and says so upstream way',
+      errorOf(asText).message ?? null,
+      'Refusing to attach known text file: README.md. Attach returns supported image files only.',
+    )
+    eq('and points at cat, not stat', errorOf(asText).suggestedOperation ?? null, 'cat')
+
+    const asBinary = await call('hf_fs', ops(attach('hf://models/integ/card-model/binary.bin')))
+    eq(
+      'a non-image binary is unsupported media',
+      errorOf(asBinary).code ?? null,
+      'HF_FS_UNSUPPORTED_MEDIA',
+    )
+    const asDir = await call('hf_fs', ops(attach('hf://models/integ/card-model/nested')))
+    eq('and so is a directory', errorOf(asDir).code ?? null, 'HF_FS_UNSUPPORTED_MEDIA')
+
+    const tooSmall = await call(
+      'hf_fs',
+      ops(attach('hf://models/integ/card-model/figures/fig1.png', '--max-bytes', '1')),
+    )
+    eq(
+      'a bound under the file size refuses rather than truncating',
+      errorOf(tooSmall).code ?? null,
+      'HF_FS_IMAGE_TOO_LARGE',
+    )
+    const overCeiling = await call(
+      'hf_fs',
+      ops(attach('hf://models/integ/card-model/figures/fig1.png', '--max-bytes', '25000000')),
+    )
+    // The bound an agent reached for when it tried to pull a 21MB file past
+    // cat's limit. Upstream names its ceiling; this fake used to answer that
+    // attach did not exist.
+    eq(
+      'and a bound over the ceiling names the ceiling',
+      errorOf(overCeiling).message ?? null,
+      'EINVAL: attach max_bytes must be between 1 and 8388608',
+    )
+    const zeroBound = await call(
+      'hf_fs',
+      ops(attach('hf://models/integ/card-model/figures/fig1.png', '--max-bytes', '0')),
+    )
+    // Zero is INVALID for attach where `cat --max-bytes 0` means the maximum.
+    // The two commands genuinely differ; each was read off the live server.
+    eq(
+      'zero is invalid here, unlike cat',
+      errorOf(zeroBound).message ?? null,
+      'EINVAL: attach max_bytes must be between 1 and 8388608',
+    )
+    const withOffset = await call(
+      'hf_fs',
+      ops(attach('hf://models/integ/card-model/figures/fig1.png', '--offset', '5')),
+    )
+    eq(
+      'and --offset is meaningless for a whole file',
+      errorOf(withOffset).message ?? null,
+      'EINVAL: unexpected argument for attach: --offset',
+    )
+    const goneImage = await call('hf_fs', ops(attach('hf://models/integ/card-model/nope.png')))
+    eq('a missing image is HF_FS_NOT_FOUND', errorOf(goneImage).code ?? null, 'HF_FS_NOT_FOUND')
+
+    // A directory that ends in `.png` is still a directory. Classified on the
+    // name alone it reads as an image, resolves to nothing, and would be
+    // reported as a file that does not exist -- of a path that does.
+    const dirNamedPng = await call('hf_fs', ops(attach('hf://models/integ/card-model/assets.png')))
+    eq(
+      'a directory named like an image is still unsupported media',
+      errorOf(dirNamedPng).code ?? null,
+      'HF_FS_UNSUPPORTED_MEDIA',
+    )
+    // `cat` answers TEXT_ONLY for the same path, and that is not an
+    // oversight: upstream refuses binary on the NAME, before it resolves
+    // anything -- "the file extension or MIME type is known to be binary" --
+    // so a directory called `assets.png` never reaches a directory check
+    // there either. attach differs because its name check is what SELECTS
+    // the image branch, so the mistake is only recoverable after the resolve.
+    const catDirPng = await call('hf_fs', ops(catOp('hf://models/integ/card-model/assets.png')))
+    eq(
+      'cat refuses it on the name, as upstream does',
+      errorOf(catDirPng).code ?? null,
+      'HF_FS_TEXT_ONLY',
+    )
+    const statDirPng = await text('hf_fs', {
+      operations: [{ cmd: 'stat', args: ['hf://models/integ/card-model/assets.png'] }],
+    })
+    check('and stat calls it a dir', statDirPng.includes('- Type: `dir`'), statDirPng.slice(0, 200))
+
+    // ---- roots the fake does not hold are not bad NAMES
+    //
+    // `docs` and `README.md` are addressable upstream -- `ls hf://docs`
+    // answers and `cat hf://README.md` is where it documents its limits --
+    // so calling them invalid types was wrong twice over.
+    const docs = await call('hf_fs', ops(catOp('hf://docs/transformers/index')))
+    check(
+      'an unserved root says which roots are served',
+      String(errorOf(docs).message ?? '').includes('the mirage hf_hub fake serves'),
+      JSON.stringify(errorOf(docs).message ?? null),
+    )
+    const readme = await call('hf_fs', ops(catOp('hf://README.md')))
+    check(
+      'and so does the root-level page',
+      String(errorOf(readme).message ?? '').includes('the mirage hf_hub fake serves'),
+      JSON.stringify(errorOf(readme).message ?? null),
+    )
 
     // ---- stat tells four things apart, which is why upstream recommends it
     // for "an uncertain target type". A repository is `repo` and not `dir`,

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -177,6 +177,26 @@ async function mcpChecks(): Promise<void> {
       const content = out.content as { type: string; text?: string }[]
       return content.map((one) => one.text ?? '').join('')
     }
+    // The whole tool result, not just its prose: `isError` lives beside the
+    // content and the per-operation error objects live inside
+    // structuredContent, and neither is visible in the rendered markdown.
+    const call = async (
+      name: string,
+      args: Record<string, unknown>,
+    ): Promise<Record<string, JsonValue>> =>
+      (await client.callTool({ name, arguments: args })) as Record<string, JsonValue>
+    const errorOf = (out: Record<string, JsonValue>, i = 0): Record<string, JsonValue> => {
+      const structured = (out.structuredContent ?? {}) as Record<string, JsonValue>
+      const rows = (structured.results ?? []) as Record<string, JsonValue>[]
+      return ((rows[i] ?? {}).error ?? {}) as Record<string, JsonValue>
+    }
+    const ops = (...list: Record<string, unknown>[]): Record<string, unknown> => ({
+      operations: list,
+    })
+    const catOp = (uri: string, ...rest: string[]): Record<string, unknown> => ({
+      cmd: 'cat',
+      args: [uri, ...rest],
+    })
 
     const who = await text('hf_whoami', {})
     check(
@@ -391,6 +411,10 @@ async function mcpChecks(): Promise<void> {
         // can be. Pushed twice under two names, because upstream decides by
         // the NAME: `.bin` is refused unread, while the same bytes under a
         // text extension are served and have to be bounded instead.
+        // A file inside a directory, so the repository HAS one: `cat` and
+        // `stat` both have to tell a directory from a missing path, and a
+        // flat repo cannot prove either.
+        JSON.stringify({ key: 'file', value: { path: 'nested/note.txt', content: 'in a dir\n' } }),
         ...['binary.bin', 'invalid.txt'].map((path) =>
           JSON.stringify({
             key: 'file',
@@ -494,6 +518,120 @@ async function mcpChecks(): Promise<void> {
       'a run of continuation bytes does not carry the read past the bound',
       blob.includes('Bytes: 11') && blob.includes('Content truncated. Resume with offset 11.'),
       blob.slice(0, 260),
+    )
+
+    // ---- the error envelope
+    //
+    // Every line below was read off https://huggingface.co/mcp. None of it is
+    // visible in the rendered markdown, and an agent that branches on a code
+    // or on `isError` sees only this.
+    const noSuchFile = await call('hf_fs', ops(catOp('hf://models/integ/card-model/nope.txt')))
+    eq('a missing file is HF_FS_NOT_FOUND', errorOf(noSuchFile).code ?? null, 'HF_FS_NOT_FOUND')
+    // `stat` answers a missing path, a directory and a binary blob without
+    // erroring on any of them, so it is the command upstream names for all
+    // three -- and names for nothing else.
+    eq('and suggests stat', errorOf(noSuchFile).suggestedOperation ?? null, 'stat')
+    eq('and the whole result is an error', noSuchFile.isError ?? null, true)
+
+    const binary = await call('hf_fs', ops(catOp('hf://models/integ/card-model/binary.bin')))
+    eq('a binary name is HF_FS_TEXT_ONLY', errorOf(binary).code ?? null, 'HF_FS_TEXT_ONLY')
+    eq('and suggests stat too', errorOf(binary).suggestedOperation ?? null, 'stat')
+
+    // Three shapes of "that is not a file", each with its own sentence.
+    const atRepo = await call('hf_fs', ops(catOp('hf://models/integ/card-model')))
+    eq('a repo root is HF_FS_NOT_A_FILE', errorOf(atRepo).code ?? null, 'HF_FS_NOT_A_FILE')
+    eq(
+      'and says so in upstream words',
+      errorOf(atRepo).message ?? null,
+      'cat requires a URI that points to a file path.',
+    )
+    const atNamespace = await call('hf_fs', ops(catOp('hf://models/integ')))
+    eq(
+      'a namespace is HF_FS_NOT_A_FILE as well',
+      errorOf(atNamespace).message ?? null,
+      'cat requires a URI that points to a file path, not a namespace.',
+    )
+    const atDir = await call('hf_fs', ops(catOp('hf://models/integ/card-model/nested')))
+    eq(
+      'and a directory names itself',
+      errorOf(atDir).message ?? null,
+      'cat requires a file path, got dir: nested',
+    )
+    eq('all three suggest stat', errorOf(atDir).suggestedOperation ?? null, 'stat')
+
+    // A malformed argument is the caller's to fix, so upstream suggests
+    // nothing -- the key is absent rather than null.
+    const flag = await call('hf_fs', ops(catOp('hf://models/integ/card-model/README.md', '--nope')))
+    eq('a bad flag is HF_FS_INVALID_ARGUMENT', errorOf(flag).code ?? null, 'HF_FS_INVALID_ARGUMENT')
+    check(
+      'and suggests nothing at all',
+      !('suggestedOperation' in errorOf(flag)),
+      JSON.stringify(errorOf(flag)),
+    )
+    const scheme = await call('hf_fs', ops(catOp('/not/a/uri')))
+    eq(
+      'a URI without the scheme says so upstream way',
+      errorOf(scheme).message ?? null,
+      'EINVAL: URI must start with hf://',
+    )
+    const bogus = await call('hf_fs', ops(catOp('hf://bogus/x/y')))
+    eq(
+      'and a type upstream does not have is named against upstream list',
+      errorOf(bogus).message ?? null,
+      "EINVAL: Invalid URI type 'bogus'. Must be one of models, datasets, spaces, buckets, collections, papers.",
+    )
+    // `papers` IS one of upstream's roots; this fake simply holds no rows for
+    // it, and saying that is more use than calling the name invalid.
+    const unserved = await call('hf_fs', ops(catOp('hf://papers/2502.16161/metadata.json')))
+    check(
+      'a real root the fake does not serve says which it serves',
+      String(errorOf(unserved).message ?? '').includes('the mirage hf_hub fake serves'),
+      JSON.stringify(errorOf(unserved).message ?? null),
+    )
+
+    // `isError` is the whole batch's, and one success clears it.
+    const bothBad = await call(
+      'hf_fs',
+      ops(catOp('hf://models/integ/card-model/nope.txt'), catOp('/not/a/uri')),
+    )
+    eq('a batch where everything failed is an error', bothBad.isError ?? null, true)
+    const mixed = await call(
+      'hf_fs',
+      ops(
+        catOp('hf://models/integ/card-model/README.md'),
+        catOp('hf://models/integ/card-model/nope.txt'),
+      ),
+    )
+    check('but one success clears it', !('isError' in mixed), JSON.stringify(mixed.isError ?? null))
+
+    // ---- stat tells four things apart, which is why upstream recommends it
+    // for "an uncertain target type". A repository is `repo` and not `dir`,
+    // and a path that is not there is `missing` and not a directory -- the
+    // fake reported both wrongly until the tree's ROWS became the test.
+    const statRepo = await text('hf_fs', {
+      operations: [{ cmd: 'stat', args: ['hf://models/integ/card-model'] }],
+    })
+    check(
+      'stat calls a repository a repo',
+      statRepo.includes('- Type: `repo`'),
+      statRepo.slice(0, 200),
+    )
+    const statDir = await text('hf_fs', {
+      operations: [{ cmd: 'stat', args: ['hf://models/integ/card-model/nested'] }],
+    })
+    check('and a directory a dir', statDir.includes('- Type: `dir`'), statDir.slice(0, 200))
+    const statGone = await text('hf_fs', {
+      operations: [{ cmd: 'stat', args: ['hf://models/integ/card-model/nope.txt'] }],
+    })
+    check(
+      'and a path that is not there missing',
+      statGone.includes('- Exists: no') && statGone.includes('- Type: `missing`'),
+      statGone.slice(0, 200),
+    )
+    check(
+      'and prints the path even then',
+      statGone.includes('- Path: `nope.txt`'),
+      statGone.slice(0, 200),
     )
 
     const stat = await text('hf_fs', {


### PR DESCRIPTION
The success shape of `hf_fs` matched upstream key for key. The error shape did not — and none of it appears in the rendered markdown, so an agent branching on a code or on `isError` sees only the half nobody had compared.

Everything here was read off `https://huggingface.co/mcp` and is asserted against it.

## What was wrong

**`isError` was never set.** Upstream puts it on the tool result when *every* operation in the batch failed, and omits it the moment one succeeds — omitted, not `false`. A client that branches on it read all of this fake's failures as successes.

**`suggestedOperation` was never emitted.** Upstream names `stat` for `HF_FS_NOT_FOUND`, `HF_FS_TEXT_ONLY` and `HF_FS_NOT_A_FILE`, and nothing for `HF_FS_INVALID_ARGUMENT`. That isn't taste: `stat` answers a missing path, a directory and a binary blob without erroring on any of them, so it is the command that helps in exactly those three cases.

**`HF_FS_NOT_A_FILE` did not exist here.** Upstream returns it, with three different sentences, wherever `cat` is pointed at something that is not a file:

| target | upstream message |
|---|---|
| `hf://models`, `hf://models/owner` | `cat requires a URI that points to a file path, not a namespace.` |
| a repository root | `cat requires a URI that points to a file path.` |
| a directory inside a repository | `cat requires a file path, got dir: NAME` |

This fake answered `HF_FS_INVALID_ARGUMENT` for the first two and `HF_FS_NOT_FOUND` for the third — telling a caller it mistyped a flag when it named a repository, and that a directory does not exist.

**Two messages were this repo's words where upstream's were available:** `EINVAL: URI must start with hf://`, and for a type outside upstream's six roots, `EINVAL: Invalid URI type 'X'. Must be one of models, datasets, spaces, buckets, collections, papers.` A root upstream serves and this fake does not still says which three it serves — that is true and useful, where calling the name invalid would be neither.

## A bug found behind the directory case

The tree route answers `200` with no rows for a path that is not there, so `ok(reply)` was true for every miss. That meant **`stat` reported any missing file as a directory that exists.** The rows are the test now, in both places.

`stat` also grew the two outcomes it could not express: a repository is `repo`, not `dir`, and a missing path is `missing` — with its `Type` and `Path` lines printed, rather than an `Exists` line alone.

## Also corrected

The comment added with `/api/validate-yaml` claimed our parser says `deficient indentation` where upstream says `unexpected end of the stream within a flow collection`. Ours says upstream's sentence. What differs is the cursor — `(1:11)` here against `(2:1)` there — because the captured block carries no trailing newline and upstream's parser is fed one.

## Verification

- **214 selftest checks**, up from 193 — the 21 new ones assert the exact upstream strings, not shapes
- **A live differential** against `huggingface.co/mcp` agrees on all 11 error cases, including both orders of a mixed batch
- `tsc`, `eslint` and `prettier` clean under the workspace's pinned versions

`routes.ts` is comment-only and `statMarkdown` has no other caller, so the REST arm and the `cli-hf` battery are untouched by construction.
