### PR TITLE
fix(sharepoint): scope the site/drive id cache to the accessor

### DIFF
--- a/integ/runners/python/adapters/__init__.py
+++ b/integ/runners/python/adapters/__init__.py
@@ -48,7 +48,6 @@ from mirage.commands.cli.types import CLISpec
 from mirage.core.databricks_volume.path import configured_root
 from mirage.core.discord.config import DiscordConfig
 from mirage.core.email.config import EmailConfig
-from mirage.core.sharepoint import resolve as sharepoint_resolver
 from mirage.resource.aliyun import AliyunConfig, AliyunResource
 from mirage.resource.backblaze import BackblazeConfig, BackblazeResource
 from mirage.resource.box import BoxConfig, BoxResource
@@ -1500,13 +1499,6 @@ class LinearService:
         return None
 
 
-def _clear_sharepoint_caches() -> None:
-    # The resolver's site/drive id caches are module globals; a fresh
-    # fake tenant per run must not see ids from the previous one.
-    sharepoint_resolver._site_cache.clear()
-    sharepoint_resolver._drive_cache.clear()
-
-
 class JaegerService:
     """Points jaeger mounts at a real jaeger all-in-one container.
 
@@ -1583,7 +1575,6 @@ class SharePointService:
     async def create(cls, run_id: str, target: dict) -> "SharePointService":
         service = cls(f"{run_id}-{target['id']}",
                       os.environ["ONEDRIVE_URL"].rstrip("/"))
-        _clear_sharepoint_caches()
         for mount in target["mounts"]:
             await service.provision(mount)
         return service
@@ -1637,7 +1628,7 @@ class SharePointService:
                              key_prefix=mount.get("prefix")))
 
     async def teardown(self) -> None:
-        _clear_sharepoint_caches()
+        return None
 
 
 class NotionService:

--- a/python/mirage/accessor/sharepoint.py
+++ b/python/mirage/accessor/sharepoint.py
@@ -26,5 +26,24 @@ class SharePointAccessor(SessionAccessor):
     def __init__(self, config: SharePointConfig) -> None:
         super().__init__(timeout=aiohttp.ClientTimeout(total=config.timeout))
         self.config = config
+        # Name -> id lookups for the two namespace levels above a drive item,
+        # so resolving a path does not call /sites and /drives on every op.
+        #
+        # They live on the accessor, not the module, on purpose: one accessor
+        # is one mount is one tenant, and a site name is only unique within a
+        # tenant. A process-wide dict handed tenant B the site id tenant A had
+        # cached under the same name.
+        #
+        # Two dicts because the keys are different shapes. A site is found by
+        # name alone; a drive name is only unique within its site, so its key
+        # must carry the site id.
+        #
+        #   site_cache["Engineering"] = "contoso.sharepoint.com,<site>,<web>"
+        #   site_cache["eng"] = <same id>  (internal name, from site_entries)
+        #   drive_cache[(<that site id>, "Documents")] = "b!driveXYZ"
+        #
+        # Entries are never evicted: a site or drive deleted and recreated
+        # under the same name keeps answering the old id for this accessor's
+        # lifetime.
         self.site_cache: dict[str, str] = {}
         self.drive_cache: dict[tuple[str, str], str] = {}

--- a/python/mirage/accessor/sharepoint.py
+++ b/python/mirage/accessor/sharepoint.py
@@ -26,3 +26,5 @@ class SharePointAccessor(SessionAccessor):
     def __init__(self, config: SharePointConfig) -> None:
         super().__init__(timeout=aiohttp.ClientTimeout(total=config.timeout))
         self.config = config
+        self.site_cache: dict[str, str] = {}
+        self.drive_cache: dict[tuple[str, str], str] = {}

--- a/python/mirage/core/sharepoint/resolve.py
+++ b/python/mirage/core/sharepoint/resolve.py
@@ -19,10 +19,6 @@ class ResolvedPath:
     item_path: str | None = None
 
 
-_site_cache: dict[str, str] = {}
-_drive_cache: dict[tuple[str, str], str] = {}
-
-
 def _scoped_item_path(key_prefix: str | None, raw: str) -> str:
     prefix = (key_prefix or "").strip("/")
     if prefix and raw:
@@ -50,26 +46,28 @@ async def _list_drives(accessor: SharePointAccessor,
 
 async def _resolve_site_id(accessor: SharePointAccessor,
                            site_name: str) -> str | None:
-    if site_name in _site_cache:
-        return _site_cache[site_name]
+    cache = accessor.site_cache
+    if site_name in cache:
+        return cache[site_name]
     sites = await _list_sites(accessor)
     for s in sites:
         display = s.get("displayName", "")
         name = s.get("name", "")
-        _site_cache[display] = s["id"]
-        _site_cache[name] = s["id"]
-    return _site_cache.get(site_name)
+        cache[display] = s["id"]
+        cache[name] = s["id"]
+    return cache.get(site_name)
 
 
 async def _resolve_drive_id(accessor: SharePointAccessor, site_id: str,
                             drive_name: str) -> str | None:
+    cache = accessor.drive_cache
     key = (site_id, drive_name)
-    if key in _drive_cache:
-        return _drive_cache[key]
+    if key in cache:
+        return cache[key]
     drives = await _list_drives(accessor, site_id)
     for d in drives:
-        _drive_cache[(site_id, d.get("name", ""))] = d["id"]
-    return _drive_cache.get(key)
+        cache[(site_id, d.get("name", ""))] = d["id"]
+    return cache.get(key)
 
 
 async def resolve(accessor: SharePointAccessor,
@@ -152,7 +150,10 @@ async def site_entries(accessor: SharePointAccessor) -> list[tuple[str, str]]:
     for s in await _list_sites(accessor):
         display = s.get("displayName", s.get("name", ""))
         entries.append((display, s["id"]))
-        _site_cache[display] = s["id"]
+        accessor.site_cache[display] = s["id"]
+        name = s.get("name", "")
+        if name:
+            accessor.site_cache[name] = s["id"]
     return sorted(entries)
 
 
@@ -183,7 +184,7 @@ async def drive_entries(accessor: SharePointAccessor,
     for d in await _list_drives(accessor, site_id):
         name = d.get("name", "")
         entries.append((name, d["id"]))
-        _drive_cache[(site_id, name)] = d["id"]
+        accessor.drive_cache[(site_id, name)] = d["id"]
     return sorted(entries)
 
 

--- a/python/tests/core/sharepoint/du/test_entries.py
+++ b/python/tests/core/sharepoint/du/test_entries.py
@@ -3,7 +3,6 @@ from aioresponses import aioresponses
 
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.core.sharepoint.du import entries
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -13,21 +12,10 @@ _DRIVE_ID = "b!driveXYZ"
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
-
-
-def _seed_caches():
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-
-
-@pytest.fixture(autouse=True)
-def _reset_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-    yield
-    _site_cache.clear()
-    _drive_cache.clear()
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 def _file_path() -> PathSpec:
@@ -39,7 +27,6 @@ def _file_path() -> PathSpec:
 
 @pytest.mark.asyncio
 async def test_entries_of_file_is_empty():
-    _seed_caches()
     with aioresponses() as m:
         m.get(f"{_BASE}/drives/{_DRIVE_ID}/root:/a.txt",
               payload={

--- a/python/tests/core/sharepoint/du/test_size.py
+++ b/python/tests/core/sharepoint/du/test_size.py
@@ -3,7 +3,6 @@ from aioresponses import aioresponses
 
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.core.sharepoint.du import size
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -13,21 +12,10 @@ _DRIVE_ID = "b!driveXYZ"
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
-
-
-def _seed_caches():
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-
-
-@pytest.fixture(autouse=True)
-def _reset_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-    yield
-    _site_cache.clear()
-    _drive_cache.clear()
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 def _file_path() -> PathSpec:
@@ -39,7 +27,6 @@ def _file_path() -> PathSpec:
 
 @pytest.mark.asyncio
 async def test_size_of_file_returns_its_own_size():
-    _seed_caches()
     with aioresponses() as m:
         m.get(f"{_BASE}/drives/{_DRIVE_ID}/root:/a.txt",
               payload={

--- a/python/tests/core/sharepoint/test_copy.py
+++ b/python/tests/core/sharepoint/test_copy.py
@@ -4,7 +4,6 @@ from aioresponses import CallbackResult, aioresponses
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.core.sharepoint.client import GraphError
 from mirage.core.sharepoint.copy import copy
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -22,7 +21,10 @@ _CONFLICT = {
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 def _spec(rel: str) -> PathSpec:
@@ -30,17 +32,6 @@ def _spec(rel: str) -> PathSpec:
     return PathSpec(resource_path=mount_key(virtual, "/sp"),
                     virtual=virtual,
                     directory=virtual)
-
-
-@pytest.fixture(autouse=True)
-def _seeded_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-    yield
-    _site_cache.clear()
-    _drive_cache.clear()
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/sharepoint/test_mkdir.py
+++ b/python/tests/core/sharepoint/test_mkdir.py
@@ -4,7 +4,6 @@ from aioresponses import CallbackResult, aioresponses
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.core.sharepoint.client import GraphError
 from mirage.core.sharepoint.mkdir import mkdir
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -15,7 +14,10 @@ _DRIVE = f"{_BASE}/drives/{_DRIVE_ID}"
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 def _spec(rel: str) -> PathSpec:
@@ -23,17 +25,6 @@ def _spec(rel: str) -> PathSpec:
     return PathSpec(resource_path=mount_key(virtual, "/sp"),
                     virtual=virtual,
                     directory=virtual)
-
-
-@pytest.fixture(autouse=True)
-def _seeded_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-    yield
-    _site_cache.clear()
-    _drive_cache.clear()
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/sharepoint/test_read.py
+++ b/python/tests/core/sharepoint/test_read.py
@@ -3,7 +3,6 @@ from aioresponses import CallbackResult, aioresponses
 
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.core.sharepoint.read import read_bytes
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -13,25 +12,10 @@ _DRIVE_ID = "b!driveXYZ"
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
-
-
-def _seed_caches():
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-
-
-def _clear_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-
-
-@pytest.fixture(autouse=True)
-def _reset_caches():
-    _clear_caches()
-    _seed_caches()
-    yield
-    _clear_caches()
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/sharepoint/test_readdir.py
+++ b/python/tests/core/sharepoint/test_readdir.py
@@ -6,7 +6,6 @@ from aioresponses import aioresponses
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.cache.index import RAMIndexCacheStore
 from mirage.core.sharepoint.readdir import readdir
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -19,24 +18,10 @@ _DRIVES_RE = re.compile(r".*/sites/.*/drives\??.*")
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
-
-
-def _seed_caches():
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-
-
-def _clear_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-
-
-@pytest.fixture(autouse=True)
-def _reset_caches():
-    _clear_caches()
-    yield
-    _clear_caches()
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 @pytest.mark.asyncio
@@ -68,7 +53,6 @@ async def test_readdir_root_lists_sites():
 
 @pytest.mark.asyncio
 async def test_readdir_site_lists_drives():
-    _site_cache["Engineering"] = _SITE_ID
     index = RAMIndexCacheStore()
     with aioresponses() as m:
         m.get(_DRIVES_RE,
@@ -94,7 +78,6 @@ async def test_readdir_site_lists_drives():
 
 @pytest.mark.asyncio
 async def test_readdir_drive_root_lists_children():
-    _seed_caches()
     index = RAMIndexCacheStore()
     with aioresponses() as m:
         m.get(f"{_BASE}/drives/{_DRIVE_ID}/root/children",
@@ -129,7 +112,6 @@ async def test_readdir_drive_root_lists_children():
 
 @pytest.mark.asyncio
 async def test_readdir_populates_index_with_metadata():
-    _seed_caches()
     index = RAMIndexCacheStore()
     with aioresponses() as m:
         m.get(f"{_BASE}/drives/{_DRIVE_ID}/root/children",
@@ -157,7 +139,6 @@ async def test_readdir_populates_index_with_metadata():
 
 @pytest.mark.asyncio
 async def test_readdir_subfolder():
-    _seed_caches()
     index = RAMIndexCacheStore()
     with aioresponses() as m:
         m.get(f"{_BASE}/drives/{_DRIVE_ID}/root:/src:/children",
@@ -181,7 +162,6 @@ async def test_readdir_subfolder():
 
 @pytest.mark.asyncio
 async def test_readdir_of_file_raises_not_a_directory():
-    _seed_caches()
     index = RAMIndexCacheStore()
     with aioresponses() as m:
         m.get(f"{_BASE}/drives/{_DRIVE_ID}/root:/a.txt:/children",
@@ -207,7 +187,6 @@ async def test_readdir_of_file_raises_not_a_directory():
 
 @pytest.mark.asyncio
 async def test_readdir_cache_hit():
-    _seed_caches()
     index = RAMIndexCacheStore()
     with aioresponses() as m:
         m.get(f"{_BASE}/drives/{_DRIVE_ID}/root/children",

--- a/python/tests/core/sharepoint/test_rename.py
+++ b/python/tests/core/sharepoint/test_rename.py
@@ -4,7 +4,6 @@ from aioresponses import CallbackResult, aioresponses
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.core.sharepoint.client import GraphError
 from mirage.core.sharepoint.rename import rename
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -16,7 +15,10 @@ _CONFLICT = {"error": {"code": "nameAlreadyExists", "message": "x"}}
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 def _spec(rel: str) -> PathSpec:
@@ -24,17 +26,6 @@ def _spec(rel: str) -> PathSpec:
     return PathSpec(resource_path=mount_key(virtual, "/sp"),
                     virtual=virtual,
                     directory=virtual)
-
-
-@pytest.fixture(autouse=True)
-def _seeded_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-    yield
-    _site_cache.clear()
-    _drive_cache.clear()
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/sharepoint/test_resolve.py
+++ b/python/tests/core/sharepoint/test_resolve.py
@@ -4,7 +4,7 @@ import pytest
 from aioresponses import aioresponses
 
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache, resolve
+from mirage.core.sharepoint.resolve import resolve, site_entries
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -15,18 +15,6 @@ _SITES_RE = re.compile(r".*/sites\??.*")
 
 def _accessor() -> SharePointAccessor:
     return SharePointAccessor(SharePointConfig(access_token="tok"))
-
-
-def _clear_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-
-
-@pytest.fixture(autouse=True)
-def _reset_caches():
-    _clear_caches()
-    yield
-    _clear_caches()
 
 
 @pytest.mark.asyncio
@@ -40,37 +28,40 @@ async def test_resolve_root():
 
 @pytest.mark.asyncio
 async def test_resolve_site():
-    _site_cache["Engineering"] = _SITE_ID
+    accessor = _accessor()
+    accessor.site_cache["Engineering"] = _SITE_ID
     path = PathSpec(resource_path=mount_key("/sp/Engineering", "/sp"),
                     virtual="/sp/Engineering",
                     directory="/sp/Engineering")
-    result = await resolve(_accessor(), path)
+    result = await resolve(accessor, path)
     assert result.level == "site"
     assert result.site_id == _SITE_ID
 
 
 @pytest.mark.asyncio
 async def test_resolve_drive():
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    accessor = _accessor()
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
     path = PathSpec(resource_path=mount_key("/sp/Engineering/Documents",
                                             "/sp"),
                     virtual="/sp/Engineering/Documents",
                     directory="/sp/Engineering/Documents")
-    result = await resolve(_accessor(), path)
+    result = await resolve(accessor, path)
     assert result.level == "drive"
     assert result.drive_id == _DRIVE_ID
 
 
 @pytest.mark.asyncio
 async def test_resolve_item():
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    accessor = _accessor()
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
     path = PathSpec(resource_path=mount_key(
         "/sp/Engineering/Documents/sub/file.txt", "/sp"),
                     virtual="/sp/Engineering/Documents/sub/file.txt",
                     directory="/sp/Engineering/Documents/sub/file.txt")
-    result = await resolve(_accessor(), path)
+    result = await resolve(accessor, path)
     assert result.level == "item"
     assert result.drive_id == _DRIVE_ID
     assert result.item_path == "sub/file.txt"
@@ -97,6 +88,24 @@ async def test_resolve_unknown_site():
     assert result.site_id is None
 
 
+@pytest.mark.asyncio
+async def test_site_entries_caches_display_name_and_name():
+    accessor = _accessor()
+    with aioresponses() as m:
+        m.get(_SITES_RE,
+              payload={
+                  "value": [{
+                      "id": _SITE_ID,
+                      "displayName": "Engineering",
+                      "name": "eng"
+                  }]
+              })
+        entries = await site_entries(accessor)
+    assert entries == [("Engineering", _SITE_ID)]
+    assert accessor.site_cache["Engineering"] == _SITE_ID
+    assert accessor.site_cache["eng"] == _SITE_ID
+
+
 def _scoped_accessor() -> SharePointAccessor:
     return SharePointAccessor(
         SharePointConfig(access_token="tok",
@@ -112,9 +121,9 @@ def _prefix_scoped_accessor() -> SharePointAccessor:
                          key_prefix="/team/reports/"))
 
 
-def _seed_scoped():
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+def _seed_scoped(accessor: SharePointAccessor) -> None:
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
 
 
 def _spec(virtual: str) -> PathSpec:
@@ -125,8 +134,9 @@ def _spec(virtual: str) -> PathSpec:
 
 @pytest.mark.asyncio
 async def test_scoped_resolve_root_is_drive_level():
-    _seed_scoped()
-    result = await resolve(_scoped_accessor(), _spec("/sp/"))
+    accessor = _scoped_accessor()
+    _seed_scoped(accessor)
+    result = await resolve(accessor, _spec("/sp/"))
     assert result.level == "drive"
     assert result.drive_id == _DRIVE_ID
     assert result.item_path is None
@@ -134,8 +144,9 @@ async def test_scoped_resolve_root_is_drive_level():
 
 @pytest.mark.asyncio
 async def test_scoped_resolve_path_is_drive_relative_item():
-    _seed_scoped()
-    result = await resolve(_scoped_accessor(), _spec("/sp/sub/a.txt"))
+    accessor = _scoped_accessor()
+    _seed_scoped(accessor)
+    result = await resolve(accessor, _spec("/sp/sub/a.txt"))
     assert result.level == "item"
     assert result.drive_id == _DRIVE_ID
     assert result.item_path == "sub/a.txt"
@@ -143,8 +154,9 @@ async def test_scoped_resolve_path_is_drive_relative_item():
 
 @pytest.mark.asyncio
 async def test_prefix_scoped_resolve_root_is_prefix_item():
-    _seed_scoped()
-    result = await resolve(_prefix_scoped_accessor(), _spec("/sp/"))
+    accessor = _prefix_scoped_accessor()
+    _seed_scoped(accessor)
+    result = await resolve(accessor, _spec("/sp/"))
     assert result.level == "item"
     assert result.drive_id == _DRIVE_ID
     assert result.item_path == "team/reports"
@@ -152,8 +164,9 @@ async def test_prefix_scoped_resolve_root_is_prefix_item():
 
 @pytest.mark.asyncio
 async def test_prefix_scoped_resolve_path_is_prefix_relative_item():
-    _seed_scoped()
-    result = await resolve(_prefix_scoped_accessor(), _spec("/sp/sub/a.txt"))
+    accessor = _prefix_scoped_accessor()
+    _seed_scoped(accessor)
+    result = await resolve(accessor, _spec("/sp/sub/a.txt"))
     assert result.level == "item"
     assert result.drive_id == _DRIVE_ID
     assert result.item_path == "team/reports/sub/a.txt"
@@ -169,10 +182,11 @@ def test_prefix_scoped_config_rejects_parent_segments():
 
 @pytest.mark.asyncio
 async def test_scoped_resolve_unknown_drive():
-    _site_cache["Engineering"] = _SITE_ID
+    accessor = _scoped_accessor()
+    accessor.site_cache["Engineering"] = _SITE_ID
     drives_url = re.compile(r".*/sites/.*/drives.*")
     with aioresponses() as m:
         m.get(drives_url, payload={"value": [{"id": "x", "name": "Other"}]})
-        result = await resolve(_scoped_accessor(), _spec("/sp/a.txt"))
+        result = await resolve(accessor, _spec("/sp/a.txt"))
     assert result.level == "drive"
     assert result.drive_id is None

--- a/python/tests/core/sharepoint/test_rmdir.py
+++ b/python/tests/core/sharepoint/test_rmdir.py
@@ -4,7 +4,6 @@ import pytest
 from aioresponses import aioresponses
 
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.core.sharepoint.rmdir import rmdir
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
@@ -23,7 +22,10 @@ _PROBE = "?$top=1&$select=id"
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 def _spec(rel: str) -> PathSpec:
@@ -31,17 +33,6 @@ def _spec(rel: str) -> PathSpec:
     return PathSpec(resource_path=mount_key(virtual, "/sp"),
                     virtual=virtual,
                     directory=virtual)
-
-
-@pytest.fixture(autouse=True)
-def _seeded_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-    yield
-    _site_cache.clear()
-    _drive_cache.clear()
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/sharepoint/test_stat.py
+++ b/python/tests/core/sharepoint/test_stat.py
@@ -5,7 +5,6 @@ from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.cache.index import RAMIndexCacheStore
 from mirage.core.sharepoint.read import read_bytes
 from mirage.core.sharepoint.readdir import readdir
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.core.sharepoint.stat import stat
 from mirage.types import FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
@@ -16,30 +15,16 @@ _DRIVE_ID = "b!driveXYZ"
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 def _ps(virtual: str) -> PathSpec:
     return PathSpec(resource_path=mount_key(virtual, "/sp"),
                     virtual=virtual,
                     directory=virtual)
-
-
-def _seed_caches():
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-
-
-def _clear_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-
-
-@pytest.fixture(autouse=True)
-def _reset_caches():
-    _clear_caches()
-    yield
-    _clear_caches()
 
 
 @pytest.mark.asyncio
@@ -53,7 +38,6 @@ async def test_stat_root_is_directory():
 
 @pytest.mark.asyncio
 async def test_stat_site_is_directory():
-    _site_cache["Engineering"] = _SITE_ID
     with aioresponses() as m:
         m.get(f"{_BASE}/sites",
               payload={
@@ -74,7 +58,6 @@ async def test_stat_site_is_directory():
 
 @pytest.mark.asyncio
 async def test_stat_drive_is_directory():
-    _seed_caches()
     path = PathSpec(resource_path=mount_key("/sp/Engineering/Documents",
                                             "/sp"),
                     virtual="/sp/Engineering/Documents",
@@ -85,7 +68,6 @@ async def test_stat_drive_is_directory():
 
 @pytest.mark.asyncio
 async def test_stat_file_from_api():
-    _seed_caches()
     url = f"{_BASE}/drives/{_DRIVE_ID}/root:/report.docx"
     with aioresponses() as m:
         m.get(url,
@@ -113,7 +95,6 @@ async def test_stat_file_from_api():
 
 @pytest.mark.asyncio
 async def test_stat_folder_from_api():
-    _seed_caches()
     url = f"{_BASE}/drives/{_DRIVE_ID}/root:/src"
     with aioresponses() as m:
         m.get(url,
@@ -137,7 +118,6 @@ async def test_stat_folder_from_api():
 
 @pytest.mark.asyncio
 async def test_stat_missing_raises_file_not_found():
-    _seed_caches()
     url = f"{_BASE}/drives/{_DRIVE_ID}/root:/nope.txt"
     with aioresponses() as m:
         m.get(url,
@@ -156,7 +136,6 @@ async def test_stat_missing_raises_file_not_found():
 
 @pytest.mark.asyncio
 async def test_stat_from_index_after_readdir():
-    _seed_caches()
     index = RAMIndexCacheStore()
     with aioresponses() as m:
         m.get(f"{_BASE}/drives/{_DRIVE_ID}/root/children",
@@ -188,7 +167,6 @@ async def test_stat_from_index_after_readdir():
 
 @pytest.mark.asyncio
 async def test_stat_site_and_drive_have_no_metadata():
-    _seed_caches()
     site_path = PathSpec(resource_path=mount_key("/sp/Engineering", "/sp"),
                          virtual="/sp/Engineering",
                          directory="/sp/Engineering")
@@ -210,7 +188,6 @@ async def test_stat_size_matches_read_for_every_file():
     # The fskit invariant behind SIZES_ALWAYS_KNOWN: the size stat reports
     # from the listing must equal the byte length a read delivers, for
     # every file in the tree, 0-byte files included.
-    _seed_caches()
     contents = {
         "/notes.txt": b"hello sharepoint",
         "/Docs/empty.bin": b"",

--- a/python/tests/core/sharepoint/test_write.py
+++ b/python/tests/core/sharepoint/test_write.py
@@ -4,7 +4,6 @@ from aioresponses import CallbackResult, aioresponses
 import mirage.core.msgraph.drive_ops as drive_ops
 import mirage.core.sharepoint.write as write_mod
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
-from mirage.core.sharepoint.resolve import _drive_cache, _site_cache
 from mirage.core.sharepoint.write import write_bytes
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
@@ -15,25 +14,10 @@ _DRIVE_ID = "b!driveXYZ"
 
 
 def _accessor() -> SharePointAccessor:
-    return SharePointAccessor(SharePointConfig(access_token="tok"))
-
-
-def _seed_caches():
-    _site_cache["Engineering"] = _SITE_ID
-    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
-
-
-def _clear_caches():
-    _site_cache.clear()
-    _drive_cache.clear()
-
-
-@pytest.fixture(autouse=True)
-def _reset_caches():
-    _clear_caches()
-    _seed_caches()
-    yield
-    _clear_caches()
+    accessor = SharePointAccessor(SharePointConfig(access_token="tok"))
+    accessor.site_cache["Engineering"] = _SITE_ID
+    accessor.drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    return accessor
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Two SharePoint mounts in one process. Two tenants. One site name.
The second mount gets the first tenant's site id.

```
                one Python process running mirage
              ----------------------------------------------
                    resolve.py (imported once)
                 +--------------------------------+
                 | _site_cache   (module global)  |
                 | "Engineering" -> contoso...AAA |
                 +-------^---------------^--------+
                         |               |
              (1) writes |               | (2) reads -> gets A's id  X
                         |               |
              +----------+---------+  +--+-----------------+
              | /spA   accessorA   |  | /spB   accessorB   |
              | Tenant A - token A |  | Tenant B - token B |
              +--------------------+  +--------------------+
```

The name -> id cache is a module global:

```python
# core/sharepoint/resolve.py
_site_cache: dict[str, str] = {}   # keyed by site display name
```

`"Engineering"` is unique inside a tenant. The dict is shared by every
accessor in the process. Whoever resolves first writes the slot; everyone
after reads it.

## Current behavior

The two lines that leak, `core/sharepoint/resolve.py`:

```python
async def _resolve_site_id(accessor, site_name):
    if site_name in _site_cache:        # (a) hits on ANY tenant's entry
        return _site_cache[site_name]   # (b) returns it, no tenant check
    ...
```

Two mounts, `accessorA` (Contoso, token A) and `accessorB` (Fabrikam,
token B). Both tenants have a site named `Engineering`.

```
(1) cat /spA/Engineering/Documents/report.docx
    _resolve_site_id(accessorA, "Engineering")
    -> miss -> GET /sites with token A -> Contoso's sites
    -> _site_cache["Engineering"] = "contoso...AAA"        OK for A

(2) cat /spB/Engineering/Documents/report.docx
    _resolve_site_id(accessorB, "Engineering")
    -> (a) hit -> (b) return "contoso...AAA"               X
    Fabrikam is never called. accessorB holds Contoso's site id.

(3) _resolve_drive_id(accessorB, "contoso...AAA", "Documents")
    -> GET /sites/contoso...AAA/drives  with token B
    Best case 403/404: mount B looks broken for no reason.
    Worst case: B's session is pointed at A's resources.
```

Order decides who is wrong. Mount B first and A breaks instead.

## To-be

Give the cache the scope its data has. One accessor is built per
`SharePointResource` -- one per mount, one config, one tenant -- and it
lives as long as the mount. Put the dicts on it.

```diff
 # accessor/sharepoint.py
 class SharePointAccessor(SessionAccessor):
     def __init__(self, config: SharePointConfig) -> None:
         super().__init__(timeout=...)
         self.config = config
+        self.site_cache: dict[str, str] = {}
+        self.drive_cache: dict[tuple[str, str], str] = {}

 # core/sharepoint/resolve.py
-_site_cache: dict[str, str] = {}
-_drive_cache: dict[tuple[str, str], str] = {}

 async def _resolve_site_id(accessor, site_name):
-    if site_name in _site_cache:
-        return _site_cache[site_name]
+    cache = accessor.site_cache
+    if site_name in cache:
+        return cache[site_name]
     ...
```

Same key. Same lookup. Same populate. Only where the dict lives changed.

```
                one Python process running mirage
              ----------------------------------------------
                    resolve.py (no module global)

              +--------------------+  +--------------------+
              | /spA   accessorA   |  | /spB   accessorB   |
              | Tenant A - token A |  | Tenant B - token B |
              |                    |  |                    |
              | site_cache (own)   |  | site_cache (own)   |
              | "Engineering"      |  | "Engineering"      |
              |  -> contoso...AAA  |  |  -> fabrikam...BBB |
              +--------------------+  +--------------------+
                 two dicts, no shared slot, nothing to collide
```

Step (2) now misses, lists Fabrikam with token B, and resolves
`"Engineering"` to `fabrikam...BBB`. Hit rate on any one mount is
unchanged: the accessor outlives every op on it. The only lookups that now
miss are the ones that used to return another tenant's id.

While here: `site_entries` now also caches a site's internal `name`, as
the TypeScript `siteEntries` does. Before, a root `readdir` filled the
cache by display name only, so a later lookup by `name` relisted `/sites`.

## Tests

1 new test, 11 existing test files changed.

Before running, the existing tests put a known site id and drive id into
the two module-level dicts, so the code under test would not call `/sites`
and `/drives`. Those dicts are gone. The tests now put the same ids on the
accessor instead.

`test_resolve.py` does this inside each test rather than once for the
whole file, because some of its tests need the cache empty to check the
not-found path. The new test there checks that `site_entries` caches both
the display name and the internal name.

## Notes

No TypeScript change. `SharePointAccessor` there already keeps
`siteCache` / `driveCache` per instance and caches both names; this brings
python in line.