### PR TITLE
Serve /raw/ on the Hub fake and list an issue's comments on the GitHub one

### DIFF
--- a/integ/server/github/issues.ts
+++ b/integ/server/github/issues.ts
@@ -206,6 +206,39 @@ async function createComment(ctx: Ctx<C>, repo: RepoRow): Promise<Reply> {
   }
 }
 
+/**
+ * Every comment on one issue, oldest first.
+ *
+ * Oldest first is the vendor's order and it is the whole of what a caller
+ * reads this for: `comments[-1]` is "what was said last", which is how a
+ * grader asks whether the reply it wanted is the reply that landed. Sorting
+ * the other way would leave every such check reading the opening comment.
+ *
+ * The shape matches what `createComment` returns, plus `created_at`, so a
+ * caller that posts and then lists sees one comment described one way.
+ */
+async function listComments(ctx: Ctx<C>, repo: RepoRow): Promise<Reply> {
+  const number = numberParam(ctx)
+  if (number === null) return fail(404, 'Not Found')
+  const issue = await issueRow(ctx.db, ctx.tenant, repo, number)
+  const pull = issue === null ? await pullRow(ctx.db, ctx.tenant, repo, number) : null
+  if (issue === null && pull === null) return fail(404, 'Not Found')
+  const rows = await ctx.db.githubComment.findMany({
+    where: { ...scope(ctx.tenant), repo: repo.fullName, issueNumber: number },
+    orderBy: { seq: 'asc' },
+  })
+  return pagedReply(
+    ctx,
+    rows.map((row) => ({
+      id: row.id,
+      body: row.body,
+      created_at: row.createdAt,
+      user: { login: row.user },
+      html_url: `https://github.com/${repo.fullName}/issues/${String(number)}#issuecomment-${String(row.id)}`,
+    })),
+  )
+}
+
 export function issueRoutes(): KitRoute<C>[] {
   return everywhere<C>(API_PREFIXES, (p) => [
     route<C>('GET', `${p}/repos/:owner/:repo/issues`, authedRoute(withRepo(listIssues))),
@@ -216,6 +249,11 @@ export function issueRoutes(): KitRoute<C>[] {
     route<C>('PATCH', `${p}/repos/:owner/:repo/issues/:number`, authedRoute(withRepo(editIssue)), {
       write: true,
     }),
+    route<C>(
+      'GET',
+      `${p}/repos/:owner/:repo/issues/:number/comments`,
+      authedRoute(withRepo(listComments)),
+    ),
     route<C>(
       'POST',
       `${p}/repos/:owner/:repo/issues/:number/comments`,

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -854,6 +854,36 @@ async function main(): Promise<void> {
     })
     check('and not what the branch gained afterwards', later.status === 404, String(later.status))
 
+    // ---- listing an issue's comments, which no mirage client asks for
+    // `gh issue comment` posts one and there is no verb that lists them, so
+    // the battery cannot reach this and the endpoint would ship untested.
+    // What does ask is everything on the other side of the fake: a grader
+    // checking that the reply it wanted is the reply that landed reads
+    // `comments[-1]`, which is only "what was said last" if the order is the
+    // vendor's -- oldest first.
+    const opened = await post(`${at}/repos/${REPO}/issues`, {
+      title: 'License info. needed',
+      body: 'Could you provide license info.?',
+    })
+    check('an issue is opened', opened.status === 201, String(opened.status))
+    const issueNo = String(field(opened.body, 'number') ?? '')
+    const empty = await get(`${at}/repos/${REPO}/issues/${issueNo}/comments`)
+    eq('a fresh issue lists no comments', empty, [])
+    for (const body of ['first', 'second']) {
+      const said = await post(`${at}/repos/${REPO}/issues/${issueNo}/comments`, { body })
+      check(`a comment is posted (${body})`, said.status === 201, String(said.status))
+    }
+    const thread = await get(`${at}/repos/${REPO}/issues/${issueNo}/comments`)
+    const bodies = Array.isArray(thread) ? thread.map((c) => field(c, 'body')) : []
+    eq('and both come back oldest first', bodies, ['first', 'second'])
+    check(
+      'each carries the author a grader checks',
+      Array.isArray(thread) && thread.every((c) => field(field(c, 'user'), 'login') !== null),
+      JSON.stringify(thread).slice(0, 200),
+    )
+    const noSuch = await fetch(`${at}/repos/${REPO}/issues/4242/comments`, { headers: HEADERS })
+    check('an issue that is not there is 404', noSuch.status === 404, String(noSuch.status))
+
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {
     fake.child.kill('SIGTERM')

--- a/integ/server/hf_hub/routes.ts
+++ b/integ/server/hf_hub/routes.ts
@@ -517,7 +517,14 @@ async function blobFor(ctx: Ctx<C>): Promise<Found | Reply> {
   const revision = ctx.params.rev ?? DEFAULT_REVISION
   const sha = await resolveRevision(ctx.db, ctx.tenant, key, revision)
   if (sha === null) return revisionNotFound(revision)
-  const path = decodeURIComponent(ctx.params.path ?? '')
+  // Not decoded here. The kit router already decodes every captured
+  // parameter, `*path` included, so a second pass is a second decode:
+  // `100%.txt` is requested as `100%25.txt`, arrives as `100%.txt`, and
+  // `decodeURIComponent` throws on the bare `%` -- a 500 where the file
+  // exists. The quieter half is worse: a file literally named `a%20b.txt`
+  // is requested as `a%2520b.txt`, arrives as `a%20b.txt`, and decodes
+  // again to `a b.txt` -- a DIFFERENT file, served with a 200.
+  const path = ctx.params.path ?? ''
   const blob = await blobAt(ctx.db, ctx.tenant, key, sha, path)
   if (blob === null) return entryNotFound()
   return { sha, blob }

--- a/integ/server/hf_hub/routes.ts
+++ b/integ/server/hf_hub/routes.ts
@@ -499,9 +499,15 @@ async function tree(ctx: Ctx<C>): Promise<Reply> {
   return pageOf(rows, ctx.query.get('cursor'), limit, ctx.url, ctx.runPrefix)
 }
 
-// ----------------------------------------------------------------- resolve
+// ------------------------------------------------------- resolve and raw
 
-async function resolve(ctx: Ctx<C>): Promise<Reply> {
+interface Found {
+  sha: string
+  blob: HfBlobRow
+}
+
+/** The one blob a `resolve` or `raw` URL names, or the error that URL earns. */
+async function blobFor(ctx: Ctx<C>): Promise<Found | Reply> {
   const kind = ctx.params.kind ?? 'models'
   const namespace = namespaceOf(ctx)
   const name = ctx.params.name ?? ''
@@ -514,6 +520,13 @@ async function resolve(ctx: Ctx<C>): Promise<Reply> {
   const path = decodeURIComponent(ctx.params.path ?? '')
   const blob = await blobAt(ctx.db, ctx.tenant, key, sha, path)
   if (blob === null) return entryNotFound()
+  return { sha, blob }
+}
+
+async function resolve(ctx: Ctx<C>): Promise<Reply> {
+  const found = await blobFor(ctx)
+  if ('status' in found) return found
+  const { sha, blob } = found
   const body = Buffer.from(blob.content)
   const etag = blob.lfsOid !== '' ? blob.lfsOid : blob.oid
   const headers: Record<string, string> = {
@@ -529,6 +542,53 @@ async function resolve(ctx: Ctx<C>): Promise<Reply> {
   // headers above ride along on whichever status comes back, because a client
   // reads `X-Repo-Commit` off a partial response exactly as off a whole one.
   const windowed = rangeReply(ctx.headers, body)
+  return { ...windowed, headers: { ...headers, ...windowed.headers } }
+}
+
+/**
+ * The git-lfs pointer a large file is tracked by, which is what `raw` serves
+ * in place of its content.
+ *
+ * Three lines and a trailing newline, exactly as the spec writes them --
+ * probed rather than recalled: `/datasets/lockon/ToolACE/raw/main/data.json`
+ * answers 133 bytes of this against 37MB through `resolve`.
+ */
+function pointer(blob: HfBlobRow): string {
+  return [
+    'version https://git-lfs.github.com/spec/v1',
+    `oid sha256:${blob.lfsOid}`,
+    `size ${String(blob.content.length)}`,
+    '',
+  ].join('\n')
+}
+
+/**
+ * `raw`, which is `resolve` for a reader rather than for a downloader.
+ *
+ * Two differences, and both are why it cannot simply forward to `resolve`.
+ * The content type is `text/plain` and there is no redirect, so a plain
+ * `requests.get` gets the file -- which is how the Hub's own web view links a
+ * README, and how anything that never learned about LFS reads one. And an
+ * LFS-tracked path answers with its POINTER, not its bytes: three lines
+ * naming the sha256 and the size. A caller that wants the file wants
+ * `resolve`; a caller that wants the pointer has no other way to ask.
+ *
+ * ETag is the git blob oid on both branches, where `resolve` swaps in the
+ * lfs oid -- the pointer IS the blob here, so its own oid is the honest one.
+ */
+async function raw(ctx: Ctx<C>): Promise<Reply> {
+  const found = await blobFor(ctx)
+  if ('status' in found) return found
+  const { sha, blob } = found
+  const body = Buffer.from(blob.lfsOid !== '' ? pointer(blob) : blob.content)
+  const headers: Record<string, string> = {
+    ETag: `"${blob.oid}"`,
+    'X-Repo-Commit': sha,
+  }
+  // The content type is the kit's to state rather than this map's: it owns the
+  // 200, the 206 and the 416 and writes the header on all three, so one set
+  // here is the single header the spread below overwrites.
+  const windowed = rangeReply(ctx.headers, body, 'text/plain; charset=utf-8')
   return { ...windowed, headers: { ...headers, ...windowed.headers } }
 }
 
@@ -913,9 +973,12 @@ function repoRoute(
 
 function resolveRoutes(kind: string, prefix: string): KitRoute<C>[] {
   const bind = (ctx: Ctx<C>): Promise<Reply> => resolve({ ...ctx, params: { ...ctx.params, kind } })
+  const bindRaw = (ctx: Ctx<C>): Promise<Reply> => raw({ ...ctx, params: { ...ctx.params, kind } })
   return [
     route('GET', `${prefix}/:ns/:name/resolve/:rev/*path`, bind),
     route('GET', `${prefix}/:name/resolve/:rev/*path`, bind),
+    route('GET', `${prefix}/:ns/:name/raw/:rev/*path`, bindRaw),
+    route('GET', `${prefix}/:name/raw/:rev/*path`, bindRaw),
   ]
 }
 

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -1902,6 +1902,41 @@ async function main(): Promise<void> {
     const unauth = await fetch(`${fake.endpoint}/api/models`)
     check('an unauthenticated listing is refused', unauth.status === 401, String(unauth.status))
 
+    // ---- raw, which is resolve for a reader
+    // `/raw/` is how the Hub's own web view links a README and how anything
+    // holding a plain `requests.get` reads one: no redirect, `text/plain`,
+    // and -- the part that is not a synonym for resolve -- an LFS-tracked
+    // path answers with its POINTER rather than its bytes. Probed against
+    // huggingface.co, where `/datasets/lockon/ToolACE/raw/main/data.json`
+    // is 133 bytes of `version https://git-lfs...` against 37MB through
+    // resolve. No client inside mirage sends this request, so the battery
+    // cannot reach it and the endpoint would otherwise ship untested.
+    const rawCard = ['---', 'license: mit', '---', '', '# Raw', ''].join('\n')
+    await repoWithCard(fake.endpoint, 'datasets', 'raw-dataset', rawCard)
+    const raw = await fetch(`${fake.endpoint}/datasets/${TENANT}/raw-dataset/raw/main/README.md`, {
+      headers: { Authorization: `Bearer ${TENANT}` },
+    })
+    check('raw serves the file', raw.status === 200, String(raw.status))
+    eq('raw serves it verbatim', await raw.text(), rawCard)
+    check(
+      'raw is text/plain, where resolve is a download',
+      (raw.headers.get('content-type') ?? '').startsWith('text/plain'),
+      raw.headers.get('content-type') ?? '',
+    )
+    check('raw names the commit', (raw.headers.get('x-repo-commit') ?? '') !== '', '')
+
+    const rawResolve = await fetch(
+      `${fake.endpoint}/datasets/${TENANT}/raw-dataset/resolve/main/README.md`,
+      { headers: { Authorization: `Bearer ${TENANT}` } },
+    )
+    eq('and resolve still answers the same bytes', await rawResolve.text(), rawCard)
+
+    const rawMissing = await fetch(
+      `${fake.endpoint}/datasets/${TENANT}/raw-dataset/raw/main/nope.txt`,
+      { headers: { Authorization: `Bearer ${TENANT}` } },
+    )
+    check('raw 404s a path that is not there', rawMissing.status === 404, String(rawMissing.status))
+
     await mcpChecks()
     await launchChecks()
 

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -1931,6 +1931,39 @@ async function main(): Promise<void> {
     )
     eq('and resolve still answers the same bytes', await rawResolve.text(), rawCard)
 
+    // ---- a path is decoded once, not twice
+    // The kit router decodes every captured parameter, `*path` included, so a
+    // `decodeURIComponent` in the handler was a second pass. Both halves are
+    // checked because only one of them is loud: `100%.txt` threw `URI
+    // malformed` and answered 500, while `a%20b.txt` decoded a second time to
+    // `a b.txt` and served a DIFFERENT file with a 200. Caught in review on
+    // the PR that added `raw`; `resolve` had carried it since it was written.
+    const pushedPct = await fetch(
+      `${fake.endpoint}/api/datasets/${TENANT}/raw-dataset/commit/main`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${TENANT}`, 'Content-Type': 'application/x-ndjson' },
+        body: [
+          JSON.stringify({ key: 'header', value: { summary: 'add percent paths' } }),
+          JSON.stringify({ key: 'file', value: { path: '100%.txt', content: 'percent' } }),
+          JSON.stringify({ key: 'file', value: { path: 'a b.txt', content: 'space' } }),
+          JSON.stringify({ key: 'file', value: { path: 'a%20b.txt', content: 'literal' } }),
+        ].join('\n'),
+      },
+    )
+    check('percent-named files are pushed', pushedPct.status === 200, String(pushedPct.status))
+    const readAt = async (encoded: string, via: string): Promise<string> => {
+      const r = await fetch(
+        `${fake.endpoint}/datasets/${TENANT}/raw-dataset/${via}/main/${encoded}`,
+        { headers: { Authorization: `Bearer ${TENANT}` } },
+      )
+      return r.status === 200 ? await r.text() : `status ${String(r.status)}`
+    }
+    eq('a literal % in a name is not a malformed URI', await readAt('100%25.txt', 'raw'), 'percent')
+    eq('nor through resolve', await readAt('100%25.txt', 'resolve'), 'percent')
+    eq('a literal %20 is not decoded twice', await readAt('a%2520b.txt', 'raw'), 'literal')
+    eq('and a real space still reaches its own file', await readAt('a%20b.txt', 'raw'), 'space')
+
     const rawMissing = await fetch(
       `${fake.endpoint}/datasets/${TENANT}/raw-dataset/raw/main/nope.txt`,
       { headers: { Authorization: `Bearer ${TENANT}` } },


### PR DESCRIPTION
Two endpoints the vendors have and the fakes did not. Neither is reachable from a mirage client — there is no `hf` verb that fetches a raw URL and no `gh` verb that lists comments — so both are covered in the selftests, which is where this repo puts HTTP surface the battery cannot see.

**`GET /<kind>/:ns/:name/raw/:rev/*path`** is `resolve` for a reader rather than a downloader: `text/plain`, no redirect, so a plain `requests.get` gets the file. It is how the Hub's own web view links a README and how anything that never learned about LFS reads one.

The part that is not a synonym for `resolve` is LFS: a tracked path answers with its **pointer**, three lines naming the sha256 and the size. Probed rather than recalled —

    $ curl -s https://huggingface.co/datasets/lockon/ToolACE/raw/main/data.json
    version https://git-lfs.github.com/spec/v1
    oid sha256:ba12c083fca7e8da48c67ad5b895e495447da7c66e39a2e19742c082e6cb537e
    size 37154735

133 bytes against 37MB through `resolve`.

**`GET /repos/:owner/:repo/issues/:number/comments`** is oldest-first, which is the whole of what it is read for: `comments[-1]` is only "what was said last" in that order, and that is how a grader asks whether the reply it wanted is the reply that landed.

## Why now

Both are needed to port Toolathlon's `dataset-license-issue`, whose agent replies to a GitHub issue and appends a licence line to two Hub dataset cards, and whose evaluator reads the comment thread and then fetches each card through `https://huggingface.co/datasets/{id}/raw/main/README.md`.

## Checks

- `pnpm run hf-hub:selftest` — 266 checks (was 258)
- `pnpm run github:selftest` — 87 checks (was 78)
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)