### PR TITLE
Remove dead code and add an optional deadcode dev dependency

### DIFF
--- a/python/mirage/accessor/pool.py
+++ b/python/mirage/accessor/pool.py
@@ -184,11 +184,3 @@ class LoopClientCache:
                          extra)
         if failures:
             raise failures[0]
-
-    def open_count(self) -> int:
-        """Return how many clients are currently held.
-
-        Returns:
-            int: number of open clients.
-        """
-        return len(self._entries)

--- a/python/mirage/cache/file/mixin.py
+++ b/python/mirage/cache/file/mixin.py
@@ -101,15 +101,6 @@ class FileCacheMixin:
     async def multi_get(self, keys: list[str]) -> list[bytes | None]:
         return [await self.get(k) for k in keys]
 
-    async def multi_set(
-        self,
-        items: list[tuple[str, bytes]],
-        fingerprint: str | None = None,
-        ttl: int | None = None,
-    ) -> None:
-        for key, data in items:
-            await self.set(key, data, fingerprint=fingerprint, ttl=ttl)
-
     @property
     def cache_size(self) -> int | None:
         """Cached bytes; None for stores that don't track them."""

--- a/python/mirage/cache/read_through.py
+++ b/python/mirage/cache/read_through.py
@@ -174,23 +174,3 @@ def cache_aware_read(raw: PolymorphicReadFn) -> PolymorphicReadFn:
         return result
 
     return reader
-
-
-async def cached_prefix_bytes(path: PathSpec, n: int | None) -> bytes | None:
-    """Return the first ``n`` cached bytes of ``path`` when warm, else None.
-
-    Lets a range-read fast path (e.g. ``head -c N``) serve from a fully
-    cached file without a partial backend fetch. ``n=None`` returns the
-    whole cached blob.
-
-    Args:
-        path (PathSpec): the path to look up.
-        n (int | None): byte count, or None for the whole file.
-    """
-    manager = active_cache_manager()
-    if manager is None:
-        return None
-    cached = await manager.cached_bytes(path)
-    if cached is None:
-        return None
-    return cached if n is None else cached[:n]

--- a/python/mirage/commands/builtin/generic/wc.py
+++ b/python/mirage/commands/builtin/generic/wc.py
@@ -142,13 +142,6 @@ async def wc(src: bytes | AsyncIterator[bytes]) -> WCCounts:
     )
 
 
-async def wc_lines(src: bytes | AsyncIterator[bytes]) -> int:
-    count = 0
-    async for chunk in ensure_stream(src):
-        count += chunk.count(b"\n")
-    return count
-
-
 def _selected_values(
     counts: WCCounts,
     *,
@@ -223,24 +216,6 @@ def format_wc_lines(
         body = " ".join(str(n).rjust(width) for n in nums)
         out.append(body if label is None else f"{body} {label}")
     return out
-
-
-def format_wc(
-    counts: WCCounts,
-    *,
-    lines: bool = False,
-    words: bool = False,
-    bytes_: bool = False,
-    chars: bool = False,
-    max_line_length: bool = False,
-    label: str | None = None,
-) -> str:
-    return format_wc_lines([(counts, label)],
-                           lines=lines,
-                           words=words,
-                           bytes_=bytes_,
-                           chars=chars,
-                           max_line_length=max_line_length)[0]
 
 
 def format_count_rows(

--- a/python/mirage/resource/qdrant/qdrant.py
+++ b/python/mirage/resource/qdrant/qdrant.py
@@ -29,7 +29,6 @@ class QdrantResource(BaseResource):
 
     accessor: QdrantAccessor
     name: str = ResourceName.QDRANT
-    is_remote: bool = True
     # readdir seeds exact rendered sizes from the scroll payloads and stat
     # falls back to rendering the row itself, so sizes are exact either way.
     SIZES_ALWAYS_KNOWN: bool = True

--- a/python/mirage/shell/array.py
+++ b/python/mirage/shell/array.py
@@ -208,16 +208,6 @@ def array_with(arr: ShellArray, idx: int, value: str) -> ShellArray:
     return updated
 
 
-def array_append(arr: ShellArray, values: list[str]) -> None:
-    """Append values after the highest assigned index, as ``arr+=(...)``.
-
-    Args:
-        arr (ShellArray): the array, mutated in place.
-        values (list[str]): the element values to add.
-    """
-    arr.extend(values)
-
-
 def array_slice(arr: ShellArray, offset: int, length: int | None) -> list[str]:
     """Take the assigned elements from index ``offset`` on, in order.
 

--- a/python/mirage/shell/helpers.py
+++ b/python/mirage/shell/helpers.py
@@ -537,20 +537,13 @@ def get_declaration_keyword(node: tree_sitter.Node) -> str:
     return node.children[0].type
 
 
-def get_unset_names(node: tree_sitter.Node) -> list[str]:
-    """Get variable names from unset_command."""
-    return [
-        get_text(c) for c in node.named_children if c.type == NT.VARIABLE_NAME
-    ]
-
-
 def get_unset_args(node: tree_sitter.Node) -> list[str]:
     """Get every operand word of unset_command, keeping ``-f``/``-v``/``-n``.
 
-    Unlike ``get_unset_names`` this preserves the leading option words so
-    the handler can tell a function unset (``unset -f``) from a variable
-    unset, and splits the operand span the way the shell does so a
-    subscript target (``unset arr[1]``, quoted or not) stays one word.
+    The leading option words are preserved so the handler can tell a
+    function unset (``unset -f``) from a variable unset, and the operand
+    span is split the way the shell does so a subscript target
+    (``unset arr[1]``, quoted or not) stays one word.
     """
     operands = node.children[1:]
     if not operands:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -278,6 +278,47 @@ dev = [
     "pytest-httpx>=0.36.0",
     "pytest-xdist>=3.8.0",
     "mypy>=2.3.0",
+    "deadcode>=2.4.1",
+]
+
+# Advisory dead-code finder for local use only. NOT a CI gate and not a
+# pre-commit hook: the tool still misreports ~200 live symbols here (see
+# below), so a red run means "read the diff", never "the build is broken".
+#
+# Run it as:  uv run deadcode mirage/
+#
+# `mirage/` and NOT `tests/` is the load-bearing part of that command. A
+# symbol referenced only by its own test is dead production code, and
+# passing tests/ would count that test as a consumer and hide it. Every
+# symbol removed in the dead-code sweep was found exactly this way.
+#
+# The ignore lists below are false positives, not debt. deadcode resolves
+# names statically, so anything invoked by a framework rather than by name
+# reads as unused, and its four --ignore-*-decorated-with flags are no-ops
+# in 2.4.1, so a decorator cannot be excused as a decorator:
+#   *_cmd            typer verbs registered via @app.command(...)
+#   _validate_*      pydantic @field_validator / @model_validator methods
+#   _normalize_*     (same)
+#   __*__            Protocol __call__, __getattr__ lazy-import shims
+#   runtime/wasm     WASI ABI constant tables, complete on purpose
+#   server/routers   FastAPI handlers registered via @router.get/post
+#   agents/*         adapters implementing third-party framework interfaces
+#   fuse/*           libfuse callbacks dispatched by signature
+[tool.deadcode]
+ignore-names = [
+    "*_cmd",
+    "__*__",
+    "_validate_*",
+    "_normalize_*",
+    "_check_*",
+    "_coerce_*",
+    "_v_*",
+]
+ignore-names-in-files = [
+    "mirage/runtime/wasm/*",
+    "mirage/server/routers/*",
+    "mirage/agents/*",
+    "mirage/fuse/*",
 ]
 
 [tool.pytest.ini_options]

--- a/python/tests/accessor/test_pool.py
+++ b/python/tests/accessor/test_pool.py
@@ -150,7 +150,7 @@ def test_client_from_a_closed_loop_is_released_not_forgotten():
 
     assert opened == [0, 1, 2]
     assert released == [0, 1, 2]
-    assert cache.open_count() == 0
+    assert len(cache._entries) == 0
 
 
 def test_a_dead_loop_is_released_once_under_concurrent_gets():
@@ -190,12 +190,12 @@ def test_a_failed_release_keeps_the_entry_retryable():
         await cache.get(_stub(opened, released, counter, fail_release=True))
         with pytest.raises(RuntimeError, match="release failed"):
             await cache.close()
-        assert cache.open_count() == 1, "a failed release must keep the entry"
+        assert len(cache._entries) == 1, "a failed release must keep the entry"
         assert released == []
         # The manager is held rather than wrapped in an AsyncExitStack, so the
         # retry really re-invokes __aexit__ instead of finding a spent stack.
         await cache.close()
-        assert cache.open_count() == 0
+        assert len(cache._entries) == 0
         assert released == [0]
 
     asyncio.run(go())
@@ -227,7 +227,7 @@ def test_close_reports_a_failed_release_instead_of_logging_it():
     # The good one was still released: one failure must not skip the rest, it
     # must only be reported. The failed one stays for a later attempt.
     assert released == [1]
-    assert cache.open_count() == 1
+    assert len(cache._entries) == 1
 
 
 def test_a_failed_release_does_not_strand_the_other_loops():
@@ -252,7 +252,7 @@ def test_a_failed_release_does_not_strand_the_other_loops():
 
     assert opened == [0, 1, 2]
     assert sorted(released) == [0, 1, 2], "a failed release stranded a client"
-    assert cache.open_count() == 0
+    assert len(cache._entries) == 0
 
 
 def test_a_loop_that_failed_to_open_leaves_no_lock_behind():
@@ -273,7 +273,7 @@ def test_a_loop_that_failed_to_open_leaves_no_lock_behind():
         asyncio.run(step())
     asyncio.run(cache.close())
 
-    assert cache.open_count() == 0
+    assert len(cache._entries) == 0
     assert cache._locks == {}, "a closed loop kept its lock"
 
 
@@ -295,14 +295,3 @@ def test_key_is_the_loop_object_not_its_id():
     assert seen[0] != seen[1], "each run needs its own client"
     asyncio.run(cache.close())
     assert sorted(released) == [0, 1]
-
-
-@pytest.mark.asyncio
-async def test_open_count_reports_live_clients():
-    opened, released, counter = [], [], [0]
-    cache = LoopClientCache("test")
-    assert cache.open_count() == 0
-    await cache.get(_stub(opened, released, counter))
-    assert cache.open_count() == 1
-    await cache.close()
-    assert cache.open_count() == 0

--- a/python/tests/cache/file/test_mixin.py
+++ b/python/tests/cache/file/test_mixin.py
@@ -88,13 +88,6 @@ class TestMulti:
         assert results[1] is None
         assert results[2] == b"bbb"
 
-    @pytest.mark.asyncio
-    async def test_multi_set(self):
-        cache = RAMFileCacheStore(cache_limit="1MB")
-        await cache.multi_set([("/a", b"aaa"), ("/b", b"bbb")])
-        assert await cache.get("/a") == b"aaa"
-        assert await cache.get("/b") == b"bbb"
-
 
 class TestExistsRemoveClear:
 

--- a/python/tests/cache/test_read_through.py
+++ b/python/tests/cache/test_read_through.py
@@ -18,8 +18,7 @@ from mirage.cache.context import push_cache_manager
 from mirage.cache.file.ram import RAMFileCacheStore
 from mirage.cache.manager import CacheManager
 from mirage.cache.read_through import (cache_aware_read_bytes,
-                                       cache_aware_read_stream,
-                                       cached_prefix_bytes)
+                                       cache_aware_read_stream)
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -157,27 +156,3 @@ async def test_read_stream_captures_manager_before_drain():
     out = await _drain(source)
     assert out == b"payload"
     assert backend.stream_calls == 0
-
-
-@pytest.mark.asyncio
-async def test_cached_prefix_bytes_slices_when_warm():
-    manager = await _warm_manager(b"payload")
-    prev = push_cache_manager(manager)
-    try:
-        out = await cached_prefix_bytes(_spec(), 4)
-        whole = await cached_prefix_bytes(_spec(), None)
-    finally:
-        push_cache_manager(prev)
-    assert out == b"payl"
-    assert whole == b"payload"
-
-
-@pytest.mark.asyncio
-async def test_cached_prefix_bytes_miss_and_no_manager_return_none():
-    miss_manager = CacheManager(RAMFileCacheStore(), None, "/s3/", True)
-    prev = push_cache_manager(miss_manager)
-    try:
-        assert await cached_prefix_bytes(_spec(), 4) is None
-    finally:
-        push_cache_manager(prev)
-    assert await cached_prefix_bytes(_spec(), 4) is None

--- a/python/tests/commands/builtin/generic/test_wc.py
+++ b/python/tests/commands/builtin/generic/test_wc.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mirage.commands.builtin.generic.wc import (WCCounts, format_multi,
-                                                format_wc, wc, wc_lines)
+                                                format_wc_lines, wc)
 from mirage.types import PathSpec
 
 
@@ -177,58 +177,43 @@ async def test_wc_binary_input_does_not_crash():
     assert counts.lines == 1  # one \n at byte 0x0a
 
 
-@pytest.mark.asyncio
-async def test_wc_lines_fast_path_matches_full():
-    """`wc_lines` fast path must agree with the full counter."""
-    data = b"alpha\nbeta\ngamma\ndelta\n"
-    fast = await wc_lines(data)
-    full = await wc(data)
-    assert fast == full.lines == 4
+def _fmt(counts, **kw):
+    label = kw.pop("label", None)
+    return format_wc_lines([(counts, label)], **kw)[0]
 
 
-@pytest.mark.asyncio
-async def test_wc_lines_fast_path_no_trailing_newline():
-    assert await wc_lines(b"a\nb\nc") == 2
-
-
-@pytest.mark.asyncio
-async def test_wc_lines_fast_path_empty():
-    assert await wc_lines(b"") == 0
-
-
-def test_format_wc_default_no_label():
+def test_format_wc_lines_default_no_label():
     counts = WCCounts(lines=2, words=4, bytes_=20)
-    assert format_wc(counts) == "      2       4      20"
+    assert _fmt(counts) == "      2       4      20"
 
 
-def test_format_wc_default_with_label():
+def test_format_wc_lines_default_with_label():
     counts = WCCounts(lines=2, words=4, bytes_=20)
-    assert format_wc(counts, label="/f.txt") == " 2  4 20 /f.txt"
+    assert _fmt(counts, label="/f.txt") == " 2  4 20 /f.txt"
 
 
-def test_format_wc_args_l():
+def test_format_wc_lines_args_l():
     counts = WCCounts(lines=2, words=4, bytes_=20)
-    assert format_wc(counts, lines=True) == "2"
-    assert format_wc(counts, lines=True, label="/f.txt") == "2 /f.txt"
+    assert _fmt(counts, lines=True) == "2"
+    assert _fmt(counts, lines=True, label="/f.txt") == "2 /f.txt"
 
 
-def test_format_wc_w_c_m():
+def test_format_wc_lines_w_c_m():
     counts = WCCounts(lines=2, words=4, bytes_=20, chars=18)
-    assert format_wc(counts, words=True) == "4"
-    assert format_wc(counts, bytes_=True) == "20"
-    assert format_wc(counts, chars=True) == "18"
+    assert _fmt(counts, words=True) == "4"
+    assert _fmt(counts, bytes_=True) == "20"
+    assert _fmt(counts, chars=True) == "18"
 
 
-def test_format_wc_combines_lines_and_max_line_length():
+def test_format_wc_lines_combines_lines_and_max_line_length():
     counts = WCCounts(lines=2, max_line_length=11)
-    assert format_wc(counts, lines=True,
-                     max_line_length=True) == "      2      11"
+    assert _fmt(counts, lines=True, max_line_length=True) == "      2      11"
 
 
-def test_format_wc_combines_selected_counts_in_canonical_order():
+def test_format_wc_lines_combines_selected_counts_in_canonical_order():
     counts = WCCounts(lines=2, words=4, bytes_=20, chars=18)
-    assert format_wc(counts, lines=True, words=True, bytes_=True,
-                     chars=True) == "      2       4      18      20"
+    assert _fmt(counts, lines=True, words=True, bytes_=True,
+                chars=True) == "      2       4      18      20"
 
 
 def test_wc_counts_merge():

--- a/python/tests/resource/qdrant/test_resource.py
+++ b/python/tests/resource/qdrant/test_resource.py
@@ -10,10 +10,9 @@ def _resource(**kw) -> QdrantResource:
     return QdrantResource(QdrantConfig(**base))
 
 
-def test_resource_name_and_remote():
+def test_resource_name_and_snapshot():
     res = _resource()
     assert res.name == "qdrant"
-    assert res.is_remote is True
     assert res.SUPPORTS_SNAPSHOT is False
 
 

--- a/python/tests/shell/test_array.py
+++ b/python/tests/shell/test_array.py
@@ -1,5 +1,5 @@
-from mirage.shell.array import (array_append, array_count, array_extent,
-                                array_get, array_has, array_indices, array_set,
+from mirage.shell.array import (array_count, array_extent, array_get,
+                                array_has, array_indices, array_set,
                                 array_slice, array_unset, array_values,
                                 build_assoc_literal, build_indexed_literal,
                                 keyed_word, make_array)
@@ -53,21 +53,6 @@ def test_unset_out_of_range_is_a_no_op():
     array_unset(arr, 5)
     array_unset(arr, -1)
     assert arr == ["x"]
-
-
-def test_append_starts_at_the_extent():
-    arr = make_array(["x", "y", "z"])
-    array_unset(arr, 1)
-    array_append(arr, ["w"])
-    assert arr == ["x", None, "z", "w"]
-    assert array_indices(arr) == [0, 2, 3]
-
-
-def test_append_refills_a_trailing_hole():
-    arr = make_array(["x", "y", "z"])
-    array_unset(arr, 2)
-    array_append(arr, ["w"])
-    assert arr == ["x", "y", "w"]
 
 
 def test_set_reassigns_a_hole():

--- a/python/tests/shell/test_helpers.py
+++ b/python/tests/shell/test_helpers.py
@@ -25,7 +25,7 @@ from mirage.shell.helpers import (  # isort: skip
     get_function_name, get_heredoc_meta, get_heredoc_parts, get_if_branches,
     get_list_parts, get_negated_command, get_parts, get_pipeline_commands,
     get_process_sub_body, get_redirects, get_subshell_body, get_text,
-    get_unset_names, get_while_parts, literal_word, split_env_prefix)
+    get_while_parts, literal_word, split_env_prefix)
 
 _LANG = tree_sitter.Language(tree_sitter_bash.language())
 _PARSER = tree_sitter.Parser(_LANG)
@@ -276,11 +276,6 @@ def test_export_keyword():
 
 def test_local_keyword():
     assert get_declaration_keyword(_first("local X=hello")) == "local"
-
-
-def test_unset_names():
-    names = get_unset_names(_first("unset VAR1 VAR2"))
-    assert names == ["VAR1", "VAR2"]
 
 
 # ── negated command ──────────────────────────────

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3285,6 +3285,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deadcode"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/ab/1122e6d6392f7860718f16e931b1976d5e579433486a84b09333811e3a6b/deadcode-2.4.1.tar.gz", hash = "sha256:1ba1e22425cf53c4b3f5ddd46e62a86d98479b47f2ac3430ae60910ac8cb318d", size = 37734, upload-time = "2024-08-09T18:12:58.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/cc/9c27bb3a1224a66740b25d8153cd41051240103fa9aaee119688362c32b6/deadcode-2.4.1-py3-none-any.whl", hash = "sha256:a16b28b601a82d5dc7ebfcab464a6f65e22a99d5684ec4c7907bdb75f8f64050", size = 44621, upload-time = "2024-08-09T18:12:56.433Z" },
+]
+
+[[package]]
 name = "deepagents"
 version = "0.7.6"
 source = { registry = "https://pypi.org/simple" }
@@ -5979,6 +5991,7 @@ wasi = [
 [package.dev-dependencies]
 dev = [
     { name = "aioresponses" },
+    { name = "deadcode" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
     { name = "moto", extra = ["s3", "server"] },
@@ -6103,6 +6116,7 @@ provides-extras = ["monty", "wasi", "quickjs", "s3", "r2", "gcs", "oci", "databr
 [package.metadata.requires-dev]
 dev = [
     { name = "aioresponses", specifier = ">=0.7.6" },
+    { name = "deadcode", specifier = ">=2.4.1" },
     { name = "grpcio", specifier = ">=1.78.0" },
     { name = "grpcio-tools", specifier = ">=1.78.0" },
     { name = "moto", extras = ["s3", "server"], specifier = ">=5.1.22" },

--- a/typescript/packages/core/src/cache/file/mixin.ts
+++ b/typescript/packages/core/src/cache/file/mixin.ts
@@ -47,7 +47,6 @@ export interface FileCache {
   exists(key: string | PathSpec): Promise<boolean>
   isFresh(key: string, remoteFingerprint: string): Promise<boolean>
   clear(): Promise<void>
-  allCached(keys: readonly string[]): Promise<boolean>
   multiGet(keys: readonly string[]): Promise<(Uint8Array | null)[]>
   // Cached bytes / entry count; null (or absent) for stores that don't
   // track them client-side (e.g. redis owns its own keyspace).

--- a/typescript/packages/core/src/cache/file/ram.test.ts
+++ b/typescript/packages/core/src/cache/file/ram.test.ts
@@ -66,13 +66,6 @@ describe('RAMFileCacheStore', () => {
     expect(await c.exists('/a')).toBe(true)
   })
 
-  it('allCached returns true only when all keys present', async () => {
-    const c = new RAMFileCacheStore()
-    await c.set('/a', encode('x'))
-    expect(await c.allCached(['/a'])).toBe(true)
-    expect(await c.allCached(['/a', '/b'])).toBe(false)
-  })
-
   it('evicts oldest entries when over limit', async () => {
     const c = new RAMFileCacheStore({ limit: 10 })
     await c.set('/a', encode('aaaaa'))

--- a/typescript/packages/core/src/cache/file/ram.ts
+++ b/typescript/packages/core/src/cache/file/ram.ts
@@ -188,13 +188,6 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
     return Promise.resolve()
   }
 
-  async allCached(keys: readonly string[]): Promise<boolean> {
-    for (const k of keys) {
-      if (!(await this.exists(k))) return false
-    }
-    return true
-  }
-
   async multiGet(keys: readonly string[]): Promise<(Uint8Array | null)[]> {
     const out: (Uint8Array | null)[] = []
     for (const k of keys) out.push(await this.get(k))

--- a/typescript/packages/core/src/cache/read_through.test.ts
+++ b/typescript/packages/core/src/cache/read_through.test.ts
@@ -19,12 +19,7 @@ import { PathSpec } from '../types.ts'
 import { runWithCacheManager } from './context.ts'
 import { RAMFileCacheStore } from './file/ram.ts'
 import { CacheManager } from './manager.ts'
-import {
-  cacheAwareReadBytes,
-  cacheAwareReadStream,
-  cacheAwareStreamEager,
-  cachedPrefixBytes,
-} from './read_through.ts'
+import { cacheAwareReadBytes, cacheAwareReadStream, cacheAwareStreamEager } from './read_through.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder()
@@ -147,24 +142,5 @@ describe('cacheAwareStreamEager', () => {
     const out = await drain(wrapped(spec()))
     expect(DEC.decode(out)).toBe('payload')
     expect(backend.streamCalls).toBe(0)
-  })
-})
-
-describe('cachedPrefixBytes', () => {
-  it('slices the cached blob when warm', async () => {
-    const manager = await warmManager(ENC.encode('payload'))
-    const [prefix, whole] = await runWithCacheManager(manager, async () => [
-      await cachedPrefixBytes(spec(), 4),
-      await cachedPrefixBytes(spec(), null),
-    ])
-    expect(prefix === null ? '' : DEC.decode(prefix)).toBe('payl')
-    expect(whole === null ? '' : DEC.decode(whole)).toBe('payload')
-  })
-
-  it('returns null on miss and with no manager', async () => {
-    const manager = new CacheManager(new RAMFileCacheStore(), null, '/s3/', true)
-    const miss = await runWithCacheManager(manager, () => cachedPrefixBytes(spec(), 4))
-    expect(miss).toBeNull()
-    expect(await cachedPrefixBytes(spec(), 4)).toBeNull()
   })
 })

--- a/typescript/packages/core/src/cache/read_through.ts
+++ b/typescript/packages/core/src/cache/read_through.ts
@@ -100,13 +100,3 @@ export function cacheAwareStreamEager(raw: PathStream): PathStream {
  * range-read fast path (e.g. `head -c N`) serve from a fully cached file
  * without a partial backend fetch. `n = null` returns the whole cached blob.
  */
-export async function cachedPrefixBytes(
-  path: PathSpec,
-  n: number | null,
-): Promise<Uint8Array | null> {
-  const manager = activeCacheManager()
-  if (manager === null || !(path instanceof PathSpec)) return null
-  const cached = await manager.cachedBytes(path)
-  if (cached === null) return null
-  return n === null ? cached : cached.slice(0, n)
-}

--- a/typescript/packages/core/src/resource/qdrant/qdrant.ts
+++ b/typescript/packages/core/src/resource/qdrant/qdrant.ts
@@ -46,7 +46,6 @@ export interface QdrantResourceState {
 
 export class QdrantResource extends BaseResource implements Resource {
   readonly kind: string = ResourceName.QDRANT
-  readonly isRemote: boolean = true
   // readdir seeds exact rendered sizes from the scroll payloads and stat
   // falls back to rendering the row itself, so sizes are exact either way.
   readonly sizesAlwaysKnown: boolean = true

--- a/typescript/packages/core/src/shell/array.test.ts
+++ b/typescript/packages/core/src/shell/array.test.ts
@@ -15,7 +15,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   type ShellArray,
-  arrayAppend,
   arrayCount,
   arrayExtent,
   arrayGet,
@@ -80,21 +79,6 @@ describe('shell array', () => {
     arrayUnset(arr, 5)
     arrayUnset(arr, -1)
     expect(arr).toEqual(['x'])
-  })
-
-  it('append starts at the extent', () => {
-    const arr = makeArray(['x', 'y', 'z'])
-    arrayUnset(arr, 1)
-    arrayAppend(arr, ['w'])
-    expect(arr).toEqual(['x', null, 'z', 'w'])
-    expect(arrayIndices(arr)).toEqual([0, 2, 3])
-  })
-
-  it('append refills a trailing hole', () => {
-    const arr = makeArray(['x', 'y', 'z'])
-    arrayUnset(arr, 2)
-    arrayAppend(arr, ['w'])
-    expect(arr).toEqual(['x', 'y', 'w'])
   })
 
   it('a hole can be reassigned', () => {

--- a/typescript/packages/core/src/shell/array.ts
+++ b/typescript/packages/core/src/shell/array.ts
@@ -92,11 +92,6 @@ export function arrayWith(arr: ShellArray, idx: number, value: string): ShellArr
   return updated
 }
 
-/** Append values after the highest assigned index, as `arr+=(...)`. */
-export function arrayAppend(arr: ShellArray, values: string[]): void {
-  arr.push(...values)
-}
-
 /**
  * Take the assigned elements from index `offset` on, in index order.
  *

--- a/typescript/packages/core/src/shell/helpers.test.ts
+++ b/typescript/packages/core/src/shell/helpers.test.ts
@@ -33,7 +33,6 @@ import {
   getSubshellBody,
   getText,
   getTestArgv,
-  getUnsetNames,
   getWhileParts,
   literalWord,
   splitEnvPrefix,
@@ -323,7 +322,7 @@ describe('getIfBranches', () => {
   })
 })
 
-describe('getDeclaration* / getUnsetNames / getCommandAssignments', () => {
+describe('getDeclaration* / getCommandAssignments', () => {
   it('getDeclarationAssignments collects VARIABLE_ASSIGNMENT children', () => {
     const n = node('declaration_command', '', {
       namedChildren: [
@@ -339,13 +338,6 @@ describe('getDeclaration* / getUnsetNames / getCommandAssignments', () => {
       children: [node(NT.EXPORT, 'export', { isNamed: false })],
     })
     expect(getDeclarationKeyword(n)).toBe('export')
-  })
-
-  it('getUnsetNames picks VARIABLE_NAME children', () => {
-    const n = node('unset_command', '', {
-      namedChildren: [node(NT.VARIABLE_NAME, 'FOO'), node(NT.VARIABLE_NAME, 'BAR')],
-    })
-    expect(getUnsetNames(n)).toEqual(['FOO', 'BAR'])
   })
 
   it('getCommandAssignments matches VARIABLE_ASSIGNMENT', () => {

--- a/typescript/packages/core/src/shell/helpers.ts
+++ b/typescript/packages/core/src/shell/helpers.ts
@@ -518,10 +518,6 @@ export function getDeclarationKeyword(node: TSNodeLike): string {
   return node.children[0]?.type ?? ''
 }
 
-export function getUnsetNames(node: TSNodeLike): string[] {
-  return node.namedChildren.filter((c) => c.type === NT.VARIABLE_NAME).map((c) => getText(c))
-}
-
 /**
  * Split a whitespace-separated operand string, honoring single and
  * double quotes the way the shell does. Returns null on an unbalanced

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -154,9 +154,6 @@ describe('Workspace custom cache option', () => {
       this.store.clear()
       return Promise.resolve()
     }
-    allCached(keys: readonly string[]): Promise<boolean> {
-      return Promise.resolve(keys.every((k) => this.store.has(k)))
-    }
     multiGet(keys: readonly string[]): Promise<(Uint8Array | null)[]> {
       return Promise.resolve(keys.map((k) => this.store.get(k) ?? null))
     }

--- a/typescript/packages/node/src/cache/file/redis.test.ts
+++ b/typescript/packages/node/src/cache/file/redis.test.ts
@@ -100,6 +100,16 @@ describe.skipIf(skip)('RedisFileCacheStore', () => {
     expect(await cache.get('k')).toBeNull()
   })
 
+  it('multiGet returns [bytes|null] in order', async () => {
+    await cache.set('a', new Uint8Array([1]))
+    await cache.set('c', new Uint8Array([3]))
+    const out = await cache.multiGet(['a', 'b', 'c'])
+    expect(out).toHaveLength(3)
+    expect(out[0]).toEqual(new Uint8Array([1]))
+    expect(out[1]).toBeNull()
+    expect(out[2]).toEqual(new Uint8Array([3]))
+  })
+
   it('isFresh matches fingerprint', async () => {
     const data = new Uint8Array([1, 1, 1])
     const fp = defaultFingerprint(data)
@@ -113,22 +123,6 @@ describe.skipIf(skip)('RedisFileCacheStore', () => {
     expect(await cache.get('k')).not.toBeNull()
     await new Promise((r) => setTimeout(r, 1100))
     expect(await cache.get('k')).toBeNull()
-  })
-
-  it('multiGet returns [bytes|null] in order', async () => {
-    await cache.set('a', new Uint8Array([1]))
-    await cache.set('c', new Uint8Array([3]))
-    const out = await cache.multiGet(['a', 'b', 'c'])
-    expect(out).toHaveLength(3)
-    expect(out[0]).toEqual(new Uint8Array([1]))
-    expect(out[1]).toBeNull()
-    expect(out[2]).toEqual(new Uint8Array([3]))
-  })
-
-  it('allCached true only when every key present', async () => {
-    await cache.set('a', new Uint8Array([1]))
-    expect(await cache.allCached(['a'])).toBe(true)
-    expect(await cache.allCached(['a', 'b'])).toBe(false)
   })
 
   it('clear removes everything under the prefix', async () => {

--- a/typescript/packages/node/src/cache/file/redis.ts
+++ b/typescript/packages/node/src/cache/file/redis.ts
@@ -203,13 +203,6 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
     }
   }
 
-  async allCached(keys: readonly string[]): Promise<boolean> {
-    for (const k of keys) {
-      if (!(await this.exists(k))) return false
-    }
-    return true
-  }
-
   async multiGet(keys: readonly string[]): Promise<(Uint8Array | null)[]> {
     const out: (Uint8Array | null)[] = []
     for (const k of keys) out.push(await this.get(k))


### PR DESCRIPTION
## Summary

Removes symbols with no production caller in either language:

- qdrant `is_remote` / `isRemote`, left over after #338 collapsed `is_remote` + `cacheable` into `caches_reads`
- `cached_prefix_bytes` / `cachedPrefixBytes`
- `format_wc`, `wc_lines` (py only)
- `array_append` / `arrayAppend`, superseded by `build_indexed_literal`
- `get_unset_names` / `getUnsetNames`, superseded by `get_unset_args`
- `open_count` (py only)
- `multi_set` (py only) and `allCached` (ts only), which converges the file cache contract from both sides

`multi_get` / `multiGet` stays: `examples/typescript/redis/redis_cache.ts` uses it and `integ/truth/typescript/redis_cache.json` pins the output.

Two tests changed rather than deleted: the `format_wc` cases covered rendering that `format_wc_lines` implements, so they now call it directly. `open_count`'s six lifecycle assertions read `_entries`.

Adds `deadcode` to the dev group with a `[tool.deadcode]` config. Advisory only, not a hook and not a CI gate. Run it as `uv run deadcode mirage/`; passing `tests/` counts a test as a consumer and hides exactly these symbols.

## Not included

- `IndexCacheStore.seed` is py only and the better design (one redis round trip vs the TS `setDir` loop). Porting it is a feature change.
- `SessionManager.lock_for` is py only with no caller, but #411 proposes using it.

## Test plan

- `uv run pytest`
- `pnpm --filter core --filter node test`
- `pnpm -r typecheck`, including `examples/typescript`
- `pre-commit run --all-files`
- `scripts/check_layout_parity.py --strict` at baseline 249

## For the next release notes

`packages/core` exports `./*`, so these were reachable by subpath and their removal is a breaking change for any external importer, even though nothing in this repo used them: `allCached`, `cachedPrefixBytes`, `arrayAppend`, `getUnsetNames`, and qdrant's `isRemote`.
