### PR TITLE
Fix zero-length Redis range reads

### DIFF
--- a/python/mirage/resource/redis/store.py
+++ b/python/mirage/resource/redis/store.py
@@ -124,6 +124,9 @@ class RedisStore:
             size (int | None): how many bytes, or None for the rest.
         """
         key = self._fk(path)
+        if size == 0:
+            # GETRANGE 0 -1 means the whole value, not an empty window.
+            return b"" if await self._client.exists(key) else None
         end = -1 if size is None else offset + size - 1
         async with self._client.pipeline(transaction=False) as pipe:
             pipe.exists(key)

--- a/python/tests/core/redis/test_read.py
+++ b/python/tests/core/redis/test_read.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import os
+import uuid
 
 import pytest
 import pytest_asyncio
@@ -135,6 +136,36 @@ async def test_read_bytes_window_past_eof_is_empty(accessor):
                     virtual="/hello.txt",
                     directory="/hello.txt")
     assert await read_bytes(accessor, offset=99, size=5, path_spec=spec) == b""
+
+
+@pytest.mark.asyncio
+async def test_read_bytes_zero_length_is_empty_and_preserves_missing():
+    prefix = f"test:read:zero:{uuid.uuid4()}:"
+    store = RedisStore(url=REDIS_URL, key_prefix=prefix)
+    try:
+        await store.set_file("/data", b"payload")
+        await store.set_file("/empty", b"")
+        accessor = RedisAccessor(store)
+        data = PathSpec(resource_path="data",
+                        virtual="/data",
+                        directory="/data")
+        empty = PathSpec(resource_path="empty",
+                         virtual="/empty",
+                         directory="/empty")
+        missing = PathSpec(resource_path="missing",
+                           virtual="/missing",
+                           directory="/missing")
+        assert await read_bytes(accessor, data, offset=0, size=0) == b""
+        assert await read_bytes(accessor, data, offset=4, size=0) == b""
+        assert await read_bytes(accessor, empty, offset=0, size=0) == b""
+        assert await read_bytes(accessor, empty, offset=4, size=0) == b""
+        with pytest.raises(FileNotFoundError):
+            await read_bytes(accessor, missing, offset=0, size=0)
+        with pytest.raises(FileNotFoundError):
+            await read_bytes(accessor, missing, offset=4, size=0)
+    finally:
+        await store.clear()
+        await store.close()
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/browser/src/resource/redis/redis_live.test.ts
+++ b/typescript/packages/browser/src/resource/redis/redis_live.test.ts
@@ -72,7 +72,10 @@ describe.skipIf(skip)('RedisResource against a live Upstash database', () => {
       await resource.store.setFile('/a.bin', ALL_BYTES)
       expect(await resource.store.getFileRange('/a.bin', 10, 5)).toEqual(ALL_BYTES.slice(10, 15))
       expect(await resource.store.getFileRange('/a.bin', 250, null)).toEqual(ALL_BYTES.slice(250))
+      expect(await resource.store.getFileRange('/a.bin', 0, 0)).toEqual(new Uint8Array(0))
+      expect(await resource.store.getFileRange('/a.bin', 10, 0)).toEqual(new Uint8Array(0))
       expect(await resource.store.getFileRange('/missing', 0, 5)).toBeNull()
+      expect(await resource.store.getFileRange('/missing', 0, 0)).toBeNull()
     },
     LIVE,
   )

--- a/typescript/packages/browser/src/resource/redis/store.test.ts
+++ b/typescript/packages/browser/src/resource/redis/store.test.ts
@@ -195,6 +195,18 @@ describe('UpstashRedisStore', () => {
     expect(await store.getFileRange('/nope', 0, 5)).toBeNull()
   })
 
+  it('getFileRange returns empty for zero-length reads and preserves missing', async () => {
+    const { store } = make()
+    await store.setFile('/data', ENC.encode('payload'))
+    await store.setFile('/empty', new Uint8Array(0))
+    expect(await store.getFileRange('/data', 0, 0)).toEqual(new Uint8Array(0))
+    expect(await store.getFileRange('/data', 4, 0)).toEqual(new Uint8Array(0))
+    expect(await store.getFileRange('/empty', 0, 0)).toEqual(new Uint8Array(0))
+    expect(await store.getFileRange('/empty', 4, 0)).toEqual(new Uint8Array(0))
+    expect(await store.getFileRange('/missing', 0, 0)).toBeNull()
+    expect(await store.getFileRange('/missing', 4, 0)).toBeNull()
+  })
+
   it('fileLen counts bytes, not characters', async () => {
     const { store } = make()
     await store.setFile('/u.txt', ENC.encode('é'))

--- a/typescript/packages/browser/src/resource/redis/store.ts
+++ b/typescript/packages/browser/src/resource/redis/store.ts
@@ -307,6 +307,8 @@ export class UpstashRedisStore implements RedisStoreLike {
     size: number | null,
   ): Promise<Uint8Array | null> {
     const key = this.fk(path)
+    // GETRANGE 0 -1 means the whole value, not an empty window.
+    if (size === 0) return (await this.integer(['EXISTS', key])) === 0 ? null : new Uint8Array(0)
     const end = size === null ? -1 : offset + size - 1
     const [exists, raw] = await this.pipeline(
       [

--- a/typescript/packages/node/src/resource/redis/store.test.ts
+++ b/typescript/packages/node/src/resource/redis/store.test.ts
@@ -61,6 +61,17 @@ describe.skipIf(skip)('RedisStore', () => {
     expect(await store.getFile('/nope')).toBeNull()
   })
 
+  it('getFileRange returns empty for zero-length reads and preserves missing', async () => {
+    await store.setFile('/data', new TextEncoder().encode('payload'))
+    await store.setFile('/empty', new Uint8Array(0))
+    expect(await store.getFileRange('/data', 0, 0)).toEqual(new Uint8Array(0))
+    expect(await store.getFileRange('/data', 4, 0)).toEqual(new Uint8Array(0))
+    expect(await store.getFileRange('/empty', 0, 0)).toEqual(new Uint8Array(0))
+    expect(await store.getFileRange('/empty', 4, 0)).toEqual(new Uint8Array(0))
+    expect(await store.getFileRange('/missing', 0, 0)).toBeNull()
+    expect(await store.getFileRange('/missing', 4, 0)).toBeNull()
+  })
+
   it('hasFile / delFile', async () => {
     await store.setFile('/x', new Uint8Array([1]))
     expect(await store.hasFile('/x')).toBe(true)

--- a/typescript/packages/node/src/resource/redis/store.ts
+++ b/typescript/packages/node/src/resource/redis/store.ts
@@ -119,6 +119,9 @@ export class RedisStore implements RedisStoreLike {
     size: number | null,
   ): Promise<Uint8Array | null> {
     const c = await this.client()
+    const key = this.fk(path)
+    // GETRANGE 0 -1 means the whole value, not an empty window.
+    if (size === 0) return (await c.exists(key)) === 0 ? null : new Uint8Array(0)
     const mod = (await import('redis')) as unknown as {
       RESP_TYPES: { readonly BLOB_STRING: number }
     }
@@ -130,7 +133,6 @@ export class RedisStore implements RedisStoreLike {
     }
     const mapping: Record<number, unknown> = { [mod.RESP_TYPES.BLOB_STRING]: Buffer }
     const end = size === null ? -1 : offset + size - 1
-    const key = this.fk(path)
     const [exists, raw] = await Promise.all([
       typed.exists(key),
       typed.withTypeMapping(mapping).getRange(key, offset, end),


### PR DESCRIPTION
## How error happens

1. A client asks Mirage to read a byte range from a Redis-mounted file, for example `read(path, offset=0, size=0)`.
2. A zero-byte request should return immediately with an empty payload. It must not transfer file content.
3. Before this change, a non-empty file could return its complete contents when the request started at offset zero. The same request at another offset or through ordinary in-memory slicing returned empty, so behavior depended on the execution path.
4. After this change, zero-byte reads return an empty payload for every offset and for both empty and non-empty files. A missing file still surfaces as ENOENT.

## System-level view

```text
Client / command / runtime
          |
          | read(path, offset, size)
          v
Redis resource read
          |
          | get_file_range / getFileRange
          v
+-----------------------------+
| Before                      |
| end = offset + size - 1     |
| offset=0, size=0 => 0..-1   |
+-----------------------------+
          |
          | GETRANGE key 0 -1
          v
Redis interprets -1 as the last byte
          |
          v
Entire file returned unexpectedly
```

The store cannot infer existence from `GETRANGE`: Redis returns the same empty value for a missing key, an empty file, and a range beyond EOF. That is why range reads pair content retrieval with `EXISTS`.

```text
After

get_file_range / getFileRange
          |
          +-- size == 0 --> EXISTS key
          |                    |
          |                    +-- exists  --> empty bytes
          |                    +-- missing --> None/null --> ENOENT
          |
          +-- size > 0 or unbounded
                               |
                               +-- existing GETRANGE path, unchanged
```

Python, Node, and browser stores implement the same branch. Redis resources declare `caches_reads` / `cachesReads` as false, so there is no Redis-resource warm-cache branch to redesign; this PR stays limited to server-side range semantics.

## Before / after contract

| Case | Before | After |
| --- | --- | --- |
| Existing non-empty file, offset 0, size 0 | Entire file | Empty bytes |
| Existing non-empty file, positive offset, size 0 | Empty bytes | Empty bytes |
| Existing empty file, size 0 | Empty bytes | Empty bytes |
| Missing file, size 0 | Missing | Missing / ENOENT |
| Positive-size or unbounded range | Normal range | Unchanged |

## Implementation

- Special-case `size=0` before constructing Redis's inclusive range.
- Issue only `EXISTS` for that case.
- Return empty bytes when the key exists; retain `None`/`null` when it does not.
- Apply identical semantics in Python, Node, and browser/Upstash stores.

## Verification

- `python/tests/core/redis/test_read.py`: covers the Python resource path for zero-byte reads at zero and positive offsets, including empty and missing files.
- `typescript/packages/node/src/resource/redis/store.test.ts`: covers the same range matrix against Redis from the Node store.
- `typescript/packages/browser/src/resource/redis/store.test.ts`: keeps browser/Upstash store semantics in parity without live credentials.
- `typescript/packages/browser/src/resource/redis/redis_live.test.ts`: verifies the zero-byte and missing-key behavior against live Upstash when credentials are available.

## CI status / known blocker

The changed Redis suites pass in CI. Current failures are unrelated existing policy/approval work: Python mypy at `python/mirage/policy/decisions.py:344`, all-files YAPF at `python/tests/policy/test_decisions.py`, and TypeScript approval behavior at `typescript/packages/dsh/src/approval.test.ts:185`. This PR does not alter those paths and should be rebased after their fixes land.
