### PR TITLE
feat(utils): add Clock interface and inject it into cache TTL, FUSE prefetch and OpTimer

### DIFF
--- a/python/mirage/cache/file/entry.py
+++ b/python/mirage/cache/file/entry.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-
 from pydantic import BaseModel
 
 
@@ -23,8 +21,12 @@ class CacheEntry(BaseModel):
     fingerprint: str | None = None
     ttl: int | None = None
 
-    @property
-    def expired(self) -> bool:
+    def is_expired(self, now: int) -> bool:
+        """Check expiry using the RAMFileCacheStore's clock reading.
+
+        Args:
+            now (int): whole seconds since the unix epoch.
+        """
         if self.ttl is None:
             return False
-        return (int(time.time()) - self.cached_at) >= self.ttl
+        return (now - self.cached_at) >= self.ttl

--- a/python/mirage/cache/file/ram.py
+++ b/python/mirage/cache/file/ram.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-import time
 from collections import OrderedDict
 from collections.abc import Iterable
 from typing import Any
@@ -23,6 +22,7 @@ from mirage.cache.file.mixin import FileCacheMixin, validate_max_drain_bytes
 from mirage.cache.file.utils import default_fingerprint, parse_limit
 from mirage.cache.lock import KeyLockMixin
 from mirage.resource.ram import RAMResource
+from mirage.utils.clock import Clock, SystemClock
 
 
 class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
@@ -31,12 +31,25 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
     Data lives in inherited _store.files (RAMStore).
     _entries tracks LRU metadata only.
     All RAM commands (cat, grep, head, ...) inherited.
+
+    This is the one file-cache store that ages entries itself, so it is
+    the one that holds a clock. The redis store expires its keys with
+    server-side ``EXPIRE`` and reads no time client-side, so there is
+    nothing there to inject.
+
+    Args:
+        cache_limit (str | int): capacity, as bytes or a size string.
+        max_drain_bytes (int | None): cap on a background drain's
+            buffer; None derives it from ``cache_limit``.
+        clock (Clock | None): the clock every entry's age is measured
+            against; None means the real one.
     """
 
     def __init__(
         self,
         cache_limit: str | int = "512MB",
         max_drain_bytes: int | None = None,
+        clock: Clock | None = None,
     ) -> None:
         parsed_limit = parse_limit(cache_limit)
         validate_max_drain_bytes(parsed_limit, max_drain_bytes)
@@ -46,14 +59,19 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
         self._entries: OrderedDict[str, CacheEntry] = OrderedDict()
         self._drain_tasks: dict[str, asyncio.Task[Any]] = {}
         self._clear_lock: asyncio.Lock = asyncio.Lock()
+        self._clock: Clock = clock if clock is not None else SystemClock()
         self.max_drain_bytes: int | None = max_drain_bytes
+
+    def _seconds(self) -> int:
+        """The current whole second, as ``cached_at`` records it."""
+        return int(self._clock.now())
 
     async def get(self, key: str) -> bytes | None:
         async with self._lock_for(key):
             entry = self._entries.get(key)
             if entry is None:
                 return None
-            if entry.expired:
+            if entry.is_expired(self._seconds()):
                 self._cache_size -= entry.size
                 del self._entries[key]
                 self._store.files.pop(key, None)
@@ -74,7 +92,7 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
                 fingerprint = default_fingerprint(data)
             entry = CacheEntry(
                 size=len(data),
-                cached_at=int(time.time()),
+                cached_at=self._seconds(),
                 fingerprint=fingerprint,
                 ttl=ttl,
             )
@@ -90,7 +108,8 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
                   ttl: int | None = None) -> bool:
         async with self._lock_for(key):
             existing = self._entries.get(key)
-            if existing is not None and not existing.expired:
+            if existing is not None and not existing.is_expired(
+                    self._seconds()):
                 return False
             if key in self._entries:
                 self._cache_size -= self._entries[key].size
@@ -99,7 +118,7 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
                 fingerprint = default_fingerprint(data)
             entry = CacheEntry(
                 size=len(data),
-                cached_at=int(time.time()),
+                cached_at=self._seconds(),
                 fingerprint=fingerprint,
                 ttl=ttl,
             )
@@ -122,7 +141,7 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
 
     async def exists(self, key: str) -> bool:
         entry = self._entries.get(key)
-        return entry is not None and not entry.expired
+        return entry is not None and not entry.is_expired(self._seconds())
 
     async def is_fresh(self, key: str, remote_fingerprint: str) -> bool:
         entry = self._entries.get(key)

--- a/python/mirage/fuse/core.py
+++ b/python/mirage/fuse/core.py
@@ -29,6 +29,7 @@ from mirage.fuse.platform.macos import is_macos_metadata
 from mirage.ops import Ops
 from mirage.runtime.handles import FileTable, merge_writes
 from mirage.types import FileStat, FileType
+from mirage.utils.clock import Clock
 from mirage.utils.stat_view import DIR_MODE, FILE_MODE, LINK_MODE, mtime_ns
 from mirage.workspace.session.session import Session
 
@@ -78,6 +79,15 @@ class MountCore:
                  session: Session | None = None) -> None:
         self._ops = ops
         self._session = session
+        # The prefetch TTL is a duration, so it is measured on the
+        # facade's clock. There is no second door: a core is always
+        # handed the facade, and the facade carries the workspace's
+        # clock, so injecting one here would be a way to disagree with
+        # the workspace about what time it is.
+        self._clock: Clock = ops.clock
+        # The mount's own creation stamp, not a deadline. It answers
+        # "when was this mounted", so it reads the real clock even when
+        # the ops facade is running on an injected one.
         self._now = time.time_ns()
         self._root = root_prefix.rstrip("/")
         self._handles: FileTable[Handle] = FileTable()
@@ -289,7 +299,7 @@ class MountCore:
         if entry is None:
             return None
         data, expires = entry
-        if time.monotonic() >= expires:
+        if self._clock.monotonic() >= expires:
             del self._prefetch[key]
             return None
         return data
@@ -332,8 +342,8 @@ class MountCore:
             return None
         # No inflight dedup: FUSE mounts run nothreads=True, so callbacks are
         # serialized and two opens cannot race (TS needs the dedup map).
-        self._prefetch[self.identity(path)] = (data,
-                                               time.monotonic() + PREFETCH_TTL)
+        self._prefetch[self.identity(path)] = (data, self._clock.monotonic() +
+                                               PREFETCH_TTL)
         return data
 
     def getattr(self, path: str, fh: int | None = None) -> dict[str, Any]:

--- a/python/mirage/observe/context.py
+++ b/python/mirage/observe/context.py
@@ -18,6 +18,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 
 from mirage.observe.record import OpRecord
+from mirage.utils.clock import Clock, SystemClock
 
 
 @dataclass(frozen=True)
@@ -205,27 +206,45 @@ class OpTimer:
     finishes, so an op module hands this around instead of reading a
     clock of its own. The wall-clock stamp the record carries is taken
     at finish time, not here.
+
+    Args:
+        clock (Clock): the clock both readings are taken from. Passing
+            one is what makes a duration assertable without a sleep.
     """
 
-    __slots__ = ("_start_ms", )
+    __slots__ = ("_clock", "_start_ms")
 
-    def __init__(self) -> None:
-        self._start_ms = int(time.monotonic() * 1000)
+    def __init__(self, clock: Clock) -> None:
+        self._clock = clock
+        self._start_ms = int(clock.monotonic() * 1000)
 
     @property
     def elapsed_ms(self) -> int:
         """Milliseconds elapsed since the timer was opened."""
-        return int(time.monotonic() * 1000) - self._start_ms
+        return int(self._clock.monotonic() * 1000) - self._start_ms
+
+    @property
+    def clock(self) -> Clock:
+        """The clock every reading of this op's timing comes from."""
+        return self._clock
 
 
-def start_op() -> OpTimer:
+def start_op(clock: Clock | None = None) -> OpTimer:
     """Open the record path's stopwatch for one op.
+
+    A component that holds the workspace's clock passes it; a backend
+    core op holds no workspace handle and passes nothing, which opens a
+    system-clocked timer exactly as before the seam existed.
+
+    Args:
+        clock (Clock | None): the clock to time with; None means the
+            real one.
 
     Returns:
         OpTimer: a running timer, to hand to :func:`record` or
         :func:`finish_record` when the op completes.
     """
-    return OpTimer()
+    return OpTimer(clock if clock is not None else SystemClock())
 
 
 def finish_record(op: str,
@@ -240,6 +259,8 @@ def finish_record(op: str,
     The one place an op's duration and wall-clock stamp are read, shared
     by the recorder sink (:func:`record`) and by the ``Ops`` facade's own
     ledger, so the two cannot disagree about what a duration measures.
+    Both readings come off the timer's own clock, so an injected one
+    governs the stamp as well as the duration.
 
     Args:
         op (str): Operation name ("read", "write").
@@ -260,7 +281,7 @@ def finish_record(op: str,
         path=path,
         source=source,
         bytes=nbytes,
-        timestamp=int(time.time() * 1000),
+        timestamp=int(timer.clock.now() * 1000),
         duration_ms=elapsed,
         fingerprint=fingerprint,
         revision=revision,

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -22,6 +22,7 @@ from mirage.observe.context import OpTimer, finish_record, start_op
 from mirage.ops.config import NO_FOLLOW_OPS, NamespaceLinks, OpsMount
 from mirage.runtime.types import DispatchFn
 from mirage.types import FileStat, FileType, MountMode, PathSpec
+from mirage.utils.clock import Clock, SystemClock
 from mirage.utils.errors import NoMountError
 from mirage.utils.path import owner_prefix
 
@@ -51,14 +52,25 @@ class Ops:
                  observer: Any | None = None,
                  agent_id: str = "default",
                  session_id: str = "default",
-                 links: NamespaceLinks | None = None) -> None:
+                 links: NamespaceLinks | None = None,
+                 clock: Clock | None = None) -> None:
         self.set_mounts(mounts)
         self._observer = observer
         self._agent_id = agent_id
         self._session_id = session_id
         self._links = links
         self._dispatch = dispatch
+        # The workspace's clock, so every op this facade times and
+        # stamps reads the same one. It is also the clock a kernel
+        # mount's core takes, since the core is handed this facade and
+        # nothing else from the workspace.
+        self._clock: Clock = clock if clock is not None else SystemClock()
         self.records: list[OpRecord] = []
+
+    @property
+    def clock(self) -> Clock:
+        """The clock this facade times ops with."""
+        return self._clock
 
     @property
     def links(self) -> NamespaceLinks | None:
@@ -196,7 +208,7 @@ class Ops:
             path (str): the virtual path.
             **kwargs: op arguments, by the op function's names.
         """
-        timer = start_op()
+        timer = start_op(self._clock)
         if (self._links is not None and op not in NO_FOLLOW_OPS
                 and not kwargs.get("nofollow")):
             path = self._links.follow(path)

--- a/python/mirage/utils/clock.py
+++ b/python/mirage/utils/clock.py
@@ -1,0 +1,81 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import time
+from typing import Protocol
+
+
+class Clock(Protocol):
+    """Wall timestamps and monotonic durations, both in seconds."""
+
+    def now(self) -> float:
+        """Seconds since the unix epoch (``time.time``)."""
+        ...
+
+    def monotonic(self) -> float:
+        """Seconds from an arbitrary origin that never moves backwards."""
+        ...
+
+
+class SystemClock:
+    """Platform clock used when no clock is supplied."""
+
+    def now(self) -> float:
+        """Seconds since the unix epoch."""
+        return time.time()
+
+    def monotonic(self) -> float:
+        """Seconds from an arbitrary origin that never moves backwards."""
+        return time.monotonic()
+
+    def __repr__(self) -> str:
+        return "SystemClock()"
+
+
+class ManualClock:
+    """Clock advanced explicitly by the caller. Readings have no side effects.
+
+    Args:
+        start (float): initial wall time in seconds; monotonic starts at zero.
+    """
+
+    __slots__ = ("_monotonic", "_wall")
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._wall = start
+        self._monotonic = 0.0
+
+    def now(self) -> float:
+        """Seconds on the virtual wall clock."""
+        return self._wall
+
+    def monotonic(self) -> float:
+        """Seconds on the virtual monotonic clock."""
+        return self._monotonic
+
+    def advance(self, seconds: float) -> None:
+        """Move the clock forward by ``seconds``.
+
+        Args:
+            seconds (float): how far forward to move; must not be
+                negative, since a monotonic reading may not go back.
+        """
+        if seconds < 0:
+            raise ValueError("cannot advance a clock backwards")
+        self._wall += seconds
+        self._monotonic += seconds
+
+    def __repr__(self) -> str:
+        return (f"ManualClock(now={self._wall!r}, "
+                f"monotonic={self._monotonic!r})")

--- a/python/mirage/workspace/workspace/cache.py
+++ b/python/mirage/workspace/workspace/cache.py
@@ -17,6 +17,7 @@ from typing import Any
 from mirage.cache.file.config import CacheConfig, RedisCacheConfig
 from mirage.cache.file.mixin import FileCacheMixin
 from mirage.cache.file.ram import RAMFileCacheStore
+from mirage.utils.clock import Clock
 
 RedisFileCacheStore: Any
 try:
@@ -29,7 +30,8 @@ else:
 
 
 def build_file_cache(cache: CacheConfig | None,
-                     cache_limit: str | int) -> FileCacheMixin:
+                     cache_limit: str | int,
+                     clock: Clock | None = None) -> FileCacheMixin:
     """Build the workspace's file cache from its config.
 
     Args:
@@ -37,6 +39,9 @@ def build_file_cache(cache: CacheConfig | None,
             RAM store sized by ``cache_limit``.
         cache_limit (str | int): the legacy size knob, used only when
             no config is given.
+        clock (Clock | None): the workspace's clock, handed to the store
+            that ages entries itself. The redis store takes none: its
+            TTLs are server-side ``EXPIRE`` and it reads no time here.
 
     Raises:
         ImportError: a Redis cache was asked for without the extra.
@@ -53,4 +58,6 @@ def build_file_cache(cache: CacheConfig | None,
         )
     limit = cache.limit if cache is not None else cache_limit
     max_drain = cache.max_drain_bytes if cache is not None else None
-    return RAMFileCacheStore(cache_limit=limit, max_drain_bytes=max_drain)
+    return RAMFileCacheStore(cache_limit=limit,
+                             max_drain_bytes=max_drain,
+                             clock=clock)

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -53,6 +53,7 @@ from mirage.shell.job_table import ConsoleFactory, JobTable
 from mirage.types import (ConsistencyPolicy, DriftPolicy, FileEvent, FileStat,
                           JsonValue, MountBackend, MountMode, PathSpec,
                           parse_mount_mode)
+from mirage.utils.clock import Clock, SystemClock
 from mirage.utils.ids import new_session_id, new_workspace_id
 from mirage.workspace.cli import CLIInstall
 from mirage.workspace.dispatcher import Dispatcher
@@ -133,7 +134,14 @@ class Workspace:
         | None = None,
         env: Mapping[str, str | EnvVar | Mapping[str, Any]] | None = None,
         secrets: Mapping[str, SecretSource | Mapping[str, Any]] | None = None,
+        clock: Clock | None = None,
     ) -> None:
+        # The workspace owns one clock and hands it to the components
+        # that measure elapsed time: the file cache (entry TTLs), the
+        # op facade (op durations and stamps) and, through that facade,
+        # a kernel mount's prefetch TTL. None keeps the real clock, so
+        # a deployment that never mentions time behaves as before.
+        self._clock: Clock = clock if clock is not None else SystemClock()
         self._registry = MountRegistry()
         # The permission profiles: one per name, and the one a session
         # gets when it names none. A profile is the whole document a
@@ -164,7 +172,8 @@ class Workspace:
                                         session_store)
         self._owns_state_store = stores.owned
         self._state_store = stores.state_store
-        self._cache: FileCacheMixin = build_file_cache(cache, cache_limit)
+        self._cache: FileCacheMixin = build_file_cache(cache, cache_limit,
+                                                       self._clock)
         self._index_config = index
         self._closed = False
         self._closing = False
@@ -289,7 +298,8 @@ class Workspace:
                         agent_id=agent_id or "",
                         session_id=session_id,
                         links=self._namespace,
-                        dispatch=self._dispatcher.dispatch)
+                        dispatch=self._dispatcher.dispatch,
+                        clock=self._clock)
         self._kernel_mounts = KernelMounts(self._ops, self._session_mgr)
         # Held only while the workspace is a context manager; set by
         # lifecycle.patch_process. Declared here because the pair was
@@ -811,15 +821,15 @@ class Workspace:
         await _write_snapshot(self, target, compress=compress)
 
     @classmethod
-    async def load(
-            cls,
-            source,
-            *,
-            resources: dict[str, Any] | None = None,
-            clis: CLIOverrides | None = None,
-            secrets: Mapping[str, SecretSource | Mapping[str, Any]]
-        | None = None,
-            drift_policy: DriftPolicy = DriftPolicy.STRICT) -> "Workspace":
+    async def load(cls,
+                   source,
+                   *,
+                   resources: dict[str, Any] | None = None,
+                   clis: CLIOverrides | None = None,
+                   secrets: Mapping[str, SecretSource | Mapping[str, Any]]
+                   | None = None,
+                   drift_policy: DriftPolicy = DriftPolicy.STRICT,
+                   clock: Clock | None = None) -> "Workspace":
         """Reconstruct a Workspace from a tar.
 
         For every recorded read:
@@ -858,23 +868,29 @@ class Workspace:
                 cache entries for fingerprinted paths; a Redis cache is
                 never restored from a snapshot, so it has nothing to
                 drop.
+            clock: the clock the restored workspace reads time through.
+                A snapshot stores an entry's `cached_at` and `ttl` as
+                data, so a restored entry ages against this clock, not
+                against the wall clock of the run that took it.
         """
         return await cls.from_state(read_tar(source),
                                     resources=resources,
                                     clis=clis,
                                     secrets=secrets,
-                                    drift_policy=drift_policy)
+                                    drift_policy=drift_policy,
+                                    clock=clock)
 
     @classmethod
-    async def from_state(
-            cls,
-            state: dict[str, Any],
-            *,
-            resources: dict[str, Any] | None = None,
-            clis: CLIOverrides | None = None,
-            secrets: Mapping[str, SecretSource | Mapping[str, Any]]
-        | None = None,
-            drift_policy: DriftPolicy = DriftPolicy.STRICT) -> "Workspace":
+    async def from_state(cls,
+                         state: dict[str, Any],
+                         *,
+                         resources: dict[str, Any] | None = None,
+                         clis: CLIOverrides | None = None,
+                         secrets: Mapping[str,
+                                          SecretSource | Mapping[str, Any]]
+                         | None = None,
+                         drift_policy: DriftPolicy = DriftPolicy.STRICT,
+                         clock: Clock | None = None) -> "Workspace":
         """Reconstruct a Workspace directly from a state dict (no tar).
 
         The in-process inverse of ``to_state_dict``: build the mounts,
@@ -898,11 +914,13 @@ class Workspace:
                 cache entries for fingerprinted paths; a Redis cache is
                 never restored from a snapshot, so it has nothing to
                 drop.
+            clock: the clock the restored workspace reads time through.
         """
         ws = await cls._from_state(state,
                                    resources=resources,
                                    clis=clis,
-                                   secrets=secrets)
+                                   secrets=secrets,
+                                   clock=clock)
         install_fingerprints(ws,
                              state.get(StateKey.FINGERPRINTS) or [],
                              drift_policy)
@@ -929,25 +947,27 @@ class Workspace:
         return await type(self)._from_state(state,
                                             resources=resources,
                                             clis=reusable_clis(self),
-                                            secrets=self._declared_sources)
+                                            secrets=self._declared_sources,
+                                            clock=self._clock)
 
     @classmethod
-    async def _from_state(
-        cls,
-        state: dict[str, Any],
-        *,
-        resources: dict[str, Any] | None = None,
-        clis: CLIOverrides | None = None,
-        secrets: Mapping[str, SecretSource | Mapping[str, Any]]
-        | None = None
-    ) -> "Workspace":
+    async def _from_state(cls,
+                          state: dict[str, Any],
+                          *,
+                          resources: dict[str, Any] | None = None,
+                          clis: CLIOverrides | None = None,
+                          secrets: Mapping[str,
+                                           SecretSource | Mapping[str, Any]]
+                          | None = None,
+                          clock: Clock | None = None) -> "Workspace":
         args = build_mount_args(state, resources, clis)
         ws = cls(args.mount_args,
                  consistency=args.consistency,
                  session_id=args.default_session_id,
                  agent_id=args.default_agent_id,
                  clis=args.clis,
-                 secrets=secrets)
+                 secrets=secrets,
+                 clock=clock)
         if resources:
             ws._shared_resources = {id(r) for r in resources.values()}
         await apply_state_dict(ws, state)

--- a/python/tests/cache/file/test_entry.py
+++ b/python/tests/cache/file/test_entry.py
@@ -31,15 +31,21 @@ def test_cache_entry_mutable():
 
 def test_expired_with_ttl():
     entry = CacheEntry(cached_at=1000, size=1, ttl=10)
-    assert entry.expired is True
+    assert entry.is_expired(1010) is True
 
 
 def test_not_expired_without_ttl():
-    entry = CacheEntry(cached_at=int(time.time()), size=1)
+    entry = CacheEntry(cached_at=1000, size=1)
     assert entry.ttl is None
-    assert entry.expired is False
+    assert entry.is_expired(999_999) is False
 
 
 def test_not_expired_within_ttl():
-    entry = CacheEntry(cached_at=int(time.time()), size=1, ttl=3600)
-    assert entry.expired is False
+    entry = CacheEntry(cached_at=1000, size=1, ttl=3600)
+    assert entry.is_expired(4599) is False
+
+
+def test_expiry_is_read_at_the_boundary():
+    entry = CacheEntry(cached_at=1000, size=1, ttl=10)
+    assert entry.is_expired(1009) is False
+    assert entry.is_expired(1010) is True

--- a/python/tests/cache/file/test_mixin.py
+++ b/python/tests/cache/file/test_mixin.py
@@ -13,12 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-from unittest.mock import patch
+import time
 
 import pytest
 
 from mirage.cache.file.ram import RAMFileCacheStore
 from mirage.cache.file.redis import RedisFileCacheStore
+from mirage.utils.clock import ManualClock
 
 
 class TestGetSet:
@@ -168,11 +169,11 @@ class TestTTL:
 
     @pytest.mark.asyncio
     async def test_ttl_expired(self):
-        cache = RAMFileCacheStore(cache_limit="1MB")
-        with patch("mirage.cache.file.entry.time.time", return_value=1000.0):
-            await cache.set("/a", b"data", ttl=10)
-        with patch("mirage.cache.file.entry.time.time", return_value=1011.0):
-            result = await cache.get("/a")
+        clock = ManualClock(start=1000.0)
+        cache = RAMFileCacheStore(cache_limit="1MB", clock=clock)
+        await cache.set("/a", b"data", ttl=10)
+        clock.advance(11)
+        result = await cache.get("/a")
         assert result is None
 
     @pytest.mark.asyncio
@@ -181,7 +182,7 @@ class TestTTL:
         await cache.set("/a", b"data")
         entry = cache._entries["/a"]
         assert entry.ttl is None
-        assert entry.expired is False
+        assert entry.is_expired(int(time.time())) is False
 
 
 class TestFingerprint:

--- a/python/tests/cache/file/test_ram.py
+++ b/python/tests/cache/file/test_ram.py
@@ -13,10 +13,12 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import time
 
 import pytest
 
 from mirage.cache.file.ram import RAMFileCacheStore
+from mirage.utils.clock import ManualClock
 
 
 @pytest.mark.asyncio
@@ -123,3 +125,56 @@ async def test_evict_prefix_reclaims_the_evicted_bytes():
     await cache.evict_prefix("/data/")
     assert cache.cache_size == 2
     assert cache.cache_entries == 1
+
+
+@pytest.mark.asyncio
+async def test_ttl_boundary_is_exact_on_an_injected_clock():
+    # The boundary the seam exists for: probed at ttl-1 and at ttl with
+    # no sleep, no real time, and nothing patched globally.
+    clock = ManualClock(start=1000.0)
+    cache = RAMFileCacheStore(cache_limit="1MB", clock=clock)
+    await cache.set("/f.txt", b"hello", ttl=10)
+    clock.advance(9)
+    assert await cache.exists("/f.txt") is True
+    assert await cache.get("/f.txt") == b"hello"
+    clock.advance(1)
+    assert await cache.exists("/f.txt") is False
+    assert await cache.get("/f.txt") is None
+
+
+@pytest.mark.asyncio
+async def test_expired_entry_is_dropped_on_read():
+    clock = ManualClock(start=0.0)
+    cache = RAMFileCacheStore(cache_limit="1MB", clock=clock)
+    await cache.set("/f.txt", b"hello", ttl=5)
+    clock.advance(5)
+    assert await cache.get("/f.txt") is None
+    assert cache.cache_size == 0
+    assert cache.cache_entries == 0
+
+
+@pytest.mark.asyncio
+async def test_add_replaces_an_entry_the_clock_expired():
+    clock = ManualClock(start=0.0)
+    cache = RAMFileCacheStore(cache_limit="1MB", clock=clock)
+    await cache.set("/f.txt", b"old", ttl=5)
+    assert await cache.add("/f.txt", b"new") is False
+    clock.advance(5)
+    assert await cache.add("/f.txt", b"new") is True
+    assert await cache.get("/f.txt") == b"new"
+
+
+@pytest.mark.asyncio
+async def test_cached_at_is_stamped_by_the_injected_clock():
+    clock = ManualClock(start=4242.0)
+    cache = RAMFileCacheStore(cache_limit="1MB", clock=clock)
+    await cache.set("/f.txt", b"hello")
+    assert cache._entries["/f.txt"].cached_at == 4242
+
+
+@pytest.mark.asyncio
+async def test_default_store_stamps_from_the_real_clock():
+    cache = RAMFileCacheStore(cache_limit="1MB")
+    await cache.set("/f.txt", b"hello")
+    assert cache._entries["/f.txt"].cached_at == pytest.approx(time.time(),
+                                                               abs=5)

--- a/python/tests/fuse/test_core.py
+++ b/python/tests/fuse/test_core.py
@@ -20,11 +20,12 @@ import time
 import pytest
 import pytest_asyncio
 
-from mirage.fuse.core import MountCore
+from mirage.fuse.core import PREFETCH_TTL, MountCore
 from mirage.observe import OpRecord
 from mirage.ops.registry import op
 from mirage.resource.ram import RAMResource
 from mirage.types import ContentType, FileStat, FileType, MountMode, PathSpec
+from mirage.utils.clock import ManualClock
 from mirage.utils.stat_view import mtime_ns
 from mirage.workspace import Workspace
 
@@ -443,3 +444,63 @@ def test_drain_ops_omits_internal_mount_identity():
     core = MountCore(ws.fs)
     assert core.drain_ops() == [record.to_dict()]
     assert core.drain_ops() == []
+
+
+class SteppingClock:
+    """A clock whose wall reading can jump while monotonic stands still.
+
+    ManualClock moves both readings together, which is right for virtual
+    time passing but cannot express the case a deadline has to survive:
+    NTP stepping the system clock while no real time has elapsed.
+    """
+
+    def __init__(self) -> None:
+        self.wall = 1_700_000_000.0
+        self.mono = 0.0
+
+    def now(self) -> float:
+        return self.wall
+
+    def monotonic(self) -> float:
+        return self.mono
+
+
+@pytest.mark.asyncio
+async def test_prefetch_ttl_boundary_on_an_injected_clock():
+    # The prefetch cache is a deadline in monotonic seconds, so an
+    # injected clock is the only way to sit on the boundary exactly:
+    # fresh one second before the TTL, gone the second it lands.
+    clock = ManualClock()
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE, clock=clock)
+    await ws.execute("tee /u.json", stdin=b"payload")
+    core = MountCore(ws.fs)
+    assert core.prefetch_read("/u.json") == b"payload"
+    clock.advance(PREFETCH_TTL - 1)
+    assert core.cached_data("/u.json") == b"payload"
+    assert core.cached_size("/u.json") == len(b"payload")
+    clock.advance(1)
+    assert core.cached_data("/u.json") is None
+    assert core.cached_size("/u.json") is None
+    assert "/u.json" not in core._prefetch
+
+
+@pytest.mark.asyncio
+async def test_prefetch_deadline_ignores_a_wall_clock_jump():
+    # The deadline is a duration, so it must be measured on the
+    # monotonic reading. Reading wall clock instead would expire every
+    # prefetched file the moment NTP stepped the system clock forward.
+    clock = SteppingClock()
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE, clock=clock)
+    await ws.execute("tee /u.json", stdin=b"payload")
+    core = MountCore(ws.fs)
+    assert core.prefetch_read("/u.json") == b"payload"
+    clock.wall += 10 * 365 * 24 * 3600
+    assert core.cached_data("/u.json") == b"payload"
+
+
+@pytest.mark.asyncio
+async def test_core_takes_the_workspace_clock_from_the_facade():
+    clock = ManualClock()
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE, clock=clock)
+    core = MountCore(ws.fs)
+    assert core._clock is clock

--- a/python/tests/observe/test_context.py
+++ b/python/tests/observe/test_context.py
@@ -14,10 +14,12 @@
 
 import pytest
 
-from mirage.observe.context import (RecordingScope, push_mount_prefix,
-                                    push_revisions, record, record_stream,
-                                    reset_revisions, revision_for, start_op,
-                                    with_mount_prefix, with_revisions)
+from mirage.observe.context import (RecordingScope, finish_record,
+                                    push_mount_prefix, push_revisions, record,
+                                    record_stream, reset_revisions,
+                                    revision_for, start_op, with_mount_prefix,
+                                    with_revisions)
+from mirage.utils.clock import ManualClock, SystemClock
 
 
 class ClosingIterator:
@@ -259,3 +261,34 @@ def test_inactive_scope_joins_enclosing():
     outer.close()
     assert [r.path for r in outer.records] == ["/a"]
     assert joined.records == []
+
+
+def test_op_timer_reads_the_injected_clock():
+    clock = ManualClock()
+    timer = start_op(clock)
+    assert timer.elapsed_ms == 0
+    clock.advance(2.5)
+    assert timer.elapsed_ms == 2500
+
+
+def test_op_timer_defaults_to_the_system_clock():
+    assert isinstance(start_op().clock, SystemClock)
+
+
+def test_finished_record_stamps_from_the_timer_clock():
+    clock = ManualClock(start=1700.0)
+    timer = start_op(clock)
+    clock.advance(3)
+    rec = finish_record("read", "/a", "s3", 4, timer)
+    assert rec.duration_ms == 3000
+    assert rec.timestamp == 1_703_000
+
+
+def test_recorded_op_carries_the_injected_duration():
+    clock = ManualClock(start=0.0)
+    scope = RecordingScope()
+    timer = start_op(clock)
+    clock.advance(1.25)
+    record("read", "/a", "s3", 1, timer)
+    scope.close()
+    assert [r.duration_ms for r in scope.records] == [1250]

--- a/python/tests/utils/test_clock.py
+++ b/python/tests/utils/test_clock.py
@@ -1,0 +1,90 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import time
+
+import pytest
+
+from mirage.utils.clock import Clock, ManualClock, SystemClock
+
+
+def test_system_clock_satisfies_the_protocol():
+    clock: Clock = SystemClock()
+    assert isinstance(clock.now(), float)
+    assert isinstance(clock.monotonic(), float)
+
+
+def test_system_clock_now_tracks_the_wall_clock():
+    before = time.time()
+    reading = SystemClock().now()
+    after = time.time()
+    assert before <= reading <= after
+
+
+def test_system_clock_monotonic_never_decreases():
+    clock = SystemClock()
+    readings = [clock.monotonic() for _ in range(50)]
+    assert readings == sorted(readings)
+
+
+def test_manual_clock_satisfies_the_protocol():
+    clock: Clock = ManualClock()
+    assert clock.now() == 0.0
+    assert clock.monotonic() == 0.0
+
+
+def test_manual_clock_stands_still_when_read():
+    # Reading must have no side effect: a deadline that moved every time
+    # the code under test glanced at the clock would make every boundary
+    # assertion depend on the number of glances.
+    clock = ManualClock(start=100.0)
+    assert clock.now() == 100.0
+    assert clock.now() == 100.0
+    assert clock.monotonic() == 0.0
+    assert clock.monotonic() == 0.0
+
+
+def test_manual_clock_advance_moves_both_readings():
+    clock = ManualClock(start=1000.0)
+    clock.advance(30)
+    assert clock.now() == 1030.0
+    assert clock.monotonic() == 30.0
+
+
+def test_manual_clock_advance_accumulates():
+    clock = ManualClock()
+    clock.advance(0.5)
+    clock.advance(0.25)
+    assert clock.monotonic() == 0.75
+
+
+def test_manual_clock_orders_two_events_by_advancing_between_them():
+    # The ordering case the ticking draft existed for, done explicitly.
+    clock = ManualClock(start=1000.0)
+    first = clock.now()
+    clock.advance(1)
+    second = clock.now()
+    assert second > first
+
+
+def test_manual_clock_refuses_to_go_backwards():
+    clock = ManualClock()
+    with pytest.raises(ValueError):
+        clock.advance(-1)
+
+
+def test_manual_clock_repr_names_both_readings():
+    assert repr(
+        ManualClock(start=5.0)) == "ManualClock(now=5.0, monotonic=0.0)"
+    assert repr(SystemClock()) == "SystemClock()"

--- a/python/tests/workspace/snapshot/test_state.py
+++ b/python/tests/workspace/snapshot/test_state.py
@@ -35,6 +35,7 @@ from mirage.secrets import registry
 from mirage.secrets.registry import register_secrets
 from mirage.secrets.types import ResolvedSecret
 from mirage.types import ContentType, FileType
+from mirage.utils.clock import ManualClock
 from mirage.workspace.snapshot.keys import (CacheKey, MountKey,
                                             ResourceStateKey, StateKey)
 from mirage.workspace.snapshot.state import (apply_state_dict,
@@ -589,3 +590,40 @@ async def test_to_state_dict_carries_no_entries_for_a_redis_cache():
         assert state[StateKey.CACHE][CacheKey.ENTRIES] == []
     finally:
         await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_restored_cache_entry_ages_on_the_injected_clock():
+    # A snapshot stores cached_at and ttl as data, so the restored
+    # entry's expiry is decided by the clock the restoring workspace
+    # was given, never by the wall clock of the run that took it.
+    src = Workspace({"/": RAMResource()},
+                    mode=MountMode.WRITE,
+                    clock=ManualClock(start=1000.0))
+    await src._cache.set("/c.txt", b"cached", ttl=10)
+    state = await to_state_dict(src)
+
+    clock = ManualClock(start=1000.0)
+    restored = await Workspace.from_state(state, clock=clock)
+    entry = restored._cache._entries["/c.txt"]
+    assert entry.cached_at == 1000
+    assert entry.ttl == 10
+    assert await restored._cache.exists("/c.txt") is True
+    clock.advance(9)
+    assert await restored._cache.exists("/c.txt") is True
+    clock.advance(1)
+    assert await restored._cache.exists("/c.txt") is False
+
+
+@pytest.mark.asyncio
+async def test_copy_keeps_the_workspace_clock():
+    # A copy reads time the way its origin does, so a TTL stamped on the
+    # copy still expires on the clock the origin was given.
+    clock = ManualClock(start=1000.0)
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE, clock=clock)
+    copied = await ws.copy()
+    await copied._cache.set("/c.txt", b"cached", ttl=10)
+    clock.advance(9)
+    assert await copied._cache.exists("/c.txt") is True
+    clock.advance(1)
+    assert await copied._cache.exists("/c.txt") is False

--- a/python/tests/workspace/workspace/test_cache.py
+++ b/python/tests/workspace/workspace/test_cache.py
@@ -1,0 +1,65 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.file.config import CacheConfig
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
+from mirage.utils.clock import ManualClock, SystemClock
+from mirage.workspace import Workspace
+from mirage.workspace.workspace.cache import build_file_cache
+
+
+@pytest.mark.asyncio
+async def test_built_cache_ages_entries_on_the_given_clock():
+    clock = ManualClock(start=1000.0)
+    cache = build_file_cache(None, "1MB", clock)
+    await cache.set("/f.txt", b"hello", ttl=10)
+    clock.advance(10)
+    assert await cache.exists("/f.txt") is False
+
+
+@pytest.mark.asyncio
+async def test_a_cache_config_does_not_lose_the_clock():
+    clock = ManualClock(start=1000.0)
+    cache = build_file_cache(CacheConfig(limit="2MB"), "1MB", clock)
+    assert cache.cache_limit == 2 * 1024 * 1024
+    await cache.set("/f.txt", b"hello", ttl=10)
+    clock.advance(10)
+    assert await cache.exists("/f.txt") is False
+
+
+def test_workspace_hands_one_clock_to_the_op_facade():
+    # The facade is the reader a mount core inherits from, so this is
+    # the one clock handoff a caller can observe.
+    clock = ManualClock()
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE, clock=clock)
+    assert ws.fs.clock is clock
+
+
+def test_workspace_without_a_clock_runs_on_the_real_one():
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+    assert isinstance(ws.fs.clock, SystemClock)
+
+
+@pytest.mark.asyncio
+async def test_workspace_cache_ttl_expires_on_its_own_clock():
+    clock = ManualClock(start=1000.0)
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE, clock=clock)
+    await ws.cache.set("/f.txt", b"hello", ttl=10)
+    clock.advance(9)
+    assert await ws.cache.exists("/f.txt") is True
+    clock.advance(1)
+    assert await ws.cache.exists("/f.txt") is False

--- a/typescript/packages/core/src/cache/file/entry.ts
+++ b/typescript/packages/core/src/cache/file/entry.ts
@@ -33,8 +33,13 @@ export class CacheEntry {
     Object.freeze(this)
   }
 
-  get expired(): boolean {
+  /**
+   * Check expiry using the RAMFileCacheStore's clock reading.
+   *
+   * @param now whole seconds since the unix epoch.
+   */
+  isExpired(now: number): boolean {
     if (this.ttl === null) return false
-    return Math.floor(Date.now() / 1000) - this.cachedAt >= this.ttl
+    return now - this.cachedAt >= this.ttl
   }
 }

--- a/typescript/packages/core/src/cache/file/ram.test.ts
+++ b/typescript/packages/core/src/cache/file/ram.test.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import { ManualClock } from '../../utils/clock.ts'
 import { RAMFileCacheStore } from './ram.ts'
 
 function encode(s: string): Uint8Array {
@@ -133,5 +134,53 @@ describe('RAMFileCacheStore', () => {
     expect(c.cacheSize).toBe(2)
     expect(c.cacheEntries).toBe(1)
     expect(await c.get('/d/a.txt')).toBeNull()
+  })
+
+  it('holds the TTL boundary exactly on an injected clock', async () => {
+    // The boundary the seam exists for: probed at ttl-1 and at ttl with
+    // no sleep, no real time, and nothing patched globally.
+    const clock = new ManualClock(1000)
+    const c = new RAMFileCacheStore({ limit: 1024, clock })
+    await c.set('/f.txt', encode('hello'), { ttl: 10 })
+    clock.advance(9)
+    expect(await c.exists('/f.txt')).toBe(true)
+    expect(decode(await c.get('/f.txt'))).toBe('hello')
+    clock.advance(1)
+    expect(await c.exists('/f.txt')).toBe(false)
+    expect(await c.get('/f.txt')).toBeNull()
+  })
+
+  it('drops an expired entry on read', async () => {
+    const clock = new ManualClock(0)
+    const c = new RAMFileCacheStore({ limit: 1024, clock })
+    await c.set('/f.txt', encode('hello'), { ttl: 5 })
+    clock.advance(5)
+    expect(await c.get('/f.txt')).toBeNull()
+    expect(c.cacheSize).toBe(0)
+    expect(c.cacheEntries).toBe(0)
+  })
+
+  it('add replaces an entry the clock expired', async () => {
+    const clock = new ManualClock(0)
+    const c = new RAMFileCacheStore({ limit: 1024, clock })
+    await c.set('/f.txt', encode('old'), { ttl: 5 })
+    expect(await c.add('/f.txt', encode('new'))).toBe(false)
+    clock.advance(5)
+    expect(await c.add('/f.txt', encode('new'))).toBe(true)
+    expect(decode(await c.get('/f.txt'))).toBe('new')
+  })
+
+  it('stamps cachedAt from the injected clock', async () => {
+    const clock = new ManualClock(4242)
+    const c = new RAMFileCacheStore({ limit: 1024, clock })
+    await c.set('/f.txt', encode('hello'))
+    expect(c.snapshotEntries()[0]?.entry.cachedAt).toBe(4242)
+  })
+
+  it('stamps from the real clock by default', async () => {
+    const c = new RAMFileCacheStore({ limit: 1024 })
+    await c.set('/f.txt', encode('hello'))
+    const cachedAt = c.snapshotEntries()[0]?.entry.cachedAt ?? 0
+    expect(Math.abs(cachedAt - Date.now() / 1000)).toBeLessThan(5)
   })
 })

--- a/typescript/packages/core/src/cache/file/ram.ts
+++ b/typescript/packages/core/src/cache/file/ram.ts
@@ -14,25 +14,54 @@
 
 import { RAMResource } from '../../resource/ram/ram.ts'
 import type { PathSpec } from '../../types.ts'
+import { type Clock, SystemClock } from '../../utils/clock.ts'
 import { KeyLock } from '../lock.ts'
 import { CacheEntry } from './entry.ts'
 import { type FileCache, validateMaxDrainBytes } from './mixin.ts'
 import { defaultFingerprint, parseLimit } from './utils.ts'
 
+/**
+ * The RAM byte cache.
+ *
+ * This is the one file-cache store that ages entries itself, so it is
+ * the one that holds a clock. The redis store expires its keys with
+ * server-side `EXPIRE` and reads no time client-side, so there is
+ * nothing there to inject.
+ */
 export class RAMFileCacheStore extends RAMResource implements FileCache {
   private readonly entries = new Map<string, CacheEntry>()
   private readonly lock = new KeyLock()
   private readonly limit: number
+  private readonly clockRef: Clock
   private size = 0
   private maxDrainBytesValue: number | null = null
   // Promises cannot be cancelled; clearing the map makes the drain's
   // completion check fail so the result is discarded instead.
   readonly drainTasks = new Map<string, Promise<void>>()
 
-  constructor(options: { limit?: string | number; maxDrainBytes?: number | null } = {}) {
+  /**
+   * @param options.limit capacity, as bytes or a size string.
+   * @param options.maxDrainBytes cap on a background drain's buffer;
+   *   null derives it from `limit`.
+   * @param options.clock the clock every entry's age is measured
+   *   against; undefined means the real one.
+   */
+  constructor(
+    options: {
+      limit?: string | number
+      maxDrainBytes?: number | null
+      clock?: Clock
+    } = {},
+  ) {
     super()
     this.limit = parseLimit(options.limit ?? '512MB')
+    this.clockRef = options.clock ?? new SystemClock()
     this.maxDrainBytes = options.maxDrainBytes ?? null
+  }
+
+  // The current whole second, as `cachedAt` records it.
+  private seconds(): number {
+    return Math.floor(this.clockRef.now())
   }
 
   get maxDrainBytes(): number | null {
@@ -70,7 +99,7 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
     return this.lock.withLock(key, () => {
       const entry = this.entries.get(key)
       if (entry === undefined) return Promise.resolve(null)
-      if (entry.expired) {
+      if (entry.isExpired(this.seconds())) {
         this.size -= entry.size
         this.entries.delete(key)
         this.store.files.delete(key)
@@ -96,7 +125,7 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
       const fp = options.fingerprint ?? defaultFingerprint(data)
       const entry = new CacheEntry({
         size: data.byteLength,
-        cachedAt: Math.floor(Date.now() / 1000),
+        cachedAt: this.seconds(),
         fingerprint: fp,
         ttl: options.ttl ?? null,
       })
@@ -115,7 +144,8 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
   ): Promise<boolean> {
     const placed = await this.lock.withLock(key, () => {
       const existing = this.entries.get(key)
-      if (existing !== undefined && !existing.expired) return Promise.resolve(false)
+      if (existing !== undefined && !existing.isExpired(this.seconds()))
+        return Promise.resolve(false)
       if (existing !== undefined) {
         this.size -= existing.size
         this.entries.delete(key)
@@ -123,7 +153,7 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
       const fp = options.fingerprint ?? defaultFingerprint(data)
       const entry = new CacheEntry({
         size: data.byteLength,
-        cachedAt: Math.floor(Date.now() / 1000),
+        cachedAt: this.seconds(),
         fingerprint: fp,
         ttl: options.ttl ?? null,
       })
@@ -172,7 +202,7 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
   override exists(key: string | PathSpec): Promise<boolean> {
     const k = typeof key === 'string' ? key : key.mountPath
     const entry = this.entries.get(k)
-    return Promise.resolve(entry !== undefined && !entry.expired)
+    return Promise.resolve(entry !== undefined && !entry.isExpired(this.seconds()))
   }
 
   isFresh(key: string, remoteFingerprint: string): Promise<boolean> {

--- a/typescript/packages/core/src/observe/context.test.ts
+++ b/typescript/packages/core/src/observe/context.test.ts
@@ -14,7 +14,9 @@
 
 /* eslint-disable @typescript-eslint/require-await */
 import { describe, expect, it } from 'vitest'
+import { ManualClock, SystemClock } from '../utils/clock.ts'
 import {
+  finishRecord,
   record,
   recordStream,
   revisionFor,
@@ -214,5 +216,39 @@ describe('revisions context', () => {
     await runWithRevisions(new Map([['/s3/a', 'v1']]), async () => {
       expect(revisionFor('/s3/a')).toBe('v1')
     })
+  })
+})
+
+describe('OpTimer clock', () => {
+  it('reads duration from the injected clock', () => {
+    const clock = new ManualClock()
+    const timer = startOp(clock)
+    expect(timer.elapsedMs).toBe(0)
+    clock.advance(2.5)
+    expect(timer.elapsedMs).toBe(2500)
+  })
+
+  it('defaults to the system clock', () => {
+    expect(startOp().clock).toBeInstanceOf(SystemClock)
+  })
+
+  it('finishRecord stamps the timestamp from the timer clock', () => {
+    const clock = new ManualClock(1700)
+    const timer = startOp(clock)
+    clock.advance(3)
+    const rec = finishRecord('read', '/a', 's3', 4, timer)
+    expect(rec.durationMs).toBe(3000)
+    expect(rec.timestamp).toBe(1_703_000)
+  })
+
+  it('a recorded op carries the injected duration', async () => {
+    const clock = new ManualClock(0)
+    const [, records] = await runWithRecording(async () => {
+      const timer = startOp(clock)
+      clock.advance(1.25)
+      record('read', '/a', 's3', 1, timer)
+      return Promise.resolve(null)
+    })
+    expect(records.map((r) => r.durationMs)).toEqual([1250])
   })
 })

--- a/typescript/packages/core/src/observe/context.ts
+++ b/typescript/packages/core/src/observe/context.ts
@@ -14,6 +14,7 @@
 
 import { createAsyncContext } from '../utils/async_context.ts'
 import type { ContextCall } from '../utils/async_context.ts'
+import { type Clock, SystemClock } from '../utils/clock.ts'
 import { OpRecord } from './record.ts'
 import { rstripSlash } from '../utils/slash.ts'
 
@@ -122,23 +123,40 @@ export interface RecordOptions {
  */
 export class OpTimer {
   private readonly startMs: number
+  private readonly clockRef: Clock
 
-  constructor() {
-    this.startMs = performance.now()
+  /**
+   * @param clock the clock both readings are taken from. Passing one is
+   *   what makes a duration assertable without a sleep.
+   */
+  constructor(clock: Clock) {
+    this.clockRef = clock
+    this.startMs = Math.floor(clock.monotonic() * 1000)
   }
 
   /** Milliseconds elapsed since the timer was opened. */
   get elapsedMs(): number {
-    return Math.floor(performance.now() - this.startMs)
+    return Math.floor(this.clockRef.monotonic() * 1000) - this.startMs
+  }
+
+  /** The clock every reading of this op's timing comes from. */
+  get clock(): Clock {
+    return this.clockRef
   }
 }
 
 /**
  * Open the record path's stopwatch for one op. Hand the timer to
  * {@link record} or {@link finishRecord} when the op completes.
+ *
+ * A component that holds the workspace's clock passes it; a backend core
+ * op holds no workspace handle and passes nothing, which opens a
+ * system-clocked timer exactly as before the seam existed.
+ *
+ * @param clock the clock to time with; undefined means the real one.
  */
-export function startOp(): OpTimer {
-  return new OpTimer()
+export function startOp(clock?: Clock): OpTimer {
+  return new OpTimer(clock ?? new SystemClock())
 }
 
 /**
@@ -147,8 +165,9 @@ export function startOp(): OpTimer {
  * The one place an op's duration and wall-clock stamp are read, shared
  * by the recorder sink ({@link record}) and by the `Ops` facade's own
  * ledger, so the two cannot disagree about what a duration measures.
- * `path` is stored as given: a caller that needs mount prefixing
- * applies it first.
+ * Both readings come off the timer's own clock, so an injected one
+ * governs the stamp as well as the duration. `path` is stored as given:
+ * a caller that needs mount prefixing applies it first.
  */
 export function finishRecord(
   op: string,
@@ -164,7 +183,7 @@ export function finishRecord(
     path,
     source,
     bytes: nbytes,
-    timestamp: Date.now(),
+    timestamp: Math.floor(timer.clock.now() * 1000),
     durationMs: elapsed,
     fingerprint: options.fingerprint ?? null,
     revision: options.revision ?? null,

--- a/typescript/packages/core/src/ops/ops.ts
+++ b/typescript/packages/core/src/ops/ops.ts
@@ -19,6 +19,7 @@ import { NO_FOLLOW_OPS, type NamespaceLinks } from './config.ts'
 import type { OpKwargs } from './registry.ts'
 import type { FileStat, SetAttrFields } from '../types.ts'
 import { FileType, PathSpec } from '../types.ts'
+import { type Clock, SystemClock } from '../utils/clock.ts'
 import { exdev, isMissingPath } from '../utils/errors.ts'
 import type { DispatchFn } from '../runtime/types.ts'
 
@@ -62,6 +63,11 @@ export class Ops {
   // for its symlink surface.
   readonly links: NamespaceLinks | null
   private readonly ownerOf: OwnerOf
+  // The workspace's clock, so every op this facade times and stamps
+  // reads the same one. It is also the clock a kernel mount's core
+  // takes, since the core is handed this facade and nothing else from
+  // the workspace.
+  private readonly clockRef: Clock
   /**
    * The op ledger: every facade op lands here, and the executor
    * appends each shell line's ops too, so this is the one
@@ -74,11 +80,18 @@ export class Ops {
     sink: OpSink | null = null,
     links: NamespaceLinks | null = null,
     ownerOf: OwnerOf = () => null,
+    clock: Clock | null = null,
   ) {
     this.dispatch = dispatch
     this.sink = sink
     this.links = links
     this.ownerOf = ownerOf
+    this.clockRef = clock ?? new SystemClock()
+  }
+
+  /** The clock this facade times ops with. */
+  get clock(): Clock {
+    return this.clockRef
   }
 
   /** Ops that moved bytes over the network, in arrival order. */
@@ -130,7 +143,7 @@ export class Ops {
     args: readonly unknown[] = [],
     kwargs: OpKwargs = {},
   ): Promise<unknown> {
-    const timer = startOp()
+    const timer = startOp(this.clockRef)
     // `nofollow` is the caller's AT_SYMLINK_NOFOLLOW and suppresses
     // both follows, so an op meant for a link entry itself (chmod -h, a
     // guest's lchown) still records the link's own path.

--- a/typescript/packages/core/src/utils/clock.test.ts
+++ b/typescript/packages/core/src/utils/clock.test.ts
@@ -1,0 +1,85 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { type Clock, ManualClock, SystemClock } from './clock.ts'
+
+describe('SystemClock', () => {
+  it('satisfies the Clock interface', () => {
+    const clock: Clock = new SystemClock()
+    expect(typeof clock.now()).toBe('number')
+    expect(typeof clock.monotonic()).toBe('number')
+  })
+
+  it('now tracks the wall clock', () => {
+    const before = Date.now() / 1000
+    const reading = new SystemClock().now()
+    const after = Date.now() / 1000
+    expect(reading).toBeGreaterThanOrEqual(before)
+    expect(reading).toBeLessThanOrEqual(after)
+  })
+
+  it('monotonic never decreases', () => {
+    const clock = new SystemClock()
+    const readings = Array.from({ length: 50 }, () => clock.monotonic())
+    expect(readings).toEqual([...readings].sort((a, b) => a - b))
+  })
+})
+
+describe('ManualClock', () => {
+  it('satisfies the Clock interface', () => {
+    const clock: Clock = new ManualClock()
+    expect(clock.now()).toBe(0)
+    expect(clock.monotonic()).toBe(0)
+  })
+
+  it('stands still when read', () => {
+    // Reading must have no side effect: a deadline that moved every time
+    // the code under test glanced at the clock would make every boundary
+    // assertion depend on the number of glances.
+    const clock = new ManualClock(100)
+    expect(clock.now()).toBe(100)
+    expect(clock.now()).toBe(100)
+    expect(clock.monotonic()).toBe(0)
+    expect(clock.monotonic()).toBe(0)
+  })
+
+  it('advance moves both readings', () => {
+    const clock = new ManualClock(1000)
+    clock.advance(30)
+    expect(clock.now()).toBe(1030)
+    expect(clock.monotonic()).toBe(30)
+  })
+
+  it('advance accumulates', () => {
+    const clock = new ManualClock()
+    clock.advance(0.5)
+    clock.advance(0.25)
+    expect(clock.monotonic()).toBe(0.75)
+  })
+
+  it('orders two events by advancing between them', () => {
+    // The ordering case the ticking draft existed for, done explicitly.
+    const clock = new ManualClock(1000)
+    const first = clock.now()
+    clock.advance(1)
+    expect(clock.now()).toBeGreaterThan(first)
+  })
+
+  it('refuses to go backwards', () => {
+    expect(() => {
+      new ManualClock().advance(-1)
+    }).toThrow(RangeError)
+  })
+})

--- a/typescript/packages/core/src/utils/clock.ts
+++ b/typescript/packages/core/src/utils/clock.ts
@@ -1,0 +1,67 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+/** Wall time for timestamps and monotonic time for durations, in seconds. */
+export interface Clock {
+  /** Seconds since the unix epoch. */
+  now(): number
+  /** Seconds from an arbitrary origin that never moves backwards. */
+  monotonic(): number
+}
+
+/** Platform clock used when no clock is supplied. */
+export class SystemClock implements Clock {
+  /** Seconds since the unix epoch. */
+  now(): number {
+    return Date.now() / 1000
+  }
+
+  /** Seconds from an arbitrary origin that never moves backwards. */
+  monotonic(): number {
+    return performance.now() / 1000
+  }
+}
+
+/** Clock advanced explicitly by the caller. Readings have no side effects. */
+export class ManualClock implements Clock {
+  private wall: number
+  private mono = 0
+
+  /** @param start initial wall time in seconds; monotonic starts at zero. */
+  constructor(start = 0) {
+    this.wall = start
+  }
+
+  /** Seconds on the virtual wall clock. */
+  now(): number {
+    return this.wall
+  }
+
+  /** Seconds on the virtual monotonic clock. */
+  monotonic(): number {
+    return this.mono
+  }
+
+  /**
+   * Move the clock forward by `seconds`.
+   *
+   * @param seconds how far forward to move; must not be negative, since
+   *   a monotonic reading may not go back.
+   */
+  advance(seconds: number): void {
+    if (seconds < 0) throw new RangeError('cannot advance a clock backwards')
+    this.wall += seconds
+    this.mono += seconds
+  }
+}

--- a/typescript/packages/core/src/workspace/snapshot.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot.test.ts
@@ -46,6 +46,7 @@ import {
 import type { MountSnapshot } from './snapshot/types.ts'
 import { ScriptSource } from '../runtime/routing/types.ts'
 import { ExecutionNode } from './types.ts'
+import { ManualClock } from '../utils/clock.ts'
 import { Workspace } from './workspace/workspace.ts'
 
 const require = createRequire(import.meta.url)
@@ -505,6 +506,63 @@ describe('cli registry snapshot', () => {
     expect(clis[0]?.name).toBe('pager')
     expect(clis[0]?.script?.source).toBe("print('hi')")
     await ws.close()
+  })
+
+  it('ages a restored cache entry on the injected clock', async () => {
+    // A snapshot stores cachedAt and ttl as data, so the restored
+    // entry's expiry is decided by the clock the restoring workspace was
+    // given, never by the wall clock of the run that took it.
+    const src = new Workspace(
+      { '/data': new RAMResource() },
+      {
+        mode: MountMode.WRITE,
+        ops: new OpsRegistry(),
+        shellParser: parser,
+        clock: new ManualClock(1000),
+      },
+    )
+    await src.cache.set('/c.txt', new TextEncoder().encode('cached'), { ttl: 10 })
+    const state = await toStateDict(src)
+
+    const clock = new ManualClock(1000)
+    const restored = await Workspace.fromState(state, {
+      mode: MountMode.WRITE,
+      ops: new OpsRegistry(),
+      shellParser: parser,
+      clock,
+    })
+    const entry = (
+      restored as unknown as {
+        cache: { snapshotEntries(): { key: string; entry: { cachedAt: number; ttl: number } }[] }
+      }
+    ).cache.snapshotEntries()[0]
+    expect(entry?.entry.cachedAt).toBe(1000)
+    expect(entry?.entry.ttl).toBe(10)
+    expect(await restored.cache.exists('/c.txt')).toBe(true)
+    clock.advance(9)
+    expect(await restored.cache.exists('/c.txt')).toBe(true)
+    clock.advance(1)
+    expect(await restored.cache.exists('/c.txt')).toBe(false)
+    await src.close()
+    await restored.close()
+  })
+
+  it('a copy keeps the workspace clock', async () => {
+    const clock = new ManualClock()
+    const ws = new Workspace(
+      { '/data': new RAMResource() },
+      { mode: MountMode.WRITE, ops: new OpsRegistry(), shellParser: parser, clock },
+    )
+    const copied = await ws.copy()
+    // A copy reads time the way its origin does, so a TTL stamped on
+    // the copy still expires on the clock the origin was given.
+    await copied.cache.set('/c.txt', new TextEncoder().encode('cached'), { ttl: 10 })
+    clock.advance(9)
+    expect(await copied.cache.exists('/c.txt')).toBe(true)
+    clock.advance(1)
+    expect(await copied.cache.exists('/c.txt')).toBe(false)
+    await ws.close()
+    await copied.close()
   })
 })
 

--- a/typescript/packages/core/src/workspace/workspace/cache.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/cache.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from 'vitest'
 import { CacheType } from '../../cache/file/config.ts'
 import { RAMFileCacheStore } from '../../cache/file/ram.ts'
+import { ManualClock, SystemClock } from '../../utils/clock.ts'
 import { Workspace } from './workspace.ts'
 import { buildFileCache, registerFileCacheStore } from './cache.ts'
 
@@ -50,6 +51,45 @@ describe('the workspace cache', () => {
     const ws = new Workspace({}, { cache: { type: CacheType.RAM, limit: 4096 } })
     expect(ws.cache).toBeInstanceOf(RAMFileCacheStore)
     expect(ws.cache.cacheLimit).toBe(4096)
+  })
+
+  it('hands one clock to the op facade', () => {
+    // The facade is the reader a mount core inherits from, so this is
+    // the one clock handoff a caller can observe.
+    const clock = new ManualClock()
+    const ws = new Workspace({}, { clock })
+    expect(ws.fs.clock).toBe(clock)
+  })
+
+  it('runs on the real clock when given none', () => {
+    expect(new Workspace({}).fs.clock).toBeInstanceOf(SystemClock)
+  })
+
+  it('expires a cached entry on its own clock', async () => {
+    const clock = new ManualClock(1000)
+    const ws = new Workspace({}, { clock })
+    await ws.cache.set('/f.txt', new TextEncoder().encode('hello'), { ttl: 10 })
+    clock.advance(9)
+    expect(await ws.cache.exists('/f.txt')).toBe(true)
+    clock.advance(1)
+    expect(await ws.cache.exists('/f.txt')).toBe(false)
+  })
+
+  it('a built cache ages entries on the given clock', async () => {
+    const clock = new ManualClock(1000)
+    const cache = buildFileCache(undefined, 1024, clock)
+    await cache.set('/f.txt', new TextEncoder().encode('hello'), { ttl: 10 })
+    clock.advance(10)
+    expect(await cache.exists('/f.txt')).toBe(false)
+  })
+
+  it('a cache config does not lose the clock', async () => {
+    const clock = new ManualClock(1000)
+    const cache = buildFileCache({ type: CacheType.RAM, limit: 2048 }, 1024, clock)
+    expect(cache.cacheLimit).toBe(2048)
+    await cache.set('/f.txt', new TextEncoder().encode('hello'), { ttl: 10 })
+    clock.advance(10)
+    expect(await cache.exists('/f.txt')).toBe(false)
   })
 
   it('closes the store it built', async () => {

--- a/typescript/packages/core/src/workspace/workspace/cache.ts
+++ b/typescript/packages/core/src/workspace/workspace/cache.ts
@@ -16,6 +16,7 @@ import { CacheType, type CacheConfig, type RedisCacheConfig } from '../../cache/
 import type { FileCache } from '../../cache/file/mixin.ts'
 import { RAMFileCacheStore } from '../../cache/file/ram.ts'
 import type { Resource } from '../../resource/base.ts'
+import type { Clock } from '../../utils/clock.ts'
 
 export type FileCacheStore = FileCache & Resource
 export type FileCacheFactory = (config: RedisCacheConfig) => FileCacheStore
@@ -45,10 +46,14 @@ export function registerFileCacheStore(type: CacheType, factory: FileCacheFactor
  * @param cache the cache config; undefined keeps the RAM store sized by
  *   `cacheLimit`.
  * @param cacheLimit the size knob used only when no config is given.
+ * @param clock the workspace's clock, handed to the store that ages
+ *   entries itself. The redis store takes none: its TTLs are
+ *   server-side `EXPIRE` and it reads no time here.
  */
 export function buildFileCache(
   cache: CacheConfig | undefined,
   cacheLimit: string | number = '512MB',
+  clock?: Clock,
 ): FileCacheStore {
   // Every CacheConfig field is optional, so a built store is
   // structurally assignable to it and would slip through to the RAM
@@ -75,5 +80,6 @@ export function buildFileCache(
   return new RAMFileCacheStore({
     limit: cache?.limit ?? cacheLimit,
     maxDrainBytes: cache?.maxDrainBytes ?? null,
+    ...(clock !== undefined ? { clock } : {}),
   })
 }

--- a/typescript/packages/core/src/workspace/workspace/types.ts
+++ b/typescript/packages/core/src/workspace/workspace/types.ts
@@ -25,6 +25,7 @@ import type { EnvEntries, SecretEntries } from '../../secrets/config.ts'
 import type { ConsoleFactory } from '../../shell/job_table/index.ts'
 import type { ShellParser } from '../../shell/parse/index.ts'
 import type { Limit, ConsistencyPolicy, DriftPolicy, MountMode, Refusal } from '../../types.ts'
+import type { Clock } from '../../utils/clock.ts'
 import type { AskHandler, Policy } from '../../policy/index.ts'
 import type { RouteDecision, RoutePolicy } from '../../runtime/routing/index.ts'
 import type { RuntimeEntry } from '../../runtime/base.ts'
@@ -74,6 +75,13 @@ export interface WorkspaceOptions {
    * closes it.
    */
   cache?: CacheConfig
+  /**
+   * The one clock this workspace and its components read time through;
+   * omitted means the real one. Threaded to the file cache (entry
+   * TTLs), the op facade (op durations and stamps) and, through that
+   * facade, a kernel mount's prefetch TTL.
+   */
+  clock?: Clock
   index?: IndexConfig
   /**
    * Builds each background job's console from its job id, so job

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -95,6 +95,7 @@ import {
 } from '../../policy/profile.ts'
 import { applyProfile, compileProfile, resolveProfile, withInline } from '../session/resolve.ts'
 import { ScriptPolicy } from '../../policy/script.ts'
+import { type Clock, SystemClock } from '../../utils/clock.ts'
 import { newSessionId, newWorkspaceId } from '../../utils/ids.ts'
 import type { WatchRuntime } from '../../watch/base.ts'
 import { resolveControlStores } from './build.ts'
@@ -131,6 +132,15 @@ export class Workspace {
   readonly jobTable: JobTable
   readonly agentId: string | null
   readonly cache: FileCache & Resource
+  /**
+   * The one clock this workspace and its components read time from: the
+   * file cache (entry TTLs), the op facade (op durations and stamps)
+   * and, through that facade, a kernel mount's prefetch TTL. Private:
+   * the injection surface is the constructor option, and a reader that
+   * needs the clock reaches it through the facade that uses it.
+   * Mirrors python's `Workspace._clock`.
+   */
+  private readonly clock: Clock
   readonly namespace: Namespace
   private readonly dispatcher: Dispatcher
   readonly observer: Observer
@@ -189,6 +199,12 @@ export class Workspace {
         resource.setIndex?.(options.index)
       }
     }
+    // The workspace owns one clock and hands it to the components that
+    // measure elapsed time: the file cache (entry TTLs), the op facade
+    // (op durations and stamps) and, through that facade, a kernel
+    // mount's prefetch TTL. Undefined keeps the real clock, so a
+    // deployment that never mentions time behaves as before.
+    this.clock = options.clock ?? new SystemClock()
     this.wsId = options.workspaceId ?? newWorkspaceId()
     this.jobTable = new JobTable(options.consoleFactory ?? null)
     const stores = resolveControlStores(this.wsId, options)
@@ -316,7 +332,7 @@ export class Workspace {
     }
     this.observer = new Observer(stores.observe)
     this.registry.mount(HISTORY_PREFIX, new HistoryViewResource(this.observer), MountMode.READ)
-    this.cache = buildFileCache(options.cache, options.cacheLimit)
+    this.cache = buildFileCache(options.cache, options.cacheLimit, this.clock)
     this.registry.attachFileCache(this.cache)
     // Only an explicit agentId claims the workspace user; a bare launch
     // adopts whatever identity the namespace store holds.
@@ -395,6 +411,7 @@ export class Workspace {
         const mount = this.registry.tryMountFor(path)
         return mount === null ? null : { prefix: mount.prefix, kind: mount.resource.kind }
       },
+      this.clock,
     )
     this.runtimes = new Runtimes({
       registry: this.registry,
@@ -1347,6 +1364,9 @@ export class Workspace {
       // instance, and without the block the copy would answer the
       // first read with "unknown secrets source".
       secrets: options.secrets ?? this.declaredSecretSources,
+      // A copy reads time the way its origin does, so a restored
+      // entry's TTL is measured on the same timeline it was stamped on.
+      clock: options.clock ?? this.clock,
     }
     const copyAgentId = options.agentId ?? this.agentId
     if (copyAgentId !== null) opts.agentId = copyAgentId

--- a/typescript/packages/node/src/fuse/core.test.ts
+++ b/typescript/packages/node/src/fuse/core.test.ts
@@ -16,10 +16,11 @@ import { constants as fsConstants } from 'node:fs'
 import { runWithSession } from '@struktoai/mirage-core/context/session_context'
 import { RAMResource } from '@struktoai/mirage-core/resource/ram/ram'
 import { ContentType, FileStat, FileType, MountMode } from '@struktoai/mirage-core/types'
+import { type Clock, ManualClock } from '@struktoai/mirage-core/utils/clock'
 import { mtimeMs } from '@struktoai/mirage-core/utils/stat_view'
 import { describe, expect, it, vi } from 'vitest'
 import { Workspace } from '../workspace.ts'
-import { MountCore } from './core.ts'
+import { MountCore, PREFETCH_TTL_MS } from './core.ts'
 
 const NAIVE_STAMP = '2026-01-02T03:04:05'
 
@@ -479,5 +480,58 @@ describe('applyStatAttrs', () => {
     const got = core.applyStatAttrs({ ...base }, epoch)
     expect(got.mtime.getTime()).toBe(0)
     expect(got.ctime.getTime()).toBe(0)
+  })
+})
+
+/**
+ * A clock whose wall reading can jump while monotonic stands still.
+ *
+ * ManualClock moves both readings together, which is right for virtual
+ * time passing but cannot express the case a deadline has to survive:
+ * NTP stepping the system clock while no real time has elapsed.
+ */
+class SteppingClock implements Clock {
+  wall = 1_700_000_000
+  mono = 0
+
+  now(): number {
+    return this.wall
+  }
+
+  monotonic(): number {
+    return this.mono
+  }
+}
+
+describe('MountCore clock', () => {
+  it('holds the prefetch TTL boundary on an injected clock', async () => {
+    // The prefetch cache is a deadline in milliseconds, so an injected
+    // clock is the only way to sit on the boundary exactly: fresh one
+    // second before the TTL, gone the second it lands.
+    const clock = new ManualClock()
+    const ws = new Workspace({ '/': new RAMResource() }, { mode: MountMode.WRITE, clock })
+    await ws.execute("echo -n 'payload' > /u.json")
+    const core = new MountCore(ws.fs)
+    expect(await core.prefetch('/u.json')).not.toBeNull()
+    clock.advance(PREFETCH_TTL_MS / 1000 - 1)
+    expect(core.cachedData('/u.json')).not.toBeNull()
+    expect(core.cachedSize('/u.json')).toBe(7)
+    clock.advance(1)
+    expect(core.cachedSize('/u.json')).toBeNull()
+    expect(core.cachedData('/u.json')).toBeNull()
+    expect(core.prefetchCache.has('/u.json')).toBe(false)
+  })
+
+  it('ignores a wall clock jump when judging the prefetch deadline', async () => {
+    // The deadline is a duration, so it must be measured on the
+    // monotonic reading. Reading wall clock instead would expire every
+    // prefetched file the moment NTP stepped the system clock forward.
+    const clock = new SteppingClock()
+    const ws = new Workspace({ '/': new RAMResource() }, { mode: MountMode.WRITE, clock })
+    await ws.execute("echo -n 'payload' > /u.json")
+    const core = new MountCore(ws.fs)
+    expect(await core.prefetch('/u.json')).not.toBeNull()
+    clock.wall += 10 * 365 * 24 * 3600
+    expect(core.cachedData('/u.json')).not.toBeNull()
   })
 })

--- a/typescript/packages/node/src/fuse/core.ts
+++ b/typescript/packages/node/src/fuse/core.ts
@@ -19,6 +19,7 @@ import type { Ops } from '@struktoai/mirage-core/ops/ops'
 import { FileTable, mergeWrites } from '@struktoai/mirage-core/runtime/handles/index'
 import { FileType } from '@struktoai/mirage-core/types'
 import type { FileStat } from '@struktoai/mirage-core/types'
+import type { Clock } from '@struktoai/mirage-core/utils/clock'
 import { isMissingOp } from '@struktoai/mirage-core/utils/errors'
 import { rstripSlash } from '@struktoai/mirage-core/utils/slash'
 import { compareCodePoints } from '@struktoai/mirage-core/utils/sort'
@@ -51,7 +52,7 @@ interface PrefetchEntry {
   expires: number
 }
 
-const PREFETCH_TTL_MS = 30_000
+export const PREFETCH_TTL_MS = 30_000
 
 export interface MountCoreOptions {
   rootPrefix?: string
@@ -85,6 +86,7 @@ export interface MountCoreOptions {
 export class MountCore {
   readonly ops: Ops
   readonly session: Session | null
+  private readonly clock: Clock
   private readonly now: Date
   private readonly root: string
   readonly handles = new FileTable<Handle>()
@@ -108,6 +110,15 @@ export class MountCore {
 
   constructor(ops: Ops, options: MountCoreOptions = {}) {
     this.ops = ops
+    // The prefetch TTL is a duration, so it is measured on the facade's
+    // clock. There is no second door: a core is always handed the
+    // facade, and the facade carries the workspace's clock, so
+    // injecting one here would be a way to disagree with the workspace
+    // about what time it is.
+    this.clock = ops.clock
+    // The mount's own creation stamp, not a deadline. It answers "when
+    // was this mounted", so it reads the real clock even when the ops
+    // facade is running on an injected one.
     this.now = new Date()
     this.root = options.rootPrefix !== undefined ? rstripSlash(options.rootPrefix) : ''
     this.uid = typeof process.getuid === 'function' ? process.getuid() : 0
@@ -224,6 +235,15 @@ export class MountCore {
     return entry
   }
 
+  // The prefetch cache keeps its deadlines in milliseconds, so the
+  // monotonic reading is expressed in the same unit. Monotonic, not
+  // wall clock: an NTP step or a manually corrected system clock would
+  // otherwise expire every prefetched file at once, or strand it.
+  // Mirrors python's `PREFETCH_TTL` comparison.
+  private monotonicMs(): number {
+    return this.clock.monotonic() * 1000
+  }
+
   cachedSize(path: string): number | null {
     return this.cachedData(path)?.byteLength ?? null
   }
@@ -234,7 +254,7 @@ export class MountCore {
       if (ctx.key === key && ctx.data !== undefined) return ctx.data
     }
     const entry = this.prefetchCache.get(key)
-    if (entry !== undefined && entry.expires > Date.now()) return entry.data
+    if (entry !== undefined && entry.expires > this.monotonicMs()) return entry.data
     if (entry !== undefined) this.prefetchCache.delete(key)
     return null
   }
@@ -260,7 +280,7 @@ export class MountCore {
           // The file changed while this read was out: what came back is
           // stale, so read again rather than install it.
           if ((this.prefetchGen.get(key) ?? 0) !== gen) continue
-          this.prefetchCache.set(key, { data, expires: Date.now() + PREFETCH_TTL_MS })
+          this.prefetchCache.set(key, { data, expires: this.monotonicMs() + PREFETCH_TTL_MS })
           return data
         }
       } catch {


### PR DESCRIPTION
RAM file-cache TTL, FUSE prefetch expiry and op timing each read the system clock directly. A test that wants to sit on an expiry boundary has to sleep for real or monkeypatch `time` process-wide, and an embedding program cannot supply its own time. This adds one injectable clock and threads it to those three readers.

## What changes

- New `Clock` (`now()` for wall time, `monotonic()` for durations, both in seconds) with a `SystemClock` default and a `ManualClock` that stays fixed until `advance()` moves it. Python `mirage/utils/clock.py`, TypeScript `core/src/utils/clock.ts`.
- `Workspace` takes an optional `clock` and hands it to the RAM file cache, the op facade and, through the facade, a kernel mount's prefetch cache. Copies keep it; `load()` and `from_state()` accept one so restored cache entries age on the caller's clock.
- `CacheEntry.is_expired(now)` replaces the `expired` getter that read the system time itself. Entries stay plain data; the store passes the reading in.
- FUSE prefetch deadlines and op durations read `monotonic()`. RAM-cache stamps stay whole-second wall time because they survive a snapshot round trip.

Deployments that never pass a clock behave exactly as before.

```python
clock = ManualClock(start=1000)
ws = Workspace({"/data": RAMResource()}, clock=clock)
await ws.cache.set("/data/file.txt", b"hello", ttl=10)
clock.advance(9)
assert await ws.cache.exists("/data/file.txt")
clock.advance(1)
assert not await ws.cache.exists("/data/file.txt")
```

## Out of scope

Index cache TTLs, retry sleeps, backend-internal `start_op()` timers, the command-recording scope and `Observer` event timestamps, and ID generation are separate tracker items (#970 item 2b and following). Only the three readers above move in this PR, so a workspace on a `ManualClock` still stamps shell commands from the system clock until 2b lands. Redis TTLs stay server-side.

## Verification

- `tests/utils/test_clock.py`, `utils/clock.test.ts`: `ManualClock` does not move when read, `advance()` moves both readings together and refuses to go backwards.
- `tests/cache/file/test_ram.py`, `cache/file/ram.test.ts`: TTL boundary probed at `ttl-1` and `ttl` with no sleep; expired entries are dropped on read and replaced by `add`.
- `tests/fuse/test_core.py`, `node/fuse/core.test.ts`: prefetch expires on the monotonic boundary and survives a wall-clock jump, which is the bug a `Date.now()` deadline would have.
- `tests/observe/test_context.py`, `observe/context.test.ts`: `OpTimer` durations and record timestamps come from the injected clock.
- `tests/workspace/snapshot/test_state.py`, `workspace/snapshot.test.ts`: a restored entry ages on the restoring workspace's clock; a copy keeps its origin's clock.
- `tests/workspace/workspace/test_cache.py`, `workspace/cache.test.ts`: the workspace hands one clock to the cache and the op facade.

Part of #970 (item 2).
