### PR TITLE
Serve hf://README.md, which the tool document tells the model to read

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,8 @@ repos:
         exclude: |
           (?x)^(
               test/data/cursor\.md|
-              typescript/.*
+              typescript/.*|
+              integ/fixtures/.*
           )$
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint

--- a/integ/fixtures/hf-mcp/README.md
+++ b/integ/fixtures/hf-mcp/README.md
@@ -1,0 +1,152 @@
+# Hugging Face virtual filesystem
+
+Use `hf://` URIs to browse Hugging Face resources:
+
+- `hf://models`
+- `hf://datasets`
+- `hf://spaces`
+- `hf://buckets`
+- `hf://collections`
+- `hf://papers`
+- `hf://docs`
+
+The `hf_fs` tool supports six operations:
+
+- `ls` lists direct children, or bounded descendants with `--recursive`.
+- `cat` reads a text or JSON file with `--offset` and `--max-bytes`.
+- `attach` returns one complete JPEG, PNG, or WebP repository or bucket file as MCP image content.
+- `stat` inspects one URI.
+- `find` traverses descendants beneath one known resource.
+- `search` performs API-backed discovery beneath a supported discovery root.
+
+Calls use an `operations` array. One call may submit up to 30 operations, which the server executes with bounded
+parallelism while preserving input order in the returned results.
+
+Use `search` for global discovery and `find` for local traversal. Global recursive crawling is intentionally unsupported.
+
+Entries use canonical `hf://` identities. A link has a local `uri` and an authoritative `target_uri`. Directly addressing a supported link resolves to its target, while recursive traversal does not follow links.
+
+Public resources work anonymously. Private or gated resources require a Hugging Face token with access.
+
+## Safe workflow and operation scope
+
+Discover before access: use `search`, `ls`, or `find` to locate a target, and use `stat` when its type is uncertain.
+Reuse the returned `uri` verbatim, or the `target_uri` for a link. Do not invent repository paths.
+
+`cat` reads confirmed UTF-8 text files only. It rejects repositories, directories, model weights, archives, images,
+media, Parquet, and other binary content. Use `stat` for metadata or `ls` on the parent directory.
+
+`attach URI [--max-bytes N]` accepts exactly one direct repository or bucket file URI. Supported extensions are
+`.jpg`, `.jpeg`, `.png`, and `.webp`, matched case-insensitively. Classification uses only the extension: bytes are
+opaque, are never inspected or altered before MCP encoding, and the complete file is returned or rejected without
+truncation.
+
+| Goal or scope | Use |
+|---|---|
+| Global repository, collection, documentation, paper, or Space discovery | `search` |
+| Recursive name/path matching inside an owner namespace, repository, or docs scope | `find` |
+| Inspect an uncertain target type or binary-file metadata | `stat` |
+| Read a confirmed UTF-8 text file | `cat` |
+| Return a supported image file to the model | `attach` |
+| Sort an owner namespace or supported collection listing | `ls --sort` |
+| Browse globally trending repositories | `ls hf://models/trending`, `hf://datasets/trending`, or `hf://spaces/trending` |
+| List repository files or documentation | `ls` without `--sort` |
+
+## Limits
+
+| Command | Default | Maximum |
+|---|---:|---:|
+| General `ls` and `find` | 1,000 | 10,000 |
+| `search` | 100 | 1,000 |
+| Documentation `search` | 5 | 25 |
+| `ls hf://models/trending` | 20 | 20 |
+| `ls hf://datasets/trending` | 20 | 20 |
+| `ls hf://spaces/trending` | 20 | 20 |
+| `ls hf://papers/trending` | 20 | 100 |
+| `cat --max-bytes` | 20,000 bytes | 80,000 bytes |
+| `attach --max-bytes` | 8 MiB | 8 MiB |
+| Operations per call | 1 | 30 |
+
+Paper listings preserve their provider-defined order. `hf://papers/trending` uses Hugging Face global trending rank, returns 20 papers by default, and accepts `--limit` up to 100. A truncated result states when more papers are available. The cumulative attachment payload for one call is limited to 8 MiB. In a batch, attachment admission is best-effort: the first attachments to reserve capacity are returned, and each attachment omitted because the shared budget is exhausted receives an `HF_FS_ATTACHMENT_BUDGET_EXCEEDED` error result. Split attachments across separate calls when deterministic inclusion is required.
+
+## Examples
+
+```text
+ls hf://models/openai --sort downloads --limit 20
+ls hf://datasets/OWNER/NAME --recursive --glob **/*.json
+find hf://spaces/OWNER/NAME --name app.py --type file
+cat hf://models/OWNER/NAME/README.md --offset 20000 --max-bytes 20000
+attach hf://datasets/OWNER/NAME/images/example.png
+search hf://datasets "speech recognition" --sort downloads --limit 20
+ls hf://spaces/trending
+ls hf://docs/diffusers
+search hf://docs/transformers "loading a pretrained model"
+```
+
+The MCP input keeps each token separate. For example:
+
+```json
+{"operations":[{"cmd":"find","args":["hf://spaces/OWNER/NAME","--name","app.py","--type","file"]}]}
+```
+
+Multiple operations can be submitted together:
+
+```json
+{
+  "operations": [
+    {"cmd":"cat","args":["hf://papers/2502.16161/metadata.json"]},
+    {"cmd":"cat","args":["hf://papers/2502.16162/metadata.json"]}
+  ]
+}
+```
+
+## Writes
+
+Authenticated servers can expose `hf_fs_write` with the same command-and-arguments convention. `put` receives file
+data separately in `content`; use `--base64` for binary data.
+
+```json
+{"cmd":"put","args":["hf://models/OWNER/NAME/README.md","--message","Update README"],"content":"# Model"}
+{"cmd":"rm","args":["hf://datasets/OWNER/NAME/old.json","--create-pr","--message","Remove stale data"]}
+```
+
+Repository writes support `--branch`, `--create-pr`, `--description`, and `--parent-commit SHA`. Use `--create-pr`
+when proposing a change to a repository you cannot or should not modify directly. Buckets do not support commit or
+pull-request options.
+
+## Trending repositories
+
+The `models`, `datasets`, and `spaces` roots each expose a virtual `trending` directory. These directories return at most 20 entries from the Hugging Face trending feed. `--sort trending` and `--sort trendingScore` are accepted but redundant because the path already determines the order.
+
+## Papers
+
+- Search by topic: `search hf://papers "vision language models"`
+- Inspect a paper: `hf://papers/2502.16161`
+- Read full text: `hf://papers/2502.16161/paper.md`
+- Current Daily Papers: `hf://papers/daily/latest`
+- Dated batch: `hf://papers/daily/YYYY/MM/DD`
+- Current global ranking: `hf://papers/trending`
+
+See [`hf://papers/README.md`](hf://papers/README.md) for details.
+
+## Documentation
+
+`hf://docs` exposes products with a current `llms.txt` manifest. Manifest paths are authoritative and include the
+current release version:
+
+```text
+ls hf://docs/diffusers
+cat hf://docs/diffusers/v0.39.0/quicktour.md
+find hf://docs/transformers --path "*/main_classes/*.md"
+search hf://docs/peft "adapter injection"
+search hf://docs/transformers/v5.13.1/internal "TextIteratorStreamer"
+cat hf://docs/transformers/v5.13.1/internal/generation_utils.md#transformers.TextIteratorStreamer
+```
+
+`ls hf://docs` lists products. Search any product, version, directory, or document scope, and use returned `hf://`
+URIs verbatim. Documentation manifests are cached for ten minutes. Reads are restricted to files in the current
+manifest; anchored reads return a best-effort bounded section.
+
+## Sandboxes
+
+For complicated or intensive filesystem operations mount the required repositories in a Sandbox and use shell or Python to programatically inspect them.

--- a/integ/fixtures/hf-mcp/tools.json
+++ b/integ/fixtures/hf-mcp/tools.json
@@ -1,6 +1,6 @@
 {
   "capturedFrom": "https://huggingface.co/mcp",
-  "capturedAt": "2026-08-29T02:00:49Z",
+  "capturedAt": "2026-09-01T09:54:20.753Z",
   "protocolVersion": "2025-06-18",
   "serverInfo": {
     "name": "huggingface.co/mcp",

--- a/integ/server/hf_hub/capture.ts
+++ b/integ/server/hf_hub/capture.ts
@@ -36,6 +36,12 @@ import { DEFAULT_FIXTURE_ROOT } from '../kit/typescript/index.ts'
 
 const URL_MCP = 'https://huggingface.co/mcp'
 const OUT = join(DEFAULT_FIXTURE_ROOT, 'hf-mcp', 'tools.json')
+// The limits page, captured for the same reason the schemas are: the tool
+// document's own closing line sends the model to `hf://README.md`, so it is
+// part of the surface being measured rather than reference material for us.
+// It is also where every bound in this fake came from -- cat's 20,000/80,000,
+// ls and find's 1,000/10,000 -- which were invented here until it was read.
+const OUT_README = join(DEFAULT_FIXTURE_ROOT, 'hf-mcp', 'README.md')
 
 interface Rpc {
   result?: Record<string, unknown>
@@ -90,6 +96,60 @@ async function listTools(token: string): Promise<{
   return { init, tools }
 }
 
+/** The bytes `cat hf://README.md` serves, without the cat rendering around them. */
+async function readmeOf(token: string): Promise<string> {
+  const opened = await rpc(
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'mirage-capture', version: '0' },
+      },
+    },
+    '',
+    token,
+  )
+  await rpc({ jsonrpc: '2.0', method: 'notifications/initialized' }, opened.session, token)
+  const got = await rpc(
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'hf_fs',
+        // No --max-bytes: the default is 20,000 and the page is a third of
+        // that, so asking for it whole is asking for it once. A page that
+        // outgrows the default would arrive truncated and SAY so, which is
+        // the assertion below.
+        arguments: { operations: [{ cmd: 'cat', args: ['hf://README.md'] }] },
+      },
+    },
+    opened.session,
+    token,
+  )
+  // Taken from the structured result and not from the markdown: the rendered
+  // form wraps the file in a header this fake generates for itself, and
+  // capturing that too would nest one copy inside another.
+  const results = (got.reply.result as { structuredContent?: { results?: unknown[] } } | undefined)
+    ?.structuredContent?.results
+  const first = Array.isArray(results) ? (results[0] as Record<string, unknown>) : undefined
+  const result = first?.result as Record<string, unknown> | undefined
+  const content = result?.content
+  if (typeof content !== 'string') {
+    throw new Error(`cat hf://README.md failed: ${JSON.stringify(got.reply).slice(0, 400)}`)
+  }
+  if (result?.truncated === true) {
+    throw new Error(
+      'hf://README.md now exceeds the default cat bound, so this capture is a prefix; ' +
+        'raise --max-bytes here before refreshing the fixture',
+    )
+  }
+  return content
+}
+
 const token = process.env.HF_TOKEN ?? ''
 const anon = await listTools('')
 if (token !== '') {
@@ -111,8 +171,14 @@ const doc = {
   tools: anon.tools,
 }
 writeFileSync(OUT, `${JSON.stringify(doc, null, 2)}\n`)
+
+// Verbatim, with no trailing newline added: this is a file the fake serves
+// byte for byte, and `Bytes:` in the reply counts whatever is written here.
+const readme = await readmeOf(token)
+writeFileSync(OUT_README, readme)
 const info = doc.serverInfo as { name?: string; version?: string }
 process.stdout.write(
-  `captured ${String(anon.tools.length)} tools from ${String(info.name)} ${String(info.version)}` +
+  `captured ${String(anon.tools.length)} tools and ${String(Buffer.byteLength(readme))} ` +
+    `README bytes from ${String(info.name)} ${String(info.version)}` +
     `${token === '' ? '' : ' (anonymous == authenticated)'}\n`,
 )

--- a/integ/server/hf_hub/capture.ts
+++ b/integ/server/hf_hub/capture.ts
@@ -152,11 +152,23 @@ async function readmeOf(token: string): Promise<string> {
 
 const token = process.env.HF_TOKEN ?? ''
 const anon = await listTools('')
+// Anonymously for BOTH, because the pair has to describe one server. The
+// document below is built from `anon`, so a README fetched with the token
+// would pin the authenticated page beside the anonymous schemas -- one
+// fixture from each of two snapshots, which is the thing this script exists
+// to prevent.
+const readme = await readmeOf('')
 if (token !== '') {
   const authed = await listTools(token)
   if (JSON.stringify(anon.tools) !== JSON.stringify(authed.tools)) {
     throw new Error(
       'the anonymous and authenticated tool lists differ; the fixture can only pin one, ' +
+        'so decide which the measurement uses before refreshing it',
+    )
+  }
+  if (readme !== (await readmeOf(token))) {
+    throw new Error(
+      'the anonymous and authenticated README pages differ; the fixture can only pin one, ' +
         'so decide which the measurement uses before refreshing it',
     )
   }
@@ -170,11 +182,15 @@ const doc = {
   instructions: anon.init.instructions,
   tools: anon.tools,
 }
-writeFileSync(OUT, `${JSON.stringify(doc, null, 2)}\n`)
 
-// Verbatim, with no trailing newline added: this is a file the fake serves
-// byte for byte, and `Bytes:` in the reply counts whatever is written here.
-const readme = await readmeOf(token)
+// Both writes LAST, after every fetch and every assertion above. Written as
+// they were reached -- tool document, then page -- a failed or truncated
+// README left tools.json already replaced and README.md still the previous
+// capture: two snapshots of a surface the fake presents as one, and the
+// script exiting non-zero would not have put it back.
+// The page is verbatim, with no trailing newline added: the fake serves it
+// byte for byte and `Bytes:` in the reply counts whatever is written here.
+writeFileSync(OUT, `${JSON.stringify(doc, null, 2)}\n`)
 writeFileSync(OUT_README, readme)
 const info = doc.serverInfo as { name?: string; version?: string }
 process.stdout.write(

--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -49,6 +49,7 @@ import {
   FS_IMAGE_ONLY,
   FS_IMAGE_TOO_LARGE,
   FS_NOT_A_FILE,
+  FS_NOT_A_DIRECTORY,
   FS_NOT_FOUND,
   FS_TEXT_ONLY,
   FS_UNSUPPORTED_MEDIA,
@@ -75,6 +76,27 @@ import {
 // live server's own `tools/list` is pinned as a fixture and replayed verbatim.
 // Refresh it with `pnpm run hf-mcp:capture`, which records what it came from.
 const TOOLS_FIXTURE = join(DEFAULT_FIXTURE_ROOT, 'hf-mcp', 'tools.json')
+// The limits page, captured beside the schemas by the same script and for the
+// same reason. `hf://README.md` is a FILE at the root of the virtual
+// filesystem -- no owner, no repository, no tree route behind it -- and the
+// tool document's own closing line sends the model to it: "Limits and
+// path-specific behavior are documented at hf://README.md". A fake that
+// refuses the path refuses an instruction it handed out itself, which is what
+// happened: an agent asked for it mid-benchmark and was told, in bytes it was
+// charged for, that "the mirage hf_hub fake" serves something else.
+const README_FIXTURE = join(DEFAULT_FIXTURE_ROOT, 'hf-mcp', 'README.md')
+const README_URI = 'hf://README.md'
+const README_PATH = 'README.md'
+// Declared by the virtual documentation files and by nothing else -- a
+// repository file's stat and cat carry no Content-Type at all.
+const README_MIME = 'text/markdown'
+
+let readmeCached: Buffer | undefined
+
+function readmeBytes(): Buffer {
+  readmeCached ??= readFileSync(README_FIXTURE)
+  return readmeCached
+}
 
 interface ToolDoc {
   capturedFrom: string
@@ -762,6 +784,70 @@ interface Budget {
   left: number
 }
 
+/**
+ * The four answers `hf://README.md` has, each read off the live server.
+ *
+ * It is a file, so `ls` and `find` refuse it as ENOTDIR and `attach` refuses
+ * it as the wrong kind of file -- the two refusals differ because upstream's
+ * differ, and an agent may branch on either code. `cat` and `stat` serve the
+ * captured page, and both name a Content-Type that a repository file does not
+ * have.
+ *
+ * Served from the fixture rather than through `callRoute` because there is no
+ * route: this page belongs to the MCP server, not to the Hub behind it, and
+ * the REST arm has nothing to answer for it. That is the one place the two
+ * arms legitimately do not share an implementation.
+ */
+function readmeOne(cmd: string, rest: string[]): FsOut {
+  const whole = readmeBytes()
+  if (cmd === 'stat') {
+    if (rest.length > 0) {
+      return fsFail(FS_INVALID, `EINVAL: unexpected argument for ${cmd}: ${rest[0] ?? ''}`)
+    }
+    return {
+      text: statMarkdown(README_URI, 'file', README_PATH, whole.length, README_MIME),
+      result: {
+        uri: README_URI,
+        op: 'stat',
+        exists: true,
+        type: 'file',
+        path: README_PATH,
+        content_type: README_MIME,
+        size: whole.length,
+      },
+    }
+  }
+  if (cmd === 'ls' || cmd === 'find') return fsFail(FS_NOT_A_DIRECTORY, 'ENOTDIR: not a directory')
+  if (cmd === 'attach') {
+    return fsFail(FS_NOT_A_FILE, 'attach requires a direct repository or bucket file URI.')
+  }
+  if (cmd !== 'cat') return fsFail(FS_INVALID, `EINVAL: unknown command: ${cmd}`)
+  const flags = catArgs(rest)
+  if ('code' in flags) return fsFail(flags.code, flags.message)
+  // The same slicing a repository file gets, including the mid-character
+  // retreat: this page is UTF-8 and a caller may resume into the middle of a
+  // character exactly as it may anywhere else.
+  const asked = Math.min(flags.offset, whole.length)
+  const from = utf8Start(whole, asked)
+  const end = utf8End(whole, Math.min(asked + flags.maxBytes, whole.length))
+  const slice = whole.subarray(from, end)
+  const bounds: CatBounds = { offset: from, total: whole.length, next: end }
+  const truncated = bounds.next < bounds.total
+  return {
+    text: catMarkdown(README_URI, README_PATH, slice, bounds, README_MIME),
+    result: {
+      uri: README_URI,
+      op: 'cat',
+      path: README_PATH,
+      content: slice.toString('utf8'),
+      content_type: README_MIME,
+      bytes: slice.length,
+      truncated,
+      ...(truncated ? { truncation_reason: 'max_bytes', next_offset: bounds.next } : {}),
+    },
+  }
+}
+
 async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget): Promise<FsOut> {
   if (cmd === 'search') {
     return fsFail(
@@ -770,6 +856,7 @@ async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget):
     )
   }
   const uri = args[0] ?? ''
+  if (uri === README_URI) return readmeOne(cmd, args.slice(1))
   const where = locate(uri, cmd)
   if (!('kind' in where)) return fsFail(where.code, where.message)
   const rest = args.slice(1)

--- a/integ/server/hf_hub/render.ts
+++ b/integ/server/hf_hub/render.ts
@@ -303,7 +303,13 @@ export function attachMarkdown(uri: string, path: string, mime: string, bytes: n
   ].join('\n')
 }
 
-export function statMarkdown(uri: string, kind: StatKind, path: string, size?: number): string {
+export function statMarkdown(
+  uri: string,
+  kind: StatKind,
+  path: string,
+  size?: number,
+  contentType?: string,
+): string {
   return [
     `# hf_fs stat`,
     '',
@@ -312,6 +318,11 @@ export function statMarkdown(uri: string, kind: StatKind, path: string, size?: n
     `- Type: \`${kind}\``,
     `- Path: \`${path}\``,
     ...(kind === 'file' && size !== undefined ? [`- Size: ${humanSize(size)}`] : []),
+    // AFTER the size here, and BEFORE the byte count in `catMarkdown`. The
+    // two orders are upstream's, captured separately, and neither is a typo:
+    // a repository file carries no Content-Type at all, and only the virtual
+    // documentation files declare one.
+    ...(contentType === undefined ? [] : [`- Content-Type: \`${contentType}\``]),
   ].join('\n')
 }
 
@@ -341,6 +352,7 @@ export function catMarkdown(
   path: string,
   content: Uint8Array,
   bounds: CatBounds,
+  contentType?: string,
 ): string {
   const text = Buffer.from(content).toString('utf8')
   const more = bounds.next < bounds.total
@@ -355,6 +367,7 @@ export function catMarkdown(
     '',
     `URI: \`${uri}\``,
     `Path: \`${path}\``,
+    ...(contentType === undefined ? [] : [`Content-Type: \`${contentType}\``]),
     `Bytes: ${String(content.length)}`,
     '',
     text,
@@ -369,6 +382,11 @@ export const FS_NOT_FOUND = 'HF_FS_NOT_FOUND'
 export const FS_INVALID = 'HF_FS_INVALID_ARGUMENT'
 export const FS_TEXT_ONLY = 'HF_FS_TEXT_ONLY'
 export const FS_NOT_A_FILE = 'HF_FS_NOT_A_FILE'
+// The mirror of NOT_A_FILE, for the commands that need a directory and were
+// handed a file. Only reachable on `hf://README.md` today -- inside a
+// repository the tree route answers a file path with no rows, which `ls` has
+// always reported as an empty listing rather than an error.
+export const FS_NOT_A_DIRECTORY = 'HF_FS_NOT_A_DIRECTORY'
 // `attach`'s own three. It refuses more precisely than `cat` does, because it
 // returns a whole file and cannot truncate: a text file is the wrong KIND of
 // thing (use cat), a non-image binary is unsupported media, and an image over
@@ -387,6 +405,8 @@ const RECOVERY: Record<string, string> = {
     'Use stat for metadata or ls on the parent directory. Do not use cat for binary or non-UTF-8 content.',
   [FS_NOT_A_FILE]:
     'Use stat to confirm the target is a file, or ls/find to discover a returned file URI.',
+  [FS_NOT_A_DIRECTORY]:
+    'Use stat to inspect the target, then run ls or find only on a directory-like scope.',
   [FS_IMAGE_ONLY]: 'Use cat to read this text file, or stat for metadata.',
   [FS_UNSUPPORTED_MEDIA]:
     'Attach supports only files ending in .jpg, .jpeg, .png, or .webp. Use stat for metadata.',
@@ -408,6 +428,7 @@ const SUGGESTED: Record<string, string> = {
   [FS_NOT_FOUND]: 'stat',
   [FS_TEXT_ONLY]: 'stat',
   [FS_NOT_A_FILE]: 'stat',
+  [FS_NOT_A_DIRECTORY]: 'stat',
   [FS_UNSUPPORTED_MEDIA]: 'stat',
   [FS_IMAGE_TOO_LARGE]: 'stat',
   // The one that is not `stat`. A text file asked for as an image is not an

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -742,20 +742,16 @@ async function mcpChecks(): Promise<void> {
 
     // ---- roots the fake does not hold are not bad NAMES
     //
-    // `docs` and `README.md` are addressable upstream -- `ls hf://docs`
-    // answers and `cat hf://README.md` is where it documents its limits --
-    // so calling them invalid types was wrong twice over.
+    // `docs` is addressable upstream, so calling it an invalid TYPE was wrong;
+    // it is a root this fake does not hold, which is a different sentence.
+    // `README.md` was in here too until the fake started serving it, and the
+    // pair is worth keeping side by side: one of these is a gap and the other
+    // was, and only the served one stops charging the agent for our name.
     const docs = await call('hf_fs', ops(catOp('hf://docs/transformers/index')))
     check(
       'an unserved root says which roots are served',
       String(errorOf(docs).message ?? '').includes('the mirage hf_hub fake serves'),
       JSON.stringify(errorOf(docs).message ?? null),
-    )
-    const readme = await call('hf_fs', ops(catOp('hf://README.md')))
-    check(
-      'and so does the root-level page',
-      String(errorOf(readme).message ?? '').includes('the mirage hf_hub fake serves'),
-      JSON.stringify(errorOf(readme).message ?? null),
     )
 
     // ---- a repository past one page
@@ -1020,6 +1016,65 @@ async function mcpChecks(): Promise<void> {
       'and a directory whose name looks like a file is still a dir',
       statNestedDir.includes('- Type: `dir`'),
       statNestedDir.slice(0, 220),
+    )
+
+    // ---- hf://README.md, the limits page the tool document points at
+    //
+    // Every expectation below was read off the live server, including which
+    // of the two "wrong kind of thing" codes each command answers with. The
+    // fake used to refuse the path outright, in a sentence naming itself.
+    const readmeStat = await text('hf_fs', {
+      operations: [{ cmd: 'stat', args: ['hf://README.md'] }],
+    })
+    check(
+      'stat hf://README.md is a file with a Content-Type',
+      readmeStat.includes('- Type: `file`') &&
+        readmeStat.includes('- Path: `README.md`') &&
+        readmeStat.includes('- Content-Type: `text/markdown`'),
+      readmeStat.slice(0, 260),
+    )
+    const readmeCat = await text('hf_fs', {
+      operations: [{ cmd: 'cat', args: ['hf://README.md'] }],
+    })
+    check(
+      'cat hf://README.md serves the captured page',
+      readmeCat.includes('# Hugging Face virtual filesystem') &&
+        readmeCat.includes('Content-Type: `text/markdown`'),
+      readmeCat.slice(0, 260),
+    )
+    // The page documents the bounds this fake implements, so a fake that
+    // served a DIFFERENT page would be telling the agent the wrong numbers.
+    check(
+      'and the page still documents the bounds the fake enforces',
+      readmeCat.includes('hf_fs_write') && readmeCat.includes('30 operations'),
+      readmeCat.slice(0, 200),
+    )
+    const readmeCut = await text('hf_fs', {
+      operations: [{ cmd: 'cat', args: ['hf://README.md', '--max-bytes', '120'] }],
+    })
+    check(
+      'a bounded read of it stops where asked, and says where to resume',
+      readmeCut.includes('Bytes: 120') &&
+        readmeCut.includes('Content truncated. Resume with offset 120.'),
+      readmeCut.slice(0, 200),
+    )
+    const readmeLs = await call('hf_fs', ops({ cmd: 'ls', args: ['hf://README.md'] }))
+    eq(
+      'ls on it is ENOTDIR, not the fake naming itself',
+      errorOf(readmeLs).code ?? null,
+      'HF_FS_NOT_A_DIRECTORY',
+    )
+    eq(
+      'and find answers the same code',
+      errorOf(await call('hf_fs', ops({ cmd: 'find', args: ['hf://README.md'] }))).code ?? null,
+      'HF_FS_NOT_A_DIRECTORY',
+    )
+    // A DIFFERENT code from ls: it is a file, just not an attachable one.
+    eq(
+      'attach on it is NOT_A_FILE, which is a different refusal',
+      errorOf(await call('hf_fs', ops({ cmd: 'attach', args: ['hf://README.md'] }))).message ??
+        null,
+      'attach requires a direct repository or bucket file URI.',
     )
 
     // Both error codes are the live server's own, captured rather than coined,


### PR DESCRIPTION
The captured `hf_fs` description ends:

> Limits and path-specific behavior are documented at **hf://README.md**.

The fake refused that path, in a sentence naming itself:

```
[HF_FS_INVALID_ARGUMENT] EINVAL: the mirage hf_hub fake serves models, datasets, spaces only: hf://README.md
```

So the surface being measured handed the model an instruction and then charged it for following one it could not carry out.

**This is not hypothetical.** An agent asked for the page during a benchmark draw, got that refusal, and stopped using `hf_fs` for the rest of the run.

## What it serves

Each behaviour was read off the live server rather than reasoned about:

| command | answer |
|---|---|
| `cat` | the page, `Content-Type: text/markdown` **before** the byte count |
| `stat` | a file, Content-Type **after** the size — the two orders differ upstream, neither is a typo |
| `ls` / `find` | `HF_FS_NOT_A_DIRECTORY`, `ENOTDIR: not a directory` |
| `attach` | `HF_FS_NOT_A_FILE`, `attach requires a direct repository or bucket file URI.` — a *different* refusal from `ls`, because it is a file, just not an attachable one |

`HF_FS_NOT_A_DIRECTORY` is new and is the mirror of `NOT_A_FILE`. Inside a repository it is unreachable: the tree route answers a file path with no rows, which `ls` has always rendered as an empty listing.

## Captured, not authored

`capture.ts` now pulls the page alongside `tools.json` — from the structured result rather than the rendered one, so the `cat` header is not nested inside itself, and it refuses to write a page that arrived truncated instead of silently pinning a prefix.

This is the same rule the schemas follow, and it matters more here than it looks: this page is where every bound in this fake came from. `cat`'s 20,000/80,000 and `ls`/`find`'s 1,000/10,000 were all invented locally until somebody read it.

Only `capturedAt` moved in `tools.json` — the four schemas are byte-identical to the 2026-08-29 capture, so the tool surface has not drifted.

## One deliberate asymmetry

This is the only place the two arms do not share an implementation. The page belongs to the MCP server, not to the Hub behind it, so there is no REST route to dispatch through and nothing for the mirage arm to read. It is served from the fixture.

## Checks

258, up from 253. One old check is **retired rather than adapted** — it asserted the refusal this PR removes.

## Known gap, not addressed here

`hf://<kind>/<namespace>` (two segments) is a **namespace** upstream — `stat` returns `type: namespace` and `ls` lists the namespace's repos. This fake answers `EINVAL: expected hf://<kind>/<namespace>/<name>`. The same benchmark run hit this too, with `ls hf://models/huggingface-upload`. It needs a different `ls` row shape (upstream fills the URI and Details columns with `repo=model, public, likes=…, downloads=…`) and richer repo metadata than the fixtures carry, so it is its own change rather than a rider on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)