### PR TITLE
Release 0.0.6

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirage-ai"
-version = "0.0.5"
+version = "0.0.6"
 description = "A unified virtual filesystem for AI agents. Mount S3, Google Drive, Slack, Gmail, GitHub, Linear, Notion, Postgres, MongoDB, SSH, and more behind one filesystem so agents read, write, and pipe across services with familiar shell commands."
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -5812,7 +5812,7 @@ wheels = [
 
 [[package]]
 name = "mirage-ai"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/typescript/packages/agents/package.json
+++ b/typescript/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-agents",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/browser/package.json
+++ b/typescript/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-browser",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/cli/package.json
+++ b/typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-core",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/dsh/package.json
+++ b/typescript/packages/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-dsh",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "DeepSeek Harness (dsh) providers backed by a mirage workspace: ctx.fs and ctx.shell over mounted resources",
   "homepage": "https://github.com/strukto-ai/mirage#readme",
   "bugs": {

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-node",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/server/package.json
+++ b/typescript/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-server",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",


### PR DESCRIPTION
Release 0.0.6, cut from main at 82fdeaaf7 (200 PRs since v0.0.5).

- `python/pyproject.toml` + `python/uv.lock` to `0.0.6`
- all seven published TypeScript packages (agents, browser, cli, core, dsh, node, server) to `0.0.6`
- `opencode` stays at 0.0.0

### dsh joins the monorepo version line

`@struktoai/mirage-dsh` was released once, as `0.0.1` on 2026-08-15, and npm's `latest` still points there. The `0.0.5` in the tree was never published: it arrived in abdefa2ca8 in the same hunk that bumped `@deepseek-ai/dsh-fs` and `dsh-shell` to `0.1.1-rc.2`, and that commit's message describes bumping those upstream seams, not mirage-dsh's own version.

So this release puts dsh on `0.0.6` with everything else rather than continuing its own line at `0.0.2`. Nothing gates that version field, so an independent line drifts every time a mass bump sweeps it, which is exactly what abdefa2ca8 did. `0.0.2` through `0.0.5` stay as gaps, which npm allows, and from here the tag, the release page and every install line are one number.

### Nothing else moves

Cross-package deps are `workspace:*`, so pnpm rewrites them at publish time and no dependency edits are needed; `pnpm-lock.yaml` is unchanged for the same reason. Both `mirage.__version__` and the TS side read their version from package metadata, so there is no second place to bump.

No test changes either: the five TypeScript `--version` assertions accept an optional prerelease suffix since 0.0.5, and `0.0.6` fits the shape they already assert. `uv lock --check` resolves clean and every pre-commit hook passes.

After merge: tag `v0.0.6`, publish the release page, then upload 0.0.6 to PyPI and npm.
