### PR TITLE
Scope repository search to the account `user:` names

### DIFF
--- a/integ/server/github/search.ts
+++ b/integ/server/github/search.ts
@@ -33,20 +33,37 @@ function descriptionOf(repo: RepoRow): string {
   return typeof value === 'string' ? value : ''
 }
 
-// Qualifiers (`user:x`, `in:name`) are dropped rather than honoured; what is
-// left is matched against the name and the description, because a repository
-// is found by what it says it does at least as often as by what it is called.
-// Terms OR together rather than AND, which is looser than GitHub and errs
-// towards showing a caller the row it is looking for; a hyphenated term also
-// matches its parts.
-function repoTerms(query: string): string[] {
-  const out: string[] = []
+interface RepoQuery {
+  owners: string[]
+  terms: string[]
+}
+
+// `user:` and `org:` are honoured, because they NARROW: GitHub answers
+// `user:integ-user` with that account's repositories and nobody else's, and a
+// caller handed every account's instead reads the surplus as fact. The rest of
+// the grammar (`in:name`, `language:`, `fork:`) is still dropped, which only
+// ever widens. What is left over is matched against the name and the
+// description, because a repository is found by what it says it does at least
+// as often as by what it is called. Terms OR together rather than AND, which is
+// looser than GitHub and errs towards showing a caller the row it is looking
+// for; a hyphenated term also matches its parts.
+function repoQuery(query: string): RepoQuery {
+  const owners: string[] = []
+  const terms: string[] = []
   for (const word of query.split(/\s+/).filter((w) => w !== '')) {
-    if (word.includes(':')) continue
-    out.push(word)
-    for (const part of word.split(/[-_]/)) if (part.length > 2) out.push(part)
+    const at = word.indexOf(':')
+    if (at >= 0) {
+      const owner = word.slice(at + 1)
+      // Several of them OR together, the way GitHub reads them.
+      if ((word.slice(0, at) === 'user' || word.slice(0, at) === 'org') && owner !== '') {
+        owners.push(owner)
+      }
+      continue
+    }
+    terms.push(word)
+    for (const part of word.split(/[-_]/)) if (part.length > 2) terms.push(part)
   }
-  return out
+  return { owners, terms }
 }
 
 // Substring rather than GitHub's own qualifier grammar, which nothing here
@@ -54,10 +71,13 @@ function repoTerms(query: string): string[] {
 // reads that as "no such repository": an agent looking for the fork it just
 // made would conclude it had not made one.
 async function searchRepos(ctx: Ctx<C>): Promise<Reply> {
+  // Lowercased before it is split, so a login compares case-insensitively the
+  // way GitHub's own do.
   const query = (ctx.query.get('q') ?? '').toLowerCase()
-  const terms = repoTerms(query)
+  const { owners, terms } = repoQuery(query)
   const repos = await allRepos(ctx.db, ctx.tenant)
   const matched = repos.filter((repo) => {
+    if (owners.length > 0 && !owners.includes(repo.owner.toLowerCase())) return false
     const haystack = `${repo.fullName} ${descriptionOf(repo)}`.toLowerCase()
     return terms.length === 0 || terms.some((t) => haystack.includes(t))
   })

--- a/integ/server/github/selftest.ts
+++ b/integ/server/github/selftest.ts
@@ -20,10 +20,12 @@ import { fileURLToPath } from 'node:url'
 import { ANNOUNCE_RE } from '../kit/typescript/announce.ts'
 import type { JsonValue } from '../kit/typescript/types.ts'
 
-// The git plumbing write path, which the corpus does not reach: the gh battery
-// exercises the porcelain, and a client that BUILDS history calls
-// `POST /git/trees` then `POST /git/commits`. That is the path a fixture uses
-// to pin a commit's own author and date, so it is the path that has to hold.
+// The routes the corpus does not reach, because the gh battery exercises the
+// porcelain and these three have no porcelain behind them. A client that BUILDS
+// history calls `POST /git/trees` then `POST /git/commits`, which is the path a
+// fixture uses to pin a commit's own author and date; a grader reads an issue's
+// comments back; and `search_repositories` is an MCP tool with no `gh`
+// equivalent, so nothing else here would notice it answering the wrong scope.
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const INTEG = resolve(HERE, '..', '..')
@@ -883,6 +885,45 @@ async function main(): Promise<void> {
     )
     const noSuch = await fetch(`${at}/repos/${REPO}/issues/4242/comments`, { headers: HEADERS })
     check('an issue that is not there is 404', noSuch.status === 404, String(noSuch.status))
+
+    // ---- `user:` and `org:` NARROW, which is the only reason to ask with one.
+    // A caller scoped to one account and handed every account's repositories
+    // cannot tell from the answer that it was not scoped at all.
+    const OTHER = 'integ-archive'
+    const born = await post(`${at}/orgs/${OTHER}/repos`, { name: 'repo-archived' })
+    check('a repo is created under a second owner', born.status === 201, String(born.status))
+
+    const found = async (q: string): Promise<JsonValue[]> => {
+      const body = await get(`${at}/search/repositories?q=${encodeURIComponent(q)}`)
+      const items = field(body, 'items')
+      return Array.isArray(items) ? items.map((r) => field(r, 'full_name')).sort() : []
+    }
+
+    eq('`user:` lists that account and no other', await found('user:integ'), [
+      'integ/repo-cli',
+      'integ/repo-trunc',
+      'integ/repo-v1',
+    ])
+    eq('`org:` scopes the same way', await found(`org:${OTHER}`), [`${OTHER}/repo-archived`])
+    eq('an account holding nothing is empty, not everything', await found('user:nobody'), [])
+    eq('two of them OR together', await found(`user:nobody org:${OTHER}`), [
+      `${OTHER}/repo-archived`,
+    ])
+    // The scope ANDs with the terms: `repo` matches all four rows by name, and
+    // the owner is what keeps the fourth out.
+    eq('a term widens only within the scope', await found('user:integ repo'), [
+      'integ/repo-cli',
+      'integ/repo-trunc',
+      'integ/repo-v1',
+    ])
+    // Unscoped, that same term reaches every owner -- the looseness the fake
+    // keeps on purpose, so that a caller hunting a row is shown it.
+    eq('and reaches every owner when nothing scopes it', await found('repo'), [
+      `${OTHER}/repo-archived`,
+      'integ/repo-cli',
+      'integ/repo-trunc',
+      'integ/repo-v1',
+    ])
 
     process.stdout.write(`github selftest: ${String(checks)} checks passed\n`)
   } finally {


### PR DESCRIPTION
## What

`GET /search/repositories` on the GitHub fake dropped **every** qualifier, so `user:integ-user` and `user:Toolathlon-Archive` both answered with all ten repositories the tenant holds. This honours `user:` and `org:` as an owner scope, ANDed with the term match.

## Why this one and not the rest of the grammar

Dropping a qualifier is safe only when it *widens*. `in:name`, `language:` and `fork:` do — the caller is shown a superset and can still find its row. `user:`/`org:` **narrow**, and narrowing is the only reason a caller writes one. The surplus rows come back indistinguishable from a real answer, so a caller asking what an account owns is told something untrue rather than something merely loose.

This was a declared divergence in vfs-bench's parity suite (`email-paper-homepage/owner_repos`) — and the only one where the two arms saw different worlds, because `search_repositories` reaches this route while `gh api users/:owner/repos` is scoped by its path and answered correctly.

The looseness that *is* on purpose stays: terms still OR rather than AND, a hyphenated term still matches its parts, and an unscoped query still reaches every owner.

## Tests

Six checks appended to `integ/server/github/selftest.ts` — that file rather than the corpus, because `search_repositories` is an MCP tool with no `gh` subcommand behind it, so a battery that drives the CLI never asks the route a question.

Check 89 fails on the old handler:

```
FAIL 89 `user:` lists that account and no other
  [got ["integ-archive/repo-archived","integ/repo-cli","integ/repo-trunc","integ/repo-v1"]
   want ["integ/repo-cli","integ/repo-trunc","integ/repo-v1"]]
```

With the fix: `github selftest: 94 checks passed`. `typecheck`, `lint` and `prettier --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)