### PR TITLE
integ: hold kit fake keep-alive sockets past aiohttp's reuse window

### DIFF
--- a/integ/server/kit/selftest/run.ts
+++ b/integ/server/kit/selftest/run.ts
@@ -15,11 +15,13 @@
 import { spawn } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
+import { createConnection } from 'node:net'
 import type { ChildProcessByStdio } from 'node:child_process'
 import type { Readable } from 'node:stream'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { ANNOUNCE_RE } from '../typescript/announce.ts'
+import { HEALTH_PATH, KEEP_ALIVE_TIMEOUT_MS } from '../typescript/http.ts'
 import { Prisma } from '../../../generated/selftest/index.js'
 import { clearTenants, deleteOrder, untenanted } from '../typescript/clear.ts'
 import type { Dmmf } from '../typescript/seed.ts'
@@ -75,6 +77,34 @@ async function launch(env: Record<string, string> = {}, argv: string[] = []): Pr
   })
   check('announce line matches ANNOUNCE_RE', ANNOUNCE_RE.test(first), first)
   return { child, endpoint: first.split('=').slice(1).join('='), stderr: () => err }
+}
+
+// The Keep-Alive header, read off the wire. It is hop-by-hop, so whether a
+// fetch surfaces it is the client's business; what the server SENDS is the
+// fact under test.
+function keepAliveHeader(endpoint: string): Promise<string> {
+  const { hostname, port } = new URL(endpoint)
+  return new Promise((resolve, reject) => {
+    let raw = ''
+    const sock = createConnection({ host: hostname, port: Number(port) }, () => {
+      sock.write(
+        `GET ${HEALTH_PATH} HTTP/1.1\r\nHost: ${hostname}\r\nConnection: keep-alive\r\n\r\n`,
+      )
+    })
+    sock.setEncoding('utf8')
+    sock.on('error', reject)
+    sock.on('data', (chunk: string) => {
+      raw += chunk
+      const end = raw.indexOf('\r\n\r\n')
+      if (end === -1) return
+      sock.destroy()
+      const line = raw
+        .slice(0, end)
+        .split('\r\n')
+        .find((l) => l.toLowerCase().startsWith('keep-alive:'))
+      resolve(line === undefined ? '' : line.slice('keep-alive:'.length).trim())
+    })
+  })
 }
 
 interface CallOpts {
@@ -924,6 +954,29 @@ async function main(): Promise<void> {
       rooted.child.kill('SIGTERM')
       rmSync(rootDir, { recursive: true, force: true })
     }
+
+    // The python host rides every backend on one aiohttp pool, which reuses a
+    // socket idle for up to 15s and never reads the timeout a server
+    // advertises. Node closes an idle keep-alive socket one second after its
+    // keepAliveTimeout, 5s by default, so a request written at that instant is
+    // answered with a disconnect, and aiohttp re-sends only an idempotent
+    // method: dropbox posts every read, and its grep died in CI with
+    // `Server disconnected` after a run of shell-only cases left the pool
+    // idle. The fake has to hold the socket past the pool's reuse window, and
+    // the header is where that promise is visible.
+    process.stdout.write('\n21. an idle keep-alive socket outlives the python pool reuse window\n')
+    const advertised = await keepAliveHeader(fake.endpoint)
+    eq(
+      'the server advertises the kit keep-alive timeout',
+      advertised,
+      `timeout=${String(KEEP_ALIVE_TIMEOUT_MS / 1000)}`,
+    )
+    const AIOHTTP_KEEPALIVE_S = 15
+    check(
+      'and it is longer than aiohttp will reuse an idle socket',
+      Number(advertised.replace('timeout=', '')) > AIOHTTP_KEEPALIVE_S,
+      advertised,
+    )
 
     process.stdout.write(`\nselftest: ${String(checks)} checks passed\n`)
   } finally {

--- a/integ/server/kit/typescript/http.ts
+++ b/integ/server/kit/typescript/http.ts
@@ -30,6 +30,20 @@ import type { JsonValue, Reply } from './types.ts'
 export const HEALTH_PATH = '/_kit/health'
 export const RESET_PATH = '/reset'
 
+// How long an idle keep-alive socket stays open, and the one number in this
+// file that is about the CLIENTS rather than the vendor being imitated. Node's
+// default is 5s (the socket actually closes a second after that). The python
+// host rides every backend on one aiohttp pool, which reuses a socket idle for
+// up to 15s and never reads the timeout a server advertises, so a run of
+// shell-only cases left the dropbox pool idle and the next request was written
+// onto a socket node was closing at that very instant. aiohttp re-sends such a
+// request only when the method is idempotent, and dropbox posts every read, so
+// `grep -rl` died in CI with `Server disconnected`. Holding the socket well past
+// the pool's reuse window is what a vendor's edge does too; undici, the
+// TypeScript host's client, reads the advertised value and stays under it
+// either way. Pinned by the kit selftest.
+export const KEEP_ALIVE_TIMEOUT_MS = 60_000
+
 export function makeRuntime<C extends MinimalClient>(
   fake: Fake<C>,
   fixtureRoot: string = DEFAULT_FIXTURE_ROOT,
@@ -276,7 +290,7 @@ async function answer<C extends MinimalClient>(
 export function createKitServer<C extends MinimalClient>(rt: Runtime<C>): Server {
   const { service, maxBodyBytes } = rt.fake.config
   const router = new Router<C>(rt.fake.routes())
-  return createServer((req: IncomingMessage, res: ServerResponse) => {
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     const host = req.headers.host ?? '127.0.0.1'
     const url = new URL(req.url ?? '/', `http://${host}`)
     const method = (req.method ?? 'GET').toUpperCase()
@@ -310,4 +324,6 @@ export function createKitServer<C extends MinimalClient>(rt: Runtime<C>): Server
         })
     })
   })
+  server.keepAliveTimeout = KEEP_ALIVE_TIMEOUT_MS
+  return server
 }

--- a/integ/server/kit/typescript/index.ts
+++ b/integ/server/kit/typescript/index.ts
@@ -45,7 +45,14 @@ export {
   loadFixture,
   schemaFor,
 } from './fixture.ts'
-export { HEALTH_PATH, RESET_PATH, createKitServer, makeRuntime, parseBody } from './http.ts'
+export {
+  HEALTH_PATH,
+  KEEP_ALIVE_TIMEOUT_MS,
+  RESET_PATH,
+  createKitServer,
+  makeRuntime,
+  parseBody,
+} from './http.ts'
 export { Minter } from './mint.ts'
 export { checkArgv, parseFixture, parseFixtureRoot, parseFlagPort, parsePort } from './port.ts'
 export { parseRange, rangeHeaderOf, rangeReply } from './range.ts'


### PR DESCRIPTION
Fixes the `integ-shared-py` failure on main (run 33578081543): `FAIL [dropbox] search_substring_scans_all ... grep: Server disconnected`, one case out of 50302.

## Root cause

- Every kit fake is a bare node `http.Server` with the default 5s `keepAliveTimeout`; the idle socket actually closes about 6s after the last response.
- The python host rides every backend on one aiohttp pool, which reuses a socket idle for up to 15s and never reads the `Keep-Alive: timeout` a server advertises. A close that lands while the client is doing synchronous work is only seen after the request is on the wire.
- aiohttp re-sends such a request once, but only for idempotent methods. Dropbox's API is POST-only, so its reads get no second try. box/gdrive/onedrive read with GET, which is why only dropbox tripped.

The failing grep followed a long run of shell-only cases, exactly the idle gap that lands a request on that boundary. Reproduced locally with a POST straddling the close instant; GET under the same timing reconnects silently, and a server with a long keep-alive stays on one connection.

## Fix

`createKitServer` sets `keepAliveTimeout` to 60s, well past the pool's reuse window. Kit selftest section 21 reads the `Keep-Alive` header off a raw socket and asserts it advertises the constant and exceeds 15s; it failed with `got timeout=5` before the change.

Left alone on purpose: the python dropbox retry policy (a transport retry would change production behaviour and cover one backend), and the notion/hf_hub MCP servers (only undici reaches them, and undici honours the advertised timeout).

## Verification

- kit selftest 107/107, launcher selftest 26/26
- integ typecheck, eslint, prettier clean
- python battery `--target dropbox --target dropbox-root --strict`: 5060 passed, 0 failed, including `search_substring_scans_all`