### PR TITLE
Owner column is the workspace user, group is the session profile

### DIFF
--- a/integ/parity.sh
+++ b/integ/parity.sh
@@ -315,7 +315,7 @@ expect "sym.cat_follow" "sym1"
 expect "sym.write_through" "via"
 # A link row is a real GNU row now: lrwxrwxrwx (a link carries no
 # permission bits of its own) and the size is the target's length.
-expect "sym.ls_arrow" "lrwxrwxrwx 1 user user 11 link.txt -> /data/s.txt"
+expect "sym.ls_arrow" "lrwxrwxrwx 1 - - 11 link.txt -> /data/s.txt"
 expect "sym.mv_entry" "/data/s.txt"
 expect "sym.rm_entry" "1"
 expect "sym.dangle" "1"

--- a/integ/resources/email/basic.json
+++ b/integ/resources/email/basic.json
@@ -535,7 +535,7 @@
       "command": "ls -l /mail/INBOX/2026-01-05/Q2_Budget_Review__1",
       "expect": {
         "exit": 0,
-        "stdout": "-rw-r--r-- 1 user user 36 Jan  1 00:00 budget.csv\n-rw-r--r-- 1 user user 37 Jan  1 00:00 notes.txt\n",
+        "stdout": "-rw-r--r-- 1 - - 36 Jan  1 00:00 budget.csv\n-rw-r--r-- 1 - - 37 Jan  1 00:00 notes.txt\n",
         "stderr": ""
       }
     },

--- a/integ/resources/gmail/basic.json
+++ b/integ/resources/gmail/basic.json
@@ -523,7 +523,7 @@
       "command": "ls -l /mail/INBOX/2026-01-05/Q2_Budget_Review__msg0001",
       "expect": {
         "exit": 0,
-        "stdout": "-rw-r--r-- 1 user user 36 Jan  1 00:00 budget.csv\n-rw-r--r-- 1 user user 37 Jan  1 00:00 notes.txt\n",
+        "stdout": "-rw-r--r-- 1 - - 36 Jan  1 00:00 budget.csv\n-rw-r--r-- 1 - - 37 Jan  1 00:00 notes.txt\n",
         "stderr": ""
       }
     },

--- a/integ/resources/notion/ops.json
+++ b/integ/resources/notion/ops.json
@@ -35,7 +35,7 @@
       "command": "ls -l /notion/pages/",
       "expect": {
         "exit": 0,
-        "stdout": "drwxr-xr-x 1 user user 0 Jan  2 00:00 Notes__bbbb2222-3333-4444-5555-666677778888\ndrwxr-xr-x 1 user user 0 Jan  2 00:00 Project_Roadmap__aaaa1111-2222-3333-4444-555566667777\n",
+        "stdout": "drwxr-xr-x 1 - - 0 Jan  2 00:00 Notes__bbbb2222-3333-4444-5555-666677778888\ndrwxr-xr-x 1 - - 0 Jan  2 00:00 Project_Roadmap__aaaa1111-2222-3333-4444-555566667777\n",
         "stderr": ""
       }
     },

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -2141,7 +2141,15 @@
           "backend": "memory",
           "fixture": "statvfs/v1"
         }
-      ]
+      ],
+      "profile": "ops",
+      "profiles": {
+        "ops": {},
+        "auditor": {}
+      },
+      "sessions": {
+        "auditor": "auditor"
+      }
     },
     {
       "id": "argerr-databricks",

--- a/integ/unix/chgrp/basic.json
+++ b/integ/unix/chgrp/basic.json
@@ -30,7 +30,7 @@
       "command": "mkdir -p /data/cg && echo alpha > /data/cg/f.txt && chmod 644 /data/cg/f.txt && touch -t 202601021530 /data/cg/f.txt && chgrp staff /data/cg/f.txt && ls -l /data/cg",
       "expect": {
         "exit": 0,
-        "stdout": "-rw-r--r-- 1 user staff 6 Jan  2 15:30 f.txt\n",
+        "stdout": "-rw-r--r-- 1 - staff 6 Jan  2 15:30 f.txt\n",
         "stderr": ""
       }
     },
@@ -64,7 +64,7 @@
       "command": "chgrp 20 /data/cg/f.txt && ls -l /data/cg",
       "expect": {
         "exit": 0,
-        "stdout": "-rw-r--r-- 1 user 20 6 Jan  2 15:30 f.txt\n",
+        "stdout": "-rw-r--r-- 1 - 20 6 Jan  2 15:30 f.txt\n",
         "stderr": ""
       }
     },

--- a/integ/unix/chgrp/relative.json
+++ b/integ/unix/chgrp/relative.json
@@ -30,7 +30,7 @@
       "command": "mkdir -p /data/relc/sub && echo x > /data/relc/sub/f.txt && chmod 644 /data/relc/sub/f.txt && touch -t 202601021530 /data/relc/sub/f.txt && cd /data/relc/sub && chgrp staff f.txt && cd / && ls -l /data/relc/sub",
       "expect": {
         "exit": 0,
-        "stdout": "-rw-r--r-- 1 user staff 2 Jan  2 15:30 f.txt\n",
+        "stdout": "-rw-r--r-- 1 - staff 2 Jan  2 15:30 f.txt\n",
         "stderr": ""
       }
     }

--- a/integ/unix/meta/chmod.json
+++ b/integ/unix/meta/chmod.json
@@ -30,7 +30,7 @@
       "command": "chmod 601 /data/metad/f.txt && ls -l /data/metad",
       "expect": {
         "exit": 0,
-        "stdout": "-rw------x 1 user user 6 Jan  2 15:30 f.txt\n",
+        "stdout": "-rw------x 1 - - 6 Jan  2 15:30 f.txt\n",
         "stderr": ""
       }
     },
@@ -64,7 +64,7 @@
       "command": "chmod u+x,go-r /data/metad/f.txt && ls -l /data/metad",
       "expect": {
         "exit": 0,
-        "stdout": "-rwx-----x 1 user user 6 Jan  2 15:30 f.txt\n",
+        "stdout": "-rwx-----x 1 - - 6 Jan  2 15:30 f.txt\n",
         "stderr": ""
       }
     },

--- a/integ/unix/meta/link.json
+++ b/integ/unix/meta/link.json
@@ -28,7 +28,7 @@
       "command": "ln -s /data/metad/g.txt /data/metad/ln.txt && chmod 604 /data/metad/ln.txt && ls -l /data/metad | sed -E 's/ [A-Z][a-z]{2} +[0-9]+ [0-9]{2}:[0-9]{2} / /'",
       "expect": {
         "exit": 0,
-        "stdout": "-rw----r-- 1 user user  6 g.txt\nlrwxrwxrwx 1 user user 17 ln.txt -> /data/metad/g.txt\n-rw-r--r-- 1 user user  0 new.txt\n",
+        "stdout": "-rw----r-- 1 - -  6 g.txt\nlrwxrwxrwx 1 - - 17 ln.txt -> /data/metad/g.txt\n-rw-r--r-- 1 - -  0 new.txt\n",
         "stderr": ""
       }
     }

--- a/integ/unix/meta/ls.json
+++ b/integ/unix/meta/ls.json
@@ -30,7 +30,7 @@
       "command": "ls -l /data/metad",
       "expect": {
         "exit": 0,
-        "stdout": "-rw-r--r-- 1 user user 6 Jan  2 15:30 f.txt\n",
+        "stdout": "-rw-r--r-- 1 - - 6 Jan  2 15:30 f.txt\n",
         "stderr": ""
       }
     }

--- a/integ/unix/meta/mv.json
+++ b/integ/unix/meta/mv.json
@@ -28,7 +28,7 @@
       "command": "mv /data/metad/f.txt /data/metad/g.txt && ls -l /data/metad",
       "expect": {
         "exit": 0,
-        "stdout": "-rwx-----x 1 alice dev 6 Mar  4 12:00 g.txt\n-rw-r--r-- 1 user user 0 Jan  2 15:30 new.txt\n",
+        "stdout": "-rwx-----x 1 alice dev 6 Mar  4 12:00 g.txt\n-rw-r--r-- 1 - - 0 Jan  2 15:30 new.txt\n",
         "stderr": ""
       }
     }

--- a/integ/unix/meta/rm.json
+++ b/integ/unix/meta/rm.json
@@ -28,7 +28,7 @@
       "command": "rm /data/metad/g.txt && echo fresh > /data/metad/g.txt && touch -t 202601021530 /data/metad/g.txt && ls -l /data/metad",
       "expect": {
         "exit": 0,
-        "stdout": "-rw-r--r-- 1 user user 6 Jan  2 15:30 g.txt\n-rw-r--r-- 1 user user 0 Jan  2 15:30 new.txt\n",
+        "stdout": "-rw-r--r-- 1 - - 6 Jan  2 15:30 g.txt\n-rw-r--r-- 1 - - 0 Jan  2 15:30 new.txt\n",
         "stderr": ""
       }
     }

--- a/integ/unix/meta/touch.json
+++ b/integ/unix/meta/touch.json
@@ -30,7 +30,7 @@
       "command": "touch -t 202601021530 /data/metad/new.txt && ls -l /data/metad",
       "expect": {
         "exit": 0,
-        "stdout": "-rwx-----x 1 alice dev 6 Jan  2 15:30 f.txt\n-rw-r--r-- 1 user user 0 Jan  2 15:30 new.txt\n",
+        "stdout": "-rwx-----x 1 alice dev 6 Jan  2 15:30 f.txt\n-rw-r--r-- 1 - - 0 Jan  2 15:30 new.txt\n",
         "stderr": ""
       }
     },
@@ -98,7 +98,7 @@
       "command": "touch -t 202603041200 /data/metad/f.txt && ls -l /data/metad",
       "expect": {
         "exit": 0,
-        "stdout": "-rwx-----x 1 alice dev 6 Mar  4 12:00 f.txt\n-rw-r--r-- 1 user user 0 Jan  2 15:30 new.txt\n",
+        "stdout": "-rwx-----x 1 alice dev 6 Mar  4 12:00 f.txt\n-rw-r--r-- 1 - - 0 Jan  2 15:30 new.txt\n",
         "stderr": ""
       }
     },

--- a/integ/unix/stat/vfs.json
+++ b/integ/unix/stat/vfs.json
@@ -48,7 +48,7 @@
       "command": "stat -c \"%U:%G\" /vfs/settings.json",
       "expect": {
         "exit": 0,
-        "stdout": "mirage-agent:mirage-agent\n",
+        "stdout": "mirage-agent:ops\n",
         "stderr": ""
       }
     },
@@ -127,6 +127,87 @@
       "expect": {
         "exit": 0,
         "stdout": "size=49%\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "vfs_owner_group_session",
+      "seq": 202010,
+      "targets": [
+        "statvfs"
+      ],
+      "session": "auditor",
+      "command": "stat -c \"%U:%G\" /vfs/settings.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "mirage-agent:auditor\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "vfs_whoami_is_owner",
+      "seq": 202011,
+      "targets": [
+        "statvfs"
+      ],
+      "command": "whoami",
+      "expect": {
+        "exit": 0,
+        "stdout": "mirage-agent\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "vfs_ls_long_owner_group",
+      "seq": 202012,
+      "targets": [
+        "statvfs"
+      ],
+      "command": "ls -l /vfs/settings.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "-rw-r----- 1 mirage-agent ops 49 Jan  2 15:30 /vfs/settings.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "vfs_ls_long_session_group",
+      "seq": 202013,
+      "targets": [
+        "statvfs"
+      ],
+      "session": "auditor",
+      "command": "ls -l /vfs/settings.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "-rw-r----- 1 mirage-agent auditor 49 Jan  2 15:30 /vfs/settings.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "vfs_find_printf_owner_group",
+      "seq": 202014,
+      "targets": [
+        "statvfs"
+      ],
+      "command": "find /vfs -name settings.json -printf \"%u %g %U %G\\n\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "mirage-agent ops mirage-agent ops\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "vfs_find_printf_session_group",
+      "seq": 202015,
+      "targets": [
+        "statvfs"
+      ],
+      "session": "auditor",
+      "command": "find /vfs -name settings.json -printf \"%u %g\\n\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "mirage-agent auditor\n",
         "stderr": ""
       }
     }

--- a/integ/unix/sym/ls.json
+++ b/integ/unix/sym/ls.json
@@ -64,7 +64,7 @@
       "command": "ls -l /data/symd | grep -- '->' | sed -E 's/ [A-Z][a-z]{2} +[0-9]+ [0-9]{2}:[0-9]{2} / /'",
       "expect": {
         "exit": 0,
-        "stdout": "lrwxrwxrwx 1 user user 16 l.txt -> /data/symd/t.txt\n",
+        "stdout": "lrwxrwxrwx 1 - - 16 l.txt -> /data/symd/t.txt\n",
         "stderr": ""
       }
     }

--- a/integ/unix/sym/surface.json
+++ b/integ/unix/sym/surface.json
@@ -132,7 +132,7 @@
       "command": "ls -l /data/symx/flink | sed -E 's/ [A-Z][a-z]{2} +[0-9]+ [0-9]{2}:[0-9]{2} / /'",
       "expect": {
         "exit": 0,
-        "stdout": "lrwxrwxrwx 1 user user 19 /data/symx/flink -> /data/symx/real.txt\n",
+        "stdout": "lrwxrwxrwx 1 - - 19 /data/symx/flink -> /data/symx/real.txt\n",
         "stderr": ""
       }
     },
@@ -166,7 +166,7 @@
       "command": "ls -l /data/symx/dangle | sed -E 's/ [A-Z][a-z]{2} +[0-9]+ [0-9]{2}:[0-9]{2} / /'",
       "expect": {
         "exit": 0,
-        "stdout": "lrwxrwxrwx 1 user user 15 /data/symx/dangle -> /data/symx/none\n",
+        "stdout": "lrwxrwxrwx 1 - - 15 /data/symx/dangle -> /data/symx/none\n",
         "stderr": ""
       }
     },
@@ -200,7 +200,7 @@
       "command": "ls -l /data/symx/dlink | sed -E 's/ [A-Z][a-z]{2} +[0-9]+ [0-9]{2}:[0-9]{2} / /'",
       "expect": {
         "exit": 0,
-        "stdout": "lrwxrwxrwx 1 user user 14 /data/symx/dlink -> /data/symx/sub\n",
+        "stdout": "lrwxrwxrwx 1 - - 14 /data/symx/dlink -> /data/symx/sub\n",
         "stderr": ""
       }
     },
@@ -268,7 +268,7 @@
       "command": "ls -lL /data/symx/flink | sed -E 's/ [A-Z][a-z]{2} +[0-9]+ [0-9]{2}:[0-9]{2} / /'",
       "expect": {
         "exit": 0,
-        "stdout": "-rw-r--r-- 1 user user 6 /data/symx/flink\n",
+        "stdout": "-rw-r--r-- 1 - - 6 /data/symx/flink\n",
         "stderr": ""
       }
     },

--- a/python/mirage/commands/builtin/find_printf.py
+++ b/python/mirage/commands/builtin/find_printf.py
@@ -15,6 +15,8 @@
 from datetime import datetime, timezone
 from stat import filemode
 
+from mirage.commands.builtin.utils.identity import (Identity, group_name,
+                                                    owner_name)
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.dates import iso_timestamp
 from mirage.utils.stat_view import CHAR_MODE, DIR_MODE, FILE_MODE, LINK_MODE
@@ -30,7 +32,7 @@ _PRINTF_ESCAPES = {
     "f": "\f",
     "v": "\v",
 }
-_STAT_DIRECTIVES = frozenset("syYmMT")
+_STAT_DIRECTIVES = frozenset("syYmMTuUgG")
 _TYPE_LETTER = {
     FileType.DIRECTORY: "d",
     FileType.SYMLINK: "l",
@@ -131,12 +133,16 @@ def expand_printf(fmt: str,
                   search: PathSpec,
                   st: FileStat | None,
                   warnings: list[str],
-                  target: FileStat | None = None) -> str:
+                  target: FileStat | None = None,
+                  identity: Identity | None = None) -> str:
     """Expand one -printf format against one result row.
 
     Directives cover what GNU's find agents actually use: the path family
-    (%p %P %f %h %d), the stat family (%s %y %Y %m %M), %T times, and the
-    backslash escapes. An unrecognized directive or escape renders
+    (%p %P %f %h %d), the stat family (%s %y %Y %m %M), the owner family
+    (%u %U %g %G, which read the entry's uid and gid and fall back to
+    the workspace user and the session's profile, the same rule
+    ``ls -l`` draws its columns by), %T times, and the backslash
+    escapes. An unrecognized directive or escape renders
     literally and adds GNU's warning line once, exit code untouched --
     which is GNU's own behavior. Times render in UTC (mirage timestamps
     are zone-carrying ISO strings; GNU renders the local zone). ``%Y``
@@ -151,6 +157,8 @@ def expand_printf(fmt: str,
         warnings (list[str]): sink for GNU's warning lines, deduplicated.
         target (FileStat | None): a symlink row's resolved target stat,
             None when the link dangles; ignored for non-link rows.
+        identity (Identity | None): who the session is, for the owner
+            family on an entry that reports no owner of its own.
     """
     out: list[str] = []
     i = 0
@@ -203,6 +211,12 @@ def expand_printf(fmt: str,
                 out.append("N" if target is None else printf_kind(target))
             else:
                 out.append(kind)
+        elif code in ("u", "U"):
+            out.append(owner_name(st.uid if st is not None else None,
+                                  identity))
+        elif code in ("g", "G"):
+            out.append(group_name(st.gid if st is not None else None,
+                                  identity))
         elif code == "m":
             out.append(format(_mode_bits(st, kind) & 0o7777, "o"))
         elif code == "M":

--- a/python/mirage/commands/builtin/generic/crossmount/relay/ls.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/ls.py
@@ -21,8 +21,9 @@ from mirage.commands.builtin.generic.ls import Stat
 from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.builtin.generic.ls import ls_options
 from mirage.commands.builtin.generic_bind.adapter import overlaid_stat
+from mirage.commands.builtin.utils.identity import identity_from
 from mirage.commands.spec.types import FlagValue
-from mirage.ops.types import NamespaceView
+from mirage.ops.types import NamespaceView, SessionView
 from mirage.runtime.types import DispatchFn
 from mirage.types import FileStat, PathSpec
 from mirage.utils.path import gnu_basename
@@ -69,9 +70,11 @@ async def relayed_stat(dispatch: DispatchFn, path: PathSpec,
     return info.model_copy(update={"name": name})
 
 
-async def run_ls(scopes: list[PathSpec], flag_kwargs: dict[str, FlagValue],
+async def run_ls(scopes: list[PathSpec],
+                 flag_kwargs: dict[str, FlagValue],
                  dispatch: DispatchFn,
-                 ns: NamespaceView | None) -> CrossResult:
+                 ns: NamespaceView | None,
+                 session_view: SessionView | None = None) -> CrossResult:
     """List operands spanning mounts through the shared generic ls.
 
     ls relays rather than fans out because its layout is decided across
@@ -95,6 +98,8 @@ async def run_ls(scopes: list[PathSpec], flag_kwargs: dict[str, FlagValue],
             itself, and it has to, because nothing runs behind a relay
             to contribute that group the way the fan-out does for a
             single-mount run.
+        session_view (SessionView | None): The session plane's door,
+            for the profile the group column renders.
     """
     p = functools.partial
     stat_fn: Stat = p(relayed_stat, dispatch)
@@ -107,4 +112,5 @@ async def run_ls(scopes: list[PathSpec], flag_kwargs: dict[str, FlagValue],
         stat=stat_fn,
         links=ns.links if ns is not None else None,
         child_mounts=(ns.child_mounts if ns is not None else None),
+        identity=identity_from(ns, session_view),
         **ls_options(flag_kwargs))

--- a/python/mirage/commands/builtin/generic/crossmount/relay/relay.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/relay.py
@@ -26,7 +26,7 @@ from mirage.commands.builtin.generic.crossmount.relay.tar import run_tar
 from mirage.commands.builtin.generic.crossmount.relay.unzip import run_unzip
 from mirage.commands.builtin.generic.crossmount.types import Cmd, CrossResult
 from mirage.commands.spec.types import FlagValue
-from mirage.ops.types import NamespaceView
+from mirage.ops.types import NamespaceView, SessionView
 from mirage.runtime.types import DispatchFn
 from mirage.types import PathSpec
 
@@ -37,7 +37,8 @@ async def run_relay(cmd_name: str,
                     flag_kwargs: dict[str, FlagValue],
                     dispatch: DispatchFn,
                     storage_key: Callable[[PathSpec], str] | None = None,
-                    ns: NamespaceView | None = None) -> CrossResult:
+                    ns: NamespaceView | None = None,
+                    session_view: SessionView | None = None) -> CrossResult:
     """Run a command whose work must see every operand at once.
 
     Pure wiring: every operand is read or written through ``dispatch``
@@ -57,9 +58,11 @@ async def run_relay(cmd_name: str,
             move from one whose two prefixes address a single store.
         ns (NamespaceView | None): Name-plane facts for the generics that
             render them (ls: links, attr overlay, child mounts).
+        session_view (SessionView | None): The session plane's door, for
+            the generic that renders the session's profile (ls -l).
     """
     if cmd_name == Cmd.LS:
-        return await run_ls(scopes, flag_kwargs, dispatch, ns)
+        return await run_ls(scopes, flag_kwargs, dispatch, ns, session_view)
     if cmd_name == Cmd.CP:
         return await run_cp(scopes, flag_kwargs, dispatch, storage_key)
     if cmd_name == Cmd.MV:

--- a/python/mirage/commands/builtin/generic/crossmount/route.py
+++ b/python/mirage/commands/builtin/generic/crossmount/route.py
@@ -25,7 +25,7 @@ from mirage.commands.spec.types import FlagValue
 from mirage.commands.spec.usage import read_fail_exit
 from mirage.io import IOResult
 from mirage.io.types import ByteSource
-from mirage.ops.types import NamespaceView
+from mirage.ops.types import NamespaceView, SessionView
 from mirage.runtime.types import DispatchFn
 from mirage.types import PathSpec
 from mirage.utils.errors import FS_ERRORS, format_fs_error
@@ -41,6 +41,7 @@ async def handle_cross_mount(
     stdin: ByteSource | None = None,
     storage_key: Callable[[PathSpec], str] | None = None,
     ns: NamespaceView | None = None,
+    session_view: SessionView | None = None,
 ) -> CrossResult:
     """Run a command whose path operands span mounts.
 
@@ -67,12 +68,14 @@ async def handle_cross_mount(
             identity (RELAY's transfer commands).
         ns (NamespaceView | None): Name-plane facts for the RELAY
             generics that render them (ls).
+        session_view (SessionView | None): The session plane's door, for
+            the RELAY generic that renders the session's profile (ls).
     """
     try:
         strategy = strategy_for(cmd_name, flag_kwargs)
         if strategy is Strategy.RELAY:
             return await run_relay(cmd_name, scopes, text_args, flag_kwargs,
-                                   dispatch, storage_key, ns)
+                                   dispatch, storage_key, ns, session_view)
         if strategy is Strategy.STREAM:
             return await run_stream(cmd_name, scopes, text_args, flag_kwargs,
                                     run_single)

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -14,6 +14,7 @@ from mirage.commands.builtin.find_parse import (parse_depth,
                                                 parse_mtime, parse_size)
 from mirage.commands.builtin.find_printf import (expand_printf, printf_kind,
                                                  printf_needs_stat)
+from mirage.commands.builtin.utils.identity import Identity, identity_of
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
 from mirage.commands.spec import SPECS
@@ -177,6 +178,7 @@ async def render_printf_rows(
     stat_path: StatPath | None,
     links: LinkView | None,
     missing: list[str],
+    identity: Identity | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Render matched rows through a -printf format.
 
@@ -194,6 +196,8 @@ async def render_printf_rows(
         stat (Callable | None): bound overlay-aware stat, when wired.
         links (LinkView | None): the namespace's symlink facts.
         missing (list[str]): diagnostics for start points not walked.
+        identity (Identity | None): who the session is, for the owner
+            directives on an entry that reports no owner of its own.
     """
     warnings: list[str] = []
     needs = printf_needs_stat(fmt)
@@ -201,7 +205,8 @@ async def render_printf_rows(
     for row, search in pairs:
         st, target = (await _printf_stat(row, search, stat, stat_path, links)
                       if needs else (None, None))
-        parts.append(expand_printf(fmt, row, search, st, warnings, target))
+        parts.append(
+            expand_printf(fmt, row, search, st, warnings, target, identity))
     err = missing + warnings
     io = IOResult(stderr=("\n".join(err) + "\n").encode() if err else None,
                   exit_code=1 if missing else 0)
@@ -472,6 +477,7 @@ async def find(
     empty: bool = False,
     links: LinkView | None = None,
     follow: bool = False,
+    identity: Identity | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     args = parse_find_args(texts,
                            name=name,
@@ -509,7 +515,7 @@ async def find(
             printf_pairs.extend((row, search_path) for row in rows)
     if args.printf is not None:
         return await render_printf_rows(printf_pairs, args.printf, stat,
-                                        stat_path, links, missing)
+                                        stat_path, links, missing, identity)
     if missing:
         return format_records(results), IOResult(stderr=("\n".join(missing) +
                                                          "\n").encode(),
@@ -1002,7 +1008,8 @@ async def find_generic(
                       mindepth=parsed.mindepth,
                       empty=parsed.empty,
                       links=opts.ns.links if opts.ns is not None else None,
-                      follow=parsed.follow)
+                      follow=parsed.follow,
+                      identity=identity_of(opts))
 
 
 async def find_walk_generic(
@@ -1083,7 +1090,7 @@ async def find_walk_generic(
         return await render_printf_rows(
             printf_pairs, args.printf,
             partial(_stat_with_index, stat, opts.index), stat_path, links,
-            missing)
+            missing, identity_of(opts))
     if missing:
         return format_records(results), IOResult(stderr=("\n".join(missing) +
                                                          "\n").encode(),

--- a/python/mirage/commands/builtin/generic/ls.py
+++ b/python/mirage/commands/builtin/generic/ls.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.commands.builtin.utils.formatting import format_ls_long
+from mirage.commands.builtin.utils.identity import Identity, identity_of
 from mirage.commands.builtin.utils.output import (format_optional_records,
                                                   format_records)
 from mirage.commands.config import CommandOpts
@@ -642,9 +643,10 @@ def _render_group(
     one_per_line: bool,
     human: bool,
     classify: bool,
+    identity: Identity | None,
 ) -> None:
     if long and not one_per_line:
-        results.extend(format_ls_long(entries, human=human))
+        results.extend(format_ls_long(entries, human=human, identity=identity))
     else:
         results.extend(format_simple(entries, classify=classify))
 
@@ -676,6 +678,7 @@ async def ls(
     child_mounts: ChildMounts | None = None,
     mounts: MountView | None = None,
     stat_path: StatPath | None = None,
+    identity: Identity | None = None,
 ) -> tuple[bytes, IOResult]:
     results: list[str] = []
     warnings: list[LsWarning] = []
@@ -704,7 +707,8 @@ async def ls(
                       long=long,
                       one_per_line=one_per_line,
                       human=human,
-                      classify=classify)
+                      classify=classify,
+                      identity=identity)
         return _finish(results, warnings)
 
     operands: list[Operand] = []
@@ -740,7 +744,8 @@ async def ls(
                   long=long,
                   one_per_line=one_per_line,
                   human=human,
-                  classify=classify)
+                  classify=classify,
+                  identity=identity)
     printed = bool(rows)
     for operand in operands:
         for dir_spec, entries in operand.groups:
@@ -755,7 +760,8 @@ async def ls(
                           long=long,
                           one_per_line=one_per_line,
                           human=human,
-                          classify=classify)
+                          classify=classify,
+                          identity=identity)
             printed = True
 
     return _finish(results, warnings)
@@ -772,8 +778,8 @@ async def ls_generic(
 
     The wiring resolves globs, defaults the operands from the cwd, and
     binds the backend ops (including the stat overlay); flag semantics
-    live here, and the namespace facts (links, child mounts) and index
-    ride ``opts``.
+    live here, and the namespace facts (links, child mounts), the
+    identity the owner columns render, and the index ride ``opts``.
 
     Args:
         paths (list[PathSpec]): Glob-resolved operands, cwd-defaulted.
@@ -792,6 +798,7 @@ async def ls_generic(
         child_mounts=opts.ns.child_mounts if opts.ns is not None else None,
         mounts=opts.ns.mounts if opts.ns is not None else None,
         stat_path=opts.stat_path,
+        identity=identity_of(opts),
         **ls_options(opts.flags))
 
 

--- a/python/mirage/commands/builtin/generic/stat.py
+++ b/python/mirage/commands/builtin/generic/stat.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from itertools import groupby
 
 from mirage.commands.builtin.utils.formatting import ls_mode_string
+from mirage.commands.builtin.utils.identity import (Identity, group_name,
+                                                    identity_of, owner_name)
 from mirage.commands.builtin.utils.operands import operand_stat
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.config import CommandOpts
@@ -28,8 +30,6 @@ _TYPE_LABELS = {
     FileType.CHAR_DEVICE: "character special file",
     FileType.FILE: "regular file",
 }
-
-_DEFAULT_OWNER = "user"
 
 _SHELL_SPECIAL = frozenset("!\"#$&()*;<=>?[\\^`{|}~")
 
@@ -82,10 +82,6 @@ def _type_bits(s: FileStat) -> int:
     if s.type == FileType.CHAR_DEVICE:
         return 0o020000
     return 0o100000
-
-
-def _owner(value: int | str | None) -> str:
-    return str(value) if value is not None else _DEFAULT_OWNER
 
 
 def _epoch(iso: str | None) -> str:
@@ -196,7 +192,8 @@ def _apply_flags(value: str, flags: str, width: str, precision: str | None,
     return value
 
 
-def _directive_value(spec: str, s: FileStat, name: str) -> str:
+def _directive_value(spec: str, s: FileStat, name: str,
+                     identity: Identity | None) -> str:
     if spec == "%":
         return "%"
     if spec == "n":
@@ -212,9 +209,9 @@ def _directive_value(spec: str, s: FileStat, name: str) -> str:
     if spec == "f":
         return format(_type_bits(s) | _effective_mode(s), "x")
     if spec in ("u", "U"):
-        return _owner(s.uid)
+        return owner_name(s.uid, identity)
     if spec in ("g", "G"):
-        return _owner(s.gid)
+        return group_name(s.gid, identity)
     if spec == "x":
         return s.atime or s.modified or ""
     if spec == "X":
@@ -264,13 +261,16 @@ def _name_parts(s: FileStat, name: str, quoted: bool) -> list[str]:
     return [_quote_name(p) for p in parts] if quoted else parts
 
 
-def _render_directive(d: _FormatDirective, s: FileStat, name: str) -> str:
+def _render_directive(d: _FormatDirective, s: FileStat, name: str,
+                      identity: Identity | None) -> str:
     """Render one directive with its flags, width and precision applied.
 
     Args:
         d (_FormatDirective): the parsed directive.
         s (FileStat): the stat being rendered.
         name (str): the operand as it was typed.
+        identity (Identity | None): who the session is, for %U and %G
+            on an entry that reports no owner of its own.
     """
     if d.spec == "N":
         # GNU formats the name and a symlink's target as two separate
@@ -279,8 +279,8 @@ def _render_directive(d: _FormatDirective, s: FileStat, name: str) -> str:
         return " -> ".join(
             _apply_flags(part, d.flags, d.width, d.precision, d.spec)
             for part in _name_parts(s, name, bare))
-    return _apply_flags(_directive_value(d.spec, s, name), d.flags, d.width,
-                        d.precision, d.spec)
+    return _apply_flags(_directive_value(d.spec, s, name, identity), d.flags,
+                        d.width, d.precision, d.spec)
 
 
 def _is_conversion(char: str) -> bool:
@@ -332,7 +332,8 @@ def _parse_format_directive(fmt: str, start: int) -> _FormatDirective | None:
                             spec=spec)
 
 
-def _format_stat(fmt: str, s: FileStat, name: str) -> str:
+def _format_stat(fmt: str, s: FileStat, name: str,
+                 identity: Identity | None) -> str:
     parts: list[str] = []
     cursor = 0
     while cursor < len(fmt):
@@ -346,7 +347,7 @@ def _format_stat(fmt: str, s: FileStat, name: str) -> str:
             parts.append("%")
             cursor = start + 1
             continue
-        parts.append(_render_directive(directive, s, name))
+        parts.append(_render_directive(directive, s, name, identity))
         cursor = directive.end
     return "".join(parts)
 
@@ -375,6 +376,7 @@ async def stat(
     links: LinkView | None = None,
     stat_path: StatPath | None = None,
     mounts: MountView | None = None,
+    identity: Identity | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Report file status, GNU stat semantics.
 
@@ -392,6 +394,9 @@ async def stat(
         mounts (MountView | None): the mount boundaries, so a mount root
             reports its own name rather than the backend's name for its
             root.
+        identity (Identity | None): who the session is: what ``%U`` and
+            ``%G`` print for an entry that reports no uid or gid of its
+            own; None outside a workspace, where both print ``-``.
     """
     if not paths:
         raise ValueError("stat: missing operand")
@@ -405,7 +410,7 @@ async def stat(
         linked = None if L or links is None else links.stat_at(p.virtual)
         if linked is not None:
             if fmt is not None:
-                lines.append(_format_stat(fmt, linked, p.raw_path))
+                lines.append(_format_stat(fmt, linked, p.raw_path, identity))
             else:
                 lines.append(_render_stat(linked))
             continue
@@ -419,7 +424,7 @@ async def stat(
             err += fs_error_line("stat", p, exc).encode()
             continue
         if fmt is not None:
-            lines.append(_format_stat(fmt, s, p.raw_path))
+            lines.append(_format_stat(fmt, s, p.raw_path, identity))
         else:
             lines.append(_render_stat(s))
     io = IOResult(exit_code=1 if err else 0, stderr=err or None)
@@ -461,4 +466,5 @@ async def stat_generic(
                       L=parsed.deref,
                       links=opts.ns.links if opts.ns is not None else None,
                       stat_path=opts.stat_path,
-                      mounts=opts.ns.mounts if opts.ns is not None else None)
+                      mounts=opts.ns.mounts if opts.ns is not None else None,
+                      identity=identity_of(opts))

--- a/python/mirage/commands/builtin/utils/formatting.py
+++ b/python/mirage/commands/builtin/utils/formatting.py
@@ -18,6 +18,8 @@ from mirage.commands.builtin.utils.constants import (DEFAULT_MODES,
                                                      EPOCH_LS_TIME, MONTHS,
                                                      NUMERIC_PREFIX,
                                                      TYPE_CHARS)
+from mirage.commands.builtin.utils.identity import (UNKNOWN_NAME, Identity,
+                                                    group_name, owner_name)
 from mirage.types import (DEVICE_NUMBERS_KEY, LINK_TARGET_KEY, FileStat,
                           FileType)
 
@@ -104,33 +106,59 @@ def _ls_name(s: FileStat) -> str:
     return f"{s.name} -> {target}" if target else s.name
 
 
+def _ls_size_and_time(s: FileStat, human: bool) -> tuple[str, str]:
+    """The size and time columns of one ``ls -l`` row.
+
+    A device row carries its major and minor numbers where GNU puts
+    them. An entry with neither a size nor a time (a synthetic
+    API-backend directory) shows ``-`` in both rather than inventing
+    size 0 and the epoch.
+
+    Args:
+        s (FileStat): the row's stat.
+        human (bool): render the size with ``-h`` units.
+    """
+    dev = s.extra.get(DEVICE_NUMBERS_KEY) if s.extra else None
+    if dev:
+        time = (UNKNOWN_NAME
+                if s.modified is None else _ls_time_string(s.modified))
+        return f"{dev[0]}, {dev[1]}", time
+    if s.size is None and s.modified is None:
+        return UNKNOWN_NAME, UNKNOWN_NAME
+    size = human_size(s.size or 0) if human else str(s.size or 0)
+    return size, _ls_time_string(s.modified)
+
+
 def format_ls_long(
     stats: list[FileStat],
     *,
     human: bool = False,
-    owner: str = "user",
-    group: str = "user",
+    identity: Identity | None = None,
     size_width: int | None = None,
 ) -> list[str]:
-    sizes = [
-        human_size(s.size or 0) if human else str(s.size or 0) for s in stats
-    ]
+    """Render ``ls -l`` rows: mode, links, owner, group, size, time, name.
+
+    The owner is the entry's uid when a backend or the attr overlay
+    reports one, else the workspace user; the group is the gid, else the
+    session's profile; ``-`` when nothing names one.
+
+    Args:
+        stats (list[FileStat]): the rows to render.
+        human (bool): render sizes with ``-h`` units.
+        identity (Identity | None): who the session is; None outside a
+            workspace, where both columns fall back to ``-``.
+        size_width (int | None): the size column's width, computed from
+            the rows when None.
+    """
+    columns = [_ls_size_and_time(s, human) for s in stats]
     width = size_width if size_width is not None else max(
-        (len(x) for x in sizes), default=1)
+        (len(size) for size, _ in columns), default=1)
     out: list[str] = []
-    for s, raw_size in zip(stats, sizes):
+    for s, (raw_size, time) in zip(stats, columns):
         mode = ls_mode_string(s)
-        dev = s.extra.get(DEVICE_NUMBERS_KEY) if s.extra else None
-        if dev:
-            out.append(f"{mode}\t{dev[0]}, {dev[1]}\t-\t{_ls_name(s)}")
-            continue
-        if s.size is None and s.modified is None:
-            out.append(f"{mode}\t-\t-\t{_ls_name(s)}")
-            continue
         size = raw_size.rjust(width)
-        time = _ls_time_string(s.modified)
-        who = str(s.uid) if s.uid is not None else owner
-        grp = str(s.gid) if s.gid is not None else group
+        who = owner_name(s.uid, identity)
+        grp = group_name(s.gid, identity)
         out.append(f"{mode} 1 {who} {grp} {size} {time} {_ls_name(s)}")
     return out
 

--- a/python/mirage/commands/builtin/utils/identity.py
+++ b/python/mirage/commands/builtin/utils/identity.py
@@ -1,0 +1,101 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+
+from mirage.commands.config import CommandOpts
+from mirage.ops.types import NamespaceView, SessionView
+
+# What an owner or group column prints when nothing names one: no uid
+# on the entry and no workspace user, or no gid and no profile.
+UNKNOWN_NAME = "-"
+
+
+@dataclass(frozen=True, slots=True)
+class Identity:
+    """Who a session is, in the two words POSIX renders as owner and group.
+
+    The user is the workspace user (what ``whoami`` prints, the launch
+    ``agent_id``); the profile is the permission set the session acts
+    with, which is what a group is. A backend that reports a uid or gid
+    on an entry (disk, or a ``chown`` held in the attr overlay) wins
+    over both, so ``ls -l``, ``stat %U %G`` and ``find -printf %u %g``
+    all agree on one rule.
+
+    Args:
+        user (str | None): the workspace user, None when no agent ever
+            claimed the workspace.
+        profile (str | None): the session's profile name, None for an
+            unrestricted session.
+    """
+
+    user: str | None = None
+    profile: str | None = None
+
+
+NO_IDENTITY = Identity()
+
+
+def identity_from(ns: NamespaceView | None,
+                  session_view: SessionView | None) -> Identity:
+    """The identity two planes' views describe.
+
+    Args:
+        ns (NamespaceView | None): the name plane, which carries the
+            workspace user; None outside a workspace.
+        session_view (SessionView | None): the session plane, which
+            carries the profile; None outside a workspace.
+    """
+    return Identity(
+        user=ns.user if ns is not None else None,
+        profile=session_view.profile() if session_view is not None else None)
+
+
+def identity_of(opts: CommandOpts) -> Identity:
+    """The identity a command invocation runs as, read off its opts.
+
+    Args:
+        opts (CommandOpts): the dispatcher context of the invocation.
+    """
+    return identity_from(opts.ns, opts.session_view)
+
+
+def owner_name(uid: int | str | None, identity: Identity | None) -> str:
+    """The owner column: the entry's own uid, else the workspace user.
+
+    Args:
+        uid (int | str | None): what the backend or overlay reported.
+        identity (Identity | None): who the session is; None outside a
+            workspace.
+    """
+    if uid is not None:
+        return str(uid)
+    if identity is not None and identity.user is not None:
+        return identity.user
+    return UNKNOWN_NAME
+
+
+def group_name(gid: int | str | None, identity: Identity | None) -> str:
+    """The group column: the entry's own gid, else the session's profile.
+
+    Args:
+        gid (int | str | None): what the backend or overlay reported.
+        identity (Identity | None): who the session is; None outside a
+            workspace.
+    """
+    if gid is not None:
+        return str(gid)
+    if identity is not None and identity.profile is not None:
+        return identity.profile
+    return UNKNOWN_NAME

--- a/python/mirage/ops/types.py
+++ b/python/mirage/ops/types.py
@@ -103,6 +103,11 @@ class EnvUnset(Protocol):
 EnvMark = Callable[[str, VarAttr | None, bool], Awaitable[None]]
 # Whether `readonly` has marked the name.
 EnvIsReadonly = Callable[[str], bool]
+# The name of the profile the session runs under, None for an
+# unrestricted session. What an owner-rendering command (ls -l, stat %g,
+# find -printf %g) prints in the group column: the profile is the
+# permission set the session acts with, which is what a group is.
+ProfileName = Callable[[], "str | None"]
 
 
 @dataclass(frozen=True)
@@ -130,6 +135,7 @@ class SessionView:
     unset: EnvUnset
     mark: EnvMark
     is_readonly: EnvIsReadonly
+    profile: ProfileName
 
 
 @dataclass(frozen=True)
@@ -227,7 +233,7 @@ class NamespaceView:
     field it wants, so there is no signature for the dispatcher to
     inspect and no registry to keep in step. Fields default to None so
     a unit test constructs only what it exercises; inside a workspace
-    the dispatcher fills all four.
+    the dispatcher fills all five.
     """
 
     # The symlink facts; None when the namespace holds no links, which
@@ -239,3 +245,7 @@ class NamespaceView:
     stat_overlay: StatOverlay | None = None
     # Child names the namespace owes a directory (mounts and links).
     child_mounts: ChildMounts | None = None
+    # The workspace user (what whoami prints), None when no agent ever
+    # claimed the workspace. What an owner-rendering command prints in
+    # the owner column for an entry whose backend reports no uid.
+    user: str | None = None

--- a/python/mirage/policy/profile.py
+++ b/python/mirage/policy/profile.py
@@ -655,6 +655,8 @@ class CompiledProfile:
             states, its own and its mount sections' in one list.
         hide_reasons (tuple[HideReason, ...]): the operator's reasons
             for grouped hides, never rendered to the agent.
+        profile (str | None): the profile's name, None for a document
+            passed without one; what the session reports as its group.
     """
 
     mount_modes: dict[str, MountMode] | None
@@ -666,3 +668,4 @@ class CompiledProfile:
     script: ProfileScript | None = None
     shown_paths: ShownPaths | None = None
     hide_reasons: tuple[HideReason, ...] = ()
+    profile: str | None = None

--- a/python/mirage/workspace/executor/command/command.py
+++ b/python/mirage/workspace/executor/command/command.py
@@ -257,7 +257,8 @@ async def handle_command(
             run_operand,
             stdin=stdin,
             storage_key=make_storage_key(registry),
-            ns=cross_ns)
+            ns=cross_ns,
+            session_view=session_view(session, registry.policies))
         if cross_parsed.warnings:
             warn = "".join(f"{cmd_name}: {w}\n"
                            for w in cross_parsed.warnings).encode()

--- a/python/mirage/workspace/executor/command/run.py
+++ b/python/mirage/workspace/executor/command/run.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import functools
-from typing import Any
 
 from mirage.commands.config import ExecContext
 from mirage.commands.errors import CommandTimeoutError, UsageError
@@ -257,7 +256,8 @@ def namespace_view_of(registry: MountRegistry, namespace: Namespace | None,
         stat_overlay=(functools.partial(namespace_stat_overlay, namespace)
                       if namespace is not None else None),
         child_mounts=functools.partial(registry_child_mounts, registry,
-                                       namespace))
+                                       namespace),
+        user=namespace.user if namespace is not None else None)
 
 
 async def drop_service_caches(registry: MountRegistry,
@@ -305,26 +305,18 @@ def namespace_stat_overlay(namespace: Namespace, virtual: str,
                            stat: FileStat) -> FileStat:
     """Merge namespace attr overlays into one stat row (ls/stat rendering).
 
-    A path never chown'd defaults its owner to the workspace user (the
-    launch agent, what ``whoami`` reports), so ``ls -l`` and ``stat -c``
-    agree on ownership. An unclaimed workspace leaves uid/gid None and the
-    formatters fall back to the neutral ``user`` placeholder.
+    Only what ``chmod``/``chown``/``chgrp``/``touch`` recorded: a path
+    never chown'd keeps uid and gid None, and the owner-rendering
+    commands fall back through ``Identity`` (the workspace user for the
+    owner, the session's profile for the group), which is the one rule
+    ``ls -l``, ``stat -c`` and ``find -printf`` share.
 
     Args:
         namespace (Namespace): addressing authority holding the overlay.
         virtual (str): absolute virtual path of the statted entry.
         stat (FileStat): backend stat result.
     """
-    merged = merge_overlay_stat(namespace.meta_for(virtual), stat)
-    user = namespace.user
-    if user is None:
-        return merged
-    update: dict[str, Any] = {}
-    if merged.uid is None:
-        update["uid"] = user
-    if merged.gid is None:
-        update["gid"] = user
-    return merged.model_copy(update=update) if update else merged
+    return merge_overlay_stat(namespace.meta_for(virtual), stat)
 
 
 async def run_on_mount(

--- a/python/mirage/workspace/session/constants.py
+++ b/python/mirage/workspace/session/constants.py
@@ -42,6 +42,7 @@ INHERITED_FIELDS: tuple[str, ...] = (
     "hide_reasons",
     "commands",
     "script",
+    "profile",
     "decisions",
     "generation",
     "pipeline_timeout_seconds",

--- a/python/mirage/workspace/session/resolve.py
+++ b/python/mirage/workspace/session/resolve.py
@@ -458,8 +458,9 @@ def compile_profile(effective: SessionProfile | None,
             inline document already added; None is an unrestricted
             session.
         name (str): the profile's name, empty for a document passed
-            without one; carried onto its script for ``ctx["profile"]``
-            and for refusals to print.
+            without one; carried onto its script for ``ctx["profile"]``,
+            for refusals to print, and onto the session as the group an
+            owner-rendering command shows.
     """
     if effective is None:
         return CompiledProfile(mount_modes=None,
@@ -467,7 +468,8 @@ def compile_profile(effective: SessionProfile | None,
                                hidden_vars=None,
                                env=None,
                                cwd=None,
-                               commands=None)
+                               commands=None,
+                               profile=name or None)
     commands = compile_commands(effective)
     check_rules(commands)
     return CompiledProfile(
@@ -481,6 +483,7 @@ def compile_profile(effective: SessionProfile | None,
         script=compile_script(effective, name),
         shown_paths=_shown(effective),
         hide_reasons=_hide_reasons(effective),
+        profile=name or None,
     )
 
 
@@ -489,7 +492,7 @@ def narrow(session: Session, compiled: CompiledProfile) -> None:
 
     The fields no shell line can edit: the per-mount modes, hidden
     paths, show entries, hidden variables, hide reasons, the admission
-    rules, the profile's script. Applied at creation
+    rules, the profile's script, the profile's name. Applied at creation
     and again whenever a stored record could carry a stale copy (the
     default session after hydration), so the document, not the store,
     is what an agent runs under.
@@ -506,6 +509,7 @@ def narrow(session: Session, compiled: CompiledProfile) -> None:
     session.hide_reasons = compiled.hide_reasons
     session.commands = compiled.commands
     session.script = compiled.script
+    session.profile = compiled.profile
 
 
 def apply_profile(session: Session, compiled: CompiledProfile) -> None:

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -267,6 +267,10 @@ class Session:
     # admission gate. A durable restriction like commands, so it
     # persists with the session record.
     script: ProfileScript | None = None
+    # The name of the profile the session runs under, None for an
+    # unrestricted session. What an owner-rendering command prints as
+    # the group. Stamped by the profile like script, so it persists.
+    profile: str | None = None
     # The host's standing answers to asked lines (design 3.9): session
     # state like functions and cwd, persisted, read and written through
     # the manager by id so a fork shares them, never another session's.
@@ -421,6 +425,8 @@ class Session:
             data["commands"] = commands_to_dict(self.commands)
         if self.script is not None:
             data["script"] = script_to_dict(self.script)
+        if self.profile is not None:
+            data["profile"] = self.profile
         if self.decisions:
             data["decisions"] = [decision_to_dict(d) for d in self.decisions]
         return data

--- a/python/mirage/workspace/session/state.py
+++ b/python/mirage/workspace/session/state.py
@@ -692,9 +692,18 @@ async def mark_var(session: Session,
     set_attr(session, name, attr, on)
 
 
+def session_profile(session: Session) -> str | None:
+    """The name of the profile the session runs under, None when none.
+
+    Args:
+        session (Session): the session to read.
+    """
+    return session.profile
+
+
 def session_view(session: Session,
                  policies: Policies | None = None) -> SessionView:
-    """The session plane's view: six facts bound to one session.
+    """The session plane's view: seven facts bound to one session.
 
     The one constructor every tier uses — builtins, the command
     dispatcher, a bare unit test — so the gate cannot be skipped by
@@ -712,4 +721,5 @@ def session_view(session: Session,
                        set=functools.partial(set_var, session, policies),
                        unset=functools.partial(unset_var, session, policies),
                        mark=functools.partial(mark_var, session, policies),
-                       is_readonly=functools.partial(env_is_readonly, session))
+                       is_readonly=functools.partial(env_is_readonly, session),
+                       profile=functools.partial(session_profile, session))

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -56,6 +56,7 @@ from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.mount.namespace.store import NamespaceStore
 from mirage.workspace.node.explain import explain_line
 from mirage.workspace.session import Session, SessionManager, SessionStore
+from mirage.workspace.session.constants import DEFAULT_PROFILE
 from mirage.workspace.session.resolve import (apply_profile, compile_profile,
                                               resolve_profile, with_inline)
 from mirage.workspace.session.session import vars_from_entries
@@ -931,8 +932,8 @@ class Workspace:
 
     def _profile_name(self, profile: str | SessionProfile | None) -> str:
         """The name of the profile ``_base_profile`` resolves, which its
-        script reads as ``ctx["profile"]``; empty for a profile document
-        passed without one.
+        script reads as ``ctx["profile"]`` and the session reports as
+        its group; empty for a profile document passed without one.
 
         Args:
             profile (str | SessionProfile | None): what the caller
@@ -942,6 +943,8 @@ class Workspace:
             return profile
         if profile is None and self._default_profile_name is not None:
             return self._default_profile_name
+        if profile is None and DEFAULT_PROFILE in self._profiles:
+            return DEFAULT_PROFILE
         return ""
 
     def _mount_prefixes(self) -> list[str]:

--- a/python/tests/commands/builtin/generic/test_stat.py
+++ b/python/tests/commands/builtin/generic/test_stat.py
@@ -5,6 +5,7 @@ import pytest
 from mirage.commands.builtin.generic.stat import stat
 from mirage.io.types import materialize
 from mirage.ops.types import LinkView
+from mirage.policy.profile import SessionProfile
 from mirage.resource.ram import RAMResource
 from mirage.types import (DEVICE_NUMBERS_KEY, LINK_TARGET_KEY, ContentType,
                           FileStat, FileType, MountMode, PathSpec)
@@ -185,9 +186,9 @@ async def test_owner_directives():
     assert await _render("%U", owned) == "1000"
     assert await _render("%g", owned) == "dev"
     assert await _render("%G", owned) == "dev"
-    # No owner -> neutral "user" placeholder (matches ls -l).
+    # No owner and no identity -> `-` in every slot (matches ls -l).
     bare = _fs(uid=None, gid=None)
-    assert await _render("%u %U %g %G", bare) == "user user user user"
+    assert await _render("%u %U %g %G", bare) == "- - - -"
 
 
 @pytest.mark.asyncio
@@ -306,18 +307,34 @@ async def test_owner_defaults_to_workspace_agent():
                    agent_id="agent7")
     code, out, _ = await _run(ws, 'stat -c "%U:%G" /data/f.txt')
     assert code == 0
-    assert out == "agent7:agent7\n"
+    # The owner is the workspace user; the group is the session's
+    # profile, and this session runs under none.
+    assert out == "agent7:-\n"
 
 
 @pytest.mark.asyncio
-async def test_owner_falls_back_to_user_when_unclaimed():
+async def test_group_is_the_session_profile():
+    resource = RAMResource()
+    resource._store.files["/f.txt"] = b"hello"
+    ws = Workspace({"/data/": (resource, MountMode.WRITE)},
+                   mode=MountMode.WRITE,
+                   agent_id="agent7",
+                   profiles={"admin": SessionProfile()},
+                   profile="admin")
+    code, out, _ = await _run(ws, 'stat -c "%U:%G" /data/f.txt')
+    assert code == 0
+    assert out == "agent7:admin\n"
+
+
+@pytest.mark.asyncio
+async def test_owner_falls_back_to_dash_when_unclaimed():
     resource = RAMResource()
     resource._store.files["/f.txt"] = b"hello"
     ws = Workspace({"/data/": (resource, MountMode.WRITE)},
                    mode=MountMode.WRITE)
     code, out, _ = await _run(ws, 'stat -c "%U:%G" /data/f.txt')
     assert code == 0
-    assert out == "user:user\n"
+    assert out == "-:-\n"
 
 
 @pytest.mark.asyncio
@@ -329,8 +346,8 @@ async def test_stat_and_ls_agree_on_owner():
                    agent_id="agent7")
     _, stat_owner, _ = await _run(ws, 'stat -c "%U %G" /data/f.txt')
     _, ls_long, _ = await _run(ws, "ls -l /data/f.txt")
-    assert stat_owner.strip() == "agent7 agent7"
-    assert "agent7 agent7" in ls_long
+    assert stat_owner.strip() == "agent7 -"
+    assert " 1 agent7 - " in ls_long
 
 
 def _link_fs(target: str = "/data/f.txt") -> FileStat:

--- a/python/tests/commands/builtin/test_find_printf.py
+++ b/python/tests/commands/builtin/test_find_printf.py
@@ -1,5 +1,6 @@
 from mirage.commands.builtin.find_printf import (expand_printf,
                                                  printf_needs_stat)
+from mirage.commands.builtin.utils.identity import Identity
 from mirage.types import ContentType, FileStat, FileType, PathSpec
 
 
@@ -28,6 +29,7 @@ def _stat(size: int = 6,
 def test_printf_needs_stat():
     assert printf_needs_stat("%s\n")
     assert printf_needs_stat("%TY\n")
+    assert printf_needs_stat("%u %g\n")
     assert not printf_needs_stat("%p %f %h %P %d\n")
     assert not printf_needs_stat("100%%score\n")
 
@@ -51,6 +53,31 @@ def test_expand_stat_directives():
     dir_out = expand_printf("%y %m\n", "/data/sub", search,
                             _stat(0, FileType.DIRECTORY), warnings)
     assert dir_out == "d 755\n"
+
+
+def test_expand_owner_directives():
+    warnings: list[str] = []
+    search = _spec("/data")
+    identity = Identity(user="alice", profile="admin")
+    # No uid/gid on the entry: the owner is the workspace user and the
+    # group the session's profile, the rule ls -l draws its columns by.
+    assert expand_printf("%u %U %g %G\n",
+                         "/data/a.txt",
+                         search,
+                         _stat(),
+                         warnings,
+                         identity=identity) == "alice alice admin admin\n"
+    # A reported owner wins; `-` when nothing names one.
+    owned = _stat().model_copy(update={"uid": 501, "gid": "staff"})
+    assert expand_printf("%u %g\n",
+                         "/data/a.txt",
+                         search,
+                         owned,
+                         warnings,
+                         identity=identity) == "501 staff\n"
+    assert expand_printf("%u %g\n", "/data/a.txt", search, _stat(),
+                         warnings) == "- -\n"
+    assert warnings == []
 
 
 def test_expand_reported_mode_over_default():

--- a/python/tests/commands/builtin/test_formatting.py
+++ b/python/tests/commands/builtin/test_formatting.py
@@ -15,7 +15,8 @@
 import pytest
 
 from mirage.commands.builtin.utils.formatting import format_ls_long, human_size
-from mirage.types import ContentType, FileStat, FileType
+from mirage.commands.builtin.utils.identity import Identity
+from mirage.types import DEVICE_NUMBERS_KEY, ContentType, FileStat, FileType
 
 # Read off GNU coreutils 9.7 (`ls -lh` on a file of each size, debian
 # stable-slim). The three rows that matter are the ones a plain
@@ -63,7 +64,43 @@ def test_format_ls_long_regular_file():
                     content=ContentType.TEXT,
                     modified="2026-01-01T00:00:00Z")
     [line] = format_ls_long([stat])
-    assert line == "-rw-r--r-- 1 user user 5 Jan  1 00:00 file.txt"
+    assert line == "-rw-r--r-- 1 - - 5 Jan  1 00:00 file.txt"
+
+
+def test_format_ls_long_owner_is_user_and_group_is_profile():
+    stat = FileStat(name="file.txt",
+                    size=5,
+                    type=FileType.FILE,
+                    modified="2026-01-01T00:00:00Z")
+    identity = Identity(user="alice", profile="admin")
+    [line] = format_ls_long([stat], identity=identity)
+    assert line == "-rw-r--r-- 1 alice admin 5 Jan  1 00:00 file.txt"
+    # A reported uid/gid (disk, or a chown in the overlay) wins over both.
+    owned = stat.model_copy(update={"uid": 501, "gid": "staff"})
+    [line] = format_ls_long([owned], identity=identity)
+    assert line == "-rw-r--r-- 1 501 staff 5 Jan  1 00:00 file.txt"
+    # Half an identity fills half the columns.
+    [line] = format_ls_long([stat], identity=Identity(profile="admin"))
+    assert line == "-rw-r--r-- 1 - admin 5 Jan  1 00:00 file.txt"
+
+
+def test_format_ls_long_metadata_less_row_keeps_the_owner_columns():
+    # A synthetic directory with neither size nor mtime shows `-` for
+    # both rather than inventing size 0 and the epoch, and still names
+    # who the session is.
+    stat = FileStat(name="dev", type=FileType.DIRECTORY)
+    [line] = format_ls_long([stat])
+    assert line == "drwxr-xr-x 1 - - - - dev"
+    [line] = format_ls_long([stat], identity=Identity(profile="admin"))
+    assert line == "drwxr-xr-x 1 - admin - - dev"
+
+
+def test_format_ls_long_device_row():
+    null = FileStat(name="null",
+                    type=FileType.CHAR_DEVICE,
+                    extra={DEVICE_NUMBERS_KEY: (1, 3)})
+    [line] = format_ls_long([null], identity=Identity(user="alice"))
+    assert line == "crw-rw-rw- 1 alice - 1, 3 - null"
 
 
 def test_format_ls_long_directory():

--- a/python/tests/commands/builtin/utils/test_identity.py
+++ b/python/tests/commands/builtin/utils/test_identity.py
@@ -1,0 +1,89 @@
+import pytest
+
+from mirage.commands.builtin.utils.identity import (NO_IDENTITY, Identity,
+                                                    group_name, identity_from,
+                                                    identity_of, owner_name)
+from mirage.commands.config import CommandOpts
+from mirage.io.types import materialize
+from mirage.ops.types import NamespaceView
+from mirage.policy.profile import SessionProfile
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
+from mirage.workspace import Workspace
+from mirage.workspace.session.session import Session
+from mirage.workspace.session.state import session_view
+
+
+def test_owner_and_group_prefer_the_entry_then_the_identity_then_dash():
+    identity = Identity(user="alice", profile="admin")
+    assert owner_name(501, identity) == "501"
+    assert owner_name(None, identity) == "alice"
+    assert owner_name(None, Identity(profile="admin")) == "-"
+    assert owner_name(None, None) == "-"
+    assert group_name("staff", identity) == "staff"
+    assert group_name(None, identity) == "admin"
+    assert group_name(None, Identity(user="alice")) == "-"
+    assert group_name(None, NO_IDENTITY) == "-"
+
+
+def test_identity_reads_the_name_plane_and_the_session_plane():
+    session = Session(session_id="s", profile="admin")
+    view = session_view(session)
+    ns = NamespaceView(user="alice")
+    assert identity_from(ns, view) == Identity(user="alice", profile="admin")
+    assert identity_from(None, None) == NO_IDENTITY
+    assert identity_of(CommandOpts(ns=ns, session_view=view)) == Identity(
+        user="alice", profile="admin")
+    assert identity_of(CommandOpts()) == NO_IDENTITY
+
+
+async def _run(ws: Workspace, line: str) -> tuple[int, str]:
+    io = await ws.execute(line)
+    out = await materialize(io.stdout) if io.stdout else b""
+    return io.exit_code, out.decode()
+
+
+def _ws(**kwargs) -> Workspace:
+    resource = RAMResource()
+    resource._store.files["/f.txt"] = b"hello"
+    return Workspace({"/data/": (resource, MountMode.WRITE)},
+                     mode=MountMode.WRITE,
+                     **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_ls_stat_and_find_render_user_and_profile():
+    ws = _ws(agent_id="alice",
+             profiles={"admin": SessionProfile()},
+             profile="admin")
+    _, ls_out = await _run(ws, "ls -l /data/f.txt")
+    assert ls_out == "-rw-r--r-- 1 alice admin 5 Jan  1 00:00 /data/f.txt\n"
+    _, stat_out = await _run(ws, 'stat -c "%U %G" /data/f.txt')
+    assert stat_out == "alice admin\n"
+    _, find_out = await _run(ws, "find /data -type f -printf '%u %g %p\\n'")
+    assert find_out == "alice admin /data/f.txt\n"
+    _, who = await _run(ws, "whoami")
+    assert who == "alice\n"
+
+
+@pytest.mark.asyncio
+async def test_missing_user_or_profile_renders_as_dash():
+    ws = _ws()
+    _, ls_out = await _run(ws, "ls -l /data/f.txt")
+    assert ls_out == "-rw-r--r-- 1 - - 5 Jan  1 00:00 /data/f.txt\n"
+    _, stat_out = await _run(ws, 'stat -c "%U %G" /data/f.txt')
+    assert stat_out == "- -\n"
+
+
+@pytest.mark.asyncio
+async def test_a_named_session_reports_its_own_profile():
+    ws = _ws(agent_id="alice",
+             profiles={
+                 "default": SessionProfile(),
+                 "reviewer": SessionProfile()
+             })
+    _, own = await _run(ws, 'stat -c "%G" /data/f.txt')
+    assert own == "default\n"
+    ws.create_session("r1", profile="reviewer")
+    io = await ws.execute('stat -c "%G" /data/f.txt', session_id="r1")
+    assert (await materialize(io.stdout)).decode() == "reviewer\n"

--- a/python/tests/workspace/executor/builtins/metadata/test_chgrp.py
+++ b/python/tests/workspace/executor/builtins/metadata/test_chgrp.py
@@ -31,7 +31,7 @@ async def test_chgrp_renders_group_keeps_default_owner():
     code, _, err = await _run(ws, "chgrp staff /data/f.txt")
     assert code == 0, err
     _, out, _ = await _run(ws, "ls -l /data")
-    assert " user staff " in out
+    assert " - staff " in out
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/executor/builtins/metadata/test_chmod.py
+++ b/python/tests/workspace/executor/builtins/metadata/test_chmod.py
@@ -81,7 +81,7 @@ async def test_chmod_follows_symlink():
     _, out, _ = await _run(ws, "ls -l /data")
     # The mode lands on the target, not the link. The link's own row is
     # listed too and is wider, so the size column pads f.txt's 5.
-    assert "-rw-r----- 1 user user  5 Jan  1 00:00 f.txt" in out
+    assert "-rw-r----- 1 - -  5 Jan  1 00:00 f.txt" in out
     assert "lrwxrwxrwx" in out
 
 

--- a/python/tests/workspace/executor/builtins/metadata/test_chown.py
+++ b/python/tests/workspace/executor/builtins/metadata/test_chown.py
@@ -55,7 +55,7 @@ async def test_chown_recursive_does_not_follow_a_link_operand():
         ws, "stat -c '%U %n' /data/dirlink /data/tree/sub/b.txt")
     assert out.splitlines() == [
         "bob /data/dirlink",
-        "user /data/tree/sub/b.txt",
+        "- /data/tree/sub/b.txt",
     ]
 
 

--- a/python/tests/workspace/session/test_resolve.py
+++ b/python/tests/workspace/session/test_resolve.py
@@ -395,3 +395,17 @@ def test_narrow_stamps_the_path_axis():
     assert session.hide_reasons == compiled.hide_reasons
     empty = compile_profile(None)
     assert empty.shown_paths is None and empty.hide_reasons == ()
+
+
+def test_compile_profile_carries_the_name_and_narrow_stamps_it():
+    compiled = compile_profile(PROFILES["reviewer"], "reviewer")
+    assert compiled.profile == "reviewer"
+    session = Session(session_id="s1")
+    narrow(session, compiled)
+    assert session.profile == "reviewer"
+    # A document passed without a name, and no document at all, leave
+    # the session with no profile to report.
+    assert compile_profile(PROFILES["reviewer"]).profile is None
+    assert compile_profile(None).profile is None
+    narrow(session, compile_profile(None))
+    assert session.profile is None

--- a/python/tests/workspace/session/test_session.py
+++ b/python/tests/workspace/session/test_session.py
@@ -564,3 +564,12 @@ def test_vars_fields_never_writes_a_fetched_value():
     fields = vars_to_fields(table)
     assert "T" not in fields["env"]
     assert vars_from_fields(fields)["T"].value is None
+
+
+def test_session_profile_round_trips_and_is_omitted_when_none():
+    assert "profile" not in Session(session_id="a").to_dict()
+    original = Session(session_id="rt", profile="admin")
+    data = original.to_dict()
+    assert data["profile"] == "admin"
+    assert Session.from_dict(data).profile == "admin"
+    assert original.fork().profile == "admin"

--- a/python/tests/workspace/session/test_state.py
+++ b/python/tests/workspace/session/test_state.py
@@ -398,3 +398,10 @@ def test_unset_var_deletes_a_managed_name_quietly():
         assert "TOKEN" not in session.vars
 
     asyncio.run(run())
+
+
+def test_profile_reads_the_session_profile():
+    view, session = _view()
+    assert view.profile() is None
+    session.profile = "admin"
+    assert view.profile() == "admin"

--- a/typescript/packages/core/src/commands/builtin/find_printf.test.ts
+++ b/typescript/packages/core/src/commands/builtin/find_printf.test.ts
@@ -22,7 +22,27 @@ describe('expandPrintf', () => {
     mtimeEpoch: 1786887930,
     mode: null,
     targetKind: null,
+    uid: null,
+    gid: null,
   }
+
+  it('expands the owner family from the identity', () => {
+    const warnings: string[] = []
+    const identity = { user: 'alice', profile: 'admin' }
+    // No uid/gid on the entry: the owner is the workspace user and the
+    // group the session's profile, the rule ls -l draws its columns by.
+    expect(expandPrintf('%u %U %g %G\n', '/data/a.txt', '/data', stat, warnings, identity)).toBe(
+      'alice alice admin admin\n',
+    )
+    // A reported owner wins; `-` when nothing names one.
+    const owned = { ...stat, uid: 501, gid: 'staff' }
+    expect(expandPrintf('%u %g\n', '/data/a.txt', '/data', owned, warnings, identity)).toBe(
+      '501 staff\n',
+    )
+    expect(expandPrintf('%u %g\n', '/data/a.txt', '/data', stat, warnings)).toBe('- -\n')
+    expect(printfNeedsStat('%u %g\n')).toBe(true)
+    expect(warnings).toEqual([])
+  })
 
   it('expands the path family', () => {
     const warnings: string[] = []
@@ -42,7 +62,7 @@ describe('expandPrintf', () => {
         '%y %m\n',
         '/data/sub',
         '/data',
-        { size: 0, kind: 'd', mtimeEpoch: 0, mode: null, targetKind: null },
+        { size: 0, kind: 'd', mtimeEpoch: 0, mode: null, targetKind: null, uid: null, gid: null },
         warnings,
       ),
     ).toBe('d 755\n')
@@ -58,7 +78,7 @@ describe('expandPrintf', () => {
         '%m %M\n',
         '/data/sub',
         '/data',
-        { size: 0, kind: 'd', mtimeEpoch: 0, mode: 0o700, targetKind: null },
+        { size: 0, kind: 'd', mtimeEpoch: 0, mode: 0o700, targetKind: null, uid: null, gid: null },
         warnings,
       ),
     ).toBe('700 drwx------\n')
@@ -66,7 +86,15 @@ describe('expandPrintf', () => {
 
   it('reports the target kind for %Y on a link, N when it dangles', () => {
     const warnings: string[] = []
-    const link = { size: 5, kind: 'l' as const, mtimeEpoch: 0, mode: null, targetKind: null }
+    const link = {
+      size: 5,
+      kind: 'l' as const,
+      mtimeEpoch: 0,
+      mode: null,
+      targetKind: null,
+      uid: null,
+      gid: null,
+    }
     expect(
       expandPrintf('%y %Y\n', '/data/lnk', '/data', { ...link, targetKind: 'd' }, warnings),
     ).toBe('l d\n')

--- a/typescript/packages/core/src/commands/builtin/find_printf.ts
+++ b/typescript/packages/core/src/commands/builtin/find_printf.ts
@@ -15,6 +15,7 @@
 import { DIR_MODE, FILE_MODE } from '../../utils/stat_view.ts'
 import { FileStat, FileType } from '../../types.ts'
 import { lsModeString } from './utils/formatting.ts'
+import { groupName, ownerName, type Identity } from './utils/identity.ts'
 
 const PRINTF_ESCAPES: Record<string, string> = {
   n: '\n',
@@ -27,7 +28,7 @@ const PRINTF_ESCAPES: Record<string, string> = {
   f: '\f',
   v: '\v',
 }
-const STAT_DIRECTIVES = new Set(['s', 'y', 'Y', 'm', 'M', 'T'])
+const STAT_DIRECTIVES = new Set(['s', 'y', 'Y', 'm', 'M', 'T', 'u', 'U', 'g', 'G'])
 // One mode per kind, spelled from the same constants every stat
 // translator uses (utils/stat_view.ts); links are 777 the way ls draws
 // them. A reported mode (chmod overlay, a backend that knows) supplies
@@ -137,6 +138,10 @@ export interface PrintfStatFacts {
   // What %Y classifies on a symlink row: the target's kind, 'N' when the
   // link dangles. Ignored for a non-link row, where %Y is %y.
   targetKind: PrintfKind | 'N' | null
+  // The owner a backend or the attr overlay reported, null when none;
+  // %u %U %g %G fall back to the session's identity from there.
+  uid: number | string | null
+  gid: number | string | null
 }
 
 export function printfKind(st: FileStat): PrintfKind {
@@ -174,6 +179,7 @@ export function expandPrintf(
   startBase: string,
   st: PrintfStatFacts | null,
   warnings: string[],
+  identity: Identity | null = null,
 ): string {
   const out: string[] = []
   let i = 0
@@ -232,6 +238,10 @@ export function expandPrintf(
       } else {
         out.push(kind)
       }
+    } else if (code === 'u' || code === 'U') {
+      out.push(ownerName(st?.uid ?? null, identity))
+    } else if (code === 'g' || code === 'G') {
+      out.push(groupName(st?.gid ?? null, identity))
     } else if (code === 'm') {
       out.push((modeBits(st, kind) & 0o7777).toString(8))
     } else if (code === 'M') {

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/ls.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { IOResult } from '../../../../../io/types.ts'
-import type { NamespaceView } from '../../../../../ops/types.ts'
+import type { NamespaceView, SessionView } from '../../../../../ops/types.ts'
 import type { FileStat, PathSpec } from '../../../../../types.ts'
 import { gnuBasename } from '../../../../../utils/path.ts'
 import type { CommandOpts } from '../../../../config.ts'
@@ -45,6 +45,7 @@ function crossingNs(ns: NamespaceView): NamespaceView {
     ...(ns.links !== undefined ? { links: ns.links } : {}),
     ...(ns.statOverlay !== undefined ? { statOverlay: ns.statOverlay } : {}),
     ...(ns.childMounts !== undefined ? { childMounts: ns.childMounts } : {}),
+    ...(ns.user !== undefined ? { user: ns.user } : {}),
   }
 }
 
@@ -72,10 +73,13 @@ export async function runLs(
   flagKwargs: Record<string, FlagValue>,
   dispatch: DispatchFn,
   ns?: NamespaceView,
+  // The session plane's door, for the profile the group column renders.
+  sessionView?: SessionView,
 ): Promise<CrossResult> {
   const opts: CommandOpts = {
     ...crossOpts(flagKwargs),
     ...(ns !== undefined ? { ns: crossingNs(ns) } : {}),
+    ...(sessionView !== undefined ? { sessionView } : {}),
   }
   const result = await lsGeneric(
     flatten(scopes),

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/relay.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/relay.ts
@@ -25,7 +25,7 @@ import { runTar } from './tar.ts'
 import { runUnzip } from './unzip.ts'
 import { Cmd, type CrossResult, type DispatchFn } from '../types.ts'
 import type { FlagValue } from '../../../../spec/types.ts'
-import type { NamespaceView } from '../../../../../ops/types.ts'
+import type { NamespaceView, SessionView } from '../../../../../ops/types.ts'
 
 // Run a command whose work must see every operand at once. Pure wiring:
 // every operand is read or written through dispatch primitives on its owning
@@ -44,8 +44,11 @@ export async function runRelay(
   // Name-plane facts for the generics that render them (ls: links, attr
   // overlay, child mounts).
   ns?: NamespaceView,
+  // The session plane's door, for the generic that renders the session's
+  // profile (ls -l).
+  sessionView?: SessionView,
 ): Promise<CrossResult> {
-  if (cmdName === Cmd.LS) return runLs(scopes, flagKwargs, dispatch, ns)
+  if (cmdName === Cmd.LS) return runLs(scopes, flagKwargs, dispatch, ns, sessionView)
   if (cmdName === Cmd.CP) return runCp(scopes, flagKwargs, dispatch, storageKey)
   if (cmdName === Cmd.MV) return runMv(scopes, flagKwargs, dispatch, storageKey)
   if (cmdName === Cmd.DIFF) return runDiff(scopes, flagKwargs, dispatch)

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/route.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/route.ts
@@ -14,7 +14,7 @@
 
 import { IOResult, type ByteSource } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
-import type { NamespaceView } from '../../../../ops/types.ts'
+import type { NamespaceView, SessionView } from '../../../../ops/types.ts'
 import { formatFsError, isFsError } from '../../../../utils/errors.ts'
 import { strategyFor } from './detect.ts'
 import { runFanout } from './fanout/index.ts'
@@ -44,6 +44,9 @@ export async function handleCrossMount(
   storageKey?: (path: PathSpec) => string,
   // Name-plane facts for the RELAY generics that render them (ls).
   ns?: NamespaceView,
+  // The session plane's door, for the RELAY generic that renders the
+  // session's profile (ls).
+  sessionView?: SessionView,
 ): Promise<CrossResult> {
   try {
     // isCrossMount gated on CROSS_MOUNT_COMMANDS membership, so the name is
@@ -51,7 +54,16 @@ export async function handleCrossMount(
     const cmd = cmdName as Cmd
     const strategy = strategyFor(cmd, flagKwargs)
     if (strategy === Strategy.RELAY) {
-      return await runRelay(cmd, scopes, textArgs, flagKwargs, dispatch, storageKey, ns)
+      return await runRelay(
+        cmd,
+        scopes,
+        textArgs,
+        flagKwargs,
+        dispatch,
+        storageKey,
+        ns,
+        sessionView,
+      )
     }
     if (strategy === Strategy.STREAM) {
       return await runStream(cmd, scopes, textArgs, flagKwargs, runSingle)

--- a/typescript/packages/core/src/commands/builtin/generic/find.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.ts
@@ -37,6 +37,7 @@ import {
   type PredNode,
 } from '../find_eval.ts'
 import { expandPrintf, printfKind, printfNeedsStat, type PrintfStatFacts } from '../find_printf.ts'
+import { identityOf } from '../utils/identity.ts'
 import type { LinkView } from '../../../ops/types.ts'
 import { pathAllowed } from '../../../context/session_context.ts'
 import { compareCodePoints } from '../../../utils/sort.ts'
@@ -548,6 +549,8 @@ async function printfStat(
       mtimeEpoch: modifiedTs(linkRow.modified ?? null) ?? 0,
       mode: linkRow.mode,
       targetKind: target === null ? 'N' : printfKind(target),
+      uid: linkRow.uid,
+      gid: linkRow.gid,
     }
   }
   let st: FileStat | null = null
@@ -577,6 +580,8 @@ async function printfStat(
     mtimeEpoch: modifiedTs(st.modified ?? null) ?? 0,
     mode: st.mode,
     targetKind: null,
+    uid: st.uid,
+    gid: st.gid,
   }
 }
 
@@ -600,7 +605,7 @@ async function renderPrintfRows(
   for (const [row, root] of pairs) {
     const st = needs ? await printfStat(row, root, stat, opts) : null
     const base = root.rawPath !== '' ? root.rawPath : root.virtual
-    parts.push(expandPrintf(fmt, row, base, st, warnings))
+    parts.push(expandPrintf(fmt, row, base, st, warnings, identityOf(opts)))
   }
   const err = [...missing, ...warnings]
   const io = new IOResult({

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -20,6 +20,7 @@ import { FileStat, FileType, PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import type { ChildMounts, LinkView, MountView, StatPath } from '../../../ops/types.ts'
 import { formatLsLong } from '../utils/formatting.ts'
+import { identityOf, type Identity } from '../utils/identity.ts'
 import { gnuStrerror, isEacces, isWalkError } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 import { CycleError, respellOne } from '../../../utils/path.ts'
@@ -124,10 +125,11 @@ function appendListing(
   long: boolean,
   human: boolean,
   classify: boolean,
+  identity: Identity,
   lines: string[],
 ): void {
   if (long) {
-    for (const line of formatLsLong(stats, { human })) lines.push(line)
+    for (const line of formatLsLong(stats, { human, identity })) lines.push(line)
     return
   }
   for (const s of stats) lines.push(formatShort(s, classify))
@@ -462,6 +464,7 @@ export async function lsGeneric(
   const sortBy: SortBy = fl.asBool('t') ? 'time' : fl.asBool('S') ? 'size' : 'name'
   const links = opts.ns?.links ?? null
   const deref = fl.asBool('L')
+  const identity = identityOf(opts)
   const warnings: LsWarning[] = []
   const lines: string[] = []
 
@@ -494,7 +497,7 @@ export async function lsGeneric(
       }
     }
     const rows = collected.length > 1 ? sortStats(collected, sortBy, reverse) : collected
-    appendListing(rows, long, human, classify, lines)
+    appendListing(rows, long, human, classify, identity, lines)
     return finish(lines, warnings)
   }
 
@@ -519,7 +522,7 @@ export async function lsGeneric(
   // (or under -R); a lone directory operand is listed bare.
   const headed = recursive || targets.length > 1
   const rows = operands.flatMap((o) => (o.row !== null ? [o.row] : []))
-  appendListing(rows, long, human, classify, lines)
+  appendListing(rows, long, human, classify, identity, lines)
   let printed = rows.length > 0
   for (const operand of operands) {
     for (const [dirSpec, entries] of operand.groups) {
@@ -527,7 +530,7 @@ export async function lsGeneric(
         if (printed) lines.push('')
         lines.push(`${respellOne(dirSpec.virtual, operand.path.virtual, operand.path.rawPath)}:`)
       }
-      appendListing(entries, long, human, classify, lines)
+      appendListing(entries, long, human, classify, identity, lines)
       printed = true
     }
   }

--- a/typescript/packages/core/src/commands/builtin/generic/stat.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/stat.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from 'vitest'
 import { materialize } from '../../../io/types.ts'
 import { OpsRegistry, type RegisteredOp } from '../../../ops/registry.ts'
+import { parseSessionProfile } from '../../../policy/profile.ts'
 import { RAMResource } from '../../../resource/ram/ram.ts'
 import { type CommandOpts } from '../../config.ts'
 import {
@@ -185,10 +186,10 @@ describe('stat -c directive formatting', () => {
     expect(await render('%N', linkFs('a\tb'))).toBe("'/data/f.txt' -> 'a'$'\\t''b'")
   })
 
-  it('renders owner directives, falling back to "user"', async () => {
+  it('renders owner directives, falling back to "-"', async () => {
     const owned = fs({ uid: 1000, gid: 'dev' })
     expect(await render('%u %U %g %G', owned)).toBe('1000 1000 dev dev')
-    expect(await render('%u %U %g %G', fs({ uid: null, gid: null }))).toBe('user user user user')
+    expect(await render('%u %U %g %G', fs({ uid: null, gid: null }))).toBe('- - - -')
   })
 
   it('renders time directives and epochs', async () => {
@@ -291,17 +292,38 @@ describe('stat -c workspace integration', () => {
     )
     const [code, out] = await run(ws, 'stat -c "%U:%G" /data/f.txt')
     expect(code).toBe(0)
-    expect(out).toBe('agent7:agent7\n')
+    // The owner is the workspace user; the group is the session's
+    // profile, and this session runs under none.
+    expect(out).toBe('agent7:-\n')
   })
 
-  it('falls back to "user" when the workspace is unclaimed', async () => {
+  it('renders the group as the session profile', async () => {
+    const parser = await getTestParser()
+    const resource = new RAMResource()
+    resource.store.files.set('/f.txt', new TextEncoder().encode('hello'))
+    const ws = new Workspace(
+      { '/data': resource },
+      {
+        mode: MountMode.WRITE,
+        shellParser: parser,
+        agentId: 'agent7',
+        profiles: { admin: parseSessionProfile({}) },
+        profile: 'admin',
+      },
+    )
+    const [code, out] = await run(ws, 'stat -c "%U:%G" /data/f.txt')
+    expect(code).toBe(0)
+    expect(out).toBe('agent7:admin\n')
+  })
+
+  it('falls back to "-" when the workspace is unclaimed', async () => {
     const parser = await getTestParser()
     const resource = new RAMResource()
     resource.store.files.set('/f.txt', new TextEncoder().encode('hello'))
     const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE, shellParser: parser })
     const [code, out] = await run(ws, 'stat -c "%U:%G" /data/f.txt')
     expect(code).toBe(0)
-    expect(out).toBe('user:user\n')
+    expect(out).toBe('-:-\n')
   })
 
   it('agrees with ls -l on owner', async () => {
@@ -314,7 +336,7 @@ describe('stat -c workspace integration', () => {
     )
     const [, statOwner] = await run(ws, 'stat -c "%U %G" /data/f.txt')
     const [, lsLong] = await run(ws, 'ls -l /data/f.txt')
-    expect(statOwner.trim()).toBe('agent7 agent7')
-    expect(lsLong).toContain('agent7 agent7')
+    expect(statOwner.trim()).toBe('agent7 -')
+    expect(lsLong).toContain(' 1 agent7 - ')
   })
 })

--- a/typescript/packages/core/src/commands/builtin/generic/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/stat.ts
@@ -28,11 +28,10 @@ import { fsErrorLine, isFsError } from '../../../utils/errors.ts'
 import { deviceRdev } from '../../../utils/stat_view.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { lsModeString } from '../utils/formatting.ts'
+import { groupName, identityOf, ownerName, type Identity } from '../utils/identity.ts'
 import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
-
-const DEFAULT_OWNER = 'user'
 
 const TYPE_LABELS: Record<string, string> = {
   [FileType.DIRECTORY]: 'directory',
@@ -62,10 +61,6 @@ function typeBits(s: FileStat): number {
   if (s.type === FileType.SYMLINK) return 0o120000
   if (s.type === FileType.CHAR_DEVICE) return 0o020000
   return 0o100000
-}
-
-function owner(value: number | string | null): string {
-  return value !== null ? String(value) : DEFAULT_OWNER
 }
 
 function epoch(iso: string | null): string {
@@ -173,7 +168,12 @@ function applyFlags(
   return value
 }
 
-function directiveValue(spec: string, s: FileStat, name: string): string {
+function directiveValue(
+  spec: string,
+  s: FileStat,
+  name: string,
+  identity: Identity | null,
+): string {
   if (spec === '%') return '%'
   if (spec === 'n') return name
   if (spec === 's') return String(s.size ?? 0)
@@ -181,8 +181,8 @@ function directiveValue(spec: string, s: FileStat, name: string): string {
   if (spec === 'a') return effectiveMode(s).toString(8)
   if (spec === 'A') return lsModeString(s)
   if (spec === 'f') return (typeBits(s) | effectiveMode(s)).toString(16)
-  if (spec === 'u' || spec === 'U') return owner(s.uid)
-  if (spec === 'g' || spec === 'G') return owner(s.gid)
+  if (spec === 'u' || spec === 'U') return ownerName(s.uid, identity)
+  if (spec === 'g' || spec === 'G') return groupName(s.gid, identity)
   if (spec === 'x') return s.atime ?? s.modified ?? ''
   if (spec === 'X') return epoch(s.atime ?? s.modified)
   if (spec === 'y' || spec === 'z') return s.modified ?? ''
@@ -219,7 +219,12 @@ function nameParts(s: FileStat, name: string, quoted: boolean): string[] {
   return quoted ? parts.map(quoteName) : parts
 }
 
-function renderDirective(d: FormatDirective, s: FileStat, name: string): string {
+function renderDirective(
+  d: FormatDirective,
+  s: FileStat,
+  name: string,
+  identity: Identity | null,
+): string {
   if (d.spec === 'N') {
     // GNU formats the name and a symlink's target as two separate fields,
     // so a width pads each one rather than the joined line.
@@ -228,7 +233,13 @@ function renderDirective(d: FormatDirective, s: FileStat, name: string): string 
       .map((part) => applyFlags(part, d.flags, d.width, d.precision, d.spec))
       .join(' -> ')
   }
-  return applyFlags(directiveValue(d.spec, s, name), d.flags, d.width, d.precision, d.spec)
+  return applyFlags(
+    directiveValue(d.spec, s, name, identity),
+    d.flags,
+    d.width,
+    d.precision,
+    d.spec,
+  )
 }
 
 function isAsciiDigit(char: string | undefined): boolean {
@@ -277,7 +288,7 @@ function parseFormatDirective(fmt: string, start: number): FormatDirective | nul
   return { end: cursor, flags, width, precision, spec }
 }
 
-function formatStat(fmt: string, s: FileStat, name: string): string {
+function formatStat(fmt: string, s: FileStat, name: string, identity: Identity | null): string {
   const parts: string[] = []
   let cursor = 0
   while (cursor < fmt.length) {
@@ -293,7 +304,7 @@ function formatStat(fmt: string, s: FileStat, name: string): string {
       cursor = start + 1
       continue
     }
-    parts.push(renderDirective(directive, s, name))
+    parts.push(renderDirective(directive, s, name, identity))
     cursor = directive.end
   }
   return parts.join('')
@@ -312,6 +323,7 @@ export async function statGeneric(
   const lines: string[] = []
   let err = ''
   const links = fl.asBool('L') ? null : (opts.ns?.links ?? null)
+  const identity = identityOf(opts)
   for (const p of paths) {
     // GNU stat lstats: a symlink operand reports the link itself, not
     // its target, unless -L asks to dereference. A link has no backend
@@ -319,7 +331,7 @@ export async function statGeneric(
     const linked = links?.statAt(p.virtual) ?? null
     if (linked !== null) {
       if (fmt !== null) {
-        lines.push(formatStat(fmt, linked, p.rawPath))
+        lines.push(formatStat(fmt, linked, p.rawPath, identity))
       } else {
         const sizeStr = linked.size === null ? 'None' : String(linked.size)
         const modStr = linked.modified ?? 'None'
@@ -339,7 +351,7 @@ export async function statGeneric(
       continue
     }
     if (fmt !== null) {
-      lines.push(formatStat(fmt, s, p.rawPath))
+      lines.push(formatStat(fmt, s, p.rawPath, identity))
     } else {
       const sizeStr = s.size === null ? 'None' : String(s.size)
       const modStr = s.modified ?? 'None'

--- a/typescript/packages/core/src/commands/builtin/utils/formatting.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/formatting.ts
@@ -14,6 +14,7 @@
 
 import { DEVICE_NUMBERS_KEY, FileType, LINK_TARGET_KEY, type FileStat } from '../../../types.ts'
 import { DEFAULT_MODES, EPOCH_LS_TIME, MONTHS, NUMERIC_PREFIX, TYPE_CHARS } from './constants.ts'
+import { UNKNOWN_NAME, groupName, ownerName, type Identity } from './identity.ts'
 
 /**
  * GNU's `human_readable` rounding, shared by `-h` and `-H`.
@@ -110,8 +111,9 @@ function lsTimeString(modified: string | null | undefined): string {
 
 export interface LsLongOptions {
   human?: boolean
-  owner?: string
-  group?: string
+  // Who the session is; null outside a workspace, where both the owner
+  // and the group column fall back to `-`.
+  identity?: Identity | null
   sizeWidth?: number
 }
 
@@ -122,28 +124,37 @@ function lsName(s: FileStat): string {
   return typeof target === 'string' && target !== '' ? `${s.name} -> ${target}` : s.name
 }
 
+// The size and time columns of one `ls -l` row. A device row carries its
+// major and minor numbers where GNU puts them. An entry with neither a
+// size nor a time (a synthetic API-backend directory) shows `-` in both
+// rather than inventing size 0 and the epoch, mirroring the python
+// formatter.
+function lsSizeAndTime(s: FileStat, human: boolean): [string, string] {
+  const device = s.extra[DEVICE_NUMBERS_KEY]
+  if (Array.isArray(device) && device.length === 2) {
+    const time = s.modified == null ? UNKNOWN_NAME : lsTimeString(s.modified)
+    return [`${String(device[0])}, ${String(device[1])}`, time]
+  }
+  if (s.size == null && s.modified == null) return [UNKNOWN_NAME, UNKNOWN_NAME]
+  const size = human ? humanSize(s.size ?? 0) : String(s.size ?? 0)
+  return [size, lsTimeString(s.modified)]
+}
+
+// `ls -l` rows: mode, links, owner, group, size, time, name. The owner is
+// the entry's uid when a backend or the attr overlay reports one, else
+// the workspace user; the group is the gid, else the session's profile;
+// `-` when nothing names one.
 export function formatLsLong(stats: readonly FileStat[], opts: LsLongOptions = {}): string[] {
-  const owner = opts.owner ?? 'user'
-  const group = opts.group ?? 'user'
+  const identity = opts.identity ?? null
   const human = opts.human ?? false
-  const sizes = stats.map((s) => (human ? humanSize(s.size ?? 0) : String(s.size ?? 0)))
-  const width = opts.sizeWidth ?? sizes.reduce((m, s) => Math.max(m, s.length), 1)
+  const columns = stats.map((s) => lsSizeAndTime(s, human))
+  const width = opts.sizeWidth ?? columns.reduce((m, [size]) => Math.max(m, size.length), 1)
   return stats.map((s, i) => {
+    const [rawSize, time] = columns[i] ?? [UNKNOWN_NAME, UNKNOWN_NAME]
     const mode = lsModeString(s)
-    const device = s.extra[DEVICE_NUMBERS_KEY]
-    if (Array.isArray(device) && device.length === 2) {
-      return `${mode}\t${String(device[0])}, ${String(device[1])}\t-\t${lsName(s)}`
-    }
-    // Metadata-less entries (synthetic API-backend directories) render the
-    // compact placeholder form instead of inventing size 0 + epoch mtime,
-    // mirroring the python formatter.
-    if (s.size == null && s.modified == null) {
-      return `${mode}\t-\t-\t${lsName(s)}`
-    }
-    const size = padLeft(sizes[i] ?? '0', width)
-    const time = lsTimeString(s.modified)
-    const who = s.uid !== null ? String(s.uid) : owner
-    const grp = s.gid !== null ? String(s.gid) : group
+    const size = padLeft(rawSize, width)
+    const who = ownerName(s.uid, identity)
+    const grp = groupName(s.gid, identity)
     return `${mode} 1 ${who} ${grp} ${size} ${time} ${lsName(s)}`
   })
 }

--- a/typescript/packages/core/src/commands/builtin/utils/identity.test.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/identity.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { parseSessionProfile } from '../../../policy/profile.ts'
+import { RAMResource } from '../../../resource/ram/ram.ts'
+import { MountMode } from '../../../types.ts'
+import { getTestParser } from '../../../workspace/fixtures/workspace_fixture.ts'
+import { Session } from '../../../workspace/session/session.ts'
+import { sessionView } from '../../../workspace/session/state.ts'
+import type { WorkspaceOptions } from '../../../workspace/workspace/types.ts'
+import { Workspace } from '../../../workspace/workspace/workspace.ts'
+import { NO_IDENTITY, groupName, identityFrom, identityOf, ownerName } from './identity.ts'
+
+describe('identity', () => {
+  it('prefers the entry, then the identity, then "-"', () => {
+    const identity = { user: 'alice', profile: 'admin' }
+    expect(ownerName(501, identity)).toBe('501')
+    expect(ownerName(null, identity)).toBe('alice')
+    expect(ownerName(null, { user: null, profile: 'admin' })).toBe('-')
+    expect(ownerName(null, null)).toBe('-')
+    expect(groupName('staff', identity)).toBe('staff')
+    expect(groupName(null, identity)).toBe('admin')
+    expect(groupName(null, { user: 'alice', profile: null })).toBe('-')
+    expect(groupName(null, NO_IDENTITY)).toBe('-')
+  })
+
+  it('reads the name plane and the session plane', () => {
+    const session = new Session({ sessionId: 's', profile: 'admin' })
+    const view = sessionView(session)
+    const ns = { user: 'alice' }
+    expect(identityFrom(ns, view)).toEqual({ user: 'alice', profile: 'admin' })
+    expect(identityFrom(undefined, undefined)).toEqual(NO_IDENTITY)
+    expect(
+      identityOf({ stdin: null, flags: {}, filetypeFns: null, cwd: '/', ns, sessionView: view }),
+    ).toEqual({
+      user: 'alice',
+      profile: 'admin',
+    })
+    expect(identityOf({ stdin: null, flags: {}, filetypeFns: null, cwd: '/' })).toEqual(NO_IDENTITY)
+  })
+})
+
+async function run(ws: Workspace, line: string, sessionId?: string): Promise<[number, string]> {
+  const io = await ws.execute(line, sessionId === undefined ? {} : { sessionId })
+  return [io.exitCode, io.stdoutText]
+}
+
+async function makeWs(options: Partial<WorkspaceOptions> = {}): Promise<Workspace> {
+  const parser = await getTestParser()
+  const resource = new RAMResource()
+  resource.store.files.set('/f.txt', new TextEncoder().encode('hello'))
+  return new Workspace(
+    { '/data': resource },
+    { mode: MountMode.WRITE, shellParser: parser, ...options },
+  )
+}
+
+describe('identity in a workspace', () => {
+  it('ls, stat and find render the user and the profile', async () => {
+    const ws = await makeWs({
+      agentId: 'alice',
+      profiles: { admin: parseSessionProfile({}) },
+      profile: 'admin',
+    })
+    expect((await run(ws, 'ls -l /data/f.txt'))[1]).toBe(
+      '-rw-r--r-- 1 alice admin 5 Jan  1 00:00 /data/f.txt\n',
+    )
+    expect((await run(ws, 'stat -c "%U %G" /data/f.txt'))[1]).toBe('alice admin\n')
+    expect((await run(ws, "find /data -type f -printf '%u %g %p\\n'"))[1]).toBe(
+      'alice admin /data/f.txt\n',
+    )
+    expect((await run(ws, 'whoami'))[1]).toBe('alice\n')
+    await ws.close()
+  })
+
+  it('renders a missing user or profile as "-"', async () => {
+    const ws = await makeWs()
+    expect((await run(ws, 'ls -l /data/f.txt'))[1]).toBe(
+      '-rw-r--r-- 1 - - 5 Jan  1 00:00 /data/f.txt\n',
+    )
+    expect((await run(ws, 'stat -c "%U %G" /data/f.txt'))[1]).toBe('- -\n')
+    await ws.close()
+  })
+
+  it('a named session reports its own profile', async () => {
+    const ws = await makeWs({
+      agentId: 'alice',
+      profiles: { default: parseSessionProfile({}), reviewer: parseSessionProfile({}) },
+    })
+    expect((await run(ws, 'stat -c "%G" /data/f.txt'))[1]).toBe('default\n')
+    ws.createSession('r1', { profile: 'reviewer' })
+    expect((await run(ws, 'stat -c "%G" /data/f.txt', 'r1'))[1]).toBe('reviewer\n')
+    await ws.close()
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/utils/identity.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/identity.ts
@@ -1,0 +1,69 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+import type { NamespaceView, SessionView } from '../../../ops/types.ts'
+import type { CommandOpts } from '../../config.ts'
+
+// What an owner or group column prints when nothing names one: no uid on
+// the entry and no workspace user, or no gid and no profile.
+export const UNKNOWN_NAME = '-'
+
+/**
+ * Who a session is, in the two words POSIX renders as owner and group.
+ *
+ * The user is the workspace user (what `whoami` prints, the launch
+ * `agentId`); the profile is the permission set the session acts with,
+ * which is what a group is. A backend that reports a uid or gid on an
+ * entry (disk, or a `chown` held in the attr overlay) wins over both, so
+ * `ls -l`, `stat %U %G` and `find -printf %u %g` all agree on one rule.
+ */
+export interface Identity {
+  readonly user: string | null
+  readonly profile: string | null
+}
+
+export const NO_IDENTITY: Identity = { user: null, profile: null }
+
+/** The identity two planes' views describe; either view may be absent outside a workspace. */
+export function identityFrom(
+  ns: NamespaceView | undefined,
+  sessionView: SessionView | undefined,
+): Identity {
+  return {
+    user: ns?.user ?? null,
+    profile: sessionView?.profile() ?? null,
+  }
+}
+
+/** The identity a command invocation runs as, read off its opts. */
+export function identityOf(opts: CommandOpts): Identity {
+  return identityFrom(opts.ns, opts.sessionView)
+}
+
+/** The owner column: the entry's own uid, else the workspace user, else `-`. */
+export function ownerName(
+  uid: number | string | null | undefined,
+  identity: Identity | null,
+): string {
+  if (uid !== null && uid !== undefined) return String(uid)
+  return identity?.user ?? UNKNOWN_NAME
+}
+
+/** The group column: the entry's own gid, else the session's profile, else `-`. */
+export function groupName(
+  gid: number | string | null | undefined,
+  identity: Identity | null,
+): string {
+  if (gid !== null && gid !== undefined) return String(gid)
+  return identity?.profile ?? UNKNOWN_NAME
+}

--- a/typescript/packages/core/src/commands/builtin/utils/utils.test.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/utils.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { FileStat, FileType } from '../../../types.ts'
+import { DEVICE_NUMBERS_KEY, FileStat, FileType } from '../../../types.ts'
 import { formatLsLong, humanSize } from './formatting.ts'
 import { readStdinAsync, resolveSource, wrapBytes } from './stream.ts'
 
@@ -73,7 +73,51 @@ describe('formatLsLong', () => {
       modified: '2026-01-01T00:00:00Z',
     })
     const [line] = formatLsLong([stat])
-    expect(line).toBe('-rw-r--r-- 1 user user 5 Jan  1 00:00 file.txt')
+    expect(line).toBe('-rw-r--r-- 1 - - 5 Jan  1 00:00 file.txt')
+  })
+
+  it('renders the owner as the user and the group as the profile', () => {
+    const stat = new FileStat({
+      name: 'file.txt',
+      size: 5,
+      type: FileType.TEXT,
+      modified: '2026-01-01T00:00:00Z',
+    })
+    const identity = { user: 'alice', profile: 'admin' }
+    expect(formatLsLong([stat], { identity })[0]).toBe(
+      '-rw-r--r-- 1 alice admin 5 Jan  1 00:00 file.txt',
+    )
+    // A reported uid/gid (disk, or a chown in the overlay) wins over both.
+    const owned = stat.with({ uid: 501, gid: 'staff' })
+    expect(formatLsLong([owned], { identity })[0]).toBe(
+      '-rw-r--r-- 1 501 staff 5 Jan  1 00:00 file.txt',
+    )
+    // Half an identity fills half the columns.
+    expect(formatLsLong([stat], { identity: { user: null, profile: 'admin' } })[0]).toBe(
+      '-rw-r--r-- 1 - admin 5 Jan  1 00:00 file.txt',
+    )
+  })
+
+  it('keeps the owner columns on a metadata-less row', () => {
+    // A synthetic directory with neither size nor mtime shows `-` for
+    // both rather than inventing size 0 and the epoch, and still names
+    // who the session is.
+    const stat = new FileStat({ name: 'dev', type: FileType.DIRECTORY })
+    expect(formatLsLong([stat])[0]).toBe('drwxr-xr-x 1 - - - - dev')
+    expect(formatLsLong([stat], { identity: { user: null, profile: 'admin' } })[0]).toBe(
+      'drwxr-xr-x 1 - admin - - dev',
+    )
+  })
+
+  it('renders a device row with its numbers in the size column', () => {
+    const nul = new FileStat({
+      name: 'null',
+      type: FileType.CHAR_DEVICE,
+      extra: { [DEVICE_NUMBERS_KEY]: [1, 3] },
+    })
+    expect(formatLsLong([nul], { identity: { user: 'alice', profile: null } })[0]).toBe(
+      'crw-rw-rw- 1 alice - 1, 3 - null',
+    )
   })
 
   it('emits "d" type char and dir perms for directories', () => {

--- a/typescript/packages/core/src/ops/types.ts
+++ b/typescript/packages/core/src/ops/types.ts
@@ -123,6 +123,11 @@ export interface SessionView {
   mark(name: string, attr: VarAttr | null, on: boolean): Promise<void>
   // Whether `readonly` has marked the name.
   isReadonly(name: string): boolean
+  // The name of the profile the session runs under, null for an
+  // unrestricted session. What an owner-rendering command (ls -l, stat
+  // %g, find -printf %g) prints in the group column: the profile is the
+  // permission set the session acts with, which is what a group is.
+  profile(): string | null
 }
 
 // The symlink facts a command may consult, as one injected object.
@@ -174,4 +179,8 @@ export interface NamespaceView {
   statOverlay?: StatOverlay
   // Child names the namespace owes a directory (mounts and links).
   childMounts?: ChildMounts
+  // The workspace user (what whoami prints), absent when no agent ever
+  // claimed the workspace. What an owner-rendering command prints in the
+  // owner column for an entry whose backend reports no uid.
+  user?: string
 }

--- a/typescript/packages/core/src/policy/profile.ts
+++ b/typescript/packages/core/src/policy/profile.ts
@@ -171,6 +171,8 @@ export interface CompiledProfile {
   readonly shownPaths?: ShownPaths | null
   /** The operator's reasons for grouped hides, never rendered to the agent. */
   readonly hideReasons?: readonly HideReason[]
+  /** The profile's name, null for a document passed without one; the session's group. */
+  readonly profile?: string | null
 }
 
 const RULE_FIELDS = ['reason', 'commands', 'paths'] as const

--- a/typescript/packages/core/src/workspace/executor/builtins/metadata/metadata.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/metadata/metadata.test.ts
@@ -181,7 +181,7 @@ describe('chmod/chown/touch (namespace-routed metadata commands)', () => {
     const [, out] = await run(ws, 'ls -l /data')
     // The mode lands on the target, not the link. The link's own row is
     // listed too and is wider, so the size column pads f.txt's 5.
-    expect(out).toContain('-rw-r----- 1 user user  5')
+    expect(out).toContain('-rw-r----- 1 - -  5')
     expect(out).toContain('lrwxrwxrwx')
     await ws.close()
   })
@@ -321,7 +321,7 @@ describe('chmod/chown/touch (namespace-routed metadata commands)', () => {
     const [code, , err] = await run(ws, 'chgrp staff /data/f.txt')
     expect(code, err).toBe(0)
     const [, out] = await run(ws, 'ls -l /data')
-    expect(out).toContain(' user staff ')
+    expect(out).toContain(' - staff ')
     await ws.close()
   })
 
@@ -447,7 +447,7 @@ describe('recursive metadata flags (-R)', () => {
     const [code] = await run(ws, 'chown -R bob /data/dirlink')
     expect(code).toBe(0)
     const [, out] = await run(ws, "stat -c '%U %n' /data/dirlink /data/tree/sub/b.txt")
-    expect(out.trimEnd().split('\n')).toEqual(['bob /data/dirlink', 'user /data/tree/sub/b.txt'])
+    expect(out.trimEnd().split('\n')).toEqual(['bob /data/dirlink', '- /data/tree/sub/b.txt'])
     await ws.close()
   })
 

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -297,6 +297,7 @@ export async function handleCommand(
       cmdStr,
       makeStorageKey(registry),
       csNs,
+      sessionView(session, registry.policies),
     )
     if (csParsed.warnings.length > 0) {
       const csWarn = new TextEncoder().encode(

--- a/typescript/packages/core/src/workspace/executor/command/run.ts
+++ b/typescript/packages/core/src/workspace/executor/command/run.ts
@@ -113,15 +113,13 @@ function scalarFindFlags(flagKwargs: Flags): Flags {
   return out
 }
 
-// Merge namespace attr overlays into one stat row (ls/stat rendering). A path
-// never chown'd defaults its owner to the workspace user (the launch agent,
-// what whoami reports) so ls -l and stat -c agree; an unclaimed workspace
-// leaves uid/gid null and the formatters fall back to the neutral "user".
+// Merge namespace attr overlays into one stat row (ls/stat rendering). Only
+// what chmod/chown/chgrp/touch recorded: a path never chown'd keeps uid and
+// gid null, and the owner-rendering commands fall back through `Identity`
+// (the workspace user for the owner, the session's profile for the group),
+// which is the one rule ls -l, stat -c and find -printf share.
 function namespaceStatOverlay(namespace: Namespace, virtual: string, stat: FileStat): FileStat {
-  const merged = mergeOverlayStat(namespace.metaFor(virtual), stat)
-  const user = namespace.user
-  if (user === null || (merged.uid !== null && merged.gid !== null)) return merged
-  return merged.with({ uid: merged.uid ?? user, gid: merged.gid ?? user })
+  return mergeOverlayStat(namespace.metaFor(virtual), stat)
 }
 
 /**
@@ -384,8 +382,8 @@ function linkView(
 }
 
 // The name plane's facts on offer, bundled as one view: symlinks, mount
-// boundaries, the attr overlay, and the child names the namespace owes a
-// directory. Which commands receive it is decided by whether the handler
+// boundaries, the attr overlay, the child names the namespace owes a
+// directory, and the workspace user. Which commands receive it is decided by whether the handler
 // reads `ns` off its context, so there is no list of aware commands to
 // keep in step here or anywhere else. Exported for the mount fan-out,
 // which reaches `executeCmd` without going through `runOnMount` and
@@ -405,5 +403,6 @@ export function namespaceViewOf(
     mounts: mountView(registry),
     ...(statOverlay !== null ? { statOverlay } : {}),
     childMounts: (parent: string) => namespaceNames(registry.mountPrefixes(), namespace, parent),
+    ...(namespace !== null && namespace.user !== null ? { user: namespace.user } : {}),
   }
 }

--- a/typescript/packages/core/src/workspace/executor/cross_mount.ts
+++ b/typescript/packages/core/src/workspace/executor/cross_mount.ts
@@ -18,7 +18,7 @@ import {
   type RunSingle,
 } from '../../commands/builtin/generic/crossmount/index.ts'
 import { materialize, type ByteSource, type IOResult } from '../../io/types.ts'
-import type { NamespaceView } from '../../ops/types.ts'
+import type { NamespaceView, SessionView } from '../../ops/types.ts'
 import type { PathSpec } from '../../types.ts'
 import { ExecutionNode } from '../types.ts'
 import type { FlagValue } from '../../commands/spec/types.ts'
@@ -44,6 +44,7 @@ export async function handleCrossMount(
   cmdStr: string,
   storageKey?: (path: PathSpec) => string,
   ns?: NamespaceView,
+  sessionView?: SessionView,
 ): Promise<Result> {
   const [stdout, io] = await routeCrossMount(
     cmdName,
@@ -55,6 +56,7 @@ export async function handleCrossMount(
     stdin,
     storageKey,
     ns,
+    sessionView,
   )
   const stderrBytes = await materialize(io.stderr)
   const exec = new ExecutionNode({ command: cmdStr, stderr: stderrBytes, exitCode: io.exitCode })

--- a/typescript/packages/core/src/workspace/session/resolve.test.ts
+++ b/typescript/packages/core/src/workspace/session/resolve.test.ts
@@ -247,6 +247,20 @@ describe('compileProfile', () => {
     expect(out.cwd).toBe('/scratch')
   })
 
+  it('carries the name, which narrow stamps onto the session', () => {
+    const profile = parseSessionProfile({ cwd: '/scratch' })
+    expect(compileProfile(profile, 'reviewer').profile).toBe('reviewer')
+    const session = new Session({ sessionId: 's1' })
+    narrow(session, compileProfile(profile, 'reviewer'))
+    expect(session.profile).toBe('reviewer')
+    // A document passed without a name, and no document at all, leave
+    // the session with no profile to report.
+    expect(compileProfile(profile).profile).toBeNull()
+    expect(compileProfile(null).profile).toBeNull()
+    narrow(session, compileProfile(null))
+    expect(session.profile).toBeNull()
+  })
+
   it('collects the hides of every mount section, anchored to it', () => {
     const out = compileProfile(
       parseSessionProfile({
@@ -283,6 +297,7 @@ describe('compileProfile', () => {
       script: null,
       shownPaths: null,
       hideReasons: [],
+      profile: null,
     })
     expect(compileProfile({})).toEqual(empty)
     // A profile that names a mount without a mode narrows nothing: the

--- a/typescript/packages/core/src/workspace/session/resolve.ts
+++ b/typescript/packages/core/src/workspace/session/resolve.ts
@@ -389,6 +389,7 @@ export function compileProfile(effective: SessionProfile | null, name = ''): Com
       script: null,
       shownPaths: null,
       hideReasons: [],
+      profile: name === '' ? null : name,
     }
   }
   const commands = compileCommands(effective)
@@ -403,6 +404,7 @@ export function compileProfile(effective: SessionProfile | null, name = ''): Com
     script: compileScript(effective, name),
     shownPaths: shownOf(effective),
     hideReasons: hideReasonsOf(effective),
+    profile: name === '' ? null : name,
   }
 }
 
@@ -410,7 +412,7 @@ export function compileProfile(effective: SessionProfile | null, name = ''): Com
  * Stamp a compiled profile's narrowing onto a session: the fields no
  * shell line can edit (the per-mount modes, hidden paths, show entries,
  * hidden variables, hide reasons, the admission rules, the profile's
- * script). Applied at creation and again
+ * script, the profile's name). Applied at creation and again
  * whenever a stored record could carry a stale copy (the default
  * session after hydration), so the document, not the store, is what an
  * agent runs under.
@@ -423,6 +425,7 @@ export function narrow(session: Session, compiled: CompiledProfile): void {
   session.hideReasons = compiled.hideReasons ?? []
   session.commands = compiled.commands
   session.script = compiled.script ?? null
+  session.profile = compiled.profile ?? null
 }
 
 /**

--- a/typescript/packages/core/src/workspace/session/session.test.ts
+++ b/typescript/packages/core/src/workspace/session/session.test.ts
@@ -91,6 +91,17 @@ describe('Session', () => {
     expect(restored.mountModes?.get('/scratch')).toBe(MountMode.WRITE)
   })
 
+  it('round-trips the profile name and omits it when none', () => {
+    expect('profile' in new Session({ sessionId: 'a' }).toJSON()).toBe(false)
+    const original = new Session({ sessionId: 'rt', profile: 'admin' })
+    const json = original.toJSON()
+    expect(json.profile).toBe('admin')
+    expect(Session.fromJSON(json as { session_id: string; profile?: string | null }).profile).toBe(
+      'admin',
+    )
+    expect(original.fork().profile).toBe('admin')
+  })
+
   it('toJSON omits mount_modes when unrestricted', () => {
     const s = new Session({ sessionId: 'x' })
     expect('mount_modes' in s.toJSON()).toBe(false)

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -159,6 +159,12 @@ export interface SessionInit {
    */
   script?: ProfileScript | null
   /**
+   * The name of the profile the session runs under, null for an
+   * unrestricted session. What an owner-rendering command prints as the
+   * group. Stamped by the profile like script, so it persists.
+   */
+  profile?: string | null
+  /**
    * The host's standing answers to asked lines (design 3.9): session
    * state like functions and cwd, persisted, read and written through
    * the manager by id so a fork shares them, never another session's.
@@ -442,6 +448,7 @@ export class Session {
   hideReasons: readonly HideReason[]
   commands: AdmissionRules | null
   script: ProfileScript | null
+  profile: string | null
   decisions: readonly Decision[]
   generation: number
   pipelineTimeoutSeconds: number | null
@@ -467,6 +474,7 @@ export class Session {
     this.hideReasons = init.hideReasons ?? []
     this.commands = init.commands ?? null
     this.script = init.script ?? null
+    this.profile = init.profile ?? null
     this.decisions = init.decisions ?? []
     this.generation = init.generation ?? 0
     this.pipelineTimeoutSeconds = init.pipelineTimeoutSeconds ?? null
@@ -522,6 +530,7 @@ export class Session {
       hideReasons: overrides.hideReasons ?? this.hideReasons,
       commands: overrides.commands ?? this.commands,
       script: overrides.script ?? this.script,
+      profile: overrides.profile ?? this.profile,
       decisions: overrides.decisions ?? this.decisions,
       generation: overrides.generation ?? this.generation,
       pipelineTimeoutSeconds: overrides.pipelineTimeoutSeconds ?? this.pipelineTimeoutSeconds,
@@ -744,6 +753,7 @@ export class Session {
     }
     if (this.commands !== null) data.commands = commandsToJSON(this.commands)
     if (this.script !== null) data.script = scriptToJSON(this.script)
+    if (this.profile !== null) data.profile = this.profile
     if (this.decisions.length > 0) data.decisions = this.decisions.map(decisionToJSON)
     return data
   }
@@ -762,6 +772,7 @@ export class Session {
     hidden_vars?: { names?: string[]; patterns?: string[] } | null
     commands?: CommandsJSON | null
     script?: ScriptJSON | null
+    profile?: string | null
     decisions?: DecisionJSON[] | null
     generation?: number
   }): Session {
@@ -801,6 +812,7 @@ export class Session {
           : [],
       commands: data.commands != null ? commandsFromJSON(data.commands) : null,
       script: data.script != null ? scriptFromJSON(data.script) : null,
+      profile: data.profile ?? null,
       decisions: data.decisions != null ? data.decisions.map(decisionFromJSON) : [],
     })
   }

--- a/typescript/packages/core/src/workspace/session/state.test.ts
+++ b/typescript/packages/core/src/workspace/session/state.test.ts
@@ -58,6 +58,13 @@ describe('sessionView', () => {
     expect('B' in session.env).toBe(false)
   })
 
+  it('profile reads the session profile', () => {
+    const [view, session] = makeView()
+    expect(view.profile()).toBeNull()
+    session.profile = 'admin'
+    expect(view.profile()).toBe('admin')
+  })
+
   it('set and unset write the session', async () => {
     const [view, session] = makeView()
     await view.set('B', '2')

--- a/typescript/packages/core/src/workspace/session/state.ts
+++ b/typescript/packages/core/src/workspace/session/state.ts
@@ -528,5 +528,6 @@ export function sessionView(session: Session, policies: Policies | null = null):
     unset: (name, followRef = true) => unsetVar(session, policies, name, followRef),
     mark: (name, attr, on) => markVar(session, policies, name, attr, on),
     isReadonly: (name) => envIsReadonly(session, name),
+    profile: () => session.profile,
   }
 }

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -74,6 +74,7 @@ import { SecretsError } from '../../secrets/errors.ts'
 import { sourceFor } from '../../secrets/registry.ts'
 import { resolveSources } from '../../secrets/sources.ts'
 import type { ResolvedSource } from '../../secrets/types.ts'
+import { DEFAULT_PROFILE } from '../session/constants.ts'
 import { SessionManager } from '../session/manager.ts'
 import type { WorkspaceFields, WorkspaceStateStore } from '../store/base.ts'
 import { varsFromEntries, type Session } from '../session/session.ts'
@@ -620,6 +621,7 @@ export class Workspace {
   private profileName(profile: string | SessionProfile | null): string {
     if (typeof profile === 'string') return profile
     if (profile === null && this.defaultProfileName !== null) return this.defaultProfileName
+    if (profile === null && DEFAULT_PROFILE in this.profiles) return DEFAULT_PROFILE
     return ''
   }
 


### PR DESCRIPTION
`ls -l`, `stat -c %U:%G` and `find -printf %u %g` now render the owner as the workspace user (what `whoami` prints) and the group as the session's profile name, with `-` when either is absent. An explicit uid/gid on the entry (disk, chown, chgrp) still wins.

- New `Identity` helper in `commands/builtin/utils/identity.{py,ts}` holds the one fallback rule; `ls`, `stat` and `find -printf` read it off `opts`. `find -printf %u %U %g %G` is new in both languages.
- `NamespaceView.user` and `SessionView.profile()` carry the two facts; the cross-mount ls relay threads the session view.
- `Session.profile` is a persisted, inherited field stamped when a profile is applied. A workspace with `profiles.default` and no explicit `profile=` now names its session `default` instead of the empty string.
- The stat overlay no longer defaults uid and gid to the workspace user, so the rule lives in one place.
- Metadata-less `ls -l` rows use the same 7-column shape as every other row.
- Integ: the `statvfs` target gains `profile: ops`, an `auditor` profile and session, and six cases pinning ls, stat, find -printf and whoami under both. Goldens with the old `user` placeholder read `-`.

Python suite, core vitest, core/node typecheck, layout parity and the ram/disk/statvfs integ targets on both hosts are green.
