### PR TITLE
integ: announce each kit fake as it starts and time-box the schema push

### DIFF
--- a/integ/server/kit/typescript/db.ts
+++ b/integ/server/kit/typescript/db.ts
@@ -43,14 +43,27 @@ function prismaBin(): string {
 // work, and a file copy is ~1ms. So the schema is pushed ONCE into a template
 // file per pool and every run file is a copy of it. A per-run push
 // would put a third of a second on the clock for each /reset.
+//
+// This is the ONE synchronous spawn on a fake's startup path, and a spawn that
+// blocks the event loop is a spawn no timer can interrupt: a CLI that stalls
+// (its own update check, an engine fetch, a wedged schema engine) hangs the
+// whole launcher with nothing written anywhere. CI saw exactly that, sixty
+// seconds of silence and then "only 0 of 14 endpoints came up". The timeout is
+// thirty times the measured cost, and the CLI's stderr is appended explicitly:
+// node folds it into the message of a failed command but not of a killed one,
+// which says only ETIMEDOUT, so the first line is kept and stderr added once.
 function pushTemplate(schema: string, target: string): void {
   try {
     execFileSync('node', [prismaBin(), 'db', 'push', '--schema', schema, '--skip-generate'], {
       env: { ...process.env, [SCHEMA_ENV]: `file:${target}` },
       stdio: 'pipe',
+      timeout: 30_000,
     })
   } catch (err: unknown) {
-    throw new KitError(`db push failed for ${schema}: ${String(err)}`)
+    const stderr =
+      err instanceof Error && 'stderr' in err ? String(err.stderr as Buffer | string).trim() : ''
+    const head = String(err).split('\n')[0] ?? String(err)
+    throw new KitError(`db push failed for ${schema}: ${head}${stderr === '' ? '' : `\n${stderr}`}`)
   }
 }
 

--- a/integ/server/launcher/main.ts
+++ b/integ/server/launcher/main.ts
@@ -204,17 +204,29 @@ export function knownFakes(): string[] {
   return Object.keys(REGISTRY).sort()
 }
 
-export async function launch(config: Record<string, JsonValue>): Promise<Instance[]> {
+// `announce` is called for each fake THE MOMENT it is up, not once the whole
+// fleet is. The fakes start one at a time, so a startup that stalls on the
+// seventh has six announce lines in the log and the config order names the
+// seventh; announcing at the end left CI with sixty seconds of empty log and
+// nothing to say which fake it was waiting on.
+export async function launch(
+  config: Record<string, JsonValue>,
+  announce: (a: Announce) => void = () => {},
+): Promise<Instance[]> {
   const out: Instance[] = []
   try {
-    return await launchAll(config, out)
+    return await launchAll(config, out, announce)
   } catch (e) {
     for (const inst of out) await inst.close()
     throw e
   }
 }
 
-async function launchAll(config: Record<string, JsonValue>, out: Instance[]): Promise<Instance[]> {
+async function launchAll(
+  config: Record<string, JsonValue>,
+  out: Instance[],
+  announce: (a: Announce) => void,
+): Promise<Instance[]> {
   for (const [name, raw] of Object.entries(config)) {
     // JSON has no comments and this config has three pinned ports that need a
     // stated reason, so a leading underscore marks a key that is prose. It is
@@ -233,15 +245,15 @@ async function launchAll(config: Record<string, JsonValue>, out: Instance[]): Pr
     // Started one at a time rather than in parallel. Seeding writes SQLite, and
     // a failure has to name the fake that caused it: Promise.all would report
     // the first rejection with nine other startups still in flight.
-    out.push(
-      await entry({
-        port: portOf(spec as Record<string, JsonValue>, 'port'),
-        fixture: str(spec, 'fixture'),
-        fixtureRoot: str(spec, 'fixtureRoot'),
-        token: str(spec, 'token'),
-        extras: spec as Record<string, JsonValue>,
-      }),
-    )
+    const inst = await entry({
+      port: portOf(spec as Record<string, JsonValue>, 'port'),
+      fixture: str(spec, 'fixture'),
+      fixtureRoot: str(spec, 'fixtureRoot'),
+      token: str(spec, 'token'),
+      extras: spec as Record<string, JsonValue>,
+    })
+    out.push(inst)
+    for (const a of inst.announces) announce(a)
   }
   // A config naming nothing is a broken config, not a healthy empty fleet:
   // returning [] would announce no URL lines and wait for a signal, turning
@@ -267,8 +279,7 @@ if (import.meta.url === `file://${process.argv[1] ?? ''}`) {
   if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
     throw new KitError('config must be a JSON object mapping instance names to specs')
   }
-  const started = await launch(raw)
-  for (const inst of started) for (const a of inst.announces) emit(a)
+  const started = await launch(raw, emit)
   const bye = (): void => {
     void Promise.all(started.map((i) => i.close())).then(() => {
       process.exit(0)

--- a/integ/server/launcher/selftest.ts
+++ b/integ/server/launcher/selftest.ts
@@ -81,15 +81,26 @@ async function inProcess(): Promise<void> {
   // The same fake twice, which is the reason the config is a map and not a
   // list: CI serves github seeded `cli` for the gh battery and github seeded
   // `empty` for the watch battery, and the two run at once.
-  const started = await launch({
-    github: { fixture: 'cli' },
-    'github-empty': { fake: 'github', fixture: 'empty', token: 'GITHUB_EMPTY_URL' },
-    mail: { imapPort: 0, smtpPort: 0 },
-  })
+  const live: string[] = []
+  const started = await launch(
+    {
+      github: { fixture: 'cli' },
+      'github-empty': { fake: 'github', fixture: 'empty', token: 'GITHUB_EMPTY_URL' },
+      mail: { imapPort: 0, smtpPort: 0 },
+    },
+    (a) => live.push(a.token),
+  )
   const lines = new Map<string, string>()
   for (const inst of started) for (const a of inst.announces) lines.set(a.token, a.url)
   try {
     check('one call started three instances', started.length === 3, String(started.length))
+    // Announced as each came up, in config order, so a stalled startup's log
+    // names the fake it is waiting on rather than sitting empty.
+    eq(
+      'every announce was delivered as its fake started',
+      live,
+      started.flatMap((i) => i.announces.map((a) => a.token)),
+    )
     check(
       'every announce line is well formed',
       [...lines].every(


### PR DESCRIPTION
## Problem

The Integ workflow on main `08c5978a0` failed in `integ-shared-ts` before any battery ran: the kit-fake launcher printed nothing for 60 seconds, then `only 0 of 14 endpoints came up`. The launcher process was still alive at job end, so this was a hang, not a crash. The same signature hit a PR job on Sept 1. Roughly 1.6% of launcher starts since it landed on Aug 30.

Ruled out with evidence: a port collision (crashes loudly with EADDRINUSE), a lazy Prisma engine download (the earlier `prisma generate` already fetches both engines), and the Prisma update check blocking the spawn (its child is detached with stdio ignored). 15 of 15 local starts came up in about 5 seconds. Two silent logs cannot separate the remaining candidates, so this PR makes the next occurrence self-diagnosing.

## Change

- `launch` takes an announce callback and calls it as each fake comes up, so the CI log shows which fake the launcher stalled on instead of staying empty.
- The per-fake `prisma db push`, the one synchronous spawn on the startup path, gets a 30 second timeout and appends the CLI's stderr once.
- Launcher selftest pins the per-fake delivery.

## Verification

- integ typecheck clean
- launcher selftest 27 checks, kit selftest 107 checks
- pre-commit hooks on the changed files pass
- the failure path prints the Prisma error exactly once for both a failed and a killed spawn