### PR TITLE
refactor(gdrive): route every Drive call through one client seam

### DIFF
--- a/python/mirage/accessor/gdrive.py
+++ b/python/mirage/accessor/gdrive.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.base import Accessor
+from mirage.core.gdrive.api import DriveApi, drive_api
 from mirage.core.google.client import TokenManager
 
 
@@ -26,3 +27,16 @@ class GDriveAccessor(Accessor):
     def __init__(self, config, token_manager: TokenManager) -> None:
         self.config = config
         self.token_manager = token_manager
+
+    @property
+    def drive(self) -> DriveApi:
+        """The single door every gdrive core op reaches Drive through.
+
+        Built per read rather than memoized in ``__init__``: an embedding
+        program constructs the resource (and with it this accessor) before
+        a test installs a fake, and a door built once at construction time
+        would already point at the live API by then. Building one is a
+        frozen dataclass holding the token manager, so it costs nothing
+        beside the request it is about to make.
+        """
+        return drive_api(self.token_manager)

--- a/python/mirage/core/gdrive/api.py
+++ b/python/mirage/core/gdrive/api.py
@@ -1,0 +1,237 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from mirage.core.gdrive.versions import (capture_file_metadata,
+                                         download_revision, list_revisions)
+from mirage.core.google.client import TokenManager
+from mirage.core.google.drive import (DEFAULT_UPLOAD_MIME, copy_file,
+                                      create_folder, delete_file,
+                                      download_file, get_file, list_files,
+                                      list_shared_drives, patch_file,
+                                      update_file_content, upload_file)
+from mirage.utils.ranges import ByteWindow
+
+
+class DriveApi(Protocol):
+    """Every Drive request the gdrive backend makes, as one object.
+
+    A core op reaches the network only through ``accessor.drive``, so the
+    whole backend can be stood up against an in-memory Drive by supplying
+    a different implementation of this protocol. Importing a wire function
+    from ``core.google.drive`` or ``core.gdrive.versions`` into a core
+    module puts a second, unswappable door beside this one, which is what
+    #684 was: the fake covered readdir's binding and ``find`` reached the
+    live API through resolve's.
+    """
+
+    async def list_files(
+        self,
+        folder_id: str = "root",
+        drive_id: str | None = None,
+        mime_type: str | None = None,
+        trashed: bool = False,
+        page_size: int = 1000,
+        modified_after: str | None = None,
+        modified_before: str | None = None,
+        name: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        ...
+
+    async def list_shared_drives(self,
+                                 page_size: int = 100) -> list[dict[str, Any]]:
+        ...
+
+    async def get_file(self, file_id: str) -> dict[str, Any]:
+        ...
+
+    async def delete_file(self, file_id: str) -> None:
+        ...
+
+    async def download_file(self,
+                            file_id: str,
+                            window: ByteWindow | None = None) -> bytes:
+        ...
+
+    async def create_folder(self, name: str, parent_id: str) -> dict[str, Any]:
+        ...
+
+    async def upload_file(
+        self,
+        name: str,
+        parent_id: str,
+        data: bytes,
+        mime_type: str = DEFAULT_UPLOAD_MIME,
+    ) -> dict[str, Any]:
+        ...
+
+    async def update_file_content(
+        self,
+        file_id: str,
+        data: bytes,
+        mime_type: str = DEFAULT_UPLOAD_MIME,
+    ) -> dict[str, Any]:
+        ...
+
+    async def patch_file(
+        self,
+        file_id: str,
+        body: dict[str, Any] | None = None,
+        add_parents: str | None = None,
+        remove_parents: str | None = None,
+    ) -> dict[str, Any]:
+        ...
+
+    async def copy_file(self, file_id: str, name: str,
+                        parent_id: str) -> dict[str, Any]:
+        ...
+
+    async def list_revisions(self, file_id: str) -> list[dict[str, Any]]:
+        ...
+
+    async def download_revision(
+        self,
+        file_id: str,
+        revision_id: str,
+        window: ByteWindow | None = None,
+    ) -> bytes:
+        ...
+
+    async def capture_file_metadata(
+            self, file_id: str) -> tuple[str | None, str | None]:
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class DriveClient:
+    """The live ``DriveApi``: one token manager, one call per method."""
+
+    token_manager: TokenManager
+
+    async def list_files(
+        self,
+        folder_id: str = "root",
+        drive_id: str | None = None,
+        mime_type: str | None = None,
+        trashed: bool = False,
+        page_size: int = 1000,
+        modified_after: str | None = None,
+        modified_before: str | None = None,
+        name: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        return await list_files(self.token_manager,
+                                folder_id=folder_id,
+                                drive_id=drive_id,
+                                mime_type=mime_type,
+                                trashed=trashed,
+                                page_size=page_size,
+                                modified_after=modified_after,
+                                modified_before=modified_before,
+                                name=name,
+                                limit=limit)
+
+    async def list_shared_drives(self,
+                                 page_size: int = 100) -> list[dict[str, Any]]:
+        return await list_shared_drives(self.token_manager,
+                                        page_size=page_size)
+
+    async def get_file(self, file_id: str) -> dict[str, Any]:
+        return await get_file(self.token_manager, file_id)
+
+    async def delete_file(self, file_id: str) -> None:
+        await delete_file(self.token_manager, file_id)
+
+    async def download_file(self,
+                            file_id: str,
+                            window: ByteWindow | None = None) -> bytes:
+        return await download_file(self.token_manager, file_id, window)
+
+    async def create_folder(self, name: str, parent_id: str) -> dict[str, Any]:
+        return await create_folder(self.token_manager, name, parent_id)
+
+    async def upload_file(
+        self,
+        name: str,
+        parent_id: str,
+        data: bytes,
+        mime_type: str = DEFAULT_UPLOAD_MIME,
+    ) -> dict[str, Any]:
+        return await upload_file(self.token_manager,
+                                 name,
+                                 parent_id,
+                                 data,
+                                 mime_type=mime_type)
+
+    async def update_file_content(
+        self,
+        file_id: str,
+        data: bytes,
+        mime_type: str = DEFAULT_UPLOAD_MIME,
+    ) -> dict[str, Any]:
+        return await update_file_content(self.token_manager,
+                                         file_id,
+                                         data,
+                                         mime_type=mime_type)
+
+    async def patch_file(
+        self,
+        file_id: str,
+        body: dict[str, Any] | None = None,
+        add_parents: str | None = None,
+        remove_parents: str | None = None,
+    ) -> dict[str, Any]:
+        return await patch_file(self.token_manager,
+                                file_id,
+                                body,
+                                add_parents=add_parents,
+                                remove_parents=remove_parents)
+
+    async def copy_file(self, file_id: str, name: str,
+                        parent_id: str) -> dict[str, Any]:
+        return await copy_file(self.token_manager, file_id, name, parent_id)
+
+    async def list_revisions(self, file_id: str) -> list[dict[str, Any]]:
+        return await list_revisions(self.token_manager, file_id)
+
+    async def download_revision(
+        self,
+        file_id: str,
+        revision_id: str,
+        window: ByteWindow | None = None,
+    ) -> bytes:
+        return await download_revision(self.token_manager, file_id,
+                                       revision_id, window)
+
+    async def capture_file_metadata(
+            self, file_id: str) -> tuple[str | None, str | None]:
+        return await capture_file_metadata(self.token_manager, file_id)
+
+
+def drive_api(token_manager: TokenManager) -> DriveApi:
+    """Build the live Drive door for a token manager.
+
+    This is the one factory a test replaces to swap the whole backend for
+    an in-memory Drive, the way ``async_session`` is for S3.
+
+    Args:
+        token_manager (TokenManager): OAuth2 token manager.
+
+    Returns:
+        DriveApi: the live implementation.
+    """
+    return DriveClient(token_manager)

--- a/python/mirage/core/gdrive/copy.py
+++ b/python/mirage/core/gdrive/copy.py
@@ -16,41 +16,37 @@ import posixpath
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.context import invalidate_after_write
+from mirage.core.gdrive.api import DriveApi
 from mirage.core.gdrive.resolve import (DriveNode, drive_target_name,
                                         eacces_on_denied, node_from_item,
                                         resolve_key, resolve_parent)
-from mirage.core.google.client import TokenManager
-from mirage.core.google.drive import (FOLDER_MIME, copy_file, create_folder,
-                                      delete_file, list_files)
+from mirage.core.google.drive import FOLDER_MIME
 from mirage.types import PathSpec
 from mirage.utils.errors import eisdir, enoent
 
 
-async def copy_children(token_manager: TokenManager, src: DriveNode,
+async def copy_children(drive: DriveApi, src: DriveNode,
                         dst_folder_id: str) -> None:
     """Recursively copy a folder's children into a destination folder.
 
     Args:
-        token_manager (TokenManager): OAuth2 token manager.
+        drive (DriveApi): the accessor's Drive door.
         src (DriveNode): source folder.
         dst_folder_id (str): destination folder id.
     """
-    children = await list_files(token_manager,
-                                folder_id=src.id,
-                                drive_id=src.drive_id)
+    children = await drive.list_files(folder_id=src.id, drive_id=src.drive_id)
     for item in children:
         child = node_from_item(item, src.drive_id)
         if child.is_folder:
-            created = await create_folder(token_manager, child.name,
-                                          dst_folder_id)
-            await copy_children(token_manager, child, created["id"])
+            created = await drive.create_folder(child.name, dst_folder_id)
+            await copy_children(drive, child, created["id"])
         else:
-            await copy_file(token_manager, child.id, child.name, dst_folder_id)
+            await drive.copy_file(child.id, child.name, dst_folder_id)
 
 
 @eacces_on_denied
 async def copy(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec) -> None:
-    token_manager = accessor.token_manager
+    drive = accessor.drive
     src_node = await resolve_key(accessor, src.resource_path)
     if src_node is None:
         raise enoent(src.virtual)
@@ -63,19 +59,19 @@ async def copy(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec) -> None:
             # one, mirroring the msgraph copy_tree.
             dst_parent_id, _ = await resolve_parent(accessor, dst)
             name = posixpath.basename(dst.resource_path)
-            created = await create_folder(token_manager, name, dst_parent_id)
+            created = await drive.create_folder(name, dst_parent_id)
             dst_node = DriveNode(id=created["id"],
                                  name=name,
                                  mime_type=FOLDER_MIME,
                                  drive_id=src_node.drive_id)
-        await copy_children(token_manager, src_node, dst_node.id)
+        await copy_children(drive, src_node, dst_node.id)
     else:
         if dst_node is not None and dst_node.is_folder:
             raise eisdir(dst.virtual)
         if dst_node is not None:
-            await delete_file(token_manager, dst_node.id)
+            await drive.delete_file(dst_node.id)
         dst_parent_id, _ = await resolve_parent(accessor, dst)
         name = drive_target_name(posixpath.basename(dst.resource_path),
                                  src_node)
-        await copy_file(token_manager, src_node.id, name, dst_parent_id)
+        await drive.copy_file(src_node.id, name, dst_parent_id)
     await invalidate_after_write(dst)

--- a/python/mirage/core/gdrive/mkdir.py
+++ b/python/mirage/core/gdrive/mkdir.py
@@ -19,7 +19,6 @@ from mirage.cache.context import invalidate_after_write
 from mirage.core.gdrive.resolve import (eacces_on_denied, node_from_item,
                                         resolve_key, resolve_parent,
                                         resolve_segment, root_context)
-from mirage.core.google.drive import create_folder
 from mirage.types import PathSpec
 
 
@@ -29,7 +28,7 @@ async def mkdir(accessor: GDriveAccessor,
                 parents: bool = False) -> None:
     virtual = path.virtual
     key = path.resource_path
-    token_manager = accessor.token_manager
+    drive = accessor.drive
     if not key:
         if parents:
             return
@@ -39,7 +38,7 @@ async def mkdir(accessor: GDriveAccessor,
         if node is not None:
             raise FileExistsError(virtual)
         parent_id, _ = await resolve_parent(accessor, path)
-        await create_folder(token_manager, posixpath.basename(key), parent_id)
+        await drive.create_folder(posixpath.basename(key), parent_id)
         await invalidate_after_write(path)
         return
     parent_id, drive_id = await root_context(accessor)
@@ -47,13 +46,13 @@ async def mkdir(accessor: GDriveAccessor,
     mount_prefix = virtual[:-len(key)].rstrip("/") if virtual.endswith(
         key) else ""
     for i, segment in enumerate(segments):
-        node = await resolve_segment(token_manager,
+        node = await resolve_segment(drive,
                                      parent_id,
                                      segment,
                                      drive_id,
                                      at_root=i == 0 and parent_id == "root")
         if node is None:
-            item = await create_folder(token_manager, segment, parent_id)
+            item = await drive.create_folder(segment, parent_id)
             node = node_from_item(item, drive_id)
             # Every created level makes its parent's cached listing stale,
             # not just the leaf's; a later warm-through resolution of the

--- a/python/mirage/core/gdrive/read.py
+++ b/python/mirage/core/gdrive/read.py
@@ -20,11 +20,8 @@ from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.cache.index.warm import entry_or_warm
 from mirage.core.gdocs.read import read_doc
 from mirage.core.gdrive import DIRECTORY_RESOURCE_TYPES
+from mirage.core.gdrive.api import DriveApi
 from mirage.core.gdrive.readdir import readdir
-from mirage.core.gdrive.versions import (capture_file_metadata,
-                                         download_revision)
-from mirage.core.google.client import TokenManager
-from mirage.core.google.drive import download_file
 from mirage.core.gsheets.read import read_spreadsheet
 from mirage.core.gslides.read import read_presentation
 from mirage.observe.context import (active_recorder, record, revision_for,
@@ -36,13 +33,13 @@ from mirage.utils.ranges import slice_window, window_for
 
 
 async def read_bytes(
-    token_manager: TokenManager,
+    drive: DriveApi,
     file_id: str,
 ) -> bytes:
-    return await download_file(token_manager, file_id)
+    return await drive.download_file(file_id)
 
 
-async def read_file_versioned(token_manager: TokenManager,
+async def read_file_versioned(drive: DriveApi,
                               file_id: str,
                               virtual: str,
                               label: str,
@@ -55,7 +52,7 @@ async def read_file_versioned(token_manager: TokenManager,
     mirroring the msgraph read_item.
 
     Args:
-        token_manager (TokenManager): OAuth2 token manager.
+        drive (DriveApi): the accessor's Drive door.
         file_id (str): file ID.
         virtual (str): full virtual path (pin lookup key).
         label (str): mount-relative path recorded with the read.
@@ -68,13 +65,12 @@ async def read_file_versioned(token_manager: TokenManager,
     fingerprint = None
     revision = pinned
     if pinned:
-        data = await download_revision(token_manager, file_id, pinned, window)
+        data = await drive.download_revision(file_id, pinned, window)
     elif active_recorder() is not None:
-        fingerprint, revision = await capture_file_metadata(
-            token_manager, file_id)
-        data = await download_file(token_manager, file_id, window)
+        fingerprint, revision = await drive.capture_file_metadata(file_id)
+        data = await drive.download_file(file_id, window)
     else:
-        data = await download_file(token_manager, file_id, window)
+        data = await drive.download_file(file_id, window)
     record("read",
            label,
            "gdrive",
@@ -126,6 +122,6 @@ async def read(
     elif entry.resource_type == "gdrive/gslide":
         rendered = await read_presentation(accessor.token_manager, entry.id)
     else:
-        return await read_file_versioned(accessor.token_manager, entry.id,
-                                         virtual, key, offset, size)
+        return await read_file_versioned(accessor.drive, entry.id, virtual,
+                                         key, offset, size)
     return slice_window(rendered, offset, size)

--- a/python/mirage/core/gdrive/readdir.py
+++ b/python/mirage/core/gdrive/readdir.py
@@ -18,8 +18,7 @@ from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
 from mirage.core.gdrive import DIRECTORY_RESOURCE_TYPES
 from mirage.core.gdrive.resolve import root_context
-from mirage.core.google.drive import (MIME_TO_EXT, list_files,
-                                      list_shared_drives)
+from mirage.core.google.drive import MIME_TO_EXT
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotdir
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
@@ -80,9 +79,8 @@ async def readdir(
         folder_id = result.entry.id
         drive_id = result.entry.extra.get("drive_id")
 
-    files = await list_files(accessor.token_manager,
-                             folder_id=folder_id,
-                             drive_id=drive_id)
+    files = await accessor.drive.list_files(folder_id=folder_id,
+                                            drive_id=drive_id)
     entries = []
     for f in files:
         mime = f.get("mimeType", "")
@@ -134,7 +132,7 @@ async def readdir(
         # A folder-scoped mount lists only the folder's children, so shared
         # drives never surface there.
         try:
-            shared_drives = await list_shared_drives(accessor.token_manager)
+            shared_drives = await accessor.drive.list_shared_drives()
         except Exception:
             logger.debug("Unable to list Google Shared Drives", exc_info=True)
             shared_drives = []

--- a/python/mirage/core/gdrive/rename.py
+++ b/python/mirage/core/gdrive/rename.py
@@ -18,7 +18,6 @@ from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.context import invalidate_subtree
 from mirage.core.gdrive.resolve import (drive_target_name, eacces_on_denied,
                                         resolve_key, resolve_parent)
-from mirage.core.google.drive import delete_file, list_files, patch_file
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotempty
 
@@ -26,7 +25,7 @@ from mirage.utils.errors import enoent, enotempty
 @eacces_on_denied
 async def rename(accessor: GDriveAccessor, src: PathSpec,
                  dst: PathSpec) -> None:
-    token_manager = accessor.token_manager
+    drive = accessor.drive
     src_node = await resolve_key(accessor, src.resource_path)
     if src_node is None:
         raise enoent(src.virtual)
@@ -36,21 +35,19 @@ async def rename(accessor: GDriveAccessor, src: PathSpec,
         # empty folder) before the move. A non-empty folder conflict is mv's
         # "Directory not empty", mirroring the msgraph rename_replace.
         if dst_node.is_folder:
-            children = await list_files(token_manager,
-                                        folder_id=dst_node.id,
-                                        drive_id=dst_node.drive_id,
-                                        limit=1)
+            children = await drive.list_files(folder_id=dst_node.id,
+                                              drive_id=dst_node.drive_id,
+                                              limit=1)
             if children:
                 raise enotempty(dst)
-        await delete_file(token_manager, dst_node.id)
+        await drive.delete_file(dst_node.id)
     src_parent_id, _ = await resolve_parent(accessor, src)
     dst_parent_id, _ = await resolve_parent(accessor, dst)
     name = drive_target_name(posixpath.basename(dst.resource_path), src_node)
     add_parents = dst_parent_id if dst_parent_id != src_parent_id else None
     remove_parents = src_parent_id if add_parents else None
-    await patch_file(token_manager,
-                     src_node.id, {"name": name},
-                     add_parents=add_parents,
-                     remove_parents=remove_parents)
+    await drive.patch_file(src_node.id, {"name": name},
+                           add_parents=add_parents,
+                           remove_parents=remove_parents)
     await invalidate_subtree(dst)
     await invalidate_subtree(src)

--- a/python/mirage/core/gdrive/resolve.py
+++ b/python/mirage/core/gdrive/resolve.py
@@ -22,9 +22,8 @@ from typing import Any, ParamSpec, TypeVar
 import aiohttp
 
 from mirage.accessor.gdrive import GDriveAccessor
-from mirage.core.google.client import TokenManager
-from mirage.core.google.drive import (FOLDER_MIME, MIME_TO_EXT, get_file,
-                                      list_files, list_shared_drives)
+from mirage.core.gdrive.api import DriveApi
+from mirage.core.google.drive import FOLDER_MIME, MIME_TO_EXT
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -74,12 +73,11 @@ async def root_context(accessor: GDriveAccessor) -> tuple[str, str | None]:
     Returns:
         tuple[str, str | None]: (root folder id, shared drive id or None).
     """
-    token_manager = accessor.token_manager
-    folder_id = token_manager.config.folder_id
+    folder_id = accessor.token_manager.config.folder_id
     if not folder_id:
         return "root", None
     if not hasattr(accessor, "root_drive_id"):
-        item = await get_file(token_manager, folder_id)
+        item = await accessor.drive.get_file(folder_id)
         accessor.root_drive_id = item.get("driveId")
     return folder_id, accessor.root_drive_id
 
@@ -153,7 +151,7 @@ def node_from_item(item: dict[str, Any], drive_id: str | None) -> DriveNode:
 
 
 async def resolve_segment(
-    token_manager: TokenManager,
+    drive: DriveApi,
     parent_id: str,
     segment: str,
     drive_id: str | None,
@@ -162,7 +160,7 @@ async def resolve_segment(
     """Resolve one path segment inside a parent folder.
 
     Args:
-        token_manager (TokenManager): OAuth2 token manager.
+        drive (DriveApi): the accessor's Drive door.
         parent_id (str): parent folder ID.
         segment (str): vfs path segment.
         drive_id (str | None): shared drive scope, if any.
@@ -170,18 +168,17 @@ async def resolve_segment(
             shared drive name is also a valid directory.
     """
     for name, mime in query_candidates(segment):
-        matches = await list_files(token_manager,
-                                   folder_id=parent_id,
-                                   drive_id=drive_id,
-                                   name=name,
-                                   mime_type=mime)
+        matches = await drive.list_files(folder_id=parent_id,
+                                         drive_id=drive_id,
+                                         name=name,
+                                         mime_type=mime)
         if matches:
             return node_from_item(matches[0], drive_id)
     if at_root:
         # Shared Drive enumeration is best-effort, mirroring readdir: a
         # missing scope must not break resolution of My Drive paths.
         try:
-            shared = await list_shared_drives(token_manager)
+            shared = await drive.list_shared_drives()
         except Exception:
             logger.debug("Unable to list Google Shared Drives", exc_info=True)
             shared = []
@@ -201,14 +198,14 @@ async def resolve_key(accessor: GDriveAccessor, key: str) -> DriveNode | None:
         accessor (GDriveAccessor): backend accessor.
         key (str): mount-relative path ("a/b/c"); "" is the mount root.
     """
-    token_manager = accessor.token_manager
+    drive = accessor.drive
     parent_id, drive_id = await root_context(accessor)
     node: DriveNode | None = None
     segments = [s for s in key.split("/") if s]
     for i, segment in enumerate(segments):
         # Shared drive names are only directories at the real Drive root,
         # never inside a folder-scoped mount.
-        node = await resolve_segment(token_manager,
+        node = await resolve_segment(drive,
                                      parent_id,
                                      segment,
                                      drive_id,

--- a/python/mirage/core/gdrive/rm.py
+++ b/python/mirage/core/gdrive/rm.py
@@ -15,7 +15,6 @@
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.context import invalidate_subtree
 from mirage.core.gdrive.resolve import eacces_on_denied, resolve_key
-from mirage.core.google.drive import delete_file
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -30,5 +29,5 @@ async def rm_r(accessor: GDriveAccessor, path: PathSpec) -> None:
     node = await resolve_key(accessor, key)
     if node is None:
         raise enoent(virtual)
-    await delete_file(accessor.token_manager, node.id)
+    await accessor.drive.delete_file(node.id)
     await invalidate_subtree(path)

--- a/python/mirage/core/gdrive/rmdir.py
+++ b/python/mirage/core/gdrive/rmdir.py
@@ -16,7 +16,6 @@ from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.context import invalidate_after_unlink
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.core.gdrive.resolve import eacces_on_denied, resolve_key
-from mirage.core.google.drive import delete_file, list_files
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent, enotdir, enotempty
 
@@ -51,11 +50,10 @@ async def rmdir(accessor: GDriveAccessor,
         raise enoent(virtual)
     if not node.is_folder:
         raise enotdir(virtual)
-    children = await list_files(accessor.token_manager,
-                                folder_id=node.id,
-                                drive_id=node.drive_id,
-                                limit=1)
+    children = await accessor.drive.list_files(folder_id=node.id,
+                                               drive_id=node.drive_id,
+                                               limit=1)
     if children:
         raise enotempty(path)
-    await delete_file(accessor.token_manager, node.id)
+    await accessor.drive.delete_file(node.id)
     await invalidate_after_unlink(path)

--- a/python/mirage/core/gdrive/stat.py
+++ b/python/mirage/core/gdrive/stat.py
@@ -20,7 +20,7 @@ from mirage.cache.index.warm import entry_or_warm
 from mirage.core.gdrive import DIRECTORY_RESOURCE_TYPES
 from mirage.core.gdrive.readdir import readdir as _readdir
 from mirage.core.gdrive.resolve import resolve_key
-from mirage.core.google.drive import FOLDER_MIME, MIME_TO_EXT, get_file
+from mirage.core.google.drive import FOLDER_MIME, MIME_TO_EXT
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.filetype import content_type_for_path
@@ -48,7 +48,7 @@ async def stat_from_api(accessor: GDriveAccessor, key: str,
     node = await resolve_key(accessor, key)
     if node is None:
         raise enoent(virtual)
-    item = await get_file(accessor.token_manager, node.id)
+    item = await accessor.drive.get_file(node.id)
     modified = item.get("modifiedTime", "")
     if node.mime_type == FOLDER_MIME:
         return FileStat(name=node.name,

--- a/python/mirage/core/gdrive/tree.py
+++ b/python/mirage/core/gdrive/tree.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.core.gdrive.resolve import resolve_dir
-from mirage.core.google.drive import FOLDER_MIME, MIME_TO_EXT, list_files
+from mirage.core.google.drive import FOLDER_MIME, MIME_TO_EXT
 from mirage.types import PathSpec
 
 
@@ -51,9 +51,7 @@ async def iter_tree(
     stack: list[tuple[str, str, str | None]] = [(base, folder_id, drive_id)]
     while stack:
         rel, fid, did = stack.pop(0)
-        children = await list_files(accessor.token_manager,
-                                    folder_id=fid,
-                                    drive_id=did)
+        children = await accessor.drive.list_files(folder_id=fid, drive_id=did)
         children.sort(key=vfs_name)
         for item in children:
             name = vfs_name(item)

--- a/python/mirage/core/gdrive/truncate.py
+++ b/python/mirage/core/gdrive/truncate.py
@@ -15,7 +15,6 @@
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.core.gdrive.resolve import eacces_on_denied, resolve_key
 from mirage.core.gdrive.write import write_bytes
-from mirage.core.google.drive import download_file
 from mirage.types import PathSpec
 from mirage.utils.errors import eisdir
 
@@ -29,7 +28,7 @@ async def truncate(accessor: GDriveAccessor, path: PathSpec,
     if node is None or node.is_native:
         data = b""
     else:
-        data = await download_file(accessor.token_manager, node.id)
+        data = await accessor.drive.download_file(node.id)
     if length <= len(data):
         new = data[:length]
     else:

--- a/python/mirage/core/gdrive/unlink.py
+++ b/python/mirage/core/gdrive/unlink.py
@@ -15,7 +15,6 @@
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.context import invalidate_after_unlink
 from mirage.core.gdrive.resolve import eacces_on_denied, resolve_key
-from mirage.core.google.drive import delete_file
 from mirage.types import PathSpec
 from mirage.utils.errors import eisdir, enoent
 
@@ -31,5 +30,5 @@ async def unlink(accessor: GDriveAccessor, path: PathSpec) -> None:
         raise enoent(virtual)
     if node.is_folder:
         raise eisdir(virtual)
-    await delete_file(accessor.token_manager, node.id)
+    await accessor.drive.delete_file(node.id)
     await invalidate_after_unlink(path)

--- a/python/mirage/core/gdrive/write.py
+++ b/python/mirage/core/gdrive/write.py
@@ -18,7 +18,6 @@ from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.gdrive.resolve import (eacces_on_denied, resolve_key,
                                         resolve_parent)
-from mirage.core.google.drive import update_file_content, upload_file
 from mirage.observe.context import record, start_op
 from mirage.types import PathSpec
 from mirage.utils.errors import eisdir
@@ -32,7 +31,7 @@ async def write_bytes(accessor: GDriveAccessor, path: PathSpec,
     if not key:
         raise eisdir(virtual)
     timer = start_op()
-    token_manager = accessor.token_manager
+    drive = accessor.drive
     node = await resolve_key(accessor, key)
     if node is not None and node.is_folder:
         raise eisdir(virtual)
@@ -41,10 +40,9 @@ async def write_bytes(accessor: GDriveAccessor, path: PathSpec,
     if node is not None and node.is_native:
         raise PermissionError(virtual)
     if node is not None:
-        await update_file_content(token_manager, node.id, data)
+        await drive.update_file_content(node.id, data)
     else:
         parent_id, _ = await resolve_parent(accessor, path)
-        await upload_file(token_manager, posixpath.basename(key), parent_id,
-                          data)
+        await drive.upload_file(posixpath.basename(key), parent_id, data)
     record("write", key, "gdrive", len(data), timer)
     await invalidate_after_write(path)

--- a/python/tests/commands/builtin/gdrive/test_read.py
+++ b/python/tests/commands/builtin/gdrive/test_read.py
@@ -23,6 +23,7 @@ from mirage.core.gdrive.read import read
 from mirage.core.google.client import TokenManager
 from mirage.core.google.config import GoogleConfig
 from mirage.types import PathSpec
+from tests.fixtures.gdrive_stub import StubDrive, install_drive
 
 
 @pytest.fixture
@@ -125,7 +126,7 @@ async def test_read_gslide(accessor, index):
 
 
 @pytest.mark.asyncio
-async def test_read_regular(accessor, index):
+async def test_read_regular(accessor, index, monkeypatch):
     await index.put(
         "/photo.png",
         IndexEntry(
@@ -136,14 +137,11 @@ async def test_read_regular(accessor, index):
             vfs_name="photo.png",
         ))
     img_bytes = b"\x89PNG\r\n"
-    with patch(
-            "mirage.core.gdrive.read.download_file",
-            new_callable=AsyncMock,
-            return_value=img_bytes,
-    ):
-        result = await read(
-            accessor,
-            PathSpec(resource_path="photo.png",
-                     virtual="/photo.png",
-                     directory="/photo.png"), index)
-        assert result == img_bytes
+    install_drive(monkeypatch,
+                  StubDrive(download_file=AsyncMock(return_value=img_bytes)))
+    result = await read(
+        accessor,
+        PathSpec(resource_path="photo.png",
+                 virtual="/photo.png",
+                 directory="/photo.png"), index)
+    assert result == img_bytes

--- a/python/tests/commands/builtin/gdrive/test_sed.py
+++ b/python/tests/commands/builtin/gdrive/test_sed.py
@@ -27,6 +27,7 @@ from mirage.core.google.config import GoogleConfig
 from mirage.io.stream import materialize
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
+from tests.fixtures.gdrive_stub import StubDrive, install_drive
 
 
 @pytest.fixture
@@ -131,7 +132,7 @@ async def test_sed_stdin(accessor, index):
 
 
 @pytest.mark.asyncio
-async def test_sed_in_place_writes_back(accessor, index):
+async def test_sed_in_place_writes_back(accessor, index, monkeypatch):
     await index.put(
         "/test/file.txt",
         IndexEntry(
@@ -143,25 +144,23 @@ async def test_sed_in_place_writes_back(accessor, index):
             size=100,
         ))
     node = DriveNode(id="file123", name="file.txt", mime_type="text/plain")
+    update = AsyncMock()
+    install_drive(
+        monkeypatch,
+        StubDrive(download_file=AsyncMock(return_value=b"hello world\n"),
+                  update_file_content=update))
     with patch(
-            "mirage.core.google.drive.google_get_bytes",
-            new_callable=AsyncMock,
-            return_value=b"hello world\n",
-    ), patch(
             "mirage.core.gdrive.write.resolve_key",
             new_callable=AsyncMock,
             return_value=node,
-    ), patch(
-            "mirage.core.gdrive.write.update_file_content",
-            new_callable=AsyncMock,
-    ) as update:
+    ):
         _result, io = await sed(accessor, [_scope('/test/file.txt')],
                                 ['s/hello/bye/'],
                                 CommandOpts(index=index, flags={'i': True}))
         assert io.exit_code == 0
         update.assert_awaited_once()
-        assert update.await_args.args[1] == "file123"
-        assert update.await_args.args[2] == b"bye world\n"
+        assert update.await_args.args[0] == "file123"
+        assert update.await_args.args[1] == b"bye world\n"
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/gdrive/conftest.py
+++ b/python/tests/core/gdrive/conftest.py
@@ -16,28 +16,23 @@ import itertools
 
 import pytest
 
-import mirage.core.gdrive.copy as copy_mod
-import mirage.core.gdrive.mkdir as mkdir_mod
-import mirage.core.gdrive.readdir as readdir_mod
-import mirage.core.gdrive.rename as rename_mod
-import mirage.core.gdrive.resolve as resolve_mod
-import mirage.core.gdrive.rm as rm_mod
-import mirage.core.gdrive.rmdir as rmdir_mod
-import mirage.core.gdrive.stat as stat_mod
-import mirage.core.gdrive.tree as tree_mod
-import mirage.core.gdrive.truncate as truncate_mod
-import mirage.core.gdrive.unlink as unlink_mod
-import mirage.core.gdrive.write as write_mod
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.core.google.client import TokenManager
 from mirage.core.google.config import GoogleConfig
 from mirage.core.google.drive import FOLDER_MIME
+from mirage.utils.ranges import ByteWindow, slice_window
+from tests.fixtures.gdrive_stub import install_drive
 
 FILE_MIME = "application/octet-stream"
 
 
 class FakeDrive:
-    """In-memory Drive: id-addressed items with parent links."""
+    """In-memory Drive: id-addressed items with parent links.
+
+    Implements the ``DriveApi`` protocol, so a test installs the whole
+    backend by handing this to the accessor's one seam instead of
+    rebinding a function inside every core module (#684).
+    """
 
     def __init__(self) -> None:
         self.items: dict[str, dict] = {}
@@ -77,7 +72,6 @@ class FakeDrive:
         return out
 
     async def list_files(self,
-                         token_manager,
                          folder_id: str = "root",
                          drive_id: str | None = None,
                          mime_type: str | None = None,
@@ -101,17 +95,13 @@ class FakeDrive:
                 break
         return out
 
-    async def list_shared_drives(self,
-                                 token_manager,
-                                 page_size: int = 100) -> list[dict]:
+    async def list_shared_drives(self, page_size: int = 100) -> list[dict]:
         return []
 
-    async def create_folder(self, token_manager, name: str,
-                            parent_id: str) -> dict:
+    async def create_folder(self, name: str, parent_id: str) -> dict:
         return self.public(self.folder(name, parent=parent_id))
 
     async def upload_file(self,
-                          token_manager,
                           name: str,
                           parent_id: str,
                           data: bytes,
@@ -120,14 +110,13 @@ class FakeDrive:
             self.add(name, parent=parent_id, mime=mime_type, content=data))
 
     async def update_file_content(self,
-                                  token_manager,
                                   file_id: str,
                                   data: bytes,
                                   mime_type: str = FILE_MIME) -> dict:
         self.items[file_id]["content"] = data
         return self.public(file_id)
 
-    async def delete_file(self, token_manager, file_id: str) -> None:
+    async def delete_file(self, file_id: str) -> None:
         stack = [file_id]
         while stack:
             current = stack.pop()
@@ -136,7 +125,6 @@ class FakeDrive:
             self.items.pop(current, None)
 
     async def patch_file(self,
-                         token_manager,
                          file_id: str,
                          body: dict | None = None,
                          add_parents: str | None = None,
@@ -150,8 +138,7 @@ class FakeDrive:
             item["parents"].remove(remove_parents)
         return self.public(file_id)
 
-    async def copy_file(self, token_manager, file_id: str, name: str,
-                        parent_id: str) -> dict:
+    async def copy_file(self, file_id: str, name: str, parent_id: str) -> dict:
         src = self.items[file_id]
         return self.public(
             self.add(name,
@@ -159,11 +146,29 @@ class FakeDrive:
                      mime=src["mimeType"],
                      content=src["content"]))
 
-    async def download_file(self, token_manager, file_id: str) -> bytes:
-        return self.items[file_id]["content"]
+    async def download_file(self,
+                            file_id: str,
+                            window: ByteWindow | None = None) -> bytes:
+        data = self.items[file_id]["content"]
+        if window is None:
+            return data
+        return slice_window(data, window.offset, window.size)
 
-    async def get_file(self, token_manager, file_id: str) -> dict:
+    async def get_file(self, file_id: str) -> dict:
         return self.public(file_id)
+
+    async def list_revisions(self, file_id: str) -> list[dict]:
+        return []
+
+    async def download_revision(self,
+                                file_id: str,
+                                revision_id: str,
+                                window: ByteWindow | None = None) -> bytes:
+        return await self.download_file(file_id, window)
+
+    async def capture_file_metadata(
+            self, file_id: str) -> tuple[str | None, str | None]:
+        return None, None
 
     def find(self, name: str) -> dict | None:
         for item in self.items.values():
@@ -172,29 +177,12 @@ class FakeDrive:
         return None
 
 
-_PATCH_TARGETS = {
-    resolve_mod: ("list_files", "list_shared_drives", "get_file"),
-    readdir_mod: ("list_files", "list_shared_drives"),
-    write_mod: ("update_file_content", "upload_file"),
-    mkdir_mod: ("create_folder", ),
-    unlink_mod: ("delete_file", ),
-    rmdir_mod: ("delete_file", "list_files"),
-    rm_mod: ("delete_file", ),
-    rename_mod: ("delete_file", "list_files", "patch_file"),
-    tree_mod: ("list_files", ),
-    stat_mod: ("get_file", ),
-    copy_mod: ("copy_file", "create_folder", "delete_file", "list_files"),
-    truncate_mod: ("download_file", ),
-}
-
-
 @pytest.fixture
 def fake_drive(monkeypatch):
-    fake = FakeDrive()
-    for mod, names in _PATCH_TARGETS.items():
-        for fn_name in names:
-            monkeypatch.setattr(mod, fn_name, getattr(fake, fn_name))
-    return fake
+    # One target: the factory the accessor builds its Drive door with.
+    # Every core op reaches Drive through that door, so nothing can slip
+    # past this and reach the live API.
+    return install_drive(monkeypatch, FakeDrive())
 
 
 @pytest.fixture

--- a/python/tests/core/gdrive/test_api.py
+++ b/python/tests/core/gdrive/test_api.py
@@ -1,0 +1,135 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import ast
+import importlib
+import inspect
+import pathlib
+
+import mirage.core.gdrive.versions as versions_mod
+import mirage.core.google.client as client_mod
+import mirage.core.google.drive as drive_mod
+from mirage.accessor.gdrive import GDriveAccessor
+from mirage.core.gdrive.api import DriveApi, DriveClient, drive_api
+
+SOURCE = pathlib.Path(
+    importlib.import_module("mirage").__file__).resolve().parent
+
+# The three modules that speak to the Drive API over HTTP. Nothing in the
+# gdrive backend may import a call from them by value: that is a second
+# door beside the accessor's, and the one the #684 fake could not cover.
+WIRE_MODULES = {
+    "mirage.core.google.drive": drive_mod,
+    "mirage.core.google.client": client_mod,
+    "mirage.core.gdrive.versions": versions_mod,
+}
+
+# The seam's own two modules: `api.py` builds the door and `versions.py`
+# is the Drive Revisions wire, the way `core/s3/client.py` is S3's.
+SEAM_MODULES = {
+    SOURCE / "core" / "gdrive" / "api.py",
+    SOURCE / "core" / "gdrive" / "versions.py",
+}
+
+BACKEND_ROOTS = [
+    SOURCE / "core" / "gdrive",
+    SOURCE / "ops" / "gdrive",
+    SOURCE / "commands" / "builtin" / "gdrive",
+    SOURCE / "resource" / "gdrive",
+]
+
+
+def _backend_modules() -> list[pathlib.Path]:
+    found = [SOURCE / "accessor" / "gdrive.py"]
+    for root in BACKEND_ROOTS:
+        found.extend(p for p in sorted(root.rglob("*.py")))
+    return [p for p in found if p not in SEAM_MODULES]
+
+
+def _wire_calls(module) -> set[str]:
+    return {
+        name
+        for name, value in vars(module).items()
+        if inspect.iscoroutinefunction(value)
+    }
+
+
+def _offending_imports(path: pathlib.Path) -> list[str]:
+    tree = ast.parse(path.read_text())
+    offences: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in WIRE_MODULES:
+                    offences.append(f"import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            module = WIRE_MODULES.get(node.module or "")
+            if module is None:
+                continue
+            calls = _wire_calls(module)
+            for alias in node.names:
+                if alias.name in calls:
+                    offences.append(f"from {node.module} import {alias.name}")
+    return offences
+
+
+def test_every_gdrive_module_reaches_drive_through_the_one_seam():
+    """No gdrive module imports a Drive call by value.
+
+    #684: the e2e fake patched ``list_files`` where readdir had bound it,
+    so ``find`` -- which reaches Drive through resolve and tree -- ran
+    against the live API mid-test. A by-value import is a door the fake
+    cannot see, and this fails the moment a new one appears.
+    """
+    offenders = {
+        str(path.relative_to(SOURCE)): offences
+        for path in _backend_modules()
+        if (offences := _offending_imports(path))
+    }
+    assert not offenders, (
+        f"these modules bypass GDriveAccessor.drive: {offenders}. Add the "
+        "call to DriveApi in core/gdrive/api.py and reach it through "
+        "accessor.drive instead.")
+
+
+def test_drive_api_builds_a_client_over_the_token_manager():
+    accessor_token = object()
+    client = drive_api(accessor_token)
+    assert isinstance(client, DriveClient)
+    assert client.token_manager is accessor_token
+
+
+def test_drive_client_answers_every_call_the_protocol_declares():
+    declared = {
+        name
+        for name in vars(DriveApi)
+        if not name.startswith("_") and callable(getattr(DriveApi, name))
+    }
+    assert declared
+    missing = [
+        name for name in declared
+        if not inspect.iscoroutinefunction(getattr(DriveClient, name, None))
+    ]
+    assert not missing, f"DriveClient does not implement {missing}"
+
+
+def test_the_accessor_builds_a_fresh_door_per_read():
+    """A cached door would freeze the live client onto the accessor.
+
+    The resource constructs its accessor before a test installs a fake,
+    so a door built once in ``__init__`` would already point at the real
+    API by the time the fake arrives.
+    """
+    accessor = GDriveAccessor(config=None, token_manager=None)
+    assert accessor.drive is not accessor.drive

--- a/python/tests/core/gdrive/test_read.py
+++ b/python/tests/core/gdrive/test_read.py
@@ -24,13 +24,14 @@ from mirage.core.google.client import TokenManager
 from mirage.core.google.config import GoogleConfig
 from mirage.types import PathSpec
 from mirage.utils.ranges import ByteWindow
+from tests.fixtures.gdrive_stub import StubDrive, install_drive
 
 
-async def fail_list_files(_tm, folder_id, drive_id=None):
+async def fail_list_files(folder_id, drive_id=None):
     raise RuntimeError("drive unavailable")
 
 
-async def empty_list_files(_tm, folder_id, drive_id=None):
+async def empty_list_files(folder_id, drive_id=None):
     return []
 
 
@@ -63,7 +64,7 @@ def index():
 
 
 @pytest.mark.asyncio
-async def test_read_file(accessor, index):
+async def test_read_file(accessor, index, monkeypatch):
     await index.put(
         "/Team Drive/report.pdf",
         IndexEntry(
@@ -75,43 +76,36 @@ async def test_read_file(accessor, index):
             extra={"drive_id": "drive1"},
         ))
     content = b"pdf content here"
-    with patch(
-            "mirage.core.gdrive.read.download_file",
-            new_callable=AsyncMock,
-            return_value=content,
-    ):
-        result = await read(
-            accessor,
-            PathSpec(resource_path="Team Drive/report.pdf",
-                     virtual="/Team Drive/report.pdf",
-                     directory="/Team Drive/report.pdf"), index)
-        assert result == content
+    install_drive(monkeypatch,
+                  StubDrive(download_file=AsyncMock(return_value=content)))
+    result = await read(
+        accessor,
+        PathSpec(resource_path="Team Drive/report.pdf",
+                 virtual="/Team Drive/report.pdf",
+                 directory="/Team Drive/report.pdf"), index)
+    assert result == content
 
 
 @pytest.mark.asyncio
 async def test_a_ranged_read_of_a_binary_file_asks_drive_for_the_range(
-        accessor, index):
+        accessor, index, monkeypatch):
     await index.put(
         "/report.pdf",
         IndexEntry(id="file123",
                    name="report",
                    resource_type="gdrive/file",
                    vfs_name="report.pdf"))
-    with patch(
-            "mirage.core.gdrive.read.download_file",
-            new_callable=AsyncMock,
-            return_value=b"tent",
-    ) as mock_download:
-        result = await read(accessor,
-                            PathSpec(resource_path="report.pdf",
-                                     virtual="/report.pdf",
-                                     directory="/report.pdf"),
-                            index,
-                            offset=3,
-                            size=4)
+    mock_download = AsyncMock(return_value=b"tent")
+    install_drive(monkeypatch, StubDrive(download_file=mock_download))
+    result = await read(accessor,
+                        PathSpec(resource_path="report.pdf",
+                                 virtual="/report.pdf",
+                                 directory="/report.pdf"),
+                        index,
+                        offset=3,
+                        size=4)
     assert result == b"tent"
-    mock_download.assert_awaited_once_with(accessor.token_manager, "file123",
-                                           ByteWindow(3, 4))
+    mock_download.assert_awaited_once_with("file123", ByteWindow(3, 4))
 
 
 @pytest.mark.asyncio
@@ -142,7 +136,8 @@ async def test_a_ranged_read_of_a_rendered_file_slices_what_we_rendered(
 
 
 @pytest.mark.asyncio
-async def test_read_shared_drive_raises_is_a_directory(accessor, index):
+async def test_read_shared_drive_raises_is_a_directory(accessor, index,
+                                                       monkeypatch):
     await index.put(
         "/Team Drive",
         IndexEntry(
@@ -152,40 +147,39 @@ async def test_read_shared_drive_raises_is_a_directory(accessor, index):
             vfs_name="Team Drive",
             extra={"drive_id": "drive1"},
         ))
-    with patch(
-            "mirage.core.gdrive.read.download_file",
-            new_callable=AsyncMock,
-    ) as mock_download:
-        # The message is the bare operand, which is what the shell renders
-        # ("cat: /Team Drive: Is a directory"). The TS twin asserts the same
-        # string through the stamped virtualPath.
-        with pytest.raises(IsADirectoryError) as excinfo:
-            await read(
-                accessor,
-                PathSpec(resource_path="Team Drive",
-                         virtual="/Team Drive",
-                         directory="/Team Drive"),
-                index,
-            )
-        assert str(excinfo.value) == "/Team Drive"
+    mock_download = AsyncMock()
+    install_drive(monkeypatch, StubDrive(download_file=mock_download))
+    # The message is the bare operand, which is what the shell renders
+    # ("cat: /Team Drive: Is a directory"). The TS twin asserts the same
+    # string through the stamped virtualPath.
+    with pytest.raises(IsADirectoryError) as excinfo:
+        await read(
+            accessor,
+            PathSpec(resource_path="Team Drive",
+                     virtual="/Team Drive",
+                     directory="/Team Drive"),
+            index,
+        )
+    assert str(excinfo.value) == "/Team Drive"
     mock_download.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_read_not_found(accessor, index):
-    with patch("mirage.core.gdrive.readdir.list_files", new=empty_list_files):
-        with pytest.raises(FileNotFoundError):
-            await read(
-                accessor,
-                PathSpec(resource_path="missing/file.txt",
-                         virtual="/missing/file.txt",
-                         directory="/missing/file.txt"), index)
+async def test_read_not_found(accessor, index, monkeypatch):
+    install_drive(monkeypatch, StubDrive(list_files=empty_list_files))
+    with pytest.raises(FileNotFoundError):
+        await read(
+            accessor,
+            PathSpec(resource_path="missing/file.txt",
+                     virtual="/missing/file.txt",
+                     directory="/missing/file.txt"), index)
 
 
 @pytest.mark.asyncio
-async def test_read_auto_bootstraps_from_empty_index(accessor, index):
+async def test_read_auto_bootstraps_from_empty_index(accessor, index,
+                                                     monkeypatch):
 
-    async def fake_list_files(_tm, folder_id, drive_id=None):
+    async def fake_list_files(folder_id, drive_id=None):
         if folder_id == "root":
             return [{
                 "id": "f1",
@@ -197,31 +191,25 @@ async def test_read_auto_bootstraps_from_empty_index(accessor, index):
             }]
         raise AssertionError(f"unexpected folder_id={folder_id}")
 
-    with (
-            patch(
-                "mirage.core.gdrive.readdir.list_files",
-                new=fake_list_files,
-            ),
-            patch(
-                "mirage.core.gdrive.read.download_file",
-                new_callable=AsyncMock,
-                return_value=b"pdf-bytes",
-            ),
-    ):
-        result = await read(
-            accessor,
-            PathSpec(resource_path="report.pdf",
-                     virtual="/report.pdf",
-                     directory="/report.pdf"),
-            index,
-        )
-        assert result == b"pdf-bytes"
+    install_drive(
+        monkeypatch,
+        StubDrive(list_files=fake_list_files,
+                  download_file=AsyncMock(return_value=b"pdf-bytes")))
+    result = await read(
+        accessor,
+        PathSpec(resource_path="report.pdf",
+                 virtual="/report.pdf",
+                 directory="/report.pdf"),
+        index,
+    )
+    assert result == b"pdf-bytes"
 
 
 @pytest.mark.asyncio
-async def test_read_missing_file_raises_after_recursion(accessor, index):
+async def test_read_missing_file_raises_after_recursion(
+        accessor, index, monkeypatch):
 
-    async def fake_list_files(_tm, folder_id, drive_id=None):
+    async def fake_list_files(folder_id, drive_id=None):
         if folder_id == "root":
             return [{
                 "id": "f1",
@@ -233,35 +221,31 @@ async def test_read_missing_file_raises_after_recursion(accessor, index):
             }]
         raise AssertionError(f"unexpected folder_id={folder_id}")
 
-    with (
-            patch(
-                "mirage.core.gdrive.readdir.list_files",
-                new=fake_list_files,
-            ),
-            patch(
-                "mirage.core.gdrive.read.download_file",
-                new_callable=AsyncMock,
-                side_effect=AssertionError("should not call download_file"),
-            ),
-    ):
-        with pytest.raises(FileNotFoundError):
-            await read(
-                accessor,
-                PathSpec(resource_path="missing.txt",
-                         virtual="/missing.txt",
-                         directory="/missing.txt"),
-                index,
-            )
+    install_drive(
+        monkeypatch,
+        StubDrive(
+            list_files=fake_list_files,
+            download_file=AsyncMock(
+                side_effect=AssertionError("should not call download_file"))))
+    with pytest.raises(FileNotFoundError):
+        await read(
+            accessor,
+            PathSpec(resource_path="missing.txt",
+                     virtual="/missing.txt",
+                     directory="/missing.txt"),
+            index,
+        )
 
 
 @pytest.mark.asyncio
-async def test_read_propagates_parent_refresh_failure(accessor, index):
-    with patch("mirage.core.gdrive.readdir.list_files", new=fail_list_files):
-        with pytest.raises(RuntimeError, match="drive unavailable"):
-            await read(
-                accessor,
-                PathSpec(resource_path="missing.txt",
-                         virtual="/missing.txt",
-                         directory="/missing.txt"),
-                index,
-            )
+async def test_read_propagates_parent_refresh_failure(accessor, index,
+                                                      monkeypatch):
+    install_drive(monkeypatch, StubDrive(list_files=fail_list_files))
+    with pytest.raises(RuntimeError, match="drive unavailable"):
+        await read(
+            accessor,
+            PathSpec(resource_path="missing.txt",
+                     virtual="/missing.txt",
+                     directory="/missing.txt"),
+            index,
+        )

--- a/python/tests/core/gdrive/test_readdir.py
+++ b/python/tests/core/gdrive/test_readdir.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -24,6 +24,7 @@ from mirage.core.gdrive.readdir import readdir
 from mirage.core.google.client import TokenManager
 from mirage.core.google.config import GoogleConfig
 from mirage.types import PathSpec
+from tests.fixtures.gdrive_stub import StubDrive, install_drive
 
 
 @pytest.fixture
@@ -54,7 +55,7 @@ def index():
 
 
 @pytest.mark.asyncio
-async def test_readdir_root(accessor, index):
+async def test_readdir_root(accessor, index, monkeypatch):
     files = [
         {
             "id": "f1",
@@ -70,15 +71,12 @@ async def test_readdir_root(accessor, index):
             },
         },
     ]
-    with patch(
-            "mirage.core.gdrive.readdir.list_files",
-            new_callable=AsyncMock,
-            return_value=files,
-    ):
-        result = await readdir(
-            accessor, PathSpec(resource_path="", virtual="/", directory="/"),
-            index)
-        assert "/readme.txt" in result
+    install_drive(monkeypatch,
+                  StubDrive(list_files=AsyncMock(return_value=files)))
+    result = await readdir(
+        accessor, PathSpec(resource_path="", virtual="/", directory="/"),
+        index)
+    assert "/readme.txt" in result
 
 
 @pytest.mark.asyncio
@@ -98,7 +96,7 @@ async def test_readdir_cached(accessor, index):
 
 
 @pytest.mark.asyncio
-async def test_readdir_subfolder(accessor, index):
+async def test_readdir_subfolder(accessor, index, monkeypatch):
     await index.put(
         "/docs",
         IndexEntry(
@@ -121,23 +119,19 @@ async def test_readdir_subfolder(accessor, index):
             },
         },
     ]
-    with patch(
-            "mirage.core.gdrive.readdir.list_files",
-            new_callable=AsyncMock,
-            return_value=files,
-    ) as mock_list:
-        result = await readdir(
-            accessor,
-            PathSpec(resource_path="docs", virtual="/docs", directory="/docs"),
-            index)
-        assert "/docs/notes.txt" in result
-        mock_list.assert_called_once_with(accessor.token_manager,
-                                          folder_id="folder1",
-                                          drive_id=None)
+    mock_list = AsyncMock(return_value=files)
+    install_drive(monkeypatch, StubDrive(list_files=mock_list))
+    result = await readdir(
+        accessor,
+        PathSpec(resource_path="docs", virtual="/docs", directory="/docs"),
+        index)
+    assert "/docs/notes.txt" in result
+    mock_list.assert_called_once_with(folder_id="folder1", drive_id=None)
 
 
 @pytest.mark.asyncio
-async def test_readdir_repopulates_evicted_subfolder(accessor, index):
+async def test_readdir_repopulates_evicted_subfolder(accessor, index,
+                                                     monkeypatch):
     root_files = [{
         "id": "folder1",
         "name": "docs",
@@ -155,27 +149,24 @@ async def test_readdir_repopulates_evicted_subfolder(accessor, index):
         "capabilities": {},
     }]
 
-    async def fake_list_files(_tm, folder_id, drive_id=None):
+    async def fake_list_files(folder_id, drive_id=None):
         if folder_id == "root":
             return root_files
         if folder_id == "folder1":
             return docs_files
         raise AssertionError(f"unexpected folder_id={folder_id}")
 
-    with patch(
-            "mirage.core.gdrive.readdir.list_files",
-            new=fake_list_files,
-    ):
-        result = await readdir(
-            accessor,
-            PathSpec(resource_path="docs", virtual="/docs", directory="/docs"),
-            index)
-        assert "/docs/notes.txt" in result
+    install_drive(monkeypatch, StubDrive(list_files=fake_list_files))
+    result = await readdir(
+        accessor,
+        PathSpec(resource_path="docs", virtual="/docs", directory="/docs"),
+        index)
+    assert "/docs/notes.txt" in result
 
 
 @pytest.mark.asyncio
 async def test_readdir_missing_subfolder_raises_after_recursion(
-        accessor, index):
+        accessor, index, monkeypatch):
     root_files = [{
         "id": "f1",
         "name": "other.txt",
@@ -185,25 +176,22 @@ async def test_readdir_missing_subfolder_raises_after_recursion(
         "capabilities": {},
     }]
 
-    async def fake_list_files(_tm, folder_id, drive_id=None):
+    async def fake_list_files(folder_id, drive_id=None):
         if folder_id == "root":
             return root_files
         raise AssertionError(f"should not list folder_id={folder_id}")
 
-    with patch(
-            "mirage.core.gdrive.readdir.list_files",
-            new=fake_list_files,
-    ):
-        with pytest.raises(FileNotFoundError):
-            await readdir(
-                accessor,
-                PathSpec(resource_path="docs",
-                         virtual="/docs",
-                         directory="/docs"), index)
+    install_drive(monkeypatch, StubDrive(list_files=fake_list_files))
+    with pytest.raises(FileNotFoundError):
+        await readdir(
+            accessor,
+            PathSpec(resource_path="docs", virtual="/docs", directory="/docs"),
+            index)
 
 
 @pytest.mark.asyncio
-async def test_readdir_under_a_file_is_not_a_directory(accessor, index):
+async def test_readdir_under_a_file_is_not_a_directory(accessor, index,
+                                                       monkeypatch):
     # Listing a file's own id answers with an empty child set rather than
     # an error, so the recursion below has to refuse at the file itself or
     # `/a.txt/x` comes back ENOENT where opendir(2) says ENOTDIR.
@@ -216,25 +204,23 @@ async def test_readdir_under_a_file_is_not_a_directory(accessor, index):
         "capabilities": {},
     }]
 
-    async def fake_list_files(_tm, folder_id, drive_id=None):
+    async def fake_list_files(folder_id, drive_id=None):
         if folder_id == "root":
             return root_files
         raise AssertionError(f"should not list folder_id={folder_id}")
 
-    with patch(
-            "mirage.core.gdrive.readdir.list_files",
-            new=fake_list_files,
-    ):
-        with pytest.raises(NotADirectoryError):
-            await readdir(
-                accessor,
-                PathSpec(resource_path="a.txt/x",
-                         virtual="/a.txt/x",
-                         directory="/a.txt/x"), index)
+    install_drive(monkeypatch, StubDrive(list_files=fake_list_files))
+    with pytest.raises(NotADirectoryError):
+        await readdir(
+            accessor,
+            PathSpec(resource_path="a.txt/x",
+                     virtual="/a.txt/x",
+                     directory="/a.txt/x"), index)
 
 
 @pytest.mark.asyncio
-async def test_readdir_root_includes_shared_drives(accessor, index):
+async def test_readdir_root_includes_shared_drives(accessor, index,
+                                                   monkeypatch):
     files = [{
         "id": "f1",
         "name": "readme.txt",
@@ -244,25 +230,25 @@ async def test_readdir_root_includes_shared_drives(accessor, index):
         "capabilities": {},
     }]
     drives = [{"id": "drive1", "name": "Team Drive"}]
-    with patch("mirage.core.gdrive.readdir.list_files",
-               new_callable=AsyncMock, return_value=files), \
-         patch("mirage.core.gdrive.readdir.list_shared_drives",
-               new_callable=AsyncMock, return_value=drives):
-        result = await readdir(
-            accessor, PathSpec(resource_path="", virtual="/", directory="/"),
-            index)
-        assert "/readme.txt" in result
-        # Shared Drives appear as top-level directories.
-        assert "/Team Drive/" in result
-        # The drive id is carried on the cached entry for nested listings.
-        entry = (await index.get("/Team Drive")).entry
-        assert entry is not None
-        assert entry.extra.get("drive_id") == "drive1"
+    install_drive(
+        monkeypatch,
+        StubDrive(list_files=AsyncMock(return_value=files),
+                  list_shared_drives=AsyncMock(return_value=drives)))
+    result = await readdir(
+        accessor, PathSpec(resource_path="", virtual="/", directory="/"),
+        index)
+    assert "/readme.txt" in result
+    # Shared Drives appear as top-level directories.
+    assert "/Team Drive/" in result
+    # The drive id is carried on the cached entry for nested listings.
+    entry = (await index.get("/Team Drive")).entry
+    assert entry is not None
+    assert entry.extra.get("drive_id") == "drive1"
 
 
 @pytest.mark.asyncio
 async def test_readdir_root_uniquifies_duplicate_shared_drive_names(
-        accessor, index):
+        accessor, index, monkeypatch):
     drives = [
         {
             "id": "drive1",
@@ -277,13 +263,13 @@ async def test_readdir_root_uniquifies_duplicate_shared_drive_names(
             "name": "Team"
         },
     ]
-    with patch("mirage.core.gdrive.readdir.list_files",
-               new_callable=AsyncMock, return_value=[]), \
-         patch("mirage.core.gdrive.readdir.list_shared_drives",
-               new_callable=AsyncMock, return_value=drives):
-        result = await readdir(
-            accessor, PathSpec(resource_path="", virtual="/", directory="/"),
-            index)
+    install_drive(
+        monkeypatch,
+        StubDrive(list_files=AsyncMock(return_value=[]),
+                  list_shared_drives=AsyncMock(return_value=drives)))
+    result = await readdir(
+        accessor, PathSpec(resource_path="", virtual="/", directory="/"),
+        index)
 
     assert result == [
         "/Team/",
@@ -296,7 +282,8 @@ async def test_readdir_root_uniquifies_duplicate_shared_drive_names(
 
 
 @pytest.mark.asyncio
-async def test_readdir_root_shared_drives_best_effort(accessor, index):
+async def test_readdir_root_shared_drives_best_effort(accessor, index,
+                                                      monkeypatch):
     """If Shared Drive enumeration fails, My Drive listing still succeeds."""
     files = [{
         "id": "f1",
@@ -306,19 +293,20 @@ async def test_readdir_root_shared_drives_best_effort(accessor, index):
         "owners": [],
         "capabilities": {},
     }]
-    with patch("mirage.core.gdrive.readdir.list_files",
-               new_callable=AsyncMock, return_value=files), \
-         patch("mirage.core.gdrive.readdir.list_shared_drives",
-               new_callable=AsyncMock, side_effect=RuntimeError("no scope")):
-        result = await readdir(
-            accessor, PathSpec(resource_path="", virtual="/", directory="/"),
-            index)
-        assert "/readme.txt" in result
+    install_drive(
+        monkeypatch,
+        StubDrive(list_files=AsyncMock(return_value=files),
+                  list_shared_drives=AsyncMock(
+                      side_effect=RuntimeError("no scope"))))
+    result = await readdir(
+        accessor, PathSpec(resource_path="", virtual="/", directory="/"),
+        index)
+    assert "/readme.txt" in result
 
 
 @pytest.mark.asyncio
 async def test_readdir_failed_shared_drives_leaves_root_uncached(
-        accessor, index):
+        accessor, index, monkeypatch):
     """A short root listing must not be cached as the directory.
 
     Caching it would keep the mount My-Drive-only until the entry expires,
@@ -335,26 +323,28 @@ async def test_readdir_failed_shared_drives_leaves_root_uncached(
         "capabilities": {},
     }]
     root = PathSpec(resource_path="", virtual="/", directory="/")
-    with patch("mirage.core.gdrive.readdir.list_files",
-               new_callable=AsyncMock, return_value=files), \
-         patch("mirage.core.gdrive.readdir.list_shared_drives",
-               new_callable=AsyncMock, side_effect=RuntimeError("no scope")):
-        await readdir(accessor, root, index)
+    install_drive(
+        monkeypatch,
+        StubDrive(list_files=AsyncMock(return_value=files),
+                  list_shared_drives=AsyncMock(
+                      side_effect=RuntimeError("no scope"))))
+    await readdir(accessor, root, index)
     assert (await index.list_dir("/")).entries is None
     assert (await index.get("/readme.txt")).entry.id == "f1"
 
     drives = [{"id": "drive1", "name": "Team"}]
-    with patch("mirage.core.gdrive.readdir.list_files",
-               new_callable=AsyncMock, return_value=files), \
-         patch("mirage.core.gdrive.readdir.list_shared_drives",
-               new_callable=AsyncMock, return_value=drives):
-        result = await readdir(accessor, root, index)
+    install_drive(
+        monkeypatch,
+        StubDrive(list_files=AsyncMock(return_value=files),
+                  list_shared_drives=AsyncMock(return_value=drives)))
+    result = await readdir(accessor, root, index)
     assert "/Team/" in result
     assert (await index.list_dir("/")).entries is not None
 
 
 @pytest.mark.asyncio
-async def test_readdir_workspace_files_get_extensions(accessor, index):
+async def test_readdir_workspace_files_get_extensions(accessor, index,
+                                                      monkeypatch):
     files = [
         {
             "id": "d1",
@@ -388,21 +378,19 @@ async def test_readdir_workspace_files_get_extensions(accessor, index):
             "capabilities": {},
         },
     ]
-    with patch(
-            "mirage.core.gdrive.readdir.list_files",
-            new_callable=AsyncMock,
-            return_value=files,
-    ):
-        result = await readdir(
-            accessor, PathSpec(resource_path="", virtual="/", directory="/"),
-            index)
-        assert "/My Document.gdoc.json" in result
-        assert "/My Sheet.gsheet.json" in result
-        assert "/My Slides.gslide.json" in result
+    install_drive(monkeypatch,
+                  StubDrive(list_files=AsyncMock(return_value=files)))
+    result = await readdir(
+        accessor, PathSpec(resource_path="", virtual="/", directory="/"),
+        index)
+    assert "/My Document.gdoc.json" in result
+    assert "/My Sheet.gsheet.json" in result
+    assert "/My Slides.gslide.json" in result
 
 
 @pytest.mark.asyncio
-async def test_readdir_size_binary_kept_google_apps_in_extra(accessor, index):
+async def test_readdir_size_binary_kept_google_apps_in_extra(
+        accessor, index, monkeypatch):
     files = [
         {
             "id": "f1",
@@ -423,14 +411,11 @@ async def test_readdir_size_binary_kept_google_apps_in_extra(accessor, index):
             "capabilities": {},
         },
     ]
-    with patch(
-            "mirage.core.gdrive.readdir.list_files",
-            new_callable=AsyncMock,
-            return_value=files,
-    ):
-        await readdir(accessor,
-                      PathSpec(resource_path="", virtual="/", directory="/"),
-                      index)
+    install_drive(monkeypatch,
+                  StubDrive(list_files=AsyncMock(return_value=files)))
+    await readdir(accessor,
+                  PathSpec(resource_path="", virtual="/", directory="/"),
+                  index)
 
     # Binary files download raw: Drive's size is the rendered byte length.
     binary = (await index.get("/report.pdf")).entry

--- a/python/tests/core/gdrive/test_resolve.py
+++ b/python/tests/core/gdrive/test_resolve.py
@@ -17,7 +17,6 @@ import pytest
 from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
-import mirage.core.gdrive.resolve as resolve_mod
 from mirage.core.gdrive.resolve import (DriveNode, drive_target_name,
                                         eacces_on_denied, query_candidates,
                                         resolve_dir, resolve_key,
@@ -141,12 +140,14 @@ async def test_root_context_memoizes_drive_lookup(fake_drive, scoped_accessor,
     accessor = scoped_accessor(scope)
     calls = 0
 
-    async def counting_get_file(token_manager, file_id):
+    real_get_file = fake_drive.get_file
+
+    async def counting_get_file(file_id):
         nonlocal calls
         calls += 1
-        return await fake_drive.get_file(token_manager, file_id)
+        return await real_get_file(file_id)
 
-    monkeypatch.setattr(resolve_mod, "get_file", counting_get_file)
+    monkeypatch.setattr(fake_drive, "get_file", counting_get_file)
     assert await resolve_dir(accessor, "", "/") == (scope, "d1")
     assert await resolve_dir(accessor, "", "/") == (scope, "d1")
     assert calls == 1

--- a/python/tests/core/gdrive/test_stat.py
+++ b/python/tests/core/gdrive/test_stat.py
@@ -23,6 +23,7 @@ from mirage.core.gdrive.stat import stat
 from mirage.core.google.client import TokenManager
 from mirage.core.google.config import GoogleConfig
 from mirage.types import FileType, PathSpec
+from tests.fixtures.gdrive_stub import StubDrive, install_drive
 
 
 @pytest.fixture
@@ -134,31 +135,23 @@ async def test_stat_shared_drive_is_directory(accessor, index):
 
 
 @pytest.mark.asyncio
-async def test_stat_not_found(accessor, index):
+async def test_stat_not_found(accessor, index, monkeypatch):
     idx = await _populate_index(index)
-    with patch(
-            "mirage.core.gdrive.readdir.list_files",
-            new_callable=AsyncMock,
-            return_value=[],
-    ), patch(
-            "mirage.core.gdrive.resolve.list_files",
-            new_callable=AsyncMock,
-            return_value=[],
-    ), patch(
-            "mirage.core.gdrive.resolve.list_shared_drives",
-            new_callable=AsyncMock,
-            return_value=[],
-    ):
-        with pytest.raises(FileNotFoundError):
-            await stat(
-                accessor,
-                PathSpec(resource_path="nonexistent.txt",
-                         virtual="/nonexistent.txt",
-                         directory="/nonexistent.txt"), idx)
+    install_drive(
+        monkeypatch,
+        StubDrive(list_files=AsyncMock(return_value=[]),
+                  list_shared_drives=AsyncMock(return_value=[])))
+    with pytest.raises(FileNotFoundError):
+        await stat(
+            accessor,
+            PathSpec(resource_path="nonexistent.txt",
+                     virtual="/nonexistent.txt",
+                     directory="/nonexistent.txt"), idx)
 
 
 @pytest.mark.asyncio
-async def test_stat_cache_miss_falls_back_via_readdir(accessor, index):
+async def test_stat_cache_miss_falls_back_via_readdir(accessor, index,
+                                                      monkeypatch):
     files = [{
         "id": "f99",
         "name": "fresh.pdf",
@@ -166,16 +159,13 @@ async def test_stat_cache_miss_falls_back_via_readdir(accessor, index):
         "modifiedTime": "2026-04-15T00:00:00.000Z",
         "size": "2048",
     }]
-    with patch(
-            "mirage.core.gdrive.readdir.list_files",
-            new_callable=AsyncMock,
-            return_value=files,
-    ) as mock_list:
-        result = await stat(
-            accessor,
-            PathSpec(resource_path="fresh.pdf",
-                     virtual="/fresh.pdf",
-                     directory="/fresh.pdf"), index)
+    mock_list = AsyncMock(return_value=files)
+    install_drive(monkeypatch, StubDrive(list_files=mock_list))
+    result = await stat(
+        accessor,
+        PathSpec(resource_path="fresh.pdf",
+                 virtual="/fresh.pdf",
+                 directory="/fresh.pdf"), index)
     assert result.name == "fresh.pdf"
     assert result.extra["file_id"] == "f99"
     # binary files download raw, so Drive's size is the rendered length

--- a/python/tests/core/gdrive/test_versions.py
+++ b/python/tests/core/gdrive/test_versions.py
@@ -20,6 +20,7 @@ from mirage.core.gdrive.read import read_file_versioned
 from mirage.core.gdrive.versions import (capture_file_metadata,
                                          download_revision, list_revisions)
 from mirage.observe.context import push_revisions, reset_revisions
+from tests.fixtures.gdrive_stub import StubDrive
 
 
 @pytest.mark.asyncio
@@ -88,38 +89,25 @@ async def test_capture_falls_back_to_head_revision(gdrive_accessor):
 
 @pytest.mark.asyncio
 async def test_read_file_versioned_pinned(gdrive_accessor):
+    pinned_read = AsyncMock(return_value=b"pinned")
+    live_read = AsyncMock()
+    drive = StubDrive(download_revision=pinned_read, download_file=live_read)
     token = push_revisions({"/data/f.txt": "r1"})
     try:
-        with patch(
-                "mirage.core.gdrive.read.download_revision",
-                new_callable=AsyncMock,
-                return_value=b"pinned",
-        ) as pinned_read, patch(
-                "mirage.core.gdrive.read.download_file",
-                new_callable=AsyncMock,
-        ) as live_read:
-            data = await read_file_versioned(gdrive_accessor.token_manager,
-                                             "f1", "/data/f.txt", "f.txt")
+        data = await read_file_versioned(drive, "f1", "/data/f.txt", "f.txt")
     finally:
         reset_revisions(token)
     assert data == b"pinned"
-    pinned_read.assert_awaited_once_with(gdrive_accessor.token_manager, "f1",
-                                         "r1", None)
+    pinned_read.assert_awaited_once_with("f1", "r1", None)
     live_read.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_read_file_versioned_unpinned_reads_live(gdrive_accessor):
-    with patch(
-            "mirage.core.gdrive.read.download_file",
-            new_callable=AsyncMock,
-            return_value=b"live",
-    ), patch(
-            "mirage.core.gdrive.read.capture_file_metadata",
-            new_callable=AsyncMock,
-    ) as capture:
-        data = await read_file_versioned(gdrive_accessor.token_manager, "f1",
-                                         "/data/f.txt", "f.txt")
+    capture = AsyncMock()
+    drive = StubDrive(download_file=AsyncMock(return_value=b"live"),
+                      capture_file_metadata=capture)
+    data = await read_file_versioned(drive, "f1", "/data/f.txt", "f.txt")
     assert data == b"live"
     # No active recorder: the extra metadata call is skipped.
     capture.assert_not_awaited()

--- a/python/tests/e2e/gdrive_mock.py
+++ b/python/tests/e2e/gdrive_mock.py
@@ -14,41 +14,21 @@
 
 import hashlib
 from contextlib import ExitStack
+from typing import Any
 from unittest.mock import patch
 
-_FAKE_TOKEN = "fake-gdrive-token"
-_FAKE_EXPIRES_IN = 9999999999
+from mirage.core.google.drive import DEFAULT_UPLOAD_MIME
+from mirage.utils.ranges import ByteWindow, slice_window
 
 _FOLDER_MIME = "application/vnd.google-apps.folder"
 _FILE_MIME = "application/octet-stream"
 
-_PATCH_TARGETS = {
-    # Every module that imports the function by value needs its own
-    # binding: patching one leaves the others pointing at the real Drive
-    # API, which 401s mid-test. `find` reaches Drive through resolve and
-    # tree, neither of which readdir's binding covers (#684).
-    "list_files": [
-        "mirage.core.gdrive.readdir.list_files",
-        "mirage.core.gdrive.resolve.list_files",
-        "mirage.core.gdrive.tree.list_files",
-        "mirage.core.gdrive.rename.list_files",
-    ],
-    "list_shared_drives": [
-        "mirage.core.gdrive.readdir.list_shared_drives",
-        "mirage.core.gdrive.resolve.list_shared_drives",
-    ],
-    "list_all_files": [
-        "mirage.core.gdocs.readdir.list_all_files",
-        "mirage.core.gsheets.readdir.list_all_files",
-        "mirage.core.gslides.readdir.list_all_files",
-    ],
-    "download_file": [
-        "mirage.core.gdrive.read.download_file",
-    ],
-    "capture_file_metadata": [
-        "mirage.core.gdrive.read.capture_file_metadata",
-    ],
-}
+# One target, because the gdrive backend has one door to Drive: the
+# accessor's `drive` property, built by this factory. Before #684 the
+# fake had to name a binding inside every core module that imported an
+# API function by value, and `find` reached the live API through the two
+# nobody had listed.
+_SEAM_TARGET = "mirage.accessor.gdrive.drive_api"
 
 
 class FakeGDrive:
@@ -63,25 +43,47 @@ class FakeGDrive:
         if not parts:
             raise ValueError(f"invalid file path: {path}")
         parent_id = self._ensure_dirs(parts[:-1])
-        name = parts[-1]
+        return self.put_file(parent_id, parts[-1], content)
+
+    def put_file(self,
+                 parent_id: str,
+                 name: str,
+                 content: bytes,
+                 mime_type: str = _FILE_MIME) -> str:
         existing = self._find_child(parent_id, name)
         if existing is not None:
             self._bytes[existing["id"]] = content
             existing["size"] = str(len(content))
             existing["modifiedTime"] = self._next_modified_time()
-            return existing["id"]
+            return str(existing["id"])
         file_id = self._mk_id("f")
         entry = {
             "id": file_id,
             "name": name,
-            "mimeType": _FILE_MIME,
+            "mimeType": mime_type,
             "size": str(len(content)),
             "modifiedTime": "2026-04-16T00:00:00Z",
             "parents": [parent_id],
         }
-        self._children[parent_id].append(entry)
+        self._children.setdefault(parent_id, []).append(entry)
         self._bytes[file_id] = content
         return file_id
+
+    def make_folder(self, parent_id: str, name: str) -> dict:
+        existing = self._find_child(parent_id, name)
+        if existing is not None and existing["mimeType"] == _FOLDER_MIME:
+            return existing
+        new_id = self._mk_id("d")
+        entry = {
+            "id": new_id,
+            "name": name,
+            "mimeType": _FOLDER_MIME,
+            "modifiedTime": "2026-04-16T00:00:00Z",
+            "parents": [parent_id],
+        }
+        self._children.setdefault(parent_id, []).append(entry)
+        self._children[new_id] = []
+        return entry
 
     def remove_file(self, path: str) -> None:
         parts = [p for p in path.strip("/").split("/") if p]
@@ -98,6 +100,33 @@ class FakeGDrive:
                 children.pop(i)
                 return
 
+    def delete_id(self, file_id: str) -> None:
+        """Drop an item and, for a folder, everything under it."""
+        stack = [file_id]
+        while stack:
+            current = stack.pop()
+            for child in self._children.pop(current, []):
+                stack.append(str(child["id"]))
+            self._bytes.pop(current, None)
+        for children in self._children.values():
+            for i, c in enumerate(list(children)):
+                if c["id"] == file_id:
+                    children.pop(i)
+                    return
+
+    def reparent(self, file_id: str, new_parent: str,
+                 old_parent: str | None) -> None:
+        """Move an item between folders, the way ``files.patch`` does."""
+        item = self.item(file_id)
+        if item is None:
+            raise FileNotFoundError(file_id)
+        if old_parent is not None:
+            siblings = self._children.get(old_parent, [])
+            if item in siblings:
+                siblings.remove(item)
+        item["parents"] = [new_parent]
+        self._children.setdefault(new_parent, []).append(item)
+
     def list_children(self, folder_id: str) -> list[dict]:
         return list(self._children.get(folder_id, []))
 
@@ -108,6 +137,13 @@ class FakeGDrive:
                 if c["mimeType"] != _FOLDER_MIME:
                     result.append(c)
         return result
+
+    def item(self, file_id: str) -> dict | None:
+        for children in self._children.values():
+            for c in children:
+                if c["id"] == file_id:
+                    return c
+        return None
 
     def get_bytes(self, file_id: str) -> bytes:
         if file_id not in self._bytes:
@@ -131,21 +167,7 @@ class FakeGDrive:
     def _ensure_dirs(self, parts: list[str]) -> str:
         parent_id = "root"
         for p in parts:
-            existing = self._find_child(parent_id, p)
-            if existing is not None and existing["mimeType"] == _FOLDER_MIME:
-                parent_id = existing["id"]
-                continue
-            new_id = self._mk_id("d")
-            entry = {
-                "id": new_id,
-                "name": p,
-                "mimeType": _FOLDER_MIME,
-                "modifiedTime": "2026-04-16T00:00:00Z",
-                "parents": [parent_id],
-            }
-            self._children[parent_id].append(entry)
-            self._children[new_id] = []
-            parent_id = new_id
+            parent_id = str(self.make_folder(parent_id, p)["id"])
         return parent_id
 
     def _lookup_dirs(self, parts: list[str]) -> str | None:
@@ -164,20 +186,141 @@ class FakeGDrive:
         return None
 
 
-def _sliced(data: bytes, range_header: str | None) -> bytes:
-    """Apply an HTTP ``Range`` value the way Drive would.
+class FakeDriveApi:
+    """A ``DriveApi`` served by one ``FakeGDrive``.
+
+    Implements the whole protocol rather than the handful of calls a
+    given suite happens to make: an unimplemented method is what let a
+    call reach the network before, and here it would be an
+    ``AttributeError`` in the fake instead.
 
     Args:
-        data (bytes): the whole object.
-        range_header (str | None): a ``bytes=<start>-<end>`` value, or
-            None for the whole thing.
+        fake (FakeGDrive): the tree this door serves.
+        registry (list): every (token_manager, FakeGDrive) pair, so a
+            download by id can be answered from a sibling mount's tree.
     """
-    if not range_header:
-        return data
-    span = range_header.split("=", 1)[1]
-    start_text, _, end_text = span.partition("-")
-    start = int(start_text)
-    return data[start:int(end_text) + 1] if end_text else data[start:]
+
+    def __init__(self, fake: FakeGDrive, registry: list) -> None:
+        self.fake = fake
+        self.registry = registry
+
+    async def list_files(
+        self,
+        folder_id: str = "root",
+        drive_id: str | None = None,
+        mime_type: str | None = None,
+        trashed: bool = False,
+        page_size: int = 1000,
+        modified_after: str | None = None,
+        modified_before: str | None = None,
+        name: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        del drive_id, trashed, page_size, modified_after, modified_before
+        out = []
+        for child in self.fake.list_children(folder_id):
+            if name is not None and child.get("name") != name:
+                continue
+            if mime_type is not None and child.get("mimeType") != mime_type:
+                continue
+            out.append(child)
+            if limit is not None and len(out) >= limit:
+                break
+        return out
+
+    async def list_shared_drives(self,
+                                 page_size: int = 100) -> list[dict[str, Any]]:
+        return []
+
+    async def get_file(self, file_id: str) -> dict[str, Any]:
+        item = self.fake.item(file_id)
+        if item is None:
+            raise FileNotFoundError(file_id)
+        return item
+
+    async def delete_file(self, file_id: str) -> None:
+        self.fake.delete_id(file_id)
+
+    async def download_file(self,
+                            file_id: str,
+                            window: ByteWindow | None = None) -> bytes:
+        data = self._bytes_of(file_id)
+        if window is None:
+            return data
+        return slice_window(data, window.offset, window.size)
+
+    async def create_folder(self, name: str, parent_id: str) -> dict[str, Any]:
+        return self.fake.make_folder(parent_id, name)
+
+    async def upload_file(
+        self,
+        name: str,
+        parent_id: str,
+        data: bytes,
+        mime_type: str = DEFAULT_UPLOAD_MIME,
+    ) -> dict[str, Any]:
+        file_id = self.fake.put_file(parent_id, name, data, mime_type)
+        return await self.get_file(file_id)
+
+    async def update_file_content(
+        self,
+        file_id: str,
+        data: bytes,
+        mime_type: str = DEFAULT_UPLOAD_MIME,
+    ) -> dict[str, Any]:
+        del mime_type
+        item = await self.get_file(file_id)
+        self.fake.put_file(str(item["parents"][0]), str(item["name"]), data)
+        return await self.get_file(file_id)
+
+    async def patch_file(
+        self,
+        file_id: str,
+        body: dict[str, Any] | None = None,
+        add_parents: str | None = None,
+        remove_parents: str | None = None,
+    ) -> dict[str, Any]:
+        item = await self.get_file(file_id)
+        if body and "name" in body:
+            item["name"] = body["name"]
+        if add_parents:
+            self.fake.reparent(file_id, add_parents, remove_parents)
+        return item
+
+    async def copy_file(self, file_id: str, name: str,
+                        parent_id: str) -> dict[str, Any]:
+        src = await self.get_file(file_id)
+        new_id = self.fake.put_file(parent_id, name, self._bytes_of(file_id),
+                                    str(src.get("mimeType", _FILE_MIME)))
+        return await self.get_file(new_id)
+
+    async def list_revisions(self, file_id: str) -> list[dict[str, Any]]:
+        digest = hashlib.md5(self._bytes_of(file_id)).hexdigest()
+        return [{"id": f"rev-{digest}"}]
+
+    async def download_revision(
+        self,
+        file_id: str,
+        revision_id: str,
+        window: ByteWindow | None = None,
+    ) -> bytes:
+        del revision_id
+        return await self.download_file(file_id, window)
+
+    async def capture_file_metadata(
+            self, file_id: str) -> tuple[str | None, str | None]:
+        digest = hashlib.md5(self._bytes_of(file_id)).hexdigest()
+        return digest, f"rev-{digest}"
+
+    def _bytes_of(self, file_id: str) -> bytes:
+        # A cross-mount copy reads a file id this door's own tree does
+        # not hold, so the sibling trees answer for it.
+        if self.fake.has_id(file_id):
+            return self.fake.get_bytes(file_id)
+        for _, other in self.registry:
+            if other.has_id(file_id):
+                return other.get_bytes(file_id)
+        raise FileNotFoundError(file_id)
 
 
 def _resolve_fake(token_manager, registry):
@@ -189,90 +332,8 @@ def _resolve_fake(token_manager, registry):
     return registry[0][1]
 
 
-def _build_fakes(registry):
-
-    async def fake_refresh(_config):
-        return _FAKE_TOKEN, _FAKE_EXPIRES_IN
-
-    async def fake_list_files(
-        token_manager,
-        folder_id: str = "root",
-        drive_id: str | None = None,
-        mime_type: str | None = None,
-        trashed: bool = False,
-        page_size: int = 1000,
-        modified_after: str | None = None,
-        modified_before: str | None = None,
-        name: str | None = None,
-    ) -> list[dict]:
-        # The signature mirrors the real list_files so a caller that passes
-        # a filter this fake ignores fails loudly at the call site rather
-        # than silently listing an unfiltered folder. `name` is honored
-        # because resolve_key walks a path one exact name at a time.
-        del drive_id, mime_type, trashed, page_size
-        del modified_after, modified_before
-        fake = _resolve_fake(token_manager, registry)
-        if fake is None:
-            return []
-        children = fake.list_children(folder_id)
-        if name is not None:
-            children = [c for c in children if c.get("name") == name]
-        return children
-
-    async def fake_list_all_files(
-        token_manager,
-        mime_type: str | None = None,
-        trashed: bool = False,
-        page_size: int = 1000,
-    ) -> tuple[list[dict], bool]:
-        del mime_type, trashed, page_size
-        fake = _resolve_fake(token_manager, registry)
-        if fake is None:
-            return [], True
-        return fake.all_files(), True
-
-    async def fake_list_shared_drives(token_manager) -> list[dict]:
-        return []
-
-    async def fake_download_file(token_manager,
-                                 file_id: str,
-                                 range_header: str | None = None) -> bytes:
-        # The Range is served here rather than ignored: Drive honours it
-        # for a binary file, so a fake that returned the whole object
-        # would hide a ranged read asking for the wrong window.
-        fake = _resolve_fake(token_manager, registry)
-        if fake is None:
-            raise FileNotFoundError(file_id)
-        data = None
-        if fake.has_id(file_id):
-            data = fake.get_bytes(file_id)
-        else:
-            for _, other in registry:
-                if other.has_id(file_id):
-                    data = other.get_bytes(file_id)
-                    break
-        if data is None:
-            raise FileNotFoundError(file_id)
-        return _sliced(data, range_header)
-
-    async def fake_capture_file_metadata(
-            token_manager, file_id: str) -> tuple[str | None, str | None]:
-        data = await fake_download_file(token_manager, file_id)
-        digest = hashlib.md5(data).hexdigest()
-        return digest, f"rev-{digest}"
-
-    return {
-        "refresh": fake_refresh,
-        "list_files": fake_list_files,
-        "list_shared_drives": fake_list_shared_drives,
-        "list_all_files": fake_list_all_files,
-        "download_file": fake_download_file,
-        "capture_file_metadata": fake_capture_file_metadata,
-    }
-
-
 def patch_gdrive(*pairs) -> ExitStack:
-    """Patch gdrive HTTP layer with (token_manager, FakeGDrive) pairs.
+    """Serve every gdrive mount from an in-memory Drive.
 
     Args:
         *pairs: tuples of (token_manager, FakeGDrive). The right fake is
@@ -283,23 +344,13 @@ def patch_gdrive(*pairs) -> ExitStack:
         registry = [(None, pairs[0])]
     else:
         registry = list(pairs)
-    fakes = _build_fakes(registry)
+
+    def fake_drive_api(token_manager):
+        fake = _resolve_fake(token_manager, registry)
+        if fake is None:
+            raise AssertionError("patch_gdrive was given no FakeGDrive")
+        return FakeDriveApi(fake, registry)
+
     stack = ExitStack()
-    stack.enter_context(
-        patch("mirage.core.google.client.refresh_access_token",
-              new=fakes["refresh"]))
-    for name, targets in _PATCH_TARGETS.items():
-        for target in targets:
-            # A target that will not resolve used to be skipped, which is
-            # how #684 stayed quiet: the binding kept pointing at the real
-            # Drive API and the test reached the network. A stale target is
-            # a fixture bug, so it fails here.
-            try:
-                stack.enter_context(patch(target, new=fakes[name]))
-            except (AttributeError, ModuleNotFoundError) as exc:
-                stack.close()
-                raise AssertionError(
-                    f"gdrive_mock cannot patch {target!r}: {exc}. Fix the "
-                    "target in _PATCH_TARGETS; leaving it unpatched sends "
-                    "the test to the real Drive API.") from exc
+    stack.enter_context(patch(_SEAM_TARGET, new=fake_drive_api))
     return stack

--- a/python/tests/e2e/test_cross_mount_matrix.py
+++ b/python/tests/e2e/test_cross_mount_matrix.py
@@ -35,7 +35,10 @@ from tests.e2e.s3_mock import patch_s3_multi
 
 REDIS_URL = os.environ.get("REDIS_URL", "")
 
-WRITABLE = {"ram", "disk", "redis", "s3"}
+# gdrive joined this set with the single-seam fake (#684): the old
+# mock patched read calls only, so a write reached the live Drive API
+# and the matrix recorded the resulting failure as "read-only".
+WRITABLE = {"ram", "disk", "redis", "s3", "gdrive"}
 
 _PAIRS = [
     ("ram", "s3"),

--- a/python/tests/fixtures/gdrive_stub.py
+++ b/python/tests/fixtures/gdrive_stub.py
@@ -1,0 +1,52 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import mirage.accessor.gdrive as accessor_mod
+
+DriveCall = Callable[..., Awaitable[Any]]
+
+
+class StubDrive:
+    """A ``DriveApi`` that answers only the calls a test armed.
+
+    Reaching an unarmed method is #684 in miniature, so it fails here
+    rather than falling through to the live Drive API.
+    """
+
+    def __init__(self, **methods: DriveCall) -> None:
+        self._methods = methods
+
+    def __getattr__(self, name: str) -> DriveCall:
+        try:
+            return self._methods[name]
+        except KeyError:
+            raise AssertionError(
+                f"the test reached Drive.{name} without arming it") from None
+
+
+def install_drive(monkeypatch, drive):
+    """Install a ``DriveApi`` behind the accessor's one seam.
+
+    One target, because ``GDriveAccessor.drive`` is the only door a
+    gdrive core op reaches Drive through.
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture.
+        drive: the ``DriveApi`` implementation to serve.
+    """
+    monkeypatch.setattr(accessor_mod, "drive_api", lambda _tm: drive)
+    return drive

--- a/python/tests/ops/gdrive/test_gdrive_vfs.py
+++ b/python/tests/ops/gdrive/test_gdrive_vfs.py
@@ -22,6 +22,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.cache.index.config import IndexEntry
 from mirage.ops import Ops
 from mirage.resource.gdrive import GoogleDriveConfig, GoogleDriveResource
+from tests.fixtures.gdrive_stub import StubDrive, install_drive
 
 
 def _make_gdrive_ops() -> tuple[Ops, IndexCacheStore]:
@@ -57,7 +58,7 @@ async def test_read_gdoc_via_filetype_cascade():
 
 
 @pytest.mark.asyncio
-async def test_read_plain_file_falls_through():
+async def test_read_plain_file_falls_through(monkeypatch):
     ops, index = _make_gdrive_ops()
     await index.put(
         "/gdrive/notes.txt",
@@ -68,13 +69,11 @@ async def test_read_plain_file_falls_through():
             remote_time="2026-04-01T00:00:00Z",
             vfs_name="notes.txt",
         ))
-    with patch(
-            "mirage.core.gdrive.read.download_file",
-            new_callable=AsyncMock,
-            return_value=b"plain content",
-    ):
-        result = await ops.read("/gdrive/notes.txt")
-        assert result == b"plain content"
+    install_drive(
+        monkeypatch,
+        StubDrive(download_file=AsyncMock(return_value=b"plain content")))
+    result = await ops.read("/gdrive/notes.txt")
+    assert result == b"plain content"
 
 
 @pytest.mark.asyncio

--- a/python/tests/ops/gdrive/test_read.py
+++ b/python/tests/ops/gdrive/test_read.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -22,6 +22,7 @@ from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.ops.gdrive import OPS
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
+from tests.fixtures.gdrive_stub import StubDrive, install_drive
 
 
 def _op(name: str):
@@ -48,7 +49,7 @@ def index():
 
 
 @pytest.mark.asyncio
-async def test_read_downloads_plain_file(accessor, index):
+async def test_read_downloads_plain_file(accessor, index, monkeypatch):
     await index.put(
         "/docs/readme.txt",
         IndexEntry(
@@ -58,14 +59,11 @@ async def test_read_downloads_plain_file(accessor, index):
             remote_time="2026-04-01T00:00:00Z",
             vfs_name="readme.txt",
         ))
-    with patch(
-            "mirage.core.gdrive.read.download_file",
-            new_callable=AsyncMock,
-            return_value=b"file content",
-    ) as mock:
-        result = await read(accessor, _scope("/docs/readme.txt"), index=index)
-        mock.assert_called_once_with(accessor.token_manager, "file123", None)
-        assert result == b"file content"
+    mock = AsyncMock(return_value=b"file content")
+    install_drive(monkeypatch, StubDrive(download_file=mock))
+    result = await read(accessor, _scope("/docs/readme.txt"), index=index)
+    mock.assert_called_once_with("file123", None)
+    assert result == b"file content"
 
 
 @pytest.mark.asyncio

--- a/python/tests/ops/gdrive/test_stat.py
+++ b/python/tests/ops/gdrive/test_stat.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -24,6 +24,7 @@ from mirage.core.google.config import GoogleConfig
 from mirage.ops.gdrive import OPS
 from mirage.types import FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
+from tests.fixtures.gdrive_stub import StubDrive, install_drive
 
 
 def _op(name: str):
@@ -76,16 +77,11 @@ async def test_stat_indexed_file(accessor, index):
 
 
 @pytest.mark.asyncio
-async def test_stat_not_found(accessor, index):
+async def test_stat_not_found(accessor, index, monkeypatch):
     await index.set_dir("/", [])
-    with patch(
-            "mirage.core.gdrive.resolve.list_files",
-            new_callable=AsyncMock,
-            return_value=[],
-    ), patch(
-            "mirage.core.gdrive.resolve.list_shared_drives",
-            new_callable=AsyncMock,
-            return_value=[],
-    ):
-        with pytest.raises(FileNotFoundError):
-            await stat(accessor, _scope("/nonexistent.txt"), index=index)
+    install_drive(
+        monkeypatch,
+        StubDrive(list_files=AsyncMock(return_value=[]),
+                  list_shared_drives=AsyncMock(return_value=[])))
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, _scope("/nonexistent.txt"), index=index)

--- a/typescript/packages/core/src/accessor/gdrive.ts
+++ b/typescript/packages/core/src/accessor/gdrive.ts
@@ -13,5 +13,14 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { GoogleApiAccessor } from './google_api.ts'
+import type { DriveApi } from '../core/gdrive/api.ts'
+import { driveApi } from '../core/gdrive/api.ts'
 
-export class GDriveAccessor extends GoogleApiAccessor {}
+export class GDriveAccessor extends GoogleApiAccessor {
+  // Built per access rather than memoized in the constructor: a resource
+  // constructs its accessor long before a test installs a fake, so a cached
+  // client would pin the live wire calls for the whole run.
+  get drive(): DriveApi {
+    return driveApi(this.tokenManager)
+  }
+}

--- a/typescript/packages/core/src/core/gdrive/_test_util.ts
+++ b/typescript/packages/core/src/core/gdrive/_test_util.ts
@@ -12,9 +12,13 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { Mock } from 'vitest'
+import { vi } from 'vitest'
 import { GDriveAccessor } from '../../accessor/gdrive.ts'
 import type { TokenManager } from '../google/client.ts'
 import type { DriveFile } from '../google/drive.ts'
+import type { DriveApi, ListFilesOptions, PatchFileOptions } from './api.ts'
+import type { DriveRevision } from './versions.ts'
 
 const FOLDER_MIME = 'application/vnd.google-apps.folder'
 const FILE_MIME = 'application/octet-stream'
@@ -30,9 +34,10 @@ export interface FakeItem {
   driveId?: string
 }
 
-// In-memory Drive: id-addressed items with parent links. Test files mock
-// ../google/drive.ts and delegate its functions to the current instance.
-export class FakeDrive {
+// In-memory Drive: id-addressed items with parent links. It implements the
+// one seam every gdrive module reaches the API through, so a test installs
+// it by handing it to the accessor rather than by mocking modules.
+export class FakeDrive implements DriveApi {
   items = new Map<string, FakeItem>()
   // Every `limit` a caller asked for, so a test can pin that an emptiness
   // probe is bounded. `pageSize` cannot express that: it caps the page, not
@@ -85,15 +90,7 @@ export class FakeDrive {
     }
   }
 
-  listFiles(
-    _tm: TokenManager,
-    opts: {
-      folderId?: string
-      mimeType?: string | null
-      name?: string | null
-      limit?: number | null
-    } = {},
-  ): Promise<DriveFile[]> {
+  listFiles(opts: ListFilesOptions = {}): Promise<DriveFile[]> {
     this.listLimits.push(opts.limit)
     const folderId = opts.folderId ?? 'root'
     const out: DriveFile[] = []
@@ -111,12 +108,11 @@ export class FakeDrive {
     return Promise.resolve([])
   }
 
-  createFolder(_tm: TokenManager, name: string, parentId: string): Promise<DriveFile> {
+  createFolder(name: string, parentId: string): Promise<DriveFile> {
     return Promise.resolve(this.public(this.folder(name, parentId)))
   }
 
   uploadFile(
-    _tm: TokenManager,
     name: string,
     parentId: string,
     data: Uint8Array,
@@ -125,14 +121,14 @@ export class FakeDrive {
     return Promise.resolve(this.public(this.add(name, parentId, mimeType, data)))
   }
 
-  updateFileContent(_tm: TokenManager, fileId: string, data: Uint8Array): Promise<DriveFile> {
+  updateFileContent(fileId: string, data: Uint8Array): Promise<DriveFile> {
     const item = this.items.get(fileId)
     if (item === undefined) throw new Error(`no item ${fileId}`)
     item.content = data
     return Promise.resolve(this.public(fileId))
   }
 
-  deleteFile(_tm: TokenManager, fileId: string): Promise<void> {
+  deleteFile(fileId: string): Promise<void> {
     const stack = [fileId]
     for (let current = stack.pop(); current !== undefined; current = stack.pop()) {
       for (const item of this.items.values()) {
@@ -143,11 +139,7 @@ export class FakeDrive {
     return Promise.resolve()
   }
 
-  patchFile(
-    _tm: TokenManager,
-    fileId: string,
-    opts: { body?: Record<string, unknown>; addParents?: string; removeParents?: string } = {},
-  ): Promise<DriveFile> {
+  patchFile(fileId: string, opts: PatchFileOptions = {}): Promise<DriveFile> {
     const item = this.items.get(fileId)
     if (item === undefined) throw new Error(`no item ${fileId}`)
     if (opts.body?.name !== undefined) item.name = opts.body.name as string
@@ -158,82 +150,91 @@ export class FakeDrive {
     return Promise.resolve(this.public(fileId))
   }
 
-  copyFile(_tm: TokenManager, fileId: string, name: string, parentId: string): Promise<DriveFile> {
+  copyFile(fileId: string, name: string, parentId: string): Promise<DriveFile> {
     const src = this.items.get(fileId)
     if (src === undefined) throw new Error(`no item ${fileId}`)
     return Promise.resolve(this.public(this.add(name, parentId, src.mimeType, src.content)))
   }
 
-  downloadFile(_tm: TokenManager, fileId: string): Promise<Uint8Array> {
+  downloadFile(fileId: string): Promise<Uint8Array> {
     const item = this.items.get(fileId)
     if (item === undefined) throw new Error(`no item ${fileId}`)
     return Promise.resolve(item.content)
   }
 
-  getFile(_tm: TokenManager, fileId: string): Promise<DriveFile> {
+  getFile(fileId: string): Promise<DriveFile> {
     if (!this.items.has(fileId)) throw new Error(`no item ${fileId}`)
     return Promise.resolve(this.public(fileId))
   }
-}
 
-// Mutable singleton the module mock delegates to; reset per test.
-let currentFakeDrive = new FakeDrive()
+  // The fake keeps no revision history: an item has only its current
+  // content. The three revision calls are here so it satisfies the whole
+  // seam, and answer from that one version.
+  listRevisions(): Promise<DriveRevision[]> {
+    return Promise.resolve([])
+  }
 
-export function resetFakeDrive(): FakeDrive {
-  currentFakeDrive = new FakeDrive()
-  return currentFakeDrive
-}
+  downloadRevision(fileId: string): Promise<Uint8Array> {
+    return this.downloadFile(fileId)
+  }
 
-// vi.mock factory body for ../google/drive.ts: keeps real constants and
-// pure helpers, routes API calls to the current FakeDrive.
-export function driveModuleMock(actual: object): object {
-  return {
-    ...actual,
-    listFiles: (...args: unknown[]) =>
-      currentFakeDrive.listFiles(args[0] as TokenManager, args[1] as never),
-    listSharedDrives: () => currentFakeDrive.listSharedDrives(),
-    createFolder: (...args: unknown[]) =>
-      currentFakeDrive.createFolder(args[0] as TokenManager, args[1] as string, args[2] as string),
-    uploadFile: (...args: unknown[]) =>
-      currentFakeDrive.uploadFile(
-        args[0] as TokenManager,
-        args[1] as string,
-        args[2] as string,
-        args[3] as Uint8Array,
-        args[4] as string | undefined,
-      ),
-    updateFileContent: (...args: unknown[]) =>
-      currentFakeDrive.updateFileContent(
-        args[0] as TokenManager,
-        args[1] as string,
-        args[2] as Uint8Array,
-      ),
-    deleteFile: (...args: unknown[]) =>
-      currentFakeDrive.deleteFile(args[0] as TokenManager, args[1] as string),
-    patchFile: (...args: unknown[]) =>
-      currentFakeDrive.patchFile(args[0] as TokenManager, args[1] as string, args[2] as never),
-    copyFile: (...args: unknown[]) =>
-      currentFakeDrive.copyFile(
-        args[0] as TokenManager,
-        args[1] as string,
-        args[2] as string,
-        args[3] as string,
-      ),
-    downloadFile: (...args: unknown[]) =>
-      currentFakeDrive.downloadFile(args[0] as TokenManager, args[1] as string),
-    getFile: (...args: unknown[]) =>
-      currentFakeDrive.getFile(args[0] as TokenManager, args[1] as string),
+  captureFileMetadata(fileId: string): Promise<[string | null, string | null]> {
+    const item = this.items.get(fileId)
+    if (item === undefined) throw new Error(`no item ${fileId}`)
+    return Promise.resolve([item.modifiedTime, null])
   }
 }
 
-export function makeGDriveAccessor(): GDriveAccessor {
-  return new GDriveAccessor({
-    tokenManager: { config: { clientId: 'cid', refreshToken: 'rt' } } as TokenManager,
-  })
+// The seam with every method a spy. A test that wants to assert on the
+// requests themselves (or to fail one) uses this instead of FakeDrive, and
+// still covers the whole surface, so a call it did not stub answers
+// undefined rather than reaching the network.
+export type StubDrive = { [K in keyof DriveApi]: Mock<DriveApi[K]> }
+
+export function stubDrive(): StubDrive {
+  return {
+    listFiles: vi.fn<DriveApi['listFiles']>(),
+    listSharedDrives: vi.fn<DriveApi['listSharedDrives']>(),
+    getFile: vi.fn<DriveApi['getFile']>(),
+    deleteFile: vi.fn<DriveApi['deleteFile']>(),
+    downloadFile: vi.fn<DriveApi['downloadFile']>(),
+    createFolder: vi.fn<DriveApi['createFolder']>(),
+    uploadFile: vi.fn<DriveApi['uploadFile']>(),
+    updateFileContent: vi.fn<DriveApi['updateFileContent']>(),
+    patchFile: vi.fn<DriveApi['patchFile']>(),
+    copyFile: vi.fn<DriveApi['copyFile']>(),
+    listRevisions: vi.fn<DriveApi['listRevisions']>(),
+    downloadRevision: vi.fn<DriveApi['downloadRevision']>(),
+    captureFileMetadata: vi.fn<DriveApi['captureFileMetadata']>(),
+  }
 }
 
-export function makeScopedGDriveAccessor(folderId: string): GDriveAccessor {
-  return new GDriveAccessor({
-    tokenManager: { config: { clientId: 'cid', refreshToken: 'rt', folderId } } as TokenManager,
-  })
+// A GDriveAccessor whose seam is the given fake. The base builds a live
+// client per access, so overriding the getter is what installs the fake for
+// every module that reaches the API through it.
+class FakeDriveAccessor extends GDriveAccessor {
+  private readonly fake: DriveApi
+
+  constructor(tokenManager: TokenManager, fake: DriveApi) {
+    super({ tokenManager })
+    this.fake = fake
+  }
+
+  override get drive(): DriveApi {
+    return this.fake
+  }
+}
+
+export function makeGDriveAccessor(drive: DriveApi): GDriveAccessor {
+  return new FakeDriveAccessor(
+    { config: { clientId: 'cid', refreshToken: 'rt' } } as TokenManager,
+    drive,
+  )
+}
+
+export function makeScopedGDriveAccessor(folderId: string, drive: DriveApi): GDriveAccessor {
+  return new FakeDriveAccessor(
+    { config: { clientId: 'cid', refreshToken: 'rt', folderId } } as TokenManager,
+    drive,
+  )
 }

--- a/typescript/packages/core/src/core/gdrive/api.test.ts
+++ b/typescript/packages/core/src/core/gdrive/api.test.ts
@@ -1,0 +1,183 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import { GDriveAccessor } from '../../accessor/gdrive.ts'
+import type { TokenManager } from '../google/client.ts'
+import { DriveClient, driveApi } from './api.ts'
+
+const GDRIVE_DIR = dirname(fileURLToPath(import.meta.url))
+const GOOGLE_DIR = join(dirname(GDRIVE_DIR), 'google')
+
+// api.ts is the seam; versions.ts is the Drive Revisions wire module the
+// seam delegates to. Their tests are allowed the same reach, since a test
+// of a wire module has to name the wire.
+const ALLOWED = new Set(['api.ts', 'api.test.ts', 'versions.ts', 'versions.test.ts'])
+
+// An import statement naming one of the three wire modules. The specifier
+// list is `[^{}]*` rather than `[\s\S]*?`: a lazy match spans newlines and
+// swallows every import between an earlier `import type {` and this one, so
+// the whole statement then reads as type-only and the violation vanishes.
+// Specifier lists never nest braces, so refusing one is exact.
+const WIRE_IMPORT =
+  /import\s+(type\s+)?(\{[^{}]*\}|\*\s+as\s+[A-Za-z0-9_$]+)\s+from\s+'([^']*(?:google\/(?:drive|client)|\/versions)\.ts)'/g
+
+const EXPORTED_FUNCTION = /^export\s+(?:async\s+)?function\s*\*?\s*([A-Za-z0-9_$]+)/gm
+
+// Every function the three wire modules export. Derived, not listed, so a
+// wire function added later is guarded the day it appears. Classes
+// (GoogleApiError, TokenManager) and constants (FOLDER_MIME, MIME_TO_EXT)
+// are deliberately not here: they carry no request.
+function wireFunctionNames(): Set<string> {
+  const names = new Set<string>()
+  const sources = [
+    join(GOOGLE_DIR, 'drive.ts'),
+    join(GOOGLE_DIR, 'client.ts'),
+    join(GDRIVE_DIR, 'versions.ts'),
+  ]
+  for (const file of sources) {
+    const source = readFileSync(file, 'utf8')
+    for (const match of source.matchAll(EXPORTED_FUNCTION)) {
+      const name = match[1]
+      if (name !== undefined) names.add(name)
+    }
+  }
+  return names
+}
+
+function gdriveSources(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...gdriveSources(full))
+    else if (entry.name.endsWith('.ts')) out.push(full)
+  }
+  return out.sort()
+}
+
+// Every wire function one source reaches by value.
+function scanSource(source: string, forbidden: Set<string>): string[] {
+  const found: string[] = []
+  for (const match of source.matchAll(WIRE_IMPORT)) {
+    const typeOnly = match[1] !== undefined
+    const clause = match[2]
+    if (typeOnly || clause === undefined) continue
+    if (clause.startsWith('*')) {
+      // A namespace import hands the module every function at once, so
+      // there is nothing to whitelist inside it.
+      found.push(clause)
+      continue
+    }
+    for (const raw of clause.slice(1, -1).split(',')) {
+      const specifier = raw.trim()
+      if (specifier === '' || specifier.startsWith('type ')) continue
+      const local = (specifier.split(/\s+as\s+/)[0] ?? '').trim()
+      if (forbidden.has(local)) found.push(local)
+    }
+  }
+  return found
+}
+
+// [file, imported name] for every wire function reached by value.
+function wireImports(forbidden: Set<string>): [string, string][] {
+  const found: [string, string][] = []
+  for (const file of gdriveSources(GDRIVE_DIR)) {
+    const name = relative(GDRIVE_DIR, file)
+    if (ALLOWED.has(name)) continue
+    for (const local of scanSource(readFileSync(file, 'utf8'), forbidden)) {
+      found.push([name, local])
+    }
+  }
+  return found
+}
+
+describe('gdrive drive seam', () => {
+  // Google Drive has no client object of its own: its calls are free
+  // functions over a TokenManager. Importing them per module meant a fake
+  // had to be installed at every one of those module sites, and a new call
+  // site escaped the fake in silence. api.ts is the one seam; every other
+  // gdrive module goes through `accessor.drive`.
+  it('no gdrive module reaches a wire function by value', () => {
+    const forbidden = wireFunctionNames()
+    // A derived set that came back empty would pass this test vacuously.
+    expect(forbidden.has('listFiles')).toBe(true)
+    expect(forbidden.has('googleGet')).toBe(true)
+    expect(forbidden.has('captureFileMetadata')).toBe(true)
+    expect(wireImports(forbidden)).toEqual([])
+  })
+
+  // The gate's own pattern is what it trusts, and the first version of it
+  // matched lazily across newlines: an earlier `import type {` in the same
+  // file absorbed the violating import, so the statement read as type-only
+  // and a real by-value import passed. Probe the detector, not just the
+  // tree it walks.
+  it('the detector sees what it is looking for', () => {
+    const forbidden = wireFunctionNames()
+    const header = "import type { GDriveAccessor } from '../../accessor/gdrive.ts'\n"
+    expect(
+      scanSource(`${header}import { deleteFile } from '../google/drive.ts'`, forbidden),
+    ).toEqual(['deleteFile'])
+    expect(
+      scanSource(`${header}import { googleGet } from '../google/client.ts'`, forbidden),
+    ).toEqual(['googleGet'])
+    expect(
+      scanSource(`${header}import { downloadRevision } from './versions.ts'`, forbidden),
+    ).toEqual(['downloadRevision'])
+    expect(scanSource(`${header}import * as drive from '../google/drive.ts'`, forbidden)).toEqual([
+      '* as drive',
+    ])
+    // A wrapped list is one statement, and a renamed specifier is still the
+    // wire function it renames.
+    expect(
+      scanSource(
+        `${header}import {\n  listFiles,\n  getFile as g,\n} from '../google/drive.ts'`,
+        forbidden,
+      ),
+    ).toEqual(['listFiles', 'getFile'])
+    // Types and constants are not requests.
+    expect(scanSource(`import type { DriveFile } from '../google/drive.ts'`, forbidden)).toEqual([])
+    expect(scanSource(`import { FOLDER_MIME } from '../google/drive.ts'`, forbidden)).toEqual([])
+    expect(scanSource(`import { type DriveFile } from '../google/drive.ts'`, forbidden)).toEqual([])
+  })
+
+  it('leaves constants and error types importable', () => {
+    const forbidden = wireFunctionNames()
+    expect(forbidden.has('FOLDER_MIME')).toBe(false)
+    expect(forbidden.has('MIME_TO_EXT')).toBe(false)
+    expect(forbidden.has('GoogleApiError')).toBe(false)
+  })
+})
+
+describe('driveApi', () => {
+  const tokenManager = { config: { clientId: 'cid', refreshToken: 'rt' } } as TokenManager
+
+  it('builds a DriveClient bound to the token manager', () => {
+    const api = driveApi(tokenManager)
+    expect(api).toBeInstanceOf(DriveClient)
+    expect((api as DriveClient).tokenManager).toBe(tokenManager)
+  })
+
+  it('the accessor builds a fresh client per access', () => {
+    // Not memoized in the constructor: a resource builds its accessor
+    // before a test installs a fake, so a cached client would pin the
+    // live wire calls for the whole run.
+    const accessor = new GDriveAccessor({ tokenManager })
+    expect(accessor.drive).not.toBe(accessor.drive)
+    expect((accessor.drive as DriveClient).tokenManager).toBe(tokenManager)
+  })
+})

--- a/typescript/packages/core/src/core/gdrive/api.ts
+++ b/typescript/packages/core/src/core/gdrive/api.ts
@@ -1,0 +1,140 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { TokenManager } from '../google/client.ts'
+import type { DriveFile, SharedDrive } from '../google/drive.ts'
+import {
+  copyFile,
+  createFolder,
+  deleteFile,
+  downloadFile,
+  getFile,
+  listFiles,
+  listSharedDrives,
+  patchFile,
+  updateFileContent,
+  uploadFile,
+} from '../google/drive.ts'
+import type { DriveRevision } from './versions.ts'
+import { captureFileMetadata, downloadRevision, listRevisions } from './versions.ts'
+import type { ByteWindow } from '../../utils/ranges.ts'
+
+// The option bags are read off the wire functions rather than restated, so
+// a change to one of them is a compile error here instead of a silent
+// divergence between the seam and the request it stands for.
+export type ListFilesOptions = NonNullable<Parameters<typeof listFiles>[1]>
+export type ListSharedDrivesOptions = NonNullable<Parameters<typeof listSharedDrives>[1]>
+export type PatchFileOptions = NonNullable<Parameters<typeof patchFile>[2]>
+
+/**
+ * Every Drive request the gdrive backend makes, in one place.
+ *
+ * gdrive is the one backend with no natural client object: its calls are
+ * free functions over a `TokenManager`, so each module used to import the
+ * ones it needed by value and a fake had to be installed at every one of
+ * those module sites. A new call site then escaped the fake silently. This
+ * is that seam: core modules take a `DriveApi`, never a wire function.
+ */
+export interface DriveApi {
+  listFiles(opts?: ListFilesOptions): Promise<DriveFile[]>
+  listSharedDrives(opts?: ListSharedDrivesOptions): Promise<SharedDrive[]>
+  getFile(fileId: string): Promise<DriveFile>
+  deleteFile(fileId: string): Promise<void>
+  downloadFile(fileId: string, window?: ByteWindow): Promise<Uint8Array>
+  createFolder(name: string, parentId: string): Promise<DriveFile>
+  uploadFile(
+    name: string,
+    parentId: string,
+    data: Uint8Array,
+    mimeType?: string,
+  ): Promise<DriveFile>
+  updateFileContent(fileId: string, data: Uint8Array, mimeType?: string): Promise<DriveFile>
+  patchFile(fileId: string, opts?: PatchFileOptions): Promise<DriveFile>
+  copyFile(fileId: string, name: string, parentId: string): Promise<DriveFile>
+  listRevisions(fileId: string): Promise<DriveRevision[]>
+  downloadRevision(fileId: string, revisionId: string, window?: ByteWindow): Promise<Uint8Array>
+  captureFileMetadata(fileId: string): Promise<[string | null, string | null]>
+}
+
+// The live implementation: one delegating method per call, with the token
+// manager prepended. Nothing else belongs here — a method that decided
+// anything would be behavior a fake silently drops.
+export class DriveClient implements DriveApi {
+  readonly tokenManager: TokenManager
+
+  constructor(tokenManager: TokenManager) {
+    this.tokenManager = tokenManager
+  }
+
+  listFiles(opts: ListFilesOptions = {}): Promise<DriveFile[]> {
+    return listFiles(this.tokenManager, opts)
+  }
+
+  listSharedDrives(opts: ListSharedDrivesOptions = {}): Promise<SharedDrive[]> {
+    return listSharedDrives(this.tokenManager, opts)
+  }
+
+  getFile(fileId: string): Promise<DriveFile> {
+    return getFile(this.tokenManager, fileId)
+  }
+
+  deleteFile(fileId: string): Promise<void> {
+    return deleteFile(this.tokenManager, fileId)
+  }
+
+  downloadFile(fileId: string, window?: ByteWindow): Promise<Uint8Array> {
+    return downloadFile(this.tokenManager, fileId, window)
+  }
+
+  createFolder(name: string, parentId: string): Promise<DriveFile> {
+    return createFolder(this.tokenManager, name, parentId)
+  }
+
+  uploadFile(
+    name: string,
+    parentId: string,
+    data: Uint8Array,
+    mimeType?: string,
+  ): Promise<DriveFile> {
+    return uploadFile(this.tokenManager, name, parentId, data, mimeType)
+  }
+
+  updateFileContent(fileId: string, data: Uint8Array, mimeType?: string): Promise<DriveFile> {
+    return updateFileContent(this.tokenManager, fileId, data, mimeType)
+  }
+
+  patchFile(fileId: string, opts: PatchFileOptions = {}): Promise<DriveFile> {
+    return patchFile(this.tokenManager, fileId, opts)
+  }
+
+  copyFile(fileId: string, name: string, parentId: string): Promise<DriveFile> {
+    return copyFile(this.tokenManager, fileId, name, parentId)
+  }
+
+  listRevisions(fileId: string): Promise<DriveRevision[]> {
+    return listRevisions(this.tokenManager, fileId)
+  }
+
+  downloadRevision(fileId: string, revisionId: string, window?: ByteWindow): Promise<Uint8Array> {
+    return downloadRevision(this.tokenManager, fileId, revisionId, window)
+  }
+
+  captureFileMetadata(fileId: string): Promise<[string | null, string | null]> {
+    return captureFileMetadata(this.tokenManager, fileId)
+  }
+}
+
+export function driveApi(tokenManager: TokenManager): DriveApi {
+  return new DriveClient(tokenManager)
+}

--- a/typescript/packages/core/src/core/gdrive/copy.test.ts
+++ b/typescript/packages/core/src/core/gdrive/copy.test.ts
@@ -12,27 +12,20 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 import { copy } from './copy.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/copy.ts
+++ b/typescript/packages/core/src/core/gdrive/copy.ts
@@ -16,8 +16,8 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { eisdir, enoent, enotdir } from '../../utils/errors.ts'
-import type { TokenManager } from '../google/client.ts'
-import { FOLDER_MIME, copyFile, createFolder, deleteFile, listFiles } from '../google/drive.ts'
+import { FOLDER_MIME } from '../google/drive.ts'
+import type { DriveApi } from './api.ts'
 import type { DriveNode } from './resolve.ts'
 import {
   driveTargetName,
@@ -28,21 +28,21 @@ import {
   resolveParent,
 } from './resolve.ts'
 
-async function copyChildren(tm: TokenManager, src: DriveNode, dstFolderId: string): Promise<void> {
-  const children = await listFiles(tm, { folderId: src.id, driveId: src.driveId })
+async function copyChildren(drive: DriveApi, src: DriveNode, dstFolderId: string): Promise<void> {
+  const children = await drive.listFiles({ folderId: src.id, driveId: src.driveId })
   for (const item of children) {
     const child = nodeFromItem(item, src.driveId)
     if (isFolder(child)) {
-      const created = await createFolder(tm, child.name, dstFolderId)
-      await copyChildren(tm, child, created.id)
+      const created = await drive.createFolder(child.name, dstFolderId)
+      await copyChildren(drive, child, created.id)
     } else {
-      await copyFile(tm, child.id, child.name, dstFolderId)
+      await drive.copyFile(child.id, child.name, dstFolderId)
     }
   }
 }
 
 async function copyImpl(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec): Promise<void> {
-  const tm = accessor.tokenManager
+  const drive = accessor.drive
   const srcNode = await resolveKey(accessor, src.resourcePath)
   if (srcNode === null) throw enoent(src)
   let dstNode = await resolveKey(accessor, dst.resourcePath)
@@ -54,7 +54,7 @@ async function copyImpl(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec):
       // cp -r merges into an existing directory and creates a missing one,
       // mirroring the msgraph copy_tree.
       const [dstParentId] = await resolveParent(accessor, dst)
-      const created = await createFolder(tm, basename, dstParentId)
+      const created = await drive.createFolder(basename, dstParentId)
       dstNode = {
         id: created.id,
         name: basename,
@@ -62,12 +62,12 @@ async function copyImpl(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec):
         driveId: srcNode.driveId,
       }
     }
-    await copyChildren(tm, srcNode, dstNode.id)
+    await copyChildren(drive, srcNode, dstNode.id)
   } else {
     if (dstNode !== null && isFolder(dstNode)) throw eisdir(dst)
-    if (dstNode !== null) await deleteFile(tm, dstNode.id)
+    if (dstNode !== null) await drive.deleteFile(dstNode.id)
     const [dstParentId] = await resolveParent(accessor, dst)
-    await copyFile(tm, srcNode.id, driveTargetName(basename, srcNode), dstParentId)
+    await drive.copyFile(srcNode.id, driveTargetName(basename, srcNode), dstParentId)
   }
   await invalidateAfterWrite(dst)
 }

--- a/typescript/packages/core/src/core/gdrive/du/du.test.ts
+++ b/typescript/packages/core/src/core/gdrive/du/du.test.ts
@@ -12,25 +12,18 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../../google/drive.ts'
-
-vi.mock('../../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../../google/drive.ts')
-  const { driveModuleMock } = await import('../_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../../accessor/gdrive.ts'
 import { PathSpec } from '../../../types.ts'
-import type { FakeDrive } from '../_test_util.ts'
-import { DOC_MIME, makeGDriveAccessor, resetFakeDrive } from '../_test_util.ts'
+import { DOC_MIME, FakeDrive, makeGDriveAccessor } from '../_test_util.ts'
 
 const ENC = new TextEncoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/exists.test.ts
+++ b/typescript/packages/core/src/core/gdrive/exists.test.ts
@@ -12,26 +12,19 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 import { exists } from './exists.ts'
 
 const ENC = new TextEncoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/find.test.ts
+++ b/typescript/packages/core/src/core/gdrive/find.test.ts
@@ -12,25 +12,18 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { DOC_MIME, makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { DOC_MIME, FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 
 const ENC = new TextEncoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/mkdir.test.ts
+++ b/typescript/packages/core/src/core/gdrive/mkdir.test.ts
@@ -12,27 +12,20 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 import { FOLDER_MIME } from '../google/drive.ts'
 import { mkdir } from './mkdir.ts'
 
 const ENC = new TextEncoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/mkdir.ts
+++ b/typescript/packages/core/src/core/gdrive/mkdir.ts
@@ -16,7 +16,6 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
 import { PathSpec } from '../../types.ts'
 import { eexist, enotdir } from '../../utils/errors.ts'
-import { createFolder } from '../google/drive.ts'
 import {
   eaccesOnDenied,
   isFolder,
@@ -29,7 +28,7 @@ import {
 
 async function mkdirImpl(accessor: GDriveAccessor, path: PathSpec, parents = false): Promise<void> {
   const key = path.resourcePath
-  const tm = accessor.tokenManager
+  const drive = accessor.drive
   if (key === '') {
     if (parents) return
     throw eexist(path)
@@ -39,7 +38,7 @@ async function mkdirImpl(accessor: GDriveAccessor, path: PathSpec, parents = fal
     if (node !== null) throw eexist(path)
     const [parentId] = await resolveParent(accessor, path)
     const basename = key.includes('/') ? key.slice(key.lastIndexOf('/') + 1) : key
-    await createFolder(tm, basename, parentId)
+    await drive.createFolder(basename, parentId)
     await invalidateAfterWrite(path)
     return
   }
@@ -49,9 +48,15 @@ async function mkdirImpl(accessor: GDriveAccessor, path: PathSpec, parents = fal
     ? path.virtual.slice(0, path.virtual.length - key.length).replace(/\/$/, '')
     : ''
   for (const [i, segment] of segments.entries()) {
-    let node = await resolveSegment(tm, parentId, segment, driveId, i === 0 && parentId === 'root')
+    let node = await resolveSegment(
+      drive,
+      parentId,
+      segment,
+      driveId,
+      i === 0 && parentId === 'root',
+    )
     if (node === null) {
-      node = nodeFromItem(await createFolder(tm, segment, parentId), driveId)
+      node = nodeFromItem(await drive.createFolder(segment, parentId), driveId)
       // Every created level makes its parent's cached listing stale, not
       // just the leaf's; a later warm-through resolution of the chain
       // would otherwise ENOENT on the stale ancestor.

--- a/typescript/packages/core/src/core/gdrive/read.test.ts
+++ b/typescript/packages/core/src/core/gdrive/read.test.ts
@@ -12,45 +12,32 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-import type * as VersionsModule from './versions.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  return { ...actual, listFiles: vi.fn(), downloadFile: vi.fn() }
-})
-
-vi.mock('./versions.ts', async () => {
-  const actual = await vi.importActual<typeof VersionsModule>('./versions.ts')
-  return { ...actual, downloadRevision: vi.fn(), captureFileMetadata: vi.fn() }
-})
-
-import { GDriveAccessor } from '../../accessor/gdrive.ts'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
 import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
 import { PathSpec } from '../../types.ts'
-import type { TokenManager } from '../google/client.ts'
 import { runWithRevisions } from '../../observe/context.ts'
-import * as drive from '../google/drive.ts'
+import type { StubDrive } from './_test_util.ts'
+import { makeGDriveAccessor, stubDrive } from './_test_util.ts'
 import { read, readFileVersioned } from './read.ts'
-import * as versions from './versions.ts'
 
-const STUB_TOKEN_MANAGER = {
-  config: { clientId: 'cid', refreshToken: 'rt' },
-} as TokenManager
+let drive: StubDrive
 
 function makeAccessor(): GDriveAccessor {
-  return new GDriveAccessor({ tokenManager: STUB_TOKEN_MANAGER })
+  return makeGDriveAccessor(drive)
 }
 
 beforeEach(() => {
-  vi.clearAllMocks()
+  drive = stubDrive()
+  // The account has no shared drives; readdir enumerates them on every
+  // listing of the mount root, so this is what a bare My Drive answers.
+  drive.listSharedDrives.mockResolvedValue([])
 })
 
 describe('gdrive read auto-bootstrap', () => {
   it('refetches root listing when entry is evicted from index', async () => {
-    vi.mocked(drive.listFiles).mockImplementation((_tm, opts) => {
+    drive.listFiles.mockImplementation((opts) => {
       if (opts?.folderId === 'root') {
         return Promise.resolve([
           {
@@ -63,7 +50,7 @@ describe('gdrive read auto-bootstrap', () => {
       }
       throw new Error(`unexpected folderId=${String(opts?.folderId)}`)
     })
-    vi.mocked(drive.downloadFile).mockResolvedValue(new TextEncoder().encode('pdf-bytes'))
+    drive.downloadFile.mockResolvedValue(new TextEncoder().encode('pdf-bytes'))
 
     const accessor = makeAccessor()
     const index = new RAMIndexCacheStore()
@@ -77,7 +64,7 @@ describe('gdrive read auto-bootstrap', () => {
   })
 
   it('throws ENOENT when file missing even after recursion', async () => {
-    vi.mocked(drive.listFiles).mockImplementation((_tm, opts) => {
+    drive.listFiles.mockImplementation((opts) => {
       if (opts?.folderId === 'root') {
         return Promise.resolve([
           {
@@ -90,7 +77,7 @@ describe('gdrive read auto-bootstrap', () => {
       }
       throw new Error(`unexpected folderId=${String(opts?.folderId)}`)
     })
-    vi.mocked(drive.downloadFile).mockRejectedValue(new Error('should not call downloadFile'))
+    drive.downloadFile.mockRejectedValue(new Error('should not call downloadFile'))
 
     const accessor = makeAccessor()
     const index = new RAMIndexCacheStore()
@@ -105,8 +92,8 @@ describe('gdrive read auto-bootstrap', () => {
   // Mirrors test_read_propagates_parent_refresh_failure: only an absent
   // parent may collapse into the operand's ENOENT.
   it('propagates a failed parent listing instead of reporting ENOENT', async () => {
-    vi.mocked(drive.listFiles).mockRejectedValue(new Error('drive unavailable'))
-    vi.mocked(drive.downloadFile).mockRejectedValue(new Error('should not call downloadFile'))
+    drive.listFiles.mockRejectedValue(new Error('drive unavailable'))
+    drive.downloadFile.mockRejectedValue(new Error('should not call downloadFile'))
     const accessor = makeAccessor()
     const index = new RAMIndexCacheStore()
     const path = new PathSpec({
@@ -118,7 +105,7 @@ describe('gdrive read auto-bootstrap', () => {
   })
 
   it('throws EISDIR when reading a shared drive root', async () => {
-    vi.mocked(drive.downloadFile).mockRejectedValue(new Error('should not call downloadFile'))
+    drive.downloadFile.mockRejectedValue(new Error('should not call downloadFile'))
     const accessor = makeAccessor()
     const index = new RAMIndexCacheStore()
     await index.put(
@@ -143,32 +130,27 @@ describe('gdrive read auto-bootstrap', () => {
       code: 'EISDIR',
       virtualPath: '/Team Drive',
     })
-    expect(vi.mocked(drive.downloadFile)).not.toHaveBeenCalled()
+    expect(drive.downloadFile).not.toHaveBeenCalled()
   })
 })
 
 describe('gdrive versioned reads', () => {
   it('a pinned path reads that revision, not live content', async () => {
     const enc = new TextEncoder()
-    vi.mocked(versions.downloadRevision).mockResolvedValue(enc.encode('pinned'))
+    drive.downloadRevision.mockResolvedValue(enc.encode('pinned'))
     const data = await runWithRevisions(new Map([['/data/f.txt', 'r1']]), () =>
-      readFileVersioned(STUB_TOKEN_MANAGER, 'f1', '/data/f.txt', 'f.txt'),
+      readFileVersioned(drive, 'f1', '/data/f.txt', 'f.txt'),
     )
     expect(new TextDecoder().decode(data)).toBe('pinned')
-    expect(versions.downloadRevision).toHaveBeenCalledWith(
-      STUB_TOKEN_MANAGER,
-      'f1',
-      'r1',
-      undefined,
-    )
+    expect(drive.downloadRevision).toHaveBeenCalledWith('f1', 'r1', undefined)
     expect(drive.downloadFile).not.toHaveBeenCalled()
   })
 
   it('an unpinned unrecorded read skips the metadata call', async () => {
     const enc = new TextEncoder()
-    vi.mocked(drive.downloadFile).mockResolvedValue(enc.encode('live'))
-    const data = await readFileVersioned(STUB_TOKEN_MANAGER, 'f1', '/data/f.txt', 'f.txt')
+    drive.downloadFile.mockResolvedValue(enc.encode('live'))
+    const data = await readFileVersioned(drive, 'f1', '/data/f.txt', 'f.txt')
     expect(new TextDecoder().decode(data)).toBe('live')
-    expect(versions.captureFileMetadata).not.toHaveBeenCalled()
+    expect(drive.captureFileMetadata).not.toHaveBeenCalled()
   })
 })

--- a/typescript/packages/core/src/core/gdrive/read.ts
+++ b/typescript/packages/core/src/core/gdrive/read.ts
@@ -19,11 +19,9 @@ import { entryOrWarm } from '../../cache/index/warm.ts'
 import { PathSpec } from '../../types.ts'
 import { record, recordingActive, revisionFor, startOp } from '../../observe/context.ts'
 import { readDoc } from '../gdocs/read.ts'
-import { downloadFile } from '../google/drive.ts'
-import { captureFileMetadata, downloadRevision } from './versions.ts'
 import { readSpreadsheet } from '../gsheets/read.ts'
 import { readPresentation } from '../gslides/read.ts'
-import type { TokenManager } from '../google/client.ts'
+import type { DriveApi } from './api.ts'
 import { DIRECTORY_RESOURCE_TYPES, readdir } from './readdir.ts'
 import { rstripSlash } from '../../utils/slash.ts'
 import { eisdir, enoent } from '../../utils/errors.ts'
@@ -34,7 +32,7 @@ import { sliceWindow, windowFor } from '../../utils/ranges.ts'
 // (fingerprint, revision) so snapshots can pin it later, mirroring the
 // msgraph read_item.
 export async function readFileVersioned(
-  tm: TokenManager,
+  drive: DriveApi,
   fileId: string,
   virtual: string,
   label: string,
@@ -48,12 +46,12 @@ export async function readFileVersioned(
   let revision: string | null = pinned
   let data: Uint8Array
   if (pinned !== null) {
-    data = await downloadRevision(tm, fileId, pinned, window)
+    data = await drive.downloadRevision(fileId, pinned, window)
   } else if (recordingActive()) {
-    ;[fingerprint, revision] = await captureFileMetadata(tm, fileId)
-    data = await downloadFile(tm, fileId, window)
+    ;[fingerprint, revision] = await drive.captureFileMetadata(fileId)
+    data = await drive.downloadFile(fileId, window)
   } else {
-    data = await downloadFile(tm, fileId, window)
+    data = await drive.downloadFile(fileId, window)
   }
   record('read', label, 'gdrive', data.length, timer, { fingerprint, revision })
   return data
@@ -101,7 +99,7 @@ export async function read(
     return sliceWindow(await readSpreadsheet(accessor.tokenManager, entry.id), offset, size)
   if (rt === 'gdrive/gslide')
     return sliceWindow(await readPresentation(accessor.tokenManager, entry.id), offset, size)
-  return readFileVersioned(accessor.tokenManager, entry.id, path.virtual, key, offset, size)
+  return readFileVersioned(accessor.drive, entry.id, path.virtual, key, offset, size)
 }
 
 export async function* stream(

--- a/typescript/packages/core/src/core/gdrive/readdir.test.ts
+++ b/typescript/packages/core/src/core/gdrive/readdir.test.ts
@@ -12,38 +12,30 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  return { ...actual, listFiles: vi.fn(), listSharedDrives: vi.fn() }
-})
-
-import { GDriveAccessor } from '../../accessor/gdrive.ts'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
 import { PathSpec } from '../../types.ts'
-import type { TokenManager } from '../google/client.ts'
-import * as drive from '../google/drive.ts'
+import type { StubDrive } from './_test_util.ts'
+import { makeGDriveAccessor, stubDrive } from './_test_util.ts'
 import { readdir } from './readdir.ts'
 
 const FOLDER_MIME = 'application/vnd.google-apps.folder'
 
-const STUB_TOKEN_MANAGER = {
-  config: { clientId: 'cid', refreshToken: 'rt' },
-} as TokenManager
+let drive: StubDrive
 
 function makeAccessor(): GDriveAccessor {
-  return new GDriveAccessor({ tokenManager: STUB_TOKEN_MANAGER })
+  return makeGDriveAccessor(drive)
 }
 
 beforeEach(() => {
-  vi.mocked(drive.listSharedDrives).mockResolvedValue([])
+  drive = stubDrive()
+  drive.listSharedDrives.mockResolvedValue([])
 })
 
 describe('readdir parent recursion', () => {
   it('repopulates evicted subfolder entry by refetching parent', async () => {
-    vi.mocked(drive.listFiles).mockImplementation((_tm, opts) => {
+    drive.listFiles.mockImplementation((opts) => {
       if (opts?.folderId === 'root') {
         return Promise.resolve([
           {
@@ -78,7 +70,7 @@ describe('readdir parent recursion', () => {
   })
 
   it('raises ENOENT when subfolder missing even after recursion', async () => {
-    vi.mocked(drive.listFiles).mockImplementation((_tm, opts) => {
+    drive.listFiles.mockImplementation((opts) => {
       if (opts?.folderId === 'root') {
         return Promise.resolve([
           {
@@ -107,7 +99,7 @@ describe('readdir parent recursion', () => {
     // Listing a file's own id answers with an empty child set rather than an
     // error, so the recursion has to refuse at the file itself or `/a.txt/x`
     // comes back ENOENT where opendir(2) says ENOTDIR.
-    vi.mocked(drive.listFiles).mockImplementation((_tm, opts) => {
+    drive.listFiles.mockImplementation((opts) => {
       if (opts?.folderId === 'root') {
         return Promise.resolve([
           {
@@ -133,7 +125,7 @@ describe('readdir parent recursion', () => {
 
 describe('readdir shared drives', () => {
   it('surfaces shared drives as top-level directories', async () => {
-    vi.mocked(drive.listFiles).mockResolvedValue([
+    drive.listFiles.mockResolvedValue([
       {
         id: 'f1',
         name: 'readme.txt',
@@ -141,7 +133,7 @@ describe('readdir shared drives', () => {
         modifiedTime: '2026-04-01T00:00:00.000Z',
       },
     ])
-    vi.mocked(drive.listSharedDrives).mockResolvedValue([{ id: 'drive1', name: 'Team Drive' }])
+    drive.listSharedDrives.mockResolvedValue([{ id: 'drive1', name: 'Team Drive' }])
 
     const accessor = makeAccessor()
     const index = new RAMIndexCacheStore()
@@ -158,8 +150,8 @@ describe('readdir shared drives', () => {
   })
 
   it('uniquifies duplicate shared drive names', async () => {
-    vi.mocked(drive.listFiles).mockResolvedValue([])
-    vi.mocked(drive.listSharedDrives).mockResolvedValue([
+    drive.listFiles.mockResolvedValue([])
+    drive.listSharedDrives.mockResolvedValue([
       { id: 'drive1', name: 'Team' },
       { id: 'drive2', name: 'Team' },
       { id: 'drive3', name: 'Team' },
@@ -179,7 +171,7 @@ describe('readdir shared drives', () => {
   })
 
   it('still lists My Drive when shared drive enumeration fails', async () => {
-    vi.mocked(drive.listFiles).mockResolvedValue([
+    drive.listFiles.mockResolvedValue([
       {
         id: 'f1',
         name: 'readme.txt',
@@ -187,7 +179,7 @@ describe('readdir shared drives', () => {
         modifiedTime: '2026-04-01T00:00:00.000Z',
       },
     ])
-    vi.mocked(drive.listSharedDrives).mockRejectedValue(new Error('no scope'))
+    drive.listSharedDrives.mockRejectedValue(new Error('no scope'))
 
     const accessor = makeAccessor()
     const index = new RAMIndexCacheStore()
@@ -212,8 +204,8 @@ describe('readdir shared drives', () => {
         modifiedTime: '2026-04-01T00:00:00.000Z',
       },
     ]
-    vi.mocked(drive.listFiles).mockResolvedValue(files)
-    vi.mocked(drive.listSharedDrives).mockRejectedValue(new Error('no scope'))
+    drive.listFiles.mockResolvedValue(files)
+    drive.listSharedDrives.mockRejectedValue(new Error('no scope'))
 
     const accessor = makeAccessor()
     const index = new RAMIndexCacheStore()
@@ -222,16 +214,16 @@ describe('readdir shared drives', () => {
     expect((await index.listDir('/')).entries).toBeUndefined()
     expect((await index.get('/readme.txt')).entry?.id).toBe('f1')
 
-    vi.mocked(drive.listFiles).mockResolvedValue(files)
-    vi.mocked(drive.listSharedDrives).mockResolvedValue([{ id: 'drive1', name: 'Team' }])
+    drive.listFiles.mockResolvedValue(files)
+    drive.listSharedDrives.mockResolvedValue([{ id: 'drive1', name: 'Team' }])
     const out = await readdir(accessor, root, index)
     expect(out).toContain('/Team/')
     expect((await index.listDir('/')).entries).toBeDefined()
   })
 
   it('passes drive_id from the cached entry when listing inside a shared drive', async () => {
-    vi.mocked(drive.listSharedDrives).mockResolvedValue([{ id: 'drive1', name: 'Team Drive' }])
-    vi.mocked(drive.listFiles).mockImplementation((_tm, opts) => {
+    drive.listSharedDrives.mockResolvedValue([{ id: 'drive1', name: 'Team Drive' }])
+    drive.listFiles.mockImplementation((opts) => {
       if (opts?.folderId === 'root') return Promise.resolve([])
       if (opts?.folderId === 'drive1') {
         return Promise.resolve([
@@ -260,14 +252,14 @@ describe('readdir shared drives', () => {
       index,
     )
     expect(out).toContain('/Team Drive/spec.pdf')
-    const innerCall = vi.mocked(drive.listFiles).mock.calls.find((c) => c[1]?.folderId === 'drive1')
-    expect(innerCall?.[1]?.driveId).toBe('drive1')
+    const innerCall = drive.listFiles.mock.calls.find((c) => c[0]?.folderId === 'drive1')
+    expect(innerCall?.[0]?.driveId).toBe('drive1')
   })
 })
 
 describe('readdir sizes', () => {
   it('keeps Drive size for binaries, moves google-apps source size to extra', async () => {
-    vi.mocked(drive.listFiles).mockResolvedValue([
+    drive.listFiles.mockResolvedValue([
       {
         id: 'f1',
         name: 'report.pdf',

--- a/typescript/packages/core/src/core/gdrive/readdir.ts
+++ b/typescript/packages/core/src/core/gdrive/readdir.ts
@@ -17,7 +17,7 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
-import { MIME_TO_EXT, listFiles, listSharedDrives } from '../google/drive.ts'
+import { MIME_TO_EXT } from '../google/drive.ts'
 import { rootContext } from './resolve.ts'
 import { rstripSlash } from '../../utils/slash.ts'
 import { compareCodePoints } from '../../utils/sort.ts'
@@ -107,7 +107,7 @@ export async function readdir(
     driveId = typeof entryDriveId === 'string' ? entryDriveId : null
   }
 
-  const files = await listFiles(accessor.tokenManager, { folderId, driveId })
+  const files = await accessor.drive.listFiles({ folderId, driveId })
   const entries: { name: string; entry: IndexEntry; isDir: boolean }[] = []
   for (const f of files) {
     const mime = f.mimeType ?? ''
@@ -149,7 +149,7 @@ export async function readdir(
     // drives never surface there.
     let sharedDrives: { id: string; name: string }[] = []
     try {
-      sharedDrives = await listSharedDrives(accessor.tokenManager)
+      sharedDrives = await accessor.drive.listSharedDrives()
     } catch {
       sharedDrives = []
       complete = false

--- a/typescript/packages/core/src/core/gdrive/rename.test.ts
+++ b/typescript/packages/core/src/core/gdrive/rename.test.ts
@@ -12,26 +12,19 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { DOC_MIME, makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { DOC_MIME, FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 import { rename } from './rename.ts'
 
 const ENC = new TextEncoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/rename.ts
+++ b/typescript/packages/core/src/core/gdrive/rename.ts
@@ -16,11 +16,10 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { invalidateSubtree } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent, enotempty } from '../../utils/errors.ts'
-import { deleteFile, listFiles, patchFile } from '../google/drive.ts'
 import { driveTargetName, eaccesOnDenied, isFolder, resolveKey, resolveParent } from './resolve.ts'
 
 async function renameImpl(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec): Promise<void> {
-  const tm = accessor.tokenManager
+  const drive = accessor.drive
   const srcNode = await resolveKey(accessor, src.resourcePath)
   if (srcNode === null) throw enoent(src)
   const dstNode = await resolveKey(accessor, dst.resourcePath)
@@ -29,14 +28,14 @@ async function renameImpl(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec
     // folder) before the move. A non-empty folder conflict is mv's
     // "Directory not empty", mirroring the msgraph rename_replace.
     if (isFolder(dstNode)) {
-      const children = await listFiles(tm, {
+      const children = await drive.listFiles({
         folderId: dstNode.id,
         driveId: dstNode.driveId,
         limit: 1,
       })
       if (children.length > 0) throw enotempty(dst)
     }
-    await deleteFile(tm, dstNode.id)
+    await drive.deleteFile(dstNode.id)
   }
   const [srcParentId] = await resolveParent(accessor, src)
   const [dstParentId] = await resolveParent(accessor, dst)
@@ -44,7 +43,7 @@ async function renameImpl(accessor: GDriveAccessor, src: PathSpec, dst: PathSpec
   const basename = dstKey.includes('/') ? dstKey.slice(dstKey.lastIndexOf('/') + 1) : dstKey
   const name = driveTargetName(basename, srcNode)
   const move = dstParentId !== srcParentId
-  await patchFile(tm, srcNode.id, {
+  await drive.patchFile(srcNode.id, {
     body: { name },
     ...(move ? { addParents: dstParentId, removeParents: srcParentId } : {}),
   })

--- a/typescript/packages/core/src/core/gdrive/resolve.test.ts
+++ b/typescript/packages/core/src/core/gdrive/resolve.test.ts
@@ -12,22 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
-import type { FakeDrive } from './_test_util.ts'
-import {
-  DOC_MIME,
-  makeGDriveAccessor,
-  makeScopedGDriveAccessor,
-  resetFakeDrive,
-} from './_test_util.ts'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
+import { DOC_MIME, FakeDrive, makeGDriveAccessor, makeScopedGDriveAccessor } from './_test_util.ts'
 import { PathSpec } from '../../types.ts'
 import { GoogleApiError } from '../google/client.ts'
 import {
@@ -42,10 +29,11 @@ const FOLDER_MIME_TEST = 'application/vnd.google-apps.folder'
 
 const ENC = new TextEncoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 describe('gdrive resolve', () => {
@@ -112,7 +100,7 @@ describe('gdrive resolve with a folder scope', () => {
     const scope = fake.folder('scope')
     const inner = fake.add('f.txt', scope, undefined, ENC.encode('in'))
     fake.add('f.txt', 'root', undefined, ENC.encode('out'))
-    const scoped = makeScopedGDriveAccessor(scope)
+    const scoped = makeScopedGDriveAccessor(scope, fake)
     const node = await resolveKey(scoped, 'f.txt')
     expect(node?.id).toBe(inner)
     expect(await resolveDir(scoped, '', '/')).toEqual([scope, null])
@@ -123,7 +111,7 @@ describe('gdrive resolve with a shared-drive scope', () => {
   it('threads the root driveId and memoizes the lookup', async () => {
     const scope = fake.add('team', 'root', FOLDER_MIME_TEST, new Uint8Array(0), 'd1')
     const inner = fake.add('f.txt', scope, undefined, ENC.encode('in'), 'd1')
-    const scoped = makeScopedGDriveAccessor(scope)
+    const scoped = makeScopedGDriveAccessor(scope, fake)
     expect(await resolveDir(scoped, '', '/')).toEqual([scope, 'd1'])
     expect(await resolveDir(scoped, '', '/')).toEqual([scope, 'd1'])
     const node = await resolveKey(scoped, 'f.txt')

--- a/typescript/packages/core/src/core/gdrive/resolve.ts
+++ b/typescript/packages/core/src/core/gdrive/resolve.ts
@@ -16,9 +16,10 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import type { PathSpec } from '../../types.ts'
 import { eacces, enoent, enotdir } from '../../utils/errors.ts'
 import { rstripSlash } from '../../utils/slash.ts'
-import { GoogleApiError, type TokenManager } from '../google/client.ts'
-import { FOLDER_MIME, MIME_TO_EXT, getFile, listFiles, listSharedDrives } from '../google/drive.ts'
+import { GoogleApiError } from '../google/client.ts'
+import { FOLDER_MIME, MIME_TO_EXT } from '../google/drive.ts'
 import type { DriveFile } from '../google/drive.ts'
+import type { DriveApi } from './api.ts'
 
 const SUFFIX_TO_MIME: Readonly<Record<string, string>> = Object.freeze(
   Object.fromEntries(Object.entries(MIME_TO_EXT).map(([mime, ext]) => [ext, mime])),
@@ -43,7 +44,7 @@ export async function rootContext(accessor: GDriveAccessor): Promise<[string, st
   const folderId = accessor.tokenManager.config.folderId
   if (folderId === undefined || folderId === '') return ['root', null]
   if (!ROOT_DRIVE_IDS.has(accessor)) {
-    const item = await getFile(accessor.tokenManager, folderId)
+    const item = await accessor.drive.getFile(folderId)
     ROOT_DRIVE_IDS.set(accessor, item.driveId ?? null)
   }
   return [folderId, ROOT_DRIVE_IDS.get(accessor) ?? null]
@@ -118,14 +119,14 @@ export function nodeFromItem(item: DriveFile, driveId: string | null): DriveNode
 }
 
 export async function resolveSegment(
-  tm: TokenManager,
+  drive: DriveApi,
   parentId: string,
   segment: string,
   driveId: string | null,
   atRoot: boolean,
 ): Promise<DriveNode | null> {
   for (const [name, mime] of queryCandidates(segment)) {
-    const matches = await listFiles(tm, {
+    const matches = await drive.listFiles({
       folderId: parentId,
       driveId,
       name,
@@ -137,9 +138,9 @@ export async function resolveSegment(
   if (atRoot) {
     // Shared Drive enumeration is best-effort, mirroring readdir: a missing
     // scope must not break resolution of My Drive paths.
-    let shared: Awaited<ReturnType<typeof listSharedDrives>>
+    let shared: Awaited<ReturnType<DriveApi['listSharedDrives']>>
     try {
-      shared = await listSharedDrives(tm)
+      shared = await drive.listSharedDrives()
     } catch {
       shared = []
     }
@@ -155,14 +156,14 @@ export async function resolveSegment(
 // Resolve a mount-relative key ("a/b/c"; "" is the mount root) to its Drive
 // item, or null.
 export async function resolveKey(accessor: GDriveAccessor, key: string): Promise<DriveNode | null> {
-  const tm = accessor.tokenManager
+  const drive = accessor.drive
   let [parentId, driveId] = await rootContext(accessor)
   let node: DriveNode | null = null
   const segments = key.split('/').filter((s) => s !== '')
   for (const [i, segment] of segments.entries()) {
     // Shared drive names are only directories at the real Drive root,
     // never inside a folder-scoped mount.
-    node = await resolveSegment(tm, parentId, segment, driveId, i === 0 && parentId === 'root')
+    node = await resolveSegment(drive, parentId, segment, driveId, i === 0 && parentId === 'root')
     if (node === null) return null
     if (i < segments.length - 1) {
       if (!isFolder(node)) throw enotdir('/' + segments.slice(0, i + 1).join('/'))

--- a/typescript/packages/core/src/core/gdrive/rm.test.ts
+++ b/typescript/packages/core/src/core/gdrive/rm.test.ts
@@ -12,26 +12,19 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 import { rmR } from './rm.ts'
 
 const ENC = new TextEncoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/rm.ts
+++ b/typescript/packages/core/src/core/gdrive/rm.ts
@@ -16,7 +16,6 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { invalidateSubtree } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent } from '../../utils/errors.ts'
-import { deleteFile } from '../google/drive.ts'
 import { eaccesOnDenied, resolveKey } from './resolve.ts'
 
 // A Drive folder delete removes its subtree in one call.
@@ -25,7 +24,7 @@ async function rmRImpl(accessor: GDriveAccessor, path: PathSpec): Promise<void> 
   if (key === '') return
   const node = await resolveKey(accessor, key)
   if (node === null) throw enoent(path)
-  await deleteFile(accessor.tokenManager, node.id)
+  await accessor.drive.deleteFile(node.id)
   await invalidateSubtree(path)
 }
 

--- a/typescript/packages/core/src/core/gdrive/rmdir.test.ts
+++ b/typescript/packages/core/src/core/gdrive/rmdir.test.ts
@@ -12,26 +12,19 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 import { rmdir } from './rmdir.ts'
 
 const ENC = new TextEncoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/rmdir.ts
+++ b/typescript/packages/core/src/core/gdrive/rmdir.ts
@@ -16,7 +16,6 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { enoent, enotdir, enotempty } from '../../utils/errors.ts'
-import { deleteFile, listFiles } from '../google/drive.ts'
 import { eaccesOnDenied, isFolder, resolveKey } from './resolve.ts'
 
 /**
@@ -36,13 +35,13 @@ async function rmdirImpl(accessor: GDriveAccessor, path: PathSpec): Promise<void
   const node = await resolveKey(accessor, key)
   if (node === null) throw enoent(path)
   if (!isFolder(node)) throw enotdir(path)
-  const children = await listFiles(accessor.tokenManager, {
+  const children = await accessor.drive.listFiles({
     folderId: node.id,
     driveId: node.driveId,
     limit: 1,
   })
   if (children.length > 0) throw enotempty(path)
-  await deleteFile(accessor.tokenManager, node.id)
+  await accessor.drive.deleteFile(node.id)
   await invalidateAfterUnlink(path)
 }
 

--- a/typescript/packages/core/src/core/gdrive/stat.test.ts
+++ b/typescript/packages/core/src/core/gdrive/stat.test.ts
@@ -26,21 +26,17 @@ vi.mock('./resolve.ts', async () => {
   return { ...actual, resolveKey: vi.fn(actual.resolveKey) }
 })
 
-import { GDriveAccessor } from '../../accessor/gdrive.ts'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
 import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
 import { FileType, PathSpec } from '../../types.ts'
-import type { TokenManager } from '../google/client.ts'
+import { makeGDriveAccessor, stubDrive } from './_test_util.ts'
 import * as readdirModule from './readdir.ts'
 import * as resolveModule from './resolve.ts'
 import { stat } from './stat.ts'
 
-const STUB_TOKEN_MANAGER = {
-  config: { clientId: 'cid', refreshToken: 'rt' },
-} as TokenManager
-
 function makeAccessor(): GDriveAccessor {
-  return new GDriveAccessor({ tokenManager: STUB_TOKEN_MANAGER })
+  return makeGDriveAccessor(stubDrive())
 }
 
 describe('gdrive stat shared drives', () => {

--- a/typescript/packages/core/src/core/gdrive/stat.ts
+++ b/typescript/packages/core/src/core/gdrive/stat.ts
@@ -19,7 +19,7 @@ import { entryOrWarm } from '../../cache/index/warm.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { DIRECTORY_RESOURCE_TYPES, readdir as coreReaddir } from './readdir.ts'
 import { enoent } from '../../utils/errors.ts'
-import { FOLDER_MIME, MIME_TO_EXT, getFile } from '../google/drive.ts'
+import { FOLDER_MIME, MIME_TO_EXT } from '../google/drive.ts'
 import { contentTypeForPath } from '../../utils/filetype.ts'
 import { resolveKey } from './resolve.ts'
 
@@ -39,7 +39,7 @@ async function statFromApi(
 ): Promise<FileStat> {
   const node = await resolveKey(accessor, key)
   if (node === null) throw enoent(virtual)
-  const item = await getFile(accessor.tokenManager, node.id)
+  const item = await accessor.drive.getFile(node.id)
   const modified = item.modifiedTime ?? ''
   if (node.mimeType === FOLDER_MIME) {
     return new FileStat({

--- a/typescript/packages/core/src/core/gdrive/tree.ts
+++ b/typescript/packages/core/src/core/gdrive/tree.ts
@@ -15,7 +15,7 @@
 import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import type { PathSpec } from '../../types.ts'
 import type { DriveFile } from '../google/drive.ts'
-import { FOLDER_MIME, MIME_TO_EXT, listFiles } from '../google/drive.ts'
+import { FOLDER_MIME, MIME_TO_EXT } from '../google/drive.ts'
 import { resolveDir } from './resolve.ts'
 import { compareCodePoints } from '../../utils/sort.ts'
 
@@ -37,7 +37,7 @@ export async function* iterTree(
   const stack: [string, string, string | null][] = [[base, folderId, driveId]]
   for (let head = stack.shift(); head !== undefined; head = stack.shift()) {
     const [rel, fid, did] = head
-    const children = await listFiles(accessor.tokenManager, { folderId: fid, driveId: did })
+    const children = await accessor.drive.listFiles({ folderId: fid, driveId: did })
     children.sort((a, b) => {
       const an = vfsName(a)
       const bn = vfsName(b)

--- a/typescript/packages/core/src/core/gdrive/truncate.test.ts
+++ b/typescript/packages/core/src/core/gdrive/truncate.test.ts
@@ -12,27 +12,20 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 import { truncate } from './truncate.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/truncate.ts
+++ b/typescript/packages/core/src/core/gdrive/truncate.ts
@@ -15,7 +15,6 @@
 import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import type { PathSpec } from '../../types.ts'
 import { eisdir } from '../../utils/errors.ts'
-import { downloadFile } from '../google/drive.ts'
 import { eaccesOnDenied, isFolder, isNative, resolveKey } from './resolve.ts'
 import { write } from './write.ts'
 
@@ -30,7 +29,7 @@ async function truncateImpl(
   if (node === null || isNative(node)) {
     data = new Uint8Array(0)
   } else {
-    data = await downloadFile(accessor.tokenManager, node.id)
+    data = await accessor.drive.downloadFile(node.id)
   }
   let out: Uint8Array
   if (length <= data.length) {

--- a/typescript/packages/core/src/core/gdrive/unlink.test.ts
+++ b/typescript/packages/core/src/core/gdrive/unlink.test.ts
@@ -12,26 +12,19 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 import { unlink } from './unlink.ts'
 
 const ENC = new TextEncoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/unlink.ts
+++ b/typescript/packages/core/src/core/gdrive/unlink.ts
@@ -16,7 +16,6 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { eisdir, enoent } from '../../utils/errors.ts'
-import { deleteFile } from '../google/drive.ts'
 import { eaccesOnDenied, isFolder, resolveKey } from './resolve.ts'
 
 async function unlinkImpl(accessor: GDriveAccessor, path: PathSpec): Promise<void> {
@@ -25,7 +24,7 @@ async function unlinkImpl(accessor: GDriveAccessor, path: PathSpec): Promise<voi
   const node = await resolveKey(accessor, key)
   if (node === null) throw enoent(path)
   if (isFolder(node)) throw eisdir(path)
-  await deleteFile(accessor.tokenManager, node.id)
+  await accessor.drive.deleteFile(node.id)
   await invalidateAfterUnlink(path)
 }
 

--- a/typescript/packages/core/src/core/gdrive/write.test.ts
+++ b/typescript/packages/core/src/core/gdrive/write.test.ts
@@ -12,27 +12,20 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as DriveModule from '../google/drive.ts'
-
-vi.mock('../google/drive.ts', async () => {
-  const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  const { driveModuleMock } = await import('./_test_util.ts')
-  return driveModuleMock(actual)
-})
-
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { PathSpec } from '../../types.ts'
-import type { FakeDrive } from './_test_util.ts'
-import { DOC_MIME, makeGDriveAccessor, resetFakeDrive } from './_test_util.ts'
+import { DOC_MIME, FakeDrive, makeGDriveAccessor } from './_test_util.ts'
 import { write } from './write.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder()
 let fake: FakeDrive
-const accessor = makeGDriveAccessor()
+let accessor: GDriveAccessor
 
 beforeEach(() => {
-  fake = resetFakeDrive()
+  fake = new FakeDrive()
+  accessor = makeGDriveAccessor(fake)
 })
 
 function spec(virtual: string): PathSpec {

--- a/typescript/packages/core/src/core/gdrive/write.ts
+++ b/typescript/packages/core/src/core/gdrive/write.ts
@@ -16,7 +16,6 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import { eacces, eisdir } from '../../utils/errors.ts'
-import { updateFileContent, uploadFile } from '../google/drive.ts'
 import { eaccesOnDenied, isFolder, isNative, resolveKey, resolveParent } from './resolve.ts'
 
 async function writeImpl(
@@ -26,17 +25,17 @@ async function writeImpl(
 ): Promise<void> {
   const key = path.resourcePath
   if (key === '') throw eisdir(path)
-  const tm = accessor.tokenManager
+  const drive = accessor.drive
   const node = await resolveKey(accessor, key)
   if (node !== null && isFolder(node)) throw eisdir(path)
   // Google-native files are written through the gws commands, not raw bytes.
   if (node !== null && isNative(node)) throw eacces(path)
   if (node !== null) {
-    await updateFileContent(tm, node.id, data)
+    await drive.updateFileContent(node.id, data)
   } else {
     const [parentId] = await resolveParent(accessor, path)
     const basename = key.includes('/') ? key.slice(key.lastIndexOf('/') + 1) : key
-    await uploadFile(tm, basename, parentId, data)
+    await drive.uploadFile(basename, parentId, data)
   }
   await invalidateAfterWrite(path)
 }


### PR DESCRIPTION
## Why

Tests could not fake Google Drive reliably. Each `core/gdrive` module imported Drive calls (`list_files`, `download_file`, ...) directly, so the e2e fake had to patch 11 places and still missed some. A missed one sent the test to the real Drive API, which failed with a 401 (#684). S3 does not have this problem: it has one connection seam, so one patch swaps the whole backend.

## What

- New `core/gdrive/api.py` and `api.ts`. `DriveApi` lists every Drive call the backend makes. `DriveClient` is the real one. `drive_api(token_manager)` builds it.
- `GDriveAccessor.drive` is the single door. Every gdrive op calls `accessor.drive.<call>()`. Helpers that took a `TokenManager` only to reach Drive now take a `DriveApi`.
- 25 direct imports removed across 13 Python modules, and the same set in TypeScript. Only `api.py` and `versions.py` (the Revisions wire module) still name a raw Drive call.
- The e2e fake patches one target. `FakeDriveApi` also covers writes, which the old mock never did.
- A guard test fails if a gdrive module imports a Drive call directly again.

## Intent

Before, the fake had to know every import site, and a new one was invisible:

```python
_PATCH_TARGETS = {
    "list_files": ["...readdir.list_files", "...resolve.list_files",
                   "...tree.list_files", "...rename.list_files"],
    "download_file": ["...read.download_file"],
    ...  # 11 targets
}
```

After, it names the door:

```python
patch("mirage.accessor.gdrive.drive_api", new=lambda tm: FakeDriveApi(...))
```

## Reviewer notes

- `GDriveAccessor.drive` builds a client per access instead of caching one in `__init__`. The resource builds its accessor before a test installs the fake, so a cached client would point at the real API. The client is a frozen dataclass; building one costs nothing next to the request.
- `test_cross_mount_matrix.py` now treats gdrive as writable. It was marked read-only only because the old mock did not fake writes, so `cp` into gdrive hit the real API and failed.
- `read.py` still imports the gdocs, gsheets and gslides renderers directly. Those backends need their own seam. Out of scope here.
- This deviates from #684, which proposed adding more patch targets. That keeps the fragility, so this PR builds the seam instead.

## Verification

- `tests/core/gdrive/test_api.py` and `core/gdrive/api.test.ts`: fail on any direct Drive import in a gdrive module. Each also plants a violation and checks its own detector catches it, so the guard is proven able to fail.
- `tests/e2e/gdrive_mock.py`: rewritten to install through the one seam, so every existing gdrive e2e test now runs through the same door as production code.
- `tests/e2e/test_cross_mount_matrix.py`: gdrive moved to the writable set, so cp, mv, cp -r and mv -r across gdrive run for real.
- TypeScript gdrive tests: 15 `vi.mock` blocks replaced by `makeGDriveAccessor(fake)`, for the same reason.

Closes #684

Part of #970 (item 6).
