### PR TITLE
Serve the discovery scopes `hf_fs` advertises

### DIFF
--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -66,6 +66,7 @@ import {
   searchMarkdown,
   statMarkdown,
   type FsEntry,
+  type RepoEntry,
 } from './render.ts'
 
 // The tool document is CAPTURED, never authored. notion's MCP arm can answer
@@ -318,16 +319,26 @@ async function detailsText(at: Dispatch, args: Record<string, JsonValue>): Promi
 
 // ------------------------------------------------------------------- hf_fs
 
-interface Located {
+// A repository and a path inside it, which is the only shape that has files
+// under it and the only shape the tree routes accept.
+interface RepoAt {
   kind: string
   id: string
   path: string
 }
 
-// `hf://<kind>/<namespace>/<name>[/<path>]`, which is the only URI shape this
-// fake has data behind. The live tool also addresses trending listings, papers,
-// collections and buckets; those are refused by name below rather than guessed
-// at, because the fake has no rows for any of them.
+// The three shapes a URI can name. The other two are DISCOVERY scopes, where
+// the entries are repositories rather than paths, and where the answer comes
+// from the listing endpoint rather than from a tree.
+type Located =
+  | ({ scope: 'repo' } & RepoAt)
+  | { scope: 'namespace'; kind: string; namespace: string }
+  | { scope: 'kind'; kind: string }
+
+// What the fake cannot answer, said in a sentence rather than guessed at. It
+// holds rows for models, datasets and spaces at all three scopes; the live
+// tool also addresses papers, collections, buckets, documentation and the
+// trending feeds, and each of those is refused by name below.
 interface Refusal {
   code: string
   message: string
@@ -349,7 +360,7 @@ const UPSTREAM_KINDS = ['models', 'datasets', 'spaces', 'buckets', 'collections'
 // true, rather than as bad names, which is not.
 const UPSTREAM_ROOTS = [...UPSTREAM_KINDS, 'docs', 'README.md']
 
-function locate(uri: string, cmd: string): Located | Refusal {
+function locate(uri: string): Located | Refusal {
   const bad = (message: string): Refusal => ({ code: FS_INVALID, message })
   if (!uri.startsWith('hf://')) return bad('EINVAL: URI must start with hf://')
   const parts = uri
@@ -364,21 +375,213 @@ function locate(uri: string, cmd: string): Located | Refusal {
   if (!KINDS.includes(kind)) {
     return bad(`EINVAL: the mirage hf_hub fake serves ${KINDS.join(', ')} only: ${uri}`)
   }
-  // A URI naming a root or an owner is a NAMESPACE, and asking `cat` for one
-  // is not a malformed argument -- it is a URI that points at the wrong kind
-  // of thing, which is what NOT_A_FILE says. The live server answers that
-  // code here, and an agent branching on the code should not be told it
-  // mistyped a flag. Every other command still gets the fake's own sentence,
-  // because a namespace listing is a thing this fake genuinely cannot do.
-  if (parts.length < 3) {
-    return cmd === 'cat'
-      ? {
-          code: FS_NOT_A_FILE,
-          message: 'cat requires a URI that points to a file path, not a namespace.',
-        }
-      : bad(`EINVAL: expected hf://${kind}/<namespace>/<name>: ${uri}`)
+  // Shape only. Whether the scope this names is one the CALLER's command can
+  // answer is the command's question, not this function's -- `cat` wants a
+  // file and `search` refuses one, and neither can be decided here.
+  if (parts.length === 1) return { scope: 'kind', kind }
+  if (parts.length === 2) return { scope: 'namespace', kind, namespace: parts[1] ?? '' }
+  return {
+    scope: 'repo',
+    kind,
+    id: `${parts[1] ?? ''}/${parts[2] ?? ''}`,
+    path: parts.slice(3).join('/'),
   }
-  return { kind, id: `${parts[1] ?? ''}/${parts[2] ?? ''}`, path: parts.slice(3).join('/') }
+}
+
+// ------------------------------------------------------- discovery scopes
+
+// The tool document's own list, and the reason this fake grew them: an agent
+// asked `ls hf://datasets/<owner> --limit 100` and `search hf://datasets
+// "Annoy" --limit 50` as its FIRST two operations, was refused both, retried
+// the listing twice, and reported the repositories unavailable. Every URI it
+// sent is in the captured grammar. A fake that refuses what its own tool
+// document promises does not measure a tool surface, it measures the fake.
+const SEARCH_DEFAULT_LIMIT = 100
+const SEARCH_MAX_LIMIT = 1000
+
+// The document spells a repo type singular in a Details cell and the routes
+// spell it plural in a path, the same split `PLURAL` bridges the other way.
+const SINGULAR: Record<string, string> = {
+  models: 'model',
+  datasets: 'dataset',
+  spaces: 'space',
+}
+
+// `--sort` names a camelCase field on the tool and a snake_case one on the
+// Hub API this fake serves. Only the five the listing route can actually
+// order by are here; the other five the grammar advertises (likes30d,
+// mainSize, id, trending, upvotes) have no key behind them, and are refused
+// by name below rather than accepted and ignored.
+const SORT_FIELDS: Record<string, string> = {
+  createdAt: 'created_at',
+  downloads: 'downloads',
+  likes: 'likes',
+  lastModified: 'last_modified',
+  trendingScore: 'trending_score',
+}
+
+function num(v: JsonValue | undefined): number {
+  return typeof v === 'number' ? v : 0
+}
+
+/**
+ * One repository, as a discovery listing prints it.
+ *
+ * Every conditional field here was captured, not reasoned about, from
+ * `ls hf://models/deepseek-ai`, `ls hf://spaces/stabilityai` and
+ * `search hf://models "meta-llama/Llama-3.1-8B"` on 2026-09-01:
+ *
+ * - a Space carries neither `downloads` nor `gated`, and carries `sdk`
+ *   where a model carries `task`;
+ * - a model or dataset that is not gated carries `gated: false`, so the key
+ *   is present and the value is a boolean, while a gated one carries the
+ *   flavour (`"manual"`) and prints `gated=manual` BESIDE `public` rather
+ *   than instead of it.
+ *
+ * `private` is the one word here with no capture behind it: nothing gated or
+ * private is visible to an anonymous probe, so `public` is observed and
+ * `private` is its complement.
+ */
+function repoEntry(kind: string, row: Record<string, JsonValue>): RepoEntry {
+  const id = String(row.id ?? '')
+  const space = kind === 'spaces'
+  const task = row.pipeline_tag
+  const sdk = row.sdk
+  const gated = row.gated
+  return {
+    type: 'repo',
+    id,
+    uri: `hf://${kind}/${id}`,
+    repoType: SINGULAR[kind] ?? kind,
+    visibility: row.private === true ? 'private' : 'public',
+    ...(space ? {} : { gated: typeof gated === 'string' && gated !== '' ? gated : false }),
+    likes: num(row.likes),
+    ...(space ? {} : { downloads: num(row.downloads) }),
+    ...(typeof task === 'string' && task !== '' ? { task } : {}),
+    ...(typeof sdk === 'string' && sdk !== '' ? { sdk } : {}),
+    updated: String(row.lastModified ?? ''),
+  }
+}
+
+// The structured half of the same row. Written from the entry rather than
+// from the API row a second time, so the table and the JSON cannot disagree
+// about what a repository is.
+function repoResult(one: RepoEntry): JsonValue {
+  return {
+    type: 'repo',
+    path: one.id,
+    uri: one.uri,
+    repo_type: one.repoType,
+    private: one.visibility === 'private',
+    ...(one.gated === undefined ? {} : { gated: one.gated }),
+    likes: one.likes,
+    ...(one.downloads === undefined ? {} : { downloads: one.downloads }),
+    ...(one.task === undefined ? {} : { task: one.task }),
+    ...(one.sdk === undefined ? {} : { sdk: one.sdk }),
+    updated_at: one.updated,
+  }
+}
+
+interface Discovery {
+  query: string
+  limit: number
+  sort: string
+  type: string
+  tags: string[]
+}
+
+/**
+ * The flags a discovery listing takes.
+ *
+ * `search` alone accepts a bare QUERY before them, which is why the caller
+ * says whether one is allowed rather than this reading it off `cmd`: a
+ * stray positional on `ls` is a mistyped flag, not a search term.
+ */
+function discoveryArgs(cmd: string, rest: string[], positional: boolean): Discovery | Refusal {
+  const bad = (message: string): Refusal => ({ code: FS_INVALID, message })
+  const max = cmd === 'search' ? SEARCH_MAX_LIMIT : LIST_MAX_LIMIT
+  const out: Discovery = {
+    query: '',
+    limit: cmd === 'search' ? SEARCH_DEFAULT_LIMIT : LIST_DEFAULT_LIMIT,
+    sort: '',
+    type: '',
+    tags: [],
+  }
+  let i = 0
+  if (positional && rest.length > 0 && !(rest[0] ?? '').startsWith('--')) {
+    out.query = rest[0] ?? ''
+    i = 1
+  }
+  for (; i < rest.length; i += 2) {
+    const flag = rest[i] ?? ''
+    const raw = rest[i + 1]
+    // `--query` is not in the grammar line the tool document prints, and the
+    // live server names it anyway when it refuses a search with no query
+    // ("requires a positional query or --query"), so it is a real spelling.
+    const known =
+      flag === '--limit' ||
+      flag === '--sort' ||
+      flag === '--type' ||
+      (cmd === 'search' && (flag === '--tag' || flag === '--query'))
+    if (!known) return bad(`EINVAL: unexpected argument for ${cmd}: ${flag}`)
+    if (raw === undefined) return bad(`EINVAL: ${flag} needs a value`)
+    if (flag === '--limit') {
+      if (!/^-?\d+$/.test(raw)) return bad(`EINVAL: ${flag} requires an integer`)
+      const value = Number(raw)
+      if (value < 1 || value > max) {
+        return bad(`EINVAL: limit must be between 1 and ${String(max)} for this command`)
+      }
+      out.limit = value
+      continue
+    }
+    if (flag === '--sort') {
+      if (SORT_FIELDS[raw] === undefined) {
+        return bad(
+          `EINVAL: the mirage hf_hub fake sorts by ${Object.keys(SORT_FIELDS).join(', ')}: ${raw}`,
+        )
+      }
+      out.sort = raw
+      continue
+    }
+    if (flag === '--type') {
+      out.type = raw
+      continue
+    }
+    if (flag === '--query') {
+      out.query = raw
+      continue
+    }
+    out.tags.push(raw)
+  }
+  return out
+}
+
+/**
+ * A discovery listing: repositories of one kind, optionally one owner's.
+ *
+ * Both scopes are the SAME listing route with one more parameter, which is
+ * why they are one function. `--type` filters to nothing unless it is `repo`,
+ * because a discovery scope holds no files and no directories -- captured:
+ * `ls hf://models/deepseek-ai --type file` answers an empty table rather than
+ * an error.
+ */
+async function discover(
+  at: Dispatch,
+  kind: string,
+  owner: string,
+  flags: Discovery,
+): Promise<RepoEntry[]> {
+  if (flags.type !== '' && flags.type !== 'repo') return []
+  const query: Record<string, string | string[]> = { full: '1' }
+  if (owner !== '') query.author = owner
+  if (flags.query !== '') query.search = flags.query
+  if (flags.sort !== '') query.sort = SORT_FIELDS[flags.sort] ?? flags.sort
+  if (flags.tags.length > 0) query.filter = flags.tags
+  // One past the limit, the way the tree listings do it: enough to know the
+  // answer was cut without carrying a tail that is about to be dropped.
+  query.limit = String(flags.limit + 1)
+  const found = rows(await callRoute(at, 'GET', `/api/${kind}`, query))
+  return found.map((one) => repoEntry(kind, one))
 }
 
 function entriesOf(reply: Reply): FsEntry[] {
@@ -421,7 +624,7 @@ function entriesOf(reply: Reply): FsEntry[] {
  * discovered rather than handing back a shorter tree that reads exactly like
  * a complete one.
  */
-async function* treePages(at: Dispatch, where: Located, recursive: boolean): AsyncGenerator<Reply> {
+async function* treePages(at: Dispatch, where: RepoAt, recursive: boolean): AsyncGenerator<Reply> {
   const suffix = where.path === '' ? '' : `/${where.path}`
   const path = `/api/${where.kind}/${where.id}/tree/main${suffix}`
   const query: Record<string, string> = recursive ? { recursive: 'true' } : {}
@@ -455,7 +658,7 @@ async function* treePages(at: Dispatch, where: Located, recursive: boolean): Asy
  */
 async function treeAt(
   at: Dispatch,
-  where: Located,
+  where: RepoAt,
   recursive: boolean,
   cap = Number.POSITIVE_INFINITY,
 ): Promise<Reply> {
@@ -723,7 +926,7 @@ function imageMime(path: string): string | undefined {
 // there, so `ok` alone calls every miss a directory. A directory in git
 // always holds something -- an empty one cannot be committed -- so the rows
 // are the test, and this is the only place that knows it.
-async function isDirectory(at: Dispatch, where: Located): Promise<boolean> {
+async function isDirectory(at: Dispatch, where: RepoAt): Promise<boolean> {
   if (where.path === '') return false
   // One page: the question is whether there is a row, not what the rows are.
   const listed = await treeAt(at, where, false, 1)
@@ -742,7 +945,7 @@ async function isDirectory(at: Dispatch, where: Located): Promise<boolean> {
  * the entire repository to keep a single row; a batch of the 30 operations one
  * call allows paid that thirty times over.
  */
-async function rowAt(at: Dispatch, where: Located): Promise<FsEntry | undefined> {
+async function rowAt(at: Dispatch, where: RepoAt): Promise<FsEntry | undefined> {
   const cut = where.path.lastIndexOf('/')
   const parent = cut === -1 ? '' : where.path.slice(0, cut)
   for await (const page of treePages(at, { ...where, path: parent }, false)) {
@@ -848,18 +1051,109 @@ function readmeOne(cmd: string, rest: string[]): FsOut {
   }
 }
 
+/**
+ * A command aimed at a discovery scope -- a kind root or an owner namespace.
+ *
+ * Split out rather than folded into the branches below because the two scopes
+ * share nothing with a repository except the command names: there is no tree
+ * to page, no path to resolve, and the entries are repositories. Every one of
+ * the refusals here is a thing the fake genuinely does not hold, and says so;
+ * none of them is a URI the caller got wrong.
+ */
+async function discoverOne(
+  at: Dispatch,
+  cmd: string,
+  uri: string,
+  where: Exclude<Located, { scope: 'repo' }>,
+  rest: string[],
+): Promise<FsOut> {
+  const owner = where.scope === 'namespace' ? where.namespace : ''
+  // A namespace is not a file, and saying so with NOT_A_FILE rather than
+  // EINVAL is upstream's own answer: an agent branching on the code should
+  // not be told it mistyped a flag.
+  if (cmd === 'cat') {
+    return fsFail(FS_NOT_A_FILE, 'cat requires a URI that points to a file path, not a namespace.')
+  }
+  if (cmd === 'attach') {
+    return fsFail(FS_INVALID, `EINVAL: expected hf://${where.kind}/<namespace>/<name>: ${uri}`)
+  }
+  if (cmd === 'stat') {
+    if (rest.length > 0) {
+      return fsFail(FS_INVALID, `EINVAL: unexpected argument for ${cmd}: ${rest[0] ?? ''}`)
+    }
+    // Neither answer is looked up. Captured: `stat hf://models/<anything>`
+    // reports `exists: yes, type: namespace` for an owner that does not
+    // exist, because the server is describing the URI's shape rather than
+    // the Hub's contents.
+    if (where.scope === 'kind') {
+      return {
+        text: statMarkdown(uri, 'dir', ''),
+        result: { uri, op: 'stat', exists: true, type: 'dir', path: '' },
+      }
+    }
+    return {
+      text: statMarkdown(uri, 'namespace', '', undefined, undefined, owner),
+      result: { uri, op: 'stat', exists: true, type: 'namespace', path: '', namespace: owner },
+    }
+  }
+  if (cmd !== 'ls' && cmd !== 'find' && cmd !== 'search') {
+    return fsFail(FS_INVALID, `EINVAL: unknown command: ${cmd}`)
+  }
+  // `ls hf://<kind>` lists one virtual `trending` directory upstream, and a
+  // trending feed is the one thing behind these roots that this fake has no
+  // rows for. Answering with an entry whose own listing then fails would be
+  // worse than saying so, so it says so and names what does work.
+  if (cmd !== 'search' && where.scope === 'kind') {
+    return fsFail(
+      FS_INVALID,
+      `EINVAL: the mirage hf_hub fake has no trending feed behind hf://${where.kind}; ` +
+        `use search hf://${where.kind} or ${cmd} hf://${where.kind}/<namespace>`,
+    )
+  }
+  const flags = discoveryArgs(cmd, rest, cmd === 'search')
+  if (!('limit' in flags)) return fsFail(flags.code, flags.message)
+  const found = await discover(at, where.kind, owner, flags)
+  const truncated = found.length > flags.limit
+  const entries = truncated ? found.slice(0, flags.limit) : found
+  return {
+    text: listingMarkdown(cmd, uri, entries, truncated),
+    result: {
+      uri,
+      op: cmd,
+      entries: entries.map(repoResult),
+      // Two different notices, and search's carries no message: captured on
+      // the same day from the same server, `ls` says `entry_limit` with the
+      // sentence and `search` says `limit` with nothing beside it.
+      ...(truncated
+        ? cmd === 'search'
+          ? { truncated: true, truncation_reason: 'limit' }
+          : {
+              truncated: true,
+              truncation_reason: 'entry_limit',
+              truncation_message: LIST_TRUNCATED,
+            }
+        : {}),
+    },
+  }
+}
+
 async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget): Promise<FsOut> {
+  const uri = args[0] ?? ''
+  if (uri === README_URI) return readmeOne(cmd, args.slice(1))
+  const where = locate(uri)
+  if (!('kind' in where)) return fsFail(where.code, where.message)
+  const rest = args.slice(1)
+  if (where.scope !== 'repo') return discoverOne(at, cmd, uri, where, rest)
+  // Upstream's own sentence, and it names every scope rather than this one:
+  // search is discovery, and a repository is the one URI that is already
+  // discovered.
   if (cmd === 'search') {
     return fsFail(
       FS_INVALID,
-      `EINVAL: ${cmd} is not served by the mirage hf_hub fake; use ls, cat, stat or find`,
+      'EINVAL: search requires hf://models|datasets|spaces[/OWNER], ' +
+        'hf://collections[/OWNER], any hf://docs scope, or exactly hf://papers',
     )
   }
-  const uri = args[0] ?? ''
-  if (uri === README_URI) return readmeOne(cmd, args.slice(1))
-  const where = locate(uri, cmd)
-  if (!('kind' in where)) return fsFail(where.code, where.message)
-  const rest = args.slice(1)
   // `stat` is the only command that takes the URI alone; cat, attach, ls and
   // find each parse their own flags below and refuse the rest by name there.
   // Listing the exceptions here was a standing trap -- attach and then ls
@@ -888,16 +1182,6 @@ async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget):
       result: {
         uri,
         op: cmd,
-        // The schema's own three, and the same vocabulary cat uses -- with
-        // `entry_limit` where cat says `max_bytes`, because that is the enum
-        // value upstream answers for a listing.
-        ...(truncated
-          ? {
-              truncated: true,
-              truncation_reason: 'entry_limit',
-              truncation_message: LIST_TRUNCATED,
-            }
-          : {}),
         // A directory entry carries no `size`, which is the live server's own
         // shape rather than a zero: the schema makes size optional precisely
         // because a Hub directory has none.
@@ -906,6 +1190,18 @@ async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget):
             ? { type: 'dir', path: one.path }
             : { type: 'file', path: one.path, size: one.size, ...(one.lfs ? { lfs: true } : {}) },
         ),
+        // The schema's own three, and the same vocabulary cat uses -- with
+        // `entry_limit` where cat says `max_bytes`, because that is the enum
+        // value upstream answers for a listing. AFTER the entries, which is
+        // the order the live result serializes in and therefore the order the
+        // model reads.
+        ...(truncated
+          ? {
+              truncated: true,
+              truncation_reason: 'entry_limit',
+              truncation_message: LIST_TRUNCATED,
+            }
+          : {}),
       },
     }
   }

--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -436,6 +436,16 @@ const SINGULAR: Record<string, string> = {
 // order by are here; the other five the grammar advertises (likes30d,
 // mainSize, id, trending, upvotes) have no key behind them, and are refused
 // by name below rather than accepted and ignored.
+// `TYPE = file|dir|repo|bucket|collection|paper|link.` -- the captured
+// grammar's own line, and a closed set. Four of the seven name entry kinds
+// this fake holds nothing of, and those still ANSWER: `ls --type bucket`
+// returns an empty table upstream rather than an error, because the value is
+// valid and simply matches nothing. A value off the list is the error, and
+// keeping the two apart is the whole point: `--type repos` is a typo, and an
+// empty listing would make it indistinguishable from an owner with no
+// repositories.
+const ENTRY_TYPES = ['file', 'dir', 'repo', 'bucket', 'collection', 'paper', 'link']
+
 const SORT_FIELDS: Record<string, string> = {
   createdAt: 'created_at',
   downloads: 'downloads',
@@ -600,6 +610,11 @@ function discoveryArgs(cmd: string, rest: string[]): Discovery | Refusal {
       continue
     }
     if (flag === '--type') {
+      // Upstream's sentence, down to the advice at the end -- which is odd
+      // out of context (why `file`?) and is copied rather than improved.
+      if (!ENTRY_TYPES.includes(raw)) {
+        return bad(`EINVAL: invalid entry type: ${raw}. Use --type file for files.`)
+      }
       out.type = raw
       continue
     }

--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -506,12 +506,31 @@ function repoResult(one: RepoEntry): JsonValue {
   }
 }
 
+/**
+ * Glob, in the flavour `find` matches names with.
+ *
+ * Two probes fix both halves of the semantics. `--name "deepseek-ai/*"`
+ * matches nothing where `--name "DeepSeek-V4*"` matches every V4 model, so
+ * the string being matched is the repository's LEAF name and not its
+ * `owner/name` id -- and `--path` behaves identically at this scope, which is
+ * the same probe run twice. `--name "deepseek-v4*"` matches nothing either,
+ * so it is case-sensitive.
+ */
+function globMatch(pattern: string, text: string): boolean {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escaped.replace(/\*/g, '.*').replace(/\?/g, '.')}$`).test(text)
+}
+
 interface Discovery {
   query: string
   limit: number
   sort: string
   type: string
-  tags: string[]
+  // `find`'s two, and at a namespace they are the same filter: both glob the
+  // leaf repository name. Kept apart anyway because upstream keeps them
+  // apart, and a caller passing both means both must hold.
+  name: string
+  path: string
 }
 
 /**
@@ -521,7 +540,7 @@ interface Discovery {
  * says whether one is allowed rather than this reading it off `cmd`: a
  * stray positional on `ls` is a mistyped flag, not a search term.
  */
-function discoveryArgs(cmd: string, rest: string[], positional: boolean): Discovery | Refusal {
+function discoveryArgs(cmd: string, rest: string[]): Discovery | Refusal {
   const bad = (message: string): Refusal => ({ code: FS_INVALID, message })
   const max = cmd === 'search' ? SEARCH_MAX_LIMIT : LIST_MAX_LIMIT
   const out: Discovery = {
@@ -529,24 +548,37 @@ function discoveryArgs(cmd: string, rest: string[], positional: boolean): Discov
     limit: cmd === 'search' ? SEARCH_DEFAULT_LIMIT : LIST_DEFAULT_LIMIT,
     sort: '',
     type: '',
-    tags: [],
+    name: '',
+    path: '',
   }
   let i = 0
-  if (positional && rest.length > 0 && !(rest[0] ?? '').startsWith('--')) {
+  if (cmd === 'search' && rest.length > 0 && !(rest[0] ?? '').startsWith('--')) {
     out.query = rest[0] ?? ''
     i = 1
   }
   for (; i < rest.length; i += 2) {
     const flag = rest[i] ?? ''
     const raw = rest[i + 1]
-    // `--query` is not in the grammar line the tool document prints, and the
-    // live server names it anyway when it refuses a search with no query
-    // ("requires a positional query or --query"), so it is a real spelling.
+    // Per command, the way the captured grammar lists them: `--sort` rides
+    // `ls` and `search` and is absent from `find`'s line, `--name` and
+    // `--path` are `find`'s alone, and `--query` is not printed in the
+    // grammar at all -- the live server names it when it refuses a search
+    // with no query ("requires a positional query or --query"), so it is a
+    // real spelling.
     const known =
       flag === '--limit' ||
-      flag === '--sort' ||
       flag === '--type' ||
-      (cmd === 'search' && (flag === '--tag' || flag === '--query'))
+      (cmd !== 'find' && flag === '--sort') ||
+      (cmd === 'find' && (flag === '--name' || flag === '--path')) ||
+      (cmd === 'search' && flag === '--query')
+    // Upstream's own sentence, and it is a narrower rule than "search only":
+    // both flags are refused on `search hf://models` as well. Answered before
+    // the generic refusal so that a caller following the tool document's
+    // "--kind mcp selects MCP Spaces" is told WHERE it applies rather than
+    // that it does not exist.
+    if (!known && (flag === '--tag' || flag === '--kind')) {
+      return bad('EINVAL: --tag and --kind are supported only with search hf://spaces')
+    }
     if (!known) return bad(`EINVAL: unexpected argument for ${cmd}: ${flag}`)
     if (raw === undefined) return bad(`EINVAL: ${flag} needs a value`)
     if (flag === '--limit') {
@@ -575,7 +607,11 @@ function discoveryArgs(cmd: string, rest: string[], positional: boolean): Discov
       out.query = raw
       continue
     }
-    out.tags.push(raw)
+    if (flag === '--name') {
+      out.name = raw
+      continue
+    }
+    out.path = raw
   }
   return out
 }
@@ -596,16 +632,28 @@ async function discover(
   flags: Discovery,
 ): Promise<RepoEntry[]> {
   if (flags.type !== '' && flags.type !== 'repo') return []
+  const globbed = flags.name !== '' || flags.path !== ''
   const query: Record<string, string | string[]> = { full: '1' }
   if (owner !== '') query.author = owner
   if (flags.query !== '') query.search = flags.query
   if (flags.sort !== '') query.sort = SORT_FIELDS[flags.sort] ?? flags.sort
-  if (flags.tags.length > 0) query.filter = flags.tags
   // One past the limit, the way the tree listings do it: enough to know the
   // answer was cut without carrying a tail that is about to be dropped.
-  query.limit = String(flags.limit + 1)
+  //
+  // Not pushed to the route when a glob is filtering, though: the route would
+  // cut the rows BEFORE the glob saw them, so a match sitting past the limit
+  // would vanish and the listing would report itself complete. The bound then
+  // applies after the filter, where it belongs.
+  if (!globbed) query.limit = String(flags.limit + 1)
   const found = rows(await callRoute(at, 'GET', `/api/${kind}`, query))
-  return found.map((one) => repoEntry(kind, one))
+  const entries = found.map((one) => repoEntry(kind, one))
+  if (!globbed) return entries
+  // Both globs match the LEAF name, so a row must satisfy every glob given.
+  const leaf = (one: RepoEntry): string => one.id.slice(one.id.indexOf('/') + 1)
+  return entries
+    .filter((one) => flags.name === '' || globMatch(flags.name, leaf(one)))
+    .filter((one) => flags.path === '' || globMatch(flags.path, leaf(one)))
+    .slice(0, flags.limit + 1)
 }
 
 function entriesOf(reply: Reply): FsEntry[] {
@@ -1144,6 +1192,27 @@ async function discoverOne(
   if (cmd !== 'ls' && cmd !== 'find' && cmd !== 'search') {
     return fsFail(FS_INVALID, `EINVAL: unknown command: ${cmd}`)
   }
+  // `search hf://spaces` is not the search the other two roots get. Probed
+  // side by side on 2026-09-01: it is SEMANTICALLY ranked, and every row
+  // carries `semantic relevance=93.8%`, a `category` a classifier assigned
+  // and a `title` -- none of which a seeded fixture can compute, and the
+  // percentage moves between calls for the same repository. Answering it in
+  // the plain listing shape would put a row in front of the model that no
+  // live server produces, which is the same silent wrongness as an empty
+  // listing for `trending`.
+  //
+  // Narrow on purpose: `search hf://spaces/<owner>` IS the plain shape, and
+  // this fake answers it. Only the bare root is refused. That URI is also the
+  // only one where `--tag` and `--kind mcp` apply, which is why neither is
+  // served: the flags are valid on exactly the search this fake cannot rank.
+  if (cmd === 'search' && where.scope === 'kind' && where.kind === 'spaces') {
+    return fsFail(
+      FS_INVALID,
+      `EINVAL: the mirage hf_hub fake cannot rank ${uri} the way upstream does ` +
+        '(semantic relevance, category, title); ' +
+        'use search hf://spaces/<namespace> or ls hf://spaces/<namespace>',
+    )
+  }
   // `search` is discovery and `trending` is already a ranking, so upstream
   // refuses it there with the same sentence it refuses a repository with.
   if (cmd === 'search' && trending) return fsFail(FS_INVALID, SEARCH_SCOPES)
@@ -1170,7 +1239,7 @@ async function discoverOne(
     }
     if (cmd === 'ls') return noFeed()
   }
-  const flags = discoveryArgs(cmd, rest, cmd === 'search')
+  const flags = discoveryArgs(cmd, rest)
   if (!('limit' in flags)) return fsFail(flags.code, flags.message)
   const found = await discover(at, where.kind, owner, flags)
   const truncated = found.length > flags.limit

--- a/integ/server/hf_hub/mcp.ts
+++ b/integ/server/hf_hub/mcp.ts
@@ -53,6 +53,7 @@ import {
   FS_NOT_FOUND,
   FS_TEXT_ONLY,
   FS_UNSUPPORTED_MEDIA,
+  FS_UNSUPPORTED_OP,
   catMarkdown,
   type CatBounds,
   detailsMarkdown,
@@ -333,6 +334,7 @@ interface RepoAt {
 type Located =
   | ({ scope: 'repo' } & RepoAt)
   | { scope: 'namespace'; kind: string; namespace: string }
+  | { scope: 'trending'; kind: string }
   | { scope: 'kind'; kind: string }
 
 // What the fake cannot answer, said in a sentence rather than guessed at. It
@@ -379,6 +381,14 @@ function locate(uri: string): Located | Refusal {
   // answer is the command's question, not this function's -- `cat` wants a
   // file and `search` refuses one, and neither can be decided here.
   if (parts.length === 1) return { scope: 'kind', kind }
+  // RESERVED, and it has to be reserved HERE. `trending` is a virtual
+  // directory upstream, not an owner, and it is the first example the captured
+  // tool description prints: `ls hf://models/trending --limit 10`. Classified
+  // as a namespace it would query `author=trending`, match nothing, and answer
+  // an empty listing with status 200 -- a successful-looking reply that says
+  // the Hub has no trending repositories. That is worse than the refusal this
+  // whole change exists to remove, because a refusal is at least visible.
+  if (parts.length === 2 && parts[1] === TRENDING) return { scope: 'trending', kind }
   if (parts.length === 2) return { scope: 'namespace', kind, namespace: parts[1] ?? '' }
   return {
     scope: 'repo',
@@ -398,6 +408,20 @@ function locate(uri: string): Located | Refusal {
 // document promises does not measure a tool surface, it measures the fake.
 const SEARCH_DEFAULT_LIMIT = 100
 const SEARCH_MAX_LIMIT = 1000
+
+// The one segment that is not an owner. Upstream exposes it under each of the
+// three kinds, and it is the only part of this fake's Hub with no rows behind
+// it at all: a trending feed is a global ranking, and a seeded fixture has no
+// such thing to rank.
+const TRENDING = 'trending'
+
+// Upstream's refusal for `search` aimed anywhere that is not a discovery
+// root -- a repository or the trending feed. One sentence, two callers, and
+// it names every scope that WOULD have worked rather than the one that did
+// not.
+const SEARCH_SCOPES =
+  'EINVAL: search requires hf://models|datasets|spaces[/OWNER], ' +
+  'hf://collections[/OWNER], any hf://docs scope, or exactly hf://papers'
 
 // The document spells a repo type singular in a Details cell and the routes
 // spell it plural in a path, the same split `PLURAL` bridges the other way.
@@ -1068,23 +1092,44 @@ async function discoverOne(
   rest: string[],
 ): Promise<FsOut> {
   const owner = where.scope === 'namespace' ? where.namespace : ''
-  // A namespace is not a file, and saying so with NOT_A_FILE rather than
-  // EINVAL is upstream's own answer: an agent branching on the code should
-  // not be told it mistyped a flag.
+  const trending = where.scope === 'trending'
+  // The one refusal in this function that is this fake's own rather than
+  // upstream's, because it is the one thing here upstream HAS and the fake
+  // does not. It names what works instead, which is the whole difference
+  // between an honest refusal and a dead end.
+  const noFeed = (): FsOut =>
+    fsFail(
+      FS_INVALID,
+      `EINVAL: the mirage hf_hub fake has no trending feed: ${uri}; ` +
+        `use search hf://${where.kind} or ls hf://${where.kind}/<namespace>`,
+    )
+  // Three different sentences for what looks like one situation, and all
+  // three are the live server's: `cat` on a namespace says it wanted a file
+  // PATH, `cat` on `trending` says the target IS a directory, and `attach`
+  // says the same thing at every non-file URI.
   if (cmd === 'cat') {
-    return fsFail(FS_NOT_A_FILE, 'cat requires a URI that points to a file path, not a namespace.')
+    return trending
+      ? fsFail(FS_NOT_A_FILE, `EISDIR: ${uri} is a directory`)
+      : fsFail(FS_NOT_A_FILE, 'cat requires a URI that points to a file path, not a namespace.')
   }
   if (cmd === 'attach') {
-    return fsFail(FS_INVALID, `EINVAL: expected hf://${where.kind}/<namespace>/<name>: ${uri}`)
+    return fsFail(FS_NOT_A_FILE, 'attach requires a direct repository or bucket file URI.')
   }
   if (cmd === 'stat') {
     if (rest.length > 0) {
       return fsFail(FS_INVALID, `EINVAL: unexpected argument for ${cmd}: ${rest[0] ?? ''}`)
     }
-    // Neither answer is looked up. Captured: `stat hf://models/<anything>`
-    // reports `exists: yes, type: namespace` for an owner that does not
-    // exist, because the server is describing the URI's shape rather than
-    // the Hub's contents.
+    // None of the three is looked up, and the three differ in the Path they
+    // report: `trending` names itself, a kind root and a namespace report an
+    // empty one. Captured: `stat hf://models/<anything>` reports `exists:
+    // yes, type: namespace` for an owner that does not exist, because the
+    // server describes the URI's shape rather than the Hub's contents.
+    if (trending) {
+      return {
+        text: statMarkdown(uri, 'dir', TRENDING),
+        result: { uri, op: 'stat', exists: true, type: 'dir', path: TRENDING },
+      }
+    }
     if (where.scope === 'kind') {
       return {
         text: statMarkdown(uri, 'dir', ''),
@@ -1099,16 +1144,31 @@ async function discoverOne(
   if (cmd !== 'ls' && cmd !== 'find' && cmd !== 'search') {
     return fsFail(FS_INVALID, `EINVAL: unknown command: ${cmd}`)
   }
-  // `ls hf://<kind>` lists one virtual `trending` directory upstream, and a
-  // trending feed is the one thing behind these roots that this fake has no
-  // rows for. Answering with an entry whose own listing then fails would be
-  // worse than saying so, so it says so and names what does work.
-  if (cmd !== 'search' && where.scope === 'kind') {
-    return fsFail(
-      FS_INVALID,
-      `EINVAL: the mirage hf_hub fake has no trending feed behind hf://${where.kind}; ` +
-        `use search hf://${where.kind} or ${cmd} hf://${where.kind}/<namespace>`,
-    )
+  // `search` is discovery and `trending` is already a ranking, so upstream
+  // refuses it there with the same sentence it refuses a repository with.
+  if (cmd === 'search' && trending) return fsFail(FS_INVALID, SEARCH_SCOPES)
+  // Upstream refuses `find` on the feed and names `ls` instead, under a code
+  // that says "not here" rather than "you asked wrongly". Reproducible
+  // without a feed, so it is reproduced rather than approximated.
+  if (cmd === 'find' && trending) {
+    return fsFail(FS_UNSUPPORTED_OP, `ENOTSUP: find is not supported on ${uri}; use ls`)
+  }
+  if (trending) return noFeed()
+  if (where.scope === 'kind') {
+    // The two roots part company here. `ls hf://<kind>` SUCCEEDS upstream,
+    // with exactly one row -- the virtual `trending` directory -- so the
+    // honest answer for a fake with no feed is to refuse rather than to list
+    // a directory that will not open. `find` upstream refuses outright, in a
+    // sentence this copies. (The envelope diverges: upstream answers that one
+    // as a whole-call rejection with no `results` array, where this stays a
+    // per-operation error like every other refusal here.)
+    if (cmd === 'find') {
+      return fsFail(
+        FS_INVALID,
+        `Listing ${where.kind} requires an explicit owner. Use hf://${where.kind}/<owner>.`,
+      )
+    }
+    if (cmd === 'ls') return noFeed()
   }
   const flags = discoveryArgs(cmd, rest, cmd === 'search')
   if (!('limit' in flags)) return fsFail(flags.code, flags.message)
@@ -1147,13 +1207,7 @@ async function fsOne(at: Dispatch, cmd: string, args: string[], budget: Budget):
   // Upstream's own sentence, and it names every scope rather than this one:
   // search is discovery, and a repository is the one URI that is already
   // discovered.
-  if (cmd === 'search') {
-    return fsFail(
-      FS_INVALID,
-      'EINVAL: search requires hf://models|datasets|spaces[/OWNER], ' +
-        'hf://collections[/OWNER], any hf://docs scope, or exactly hf://papers',
-    )
-  }
+  if (cmd === 'search') return fsFail(FS_INVALID, SEARCH_SCOPES)
   // `stat` is the only command that takes the URI alone; cat, attach, ls and
   // find each parse their own flags below and refuse the rest by name there.
   // Listing the exceptions here was a standing trap -- attach and then ls

--- a/integ/server/hf_hub/render.ts
+++ b/integ/server/hf_hub/render.ts
@@ -246,19 +246,86 @@ export interface FsEntry {
 export const LIST_TRUNCATED =
   'Result truncated after reaching the entry limit. Rerun with a larger --limit, up to 10000.'
 
+// `search` says something else, and says less of it. Captured on the same day
+// as the sentence above, from `search hf://datasets "toolace" --limit 2`: no
+// ceiling is quoted, because search's own is 1,000 rather than the listing's
+// 10,000 and upstream simply does not name it here.
+export const SEARCH_TRUNCATED = 'Result truncated: limit.'
+
+/**
+ * A repository row, which is what the discovery scopes list instead of files.
+ *
+ * Captured (`ls hf://models/deepseek-ai --limit 1`):
+ *
+ *   | repo | deepseek-ai/DeepSeek-V4-Flash-Vision-Exp |
+ *     hf://models/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp |  |
+ *     repo=model, public, likes=444, downloads=17893,
+ *     task=image-text-to-text, updated=2026-09-01T09:22:10.000Z |
+ *
+ * Two columns a file row leaves empty are filled here: `Path` carries the full
+ * `owner/name` rather than a leaf and `URI` carries the repository's own hf://
+ * identity. `Details` is a comma-joined summary rather than a size.
+ */
+export interface RepoEntry {
+  type: 'repo'
+  id: string
+  uri: string
+  repoType: string
+  // `false` where the key is present and the repository is not gated, and the
+  // flavour word where it is; absent entirely for a Space, which carries no
+  // such key at all.
+  gated?: string | false
+  visibility: string
+  likes: number
+  downloads?: number
+  task?: string
+  sdk?: string
+  updated: string
+}
+
+function isRepo(row: FsEntry | RepoEntry): row is RepoEntry {
+  return row.type === 'repo'
+}
+
+// Four of these ride only some kinds, and each absence was captured rather
+// than reasoned about. A space carries no `downloads` and no `gated` at all --
+// not a zero and not `gated=false` -- and carries `sdk` where a model carries
+// `task`. `gated=manual` sits BESIDE `public` rather than replacing it, which
+// is the one that would have been guessed wrong: gating and visibility are two
+// facts about a repository, not two values of one.
+function repoDetails(row: RepoEntry): string {
+  return [
+    `repo=${row.repoType}`,
+    row.visibility,
+    ...(typeof row.gated === 'string' ? [`gated=${row.gated}`] : []),
+    `likes=${String(row.likes)}`,
+    ...(row.downloads === undefined ? [] : [`downloads=${String(row.downloads)}`]),
+    ...(row.task === undefined ? [] : [`task=${row.task}`]),
+    ...(row.sdk === undefined ? [] : [`sdk=${row.sdk}`]),
+    `updated=${row.updated}`,
+  ].join(', ')
+}
+
 export function listingMarkdown(
   cmd: string,
   uri: string,
-  rows: FsEntry[],
+  rows: (FsEntry | RepoEntry)[],
   truncated = false,
 ): string {
   const out = [`# hf_fs ${cmd}`, '', `URI: \`${uri}\``, '']
   out.push('| Type | Path | URI | Target | Details |', '|---|---|---|---|---|')
   for (const row of rows) {
+    if (isRepo(row)) {
+      out.push(`| repo | ${escapeCell(row.id)} | ${escapeCell(row.uri)} |  | ${repoDetails(row)} |`)
+      continue
+    }
     const details = row.type === 'dir' ? '' : `${row.lfs ? 'lfs, ' : ''}size=${humanSize(row.size)}`
     out.push(`| ${row.type} | ${escapeCell(row.path)} |  |  | ${details} |`)
   }
-  if (truncated) out.push('', LIST_TRUNCATED)
+  // Which sentence depends on the command, because upstream's does: `ls` and
+  // `find` stop at an entry limit and `search` stops at a limit, and they are
+  // not the same notice.
+  if (truncated) out.push('', cmd === 'search' ? SEARCH_TRUNCATED : LIST_TRUNCATED)
   return out.join('\n')
 }
 
@@ -278,7 +345,11 @@ export function listingMarkdown(
 // directory upstream, and a path that is not there is `missing` rather than an
 // absent Type line -- both are printed, and both are printed for every
 // outcome, so a reader never has to infer a field from its absence.
-export type StatKind = 'file' | 'dir' | 'repo' | 'missing'
+// `namespace` is upstream's fifth, and it is not conditional on the owner
+// existing: `stat hf://models/no-such-owner-xyz-42` answers `exists: yes` and
+// `type: namespace`. The server is describing the SHAPE of the URI there, not
+// looking anything up, which is why this fake can answer it without a query.
+export type StatKind = 'file' | 'dir' | 'repo' | 'missing' | 'namespace'
 
 /**
  * Captured:
@@ -309,6 +380,7 @@ export function statMarkdown(
   path: string,
   size?: number,
   contentType?: string,
+  namespace?: string,
 ): string {
   return [
     `# hf_fs stat`,
@@ -317,6 +389,9 @@ export function statMarkdown(
     `- Exists: ${kind === 'missing' ? 'no' : 'yes'}`,
     `- Type: \`${kind}\``,
     `- Path: \`${path}\``,
+    // Only a namespace prints it, and it prints AFTER the path rather than
+    // beside the URI it came from.
+    ...(namespace === undefined ? [] : [`- Namespace: \`${namespace}\``]),
     ...(kind === 'file' && size !== undefined ? [`- Size: ${humanSize(size)}`] : []),
     // AFTER the size here, and BEFORE the byte count in `catMarkdown`. The
     // two orders are upstream's, captured separately, and neither is a typo:

--- a/integ/server/hf_hub/render.ts
+++ b/integ/server/hf_hub/render.ts
@@ -470,6 +470,11 @@ export const FS_IMAGE_ONLY = 'HF_FS_IMAGE_ONLY'
 export const FS_UNSUPPORTED_MEDIA = 'HF_FS_UNSUPPORTED_MEDIA'
 export const FS_IMAGE_TOO_LARGE = 'HF_FS_IMAGE_TOO_LARGE'
 export const FS_BUDGET = 'HF_FS_ATTACHMENT_BUDGET_EXCEEDED'
+// Not "you asked wrongly" but "not here": the command and the URI are both
+// valid and the combination is refused. Captured from
+// `find hf://models/trending`, which upstream answers with this code and a
+// sentence naming the command that WOULD work.
+export const FS_UNSUPPORTED_OP = 'HF_FS_UNSUPPORTED_OPERATION'
 
 const RECOVERY: Record<string, string> = {
   [FS_NOT_FOUND]:
@@ -487,6 +492,8 @@ const RECOVERY: Record<string, string> = {
     'Attach supports only files ending in .jpg, .jpeg, .png, or .webp. Use stat for metadata.',
   [FS_IMAGE_TOO_LARGE]:
     'Use stat for metadata. Attach cannot truncate images or exceed its configured complete-file limit.',
+  [FS_UNSUPPORTED_OP]:
+    'Follow the supported operation named in the error. Otherwise narrow the URI scope or remove the unsupported option.',
   // Upstream's own sentence, curly apostrophe included -- it is bytes the
   // model is charged for, so it is copied rather than tidied.
   [FS_BUDGET]:

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -1074,13 +1074,91 @@ async function mcpChecks(): Promise<void> {
     )
     eq('a discovery scope holds no files', entriesOf(typed).length, 0)
 
-    // The one discovery URI this fake still refuses, and it refuses it for
-    // what it does not hold rather than by calling the URI wrong.
-    const trending = await call('hf_fs', ops({ cmd: 'ls', args: ['hf://models'] }))
+    // ---- `trending` is RESERVED, not an owner
+    //
+    // `ls hf://models/trending --limit 10` is the first example the captured
+    // tool description prints, so a model WILL send it. Classified as a
+    // namespace it would query `author=trending`, match nothing, and answer
+    // an empty listing with status 200 -- a successful-looking reply that
+    // says the Hub has no trending repositories. Every check below exists to
+    // keep that from being the answer.
+    const feed = await call('hf_fs', ops({ cmd: 'ls', args: ['hf://models/trending'] }))
+    check(
+      'ls on the feed is refused, not answered empty',
+      'error' in
+        ((
+          (((feed.structuredContent ?? {}) as Record<string, JsonValue>).results ?? []) as Record<
+            string,
+            JsonValue
+          >[]
+        )[0] ?? {}),
+      JSON.stringify(resultOf(feed)),
+    )
+    check(
+      'and it names what is missing and what works instead',
+      String(errorOf(feed).message ?? '').includes('no trending feed: hf://models/trending'),
+      String(errorOf(feed).message ?? ''),
+    )
+    // The other three commands on the feed need no feed at all, so they are
+    // upstream's answers rather than this fake's.
+    const feedStat = await call('hf_fs', ops({ cmd: 'stat', args: ['hf://datasets/trending'] }))
+    eq('stat calls the feed a dir', resultOf(feedStat).type ?? null, 'dir')
+    eq('and the feed names itself as the path', resultOf(feedStat).path ?? null, 'trending')
+    const feedFind = await call('hf_fs', ops({ cmd: 'find', args: ['hf://models/trending'] }))
+    eq(
+      'find on the feed is ENOTSUP, not EINVAL',
+      errorOf(feedFind).code ?? null,
+      'HF_FS_UNSUPPORTED_OPERATION',
+    )
+    eq(
+      'and names the command that works',
+      errorOf(feedFind).message ?? null,
+      'ENOTSUP: find is not supported on hf://models/trending; use ls',
+    )
+    const feedCat = await call('hf_fs', ops(catOp('hf://models/trending')))
+    eq(
+      'cat on the feed says directory, where a namespace says file path',
+      errorOf(feedCat).message ?? null,
+      'EISDIR: hf://models/trending is a directory',
+    )
+    const feedSearch = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://models/trending', 'llama'] }),
+    )
+    check(
+      'search on the feed is refused the way it is on a repository',
+      String(errorOf(feedSearch).message ?? '').startsWith('EINVAL: search requires hf://models'),
+      String(errorOf(feedSearch).message ?? ''),
+    )
+    // A third segment is an ordinary repository again, owned by someone
+    // called `trending`: upstream resolves `hf://models/trending/foo` through
+    // the repository route, so the reservation is exactly two segments deep.
+    const deeper = await call('hf_fs', ops({ cmd: 'ls', args: ['hf://models/trending/foo'] }))
+    eq('and the reservation is two segments deep', errorOf(deeper).code ?? null, 'HF_FS_NOT_FOUND')
+
+    // The kind roots part company between the two listing commands, because
+    // upstream does: `ls hf://models` succeeds there with the feed as its one
+    // row, and `find hf://models` refuses outright.
+    const rootLs = await call('hf_fs', ops({ cmd: 'ls', args: ['hf://models'] }))
     check(
       'ls on a kind root says what is missing and what works',
-      String(errorOf(trending).message ?? '').includes('no trending feed behind hf://models'),
-      String(errorOf(trending).message ?? ''),
+      String(errorOf(rootLs).message ?? '').includes('no trending feed: hf://models'),
+      String(errorOf(rootLs).message ?? ''),
+    )
+    const rootFind = await call('hf_fs', ops({ cmd: 'find', args: ['hf://models'] }))
+    eq(
+      'and find on one is refused in upstream words',
+      errorOf(rootFind).message ?? null,
+      'Listing models requires an explicit owner. Use hf://models/<owner>.',
+    )
+
+    // `attach` says the same thing at every non-file URI, which is upstream's
+    // sentence and not the EINVAL this fake used to invent.
+    const attachNs = await call('hf_fs', ops({ cmd: 'attach', args: ['hf://models/integ'] }))
+    eq(
+      'attach on a namespace is NOT_A_FILE in upstream words',
+      errorOf(attachNs).message ?? null,
+      'attach requires a direct repository or bucket file URI.',
     )
 
     // ---- the shared attachment budget

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -195,6 +195,17 @@ async function mcpChecks(): Promise<void> {
       const rows = (structured.results ?? []) as Record<string, JsonValue>[]
       return ((rows[i] ?? {}).error ?? {}) as Record<string, JsonValue>
     }
+    const resultOf = (out: Record<string, JsonValue>, i = 0): Record<string, JsonValue> => {
+      const structured = (out.structuredContent ?? {}) as Record<string, JsonValue>
+      const rows = (structured.results ?? []) as Record<string, JsonValue>[]
+      return ((rows[i] ?? {}).result ?? {}) as Record<string, JsonValue>
+    }
+    const entriesOf = (out: Record<string, JsonValue>, i = 0): Record<string, JsonValue>[] =>
+      (resultOf(out, i).entries ?? []) as Record<string, JsonValue>[]
+    const textOf = (out: Record<string, JsonValue>): string =>
+      ((out.content ?? []) as Record<string, JsonValue>[])
+        .map((one) => String(one.text ?? ''))
+        .join('')
     const ops = (...list: Record<string, unknown>[]): Record<string, unknown> => ({
       operations: list,
     })
@@ -886,6 +897,190 @@ async function mcpChecks(): Promise<void> {
       'and stat finds a file past the first page',
       statLate.includes('- Type: `file`') && statLate.includes('- Exists: yes'),
       statLate.slice(0, 220),
+    )
+
+    // ---- the discovery scopes
+    //
+    // `hf://<kind>` and `hf://<kind>/<owner>` are URIs the captured grammar
+    // names and this fake used to refuse. The refusal was not theoretical: an
+    // agent opened a benchmark run with `ls hf://datasets/<owner> --limit 100`
+    // and `search hf://datasets "Annoy" --limit 50`, was refused both, and
+    // reported the repositories unavailable.
+    // Created the way `paged-model` above is: the owner comes from
+    // `organization`, and the bearer is the tenant rather than the namespace.
+    await fetch(`${mcp.rest.endpoint}/api/repos/create`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${DEFAULT_TENANT}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'discovery-dataset', type: 'dataset', organization: 'integ' }),
+    })
+
+    const owned = await call('hf_fs', ops({ cmd: 'ls', args: ['hf://models/integ'] }))
+    check(
+      'ls on a namespace lists repositories',
+      entriesOf(owned).length > 0 && entriesOf(owned).every((one) => one.type === 'repo'),
+      JSON.stringify(entriesOf(owned).slice(0, 2)),
+    )
+    check(
+      'and every row carries the repository own URI',
+      entriesOf(owned).every((one) => String(one.uri ?? '').startsWith('hf://models/integ/')),
+      JSON.stringify(entriesOf(owned).map((one) => String(one.uri ?? ''))),
+    )
+    const card = entriesOf(owned).find((one) => one.path === 'integ/card-model') ?? {}
+    // Every key below was captured from the live server rather than chosen:
+    // a model row carries `gated: false` where a Space carries no such key,
+    // and `updated_at` rather than `lastModified`.
+    eq('a row names its repo type', card.repo_type ?? null, 'model')
+    eq('and its visibility', card.private ?? null, false)
+    eq('and gating, present and false rather than absent', card.gated ?? null, false)
+    check('and a download count', typeof card.downloads === 'number', JSON.stringify(card))
+    check('and a modification time', typeof card.updated_at === 'string', JSON.stringify(card))
+    const ownedText = textOf(owned)
+    check(
+      'the table renders the details cell upstream way',
+      ownedText.includes(
+        '| repo | integ/card-model | hf://models/integ/card-model |  | repo=model',
+      ),
+      ownedText.slice(0, 400),
+    )
+
+    // A namespace that holds nothing is empty rather than missing: upstream
+    // answers an empty table for an owner it has never heard of, and calling
+    // that an error would tell an agent the URI was malformed.
+    const nobody = await call('hf_fs', ops({ cmd: 'ls', args: ['hf://models/nobody-xyz-42'] }))
+    eq('an owner with nothing lists nothing', entriesOf(nobody).length, 0)
+    check('and is not an error', !('isError' in nobody), JSON.stringify(nobody.isError ?? null))
+
+    const statNs = await call('hf_fs', ops({ cmd: 'stat', args: ['hf://models/integ'] }))
+    eq('stat on a namespace says namespace', resultOf(statNs).type ?? null, 'namespace')
+    eq('and names it', resultOf(statNs).namespace ?? null, 'integ')
+    check(
+      'and prints the namespace line after the path',
+      textOf(statNs).includes('- Path: ``\n- Namespace: `integ`'),
+      textOf(statNs),
+    )
+    // Not looked up, which is upstream's own behaviour: the server is
+    // describing the URI shape, not the Hub contents.
+    const statNobody = await call(
+      'hf_fs',
+      ops({ cmd: 'stat', args: ['hf://models/nobody-xyz-42'] }),
+    )
+    eq('an owner that holds nothing still exists', resultOf(statNobody).exists ?? null, true)
+    const statRoot = await call('hf_fs', ops({ cmd: 'stat', args: ['hf://models'] }))
+    eq('and a kind root is a dir', resultOf(statRoot).type ?? null, 'dir')
+
+    // ---- search
+    const hits = await call('hf_fs', ops({ cmd: 'search', args: ['hf://models', 'card-model'] }))
+    eq(
+      'search finds the model by name',
+      entriesOf(hits).map((one) => String(one.path ?? '')),
+      ['integ/card-model'],
+    )
+    eq('and answers under its own op', resultOf(hits).op ?? null, 'search')
+    const crossKind = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://datasets', 'card-model'] }),
+    )
+    eq('the kind in the URI scopes the search', entriesOf(crossKind).length, 0)
+    const inDatasets = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://datasets', 'discovery'] }),
+    )
+    eq(
+      'and the dataset is found under its own kind',
+      entriesOf(inDatasets).map((one) => String(one.path ?? '')),
+      ['integ/discovery-dataset'],
+    )
+    const owner = await call('hf_fs', ops({ cmd: 'search', args: ['hf://models/integ', 'card'] }))
+    check('search accepts an owner scope', entriesOf(owner).length > 0, '')
+    const elsewhere = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://models/nobody-xyz-42', 'card'] }),
+    )
+    eq('and the owner narrows it', entriesOf(elsewhere).length, 0)
+    const nothing = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://models', 'zzz-nothing'] }),
+    )
+    eq('a query that matches nothing is empty, not an error', entriesOf(nothing).length, 0)
+    check('and carries no error flag', !('isError' in nothing), '')
+
+    // Search has its OWN ceiling -- 1,000 where a listing is 10,000 -- and its
+    // own truncation notice, which carries no message beside it.
+    const searchLimit = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://models', 'card', '--limit', '1001'] }),
+    )
+    eq(
+      'search names its own ceiling',
+      errorOf(searchLimit).message ?? null,
+      'EINVAL: limit must be between 1 and 1000 for this command',
+    )
+    const cutSearch = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://models', '--limit', '1'] }),
+    )
+    eq('a cut search says so', resultOf(cutSearch).truncated ?? null, true)
+    eq('in search own vocabulary', resultOf(cutSearch).truncation_reason ?? null, 'limit')
+    check(
+      'and carries no message, where a listing does',
+      !('truncation_message' in resultOf(cutSearch)),
+      JSON.stringify(Object.keys(resultOf(cutSearch))),
+    )
+    check(
+      'and the prose notice is search own sentence',
+      textOf(cutSearch).trimEnd().endsWith('Result truncated: limit.'),
+      textOf(cutSearch).slice(-120),
+    )
+
+    // A repository is the one URI search refuses, and upstream refuses it by
+    // naming every scope that would have worked.
+    const atRepoSearch = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://models/integ/card-model', 'anything'] }),
+    )
+    eq(
+      'search refuses a repository in upstream words',
+      errorOf(atRepoSearch).message ?? null,
+      'EINVAL: search requires hf://models|datasets|spaces[/OWNER], hf://collections[/OWNER], ' +
+        'any hf://docs scope, or exactly hf://papers',
+    )
+
+    // `--sort` is accepted where the fake can order by it and refused by name
+    // where it cannot, rather than accepted and ignored.
+    const sorted = await call(
+      'hf_fs',
+      ops({ cmd: 'ls', args: ['hf://models/integ', '--sort', 'likes'] }),
+    )
+    check(
+      'a namespace listing sorts',
+      entriesOf(sorted).length > 0,
+      JSON.stringify(errorOf(sorted)),
+    )
+    const unsortable = await call(
+      'hf_fs',
+      ops({ cmd: 'ls', args: ['hf://models/integ', '--sort', 'mainSize'] }),
+    )
+    eq(
+      'and a sort key with nothing behind it is an honest EINVAL',
+      errorOf(unsortable).message ?? null,
+      'EINVAL: the mirage hf_hub fake sorts by createdAt, downloads, likes, ' +
+        'lastModified, trendingScore: mainSize',
+    )
+    // Captured: a discovery scope holds no files, so `--type file` answers an
+    // empty table rather than an error.
+    const typed = await call(
+      'hf_fs',
+      ops({ cmd: 'ls', args: ['hf://models/integ', '--type', 'file'] }),
+    )
+    eq('a discovery scope holds no files', entriesOf(typed).length, 0)
+
+    // The one discovery URI this fake still refuses, and it refuses it for
+    // what it does not hold rather than by calling the URI wrong.
+    const trending = await call('hf_fs', ops({ cmd: 'ls', args: ['hf://models'] }))
+    check(
+      'ls on a kind root says what is missing and what works',
+      String(errorOf(trending).message ?? '').includes('no trending feed behind hf://models'),
+      String(errorOf(trending).message ?? ''),
     )
 
     // ---- the shared attachment budget

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -1073,6 +1073,36 @@ async function mcpChecks(): Promise<void> {
       ops({ cmd: 'ls', args: ['hf://models/integ', '--type', 'file'] }),
     )
     eq('a discovery scope holds no files', entriesOf(typed).length, 0)
+    // ...but only for a type that EXISTS. The grammar's TYPE is a closed set
+    // of seven, and four of them name entry kinds this fake holds nothing of;
+    // those still answer empty, because the value is valid and matches
+    // nothing. A value off the list is a typo, and answering it empty would
+    // make `--type repos` indistinguishable from an owner with no
+    // repositories.
+    const validButAbsent = await call(
+      'hf_fs',
+      ops({ cmd: 'ls', args: ['hf://models/integ', '--type', 'bucket'] }),
+    )
+    eq('a valid type this fake has none of is empty', entriesOf(validButAbsent).length, 0)
+    check('and not an error', !('isError' in validButAbsent), '')
+    const mistyped = await call(
+      'hf_fs',
+      ops({ cmd: 'ls', args: ['hf://models/integ', '--type', 'repos'] }),
+    )
+    eq(
+      'while a type off the list is refused in upstream words',
+      errorOf(mistyped).message ?? null,
+      'EINVAL: invalid entry type: repos. Use --type file for files.',
+    )
+    const mistypedSearch = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://models', 'card', '--type', 'nonsense'] }),
+    )
+    eq(
+      'and search says the same thing',
+      errorOf(mistypedSearch).message ?? null,
+      'EINVAL: invalid entry type: nonsense. Use --type file for files.',
+    )
 
     // ---- `trending` is RESERVED, not an owner
     //

--- a/integ/server/hf_hub/selftest.ts
+++ b/integ/server/hf_hub/selftest.ts
@@ -1152,6 +1152,121 @@ async function mcpChecks(): Promise<void> {
       'Listing models requires an explicit owner. Use hf://models/<owner>.',
     )
 
+    // ---- `find` at a namespace filters, rather than ignoring its own flags
+    //
+    // `find hf://<kind>/<owner> --name GLOB` is the row the captured
+    // README gives find: "Recursive name/path matching inside an owner
+    // namespace". What it matches is the repository's LEAF name -- probed,
+    // `--name "deepseek-ai/*"` finds nothing on the live server where
+    // `--name "DeepSeek-V4*"` finds every V4 model.
+    const byName = await call(
+      'hf_fs',
+      ops({ cmd: 'find', args: ['hf://models/integ', '--name', 'card-*'] }),
+    )
+    eq(
+      'find globs the repository name',
+      entriesOf(byName).map((one) => String(one.path ?? '')),
+      ['integ/card-model'],
+    )
+    const byId = await call(
+      'hf_fs',
+      ops({ cmd: 'find', args: ['hf://models/integ', '--name', 'integ/*'] }),
+    )
+    eq('and the owner is not part of what it matches', entriesOf(byId).length, 0)
+    const byCase = await call(
+      'hf_fs',
+      ops({ cmd: 'find', args: ['hf://models/integ', '--name', 'CARD-*'] }),
+    )
+    eq('and the match is case-sensitive', entriesOf(byCase).length, 0)
+    const byPath = await call(
+      'hf_fs',
+      ops({ cmd: 'find', args: ['hf://models/integ', '--path', '*-model'] }),
+    )
+    check('--path globs the same string', entriesOf(byPath).length > 0, '')
+    const bothGlobs = await call(
+      'hf_fs',
+      ops({ cmd: 'find', args: ['hf://models/integ', '--name', 'card-*', '--path', 'paged-*'] }),
+    )
+    eq('and two globs must both hold', entriesOf(bothGlobs).length, 0)
+    // `--sort` rides `ls` and `search` in the captured grammar and is absent
+    // from `find`'s line, so `find` refuses it.
+    const findSort = await call(
+      'hf_fs',
+      ops({ cmd: 'find', args: ['hf://models/integ', '--sort', 'likes'] }),
+    )
+    eq(
+      'find takes no --sort, which is its own grammar',
+      errorOf(findSort).message ?? null,
+      'EINVAL: unexpected argument for find: --sort',
+    )
+
+    // ---- `--tag` and `--kind` belong to exactly one URI
+    const taggedElsewhere = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://datasets', 'discovery', '--tag', 'gradio'] }),
+    )
+    eq(
+      'the tag flags name where they apply, in upstream words',
+      errorOf(taggedElsewhere).message ?? null,
+      'EINVAL: --tag and --kind are supported only with search hf://spaces',
+    )
+    const mcpKind = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://models', 'card', '--kind', 'mcp'] }),
+    )
+    eq(
+      'and --kind mcp gets the same sentence off spaces',
+      errorOf(mcpKind).message ?? null,
+      'EINVAL: --tag and --kind are supported only with search hf://spaces',
+    )
+
+    // ---- the one search this fake will not fake
+    //
+    // `search hf://spaces` is semantically ranked upstream: every row carries
+    // `semantic relevance=93.8%`, a classifier `category` and a `title`, and
+    // the percentage moves between calls for the same repository. The plain
+    // shape would be a row no live server produces.
+    await fetch(`${mcp.rest.endpoint}/api/repos/create`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${DEFAULT_TENANT}`, 'Content-Type': 'application/json' },
+      // The fake refuses a Space without one, the way the Hub does.
+      body: JSON.stringify({
+        name: 'discovery-space',
+        type: 'space',
+        organization: 'integ',
+        sdk: 'gradio',
+      }),
+    })
+    const spacesRoot = await call('hf_fs', ops({ cmd: 'search', args: ['hf://spaces', 'disc'] }))
+    check(
+      'search on the spaces root is refused, with the reason',
+      String(errorOf(spacesRoot).message ?? '').includes('cannot rank hf://spaces'),
+      String(errorOf(spacesRoot).message ?? ''),
+    )
+    // Narrow on purpose: the owner-scoped form IS the plain shape upstream,
+    // so it is answered rather than swept into the same refusal.
+    const spacesOwner = await call(
+      'hf_fs',
+      ops({ cmd: 'search', args: ['hf://spaces/integ', 'discovery'] }),
+    )
+    eq(
+      'while the owner-scoped form still answers',
+      entriesOf(spacesOwner).map((one) => String(one.path ?? '')),
+      ['integ/discovery-space'],
+    )
+    eq('and a space row names its kind', entriesOf(spacesOwner)[0]?.repo_type ?? null, 'space')
+    check(
+      'and carries no downloads, the way upstream spaces do not',
+      !('downloads' in (entriesOf(spacesOwner)[0] ?? {})),
+      JSON.stringify(entriesOf(spacesOwner)[0] ?? {}),
+    )
+    check(
+      'nor a gated key, which only a model or dataset row has',
+      !('gated' in (entriesOf(spacesOwner)[0] ?? {})),
+      JSON.stringify(entriesOf(spacesOwner)[0] ?? {}),
+    )
+    eq('but does carry its sdk', entriesOf(spacesOwner)[0]?.sdk ?? null, 'gradio')
+
     // `attach` says the same thing at every non-file URI, which is upstream's
     // sentence and not the EINVAL this fake used to invent.
     const attachNs = await call('hf_fs', ops({ cmd: 'attach', args: ['hf://models/integ'] }))


### PR DESCRIPTION
## The failure this fixes

A benchmark run's MCP arm opened with exactly this, as its first tool call:

```json
{"operations":[{"cmd":"ls","args":["hf://datasets/integ-org","--limit","100"]},
               {"cmd":"search","args":["hf://datasets","Annoy","--limit","50"]}]}
```

Both operations were refused. It retried the listing twice, then answered *"the GitHub issue and Hugging Face dataset repositories were unavailable through the connected services"* and stopped. The draw was discarded, and until now the cause was unexplained.

Every URI it sent is in the grammar the server itself handed it. The captured tool document names `hf://models|datasets|spaces[/OWNER]` as search scopes and prints `ls hf://models/openai --sort downloads --limit 20` as an example — while the fake refused every URI shorter than three segments, in a sentence telling the caller it had mistyped (`EINVAL: expected hf://datasets/<namespace>/<name>`), and refused `search` outright.

## What changed

`locate` returns the *scope* (`kind` / `namespace` / `repo`) instead of an error, and a new `discoverOne` answers the two new scopes off the same listing route the REST arm serves — one world, one implementation, which is the point of the arm.

| scope | `ls` / `find` | `stat` | `search` |
|---|---|---|---|
| `hf://<kind>` | refused (no trending feed) | `type: dir` | repositories of that kind |
| `hf://<kind>/<owner>` | that owner's repositories | `type: namespace` | that owner's repositories |
| `hf://<kind>/<ns>/<name>` | unchanged | unchanged | refused, upstream's words |

Flags: `--limit`, `--sort`, `--type` on discovery listings; `--tag` and `--query` on `search`.

## Captured, not reasoned about

All from `https://huggingface.co/mcp`, anonymously, on 2026-09-01:

- a repository row's Details cell and its structured twin — `updated_at` rather than `lastModified`; `gated: false` **present** on a model that is not gated; `gated=manual` sitting **beside** `public` rather than replacing it; a Space carrying neither `downloads` nor `gated` but carrying `sdk` where a model carries `task`;
- two different truncation notices — `ls` says `entry_limit` with a sentence naming the 10,000 ceiling, `search` says `limit` with **no message at all** and a ceiling of 1,000;
- `stat hf://models/<owner>` reporting `exists: yes, type: namespace` for an owner that does not exist, because the server describes the URI's *shape*, not the Hub's contents;
- `search` on a repository URI, refused by naming every scope that would have worked;
- `ls --type file` on a namespace answering an empty table rather than an error.

The one word with no capture behind it is `private`: nothing private or gated is visible anonymously, so `public` is observed and `private` is its complement.

## Still refused, deliberately

Both for what the fake does not hold, rather than by calling the URI wrong:

- `ls hf://<kind>` — upstream's only entry there is a virtual `trending` directory, and there is no feed behind it. Answering with an entry whose own listing then fails would be worse than saying so, so the refusal names `search hf://<kind>` and `ls hf://<kind>/<namespace>` instead.
- the five `--sort` keys the listing route has no column for (`likes30d`, `mainSize`, `id`, `trending`, `upvotes`).

Repository-scope flags (`--recursive`, `--glob`, `--name`, `--path`) are untouched and still refused by name — a separate gap, and a separate change.

## Also

The structured listing result now puts `entries` before the truncation keys, which is the order the live result serializes in and therefore the order the model reads.

## Tests

`hf_hub selftest: 304 checks passed`, up from 271. `typecheck`, `lint` and `prettier --check` are clean; the kit selftest's 105 checks still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)