### PR TITLE
Preserve Redis index entry metadata

### DIFF
--- a/typescript/packages/core/src/cache/index/redis.test.ts
+++ b/typescript/packages/core/src/cache/index/redis.test.ts
@@ -54,12 +54,28 @@ describe.skipIf(skip)('RedisIndexCacheStore', () => {
     expect(r.status).toBe(LookupStatus.NOT_FOUND)
   })
 
-  it('put + get round-trips entry', async () => {
-    await store.put('/a', entry('id-a', 'a'))
+  it('put + get round-trips entry metadata', async () => {
+    const extra = { drive_id: 'drive-a', nested: { slug: 'alpha', tags: ['x', 'y'] } }
+    await store.put('/a', new IndexEntry({ id: 'id-a', name: 'a', resourceType: 'file', extra }))
     const r = await store.get('/a')
     expect(r.entry?.id).toBe('id-a')
     expect(r.entry?.name).toBe('a')
     expect(r.entry?.indexTime).not.toBe('')
+    expect(r.entry?.extra).toEqual(extra)
+  })
+
+  it('setDir + get round-trips metadata and default empty extra', async () => {
+    const extra = { attachment: { url: 'https://example.test/file', size: 42 } }
+    await store.setDir('/dir', [
+      [
+        'with-extra',
+        new IndexEntry({ id: 'id-extra', name: 'with-extra', resourceType: 'file', extra }),
+      ],
+      ['without-extra', entry('id-empty', 'without-extra')],
+    ])
+
+    expect((await store.get('/dir/with-extra')).entry?.extra).toEqual(extra)
+    expect((await store.get('/dir/without-extra')).entry?.extra).toEqual({})
   })
 
   it('setDir stores entries and listDir preserves insertion (readdir) order', async () => {

--- a/typescript/packages/core/src/cache/index/redis.ts
+++ b/typescript/packages/core/src/cache/index/redis.ts
@@ -121,6 +121,7 @@ export class RedisIndexCacheStore extends IndexCacheStore {
       indexTime?: string
       vfsName?: string
       size?: number | null
+      extra?: Record<string, unknown>
     }
     return { entry: new IndexEntry(parsed) }
   }
@@ -248,6 +249,7 @@ export class RedisIndexCacheStore extends IndexCacheStore {
       indexTime: e.indexTime,
       vfsName: e.vfsName,
       size: e.size,
+      extra: e.extra,
     }
   }
 }


### PR DESCRIPTION
## Summary

- Before: TypeScript Redis index serialization omitted `IndexEntry.extra`, so metadata present on a cold entry disappeared after a Redis-backed warm lookup.
- After: Redis `put` and `setDir` persist `extra`, and `get` restores it. Existing records without the field remain compatible and default to an empty object.
- Scope is limited to index entry serialization; TTL, child cleanup, empty-directory representation, and cache identity are unchanged.

## Verification

- Reproduced on current `origin/main`: nested `extra` round-tripped as `{}`.
- Focused Redis suite: 12 tests passed using an isolated local Redis instance and unique per-test key prefixes.
