### PR TITLE
Fix workspace lifecycle parity and add shared integration coverage

### DIFF
--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -212,6 +212,27 @@ jobs:
       - name: Run virtual-root mount switching (ram/disk/yaml)
         run: ./python/.venv/bin/python integ/root.py
 
+      - name: Cache the lifecycle policy engine
+        id: lifecycle-quickjs-cache
+        uses: actions/cache@v6
+        with:
+          path: /tmp/quickjs
+          key: quickjs-wasi-v0.16.2
+
+      - name: Download the lifecycle policy engine
+        if: steps.lifecycle-quickjs-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/quickjs
+          gh release download v0.16.2 -R quickjs-ng/quickjs \
+            -p qjs-wasi.wasm -O /tmp/quickjs/qjs-wasi.wasm
+
+      - name: Run workspace lifecycle JSON scenarios (Python)
+        env:
+          MIRAGE_QUICKJS_HOME: /tmp/quickjs
+        run: ./python/.venv/bin/python integ/lifecycle/run.py
+
   integ-ts:
     needs: [changes, typescript-build]
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.ts == 'true') }}
@@ -330,6 +351,10 @@ jobs:
       - name: Run cross-mount commands (ram -> ram/s3 via MinIO)
         working-directory: integ
         run: pnpm exec tsx cross_commands.ts
+
+      - name: Run workspace lifecycle JSON scenarios (Node and browser wrappers)
+        working-directory: integ
+        run: pnpm exec tsx lifecycle/run.ts
 
       - name: Generate integ Prisma clients
         working-directory: integ

--- a/integ/lifecycle/cases.json
+++ b/integ/lifecycle/cases.json
@@ -1936,6 +1936,157 @@
           "op": "close"
         }
       ]
+    },
+    {
+      "id": "remount_evicts_the_previous_resources_cached_bytes",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/data": {
+            "resource": "cached-ram",
+            "config": {
+              "files": {
+                "/file.txt": "old account\n"
+              }
+            }
+          },
+          "/database": {
+            "resource": "cached-ram",
+            "config": {
+              "files": {
+                "/file.txt": "peer\n"
+              }
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "op": "exec",
+          "command": "cat /data/file.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "old account\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "cached",
+          "path": "/data/file.txt",
+          "expect": {
+            "value": "old account\n"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "cat /database/file.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "peer\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "cached",
+          "path": "/database/file.txt",
+          "expect": {
+            "value": "peer\n"
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/data"
+        },
+        {
+          "op": "cached",
+          "path": "/data/file.txt",
+          "expect": {
+            "value": null
+          }
+        },
+        {
+          "op": "cached",
+          "path": "/database/file.txt",
+          "expect": {
+            "value": "peer\n"
+          }
+        },
+        {
+          "op": "mount",
+          "path": "/data",
+          "resource": "cached-ram",
+          "config": {
+            "files": {
+              "/file.txt": "new account\n"
+            }
+          },
+          "expect": {
+            "value": "/data/"
+          }
+        },
+        {
+          "op": "read",
+          "path": "/data/file.txt",
+          "expect": {
+            "value": "new account\n"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "cat /data/file.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "new account\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "cached",
+          "path": "/data/file.txt",
+          "expect": {
+            "value": "new account\n"
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/data"
+        },
+        {
+          "op": "mount",
+          "path": "/data",
+          "resource": "cached-ram",
+          "config": {
+            "files": {}
+          },
+          "expect": {
+            "value": "/data/"
+          }
+        },
+        {
+          "op": "read",
+          "path": "/data/file.txt",
+          "expect": {
+            "errno": "ENOENT"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "cat /database/file.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "peer\n",
+              "stderr": ""
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/lifecycle/cases.json
+++ b/integ/lifecycle/cases.json
@@ -1,0 +1,1941 @@
+{
+  "suite": "workspace-lifecycle",
+  "description": "Live host API transitions driven by shared JSON settings. Python, Node and the browser workspace wrapper run the same scenarios; the browser wrapper is exercised under Node with its WASM shell parser.",
+  "cases": [
+    {
+      "id": "empty_workspace_add_remove_and_remount",
+      "settings": {
+        "mode": "write",
+        "mounts": {}
+      },
+      "steps": [
+        {
+          "op": "readdir",
+          "path": "/",
+          "expect": {
+            "value": ["/.bash_history", "/dev"]
+          }
+        },
+        {
+          "op": "stat",
+          "path": "/",
+          "expect": {
+            "value": {
+              "type": "directory",
+              "size": null
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "mount",
+          "path": "/data",
+          "resource": "ram",
+          "config": {},
+          "mode": "write",
+          "expect": {
+            "value": "/data/"
+          }
+        },
+        {
+          "op": "write",
+          "path": "/data/file.txt",
+          "data": "first\n"
+        },
+        {
+          "op": "read",
+          "path": "/data/file.txt",
+          "expect": {
+            "value": "first\n"
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/data"
+        },
+        {
+          "op": "readdir",
+          "path": "/",
+          "expect": {
+            "value": ["/.bash_history", "/dev"]
+          }
+        },
+        {
+          "op": "stat",
+          "path": "/",
+          "expect": {
+            "value": {
+              "type": "directory",
+              "size": null
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "mount",
+          "path": "/data",
+          "resource": "ram",
+          "config": {},
+          "mode": "write",
+          "expect": {
+            "value": "/data/"
+          }
+        },
+        {
+          "op": "read",
+          "path": "/data/file.txt",
+          "expect": {
+            "errno": "ENOENT"
+          }
+        },
+        {
+          "op": "write",
+          "path": "/data/file.txt",
+          "data": "replacement\n"
+        },
+        {
+          "op": "exec",
+          "command": "cat /data/file.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "replacement\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/data"
+        },
+        {
+          "op": "readdir",
+          "path": "/",
+          "expect": {
+            "value": ["/.bash_history", "/dev"]
+          }
+        },
+        {
+          "op": "stat",
+          "path": "/",
+          "expect": {
+            "value": {
+              "type": "directory",
+              "size": null
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "removing_one_ram_preserves_its_peer",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/a": {
+            "resource": "ram",
+            "config": {}
+          },
+          "/b": {
+            "resource": "ram",
+            "config": {}
+          }
+        }
+      },
+      "steps": [
+        {
+          "op": "write",
+          "path": "/b/file.txt",
+          "data": "surviving\n"
+        },
+        {
+          "op": "unmount",
+          "path": "/a"
+        },
+        {
+          "op": "read",
+          "path": "/b/file.txt",
+          "expect": {
+            "value": "surviving\n"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "cat /b/file.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "surviving\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/b"
+        },
+        {
+          "op": "readdir",
+          "path": "/",
+          "expect": {
+            "value": ["/.bash_history", "/dev"]
+          }
+        },
+        {
+          "op": "stat",
+          "path": "/",
+          "expect": {
+            "value": {
+              "type": "directory",
+              "size": null
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "all_user_mounts_hidden_then_removed",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/a": {
+            "resource": "ram",
+            "config": {}
+          },
+          "/b": {
+            "resource": "ram",
+            "config": {}
+          }
+        },
+        "profiles": {
+          "default": {
+            "paths": {
+              "hide": ["/a", "/b"]
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/a"
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/b"
+        },
+        {
+          "op": "readdir",
+          "path": "/",
+          "expect": {
+            "value": ["/.bash_history", "/dev"]
+          }
+        },
+        {
+          "op": "stat",
+          "path": "/",
+          "expect": {
+            "value": {
+              "type": "directory",
+              "size": null
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "mount",
+          "path": "/a",
+          "resource": "ram",
+          "config": {},
+          "mode": "write",
+          "expect": {
+            "value": "/a/"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/a"
+        },
+        {
+          "op": "readdir",
+          "path": "/",
+          "expect": {
+            "value": ["/.bash_history", "/dev"]
+          }
+        },
+        {
+          "op": "stat",
+          "path": "/",
+          "expect": {
+            "value": {
+              "type": "directory",
+              "size": null
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "explicit_root_keeps_its_files",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/": {
+            "resource": "ram",
+            "config": {}
+          },
+          "/data": {
+            "resource": "ram",
+            "config": {}
+          }
+        }
+      },
+      "steps": [
+        {
+          "op": "write",
+          "path": "/note.txt",
+          "data": "root data\n"
+        },
+        {
+          "op": "write",
+          "path": "/data/file.txt",
+          "data": "child\n"
+        },
+        {
+          "op": "unmount",
+          "path": "/data"
+        },
+        {
+          "op": "read",
+          "path": "/note.txt",
+          "expect": {
+            "value": "root data\n"
+          }
+        },
+        {
+          "op": "stat",
+          "path": "/",
+          "expect": {
+            "value": {
+              "type": "directory",
+              "size": null
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\nnote.txt\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "mount",
+          "path": "/data",
+          "resource": "ram",
+          "config": {},
+          "mode": "write",
+          "expect": {
+            "value": "/data/"
+          }
+        },
+        {
+          "op": "write",
+          "path": "/data/file.txt",
+          "data": "new child\n"
+        },
+        {
+          "op": "read",
+          "path": "/note.txt",
+          "expect": {
+            "value": "root data\n"
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/data"
+        },
+        {
+          "op": "read",
+          "path": "/note.txt",
+          "expect": {
+            "value": "root data\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": "nested_mount_survives_parent_removal",
+      "settings": {
+        "mode": "write",
+        "mounts": {}
+      },
+      "steps": [
+        {
+          "op": "mount",
+          "path": "/parent",
+          "resource": "ram",
+          "config": {},
+          "mode": "write",
+          "expect": {
+            "value": "/parent/"
+          }
+        },
+        {
+          "op": "mount",
+          "path": "/parent/child",
+          "resource": "ram",
+          "config": {},
+          "mode": "write",
+          "expect": {
+            "value": "/parent/child/"
+          }
+        },
+        {
+          "op": "write",
+          "path": "/parent/file.txt",
+          "data": "parent\n"
+        },
+        {
+          "op": "write",
+          "path": "/parent/child/file.txt",
+          "data": "child\n"
+        },
+        {
+          "op": "unmount",
+          "path": "/parent"
+        },
+        {
+          "op": "read",
+          "path": "/parent/child/file.txt",
+          "expect": {
+            "value": "child\n"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /parent",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "child\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/parent/child"
+        },
+        {
+          "op": "read",
+          "path": "/parent/file.txt",
+          "expect": {
+            "errno": "ENOENT"
+          }
+        },
+        {
+          "op": "readdir",
+          "path": "/",
+          "expect": {
+            "value": ["/.bash_history", "/dev"]
+          }
+        },
+        {
+          "op": "stat",
+          "path": "/",
+          "expect": {
+            "value": {
+              "type": "directory",
+              "size": null
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "default_mode_and_lifecycle_refusals",
+      "settings": {
+        "mode": "write",
+        "mounts": {}
+      },
+      "steps": [
+        {
+          "op": "mount",
+          "path": "/data",
+          "resource": "ram",
+          "config": {},
+          "expect": {
+            "value": "/data/"
+          }
+        },
+        {
+          "op": "write",
+          "path": "/data/file.txt",
+          "data": "refused",
+          "expect": {
+            "errno": "EROFS"
+          }
+        },
+        {
+          "op": "mount",
+          "path": "data/",
+          "resource": "ram",
+          "config": {},
+          "expect": {
+            "error": "duplicate mount prefix"
+          }
+        },
+        {
+          "op": "mounts",
+          "expect": {
+            "value": ["/", "/.bash_history/", "/data/", "/dev/"]
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/data"
+        },
+        {
+          "op": "unmount",
+          "path": "/",
+          "expect": {
+            "error": "root"
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/dev",
+          "expect": {
+            "error": "reserved"
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/.bash_history",
+          "expect": {
+            "error": "history"
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/missing",
+          "expect": {
+            "error": "no mount"
+          }
+        },
+        {
+          "op": "readdir",
+          "path": "/",
+          "expect": {
+            "value": ["/.bash_history", "/dev"]
+          }
+        },
+        {
+          "op": "stat",
+          "path": "/",
+          "expect": {
+            "value": {
+              "type": "directory",
+              "size": null
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "close"
+        },
+        {
+          "op": "close"
+        },
+        {
+          "op": "mount",
+          "path": "/late",
+          "resource": "ram",
+          "config": {},
+          "expect": {
+            "error": "Workspace is closed"
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/late",
+          "expect": {
+            "error": "Workspace is closed"
+          }
+        }
+      ]
+    },
+    {
+      "id": "cli-registration-runtime-switch-and-removal",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/work": {
+            "resource": "ram",
+            "config": {}
+          }
+        },
+        "runtimes": ["vfs"]
+      },
+      "steps": [
+        {
+          "op": "clis",
+          "expect": {
+            "value": []
+          }
+        },
+        {
+          "op": "exec",
+          "command": "probe",
+          "expect": {
+            "value": {
+              "exit_code": 127,
+              "stdout": "",
+              "stderr": "probe: command not found\n"
+            }
+          }
+        },
+        {
+          "op": "add_runtime",
+          "name": "monty",
+          "expect": {
+            "value": "monty"
+          }
+        },
+        {
+          "op": "register_cli",
+          "name": "probe",
+          "script": {
+            "source": "print('python', argv[0], argv[1])",
+            "language": "python"
+          },
+          "runtime": "monty"
+        },
+        {
+          "op": "exec",
+          "command": "probe one",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "python probe one\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "type -t probe",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "cli\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "which probe",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "probe\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "register_cli",
+          "name": "probe",
+          "script": {
+            "source": "print('wrong')",
+            "language": "python"
+          },
+          "expect": {
+            "error": "already installed"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "probe two",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "python probe two\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unregister_cli",
+          "name": "probe"
+        },
+        {
+          "op": "clis",
+          "expect": {
+            "value": []
+          }
+        },
+        {
+          "op": "exec",
+          "command": "probe",
+          "expect": {
+            "value": {
+              "exit_code": 127,
+              "stdout": "",
+              "stderr": "probe: command not found\n"
+            }
+          }
+        },
+        {
+          "op": "unregister_cli",
+          "name": "probe",
+          "expect": {
+            "error": "not installed"
+          }
+        },
+        {
+          "op": "register_cli",
+          "name": "probe",
+          "script": {
+            "source": "console.log('js', scriptArgs[0], scriptArgs[1]);",
+            "language": "js"
+          },
+          "runtime": "quickjs"
+        },
+        {
+          "op": "exec",
+          "command": "probe unavailable",
+          "expect": {
+            "value": {
+              "exit_code": 127,
+              "stderr_contains": "unknown runtime"
+            }
+          }
+        },
+        {
+          "op": "add_runtime",
+          "name": "quickjs",
+          "expect": {
+            "value": "quickjs"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "probe three",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "js probe three\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "add_runtime",
+          "name": "quickjs",
+          "expect": {
+            "error": "duplicate runtime entry"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "probe four",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "js probe four\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unregister_cli",
+          "name": "probe"
+        },
+        {
+          "op": "register_cli",
+          "name": "probe",
+          "script": {
+            "source": "print('back', argv[1])",
+            "language": "python"
+          },
+          "runtime": "monty"
+        },
+        {
+          "op": "exec",
+          "command": "probe five",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "back five\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unregister_cli",
+          "name": "probe"
+        },
+        {
+          "op": "register_cli",
+          "name": "probe",
+          "script": {
+            "source": "console.log('wrong')",
+            "language": "js"
+          },
+          "runtime": "monty"
+        },
+        {
+          "op": "exec",
+          "command": "probe",
+          "expect": {
+            "value": {
+              "exit_code": 127,
+              "stderr_contains": "does not run js scripts"
+            }
+          }
+        },
+        {
+          "op": "unregister_cli",
+          "name": "probe"
+        },
+        {
+          "op": "register_cli",
+          "name": "probe",
+          "script": {
+            "source": "console.log('default js')",
+            "language": "js"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "probe",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "default js\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unregister_cli",
+          "name": "probe"
+        },
+        {
+          "op": "exec",
+          "command": "echo intact",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "intact\n",
+              "stderr": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "coded-policy-registration-removal-and-warm-reads",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/work": {
+            "resource": "ram",
+            "config": {}
+          }
+        },
+        "runtimes": ["vfs"]
+      },
+      "steps": [
+        {
+          "op": "write",
+          "path": "/work/data",
+          "data": "kept"
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "value": "kept"
+          }
+        },
+        {
+          "op": "register_policy",
+          "id": "first",
+          "commands": ["echo"],
+          "paths": ["/work/data"],
+          "reason": "first gate"
+        },
+        {
+          "op": "exec",
+          "command": "echo blocked",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "echo: Permission denied\n",
+              "refusal": "first gate"
+            }
+          }
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "errno": "EACCES"
+          }
+        },
+        {
+          "op": "register_policy",
+          "id": "second",
+          "commands": ["echo"],
+          "reason": "second gate"
+        },
+        {
+          "op": "exec",
+          "command": "echo blocked",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "echo: Permission denied\n",
+              "refusal": "first gate"
+            }
+          }
+        },
+        {
+          "op": "unregister_policy",
+          "id": "first",
+          "expect": {
+            "value": true
+          }
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "value": "kept"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo blocked",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "echo: Permission denied\n",
+              "refusal": "second gate"
+            }
+          }
+        },
+        {
+          "op": "unregister_policy",
+          "id": "first",
+          "expect": {
+            "value": false
+          }
+        },
+        {
+          "op": "unregister_policy",
+          "id": "second",
+          "expect": {
+            "value": true
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo restored",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "restored\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "value": "kept"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls -1 /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\nwork\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "register_policy",
+          "id": "first",
+          "commands": ["echo"],
+          "reason": "replacement gate"
+        },
+        {
+          "op": "exec",
+          "command": "echo blocked",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "echo: Permission denied\n",
+              "refusal": "replacement gate"
+            }
+          }
+        },
+        {
+          "op": "unregister_policy",
+          "id": "first",
+          "expect": {
+            "value": true
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo restored",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "restored\n",
+              "stderr": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "profile-policy-runtime-switch-and-cache-invalidation",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/work": {
+            "resource": "ram",
+            "config": {}
+          }
+        },
+        "runtimes": ["vfs"]
+      },
+      "steps": [
+        {
+          "op": "write",
+          "path": "/work/data",
+          "data": "visible"
+        },
+        {
+          "op": "exec",
+          "command": "echo before",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "before\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "policy": {
+              "script": {
+                "source": "def pre_command(ctx):\n    if ctx['command']['name'] == 'echo':\n        return {'deny': 'python gate'}\n",
+                "language": "python"
+              },
+              "runtime": "monty"
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo blocked",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "echo: Permission denied\n",
+              "refusal": "python gate"
+            }
+          }
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "value": "visible"
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "policy": {
+              "script": {
+                "source": "function preCommand(ctx) { if (ctx.command.name === 'echo') return {deny: 'js gate'}; return null; }",
+                "language": "js"
+              },
+              "runtime": "quickjs"
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo blocked",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "echo: Permission denied\n",
+              "refusal": "js gate"
+            }
+          }
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "value": "visible"
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "policy": {
+              "script": {
+                "source": "def pre_command(ctx):\n    if ctx['command']['name'] == 'echo':\n        return {'deny': 'python gate'}\n",
+                "language": "python"
+              },
+              "runtime": "missing-lifecycle-engine"
+            }
+          }
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "errno": "EACCES"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo blocked",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "refusal_contains": "missing-lifecycle-engine"
+            }
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "policy": {
+              "script": {
+                "source": "def pre_command(ctx):\n    if ctx['command']['name'] == 'echo':\n        return {'deny': 'python gate'}\n",
+                "language": "python"
+              },
+              "runtime": "monty"
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo blocked",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "echo: Permission denied\n",
+              "refusal": "python gate"
+            }
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "policy": {
+              "script": {
+                "source": "def pre_ops(ctx):\n    if ctx['op']['path'] == '/work/data':\n        return {'deny': 'op gate'}\n",
+                "language": "python"
+              },
+              "runtime": "monty"
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo allowed",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "allowed\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "errno": "EACCES"
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {}
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "value": "visible"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo after",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "after\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "policy": {
+              "script": {
+                "source": "function preCommand(ctx) { if (ctx.command.name === 'echo') return {deny: 'js gate'}; return null; }",
+                "language": "js"
+              },
+              "runtime": "quickjs"
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo again",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "echo: Permission denied\n",
+              "refusal": "js gate"
+            }
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {}
+        },
+        {
+          "op": "exec",
+          "command": "echo done",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "done\n",
+              "stderr": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "mount-mode-transitions-preserve-data-and-session-caps",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/work": {
+            "resource": "ram",
+            "config": {}
+          }
+        },
+        "runtimes": ["monty", "vfs"]
+      },
+      "steps": [
+        {
+          "op": "write",
+          "path": "/work/run.py",
+          "data": "print('ran')\n"
+        },
+        {
+          "op": "write",
+          "path": "/work/data",
+          "data": "one"
+        },
+        {
+          "op": "set_mode",
+          "path": "work/",
+          "mode": "read"
+        },
+        {
+          "op": "write",
+          "path": "/work/data",
+          "data": "wrong",
+          "expect": {
+            "errno": "EROFS"
+          }
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "value": "one"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "python3 /work/run.py",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "python3: /work/run.py: not in EXEC mode\n"
+            }
+          }
+        },
+        {
+          "op": "set_mode",
+          "path": "/work",
+          "mode": "write"
+        },
+        {
+          "op": "write",
+          "path": "/work/data",
+          "data": "two"
+        },
+        {
+          "op": "exec",
+          "command": "python3 /work/run.py",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "python3: /work/run.py: not in EXEC mode\n"
+            }
+          }
+        },
+        {
+          "op": "set_mode",
+          "path": "/work/",
+          "mode": "exec"
+        },
+        {
+          "op": "exec",
+          "command": "python3 /work/run.py",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "ran\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "session",
+          "id": "limited",
+          "profile": {
+            "mounts": {
+              "/work": {
+                "mode": "read"
+              }
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "python3 /work/run.py",
+          "session": "limited",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "python3: /work/run.py: not in EXEC mode\n"
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "echo wrong > /work/data",
+          "session": "limited",
+          "expect": {
+            "value": {
+              "exit_code": 1,
+              "stderr_contains": "Read-only file system"
+            }
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "mounts": {
+              "/work": {
+                "mode": "exec"
+              }
+            }
+          },
+          "session": "limited"
+        },
+        {
+          "op": "exec",
+          "command": "python3 /work/run.py",
+          "session": "limited",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "ran\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "set_mode",
+          "path": "/work",
+          "mode": "read"
+        },
+        {
+          "op": "exec",
+          "command": "python3 /work/run.py",
+          "session": "limited",
+          "expect": {
+            "value": {
+              "exit_code": 126,
+              "stdout": "",
+              "stderr": "python3: /work/run.py: not in EXEC mode\n"
+            }
+          }
+        },
+        {
+          "op": "set_mode",
+          "path": "/work/missing",
+          "mode": "write",
+          "expect": {
+            "errno": "ENOENT"
+          }
+        },
+        {
+          "op": "write",
+          "path": "/work/data",
+          "data": "wrong",
+          "expect": {
+            "errno": "EROFS"
+          }
+        },
+        {
+          "op": "set_mode",
+          "path": "/work",
+          "mode": "exec"
+        },
+        {
+          "op": "exec",
+          "command": "python3 /work/run.py",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "ran\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "read",
+          "path": "/work/data",
+          "expect": {
+            "value": "two"
+          }
+        }
+      ]
+    },
+    {
+      "id": "live-hide-patterns-session-isolation-and-state",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/work": {
+            "resource": "ram",
+            "config": {}
+          }
+        },
+        "runtimes": ["vfs"]
+      },
+      "steps": [
+        {
+          "op": "session",
+          "id": "viewer"
+        },
+        {
+          "op": "exec",
+          "command": "mkdir -p /work/aaa/nested /work/bbb",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "",
+              "stderr": ""
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "write",
+          "path": "/work/aaa/a.txt",
+          "data": "text",
+          "session": "viewer"
+        },
+        {
+          "op": "write",
+          "path": "/work/aaa/keep.md",
+          "data": "markdown",
+          "session": "viewer"
+        },
+        {
+          "op": "write",
+          "path": "/work/aaa/nested/deep.txt",
+          "data": "deep",
+          "session": "viewer"
+        },
+        {
+          "op": "write",
+          "path": "/work/bbb/a.txt",
+          "data": "other",
+          "session": "viewer"
+        },
+        {
+          "op": "exec",
+          "command": "cd /work; export SAVED=yes; keep() { echo function; }",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "",
+              "stderr": ""
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "session",
+          "id": "peer"
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "mounts": {
+              "/work": {
+                "paths": {
+                  "hide": ["/work/aaa/*.txt"]
+                }
+              }
+            },
+            "cwd": "/",
+            "env": {
+              "SAVED": "reset"
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "exec",
+          "command": "pwd; echo $SAVED; keep",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "/work\nyes\nfunction\n",
+              "stderr": ""
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "read",
+          "path": "/work/aaa/a.txt",
+          "expect": {
+            "errno": "ENOENT"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "read",
+          "path": "/work/aaa/nested/deep.txt",
+          "expect": {
+            "errno": "ENOENT"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "write",
+          "path": "/work/aaa/new.txt",
+          "data": "wrong",
+          "expect": {
+            "errno": "EACCES"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "read",
+          "path": "/work/aaa/keep.md",
+          "expect": {
+            "value": "markdown"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "read",
+          "path": "/work/bbb/a.txt",
+          "expect": {
+            "value": "other"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "exec",
+          "command": "ls -1 /work/aaa",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "keep.md\nnested\n",
+              "stderr": ""
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "exec",
+          "command": "cat /work/aaa/a.txt",
+          "session": "peer",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "text",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "paths": {
+              "hide": ["/work/aaa"]
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "exec",
+          "command": "ls -1 /work",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "bbb\n",
+              "stderr": ""
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "stat",
+          "path": "/work/aaa",
+          "expect": {
+            "errno": "ENOENT"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "paths": {
+              "hide": ["/work"]
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "exec",
+          "command": "ls -1 /",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "dev\n",
+              "stderr": ""
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "set_profile",
+          "profile": {},
+          "session": "viewer"
+        },
+        {
+          "op": "read",
+          "path": "/work/aaa/a.txt",
+          "expect": {
+            "value": "text"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "read",
+          "path": "/work/aaa/nested/deep.txt",
+          "expect": {
+            "value": "deep"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "exec",
+          "command": "pwd; echo $SAVED; keep",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "/work\nyes\nfunction\n",
+              "stderr": ""
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "set_profile",
+          "profile": {
+            "mounts": {
+              "/work": {
+                "paths": {
+                  "hide": ["/work/aaa/*.txt"]
+                }
+              }
+            }
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "set_profile",
+          "profile": "missing-profile",
+          "expect": {
+            "error": "unknown profile"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "read",
+          "path": "/work/aaa/a.txt",
+          "expect": {
+            "errno": "ENOENT"
+          },
+          "session": "viewer"
+        },
+        {
+          "op": "set_profile",
+          "profile": {},
+          "session": "viewer"
+        },
+        {
+          "op": "read",
+          "path": "/work/aaa/a.txt",
+          "expect": {
+            "value": "text"
+          },
+          "session": "viewer"
+        }
+      ]
+    },
+    {
+      "id": "closed-workspace-rejects-lifecycle-mutations",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/work": {
+            "resource": "ram",
+            "config": {}
+          }
+        },
+        "runtimes": ["vfs"]
+      },
+      "steps": [
+        {
+          "op": "register_cli",
+          "name": "probe",
+          "script": {
+            "source": "print('installed')",
+            "language": "python"
+          },
+          "runtime": "monty"
+        },
+        {
+          "op": "close"
+        },
+        {
+          "op": "register_cli",
+          "name": "late",
+          "script": {
+            "source": "print('late')",
+            "language": "python"
+          },
+          "expect": {
+            "error": "Workspace is closed"
+          }
+        },
+        {
+          "op": "unregister_cli",
+          "name": "probe",
+          "expect": {
+            "error": "Workspace is closed"
+          }
+        },
+        {
+          "op": "add_runtime",
+          "name": "monty",
+          "expect": {
+            "error": "Workspace is closed"
+          }
+        },
+        {
+          "op": "set_mode",
+          "path": "/work",
+          "mode": "exec",
+          "expect": {
+            "error": "Workspace is closed"
+          }
+        },
+        {
+          "op": "set_profile",
+          "profile": {},
+          "expect": {
+            "error": "Workspace is closed"
+          }
+        },
+        {
+          "op": "close"
+        }
+      ]
+    }
+  ]
+}

--- a/integ/lifecycle/cases.json
+++ b/integ/lifecycle/cases.json
@@ -2184,6 +2184,119 @@
           }
         }
       ]
+    },
+    {
+      "id": "metadata_globs_follow_dynamic_mount_ownership",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/parent": {
+            "resource": "cached-ram",
+            "config": {
+              "files": {
+                "/child/stale.txt": "ancestor\n"
+              }
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "op": "exec",
+          "command": "mkdir -p /parent/child; ls /parent/child",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "stale.txt\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "mount",
+          "path": "/parent/child",
+          "resource": "cached-ram",
+          "mode": "write",
+          "config": {
+            "files": {
+              "/fresh.txt": "child\n"
+            }
+          },
+          "expect": {
+            "value": "/parent/child/"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "touch /parent/child/*.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "chmod 600 /parent/child/*.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "chown 123 /parent/child/*.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "chgrp 456 /parent/child/*.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "exec",
+          "command": "ls /parent/child; stat -c '%a %u %g' /parent/child/fresh.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "fresh.txt\n600 123 456\n",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/parent/child"
+        },
+        {
+          "op": "exec",
+          "command": "cat /parent/child/stale.txt",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "ancestor\n",
+              "stderr": ""
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/lifecycle/cases.json
+++ b/integ/lifecycle/cases.json
@@ -2087,6 +2087,103 @@
           }
         }
       ]
+    },
+    {
+      "id": "new_mount_discards_shadowed_ancestor_cache",
+      "settings": {
+        "mode": "write",
+        "mounts": {
+          "/parent": {
+            "resource": "cached-ram",
+            "config": {
+              "files": {
+                "/child/file": "ancestor",
+                "/peer": "peer"
+              }
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "op": "exec",
+          "command": "cat /parent/child/file",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "ancestor",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "cached",
+          "path": "/parent/child/file",
+          "expect": {
+            "value": "ancestor"
+          }
+        },
+        {
+          "op": "mount",
+          "path": "/parent/child",
+          "resource": "cached-ram",
+          "config": {
+            "files": {
+              "/file": "child"
+            }
+          },
+          "expect": {
+            "value": "/parent/child/"
+          }
+        },
+        {
+          "op": "read",
+          "path": "/parent/child/file",
+          "expect": {
+            "value": "child"
+          }
+        },
+        {
+          "op": "exec",
+          "command": "cat /parent/child/file",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "child",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "cached",
+          "path": "/parent/child/file",
+          "expect": {
+            "value": "child"
+          }
+        },
+        {
+          "op": "unmount",
+          "path": "/parent/child"
+        },
+        {
+          "op": "exec",
+          "command": "cat /parent/child/file",
+          "expect": {
+            "value": {
+              "exit_code": 0,
+              "stdout": "ancestor",
+              "stderr": ""
+            }
+          }
+        },
+        {
+          "op": "read",
+          "path": "/parent/peer",
+          "expect": {
+            "value": "peer"
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/lifecycle/run.py
+++ b/integ/lifecycle/run.py
@@ -1,0 +1,211 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+"""Host-side workspace lifecycle cases shared with both TypeScript wrappers.
+
+The JSON supplies workspace settings, ordered API actions and expected
+results. Filesystem facade checks exercise the dispatcher even when a
+shell command can answer directly through a backend's command handler.
+"""
+
+import asyncio
+import errno
+import json
+from pathlib import Path
+from typing import Any
+
+from mirage.commands.cli.types import CLISpec
+from mirage.config import load_config
+from mirage.context import reset_current_session, set_current_session
+from mirage.errors import classify
+from mirage.policy import Policy
+from mirage.policy.types import CommandContext, Deny, OpsContext
+from mirage.resource.registry import build_resource
+from mirage.runtime.types import ScriptSource
+from mirage.types import MountMode
+from mirage.workspace import Workspace
+
+SUITE = Path(__file__).with_name("cases.json")
+
+
+class RulePolicy(Policy):
+    """A host policy whose command and op refusals are supplied by JSON."""
+
+    def __init__(self, rule: dict[str, Any]) -> None:
+        self.rule = rule
+
+    async def pre_command(self, ctx: CommandContext) -> Deny | None:
+        if ctx.command in self.rule.get("commands", []):
+            return Deny(self.rule["reason"])
+        return None
+
+    async def pre_ops(self, ctx: OpsContext) -> Deny | None:
+        if ctx.path.virtual in self.rule.get("paths", []):
+            return Deny(self.rule["reason"])
+        return None
+
+
+def profile_document(raw: dict[str, Any]) -> dict[str, Any]:
+    """Embed a JSON policy program as the ordinary config loader does."""
+    doc = dict(raw)
+    if doc.get("policy") is not None:
+        policy = dict(doc["policy"])
+        policy["script"] = ScriptSource(**policy["script"])
+        doc["policy"] = policy
+    return doc
+
+
+async def action(ws: Workspace, step: dict[str, Any],
+                 policies: dict[str, RulePolicy]) -> Any:
+    """Run one host API action; no shell command mutates the mount table."""
+    op = step["op"]
+    if op in {"read", "write", "readdir", "stat"} and "session" in step:
+        token = set_current_session(ws.get_session(step["session"]))
+        try:
+            return await action(ws, {
+                k: v
+                for k, v in step.items() if k != "session"
+            }, policies)
+        finally:
+            reset_current_session(token)
+    if op == "mount":
+        resource = build_resource(step["resource"], step.get("config", {}))
+        try:
+            return ws.add_mount(step["path"], resource,
+                                MountMode(step.get("mode", "read"))).prefix
+        except Exception:
+            await resource.close()
+            raise
+    if op == "unmount":
+        await ws.unmount(step["path"])
+    elif op == "set_mode":
+        ws.set_mount_mode(step["path"], MountMode(step["mode"]))
+    elif op == "session":
+        ws.create_session(step["id"],
+                          profile=profile_document(step.get("profile", {})))
+    elif op == "set_profile":
+        raw = step["profile"]
+        profile = profile_document(raw) if isinstance(raw, dict) else raw
+        await ws.set_session_profile(
+            step.get("session", ws.default_session_id), profile)
+    elif op == "register_cli":
+        ws.register_cli(
+            step["name"],
+            CLISpec(name=step["name"],
+                    script=ScriptSource(**step["script"]),
+                    runtime=step.get("runtime")), step.get("config"))
+    elif op == "unregister_cli":
+        ws.unregister_cli(step["name"])
+    elif op == "clis":
+        return sorted(ws.clis())
+    elif op == "add_runtime":
+        return ws.add_runtime(step["name"]).name
+    elif op == "register_policy":
+        if step["id"] in policies:
+            raise ValueError("policy already registered")
+        policy = RulePolicy(step)
+        ws.policies.add(policy)
+        policies[step["id"]] = policy
+    elif op == "unregister_policy":
+        policy = policies.pop(step["id"], None)
+        return ws.policies.remove(policy) if policy is not None else False
+    elif op == "write":
+        await ws.fs.write(step["path"], step["data"].encode())
+    elif op == "read":
+        return (await ws.fs.read(step["path"])).decode()
+    elif op == "readdir":
+        return sorted(await ws.fs.readdir(step["path"]))
+    elif op == "stat":
+        row = await ws.fs.stat(step["path"])
+        return {"type": row.type.value, "size": row.size}
+    elif op == "exec":
+        result = await ws.execute(step["command"],
+                                  session_id=step.get("session"))
+        return {
+            "exit_code": result.exit_code,
+            "stdout": await result.stdout_str(),
+            "stderr": await result.stderr_str(),
+            "refusal": result.refusal.reason if result.refusal else None,
+        }
+    elif op == "mounts":
+        return sorted(m.prefix for m in ws.mounts())
+    elif op == "close":
+        await ws.close()
+    else:
+        raise ValueError(f"unknown lifecycle action: {op}")
+    return None
+
+
+async def run(case: dict[str, Any]) -> int:
+    """Stop a failed scenario at its first mismatch and always close it."""
+    ws = Workspace(**load_config(case["settings"]).to_workspace_kwargs())
+    policies: dict[str, RulePolicy] = {}
+    try:
+        for index, step in enumerate(case["steps"]):
+            try:
+                actual = {"value": await action(ws, step, policies)}
+            except Exception as exc:
+                actual = {"error": str(exc)}
+                condition = classify(exc)
+                if isinstance(exc, OSError) and exc.errno is not None:
+                    actual["errno"] = errno.errorcode.get(exc.errno)
+                elif condition is not None:
+                    actual["errno"] = condition.name
+            expected = step.get("expect", {"value": None})
+            if not matches(actual, expected):
+                raise AssertionError(f"step {index + 1} ({step['op']}): "
+                                     f"expected {expected!r}, got {actual!r}")
+        return len(case["steps"])
+    finally:
+        await ws.close()
+
+
+def matches(actual: Any, expected: Any) -> bool:
+    """Objects select fields; error and *_contains assertions select text."""
+    if not isinstance(expected, dict):
+        return actual == expected
+    if not isinstance(actual, dict):
+        return False
+    for key, want in expected.items():
+        field = key.removesuffix("_contains")
+        if field not in actual:
+            return False
+        got = actual[field]
+        if key == "error" or key.endswith("_contains"):
+            if not isinstance(got, str) or want not in got:
+                return False
+        elif not matches(got, want):
+            return False
+    return True
+
+
+async def main() -> int:
+    suite = json.loads(SUITE.read_text())
+    passed = 0
+    steps = 0
+    failures = 0
+    for case in suite["cases"]:
+        try:
+            steps += await run(case)
+        except Exception as exc:
+            failures += 1
+            print(f"FAIL python/{case['id']}: {exc}")
+        else:
+            passed += 1
+            print(f"ok python/{case['id']}")
+    print(f"{passed} cases / {steps} steps passed, {failures} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/integ/lifecycle/run.py
+++ b/integ/lifecycle/run.py
@@ -30,12 +30,31 @@ from mirage.context import reset_current_session, set_current_session
 from mirage.errors import classify
 from mirage.policy import Policy
 from mirage.policy.types import CommandContext, Deny, OpsContext
-from mirage.resource.registry import build_resource
+from mirage.resource.ram import RAMResource
+from mirage.resource.registry import build_resource, register_resource
 from mirage.runtime.types import ScriptSource
 from mirage.types import MountMode
 from mirage.workspace import Workspace
 
 SUITE = Path(__file__).with_name("cases.json")
+
+
+class CachedRAMResource(RAMResource):
+    """A local fixture exercising the same read cache as remote resources."""
+
+    caches_reads = True
+
+    def __init__(self, files: dict[str, str] | None = None) -> None:
+        super().__init__()
+        self.load_state({
+            "files": {
+                path: data.encode()
+                for path, data in (files or {}).items()
+            }
+        })
+
+
+register_resource("cached-ram", CachedRAMResource)
 
 
 class RulePolicy(Policy):
@@ -69,6 +88,9 @@ async def action(ws: Workspace, step: dict[str, Any],
                  policies: dict[str, RulePolicy]) -> Any:
     """Run one host API action; no shell command mutates the mount table."""
     op = step["op"]
+    if op == "cached":
+        value = await ws.cache.get(step["path"])
+        return value.decode() if value is not None else None
     if op in {"read", "write", "readdir", "stat"} and "session" in step:
         token = set_current_session(ws.get_session(step["session"]))
         try:

--- a/integ/lifecycle/run.ts
+++ b/integ/lifecycle/run.ts
@@ -1,0 +1,290 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { isDeepStrictEqual } from 'node:util'
+import { readFileSync } from 'node:fs'
+import {
+  Workspace as NodeWorkspace,
+  buildResource as buildNodeResource,
+} from '@struktoai/mirage-node'
+import {
+  Workspace as BrowserWorkspace,
+  buildResource as buildBrowserResource,
+} from '@struktoai/mirage-browser'
+import { MountMode } from '@struktoai/mirage-core/types'
+import type { Resource } from '@struktoai/mirage-core/resource/base'
+import type {
+  Workspace,
+  WorkspaceOptions,
+} from '@struktoai/mirage-core/workspace/workspace/workspace'
+import { parseSessionProfile } from '@struktoai/mirage-core/policy/profile'
+import { classify } from '@struktoai/mirage-core/errors/classify'
+import { ScriptSource } from '@struktoai/mirage-core/runtime/routing/types'
+import type { Policy } from '@struktoai/mirage-core/policy/base'
+import { CLISpec } from '@struktoai/mirage-core/commands/cli/types'
+import { runWithSession } from '@struktoai/mirage-core/context/session_context'
+
+interface ResourceConfig {
+  resource: string
+  config?: Record<string, unknown>
+}
+
+interface Case {
+  id: string
+  settings: {
+    mounts: Record<string, ResourceConfig>
+    mode: MountMode
+    profiles?: Record<string, unknown>
+    runtimes?: string[]
+  }
+  steps: Step[]
+}
+
+type Step = (
+  | ({ op: 'mount'; path: string; mode?: MountMode } & ResourceConfig)
+  | { op: 'unmount' | 'read' | 'readdir' | 'stat'; path: string }
+  | { op: 'write'; path: string; data: string }
+  | { op: 'exec'; command: string; session?: string }
+  | { op: 'set_mode'; path: string; mode: MountMode }
+  | { op: 'session'; id: string; profile?: Record<string, unknown> }
+  | { op: 'set_profile'; session?: string; profile: Record<string, unknown> | string | null }
+  | {
+      op: 'register_cli'
+      name: string
+      script: ScriptDocument
+      runtime?: string
+      config?: Record<string, unknown>
+    }
+  | { op: 'unregister_cli' | 'add_runtime'; name: string }
+  | { op: 'register_policy'; id: string; commands?: string[]; paths?: string[]; reason: string }
+  | { op: 'unregister_policy'; id: string }
+  | { op: 'mounts' | 'clis' | 'close' }
+) & { expect?: Record<string, unknown>; session?: string }
+
+interface ScriptDocument {
+  source: string
+  language: 'python' | 'js'
+}
+
+function profileDocument(raw: Record<string, unknown>) {
+  const doc = { ...raw }
+  if (doc.policy != null) {
+    const policy = doc.policy as { script: ScriptDocument; runtime: string }
+    doc.policy = {
+      ...policy,
+      script: new ScriptSource(policy.script.source, policy.script.language),
+    }
+  }
+  return parseSessionProfile(doc)
+}
+
+interface Host {
+  name: string
+  workspace: new (resources: Record<string, Resource>, options: WorkspaceOptions) => Workspace
+  build: (name: string, config: Record<string, unknown>) => Promise<Resource>
+}
+
+const HOSTS: Host[] = [
+  { name: 'node', workspace: NodeWorkspace, build: buildNodeResource },
+  { name: 'browser', workspace: BrowserWorkspace, build: buildBrowserResource },
+]
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+async function action(
+  host: Host,
+  ws: Workspace,
+  step: Step,
+  policies: Map<string, Policy>,
+): Promise<unknown> {
+  if (['read', 'write', 'readdir', 'stat'].includes(step.op) && step.session !== undefined) {
+    const { session, ...unbound } = step
+    return runWithSession(ws.getSession(session), () => action(host, ws, unbound, policies))
+  }
+  switch (step.op) {
+    case 'mount': {
+      const resource = await host.build(step.resource, step.config ?? {})
+      try {
+        return ws.addMount(step.path, resource, step.mode ?? MountMode.READ).prefix
+      } catch (err) {
+        await resource.close()
+        throw err
+      }
+    }
+    case 'unmount':
+      await ws.unmount(step.path)
+      break
+    case 'set_mode':
+      ws.setMountMode(step.path, step.mode)
+      break
+    case 'session':
+      ws.createSession(step.id, { profile: profileDocument(step.profile ?? {}) })
+      break
+    case 'set_profile':
+      await ws.setSessionProfile(
+        step.session ?? ws.defaultSessionId,
+        typeof step.profile === 'object' && step.profile !== null
+          ? profileDocument(step.profile)
+          : step.profile,
+      )
+      break
+    case 'register_cli':
+      ws.registerCli(
+        step.name,
+        new CLISpec({
+          name: step.name,
+          script: new ScriptSource(step.script.source, step.script.language),
+          ...(step.runtime !== undefined ? { runtime: step.runtime } : {}),
+        }),
+        step.config ?? null,
+      )
+      break
+    case 'unregister_cli':
+      ws.unregisterCli(step.name)
+      break
+    case 'clis':
+      return [...ws.clis().keys()].sort()
+    case 'add_runtime':
+      return ws.addRuntime(step.name).name
+    case 'register_policy': {
+      if (policies.has(step.id)) throw new Error('policy already registered')
+      const policy: Policy = {
+        preCommand: (ctx) =>
+          step.commands?.includes(ctx.command) ? { kind: 'deny', reason: step.reason } : null,
+        preOps: (ctx) =>
+          step.paths?.includes(ctx.path.virtual) ? { kind: 'deny', reason: step.reason } : null,
+      }
+      ws.policies.add(policy)
+      policies.set(step.id, policy)
+      break
+    }
+    case 'unregister_policy': {
+      const policy = policies.get(step.id)
+      if (policy === undefined) return false
+      policies.delete(step.id)
+      return ws.policies.remove(policy)
+    }
+    case 'write':
+      await ws.fs.writeFile(step.path, ENC.encode(step.data))
+      break
+    case 'read':
+      return DEC.decode(await ws.fs.readFile(step.path))
+    case 'readdir':
+      return (await ws.fs.readdir(step.path)).sort()
+    case 'stat': {
+      const row = await ws.fs.stat(step.path)
+      return { type: row.type, size: row.size }
+    }
+    case 'exec': {
+      const result = await ws.execute(
+        step.command,
+        step.session === undefined ? {} : { sessionId: step.session },
+      )
+      return {
+        exit_code: result.exitCode,
+        stdout: result.stdoutText,
+        stderr: result.stderrText,
+        refusal: result.refusal?.reason ?? null,
+      }
+    }
+    case 'mounts':
+      return ws
+        .mounts()
+        .map((m) => m.prefix)
+        .sort()
+    case 'close':
+      await ws.close()
+      break
+    default:
+      throw new Error(`unknown lifecycle action: ${String((step as { op: string }).op)}`)
+  }
+  return null
+}
+
+async function run(host: Host, testCase: Case): Promise<number> {
+  const resources: Record<string, Resource> = {}
+  for (const [prefix, config] of Object.entries(testCase.settings.mounts)) {
+    resources[prefix] = await host.build(config.resource, config.config ?? {})
+  }
+  const profiles = Object.fromEntries(
+    Object.entries(testCase.settings.profiles ?? {}).map(([name, profile]) => [
+      name,
+      parseSessionProfile(profile),
+    ]),
+  )
+  const ws = new host.workspace(resources, {
+    mode: testCase.settings.mode,
+    profiles,
+    ...(testCase.settings.runtimes !== undefined ? { runtimes: testCase.settings.runtimes } : {}),
+  })
+  const policies = new Map<string, Policy>()
+  try {
+    for (const [index, step] of testCase.steps.entries()) {
+      let actual: Record<string, unknown>
+      try {
+        actual = { value: await action(host, ws, step, policies) }
+      } catch (err) {
+        actual = { error: err instanceof Error ? err.message : String(err) }
+        const condition = classify(err)
+        if (condition !== null) actual.errno = condition
+      }
+      const expected = step.expect ?? { value: null }
+      if (!matches(actual, expected)) {
+        throw new Error(
+          `step ${index + 1} (${step.op}): expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+        )
+      }
+    }
+    return testCase.steps.length
+  } finally {
+    await ws.close()
+  }
+}
+
+function matches(actual: unknown, expected: unknown): boolean {
+  if (expected === null || typeof expected !== 'object' || Array.isArray(expected)) {
+    return isDeepStrictEqual(actual, expected)
+  }
+  if (actual === null || typeof actual !== 'object') return false
+  const fields = actual as Record<string, unknown>
+  return Object.entries(expected).every(([key, want]) => {
+    const field = key.replace(/_contains$/, '')
+    if (!(field in fields)) return false
+    const got = fields[field]
+    return key === 'error' || key.endsWith('_contains')
+      ? typeof got === 'string' && typeof want === 'string' && got.includes(want)
+      : matches(got, want)
+  })
+}
+
+const suite = JSON.parse(readFileSync(new URL('./cases.json', import.meta.url), 'utf8')) as {
+  cases: Case[]
+}
+let passed = 0
+let steps = 0
+let failures = 0
+for (const host of HOSTS) {
+  for (const testCase of suite.cases) {
+    try {
+      steps += await run(host, testCase)
+      passed++
+      console.log(`ok ${host.name}/${testCase.id}`)
+    } catch (err) {
+      failures++
+      console.error(`FAIL ${host.name}/${testCase.id}: ${String(err)}`)
+    }
+  }
+}
+console.log(`${passed} cases / ${steps} steps passed, ${failures} failed`)
+process.exitCode = failures > 0 ? 1 : 0

--- a/integ/lifecycle/run.ts
+++ b/integ/lifecycle/run.ts
@@ -17,13 +17,16 @@ import { readFileSync } from 'node:fs'
 import {
   Workspace as NodeWorkspace,
   buildResource as buildNodeResource,
+  registerResourceFactory as registerNodeResource,
 } from '@struktoai/mirage-node'
 import {
   Workspace as BrowserWorkspace,
   buildResource as buildBrowserResource,
+  registerResourceFactory as registerBrowserResource,
 } from '@struktoai/mirage-browser'
 import { MountMode } from '@struktoai/mirage-core/types'
 import type { Resource } from '@struktoai/mirage-core/resource/base'
+import { RAMResource } from '@struktoai/mirage-core/resource/ram/ram'
 import type {
   Workspace,
   WorkspaceOptions,
@@ -53,7 +56,7 @@ interface Case {
 
 type Step = (
   | ({ op: 'mount'; path: string; mode?: MountMode } & ResourceConfig)
-  | { op: 'unmount' | 'read' | 'readdir' | 'stat'; path: string }
+  | { op: 'unmount' | 'read' | 'readdir' | 'stat' | 'cached'; path: string }
   | { op: 'write'; path: string; data: string }
   | { op: 'exec'; command: string; session?: string }
   | { op: 'set_mode'; path: string; mode: MountMode }
@@ -102,6 +105,25 @@ const HOSTS: Host[] = [
 const ENC = new TextEncoder()
 const DEC = new TextDecoder()
 
+class CachedRAMResource extends RAMResource {
+  override readonly cachesReads = true
+}
+
+// Register a fixture through the same factory extension point as an embedder.
+for (const register of [registerNodeResource, registerBrowserResource]) {
+  register('cached-ram', (config) => {
+    const resource = new CachedRAMResource()
+    const files = (config.files ?? {}) as Record<string, string>
+    resource.loadState({
+      type: 'ram',
+      files: Object.fromEntries(
+        Object.entries(files).map(([path, data]) => [path, ENC.encode(data)]),
+      ),
+    })
+    return Promise.resolve(resource)
+  })
+}
+
 async function action(
   host: Host,
   ws: Workspace,
@@ -113,6 +135,10 @@ async function action(
     return runWithSession(ws.getSession(session), () => action(host, ws, unbound, policies))
   }
   switch (step.op) {
+    case 'cached': {
+      const value = await ws.cache.get(step.path)
+      return value === null ? null : DEC.decode(value)
+    }
     case 'mount': {
       const resource = await host.build(step.resource, step.config ?? {})
       try {

--- a/python/mirage/cache/file/io.py
+++ b/python/mirage/cache/file/io.py
@@ -51,6 +51,7 @@ async def _set_cached(
     path: str,
     data: bytes,
     records: list[OpRecord] | None,
+    is_cacheable: Callable[[str], bool] | None,
 ) -> None:
     fingerprint = read_fingerprint(records, path)
     if fingerprint is None and await cache.get(path) == data:
@@ -59,12 +60,14 @@ async def _set_cached(
         # fingerprint stamped on the cold read with the MD5 default and
         # force ALWAYS mode to evict and refetch on every read.
         return
-    await cache.set(path, data, fingerprint=fingerprint)
+    if is_cacheable is None or is_cacheable(path):
+        await cache.set(path, data, fingerprint=fingerprint)
 
 
 def _drop_drain_task(cache: FileCacheMixin, path: str,
                      task: asyncio.Task[Any]) -> None:
-    cache._drain_tasks.pop(path, None)
+    if cache._drain_tasks.get(path) is task:
+        cache._drain_tasks.pop(path, None)
 
 
 async def apply_io(
@@ -83,18 +86,19 @@ async def apply_io(
         if data is None:
             continue
         if isinstance(data, bytes):
-            await _set_cached(cache, path, data, records)
+            await _set_cached(cache, path, data, records, is_cacheable)
         elif isinstance(data, CachableAsyncIterator):
             if data.exhausted:
                 await _set_cached(cache, path, b"".join(data.buffered_chunks),
-                                  records)
+                                  records, is_cacheable)
             else:
                 if (hasattr(cache, "_drain_tasks")
                         and path not in cache._drain_tasks
                         and not await cache.exists(path)):
                     task = asyncio.create_task(
                         _background_drain(cache, path, data,
-                                          cache.drain_budget, records))
+                                          cache.drain_budget, records,
+                                          is_cacheable))
                     cache._drain_tasks[path] = task
                     task.add_done_callback(
                         partial(_drop_drain_task, cache, path))
@@ -112,6 +116,7 @@ async def _background_drain(
     it: CachableAsyncIterator,
     max_bytes: int,
     records: list[OpRecord] | None = None,
+    is_cacheable: Callable[[str], bool] | None = None,
 ) -> None:
     """Drain an unconsumed stream and write to cache.
 
@@ -126,9 +131,11 @@ async def _background_drain(
     try:
         materialized = await it.drain_bounded(max_bytes)
         if materialized is not None:
-            await cache.add(path,
-                            materialized,
-                            fingerprint=read_fingerprint(records, path))
+            if (cache._drain_tasks.get(path) is asyncio.current_task()
+                    and (is_cacheable is None or is_cacheable(path))):
+                await cache.add(path,
+                                materialized,
+                                fingerprint=read_fingerprint(records, path))
         else:
             logger.info(
                 "cache drain budget exceeded for %s "

--- a/python/mirage/cache/file/io.py
+++ b/python/mirage/cache/file/io.py
@@ -16,12 +16,24 @@ import asyncio
 import logging
 from functools import partial
 from typing import Any, Callable
+from weakref import WeakKeyDictionary
 
 from mirage.cache.file.mixin import FileCacheMixin
 from mirage.io import CachableAsyncIterator, IOResult
 from mirage.observe.record import OpRecord
 
 logger = logging.getLogger(__name__)
+_mutation_locks: WeakKeyDictionary[FileCacheMixin,
+                                   asyncio.Lock] = WeakKeyDictionary()
+
+
+def mutation_lock(cache: FileCacheMixin) -> asyncio.Lock:
+    """Serialize cache fills with mount ownership changes."""
+    lock = _mutation_locks.get(cache)
+    if lock is None:
+        lock = asyncio.Lock()
+        _mutation_locks[cache] = lock
+    return lock
 
 
 def read_fingerprint(records: list[OpRecord] | None, path: str) -> str | None:
@@ -53,6 +65,17 @@ async def _set_cached(
     records: list[OpRecord] | None,
     is_cacheable: Callable[[str], bool] | None,
 ) -> None:
+    async with mutation_lock(cache):
+        if is_cacheable is None or is_cacheable(path):
+            await _set_cached_locked(cache, path, data, records)
+
+
+async def _set_cached_locked(
+    cache: FileCacheMixin,
+    path: str,
+    data: bytes,
+    records: list[OpRecord] | None,
+) -> None:
     fingerprint = read_fingerprint(records, path)
     if fingerprint is None and await cache.get(path) == data:
         # Warm read: the bytes were served from this cache, so there is
@@ -60,8 +83,7 @@ async def _set_cached(
         # fingerprint stamped on the cold read with the MD5 default and
         # force ALWAYS mode to evict and refetch on every read.
         return
-    if is_cacheable is None or is_cacheable(path):
-        await cache.set(path, data, fingerprint=fingerprint)
+    await cache.set(path, data, fingerprint=fingerprint)
 
 
 def _drop_drain_task(cache: FileCacheMixin, path: str,
@@ -131,11 +153,13 @@ async def _background_drain(
     try:
         materialized = await it.drain_bounded(max_bytes)
         if materialized is not None:
-            if (cache._drain_tasks.get(path) is asyncio.current_task()
-                    and (is_cacheable is None or is_cacheable(path))):
-                await cache.add(path,
-                                materialized,
-                                fingerprint=read_fingerprint(records, path))
+            async with mutation_lock(cache):
+                if (cache._drain_tasks.get(path) is asyncio.current_task()
+                        and (is_cacheable is None or is_cacheable(path))):
+                    await cache.add(path,
+                                    materialized,
+                                    fingerprint=read_fingerprint(
+                                        records, path))
         else:
             logger.info(
                 "cache drain budget exceeded for %s "

--- a/python/mirage/cache/file/ram.py
+++ b/python/mirage/cache/file/ram.py
@@ -141,8 +141,9 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
             self._clear_locks()
 
     async def evict_prefix(self, prefix: str) -> None:
-        # Snapshot first: remove() mutates _entries as it goes.
-        for key in [k for k in self._entries if k.startswith(prefix)]:
+        # A pending fill may not have installed an entry yet.
+        keys = self._entries.keys() | self._drain_tasks.keys()
+        for key in [k for k in keys if k.startswith(prefix)]:
             await self.remove(key)
 
     def evict_paths(self, paths: Iterable[str]) -> None:

--- a/python/mirage/cache/index/view.py
+++ b/python/mirage/cache/index/view.py
@@ -1,0 +1,119 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import Callable
+from datetime import datetime
+
+from mirage.cache.file.io import mutation_lock
+from mirage.cache.file.mixin import FileCacheMixin
+from mirage.cache.index.config import (IndexEntry, ListResult, LookupResult,
+                                       LookupStatus)
+from mirage.cache.index.store import IndexCacheStore
+
+
+class IndexView(IndexCacheStore):
+    """A mount-owned view over a resource's metadata index.
+
+    Backend calls retain this view across awaits. Ownership is checked under
+    the same lock that retires mount cache state, so late metadata writes
+    cannot refill a replacement mount's index.
+    """
+
+    def __init__(self, store: IndexCacheStore, cache: FileCacheMixin,
+                 prefix: str, owns: Callable[[str], bool]) -> None:
+        super().__init__()
+        self._store = store
+        self._cache = cache
+        self._prefix = prefix or "/"
+        self._owns = owns
+
+    async def get(self, resource_path: str) -> LookupResult:
+        # A lookup may flush a queued snapshot, so reads share the write fence.
+        async with mutation_lock(self._cache):
+            if not self._owns(resource_path):
+                return LookupResult(status=LookupStatus.NOT_FOUND)
+            result = await self._store.get(resource_path)
+            return result if self._owns(resource_path) else LookupResult(
+                status=LookupStatus.NOT_FOUND)
+
+    async def list_dir(self, resource_path: str) -> ListResult:
+        async with mutation_lock(self._cache):
+            if not self._owns(resource_path):
+                return ListResult(status=LookupStatus.NOT_FOUND)
+            result = await self._store.list_dir(resource_path)
+            if not self._owns(resource_path):
+                return ListResult(status=LookupStatus.NOT_FOUND)
+            if result.entries is None:
+                return result
+            return result.model_copy(update={
+                "entries":
+                [path for path in result.entries if self._owns(path)]
+            })
+
+    async def put(self, resource_path: str, entry: IndexEntry) -> None:
+        async with mutation_lock(self._cache):
+            if self._owns(resource_path):
+                await self._store.put(resource_path, entry)
+
+    async def set_dir(self,
+                      resource_path: str,
+                      entries: list[tuple[str, IndexEntry]],
+                      expired_at: datetime | None = None) -> None:
+        async with mutation_lock(self._cache):
+            if self._owns(resource_path):
+                prefix = resource_path.rstrip("/") + "/"
+                owned = [(name, entry) for name, entry in entries
+                         if self._owns(prefix + name)]
+                await self._store.set_dir(resource_path, owned, expired_at)
+
+    def seed(self, entries: dict[str, IndexEntry],
+             children: dict[str, list[str]], expires_at: datetime) -> None:
+        if not self._owns(self._prefix):
+            return
+        self._store.seed(
+            {
+                path: entry
+                for path, entry in entries.items() if self._owns(path)
+            }, {
+                path: [key for key in keys if self._owns(key)]
+                for path, keys in children.items() if self._owns(path)
+            }, expires_at)
+
+    async def entries(self) -> dict[str, IndexEntry]:
+        async with mutation_lock(self._cache):
+            if not self._owns(self._prefix):
+                return {}
+            entries = await self._store.entries()
+            return {
+                path: entry
+                for path, entry in entries.items() if self._owns(path)
+            }
+
+    async def invalidate_dir(self, resource_path: str) -> None:
+        async with mutation_lock(self._cache):
+            if self._owns(resource_path):
+                await self._store.invalidate_dir(resource_path)
+
+    async def invalidate_prefix(self, resource_path: str) -> None:
+        async with mutation_lock(self._cache):
+            if self._owns(resource_path):
+                await self._store.invalidate_prefix(resource_path)
+
+    async def invalidate(self) -> None:
+        async with mutation_lock(self._cache):
+            if self._owns(self._prefix):
+                await self._store.invalidate()
+
+    async def clear(self) -> None:
+        await self.invalidate_prefix(self._prefix)

--- a/python/mirage/cache/manager.py
+++ b/python/mirage/cache/manager.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import Callable
+
 from mirage.cache.file.mixin import FileCacheMixin
 from mirage.cache.index.store import IndexCacheStore
 from mirage.types import PathSpec
@@ -31,9 +33,12 @@ class CacheManager:
     pipeline runs instead of after the whole command tree.
     """
 
-    def __init__(self, file_cache: FileCacheMixin | None,
-                 index: IndexCacheStore, prefix: str,
-                 caches_reads: bool) -> None:
+    def __init__(self,
+                 file_cache: FileCacheMixin | None,
+                 index: IndexCacheStore,
+                 prefix: str,
+                 caches_reads: bool,
+                 is_active: Callable[[], bool] = lambda: True) -> None:
         """Args:
             file_cache (FileCacheMixin | None): Workspace file cache
                 store; entries are keyed by mount-absolute path.
@@ -43,11 +48,13 @@ class CacheManager:
             prefix (str): Mount prefix (e.g. "/data/").
             caches_reads (bool): Whether the resource caches reads; the
                 file cache only holds paths for read-caching backends.
+            is_active: whether this mount still owns its cache entries.
         """
         self._file_cache = file_cache
         self._index = index
         self._prefix = prefix.rstrip("/")
         self._caches_reads = caches_reads
+        self._is_active = is_active
 
     async def _evict_dir(self, key: str) -> None:
         """Drop one directory's cached listing.
@@ -104,11 +111,13 @@ class CacheManager:
         Args:
             path (PathSpec): the path to look up.
         """
-        if not self._caches_reads or self._file_cache is None:
+        if (not self._caches_reads or self._file_cache is None
+                or not self._is_active()):
             return None
         key = self._cache_key(path)
         if await self._file_cache.exists(key):
-            return await self._file_cache.get(key)
+            cached = await self._file_cache.get(key)
+            return cached if self._is_active() else None
         return None
 
     async def invalidate_after_write(self, path: PathSpec) -> None:

--- a/python/mirage/cache/manager.py
+++ b/python/mirage/cache/manager.py
@@ -38,7 +38,7 @@ class CacheManager:
                  index: IndexCacheStore,
                  prefix: str,
                  caches_reads: bool,
-                 is_active: Callable[[], bool] = lambda: True) -> None:
+                 owns_path: Callable[[str], bool] = lambda _: True) -> None:
         """Args:
             file_cache (FileCacheMixin | None): Workspace file cache
                 store; entries are keyed by mount-absolute path.
@@ -48,13 +48,13 @@ class CacheManager:
             prefix (str): Mount prefix (e.g. "/data/").
             caches_reads (bool): Whether the resource caches reads; the
                 file cache only holds paths for read-caching backends.
-            is_active: whether this mount still owns its cache entries.
+            owns_path: whether this mount still owns a virtual cache key.
         """
         self._file_cache = file_cache
         self._index = index
         self._prefix = prefix.rstrip("/")
         self._caches_reads = caches_reads
-        self._is_active = is_active
+        self._owns_path = owns_path
 
     async def _evict_dir(self, key: str) -> None:
         """Drop one directory's cached listing.
@@ -111,13 +111,13 @@ class CacheManager:
         Args:
             path (PathSpec): the path to look up.
         """
-        if (not self._caches_reads or self._file_cache is None
-                or not self._is_active()):
-            return None
         key = self._cache_key(path)
+        if (not self._caches_reads or self._file_cache is None
+                or not self._owns_path(key)):
+            return None
         if await self._file_cache.exists(key):
             cached = await self._file_cache.get(key)
-            return cached if self._is_active() else None
+            return cached if self._owns_path(key) else None
         return None
 
     async def invalidate_after_write(self, path: PathSpec) -> None:

--- a/python/mirage/cache/manager.py
+++ b/python/mirage/cache/manager.py
@@ -12,8 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
 
+from mirage.cache.file.io import mutation_lock
 from mirage.cache.file.mixin import FileCacheMixin
 from mirage.cache.index.store import IndexCacheStore
 from mirage.cache.index.view import IndexView
@@ -56,6 +58,15 @@ class CacheManager:
         self._prefix = prefix.rstrip("/")
         self._caches_reads = caches_reads
         self._owns_path = owns_path
+
+    @asynccontextmanager
+    async def mutation(self) -> AsyncIterator[None]:
+        """Drain raw backend index access before mount cache eviction."""
+        if self._file_cache is None:
+            yield
+            return
+        async with mutation_lock(self._file_cache):
+            yield
 
     def scope_index(self, index: IndexCacheStore) -> IndexCacheStore:
         """Bind backend metadata writes to this mount's lifetime."""

--- a/python/mirage/cache/manager.py
+++ b/python/mirage/cache/manager.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 
 from mirage.cache.file.mixin import FileCacheMixin
 from mirage.cache.index.store import IndexCacheStore
+from mirage.cache.index.view import IndexView
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -55,6 +56,13 @@ class CacheManager:
         self._prefix = prefix.rstrip("/")
         self._caches_reads = caches_reads
         self._owns_path = owns_path
+
+    def scope_index(self, index: IndexCacheStore) -> IndexCacheStore:
+        """Bind backend metadata writes to this mount's lifetime."""
+        if self._file_cache is None or isinstance(index, IndexView):
+            return index
+        return IndexView(index, self._file_cache, self._prefix,
+                         self._owns_path)
 
     async def _evict_dir(self, key: str) -> None:
         """Drop one directory's cached listing.

--- a/python/mirage/commands/builtin/generic/patch.py
+++ b/python/mirage/commands/builtin/generic/patch.py
@@ -138,6 +138,7 @@ async def patch(
     R: bool = False,
     i: PathSpec | None = None,
     N: bool = False,
+    mount_prefix: str = "",
 ) -> tuple[ByteSource | None, IOResult]:
     if len(paths) > 2:
         raise extra_operand_error(CommandName.PATCH, paths[2].raw_path
@@ -149,7 +150,9 @@ async def patch(
     file_hunks = _parse_patch(patch_text, strip_count)
     writes: dict[str, ByteSource] = {}
     for file_path, hunks in file_hunks.items():
-        file_spec = PathSpec.from_str_path(file_path)
+        file_spec = PathSpec.from_str_path(
+            mount_prefix.rstrip("/") + "/" + file_path.lstrip("/"),
+            file_path.lstrip("/"))
         try:
             original = (await read_bytes(file_spec)).decode(errors="replace")
         except FileNotFoundError:
@@ -203,4 +206,5 @@ async def patch_generic(
                        p=parsed.strip,
                        R=parsed.reverse,
                        i=parsed.input_path,
-                       N=parsed.forward)
+                       N=parsed.forward,
+                       mount_prefix=opts.mount_prefix or "")

--- a/python/mirage/core/generic/find.py
+++ b/python/mirage/core/generic/find.py
@@ -7,7 +7,7 @@ from mirage.commands.builtin.find_eval import (FindEntry, PredNode, build_tree,
                                                tree_has_empty, tree_has_type)
 from mirage.types import FileStat, PathSpec
 from mirage.utils.dates import matches_mtime
-from mirage.utils.key_prefix import mount_key, mount_prefix_of
+from mirage.utils.key_prefix import mount_prefix_of
 
 
 class ResolvedPath(Protocol):
@@ -94,7 +94,9 @@ async def _matches(
     item_norm = item.rstrip("/") or "/"
     item_name = (start_name if item_norm == root_norm else
                  item.rstrip("/").rsplit("/", 1)[-1])
-    spec = PathSpec.from_str_path(item, mount_key(item, prefix))
+    # The walk strips its mount prefix; backend probes still need both paths.
+    virtual = (prefix.rstrip("/") + "/" + item.lstrip("/")).rstrip("/") or "/"
+    spec = PathSpec.from_str_path(virtual, item.lstrip("/"))
     kind = "f"
     if needs_kind:
         resolved = await resolve_path(accessor, spec, index)

--- a/python/mirage/fuse/core.py
+++ b/python/mirage/fuse/core.py
@@ -18,7 +18,7 @@ import os
 import posixpath
 import threading
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import Any, Coroutine
 
 from mirage.bridge.sync import run_async_from_sync
@@ -263,7 +263,7 @@ class MountCore:
         return entry
 
     def drain_ops(self) -> list[dict[str, Any]]:
-        records = [asdict(r) for r in self._ops.records]
+        records = [r.to_dict() for r in self._ops.records]
         self._ops.records.clear()
         return records
 

--- a/python/mirage/observe/context.py
+++ b/python/mirage/observe/context.py
@@ -35,10 +35,12 @@ class Recorder:
         sink (list[OpRecord]): Where new records are appended.
         mount_prefix (str): Current frame's mount prefix (e.g. "/s3").
             Empty when no mount is active.
+        mount_id (str | None): Identity of the mounted instance serving reads.
     """
 
     sink: list[OpRecord] = field(default_factory=list)
     mount_prefix: str = ""
+    mount_id: str | None = None
 
 
 _recorder: ContextVar[Recorder | None] = ContextVar("_recorder", default=None)
@@ -124,12 +126,27 @@ def push_mount_prefix(prefix: str) -> str:
     rec = _recorder.get()
     if rec is None:
         return ""
-    _recorder.set(Recorder(sink=rec.sink, mount_prefix=prefix))
+    _recorder.set(
+        Recorder(sink=rec.sink, mount_prefix=prefix, mount_id=rec.mount_id))
     return rec.mount_prefix
 
 
-async def with_mount_prefix(prefix: str,
-                            it: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+def push_mount_context(prefix: str, mount_id: str | None):
+    """Bind the mount instance that owns reads in this async frame.
+
+    Args:
+        prefix (str): virtual mount prefix.
+        mount_id (str | None): instance identity, absent outside a mount.
+    """
+    rec = _recorder.get()
+    return _recorder.set(None if rec is None else Recorder(
+        sink=rec.sink, mount_prefix=prefix, mount_id=mount_id))
+
+
+async def with_mount_prefix(
+        prefix: str,
+        it: AsyncIterator[bytes],
+        mount_id: str | None = None) -> AsyncIterator[bytes]:
     """Wrap an async iterator so the recorder's mount prefix is `prefix`
     during each ``__anext__`` of the underlying stream.
 
@@ -141,17 +158,21 @@ async def with_mount_prefix(prefix: str,
     Args:
         prefix (str): Mount prefix to push during iteration.
         it (AsyncIterator[bytes]): The stream to wrap.
+        mount_id (str | None): Captured mount identity for lazy reads.
     """
     aiter = it.__aiter__()
     try:
         while True:
-            prev = push_mount_prefix(prefix)
+            previous = _recorder.get()
+            token = push_mount_context(
+                prefix, mount_id if mount_id is not None else
+                previous.mount_id if previous else None)
             try:
                 chunk = await aiter.__anext__()
             except StopAsyncIteration:
                 return
             finally:
-                push_mount_prefix(prev)
+                reset_active_recorder(token)
             yield chunk
     finally:
         close = getattr(aiter, "aclose", None)
@@ -233,6 +254,7 @@ def finish_record(op: str,
             backend (S3 ``VersionId``, Drive ``revisionId``, Git SHA).
     """
     elapsed = timer.elapsed_ms
+    recorder = _recorder.get()
     return OpRecord(
         op=op,
         path=path,
@@ -242,6 +264,7 @@ def finish_record(op: str,
         duration_ms=elapsed,
         fingerprint=fingerprint,
         revision=revision,
+        mount_id=recorder.mount_id if recorder is not None else None,
     )
 
 
@@ -322,6 +345,7 @@ def record_stream(op: str,
         duration_ms=0,
         fingerprint=fingerprint,
         revision=revision,
+        mount_id=rec.mount_id,
     )
     rec.sink.append(op_rec)
     return op_rec
@@ -395,6 +419,7 @@ async def with_revisions(revisions: dict[str, str] | None,
         revisions (dict[str, str] | None): Revisions to push during
             iteration.
         it (AsyncIterator[bytes]): The stream to wrap.
+        mount_id (str | None): Captured mount identity for lazy reads.
     """
     aiter = it.__aiter__()
     try:

--- a/python/mirage/observe/record.py
+++ b/python/mirage/observe/record.py
@@ -39,6 +39,8 @@ class OpRecord:
             bytes can be re-fetched even if the live object has moved on.
             Strictly stronger than ``fingerprint`` — populated only by
             backends that can guarantee revision durability.
+        mount_id (str | None): In-process mount identity for snapshot
+            ownership checks; never used as a persisted backend revision.
     """
 
     op: str
@@ -49,6 +51,7 @@ class OpRecord:
     duration_ms: int
     fingerprint: str | None = field(default=None)
     revision: str | None = field(default=None)
+    mount_id: str | None = field(default=None, repr=False, compare=False)
 
     @property
     def is_cache(self) -> bool:

--- a/python/mirage/observe/record.py
+++ b/python/mirage/observe/record.py
@@ -57,3 +57,16 @@ class OpRecord:
     def is_cache(self) -> bool:
         """Whether this op was served from the in-memory cache."""
         return self.source == "ram"
+
+    def to_dict(self) -> dict[str, str | int | None]:
+        """Public observation fields, excluding in-process mount ownership."""
+        return {
+            "op": self.op,
+            "path": self.path,
+            "source": self.source,
+            "bytes": self.bytes,
+            "timestamp": self.timestamp,
+            "duration_ms": self.duration_ms,
+            "fingerprint": self.fingerprint,
+            "revision": self.revision,
+        }

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -52,9 +52,7 @@ class Ops:
                  agent_id: str = "default",
                  session_id: str = "default",
                  links: NamespaceLinks | None = None) -> None:
-        self._mounts = sorted(mounts,
-                              key=lambda m: len(m.prefix),
-                              reverse=True)
+        self.set_mounts(mounts)
         self._observer = observer
         self._agent_id = agent_id
         self._session_id = session_id
@@ -78,6 +76,16 @@ class Ops:
             list[str]: mount prefixes, longest first.
         """
         return [m.prefix for m in self._mounts]
+
+    def set_mounts(self, mounts: list[OpsMount]) -> None:
+        """Refresh mount metadata without replacing the facade or its ledger.
+
+        Args:
+            mounts (list[OpsMount]): the workspace's current mount table.
+        """
+        self._mounts = sorted(mounts,
+                              key=lambda m: len(m.prefix),
+                              reverse=True)
 
     def unsized_mounts(self, root_prefix: str = "") -> list[tuple[str, str]]:
         """Mounts whose files cannot be sized without reading them.

--- a/python/mirage/policy/decisions.py
+++ b/python/mirage/policy/decisions.py
@@ -317,15 +317,15 @@ class Decisions:
         # standing for the next identical one, and whoever allowed once
         # would have allowed twice.
         await self._spend(
-            ctx.session_id, spent if hand_off else
-            self._once_answers(ctx.session_id, rules, argv, ctx.cwd))
+            ctx.session_id, spent if hand_off else self._once_answers(
+                ctx.session_id, rules, argv, ctx.cwd))
         return None
 
     def _once_answers(
         self,
         session_id: str,
         rules: Sequence[CommandRule],
-        argv: Sequence[str],
+        argv: tuple[str, ...],
         cwd: str,
     ) -> tuple[Decision, ...]:
         """Every ONCE answer standing behind this line, as the ledger
@@ -334,7 +334,7 @@ class Decisions:
         Args:
             session_id (str): the asking session.
             rules (Sequence[CommandRule]): the rules the ask named.
-            argv (Sequence[str]): the line, command name first.
+            argv (tuple[str, ...]): the line, command name first.
             cwd (str): the directory the line was typed in.
 
         Returns:

--- a/python/mirage/policy/policies.py
+++ b/python/mirage/policy/policies.py
@@ -285,6 +285,21 @@ class Policies:
         self._policies.append(policy)
         self._rescan()
 
+    def remove(self, policy: Policy) -> bool:
+        """Remove one registration by identity; return whether it existed.
+
+        Host-side only, like add(). Other policies keep their order.
+
+        Args:
+            policy (Policy): the exact instance passed to add().
+        """
+        for index, entry in enumerate(self._policies):
+            if entry is policy:
+                del self._policies[index]
+                self._rescan()
+                return True
+        return False
+
     def wants(self, hook: str) -> bool:
         """True when any policy overrides ``hook``.
 
@@ -312,7 +327,7 @@ class Policies:
             session_id (str): the session, empty when none is bound.
         """
         base = getattr(Policy, hook)
-        for policy in self._policies:
+        for policy in tuple(self._policies):
             if getattr(type(policy), hook) is base:
                 continue
             if not isinstance(policy, SessionScopedMixin):
@@ -346,7 +361,9 @@ class Policies:
         base = getattr(Policy, hook)
         limits: list[Limit] = []
         asked: Ask | None = None
-        for policy in self._policies:
+        # Keep this gate's order stable if the host edits registrations
+        # while a hook awaits. Changes take effect at the next gate.
+        for policy in tuple(self._policies):
             if getattr(type(policy), hook) is base:
                 continue
             name = type(policy).__name__

--- a/python/mirage/policy/script.py
+++ b/python/mirage/policy/script.py
@@ -340,7 +340,7 @@ class ScriptPolicy(Policy, SessionScopedMixin):
         self._dispatch = dispatch
         self._resolver = resolver
         self._engines: dict[str, Runtime] = {}
-        self._defined: dict[tuple[str, str], frozenset[str]] = {}
+        self._defined: dict[tuple[str, str, str], frozenset[str]] = {}
         self._lock = asyncio.Lock()
 
     async def pre_command(self, ctx: CommandContext) -> Action | None:
@@ -431,14 +431,14 @@ class ScriptPolicy(Policy, SessionScopedMixin):
 
     async def _hooks_of(self, entry: ProfileScript) -> frozenset[str]:
         """The hooks one profile's program defines, probed on its first
-        judgment and remembered by program text and language: the probe
-        asks in the program's own spelling, so one text read as two
-        languages is two programs.
+        judgment and remembered by runtime, program text and language.
+        A runtime change must probe again, including its validation;
+        a cached absent hook must never bypass a broken new engine.
 
         Args:
             entry (ProfileScript): the session's policy.
         """
-        key = (entry.script.language, entry.script.source)
+        key = (entry.runtime, entry.script.language, entry.script.source)
         defined = self._defined.get(key)
         if defined is None:
             value = await self._evaluate(entry, hook_probe(entry.script), {})

--- a/python/mirage/resource/base.py
+++ b/python/mirage/resource/base.py
@@ -203,6 +203,11 @@ class BaseResource:
     def load_state(self, state: dict[str, Any]) -> None:
         pass
 
+    @property
+    def is_closed(self) -> bool:
+        """Whether this instance has completed its resource lifecycle."""
+        return self._closed
+
     async def close(self) -> None:
         if self._closed:
             return

--- a/python/mirage/utils/errors.py
+++ b/python/mirage/utils/errors.py
@@ -98,6 +98,10 @@ def enoent(path: str | PathSpec) -> FileNotFoundError:
     return FileNotFoundError(_virtual_of(path))
 
 
+def ebusy(path: str | PathSpec) -> OSError:
+    return OSError(errno.EBUSY, "Device or resource busy", _virtual_of(path))
+
+
 def enotdir(path: str | PathSpec) -> NotADirectoryError:
     return NotADirectoryError(_virtual_of(path))
 

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -358,7 +358,7 @@ class Dispatcher:
         if caches_reads and not raw and op in DISPATCH_READ_OPS:
             cached = await self._cache.get(path.virtual)
             if cached is not None and await self._reconciler.may_serve_cached(
-                    mount, path.virtual):
+                    mount, path.virtual) and not mount.retiring:
                 # The cache holds the whole object, so a ranged read is
                 # answered by slicing it, never by handing back the
                 # whole file: the window is what the caller asked for
@@ -873,19 +873,32 @@ class Dispatcher:
         raw, _ = await self.dispatch("readdir", scope)
         return raw
 
-    async def apply_io(self,
-                       io: IOResult,
-                       records: list[OpRecord] | None = None) -> None:
+    async def apply_io(
+            self,
+            io: IOResult,
+            records: list[OpRecord] | None = None,
+            is_cacheable: Callable[[str], bool] | None = None) -> None:
         await cache_io.apply_io(self._cache,
                                 io,
-                                self.is_cacheable_path,
+                                is_cacheable or self.is_cacheable_path,
                                 records=records)
+
+    def capture_cacheable_paths(self) -> Callable[[str], bool]:
+        """Bind deferred command results to the mounts that produced them."""
+        mounts = {m.prefix: m for m in self._namespace.registry.mounts()}
+
+        def cacheable(path: str) -> bool:
+            mount = self._namespace.try_mount_for(path)
+            return (mount is not None and mounts.get(mount.prefix) is mount
+                    and not mount.retiring and mount.resource.caches_reads)
+
+        return cacheable
 
     def is_cacheable_path(self, path: str) -> bool:
         mount = self._namespace.try_mount_for(path)
         if mount is None:
             return False
-        return mount.resource.caches_reads
+        return not mount.retiring and mount.resource.caches_reads
 
     async def invalidate_all_after_remote(self) -> None:
         """Drop the file cache and every mount index wholesale.

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -39,7 +39,7 @@ from mirage.types import (ConsistencyPolicy, FileStat, FileType, PathSpec,
 from mirage.utils.errors import MISS_ERRORS, no_mount
 from mirage.utils.hidden import move_reveals
 from mirage.utils.key_prefix import mount_key
-from mirage.utils.path import norm_dir
+from mirage.utils.path import norm_dir, owner_prefix
 from mirage.utils.ranges import slice_window
 from mirage.utils.remnants import remove_remnants, visible_below
 from mirage.workspace.dispatcher.lineage import require_turf_writable
@@ -890,8 +890,10 @@ class Dispatcher:
         mounts = {m.prefix: m for m in self._namespace.registry.mounts()}
 
         def cacheable(path: str) -> bool:
+            prefix = owner_prefix(mounts, path)
+            original = mounts.get(prefix) if prefix is not None else None
             mount = self._namespace.try_mount_for(path)
-            return (mount is not None and mounts.get(mount.prefix) is mount
+            return (mount is not None and original is mount
                     and not mount.retiring and mount.resource.caches_reads)
 
         return cacheable

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -347,6 +347,7 @@ class Dispatcher:
         if op == "rename" and isinstance(dst, PathSpec):
             await pre_ops_gate(policies, op, dst, True, mount.prefix,
                                _session_id())
+        await mount.ensure_ready()
         caches_reads = mount.resource.caches_reads
         # The file cache is keyed on the path alone, and what a command
         # put there is the rendered read. A raw read asks for a
@@ -357,8 +358,9 @@ class Dispatcher:
 
         if caches_reads and not raw and op in DISPATCH_READ_OPS:
             cached = await self._cache.get(path.virtual)
-            if cached is not None and await self._reconciler.may_serve_cached(
-                    mount, path.virtual) and not mount.retiring:
+            if (cached is not None and await self._reconciler.may_serve_cached(
+                    mount, path.virtual) and not mount.retiring
+                    and self._namespace.try_mount_for(path.virtual) is mount):
                 # The cache holds the whole object, so a ranged read is
                 # answered by slicing it, never by handing back the
                 # whole file: the window is what the caller asked for

--- a/python/mirage/workspace/executor/builtins/shared.py
+++ b/python/mirage/workspace/executor/builtins/shared.py
@@ -197,8 +197,8 @@ async def expand_operands(
             str(item))
         if spec.pattern:
             mount = namespace.mount_for(spec.virtual)
-            expanded = await mount.resource.resolve_glob(
-                [spec], mount.prefix.rstrip("/"))
+            expanded = await mount.expand_glob([spec],
+                                               mount.prefix.rstrip("/"))
             out.extend(p for p in expanded if isinstance(p, PathSpec))
             continue
         out.append(spec)

--- a/python/mirage/workspace/expand/globs.py
+++ b/python/mirage/workspace/expand/globs.py
@@ -14,6 +14,7 @@
 
 import dataclasses
 
+from mirage.cache.file.io import mutation_lock
 from mirage.ops.config import NamespaceLinks
 from mirage.ops.namespace_view import child_mount_names, namespace_names
 from mirage.shell.constants import SHOPT_DEFAULTS
@@ -31,6 +32,18 @@ from mirage.workspace.session import Session
 # listing per directory, so an accidental `**` over a large tree is
 # bounded rather than open-ended.
 GLOBSTAR_MAX_DEPTH = 32
+
+
+async def _backend_glob(registry: MountRegistry, mount: MountEntry,
+                        paths: list[PathSpec], prefix: str) -> list[PathSpec]:
+    """Prepare the mount; drain resource index writes before eviction."""
+    await mount.ensure_ready()
+    cache = registry.file_cache
+    if cache is None:
+        return await mount.resource.resolve_glob(paths, prefix=prefix)
+    async with mutation_lock(cache):
+        await mount.ensure_ready()
+        return await mount.resource.resolve_glob(paths, prefix=prefix)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -231,6 +244,7 @@ async def _level_matches(registry: MountRegistry, mount: MountEntry,
     """
     real = _listing_dir(links, dir_virtual)
     owner = _mount_of(registry, real, mount)
+    await owner.ensure_ready()
     prefix = owner.prefix.rstrip("/")
     spec = PathSpec(virtual=real,
                     directory=real,
@@ -238,7 +252,7 @@ async def _level_matches(registry: MountRegistry, mount: MountEntry,
                     pattern=seg,
                     resolved=False)
     try:
-        matches = await owner.resource.resolve_glob([spec], prefix=prefix)
+        matches = await _backend_glob(registry, owner, [spec], prefix)
     except OSError:
         # This parent is not a listable directory; bash skips it during
         # descent. A nested mount root or a link under it is still real.
@@ -506,6 +520,7 @@ async def resolve_globs(
             item = dataclasses.replace(item,
                                        resource_path=mount_key(
                                            item.virtual, prefix))
+            await mount.ensure_ready()
             try:
                 # The parent directory is a real directory to list, so a
                 # glob character quoted inside it is part of its name.
@@ -534,8 +549,8 @@ async def resolve_globs(
                     # spec has no literal to reinstate, so an empty list
                     # means no match and every spec returned is one.
                     resolved = _merge_namespace(
-                        list(await mount.resource.resolve_glob([item.dir],
-                                                               prefix=prefix)),
+                        list(await _backend_glob(registry, mount, [item.dir],
+                                                 prefix)),
                         _namespace_children(registry, links, directory,
                                             pattern), directory, prefix,
                         registry, mount)

--- a/python/mirage/workspace/expand/globs.py
+++ b/python/mirage/workspace/expand/globs.py
@@ -14,7 +14,6 @@
 
 import dataclasses
 
-from mirage.cache.file.io import mutation_lock
 from mirage.ops.config import NamespaceLinks
 from mirage.ops.namespace_view import child_mount_names, namespace_names
 from mirage.shell.constants import SHOPT_DEFAULTS
@@ -32,18 +31,6 @@ from mirage.workspace.session import Session
 # listing per directory, so an accidental `**` over a large tree is
 # bounded rather than open-ended.
 GLOBSTAR_MAX_DEPTH = 32
-
-
-async def _backend_glob(registry: MountRegistry, mount: MountEntry,
-                        paths: list[PathSpec], prefix: str) -> list[PathSpec]:
-    """Prepare the mount; drain resource index writes before eviction."""
-    async with mount.use():
-        cache = registry.file_cache
-        if cache is None:
-            return await mount.resource.resolve_glob(paths, prefix=prefix)
-        async with mutation_lock(cache):
-            await mount.ensure_ready()
-            return await mount.resource.resolve_glob(paths, prefix=prefix)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -252,7 +239,7 @@ async def _level_matches(registry: MountRegistry, mount: MountEntry,
                     pattern=seg,
                     resolved=False)
     try:
-        matches = await _backend_glob(registry, owner, [spec], prefix)
+        matches = await owner.expand_glob([spec], prefix)
     except OSError:
         # This parent is not a listable directory; bash skips it during
         # descent. A nested mount root or a link under it is still real.
@@ -549,8 +536,7 @@ async def resolve_globs(
                     # spec has no literal to reinstate, so an empty list
                     # means no match and every spec returned is one.
                     resolved = _merge_namespace(
-                        list(await _backend_glob(registry, mount, [item.dir],
-                                                 prefix)),
+                        list(await mount.expand_glob([item.dir], prefix)),
                         _namespace_children(registry, links, directory,
                                             pattern), directory, prefix,
                         registry, mount)

--- a/python/mirage/workspace/expand/globs.py
+++ b/python/mirage/workspace/expand/globs.py
@@ -37,13 +37,13 @@ GLOBSTAR_MAX_DEPTH = 32
 async def _backend_glob(registry: MountRegistry, mount: MountEntry,
                         paths: list[PathSpec], prefix: str) -> list[PathSpec]:
     """Prepare the mount; drain resource index writes before eviction."""
-    await mount.ensure_ready()
-    cache = registry.file_cache
-    if cache is None:
-        return await mount.resource.resolve_glob(paths, prefix=prefix)
-    async with mutation_lock(cache):
-        await mount.ensure_ready()
-        return await mount.resource.resolve_glob(paths, prefix=prefix)
+    async with mount.use():
+        cache = registry.file_cache
+        if cache is None:
+            return await mount.resource.resolve_glob(paths, prefix=prefix)
+        async with mutation_lock(cache):
+            await mount.ensure_ready()
+            return await mount.resource.resolve_glob(paths, prefix=prefix)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)

--- a/python/mirage/workspace/mount/activity.py
+++ b/python/mirage/workspace/mount/activity.py
@@ -1,0 +1,88 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+
+from mirage.io.cachable_iterator import CachableAsyncIterator
+from mirage.io.types import ByteSource
+
+
+class ResourceActivity:
+    """Calls and streams sharing a resource, including removed aliases."""
+
+    def __init__(self) -> None:
+        self._count = 0
+        self._idle = asyncio.Event()
+        self._idle.set()
+
+    def acquire(self) -> Callable[[], None]:
+        self._count += 1
+        self._idle.clear()
+        released = False
+
+        def release() -> None:
+            nonlocal released
+            if released:
+                return
+            released = True
+            self._count -= 1
+            if self._count == 0:
+                self._idle.set()
+
+        return release
+
+    async def wait(self) -> None:
+        await self._idle.wait()
+
+    def hold(self, source: ByteSource) -> ByteSource:
+        if isinstance(source, (bytes, bytearray)):
+            return source
+        if isinstance(source, CachableAsyncIterator):
+            if source.exhausted:
+                return source
+            source.replace_source(ActivityStream(source.source,
+                                                 self.acquire()))
+            return source
+        return ActivityStream(source, self.acquire())
+
+
+class ActivityStream:
+    """Release a stream's resource on EOF, error, or explicit close."""
+
+    def __init__(self, source: AsyncIterator[bytes],
+                 release: Callable[[], None]) -> None:
+        self._source = source.__aiter__()
+        self._release = release
+        self._pull_lock = asyncio.Lock()
+
+    def __aiter__(self) -> "ActivityStream":
+        return self
+
+    async def __anext__(self) -> bytes:
+        async with self._pull_lock:
+            try:
+                return await self._source.__anext__()
+            except BaseException:
+                self._release()
+                raise
+
+    async def aclose(self) -> None:
+        async with self._pull_lock:
+            try:
+                close = getattr(self._source, "aclose", None)
+                if close is not None:
+                    await close()
+            finally:
+                self._release()

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -32,9 +32,9 @@ from mirage.context import (effective_mount_mode, effective_path_mode,
                             strongest_mode_under)
 from mirage.io.cachable_iterator import CachableAsyncIterator
 from mirage.io.types import ByteSource, IOResult
-from mirage.observe.context import (push_mount_prefix, push_revisions,
-                                    reset_revisions, with_mount_prefix,
-                                    with_revisions)
+from mirage.observe.context import (push_mount_context, push_revisions,
+                                    reset_active_recorder, reset_revisions,
+                                    with_mount_prefix, with_revisions)
 from mirage.ops.host_io import host_io, with_host_io
 from mirage.ops.registry import RegisteredOp
 from mirage.policy import resolve_limit
@@ -42,6 +42,7 @@ from mirage.resource.base import BaseResource
 from mirage.types import (ConsistencyPolicy, FileType, Limit, MountMode,
                           PathSpec, Producer)
 from mirage.utils.errors import ReadOnlyError, ebusy, enotsup
+from mirage.utils.ids import uuid7
 from mirage.utils.key_prefix import mount_key
 
 # Ops that mutate everything under their endpoints in one backend call
@@ -56,6 +57,7 @@ def _wrap_cmd_streams(
     result: tuple[ByteSource | None, IOResult],
     mount_prefix: str,
     revisions: dict[str, str] | None,
+    mount_id: str | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Wrap any async-iterator streams in ``result`` with the mount
     prefix and active revisions, so ``record_stream`` and
@@ -72,6 +74,7 @@ def _wrap_cmd_streams(
         mount_prefix: prefix to push during stream consumption.
         revisions: revisions map to push during stream consumption
             (None when the mount has no pins installed).
+        mount_id (str | None): identity of the serving mount.
     """
     stream, io = result
     seen: dict[int, ByteSource] = {}
@@ -83,7 +86,7 @@ def _wrap_cmd_streams(
         if oid in seen:
             return seen[oid]
         source = obj.source if isinstance(obj, CachableAsyncIterator) else obj
-        wrapped = with_mount_prefix(mount_prefix, source)
+        wrapped = with_mount_prefix(mount_prefix, source, mount_id)
         if revisions:
             wrapped = with_revisions(revisions, wrapped)
         wrapped = with_host_io(wrapped)
@@ -101,7 +104,7 @@ def _wrap_cmd_streams(
     return stream, io
 
 
-def _wrap_op_stream(result: Any) -> Any:
+def _wrap_op_stream(result: Any, mount_prefix: str, mount_id: str) -> Any:
     """Hold the host-I/O bypass around an op result that streams.
 
     An op that returns an async iterator has not run its body yet: the
@@ -111,12 +114,16 @@ def _wrap_op_stream(result: Any) -> Any:
 
     Args:
         result (Any): whatever the op returned.
+        mount_prefix (str): virtual mount prefix.
+        mount_id (str): identity of the serving mount.
     """
     if isinstance(result, CachableAsyncIterator):
-        result.replace_source(with_host_io(result.source))
+        result.replace_source(
+            with_host_io(
+                with_mount_prefix(mount_prefix, result.source, mount_id)))
         return result
     if hasattr(result, "__aiter__"):
-        return with_host_io(result)
+        return with_host_io(with_mount_prefix(mount_prefix, result, mount_id))
     return result
 
 
@@ -146,6 +153,7 @@ class MountEntry:
             raise ValueError(f"prefix must end with /: {prefix!r}")
         if "//" in prefix:
             raise ValueError(f"prefix must not contain //: {prefix!r}")
+        self.mount_id = uuid7()
         self.prefix = prefix
         self.resource = resource
         self.mode = mode
@@ -604,7 +612,7 @@ class MountEntry:
             session_view=context.session_view,
         )
 
-        prev_prefix = push_mount_prefix(mount_prefix)
+        recording_token = push_mount_context(mount_prefix, self.mount_id)
         revs_token = push_revisions(self.revisions or None)
         prev_manager = push_cache_manager(self.cache_manager)
         # What the command tier's mode guard reads: the write-command
@@ -651,7 +659,8 @@ class MountEntry:
                         cmd_timeout, cmd_name)
                 if result is not None:
                     stream, io = _wrap_cmd_streams(result, mount_prefix,
-                                                   self.revisions or None)
+                                                   self.revisions or None,
+                                                   self.mount_id)
                     io.producer = Producer(command=cmd_name,
                                            prefixes=(self.prefix, ),
                                            declared=cmd.limit)
@@ -660,7 +669,7 @@ class MountEntry:
         finally:
             reset_mount_gate(gate_token)
             reset_revisions(revs_token)
-            push_mount_prefix(prev_prefix)
+            reset_active_recorder(recording_token)
             push_cache_manager(prev_manager)
 
     def supports_op(self, op_name: str, path: str) -> bool:
@@ -747,7 +756,7 @@ class MountEntry:
         op_override = self.command_limits.get(op_name)
         op_timeout = (op_override.timeout_seconds
                       if op_override is not None else None)
-        prev_prefix = push_mount_prefix(mount_prefix)
+        recording_token = push_mount_context(mount_prefix, self.mount_id)
         revs_token = push_revisions(self.revisions or None)
         try:
             for op in levels:
@@ -763,8 +772,8 @@ class MountEntry:
                         result = await run_with_timeout(
                             result, op_timeout, op_name)
                 if result is not None:
-                    return _wrap_op_stream(result)
+                    return _wrap_op_stream(result, mount_prefix, self.mount_id)
             return None
         finally:
             reset_revisions(revs_token)
-            push_mount_prefix(prev_prefix)
+            reset_active_recorder(recording_token)

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -12,10 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 import dataclasses
 import errno
 import inspect
-from collections.abc import Iterable
+from collections.abc import Awaitable, Iterable
 from typing import Any, Callable
 
 from mirage.cache.context import push_cache_manager
@@ -149,6 +150,8 @@ class MountEntry:
         self.mode = mode
         self.consistency = consistency
         self.retiring = False
+        self.before_use: Callable[[], Awaitable[None]] | None = None
+        self._ready_lock = asyncio.Lock()
         self.cache_manager: CacheManager | None = None
         # Per-path revision pins installed at Workspace.load time. Read
         # functions consult these via the ``revision_for`` contextvar
@@ -170,6 +173,15 @@ class MountEntry:
         self._general_ops: dict[str, RegisteredOp] = {}
         # key: (cmd_name, target_resource_type)
         self._cross_cmds: dict[tuple[Any, ...], RegisteredCommand] = {}
+
+    async def ensure_ready(self) -> None:
+        """Finish mount preparation before any backend or cache read."""
+        if self.before_use is None:
+            return
+        async with self._ready_lock:
+            if self.before_use is not None:
+                await self.before_use()
+                self.before_use = None
 
     def effective_mode(self) -> MountMode:
         """This mount's mode narrowed by the current session's cap.
@@ -492,6 +504,7 @@ class MountEntry:
                 reads the fields it wants, so no list of command names
                 is kept here.
         """
+        await self.ensure_ready()
         stdin = context.stdin
         cwd = context.cwd
         stat_path = context.stat_path
@@ -675,6 +688,7 @@ class MountEntry:
             op_name (str): operation name (e.g. "read", "stat").
             path (str): virtual path.
         """
+        await self.ensure_ready()
         filetype = (kwargs.pop("filetype")
                     if "filetype" in kwargs else get_extension(path))
         levels = self._resolve_cascade(op_name, filetype, self._ops,

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -41,7 +41,7 @@ from mirage.policy import resolve_limit
 from mirage.resource.base import BaseResource
 from mirage.types import (ConsistencyPolicy, FileType, Limit, MountMode,
                           PathSpec, Producer)
-from mirage.utils.errors import ReadOnlyError, enotsup
+from mirage.utils.errors import ReadOnlyError, ebusy, enotsup
 from mirage.utils.key_prefix import mount_key
 
 # Ops that mutate everything under their endpoints in one backend call
@@ -183,12 +183,16 @@ class MountEntry:
 
     async def ensure_ready(self) -> None:
         """Finish mount preparation before any backend or cache read."""
+        if self.retiring:
+            raise ebusy(self.prefix)
         if self.before_use is None:
             return
         async with self._ready_lock:
             if self.before_use is not None:
                 await self.before_use()
                 self.before_use = None
+        if self.retiring:
+            raise ebusy(self.prefix)
 
     def effective_mode(self) -> MountMode:
         """This mount's mode narrowed by the current session's cap.

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -148,6 +148,7 @@ class MountEntry:
         self.resource = resource
         self.mode = mode
         self.consistency = consistency
+        self.retiring = False
         self.cache_manager: CacheManager | None = None
         # Per-path revision pins installed at Workspace.load time. Read
         # functions consult these via the ``revision_for`` contextvar

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -16,7 +16,8 @@ import asyncio
 import dataclasses
 import errno
 import inspect
-from collections.abc import Awaitable, Iterable
+from collections.abc import AsyncIterator, Awaitable, Iterable
+from contextlib import asynccontextmanager
 from typing import Any, Callable
 
 from mirage.cache.context import push_cache_manager
@@ -44,6 +45,7 @@ from mirage.types import (ConsistencyPolicy, FileType, Limit, MountMode,
 from mirage.utils.errors import ReadOnlyError, ebusy, enotsup
 from mirage.utils.ids import uuid7
 from mirage.utils.key_prefix import mount_key
+from mirage.workspace.mount.activity import ResourceActivity
 
 # Ops that mutate everything under their endpoints in one backend call
 # (a directory rename relocates its whole subtree), so the door also
@@ -58,6 +60,7 @@ def _wrap_cmd_streams(
     mount_prefix: str,
     revisions: dict[str, str] | None,
     mount_id: str | None = None,
+    activity: ResourceActivity | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Wrap any async-iterator streams in ``result`` with the mount
     prefix and active revisions, so ``record_stream`` and
@@ -93,8 +96,9 @@ def _wrap_cmd_streams(
         if isinstance(obj, CachableAsyncIterator):
             obj.replace_source(wrapped)
             wrapped = obj
-        seen[oid] = wrapped
-        return wrapped
+        held = activity.hold(wrapped) if activity is not None else wrapped
+        seen[oid] = held
+        return held
 
     stream = _wrap(stream) if stream is not None else None
     for k, v in list(io.reads.items()):
@@ -104,7 +108,8 @@ def _wrap_cmd_streams(
     return stream, io
 
 
-def _wrap_op_stream(result: Any, mount_prefix: str, mount_id: str) -> Any:
+def _wrap_op_stream(result: Any, mount_prefix: str, mount_id: str,
+                    activity: ResourceActivity) -> Any:
     """Hold the host-I/O bypass around an op result that streams.
 
     An op that returns an async iterator has not run its body yet: the
@@ -121,9 +126,10 @@ def _wrap_op_stream(result: Any, mount_prefix: str, mount_id: str) -> Any:
         result.replace_source(
             with_host_io(
                 with_mount_prefix(mount_prefix, result.source, mount_id)))
-        return result
+        return activity.hold(result)
     if hasattr(result, "__aiter__"):
-        return with_host_io(with_mount_prefix(mount_prefix, result, mount_id))
+        return activity.hold(
+            with_host_io(with_mount_prefix(mount_prefix, result, mount_id)))
     return result
 
 
@@ -158,6 +164,7 @@ class MountEntry:
         self.resource = resource
         self.mode = mode
         self.consistency = consistency
+        self.activity = ResourceActivity()
         self.retiring = False
         self.before_use: Callable[[], Awaitable[None]] | None = None
         self._ready_lock = asyncio.Lock()
@@ -182,6 +189,17 @@ class MountEntry:
         self._general_ops: dict[str, RegisteredOp] = {}
         # key: (cmd_name, target_resource_type)
         self._cross_cmds: dict[tuple[Any, ...], RegisteredCommand] = {}
+
+    @asynccontextmanager
+    async def use(self) -> AsyncIterator[None]:
+        await self.ensure_ready()
+        if self.retiring:
+            raise ebusy(self.prefix)
+        release = self.activity.acquire()
+        try:
+            yield
+        finally:
+            release()
 
     @property
     def index(self) -> IndexCacheStore:
@@ -523,154 +541,156 @@ class MountEntry:
                 reads the fields it wants, so no list of command names
                 is kept here.
         """
-        await self.ensure_ready()
-        stdin = context.stdin
-        cwd = context.cwd
-        stat_path = context.stat_path
-        extension = get_extension(paths[0].virtual) if paths else None
-        # A filetype handler is selected from the operand's NAME, and a
-        # directory can carry any extension, so the cascade would hand a
-        # renderer a directory to read. One stat settles it, and only when
-        # a handler for this exact extension exists, so a mount with no
-        # filetype registrations never reaches the probe. The built-in is
-        # what a directory should get: it owns GNU's `Is a directory`
-        # wording, and the renderer owns nothing but its own format.
-        # The DISPATCHER's stat, not the backend's, so a mount root and a
-        # namespace-only directory answer too; None means neither plane
-        # saw anything, in which case the renderer reports its own miss.
-        if (extension is not None and paths and stat_path is not None
-                and (cmd_name, extension) in self._cmds):
-            entry = await stat_path(paths[0].virtual)
-            if entry is not None and entry.type == FileType.DIRECTORY:
-                extension = None
+        async with self.use():
+            stdin = context.stdin
+            cwd = context.cwd
+            stat_path = context.stat_path
+            extension = get_extension(paths[0].virtual) if paths else None
+            # A filetype handler is selected from the operand's NAME, and a
+            # directory can carry any extension, so the cascade would hand a
+            # renderer a directory to read. One stat settles it, and only when
+            # a handler for this exact extension exists, so a mount with no
+            # filetype registrations never reaches the probe. The built-in is
+            # what a directory should get: it owns GNU's `Is a directory`
+            # wording, and the renderer owns nothing but its own format.
+            # The DISPATCHER's stat, not the backend's, so a mount root and a
+            # namespace-only directory answer too; None means neither plane
+            # saw anything, in which case the renderer reports its own miss.
+            if (extension is not None and paths and stat_path is not None
+                    and (cmd_name, extension) in self._cmds):
+                entry = await stat_path(paths[0].virtual)
+                if entry is not None and entry.type == FileType.DIRECTORY:
+                    extension = None
 
-        handlers = self._resolve_cascade(cmd_name, extension, self._cmds,
-                                         self._general_cmds)
-        if not handlers:
-            return None, IOResult(
-                exit_code=127,
-                stderr=(f"{cmd_name}: command not found".encode()))
+            handlers = self._resolve_cascade(cmd_name, extension, self._cmds,
+                                             self._general_cmds)
+            if not handlers:
+                return None, IOResult(
+                    exit_code=127,
+                    stderr=(f"{cmd_name}: command not found".encode()))
 
-        mount_prefix = self.prefix.rstrip("/")
-        filetype_fns = self.filetype_handlers(cmd_name)
-        is_filetype_cmd = extension is not None and (cmd_name,
-                                                     extension) in self._cmds
+            mount_prefix = self.prefix.rstrip("/")
+            filetype_fns = self.filetype_handlers(cmd_name)
+            is_filetype_cmd = extension is not None and (
+                cmd_name, extension) in self._cmds
 
-        paths = [
-            dataclasses.replace(
-                p, resource_path=mount_key(p.virtual, mount_prefix))
-            if isinstance(p, PathSpec) else p for p in paths
-        ]
+            paths = [
+                dataclasses.replace(
+                    p, resource_path=mount_key(p.virtual, mount_prefix))
+                if isinstance(p, PathSpec) else p for p in paths
+            ]
 
-        # Stamp this mount's backend key onto path-shaped flag values so
-        # backend reads can address them: a single PathSpec (e.g. awk -f,
-        # single grep -f) or a list of PathSpec (multiple grep -f).
-        # Everything else (bools, strings, list[str] like repeated -e) is
-        # not a path and passes through unchanged.
-        flags: dict[str, FlagValue] = {}
-        for k, v in flag_kwargs.items():
-            if isinstance(v, PathSpec):
-                flags[k] = dataclasses.replace(v,
-                                               resource_path=mount_key(
-                                                   v.virtual, mount_prefix))
-            elif isinstance(v, list) and v and all(
-                    isinstance(item, PathSpec) for item in v):
-                specs = [item for item in v if isinstance(item, PathSpec)]
-                flags[k] = [
-                    dataclasses.replace(item,
-                                        resource_path=mount_key(
-                                            item.virtual, mount_prefix))
-                    for item in specs
-                ]
-            else:
-                flags[k] = v
-        # One typed bag, constructed here and nowhere else; a handler
-        # reads the fields it wants and ignores the rest, so there is no
-        # opt-in registry (mirrors Mount.executeCmd building CommandOpts).
-        opts = CommandOpts(
-            stdin=stdin,
-            flags=flags,
-            cwd=PathSpec(
-                virtual=cwd,
-                directory=cwd,
-                resolved=False,
-                resource_path=mount_key(cwd, mount_prefix),
-            ),
-            mount_prefix=mount_prefix,
-            filetype_fns=(filetype_fns if not is_filetype_cmd else None),
-            index=self.index,
-            dispatch=context.dispatch,
-            session_id=context.session_id,
-            env=context.env,
-            exec_allowed=context.exec_allowed,
-            exec_path_allowed=context.exec_path_allowed,
-            runtime=context.runtime,
-            runtime_unavailable=context.runtime_unavailable,
-            ns=context.ns,
-            stat_path=stat_path,
-            readdir_path=context.readdir_path,
-            session_view=context.session_view,
-        )
+            # Stamp this mount's backend key onto path-shaped flag values so
+            # backend reads can address them: a single PathSpec (e.g. awk -f,
+            # single grep -f) or a list of PathSpec (multiple grep -f).
+            # Everything else (bools, strings, list[str] like repeated -e) is
+            # not a path and passes through unchanged.
+            flags: dict[str, FlagValue] = {}
+            for k, v in flag_kwargs.items():
+                if isinstance(v, PathSpec):
+                    flags[k] = dataclasses.replace(v,
+                                                   resource_path=mount_key(
+                                                       v.virtual,
+                                                       mount_prefix))
+                elif isinstance(v, list) and v and all(
+                        isinstance(item, PathSpec) for item in v):
+                    specs = [item for item in v if isinstance(item, PathSpec)]
+                    flags[k] = [
+                        dataclasses.replace(item,
+                                            resource_path=mount_key(
+                                                item.virtual, mount_prefix))
+                        for item in specs
+                    ]
+                else:
+                    flags[k] = v
+            # One typed bag, constructed here and nowhere else; a handler
+            # reads the fields it wants and ignores the rest, so there is no
+            # opt-in registry (mirrors Mount.executeCmd building CommandOpts).
+            opts = CommandOpts(
+                stdin=stdin,
+                flags=flags,
+                cwd=PathSpec(
+                    virtual=cwd,
+                    directory=cwd,
+                    resolved=False,
+                    resource_path=mount_key(cwd, mount_prefix),
+                ),
+                mount_prefix=mount_prefix,
+                filetype_fns=(filetype_fns if not is_filetype_cmd else None),
+                index=self.index,
+                dispatch=context.dispatch,
+                session_id=context.session_id,
+                env=context.env,
+                exec_allowed=context.exec_allowed,
+                exec_path_allowed=context.exec_path_allowed,
+                runtime=context.runtime,
+                runtime_unavailable=context.runtime_unavailable,
+                ns=context.ns,
+                stat_path=stat_path,
+                readdir_path=context.readdir_path,
+                session_view=context.session_view,
+            )
 
-        recording_token = push_mount_context(mount_prefix, self.mount_id)
-        revs_token = push_revisions(self.revisions or None)
-        prev_manager = push_cache_manager(self.cache_manager)
-        # What the command tier's mode guard reads: the write-command
-        # gate below admits a command when any shown subtree grants
-        # writes, and this binding is how each write the handler then
-        # makes is held to its own region's mode.
-        gate_token = set_mount_gate(self.prefix, self.mode)
-        try:
-            # --help / --version short-circuit inside the handler wrapper
-            # and never touch the backend, so a read-only mount answers
-            # them like GNU instead of refusing them as writes.
-            info_only = (flags.get("help") is True
-                         or flags.get("version") is True)
-            for cmd in handlers:
-                # strongest_mode_under, not effective_mode: a mount
-                # whose only writable region is a show entry still runs
-                # the command, and the op door refuses per path. The
-                # trailing newline is load-bearing: stderr accumulates
-                # across a line, so two refusals in one list ran
-                # together as `...at /ro/rm: read-only mount at /ro/`,
-                # and the node table's twin of this refusal (a symlink
-                # `rm`, rendered by shared.read_only_error) concatenates
-                # with it.
-                if (cmd.write and not info_only and strongest_mode_under(
-                        self.prefix, self.mode) == MountMode.READ):
-                    return None, IOResult(
-                        exit_code=1,
-                        stderr=(f"{cmd_name}: read-only mount "
-                                f"at {self.prefix}\n".encode()))
-                # The dispatch-level guard only sees default limits
-                # (the mount is unknown before routing), so the
-                # mount-resolved timeout must also bound the command
-                # body: eager commands do their work inside cmd.fn,
-                # where the stream-consumption guard never runs.
-                resolved_limit = resolve_limit(
-                    cmd_name,
-                    command_default=cmd.limit,
-                    mount_override=self.command_limits.get(cmd_name))
-                cmd_timeout = (resolved_limit.timeout_seconds
-                               if resolved_limit is not None else None)
-                with host_io():
-                    result = await run_with_timeout(
-                        cmd.fn(self.resource.accessor, paths, texts, opts),
-                        cmd_timeout, cmd_name)
-                if result is not None:
-                    stream, io = _wrap_cmd_streams(result, mount_prefix,
-                                                   self.revisions or None,
-                                                   self.mount_id)
-                    io.producer = Producer(command=cmd_name,
-                                           prefixes=(self.prefix, ),
-                                           declared=cmd.limit)
-                    return stream, io
-            return None, IOResult()
-        finally:
-            reset_mount_gate(gate_token)
-            reset_revisions(revs_token)
-            reset_active_recorder(recording_token)
-            push_cache_manager(prev_manager)
+            recording_token = push_mount_context(mount_prefix, self.mount_id)
+            revs_token = push_revisions(self.revisions or None)
+            prev_manager = push_cache_manager(self.cache_manager)
+            # What the command tier's mode guard reads: the write-command
+            # gate below admits a command when any shown subtree grants
+            # writes, and this binding is how each write the handler then
+            # makes is held to its own region's mode.
+            gate_token = set_mount_gate(self.prefix, self.mode)
+            try:
+                # --help / --version short-circuit inside the handler wrapper
+                # and never touch the backend, so a read-only mount answers
+                # them like GNU instead of refusing them as writes.
+                info_only = (flags.get("help") is True
+                             or flags.get("version") is True)
+                for cmd in handlers:
+                    # strongest_mode_under, not effective_mode: a mount
+                    # whose only writable region is a show entry still runs
+                    # the command, and the op door refuses per path. The
+                    # trailing newline is load-bearing: stderr accumulates
+                    # across a line, so two refusals in one list ran
+                    # together as `...at /ro/rm: read-only mount at /ro/`,
+                    # and the node table's twin of this refusal (a symlink
+                    # `rm`, rendered by shared.read_only_error) concatenates
+                    # with it.
+                    if (cmd.write and not info_only and strongest_mode_under(
+                            self.prefix, self.mode) == MountMode.READ):
+                        return None, IOResult(
+                            exit_code=1,
+                            stderr=(f"{cmd_name}: read-only mount "
+                                    f"at {self.prefix}\n".encode()))
+                    # The dispatch-level guard only sees default limits
+                    # (the mount is unknown before routing), so the
+                    # mount-resolved timeout must also bound the command
+                    # body: eager commands do their work inside cmd.fn,
+                    # where the stream-consumption guard never runs.
+                    resolved_limit = resolve_limit(
+                        cmd_name,
+                        command_default=cmd.limit,
+                        mount_override=self.command_limits.get(cmd_name))
+                    cmd_timeout = (resolved_limit.timeout_seconds
+                                   if resolved_limit is not None else None)
+                    with host_io():
+                        result = await run_with_timeout(
+                            cmd.fn(self.resource.accessor, paths, texts, opts),
+                            cmd_timeout, cmd_name)
+                    if result is not None:
+                        stream, io = _wrap_cmd_streams(result, mount_prefix,
+                                                       self.revisions or None,
+                                                       self.mount_id,
+                                                       self.activity)
+                        io.producer = Producer(command=cmd_name,
+                                               prefixes=(self.prefix, ),
+                                               declared=cmd.limit)
+                        return stream, io
+                return None, IOResult()
+            finally:
+                reset_mount_gate(gate_token)
+                reset_revisions(revs_token)
+                reset_active_recorder(recording_token)
+                push_cache_manager(prev_manager)
 
     def supports_op(self, op_name: str, path: str) -> bool:
         """Report whether an op would resolve for a path on this mount.
@@ -708,72 +728,75 @@ class MountEntry:
             op_name (str): operation name (e.g. "read", "stat").
             path (str): virtual path.
         """
-        await self.ensure_ready()
-        filetype = (kwargs.pop("filetype")
-                    if "filetype" in kwargs else get_extension(path))
-        levels = self._resolve_cascade(op_name, filetype, self._ops,
-                                       self._general_ops)
-        if not levels:
-            raise enotsup(str(self.resource.name), op_name, path)
+        async with self.use():
+            filetype = (kwargs.pop("filetype")
+                        if "filetype" in kwargs else get_extension(path))
+            levels = self._resolve_cascade(op_name, filetype, self._ops,
+                                           self._general_ops)
+            if not levels:
+                raise enotsup(str(self.resource.name), op_name, path)
 
-        if any(o.write for o in levels):
-            # GNU reports the operand, not the guard's own wording, so
-            # stamp errno + filename and let format_fs_error render
-            # "<cmd>: <path>: Read-only file system" (mirrors the
-            # TypeScript erofsReadOnly stamp). Per path, not per mount:
-            # a show entry can hold one subtree below `w` on a writable
-            # mount, or one writable region on a read mount. A rename
-            # mutates its destination too, so both endpoints answer,
-            # and it relocates whole subtrees in one call, so a
-            # read-only region below either endpoint refuses it too.
-            if effective_path_mode(path, self.prefix,
-                                   self.mode) == MountMode.READ:
-                raise ReadOnlyError(errno.EROFS, "Read-only file system", path)
-            dst = kwargs.get("dst")
-            if isinstance(dst, PathSpec) and effective_path_mode(
-                    dst.virtual, self.prefix, self.mode) == MountMode.READ:
-                raise ReadOnlyError(errno.EROFS, "Read-only file system",
-                                    dst.virtual)
-            if op_name in _SUBTREE_OPS:
-                endpoints = [path]
-                if isinstance(dst, PathSpec):
-                    endpoints.append(dst.virtual)
-                for endpoint in endpoints:
-                    blame = readonly_below(endpoint, self.prefix, self.mode)
-                    if blame is not None:
-                        raise ReadOnlyError(errno.EROFS,
-                                            "Read-only file system", blame)
+            if any(o.write for o in levels):
+                # GNU reports the operand, not the guard's own wording, so
+                # stamp errno + filename and let format_fs_error render
+                # "<cmd>: <path>: Read-only file system" (mirrors the
+                # TypeScript erofsReadOnly stamp). Per path, not per mount:
+                # a show entry can hold one subtree below `w` on a writable
+                # mount, or one writable region on a read mount. A rename
+                # mutates its destination too, so both endpoints answer,
+                # and it relocates whole subtrees in one call, so a
+                # read-only region below either endpoint refuses it too.
+                if effective_path_mode(path, self.prefix,
+                                       self.mode) == MountMode.READ:
+                    raise ReadOnlyError(errno.EROFS, "Read-only file system",
+                                        path)
+                dst = kwargs.get("dst")
+                if isinstance(dst, PathSpec) and effective_path_mode(
+                        dst.virtual, self.prefix, self.mode) == MountMode.READ:
+                    raise ReadOnlyError(errno.EROFS, "Read-only file system",
+                                        dst.virtual)
+                if op_name in _SUBTREE_OPS:
+                    endpoints = [path]
+                    if isinstance(dst, PathSpec):
+                        endpoints.append(dst.virtual)
+                    for endpoint in endpoints:
+                        blame = readonly_below(endpoint, self.prefix,
+                                               self.mode)
+                        if blame is not None:
+                            raise ReadOnlyError(errno.EROFS,
+                                                "Read-only file system", blame)
 
-        mount_prefix = self.prefix.rstrip("/")
-        scope = PathSpec(
-            virtual=path,
-            directory=path.rsplit("/", 1)[0] or "/",
-            resource_path=mount_key(path, mount_prefix),
-        )
-        kwargs.setdefault("index", self.index)
-        # Per-op caps are policy and fire at the op doors (post_ops);
-        # only the timeout stays here, bounding the backend call itself.
-        op_override = self.command_limits.get(op_name)
-        op_timeout = (op_override.timeout_seconds
-                      if op_override is not None else None)
-        recording_token = push_mount_context(mount_prefix, self.mount_id)
-        revs_token = push_revisions(self.revisions or None)
-        try:
-            for op in levels:
-                # The backend's own paths are host paths, so the process
-                # patch (ops/os_patch.py, ops/open.py) must not answer
-                # them: a disk mount rooted at its own virtual prefix
-                # spells the two the same, and routing the physical one
-                # hands the op back to the backend serving it.
-                with host_io():
-                    result = op.fn(self.resource.accessor, scope, *args,
-                                   **kwargs)
-                    if inspect.isawaitable(result):
-                        result = await run_with_timeout(
-                            result, op_timeout, op_name)
-                if result is not None:
-                    return _wrap_op_stream(result, mount_prefix, self.mount_id)
-            return None
-        finally:
-            reset_revisions(revs_token)
-            reset_active_recorder(recording_token)
+            mount_prefix = self.prefix.rstrip("/")
+            scope = PathSpec(
+                virtual=path,
+                directory=path.rsplit("/", 1)[0] or "/",
+                resource_path=mount_key(path, mount_prefix),
+            )
+            kwargs.setdefault("index", self.index)
+            # Per-op caps are policy and fire at the op doors (post_ops);
+            # only the timeout stays here, bounding the backend call itself.
+            op_override = self.command_limits.get(op_name)
+            op_timeout = (op_override.timeout_seconds
+                          if op_override is not None else None)
+            recording_token = push_mount_context(mount_prefix, self.mount_id)
+            revs_token = push_revisions(self.revisions or None)
+            try:
+                for op in levels:
+                    # The backend's own paths are host paths, so the process
+                    # patch (ops/os_patch.py, ops/open.py) must not answer
+                    # them: a disk mount rooted at its own virtual prefix
+                    # spells the two the same, and routing the physical one
+                    # hands the op back to the backend serving it.
+                    with host_io():
+                        result = op.fn(self.resource.accessor, scope, *args,
+                                       **kwargs)
+                        if inspect.isawaitable(result):
+                            result = await run_with_timeout(
+                                result, op_timeout, op_name)
+                    if result is not None:
+                        return _wrap_op_stream(result, mount_prefix,
+                                               self.mount_id, self.activity)
+                return None
+            finally:
+                reset_revisions(revs_token)
+                reset_active_recorder(recording_token)

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -20,6 +20,7 @@ from collections.abc import Awaitable, Iterable
 from typing import Any, Callable
 
 from mirage.cache.context import push_cache_manager
+from mirage.cache.index.store import IndexCacheStore
 from mirage.cache.manager import CacheManager
 from mirage.commands.builtin.utils.limit import run_with_timeout
 from mirage.commands.config import CommandOpts, ExecContext, RegisteredCommand
@@ -173,6 +174,12 @@ class MountEntry:
         self._general_ops: dict[str, RegisteredOp] = {}
         # key: (cmd_name, target_resource_type)
         self._cross_cmds: dict[tuple[Any, ...], RegisteredCommand] = {}
+
+    @property
+    def index(self) -> IndexCacheStore:
+        index = self.resource.index
+        return self.cache_manager.scope_index(
+            index) if self.cache_manager else index
 
     async def ensure_ready(self) -> None:
         """Finish mount preparation before any backend or cache read."""
@@ -579,7 +586,7 @@ class MountEntry:
             ),
             mount_prefix=mount_prefix,
             filetype_fns=(filetype_fns if not is_filetype_cmd else None),
-            index=self.resource.index,
+            index=self.index,
             dispatch=context.dispatch,
             session_id=context.session_id,
             env=context.env,
@@ -730,7 +737,7 @@ class MountEntry:
             directory=path.rsplit("/", 1)[0] or "/",
             resource_path=mount_key(path, mount_prefix),
         )
-        kwargs.setdefault("index", self.resource.index)
+        kwargs.setdefault("index", self.index)
         # Per-op caps are policy and fire at the op doors (post_ops);
         # only the timeout stays here, bounding the backend call itself.
         op_override = self.command_limits.get(op_name)

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -201,6 +201,16 @@ class MountEntry:
         finally:
             release()
 
+    async def expand_glob(self, paths: list[PathSpec],
+                          prefix: str) -> list[PathSpec]:
+        """Keep the resource open and prepared while its glob hook runs."""
+        async with self.use():
+            if self.cache_manager is None:
+                return await self.resource.resolve_glob(paths, prefix=prefix)
+            async with self.cache_manager.mutation():
+                await self.ensure_ready()
+                return await self.resource.resolve_glob(paths, prefix=prefix)
+
     @property
     def index(self) -> IndexCacheStore:
         index = self.resource.index

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -141,7 +141,8 @@ class MountRegistry:
 
     def _attach_manager(self, m: MountEntry) -> None:
         m.cache_manager = CacheManager(self._file_cache, m.resource.index,
-                                       m.prefix, m.resource.caches_reads)
+                                       m.prefix, m.resource.caches_reads,
+                                       lambda: not m.retiring)
 
     def mount(
         self,

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -70,6 +70,7 @@ class MountRegistry:
 
     def __init__(self) -> None:
         self._mounts: list[MountEntry] = []
+        self.retiring_resources: set[int] = set()
         self._root: MountEntry | None = None
         # Workspace-level command -> runtime bindings (first listed
         # capturer wins), set by Workspace after construction (same
@@ -140,9 +141,16 @@ class MountRegistry:
             self._attach_manager(m)
 
     def _attach_manager(self, m: MountEntry) -> None:
-        m.cache_manager = CacheManager(self._file_cache, m.resource.index,
-                                       m.prefix, m.resource.caches_reads,
-                                       lambda: not m.retiring)
+        m.cache_manager = CacheManager(
+            self._file_cache, m.resource.index, m.prefix,
+            m.resource.caches_reads,
+            lambda path: not m.retiring and self.try_mount_for(path) is m)
+
+    def check_resource_available(self, resource: BaseResource) -> None:
+        """Refuse reuse until the previous lifecycle has finished closing."""
+        if id(resource) in self.retiring_resources or any(
+                m.resource is resource and m.retiring for m in self._mounts):
+            raise ValueError("resource is being unmounted")
 
     def mount(
         self,
@@ -152,6 +160,7 @@ class MountRegistry:
         consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY,
     ) -> MountEntry:
         """Mount a resource and return the Mount object."""
+        self.check_resource_available(resource)
         stripped = prefix.strip("/")
         norm_prefix = ("/" + stripped + "/" if stripped else "/")
         for existing in self._mounts:

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -14,6 +14,7 @@
 
 import asyncio
 from typing import Protocol
+from weakref import WeakValueDictionary
 
 from mirage.cache.file.mixin import FileCacheMixin
 from mirage.cache.manager import CacheManager
@@ -72,6 +73,8 @@ class MountRegistry:
     def __init__(self) -> None:
         self._mounts: list[MountEntry] = []
         self.retiring_resources: dict[int, asyncio.Task[None]] = {}
+        self.retired_resources: WeakValueDictionary[int, BaseResource] = (
+            WeakValueDictionary())
         self._root: MountEntry | None = None
         # Workspace-level command -> runtime bindings (first listed
         # capturer wins), set by Workspace after construction (same
@@ -148,10 +151,14 @@ class MountRegistry:
             lambda path: not m.retiring and self.try_mount_for(path) is m)
 
     def check_resource_available(self, resource: BaseResource) -> None:
-        """Refuse reuse until the previous lifecycle has finished closing."""
+        """A removed resource instance cannot start a second lifecycle."""
         if id(resource) in self.retiring_resources or any(
                 m.resource is resource and m.retiring for m in self._mounts):
             raise ValueError("resource is being unmounted")
+        if (resource.is_closed
+                or self.retired_resources.get(id(resource)) is resource):
+            raise ValueError(
+                "resource is closed; create a new resource instance")
 
     def mount(
         self,
@@ -169,6 +176,10 @@ class MountRegistry:
                 raise ValueError(f"duplicate mount prefix: "
                                  f"{norm_prefix!r}")
         m = MountEntry(norm_prefix, resource, mode, consistency)
+        for existing in self._mounts:
+            if existing.resource is resource:
+                m.activity = existing.activity
+                break
         for cmd in resource.commands():
             m.register(cmd)
         for cmd in GENERAL_COMMANDS:

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 from typing import Protocol
 
 from mirage.cache.file.mixin import FileCacheMixin
@@ -70,7 +71,7 @@ class MountRegistry:
 
     def __init__(self) -> None:
         self._mounts: list[MountEntry] = []
-        self.retiring_resources: set[int] = set()
+        self.retiring_resources: dict[int, asyncio.Task[None]] = {}
         self._root: MountEntry | None = None
         # Workspace-level command -> runtime bindings (first listed
         # capturer wins), set by Workspace after construction (same
@@ -413,6 +414,7 @@ class MountRegistry:
         if mount is None:
             return None
 
+        await mount.ensure_ready()
         resolved = mount.resolve_command(cmd_name)
         # Warm reads are served in place by with_read_cache, so a read-only
         # command stays on its real mount. Single-mount reads do not go

--- a/python/mirage/workspace/provision/command.py
+++ b/python/mirage/workspace/provision/command.py
@@ -144,60 +144,61 @@ async def handle_command_provision(
                                    precision=Precision.UNKNOWN)
         mount = mounts[0]
 
-    await mount.ensure_ready()
-    extension = get_extension(first_scope.virtual) if first_scope else None
-    cmd = mount.resolve_command(cmd_name, extension)
-    if cmd is None or cmd.provision_fn is None:
-        return ProvisionResult(command=cmd_str, precision=Precision.UNKNOWN)
+    async with mount.use():
+        extension = get_extension(first_scope.virtual) if first_scope else None
+        cmd = mount.resolve_command(cmd_name, extension)
+        if cmd is None or cmd.provision_fn is None:
+            return ProvisionResult(command=cmd_str,
+                                   precision=Precision.UNKNOWN)
 
-    mount_prefix = mount.prefix.rstrip("/")
-    resource_scopes = []
-    for i, p in enumerate(parts[1:], start=1):
-        if isinstance(p, PathSpec):
-            scoped = dataclasses.replace(p,
-                                         resource_path=mount_key(
-                                             p.virtual, mount_prefix))
-            parts[i] = scoped
-            resource_scopes.append(scoped)
+        mount_prefix = mount.prefix.rstrip("/")
+        resource_scopes = []
+        for i, p in enumerate(parts[1:], start=1):
+            if isinstance(p, PathSpec):
+                scoped = dataclasses.replace(p,
+                                             resource_path=mount_key(
+                                                 p.virtual, mount_prefix))
+                parts[i] = scoped
+                resource_scopes.append(scoped)
 
-    # Parse flags so plan functions receive them as kwargs (e.g. r=True)
-    argv = [p.virtual if isinstance(p, PathSpec) else p for p in parts[1:]]
-    spec = mount.spec_for(cmd_name)
-    if spec is not None:
-        parsed = parse_command(spec, argv, cwd=session.cwd)
-        flag_kwargs = parse_to_kwargs(parsed)
-        text_args = parsed.texts()
-    else:
-        flag_kwargs = {}
-        text_args = [p for p in parts[1:] if not isinstance(p, PathSpec)]
+        # Parse flags so plan functions receive them as kwargs (e.g. r=True)
+        argv = [p.virtual if isinstance(p, PathSpec) else p for p in parts[1:]]
+        spec = mount.spec_for(cmd_name)
+        if spec is not None:
+            parsed = parse_command(spec, argv, cwd=session.cwd)
+            flag_kwargs = parse_to_kwargs(parsed)
+            text_args = parsed.texts()
+        else:
+            flag_kwargs = {}
+            text_args = [p for p in parts[1:] if not isinstance(p, PathSpec)]
 
-    # One typed bag, the provision-path twin of Mount.execute_cmd's
-    # (mirrors handleCommandProvision building CommandOpts in TS),
-    # promoting cwd the same way: CommandOpts.cwd is always a PathSpec.
-    opts = CommandOpts(
-        flags=flag_kwargs,
-        cwd=PathSpec(
-            virtual=session.cwd,
-            directory=session.cwd,
-            resolved=False,
-            resource_path=mount_key(session.cwd, mount_prefix),
-        ),
-        mount_prefix=mount_prefix,
-        command=cmd_str,
-        spec=spec,
-        index=mount.index,
-    )
-    result = await cmd.provision_fn(mount.resource.accessor, resource_scopes,
-                                    text_args, opts)
-    if not result.command:
-        result.command = cmd_str
+        # One typed bag, the provision-path twin of Mount.execute_cmd's
+        # (mirrors handleCommandProvision building CommandOpts in TS),
+        # promoting cwd the same way: CommandOpts.cwd is always a PathSpec.
+        opts = CommandOpts(
+            flags=flag_kwargs,
+            cwd=PathSpec(
+                virtual=session.cwd,
+                directory=session.cwd,
+                resolved=False,
+                resource_path=mount_key(session.cwd, mount_prefix),
+            ),
+            mount_prefix=mount_prefix,
+            command=cmd_str,
+            spec=spec,
+            index=mount.index,
+        )
+        result = await cmd.provision_fn(mount.resource.accessor,
+                                        resource_scopes, text_args, opts)
+        if not result.command:
+            result.command = cmd_str
 
-    hits = await _check_cache_hits(registry.file_cache, parts)
-    if hits > 0:
-        result.cache_hits = hits
-        result.cache_read_low = result.network_read_low
-        result.cache_read_high = result.network_read_high
-        result.network_read_low = 0
-        result.network_read_high = 0
+        hits = await _check_cache_hits(registry.file_cache, parts)
+        if hits > 0:
+            result.cache_hits = hits
+            result.cache_read_low = result.network_read_low
+            result.cache_read_high = result.network_read_high
+            result.network_read_low = 0
+            result.network_read_high = 0
 
-    return result
+        return result

--- a/python/mirage/workspace/provision/command.py
+++ b/python/mirage/workspace/provision/command.py
@@ -144,6 +144,7 @@ async def handle_command_provision(
                                    precision=Precision.UNKNOWN)
         mount = mounts[0]
 
+    await mount.ensure_ready()
     extension = get_extension(first_scope.virtual) if first_scope else None
     cmd = mount.resolve_command(cmd_name, extension)
     if cmd is None or cmd.provision_fn is None:
@@ -184,7 +185,7 @@ async def handle_command_provision(
         mount_prefix=mount_prefix,
         command=cmd_str,
         spec=spec,
-        index=mount.resource.index,
+        index=mount.index,
     )
     result = await cmd.provision_fn(mount.resource.accessor, resource_scopes,
                                     text_args, opts)

--- a/python/mirage/workspace/session/manager.py
+++ b/python/mirage/workspace/session/manager.py
@@ -359,6 +359,12 @@ class SessionManager:
             async with self._locks[session.session_id]:
                 await self._flush_one(session)
 
+    async def settle(self) -> None:
+        """Wait for admitted session writes before their store closes."""
+        for lock in list(self._locks.values()):
+            async with lock:
+                pass
+
     async def _flush_one(self, session: Session) -> None:
         """Persist one session, retrying when another writer races us."""
         sid = session.session_id

--- a/python/mirage/workspace/session/manager.py
+++ b/python/mirage/workspace/session/manager.py
@@ -428,6 +428,20 @@ class SessionManager:
     def get(self, session_id: str) -> Session:
         return self._sessions[session_id]
 
+    def set_profile(self, session_id: str,
+                    compiled: CompiledProfile) -> Session:
+        """Replace restrictions without resetting the session's scratch state.
+
+        Args:
+            session_id (str): an existing, hydrated session.
+            compiled (CompiledProfile): its replacement profile.
+        """
+        session = self.get(session_id)
+        narrow(session, compiled)
+        if session_id == self._default_id:
+            self._default_profile = compiled
+        return session
+
     def list(self) -> list[Session]:
         return list(self._sessions.values())
 

--- a/python/mirage/workspace/session/manager.py
+++ b/python/mirage/workspace/session/manager.py
@@ -356,7 +356,8 @@ class SessionManager:
     async def flush(self) -> None:
         """Write dirty sessions through the store's generation gate."""
         for session in list(self._sessions.values()):
-            await self._flush_one(session)
+            async with self._locks[session.session_id]:
+                await self._flush_one(session)
 
     async def _flush_one(self, session: Session) -> None:
         """Persist one session, retrying when another writer races us."""
@@ -428,19 +429,24 @@ class SessionManager:
     def get(self, session_id: str) -> Session:
         return self._sessions[session_id]
 
-    def set_profile(self, session_id: str,
-                    compiled: CompiledProfile) -> Session:
+    async def set_profile(self, session_id: str,
+                          compiled: CompiledProfile) -> Session:
         """Replace restrictions without resetting the session's scratch state.
 
         Args:
             session_id (str): an existing, hydrated session.
             compiled (CompiledProfile): its replacement profile.
         """
-        session = self.get(session_id)
-        narrow(session, compiled)
-        if session_id == self._default_id:
-            self._default_profile = compiled
-        return session
+        async with self._locks[session_id]:
+            session = self.get(session_id)
+            candidate = copy.copy(session)
+            narrow(candidate, compiled)
+            await self._flush_one(candidate)
+            narrow(session, compiled)
+            session.generation = candidate.generation
+            if session_id == self._default_id:
+                self._default_profile = compiled
+            return session
 
     def list(self) -> list[Session]:
         return list(self._sessions.values())

--- a/python/mirage/workspace/snapshot/drift.py
+++ b/python/mirage/workspace/snapshot/drift.py
@@ -147,10 +147,11 @@ def capture_fingerprints(ws: "Workspace", ) -> list[dict[str, Any]]:
             continue
         if rec.fingerprint is None and rec.revision is None:
             continue
-        seen.add(rec.path)
         mount = ws._registry.try_mount_for(rec.path)
-        if mount is None:
+        if mount is None or (rec.mount_id is not None
+                             and rec.mount_id != mount.mount_id):
             continue
+        seen.add(rec.path)
         if not getattr(mount.resource, "SUPPORTS_SNAPSHOT", False):
             continue
         entry: dict[str, Any] = {

--- a/python/mirage/workspace/snapshot/drift.py
+++ b/python/mirage/workspace/snapshot/drift.py
@@ -66,7 +66,7 @@ class DriftQueue:
     """
 
     def __init__(self) -> None:
-        self._entries: list[tuple[str, str]] = []
+        self._entries: list[tuple[str, str, str | None]] = []
         self._pending = False
 
     @property
@@ -76,16 +76,20 @@ class DriftQueue:
     @property
     def paths(self) -> list[str]:
         """Paths still queued for a check (audit surface)."""
-        return [path for path, _ in self._entries]
+        return [path for path, _, _ in self._entries]
 
-    def queue(self, path: str, fingerprint: str) -> None:
+    def queue(self,
+              path: str,
+              fingerprint: str,
+              mount_id: str | None = None) -> None:
         """Record one path to check against its live source.
 
         Args:
             path (str): virtual path recorded in the snapshot.
             fingerprint (str): marker the snapshot recorded for it.
+            mount_id (str | None): identity of the mount being restored.
         """
-        self._entries.append((path, fingerprint))
+        self._entries.append((path, fingerprint, mount_id))
         self._pending = True
 
     async def drain(self, mount_for: TryMountFor) -> None:
@@ -107,8 +111,8 @@ class DriftQueue:
         if not self._entries:
             return
         checks = [
-            check_drift(mount_for, path, fingerprint)
-            for path, fingerprint in self._entries
+            check_drift(mount_for, path, fingerprint, mount_id)
+            for path, fingerprint, mount_id in self._entries
         ]
         self._entries.clear()
         results = await asyncio.gather(*checks, return_exceptions=True)
@@ -198,7 +202,7 @@ def install_fingerprints(
             continue
         fingerprint = f.get(FingerprintKey.FINGERPRINT)
         if fingerprint is not None:
-            ws._drift.queue(path, fingerprint)
+            ws._drift.queue(path, fingerprint, mount.mount_id)
 
 
 def live_only_mount_prefixes(ws: "Workspace", ) -> list[str]:
@@ -223,8 +227,10 @@ def live_only_mount_prefixes(ws: "Workspace", ) -> list[str]:
     return out
 
 
-async def check_drift(mount_for: TryMountFor, path: str,
-                      recorded: str) -> None:
+async def check_drift(mount_for: TryMountFor,
+                      path: str,
+                      recorded: str,
+                      mount_id: str | None = None) -> None:
     """Stat `path` against its mount and raise ContentDriftError if the
     live fingerprint does not match `recorded`.
 
@@ -236,19 +242,24 @@ async def check_drift(mount_for: TryMountFor, path: str,
             mount, None for none.
         path (str): Virtual path to check.
         recorded (str): Fingerprint recorded at snapshot time.
+        mount_id (str | None): instance that owns the queued check.
 
     Raises:
         ContentDriftError: live fingerprint differs from recorded.
     """
     mount = mount_for(path)
-    if mount is None:
+    if mount is None or (mount_id is not None and mount.mount_id != mount_id):
         return
     if not getattr(mount.resource, "SUPPORTS_SNAPSHOT", False):
         return
     try:
         stat = await mount.execute_op("stat", path)
     except FileNotFoundError as exc:
+        if mount_for(path) is not mount:
+            return
         raise ContentDriftError(path, recorded, None) from exc
+    if mount_for(path) is not mount:
+        return
     live = getattr(stat, "fingerprint", None)
     if live is None:
         return

--- a/python/mirage/workspace/snapshot/state.py
+++ b/python/mirage/workspace/snapshot/state.py
@@ -143,8 +143,11 @@ def cli_spec_from_entry(entry: dict[str, Any]) -> str | CLISpec:
 async def to_state_dict(ws) -> dict[str, Any]:
     auto_prefixes = {"/dev/", norm_mount_prefix(HISTORY_PREFIX)}
 
+    mounted = ws._registry.mounts()
+    for mount in mounted:
+        await mount.ensure_ready()
     mounts_state = []
-    for idx, m in enumerate(mt for mt in ws._registry.mounts()
+    for idx, m in enumerate(mt for mt in mounted
                             if mt.prefix not in auto_prefixes):
         mounts_state.append({
             MountKey.INDEX: idx,
@@ -182,6 +185,8 @@ async def to_state_dict(ws) -> dict[str, Any]:
         if j.status != JobStatus.RUNNING
     ]
 
+    if mounted != ws._registry.mounts() or any(m.retiring for m in mounted):
+        raise RuntimeError("mounts changed during snapshot")
     fingerprints = capture_fingerprints(ws)
     live_only_mounts = live_only_mount_prefixes(ws)
 

--- a/python/mirage/workspace/types.py
+++ b/python/mirage/workspace/types.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import Any
 
 from mirage.observe import OpRecord
@@ -59,5 +59,5 @@ class ExecutionNode:
         if self.children:
             d["children"] = [c.to_dict() for c in self.children]
         if self.records:
-            d["records"] = [asdict(r) for r in self.records]
+            d["records"] = [r.to_dict() for r in self.records]
         return d

--- a/python/mirage/workspace/workspace/execute.py
+++ b/python/mirage/workspace/workspace/execute.py
@@ -168,6 +168,7 @@ async def execute_line(
     """
     if cancel is not None and cancel.is_set():
         raise MirageAbortError()
+    cacheable = ws._dispatcher.capture_cacheable_paths()
     await ws._namespace.ensure_loaded()
     await ws._meta.ensure()
     await ws._session_mgr.ensure_loaded()
@@ -368,7 +369,7 @@ async def execute_line(
         if io.refusal is None:
             io.refusal = nested.latest
         session.last_exit_code = io.exit_code
-        await ws.apply_io(io, records=scope.records)
+        await ws.apply_io(io, records=scope.records, is_cacheable=cacheable)
         return io
     except CommandTimeoutError as exc:
         logger.debug("command %r timed out after %ss", exc.command,

--- a/python/mirage/workspace/workspace/lifecycle.py
+++ b/python/mirage/workspace/workspace/lifecycle.py
@@ -134,6 +134,9 @@ async def close_async(ws: "Workspace", ) -> None:
     Args:
         ws: the workspace being closed.
     """
+    # Stop lifecycle mutations before teardown yields or captures its close
+    # lists. Keep _closed separate so runtime journals can still dispatch.
+    ws._closing = True
     async with ws._close_lock:
         if ws._async_closed:
             return

--- a/python/mirage/workspace/workspace/lifecycle.py
+++ b/python/mirage/workspace/workspace/lifecycle.py
@@ -148,6 +148,13 @@ async def close_async(ws: "Workspace", ) -> None:
         await ws._script_policy.close()
         for line_runtime in ws._runtimes.entries:
             await line_runtime.close()
+        retirements = await asyncio.gather(
+            *(asyncio.shield(task)
+              for task in list(ws._registry.retiring_resources.values())),
+            return_exceptions=True)
+        for result in retirements:
+            if isinstance(result, BaseException):
+                raise result
         resources = {
             id(mount.resource): mount.resource
             for mount in ws._registry.mounts()

--- a/python/mirage/workspace/workspace/lifecycle.py
+++ b/python/mirage/workspace/workspace/lifecycle.py
@@ -140,6 +140,7 @@ async def close_async(ws: "Workspace", ) -> None:
     async with ws._close_lock:
         if ws._async_closed:
             return
+        await ws._session_mgr.settle()
         await ws._watch.detach()
         await ws.job_table.kill_all()
         await ws.job_table.close_consoles()

--- a/python/mirage/workspace/workspace/mounts.py
+++ b/python/mirage/workspace/workspace/mounts.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import inspect
+from collections.abc import Callable
 
 from mirage.cache.index import IndexConfig
 from mirage.ops import Ops
@@ -136,7 +137,8 @@ def install_mounts(registry: MountRegistry, specs: list[MountSpec],
     return implicit_root
 
 
-async def unmount(registry: MountRegistry, ops: Ops, prefix: str) -> None:
+async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
+                  is_shutting_down: Callable[[], bool]) -> None:
     """Remove one mount, closing its resource if nothing else uses it.
 
     The virtual root, the device mount, and the history view are
@@ -148,6 +150,7 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str) -> None:
         registry (MountRegistry): the workspace's mount table.
         ops (Ops): the ops facade to detach the prefix from.
         prefix (str): the mount's virtual prefix.
+        is_shutting_down: live admission check after asynchronous cleanup.
 
     Raises:
         ValueError: the prefix names a permanent mount.
@@ -160,7 +163,27 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str) -> None:
         raise ValueError("cannot unmount reserved prefix: '/dev/'")
     if norm == HISTORY_PREFIX + "/":
         raise ValueError(f"cannot unmount history view: {HISTORY_PREFIX!r}")
-    removed = registry.unmount(prefix)
+    entry = registry.try_mount_for_prefix(prefix)
+    if entry is None:
+        raise ValueError(f"no mount at prefix: {norm!r}")
+    if entry.retiring:
+        raise ValueError(f"mount is being unmounted: {norm!r}")
+    entry.retiring = True
+    try:
+        cache = registry.file_cache
+        if cache is not None:
+            # Retain the mount until cleanup succeeds; retiring prevents new
+            # cache fills while a replacement is waiting for this prefix.
+            await cache.remove(norm.rstrip("/"))
+            await cache.evict_prefix(norm)
+        if is_shutting_down():
+            raise RuntimeError("Workspace is closed")
+        if registry.try_mount_for_prefix(prefix) is not entry:
+            raise ValueError(f"mount changed while unmounting: {prefix!r}")
+        removed = registry.unmount(prefix)
+    except BaseException:
+        entry.retiring = False
+        raise
     ops.unmount(prefix)
     remaining = registry.mounts()
     still_instance = any(m.resource is removed.resource for m in remaining)

--- a/python/mirage/workspace/workspace/mounts.py
+++ b/python/mirage/workspace/workspace/mounts.py
@@ -14,14 +14,19 @@
 
 import inspect
 from collections.abc import Callable
+from functools import partial
 
+from mirage.cache.file.io import mutation_lock
+from mirage.cache.file.mixin import FileCacheMixin
 from mirage.cache.index import IndexConfig
+from mirage.cache.index.store import IndexCacheStore
 from mirage.ops import Ops
 from mirage.resource.base import BaseResource
 from mirage.resource.history import HISTORY_PREFIX
 from mirage.resource.ram import RAMResource
 from mirage.types import KERNEL_BACKENDS, MountBackend, MountMode
 from mirage.workspace.mount import MountRegistry
+from mirage.workspace.mount.mount import MountEntry
 from mirage.workspace.mount.spec import Mount
 from mirage.workspace.workspace.types import MountSpec, ResourceMount
 
@@ -137,6 +142,33 @@ def install_mounts(registry: MountRegistry, specs: list[MountSpec],
     return implicit_root
 
 
+async def clear_mount_cache(cache: FileCacheMixin | None, prefix: str,
+                            indices: list[IndexCacheStore]) -> None:
+    """Drop a mount's cache state atomically with deferred file-cache fills."""
+
+    async def clear_indices() -> None:
+        for index in dict.fromkeys(indices):
+            await index.invalidate_prefix(prefix.rstrip("/"))
+
+    if cache is None:
+        await clear_indices()
+        return
+    async with mutation_lock(cache):
+        await cache.remove(prefix.rstrip("/"))
+        await cache.evict_prefix(prefix)
+        await clear_indices()
+
+
+def prepare_added_mount(registry: MountRegistry, entry: MountEntry,
+                        previous: list[MountEntry]) -> None:
+    """Keep synchronous registration; I/O awaits removal of shadowed state."""
+    indices = [entry.resource.index]
+    indices.extend(m.resource.index for m in previous
+                   if entry.prefix.startswith(m.prefix))
+    entry.before_use = partial(clear_mount_cache, registry.file_cache,
+                               entry.prefix, indices)
+
+
 async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
                   is_shutting_down: Callable[[], bool]) -> None:
     """Remove one mount, closing its resource if nothing else uses it.
@@ -170,13 +202,8 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
         raise ValueError(f"mount is being unmounted: {norm!r}")
     entry.retiring = True
     try:
-        cache = registry.file_cache
-        if cache is not None:
-            # Retain the mount until cleanup succeeds; retiring prevents new
-            # cache fills while a replacement is waiting for this prefix.
-            await cache.remove(norm.rstrip("/"))
-            await cache.evict_prefix(norm)
-        await entry.resource.index.invalidate_prefix(norm.rstrip("/"))
+        await clear_mount_cache(registry.file_cache, norm,
+                                [entry.resource.index])
         if is_shutting_down():
             raise RuntimeError("Workspace is closed")
         if registry.try_mount_for_prefix(prefix) is not entry:
@@ -191,8 +218,12 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
     # The mount owns its op table, so dropping the mount drops the ops
     # with it; the facade keeps no second registry to clean up.
     if not still_instance:
-        close = getattr(removed.resource, "close", None)
-        if callable(close):
-            result = close()
-            if hasattr(result, "__await__"):
-                await result
+        registry.retiring_resources.add(id(removed.resource))
+        try:
+            close = getattr(removed.resource, "close", None)
+            if callable(close):
+                result = close()
+                if inspect.isawaitable(result):
+                    await result
+        finally:
+            registry.retiring_resources.discard(id(removed.resource))

--- a/python/mirage/workspace/workspace/mounts.py
+++ b/python/mirage/workspace/workspace/mounts.py
@@ -176,6 +176,7 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
             # cache fills while a replacement is waiting for this prefix.
             await cache.remove(norm.rstrip("/"))
             await cache.evict_prefix(norm)
+        await entry.resource.index.invalidate_prefix(norm.rstrip("/"))
         if is_shutting_down():
             raise RuntimeError("Workspace is closed")
         if registry.try_mount_for_prefix(prefix) is not entry:

--- a/python/mirage/workspace/workspace/mounts.py
+++ b/python/mirage/workspace/workspace/mounts.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 import inspect
 from collections.abc import Callable
 from functools import partial
@@ -218,12 +219,25 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
     # The mount owns its op table, so dropping the mount drops the ops
     # with it; the facade keeps no second registry to clean up.
     if not still_instance:
-        registry.retiring_resources.add(id(removed.resource))
-        try:
-            close = getattr(removed.resource, "close", None)
-            if callable(close):
-                result = close()
-                if inspect.isawaitable(result):
-                    await result
-        finally:
-            registry.retiring_resources.discard(id(removed.resource))
+        identity = id(removed.resource)
+        closing = asyncio.create_task(_close_resource(removed.resource))
+        registry.retiring_resources[identity] = closing
+        closing.add_done_callback(
+            partial(_release_resource, registry, identity))
+        await asyncio.shield(closing)
+
+
+async def _close_resource(resource: BaseResource) -> None:
+    close = getattr(resource, "close", None)
+    if callable(close):
+        result = close()
+        if inspect.isawaitable(result):
+            await result
+
+
+def _release_resource(registry: MountRegistry, identity: int,
+                      closing: asyncio.Task[None]) -> None:
+    registry.retiring_resources.pop(identity, None)
+    # The caller may have been cancelled while shield kept cleanup alive.
+    if not closing.cancelled():
+        closing.exception()

--- a/python/mirage/workspace/workspace/mounts.py
+++ b/python/mirage/workspace/workspace/mounts.py
@@ -141,8 +141,8 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str) -> None:
 
     The virtual root, the device mount, and the history view are
     permanent. The resource is closed only when no remaining mount
-    holds the same instance; its command registration is dropped only
-    when no remaining mount holds the same kind.
+    holds the same instance. Commands and operations belong to each
+    mount, so removing one leaves other mounts of the same kind intact.
 
     Args:
         registry (MountRegistry): the workspace's mount table.

--- a/python/mirage/workspace/workspace/mounts.py
+++ b/python/mirage/workspace/workspace/mounts.py
@@ -133,6 +133,7 @@ def install_mounts(registry: MountRegistry, specs: list[MountSpec],
         bool: whether the root mount was synthesized.
     """
     for spec in specs:
+        registry.check_resource_available(spec.resource)
         spec.resource.set_index(index)
         entry = registry.mount(spec.prefix, spec.resource, spec.mode)
         if spec.command_limits:
@@ -176,7 +177,9 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
 
     The virtual root, the device mount, and the history view are
     permanent. The resource is closed only when no remaining mount
-    holds the same instance. Commands and operations belong to each
+    holds the same instance. Admitted calls and streams finish first;
+    callers must consume or close streams. Closed instances cannot be
+    mounted again. Commands and operations belong to each
     mount, so removing one leaves other mounts of the same kind intact.
 
     Args:
@@ -220,15 +223,17 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
     # with it; the facade keeps no second registry to clean up.
     if not still_instance:
         identity = id(removed.resource)
-        closing = asyncio.create_task(_close_resource(removed.resource))
+        registry.retired_resources[identity] = removed.resource
+        closing = asyncio.create_task(_close_resource(removed))
         registry.retiring_resources[identity] = closing
         closing.add_done_callback(
             partial(_release_resource, registry, identity))
         await asyncio.shield(closing)
 
 
-async def _close_resource(resource: BaseResource) -> None:
-    close = getattr(resource, "close", None)
+async def _close_resource(entry: MountEntry) -> None:
+    await entry.activity.wait()
+    close = getattr(entry.resource, "close", None)
     if callable(close):
         result = close()
         if inspect.isawaitable(result):

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -1060,9 +1060,7 @@ class Workspace:
             raise RuntimeError("Workspace is closed")
         if was_default:
             session_id = self.default_session_id
-        session = self._session_mgr.set_profile(session_id, compiled)
-        await self._session_mgr.flush()
-        return session
+        return await self._session_mgr.set_profile(session_id, compiled)
 
     def list_sessions(self) -> list[Session]:
         return self._session_mgr.list()

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -34,6 +34,7 @@ from mirage.policy import (AskHandler, Decisions, Explanation,
                            PermissionsPolicy, Policies, Policy, PolicyError,
                            ScriptPolicy, SessionProfile)
 from mirage.provision import ProvisionResult
+from mirage.resource.base import BaseResource
 from mirage.resource.history import HISTORY_PREFIX, HistoryViewResource
 from mirage.runtime.base import Runtime
 from mirage.runtime.resolver import PrefixResolver
@@ -46,7 +47,8 @@ from mirage.secrets.types import ResolvedSource
 from mirage.shell import parse
 from mirage.shell.job_table import ConsoleFactory, JobTable
 from mirage.types import (ConsistencyPolicy, DriftPolicy, FileEvent, FileStat,
-                          JsonValue, MountBackend, MountMode, PathSpec)
+                          JsonValue, MountBackend, MountMode, PathSpec,
+                          parse_mount_mode)
 from mirage.utils.ids import new_session_id, new_workspace_id
 from mirage.workspace.cli import CLIInstall
 from mirage.workspace.dispatcher import Dispatcher
@@ -80,7 +82,8 @@ from mirage.workspace.workspace.lifecycle import (close_async, patch_process,
                                                   stop_vfs_loop,
                                                   unpatch_process)
 from mirage.workspace.workspace.meta import WorkspaceMeta
-from mirage.workspace.workspace.mounts import (install_mounts, kernel_targets,
+from mirage.workspace.workspace.mounts import (check_resource, install_mounts,
+                                               kernel_targets,
                                                normalize_resources)
 from mirage.workspace.workspace.mounts import unmount as unmount_prefix
 from mirage.workspace.workspace.types import ResourceMount
@@ -473,10 +476,44 @@ class Workspace:
     def mount(self, prefix: str):
         return self._registry.mount_for(prefix)
 
+    def add_mount(self,
+                  prefix: str,
+                  resource: BaseResource,
+                  mode: MountMode = MountMode.READ) -> MountEntry:
+        """Add a resource to a running workspace, mirroring TS ``addMount``.
+
+        Args:
+            prefix (str): virtual mount point; duplicates are refused.
+            resource (BaseResource): resource providing commands and ops.
+            mode (MountMode): access mode, read-only unless explicitly raised.
+
+        Returns:
+            MountEntry: the installed mount, with its normalized prefix.
+        """
+        if self._closed:
+            raise RuntimeError("Workspace is closed")
+        check_resource(prefix, resource)
+        entry = self._registry.mount(prefix, resource, mode)
+        self._ops.set_mounts(self._registry.ops_mounts())
+        return entry
+
     async def unmount(self, prefix: str) -> None:
         if self._closed:
             raise RuntimeError("Workspace is closed")
         await unmount_prefix(self._registry, self._ops, prefix)
+
+    def set_mount_mode(self, prefix: str, mode: MountMode) -> None:
+        """Change an exact mount's ceiling, retaining data and session caps.
+
+        Args:
+            prefix (str): mount prefix, not a path inside a mount.
+            mode (MountMode): the replacement read, write or exec mode.
+        """
+        if self._closed:
+            raise RuntimeError("Workspace is closed")
+        mode = parse_mount_mode(mode)
+        self._registry.mount_for_prefix(prefix).mode = mode
+        self._ops.set_mounts(self._registry.ops_mounts())
 
     def add_fuse_mount(self,
                        prefix: str,
@@ -525,6 +562,8 @@ class Workspace:
                 validated through the spec's ``config_model`` (fail
                 loud at install time).
         """
+        if self._closed:
+            raise RuntimeError("Workspace is closed")
         return self._registry.clis.install(name, spec, config)
 
     def unregister_cli(self, name: str) -> None:
@@ -533,6 +572,8 @@ class Workspace:
         Args:
             name (str): installed head word.
         """
+        if self._closed:
+            raise RuntimeError("Workspace is closed")
         self._registry.clis.uninstall(name)
 
     def clis(self) -> dict[str, CLIInstall]:
@@ -572,6 +613,8 @@ class Workspace:
         Raises:
             ValueError: unknown name or duplicate entry.
         """
+        if self._closed:
+            raise RuntimeError("Workspace is closed")
         return self._runtimes.add(runtime)
 
     @property
@@ -968,6 +1011,35 @@ class Workspace:
 
     def get_session(self, session_id: str) -> Session:
         return self._session_mgr.get(session_id)
+
+    async def set_session_profile(
+        self,
+        session_id: str,
+        profile: str | SessionProfile | Mapping[str, Any] | None,
+    ) -> Session:
+        """Replace a live session's permissions, including its policy runtime.
+
+        Compilation succeeds before anything changes. This replaces modes,
+        hides, shows and policy rules; cwd/env presets apply only at creation.
+        Existing cwd, variables, functions and history survive. This is a
+        host-side operation, like creating a session.
+
+        Args:
+            session_id (str): the session to update.
+            profile: named profile or complete document; None selects the
+                workspace default, and an empty document clears restrictions.
+        """
+        if self._closed:
+            raise RuntimeError("Workspace is closed")
+        if isinstance(profile, Mapping):
+            profile = SessionProfile.model_validate(profile)
+        compiled = compile_profile(self._base_profile(profile),
+                                   self._profile_name(profile))
+        check_cli_verbs(compiled.commands, self._cli_verbs())
+        await self.ensure_sessions_loaded()
+        session = self._session_mgr.set_profile(session_id, compiled)
+        await self._session_mgr.flush()
+        return session
 
     def list_sessions(self) -> list[Session]:
         return self._session_mgr.list()

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -1049,7 +1049,12 @@ class Workspace:
         compiled = compile_profile(self._base_profile(profile),
                                    self._profile_name(profile))
         check_cli_verbs(compiled.commands, self._cli_verbs())
+        was_default = session_id == self.default_session_id
         await self.ensure_sessions_loaded()
+        if self._shutting_down:
+            raise RuntimeError("Workspace is closed")
+        if was_default:
+            session_id = self.default_session_id
         session = self._session_mgr.set_profile(session_id, compiled)
         await self._session_mgr.flush()
         return session

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -159,7 +159,9 @@ class Workspace:
         self._owns_state_store = stores.owned
         self._state_store = stores.state_store
         self._cache: FileCacheMixin = build_file_cache(cache, cache_limit)
+        self._index_config = index
         self._closed = False
+        self._closing = False
         self._async_closed = False
         self._close_lock = asyncio.Lock()
         # Resources reused from another live workspace (copy() / load
@@ -476,6 +478,11 @@ class Workspace:
     def mount(self, prefix: str):
         return self._registry.mount_for(prefix)
 
+    @property
+    def _shutting_down(self) -> bool:
+        """Reject lifecycle changes while runtimes drain into open mounts."""
+        return self._closing or self._closed
+
     def add_mount(self,
                   prefix: str,
                   resource: BaseResource,
@@ -490,15 +497,21 @@ class Workspace:
         Returns:
             MountEntry: the installed mount, with its normalized prefix.
         """
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         check_resource(prefix, resource)
+        # Configure before mount() captures the index in its CacheManager.
+        # An alias must retain the index used by the resource's other mounts.
+        if (self._registry.try_mount_for_prefix(prefix) is None
+                and not any(m.resource is resource
+                            for m in self._registry.mounts())):
+            resource.set_index(self._index_config)
         entry = self._registry.mount(prefix, resource, mode)
         self._ops.set_mounts(self._registry.ops_mounts())
         return entry
 
     async def unmount(self, prefix: str) -> None:
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         await unmount_prefix(self._registry, self._ops, prefix)
 
@@ -509,7 +522,7 @@ class Workspace:
             prefix (str): mount prefix, not a path inside a mount.
             mode (MountMode): the replacement read, write or exec mode.
         """
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         mode = parse_mount_mode(mode)
         self._registry.mount_for_prefix(prefix).mode = mode
@@ -562,7 +575,7 @@ class Workspace:
                 validated through the spec's ``config_model`` (fail
                 loud at install time).
         """
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         return self._registry.clis.install(name, spec, config)
 
@@ -572,7 +585,7 @@ class Workspace:
         Args:
             name (str): installed head word.
         """
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         self._registry.clis.uninstall(name)
 
@@ -613,7 +626,7 @@ class Workspace:
         Raises:
             ValueError: unknown name or duplicate entry.
         """
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         return self._runtimes.add(runtime)
 
@@ -669,7 +682,7 @@ class Workspace:
             RuntimeError: The workspace is closed, or a runtime is
                 already attached.
         """
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         self._watch.attach(runtime)
 
@@ -705,7 +718,7 @@ class Workspace:
             p if isinstance(p, PathSpec) else PathSpec.from_str_path(p)
             for p in raw
         ]
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         return self._watch.watch(specs)
 
@@ -721,7 +734,7 @@ class Workspace:
         Args:
             change (FileEvent): Observed change.
         """
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         await self._watch.notify(change)
 
@@ -1029,7 +1042,7 @@ class Workspace:
             profile: named profile or complete document; None selects the
                 workspace default, and an empty document clears restrictions.
         """
-        if self._closed:
+        if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         if isinstance(profile, Mapping):
             profile = SessionProfile.model_validate(profile)

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -84,7 +84,8 @@ from mirage.workspace.workspace.lifecycle import (close_async, patch_process,
 from mirage.workspace.workspace.meta import WorkspaceMeta
 from mirage.workspace.workspace.mounts import (check_resource, install_mounts,
                                                kernel_targets,
-                                               normalize_resources)
+                                               normalize_resources,
+                                               prepare_added_mount)
 from mirage.workspace.workspace.mounts import unmount as unmount_prefix
 from mirage.workspace.workspace.types import ResourceMount
 from mirage.workspace.workspace.watch import WatchDelegate, WatchManager
@@ -500,6 +501,8 @@ class Workspace:
         if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         check_resource(prefix, resource)
+        self._registry.check_resource_available(resource)
+        previous = self._registry.mounts()
         # Configure before mount() captures the index in its CacheManager.
         # An alias must retain the index used by the resource's other mounts.
         if (self._registry.try_mount_for_prefix(prefix) is None
@@ -507,6 +510,7 @@ class Workspace:
                             for m in self._registry.mounts())):
             resource.set_index(self._index_config)
         entry = self._registry.mount(prefix, resource, mode)
+        prepare_added_mount(self._registry, entry, previous)
         self._ops.set_mounts(self._registry.ops_mounts())
         return entry
 

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -513,7 +513,8 @@ class Workspace:
     async def unmount(self, prefix: str) -> None:
         if self._shutting_down:
             raise RuntimeError("Workspace is closed")
-        await unmount_prefix(self._registry, self._ops, prefix)
+        await unmount_prefix(self._registry, self._ops, prefix,
+                             lambda: self._shutting_down)
 
     def set_mount_mode(self, prefix: str, mode: MountMode) -> None:
         """Change an exact mount's ceiling, retaining data and session caps.
@@ -1123,10 +1124,14 @@ class Workspace:
 
     # ── execution ────────────────────────────────────────────────────────────
 
-    async def apply_io(self,
-                       io: IOResult,
-                       records: list[OpRecord] | None = None) -> None:
-        await self._dispatcher.apply_io(io, records=records)
+    async def apply_io(
+            self,
+            io: IOResult,
+            records: list[OpRecord] | None = None,
+            is_cacheable: Callable[[str], bool] | None = None) -> None:
+        await self._dispatcher.apply_io(io,
+                                        records=records,
+                                        is_cacheable=is_cacheable)
 
     @overload
     async def execute(

--- a/python/tests/cache/file/test_io.py
+++ b/python/tests/cache/file/test_io.py
@@ -235,6 +235,54 @@ async def test_no_drain_if_already_cached():
     assert await cache.get("/f.txt") == b"cached"
 
 
+@pytest.mark.asyncio
+async def test_prefix_eviction_retires_a_fill_before_a_replacement_starts():
+    cache = RAMFileCacheStore()
+    started = asyncio.Event()
+    release_old = asyncio.Event()
+    release_new = asyncio.Event()
+
+    async def old_stream():
+        started.set()
+        try:
+            await release_old.wait()
+        except asyncio.CancelledError:
+            await release_old.wait()
+        yield b"old account"
+
+    async def new_stream():
+        await release_new.wait()
+        yield b"new account"
+
+    path = "/data/file"
+    await cache_io.apply_io(
+        cache,
+        IOResult(reads={path: CachableAsyncIterator(old_stream())},
+                 cache=[path]))
+    old = cache._drain_tasks[path]
+    await started.wait()
+    await cache.evict_prefix("/data/")
+    assert path not in cache._drain_tasks
+    await cache_io.apply_io(
+        cache,
+        IOResult(reads={path: CachableAsyncIterator(new_stream())},
+                 cache=[path]))
+    new = cache._drain_tasks[path]
+    try:
+        release_old.set()
+        await old
+        await asyncio.sleep(0)
+        assert await cache.get(path) is None
+        assert cache._drain_tasks[path] is new
+        release_new.set()
+        await new
+        assert await cache.get(path) == b"new account"
+    finally:
+        release_old.set()
+        release_new.set()
+        await asyncio.gather(old, new, return_exceptions=True)
+
+
 # ── max_drain_bytes (cancellable cache drain) ───────────────────────────
 
 

--- a/python/tests/cache/index/test_view.py
+++ b/python/tests/cache/index/test_view.py
@@ -1,0 +1,125 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import os
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from mirage.cache.index.config import (IndexConfig, IndexEntry, LookupStatus,
+                                       RedisIndexConfig)
+from mirage.ops.registry import RegisteredOp
+from mirage.resource.ram import RAMResource
+from mirage.workspace import Workspace
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("store_kind", ["ram", "redis"])
+@pytest.mark.parametrize("phase", ["backend", "store"])
+@pytest.mark.parametrize(
+    "method", ["put", "set_dir", "seed_get", "seed_list_dir", "seed_entries"])
+@pytest.mark.parametrize("shadow", [False, True])
+async def test_late_index_write_cannot_cross_mount_ownership(
+        monkeypatch, store_kind, phase, method, shadow):
+    config = IndexConfig()
+    if store_kind == "redis":
+        url = os.environ.get("REDIS_URL")
+        if not url:
+            pytest.skip("REDIS_URL not set")
+        config = RedisIndexConfig(url=url, key_prefix=f"lifecycle:{uuid4()}:")
+    resource = RAMResource()
+    prefix = "/" if shadow else "/data"
+    ws = Workspace({prefix: resource}, index=config)
+    ws.add_mount("/alias", resource)
+    index = resource.index
+    entry = IndexEntry(id="old", name="stale", resource_type="file")
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def pause():
+        entered.set()
+        await release.wait()
+
+    if phase == "store":
+        store_method = method.removeprefix("seed_")
+        original = getattr(index, store_method)
+
+        async def delayed_store(*args, **kwargs):
+            await pause()
+            return await original(*args, **kwargs)
+
+        monkeypatch.setattr(index, store_method, delayed_store)
+
+    async def delayed_readdir(_accessor, _path, *, index, **_kwargs):
+        if phase == "backend":
+            await pause()
+        if method == "put":
+            await index.put("/data/stale", entry)
+        elif method == "set_dir":
+            await index.set_dir("/data", [("stale", entry)])
+        else:
+            index.seed({"/data/stale": entry}, {"/data": ["/data/stale"]},
+                       datetime.now(timezone.utc) + timedelta(hours=1))
+            if method == "seed_get":
+                await index.get("/data/stale")
+            elif method == "seed_list_dir":
+                await index.list_dir("/data")
+            else:
+                await index.entries()
+        return ["/data/stale"]
+
+    ws.mount(prefix).register_op(
+        RegisteredOp(name="readdir",
+                     resource="ram",
+                     filetype=None,
+                     fn=delayed_readdir))
+    reading = asyncio.create_task(ws.fs.readdir("/data"))
+    changing = None
+    replacement = RAMResource()
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        if shadow:
+            ws.add_mount("/data", replacement)
+            changing = asyncio.create_task(ws.fs.readdir("/data"))
+        else:
+            changing = asyncio.create_task(ws.unmount("/data"))
+        await asyncio.sleep(0)
+        if phase == "store":
+            assert not changing.done()
+            release.set()
+        await asyncio.wait_for(changing, timeout=5)
+        if not shadow:
+            ws.add_mount("/data", replacement)
+            await ws.fs.readdir("/data")
+        fresh = IndexEntry(id="new", name="fresh", resource_type="file")
+        await replacement.index.put("/data/fresh", fresh)
+        release.set()
+        await asyncio.wait_for(reading, timeout=5)
+        for candidate in (index, replacement.index):
+            assert (
+                await
+                candidate.get("/data/stale")).status == LookupStatus.NOT_FOUND
+            assert "/data/stale" not in ((await
+                                          candidate.list_dir("/data")).entries
+                                         or [])
+        assert (await replacement.index.get("/data/fresh")).entry.id == "new"
+    finally:
+        release.set()
+        await asyncio.gather(reading,
+                             *([changing] if changing else []),
+                             return_exceptions=True)
+        await index.clear()
+        await ws.close()

--- a/python/tests/commands/builtin/test_patch.py
+++ b/python/tests/commands/builtin/test_patch.py
@@ -14,6 +14,10 @@
 
 import asyncio
 
+import pytest
+
+from mirage.commands.builtin.generic.patch import patch_generic
+from mirage.commands.config import CommandOpts
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode, PathSpec
 from mirage.workspace import Workspace
@@ -87,3 +91,34 @@ def test_patch_N():
     _run_raw(ws, "patch -p1 -N", cwd="/data", stdin=diff_text.encode())
     stdout, _ = _run_raw(ws, "cat /data/hello.txt")
     assert b"universe" in _bytes(stdout)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", ["", "/data", "/nested/data"])
+@pytest.mark.parametrize("source", ["stdin", "operand", "input"])
+async def test_patch_preserves_virtual_paths_for_mounted_io(prefix, source):
+    patch_data = (b"--- a/hello.txt\n+++ b/hello.txt\n@@ -1,2 +1,2 @@\n"
+                  b" hello\n-world\n+universe\n")
+    files = {"hello.txt": b"hello\nworld\n", "fix.diff": patch_data}
+    seen = []
+
+    async def read(path):
+        assert path.virtual == prefix + "/" + path.resource_path
+        seen.append(path.resource_path)
+        return files[path.resource_path]
+
+    async def write(path, data):
+        assert path.virtual == prefix + "/" + path.resource_path
+        files[path.resource_path] = data
+
+    input_path = PathSpec.from_str_path(prefix + "/fix.diff", "fix.diff")
+    flags = {"p": "1"}
+    if source == "input":
+        flags["i"] = input_path
+    opts = CommandOpts(flags=flags,
+                       mount_prefix=prefix,
+                       stdin=patch_data if source == "stdin" else None)
+    await patch_generic([input_path] if source == "operand" else [], [], opts,
+                        read, write, True)
+    assert "hello.txt" in seen
+    assert files["hello.txt"] == b"hello\nuniverse\n"

--- a/python/tests/core/generic/test_find.py
+++ b/python/tests/core/generic/test_find.py
@@ -24,18 +24,21 @@ class Ops:
         self.walk_kwargs: dict[str, object] = {}
         self.resolve_calls = 0
         self.stat_calls = 0
+        self.probes: list[PathSpec] = []
 
     async def walk(self, accessor, path, index, **kwargs):
         self.walk_kwargs = kwargs
         return list(self.keys)
 
     async def resolve_path(self, accessor, spec, index):
+        self.probes.append(spec)
         self.resolve_calls += 1
         return Resolved(is_dir=spec.mount_path.rstrip("/") in
                         {d.rstrip("/")
                          for d in DIRS} or spec.mount_path == "/")
 
     async def stat(self, accessor, spec, index):
+        self.probes.append(spec)
         self.stat_calls += 1
         return FileStat(type=FileType.FILE,
                         name=spec.mount_path.rsplit("/", 1)[-1],
@@ -47,6 +50,23 @@ def build(ops: Ops):
 
 
 ROOT = PathSpec.from_str_path("/", "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", ["", "/knowledge", "/api", "/nested/mount"])
+@pytest.mark.parametrize("root", ["/", "/api"])
+async def test_metadata_probes_preserve_both_paths(prefix, root):
+    keys = ["/", "/api", "/api/reference"
+            ] if root == "/" else ["/api", "/api/reference"]
+    ops = Ops(keys=keys)
+    path = PathSpec.from_str_path((prefix + root).rstrip("/") or "/",
+                                  root.lstrip("/"))
+    assert await build(ops)(object(), path, type="f",
+                            min_size=1) == ["/api/reference"]
+    assert {(p.virtual, p.resource_path)
+            for p in ops.probes} == {((prefix + key).rstrip("/")
+                                      or "/", key.lstrip("/"))
+                                     for key in keys}
 
 
 @pytest.mark.asyncio

--- a/python/tests/fuse/test_core.py
+++ b/python/tests/fuse/test_core.py
@@ -21,6 +21,7 @@ import pytest
 import pytest_asyncio
 
 from mirage.fuse.core import MountCore
+from mirage.observe import OpRecord
 from mirage.ops.registry import op
 from mirage.resource.ram import RAMResource
 from mirage.types import ContentType, FileStat, FileType, MountMode, PathSpec
@@ -326,3 +327,18 @@ async def test_epoch_zero_mtime_lands_instead_of_reading_as_unknown(seeded):
     got = seeded._apply_stat_attrs(dict(entry), epoch)
     assert got["st_mtime"] == 0
     assert got["st_ctime"] == 0
+
+
+def test_drain_ops_omits_internal_mount_identity():
+    ws = Workspace({"/data": RAMResource()})
+    record = OpRecord(op="read",
+                      path="/data/file",
+                      source="ram",
+                      bytes=3,
+                      timestamp=1,
+                      duration_ms=2,
+                      mount_id="internal-mount")
+    ws.fs.records.append(record)
+    core = MountCore(ws.fs)
+    assert core.drain_ops() == [record.to_dict()]
+    assert core.drain_ops() == []

--- a/python/tests/observe/test_op_record.py
+++ b/python/tests/observe/test_op_record.py
@@ -110,3 +110,21 @@ def test_execution_node_records_in_to_dict():
     d = node.to_dict()
     assert len(d["records"]) == 1
     assert d["records"][0]["op"] == "read"
+
+
+def test_internal_mount_identity_is_not_serialized():
+    record = OpRecord(op="read",
+                      path="/data/file",
+                      source="s3",
+                      bytes=3,
+                      timestamp=1,
+                      duration_ms=2,
+                      fingerprint="fp",
+                      revision="v1",
+                      mount_id="internal-mount")
+    fields = record.to_dict()
+    assert set(fields) == {
+        "op", "path", "source", "bytes", "timestamp", "duration_ms",
+        "fingerprint", "revision"
+    }
+    assert ExecutionNode(records=[record]).to_dict()["records"] == [fields]

--- a/python/tests/policy/test_decisions.py
+++ b/python/tests/policy/test_decisions.py
@@ -219,8 +219,8 @@ async def test_an_inline_answer_is_spent_by_the_line_that_asked():
     # standing, so the gate behind it consumes the same one.
     handed = Decisions(on_ask=allow)
     asked.clear()
-    assert await handed.resolve(
-        _ctx(), Ask("sign-off", rule=RULE), None, True) is None
+    assert await handed.resolve(_ctx(), Ask("sign-off", rule=RULE), None,
+                                True) is None
     assert await handed.resolve(_ctx(), Ask("sign-off", rule=RULE)) is None
     assert len(asked) == 1
 

--- a/python/tests/policy/test_policies.py
+++ b/python/tests/policy/test_policies.py
@@ -450,3 +450,28 @@ async def test_wants_for_refines_wants_per_session():
     # A policy speaking for every session settles it, wherever it stands.
     both = Policies([ForSomeSessions(), ForEveryone()])
     assert await both.wants_for("pre_session", "b") is True
+
+
+@pytest.mark.asyncio
+async def test_remove_by_identity_refreshes_hooks_and_keeps_admission_order():
+    policies = Policies()
+
+    class RemovesItself(Policy):
+
+        async def pre_command(self, ctx):
+            assert policies.remove(self)
+            return None
+
+    first = RemovesItself()
+    last = DenyWeird()
+    policies.add(first)
+    policies.add(last)
+    assert not policies.remove(DenyWeird())
+    refusal = await policies.pre_command(_ctx("weird"))
+    assert isinstance(refusal, Deny)
+    assert refusal.reason == "nope"
+    assert policies.wants("pre_command")
+    assert policies.remove(last)
+    assert not policies.wants("pre_command")
+    assert not policies.remove(first)
+    assert await policies.pre_command(_ctx("weird")) is None

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -70,6 +70,7 @@ def _dispatcher(policies: Policies) -> tuple[Dispatcher, MagicMock]:
     namespace.follow = MagicMock(side_effect=lambda p: p)
     mount = MagicMock()
     mount.prefix = "/data/"
+    mount.retiring = False
     mount.resource.caches_reads = True
     mount.execute_op = AsyncMock(return_value=b"cold")
     namespace.try_mount_for = MagicMock(return_value=mount)

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -71,6 +71,7 @@ def _dispatcher(policies: Policies) -> tuple[Dispatcher, MagicMock]:
     mount = MagicMock()
     mount.prefix = "/data/"
     mount.retiring = False
+    mount.ensure_ready = AsyncMock()
     mount.resource.caches_reads = True
     mount.execute_op = AsyncMock(return_value=b"cold")
     namespace.try_mount_for = MagicMock(return_value=mount)

--- a/python/tests/workspace/expand/test_globs.py
+++ b/python/tests/workspace/expand/test_globs.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from mirage.cache.index import RAMIndexCacheStore
 from mirage.core.ram.readdir import readdir as ram_readdir
@@ -29,6 +29,7 @@ from mirage.workspace.expand.globs import resolve_globs
 def _mock_registry(resolve_result=None):
     mount = MagicMock()
     mount.prefix = "/data/"
+    mount.ensure_ready = AsyncMock()
 
     async def _resolve_glob(scopes, prefix=""):
         if callable(resolve_result):
@@ -44,6 +45,7 @@ def _mock_registry(resolve_result=None):
     mount.resource.resolve_glob = _resolve_glob
 
     reg = MagicMock()
+    reg.file_cache = None
     reg.clis = CLIRegistry()
     reg.try_mount_for = MagicMock(return_value=mount)
     reg.mounts = MagicMock(return_value=[mount])

--- a/python/tests/workspace/expand/test_globs.py
+++ b/python/tests/workspace/expand/test_globs.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 from mirage.cache.index import RAMIndexCacheStore
 from mirage.core.ram.readdir import readdir as ram_readdir
@@ -24,12 +24,10 @@ from mirage.utils.key_prefix import mount_key
 from mirage.workspace import Workspace
 from mirage.workspace.cli.registry import CLIRegistry
 from mirage.workspace.expand.globs import resolve_globs
+from mirage.workspace.mount.mount import MountEntry
 
 
 def _mock_registry(resolve_result=None):
-    mount = MagicMock()
-    mount.prefix = "/data/"
-    mount.ensure_ready = AsyncMock()
 
     async def _resolve_glob(scopes, prefix=""):
         if callable(resolve_result):
@@ -41,8 +39,9 @@ def _mock_registry(resolve_result=None):
         # dir-shaped ask with the directory itself.
         return [s for s in scopes if not s.pattern]
 
-    mount.resource = MagicMock()
-    mount.resource.resolve_glob = _resolve_glob
+    resource = RAMResource()
+    resource.resolve_glob = _resolve_glob
+    mount = MountEntry("/data/", resource, MountMode.READ)
 
     reg = MagicMock()
     reg.file_cache = None

--- a/python/tests/workspace/mount/test_activity.py
+++ b/python/tests/workspace/mount/test_activity.py
@@ -1,0 +1,95 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+import pytest
+
+from mirage.io.cachable_iterator import CachableAsyncIterator
+from mirage.workspace.mount.activity import ResourceActivity
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("finish", ["eof", "error", "close", "bounded"])
+async def test_resource_usage_ends_with_its_stream(finish):
+    activity = ResourceActivity()
+
+    async def chunks():
+        yield b"value"
+        if finish == "error":
+            raise ValueError("read failed")
+
+    source = chunks()
+    if finish == "bounded":
+        source = CachableAsyncIterator(source)
+    source = activity.hold(source)
+    waiting = asyncio.create_task(activity.wait())
+    await asyncio.sleep(0)
+    assert not waiting.done()
+    if finish == "close":
+        await source.aclose()
+        await source.aclose()
+    elif finish == "bounded":
+        assert await source.drain_bounded(0) is None
+    elif finish == "error":
+        with pytest.raises(ValueError, match="read failed"):
+            async for _ in source:
+                pass
+    else:
+        assert b"".join([chunk async for chunk in source]) == b"value"
+    await asyncio.wait_for(waiting, 5)
+    release = activity.acquire()
+    waiting = asyncio.create_task(activity.wait())
+    await asyncio.sleep(0)
+    assert not waiting.done()
+    release()
+    await asyncio.wait_for(waiting, 5)
+
+
+@pytest.mark.asyncio
+async def test_exhausted_cache_stream_does_not_keep_a_resource_active():
+    content = b"value"
+
+    async def chunks():
+        yield content
+
+    cached = CachableAsyncIterator(chunks())
+    assert await cached.drain() == content
+    activity = ResourceActivity()
+    activity.hold(cached)
+    await asyncio.wait_for(activity.wait(), 1)
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_a_pending_pull_before_releasing_usage():
+    activity = ResourceActivity()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def chunks():
+        entered.set()
+        await release.wait()
+        yield b"value"
+
+    source = activity.hold(chunks())
+    pulling = asyncio.create_task(source.__anext__())
+    await entered.wait()
+    closing = asyncio.create_task(source.aclose())
+    waiting = asyncio.create_task(activity.wait())
+    await asyncio.sleep(0)
+    assert not closing.done()
+    assert not waiting.done()
+    release.set()
+    assert await pulling == b"value"
+    await asyncio.wait_for(asyncio.gather(closing, waiting), 1)

--- a/python/tests/workspace/node/test_execute_node.py
+++ b/python/tests/workspace/node/test_execute_node.py
@@ -79,6 +79,7 @@ async def _no_match_resolve_glob(scopes, prefix=""):
 def _mock_registry():
     mount = MagicMock()
     mount.prefix = "/data/"
+    mount.ensure_ready = AsyncMock()
     mount.mode = MountMode.EXEC
     mount.execute_cmd = AsyncMock(return_value=(b"ok\n", IOResult()))
     mount.resource = MagicMock()
@@ -86,6 +87,7 @@ def _mock_registry():
     mount.spec_for = MagicMock(return_value=None)
 
     reg = MagicMock()
+    reg.file_cache = None
     reg.mount_for = MagicMock(return_value=mount)
     reg.try_mount_for = MagicMock(return_value=mount)
     reg.resolve_mount = AsyncMock(return_value=mount)

--- a/python/tests/workspace/session/test_manager.py
+++ b/python/tests/workspace/session/test_manager.py
@@ -694,3 +694,73 @@ def test_merged_seed_lands_durably_on_the_next_flush():
 
     entries = _run(scenario())
     assert entries["default"]["managed"]["TOKEN"]["ref"] == "p"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [False, True])
+async def test_profile_changes_publish_only_after_persistence(
+        monkeypatch, failure):
+    store = RAMSessionStore()
+    mgr = SessionManager("default", store=store)
+    original = CompiledProfile(
+        mount_modes={"/data": MountMode.READ},
+        hidden_paths=HiddenPaths(paths=("/data/secret", )),
+        hidden_vars=HiddenVars(names=("TOKEN", )),
+        env=None,
+        cwd=None,
+        commands=AdmissionRules(allow=("cat", )),
+        script=ProfileScript(profile="judge",
+                             script=ScriptSource("None", language="python"),
+                             runtime="monty"),
+    )
+    mgr.default_profile = original
+    await mgr.flush()
+    session = mgr.get("default")
+    before = session.to_dict()
+    persisted = await store.load()
+    entered, release = asyncio.Event(), asyncio.Event()
+    cas_set = store.cas_set
+
+    async def delayed_write(*args):
+        entered.set()
+        await release.wait()
+        if failure:
+            raise RuntimeError("store unavailable")
+        return await cas_set(*args)
+
+    monkeypatch.setattr(store, "cas_set", delayed_write)
+    cleared = CompiledProfile(mount_modes=None,
+                              hidden_paths=None,
+                              hidden_vars=None,
+                              env=None,
+                              cwd=None,
+                              commands=None)
+    updating = asyncio.create_task(mgr.set_profile("default", cleared))
+    try:
+        await asyncio.wait_for(entered.wait(), 5)
+        assert session.to_dict() == before
+        assert mgr.commands_of("") == original.commands
+        assert mgr.script_of("") == original.script
+        session.cwd = "/changed-during-write"
+        release.set()
+        if failure:
+            with pytest.raises(RuntimeError, match="store unavailable"):
+                await updating
+            before["cwd"] = session.cwd
+            assert session.to_dict() == before
+            assert await store.load() == persisted
+            assert mgr.commands_of("") == original.commands
+            assert mgr.script_of("") == original.script
+        else:
+            assert await updating is session
+            assert session.mount_modes is None
+            assert session.hidden_paths is None
+            assert mgr.commands_of("") is None
+            assert mgr.script_of("") is None
+        assert session.cwd == "/changed-during-write"
+        monkeypatch.setattr(store, "cas_set", cas_set)
+        await mgr.flush()
+        assert (await store.load())["default"] == session.to_dict()
+    finally:
+        release.set()
+        await asyncio.gather(updating, return_exceptions=True)

--- a/python/tests/workspace/session/test_manager.py
+++ b/python/tests/workspace/session/test_manager.py
@@ -764,3 +764,47 @@ async def test_profile_changes_publish_only_after_persistence(
     finally:
         release.set()
         await asyncio.gather(updating, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [False, True])
+async def test_session_close_waits_for_profile_persistence(
+        monkeypatch, failure):
+    store = RAMSessionStore()
+    mgr = SessionManager("default", store=store)
+    mgr.create("agent")
+    entered, release = asyncio.Event(), asyncio.Event()
+    cas_set = store.cas_set
+
+    async def delayed_write(*args):
+        entered.set()
+        await release.wait()
+        if failure:
+            raise RuntimeError("store unavailable")
+        return await cas_set(*args)
+
+    monkeypatch.setattr(store, "cas_set", delayed_write)
+    cleared = CompiledProfile(mount_modes=None,
+                              hidden_paths=None,
+                              hidden_vars=None,
+                              env=None,
+                              cwd=None,
+                              commands=None)
+    updating = asyncio.create_task(mgr.set_profile("agent", cleared))
+    closing = None
+    try:
+        await asyncio.wait_for(entered.wait(), 5)
+        closing = asyncio.create_task(mgr.close("agent"))
+        await asyncio.sleep(0.02)
+        assert not closing.done()
+        release.set()
+        await asyncio.gather(updating, return_exceptions=True)
+        await closing
+        with pytest.raises(KeyError):
+            mgr.get("agent")
+        assert "agent" not in await store.load()
+    finally:
+        release.set()
+        await asyncio.gather(updating, return_exceptions=True)
+        if closing is not None:
+            await closing

--- a/python/tests/workspace/store/test_workspace_wiring.py
+++ b/python/tests/workspace/store/test_workspace_wiring.py
@@ -159,6 +159,69 @@ async def test_explicit_session_id_is_not_adopted_away():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("target", ["default", "named"])
+async def test_profile_change_targets_the_session_after_hydration(target):
+    store = RAMWorkspaceStateStore()
+    writer = Workspace({}, workspace_id="shared", store=store)
+    writer.create_session("named")
+    await writer.ensure_sessions_loaded()
+    await writer.flush_sessions()
+    attached = Workspace({}, workspace_id="shared", store=store)
+    provisional = attached.default_session_id
+    requested = provisional if target == "default" else "named"
+    expected = writer.default_session_id if target == "default" else "named"
+    try:
+        session = await attached.set_session_profile(
+            requested, {"commands": {
+                "allow": ["cat"]
+            }})
+        assert session.session_id == expected
+        assert attached.default_session_id == writer.default_session_id
+        assert attached.default_session_id != provisional
+        assert session.commands.allow == ("cat", )
+        persisted = await store.sessions("shared").load()
+        assert persisted[expected]["commands"]["allow"] == ["cat"]
+    finally:
+        await writer.close()
+        await attached.close()
+
+
+@pytest.mark.asyncio
+async def test_profile_change_refuses_shutdown_during_hydration(monkeypatch):
+    store = RAMWorkspaceStateStore()
+    ws = Workspace({}, workspace_id="shared", store=store)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    sessions = store.sessions("shared")
+    load = sessions.load
+
+    async def blocked_load():
+        entered.set()
+        await release.wait()
+        return await load()
+
+    monkeypatch.setattr(sessions, "load", blocked_load)
+    session = ws.get_session(ws.default_session_id)
+    commands = session.commands
+    changing = asyncio.create_task(
+        ws.set_session_profile(ws.default_session_id,
+                               {"commands": {
+                                   "allow": ["cat"]
+                               }}))
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        await ws.close()
+    finally:
+        release.set()
+        await asyncio.gather(changing, return_exceptions=True)
+        await ws.close()
+    with pytest.raises(RuntimeError, match="Workspace is closed"):
+        await changing
+    assert session.commands is commands
+    assert await load() == {}
+
+
+@pytest.mark.asyncio
 async def test_existing_meta_wins():
     store = RAMWorkspaceStateStore()
     await store.set_meta("ws-a", {

--- a/python/tests/workspace/test_index_config.py
+++ b/python/tests/workspace/test_index_config.py
@@ -15,10 +15,12 @@
 import pytest
 
 from mirage import Workspace
-from mirage.cache.index import (RAMIndexCacheStore, RedisIndexCacheStore,
-                                RedisIndexConfig)
+from mirage.cache.index import (IndexConfig, RAMIndexCacheStore,
+                                RedisIndexCacheStore, RedisIndexConfig)
+from mirage.cache.index.config import LookupStatus
 from mirage.config import MountBlock, RedisIndexBlock, WorkspaceConfig
 from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
 
 
 def test_redis_index_config_default_key_prefix():
@@ -47,3 +49,55 @@ async def test_config_index_redis_block_builds_redis_config():
     kwargs = cfg.to_workspace_kwargs()
     assert isinstance(kwargs["index"], RedisIndexConfig)
     assert kwargs["index"].key_prefix == "mirage:index:"
+
+
+@pytest.mark.asyncio
+async def test_added_mount_inherits_redis_index():
+    ws = Workspace({}, index=RedisIndexConfig(key_prefix="shared:"))
+    resource = RAMResource()
+    ws.add_mount("/late", resource)
+    try:
+        assert isinstance(resource.index, RedisIndexCacheStore)
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_added_mount_inherits_index_ttl():
+    initial = RAMResource()
+    ws = Workspace({"/initial": initial}, index=IndexConfig(ttl=-1))
+    added = RAMResource()
+    ws.add_mount("/late", added)
+    try:
+        for resource in (initial, added):
+            await resource.index.set_dir("/listing", [])
+            assert (await resource.index.list_dir("/listing")).status == \
+                LookupStatus.EXPIRED
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_added_mount_keeps_index_coherent_across_aliases_and_duplicates(
+):
+    ws = Workspace({}, index=IndexConfig(ttl=3600))
+    resource = RAMResource()
+    ws.add_mount("/late", resource, MountMode.WRITE)
+    index = resource.index
+    rejected = RAMResource()
+    rejected_index = rejected.index
+    try:
+        await index.set_dir("/late", [])
+        ws.add_mount("/alias", resource)
+        assert resource.index is index
+        assert (await index.list_dir("/late")).entries == []
+        with pytest.raises(ValueError, match="duplicate mount prefix"):
+            ws.add_mount("late/", rejected)
+        assert rejected.index is rejected_index
+        # The manager must invalidate the configured index, not the store
+        # the resource had before it was attached to the workspace.
+        await ws.fs.write("/late/new.txt", b"new")
+        assert (await index.list_dir("/late")).status == LookupStatus.NOT_FOUND
+    finally:
+        await ws.close()
+        await rejected.close()

--- a/python/tests/workspace/test_io_key_prefix.py
+++ b/python/tests/workspace/test_io_key_prefix.py
@@ -64,9 +64,9 @@ def _capture_io(ws: Workspace) -> list:
     captured: list = []
     orig = ws._dispatcher.apply_io
 
-    async def recording(result, records=None):
+    async def recording(result, records=None, is_cacheable=None):
         captured.append(result)
-        return await orig(result, records=records)
+        return await orig(result, records=records, is_cacheable=is_cacheable)
 
     ws._dispatcher.apply_io = recording
     return captured

--- a/python/tests/workspace/test_snapshot_drift.py
+++ b/python/tests/workspace/test_snapshot_drift.py
@@ -17,11 +17,16 @@ from contextlib import ExitStack
 
 import pytest
 
+from mirage.commands.cli.types import CLISpec
+from mirage.io import IOResult
+from mirage.observe.context import RecordingScope, record, start_op
+from mirage.ops.registry import op
 from mirage.resource.ram import RAMResource
 from mirage.resource.s3 import S3Config, S3Resource
-from mirage.types import DriftPolicy, MountMode
+from mirage.types import DriftPolicy, MountMode, PathSpec
 from mirage.workspace import Workspace
-from mirage.workspace.snapshot import ContentDriftError, install_fingerprints
+from mirage.workspace.snapshot import (ContentDriftError, install_fingerprints,
+                                       to_state_dict)
 from tests.e2e.s3_mock import patch_s3_multi
 
 
@@ -231,3 +236,138 @@ def test_live_only_mount_does_not_block_snapshot(tmp_path, caplog):
                    "no drift" in r.message.lower()
                    or "no drift" in r.getMessage().lower()
                    for r in caplog.records)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("capture", ["state", "copy"])
+async def test_snapshot_prepares_new_mount_before_capturing_cache(capture):
+    old = {"data/file": b"old", "outside": b"keep", "data2/file": b"sibling"}
+    new = {"file": b"new"}
+    with patch_s3_multi({"old": old, "new": new}):
+        ancestor = S3Resource(_config().model_copy(update={"bucket": "old"}))
+        replacement = S3Resource(
+            _config().model_copy(update={"bucket": "new"}))
+        ws = Workspace({"/": ancestor})
+        clone = None
+        try:
+            assert (await ws.execute("cat /data/file /outside /data2/file")
+                    ).stdout == b"oldkeepsibling"
+            assert await ws.cache.get("/data/file") == b"old"
+            ws.add_mount("/data", replacement)
+            if capture == "copy":
+                clone = await ws.copy()
+            else:
+                state = await to_state_dict(ws)
+                assert "/data/file" not in [
+                    e["key"] for e in state["cache"]["entries"]
+                ]
+                clone = await Workspace.from_state(state,
+                                                   resources={
+                                                       "/": ancestor,
+                                                       "/data": replacement
+                                                   })
+            assert await clone.cache.get("/data/file") is None
+            assert await clone.cache.get("/outside") == b"keep"
+            assert await clone.cache.get("/data2/file") == b"sibling"
+            assert (await clone.execute("cat /data/file")).stdout == b"new"
+        finally:
+            if clone is not None:
+                await clone.close()
+            await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shadow", [False, True])
+@pytest.mark.parametrize("delayed", [False, True])
+async def test_snapshot_fingerprints_keep_read_mount_ownership(
+        shadow, delayed):
+    old = {"data/file" if shadow else "file": b"old"}
+    with patch_s3_multi({
+            "old": old,
+            "new": {
+                "file": b"new"
+            },
+            "keep": {
+                "file": b"keep"
+            }
+    }):
+        ancestor = S3Resource(_config().model_copy(update={"bucket": "old"}))
+        replacement = S3Resource(
+            _config().model_copy(update={"bucket": "new"}))
+        sibling = S3Resource(_config().model_copy(update={"bucket": "keep"}))
+        ws = Workspace({
+            "/" if shadow else "/data": ancestor,
+            "/data/nested": sibling
+        })
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def gate(_inv):
+            entered.set()
+            await release.wait()
+            return None, IOResult()
+
+        ws.register_cli("gate", CLISpec(name="gate", fn=gate))
+        reading = None
+        try:
+            await ws.execute("cat /data/nested/file")
+            if delayed:
+                reading = asyncio.create_task(
+                    ws.execute("cat /data/file; gate"))
+                await asyncio.wait_for(entered.wait(), 5)
+            else:
+                await ws.execute("cat /data/file")
+            if not shadow:
+                await ws.unmount("/data")
+            ws.add_mount("/data", replacement)
+            release.set()
+            if reading is not None:
+                assert (await reading).stdout == b"old"
+            state = await to_state_dict(ws)
+            assert [e["path"]
+                    for e in state["fingerprints"]] == ["/data/nested/file"]
+            await ws.execute("cat /data/file")
+            state = await to_state_dict(ws)
+            entries = {e["path"]: e for e in state["fingerprints"]}
+            new_read = next(
+                r for r in ws._ops.records if r.path == "/data/file"
+                and r.mount_id == ws.mount("/data").mount_id and r.fingerprint)
+            assert entries["/data/file"]["fingerprint"] == new_read.fingerprint
+            assert "/data/nested/file" in entries
+        finally:
+            release.set()
+            if reading is not None:
+                await asyncio.gather(reading, return_exceptions=True)
+            await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_rejects_fingerprint_from_retired_lazy_op():
+    resource = RAMResource()
+    resource.SUPPORTS_SNAPSHOT = True
+    payload = b"old"
+
+    @op("read", resource="ram")
+    async def lazy_read(accessor, scope, **kwargs):
+        record("read", scope.virtual, "ram", 3, start_op(), fingerprint="old")
+        yield payload
+
+    resource.register_op(lazy_read)
+    ws = Workspace({"/data": resource})
+    scope = RecordingScope()
+    try:
+        stream, _ = await ws.dispatch("read",
+                                      PathSpec.from_str_path("/data/file"))
+        old_id = ws.mount("/data").mount_id
+        await ws.unmount("/data")
+        replacement = RAMResource()
+        replacement.SUPPORTS_SNAPSHOT = True
+        ws.add_mount("/data", replacement)
+        async for chunk in stream:
+            assert chunk == payload
+        ws._ops.records.extend(scope.records)
+        assert scope.records[0].mount_id == old_id
+        assert (await to_state_dict(ws))["fingerprints"] == []
+    finally:
+        scope.close()
+        await ws.close()

--- a/python/tests/workspace/test_snapshot_drift.py
+++ b/python/tests/workspace/test_snapshot_drift.py
@@ -359,13 +359,17 @@ async def test_snapshot_rejects_fingerprint_from_retired_lazy_op():
         stream, _ = await ws.dispatch("read",
                                       PathSpec.from_str_path("/data/file"))
         old_id = ws.mount("/data").mount_id
-        await ws.unmount("/data")
+        removing = asyncio.create_task(ws.unmount("/data"))
+        async with asyncio.timeout(5):
+            while ws._registry.try_mount_for_prefix("/data") is not None:
+                await asyncio.sleep(0)
         replacement = RAMResource()
         replacement.SUPPORTS_SNAPSHOT = True
         ws.add_mount("/data", replacement)
         async for chunk in stream:
             assert chunk == payload
         ws._ops.records.extend(scope.records)
+        await removing
         assert scope.records[0].mount_id == old_id
         assert (await to_state_dict(ws))["fingerprints"] == []
     finally:

--- a/python/tests/workspace/test_snapshot_drift.py
+++ b/python/tests/workspace/test_snapshot_drift.py
@@ -371,3 +371,32 @@ async def test_snapshot_rejects_fingerprint_from_retired_lazy_op():
     finally:
         scope.close()
         await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shadow", [False, True])
+async def test_restored_drift_checks_do_not_follow_replaced_mounts(shadow):
+    prefix = "/" if shadow else "/data"
+    with patch_s3_multi({"old": {}, "new": {"file": b"new"}}):
+        ancestor = S3Resource(_config().model_copy(update={"bucket": "old"}))
+        replacement = S3Resource(
+            _config().model_copy(update={"bucket": "new"}))
+        source = Workspace({prefix: ancestor})
+        loaded = None
+        try:
+            state = await to_state_dict(source)
+            state["fingerprints"] = [{
+                "path": "/data/file",
+                "mount_prefix": prefix,
+                "fingerprint": "old-account"
+            }]
+            loaded = await Workspace.from_state(state,
+                                                resources={prefix: ancestor})
+            if not shadow:
+                await loaded.unmount("/data")
+            loaded.add_mount("/data", replacement)
+            assert (await loaded.execute("cat /data/file")).stdout == b"new"
+        finally:
+            if loaded is not None:
+                await loaded.close()
+            await source.close()

--- a/python/tests/workspace/test_workspace.py
+++ b/python/tests/workspace/test_workspace.py
@@ -18,7 +18,7 @@ import pytest
 
 from mirage.resource.ram import RAMResource
 from mirage.runtime.python import LocalRuntime
-from mirage.types import MountMode
+from mirage.types import FileType, MountMode
 from mirage.workspace import Workspace
 
 
@@ -2678,7 +2678,133 @@ def test_while_loop_under_limit_no_warning():
     assert err == ""
 
 
-# ── unmount ────────────────────────────────────────────────────────────
+# ── dynamic mounts ─────────────────────────────────────────────────────
+
+
+def test_add_mount_refreshes_the_existing_filesystem_facade():
+    ws = Workspace({}, mode=MountMode.WRITE)
+    fs = ws.fs
+
+    async def run():
+        try:
+            await fs.write("/root.txt", b"root")
+            records = list(fs.records)
+            resource = RAMResource()
+            entry = ws.add_mount("/data/nested", resource, MountMode.WRITE)
+            assert entry.prefix == "/data/nested/"
+            assert entry.resource is resource
+            assert ws.fs is fs
+            assert fs.records == records
+            assert "/data/nested/" in fs.mount_prefixes()
+            assert ("/data/nested/", "ram") in fs.writable_mounts()
+            assert not fs.unsized_mounts("/data/nested")
+            await fs.write("/data/nested/file.txt", b"dynamic")
+            assert await fs.read("/data/nested/file.txt") == b"dynamic"
+            result = await ws.execute("cat /data/nested/file.txt")
+            assert result.exit_code == 0 and result.stdout == b"dynamic"
+            await ws.unmount("/data/nested")
+            assert "/data/nested/" not in fs.mount_prefixes()
+            assert await fs.read("/root.txt") == b"root"
+        finally:
+            await ws.close()
+
+    asyncio.run(run())
+
+
+def test_add_mount_defaults_to_read_only():
+    ws = Workspace({}, mode=MountMode.WRITE)
+    entry = ws.add_mount("/data", RAMResource())
+    assert entry.mode == MountMode.READ
+
+    async def run():
+        try:
+            with pytest.raises(PermissionError):
+                await ws.fs.write("/data/file.txt", b"refused")
+        finally:
+            await ws.close()
+
+    asyncio.run(run())
+
+
+def test_add_mount_refuses_duplicates_invalid_resources_and_closed_workspace():
+    ws = Workspace({"/data": RAMResource()})
+    before = ws.mounts()
+    with pytest.raises(ValueError, match="duplicate mount prefix"):
+        ws.add_mount("data/", RAMResource())
+    with pytest.raises(TypeError, match="expected a BaseResource"):
+        ws.add_mount("/bad", None)
+    assert ws.mounts() == before
+    asyncio.run(ws.close())
+    with pytest.raises(RuntimeError, match="Workspace is closed"):
+        ws.add_mount("/late", RAMResource())
+
+
+def test_add_mount_keeps_a_shared_resource_open_until_its_last_unmount():
+    closed = []
+
+    class TrackingRAM(RAMResource):
+
+        async def close(self):
+            closed.append("closed")
+
+    resource = TrackingRAM()
+    ws = Workspace({})
+    ws.add_mount("/a", resource, MountMode.WRITE)
+    ws.add_mount("/b", resource, MountMode.WRITE)
+
+    async def run():
+        try:
+            await ws.fs.write("/a/file.txt", b"shared")
+            await ws.unmount("/a")
+            assert closed == []
+            assert await ws.fs.read("/b/file.txt") == b"shared"
+            await ws.unmount("/b")
+            assert closed == ["closed"]
+        finally:
+            await ws.close()
+        assert closed == ["closed"]
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("explicit_root", [False, True])
+def test_unmount_preserves_root_operations(explicit_root):
+    resources = {"/data": RAMResource()}
+    if explicit_root:
+        resources["/"] = RAMResource()
+    ws = Workspace(resources)
+
+    async def run():
+        try:
+            await ws.unmount("/data")
+            assert "/dev" in await ws.fs.readdir("/")
+            assert (await ws.fs.stat("/")).type == FileType.DIRECTORY
+            result = await ws.execute("ls /")
+            assert result.exit_code == 0
+            assert result.stdout == b"dev\n"
+            assert not result.stderr
+        finally:
+            await ws.close()
+
+    asyncio.run(run())
+
+
+def test_unmount_keeps_other_ram_instances_readable():
+    a, b = RAMResource(), RAMResource()
+    content = b"surviving mount\n"
+    b._store.files["/file.txt"] = content
+    ws = Workspace({"/a": a, "/b": b})
+
+    async def run():
+        try:
+            await ws.unmount("/a")
+            assert await ws.fs.read("/b/file.txt") == content
+            await ws.unmount("/b")
+            assert "/dev" in await ws.fs.readdir("/")
+        finally:
+            await ws.close()
+
+    asyncio.run(run())
 
 
 def test_unmount_removes_mount():
@@ -2838,3 +2964,51 @@ def test_man_index_lists_commands():
     assert text.startswith("# commands\n\n")
     assert "- bc" in text
     assert "# general" not in text
+
+
+@pytest.mark.asyncio
+async def test_set_mount_mode_refreshes_facade_without_remounting():
+    ws = Workspace({"/data": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        fs = ws.fs
+        mount = ws.mount("/data")
+        await fs.write("/data/file", b"kept")
+        for mode in (MountMode.READ, MountMode.EXEC, MountMode.WRITE):
+            ws.set_mount_mode("data/", mode)
+            assert ws.fs is fs
+            assert ws.mount("/data") is mount
+            assert mount.mode == mode
+            assert (("/data/", "ram")
+                    in fs.writable_mounts()) == (mode != MountMode.READ)
+            assert await fs.read("/data/file") == b"kept"
+        with pytest.raises(ValueError):
+            ws.set_mount_mode("/data", "invalid")
+        assert mount.mode == MountMode.WRITE
+
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_live_default_profile_updates_unbound_policy():
+    ws = Workspace({"/data": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        session = ws.get_session(ws.default_session_id)
+        await ws.fs.write("/data/file", b"kept")
+        profile = {
+            "commands": {
+                "deny": [{
+                    "paths": ["/data/file"],
+                    "reason": "sealed"
+                }]
+            }
+        }
+        assert await ws.set_session_profile(ws.default_session_id,
+                                            profile) is session
+        with pytest.raises(PermissionError):
+            await ws.fs.read("/data/file")
+        await ws.set_session_profile(ws.default_session_id, {})
+        assert ws.get_session(ws.default_session_id) is session
+        assert await ws.fs.read("/data/file") == b"kept"
+    finally:
+        await ws.close()

--- a/python/tests/workspace/workspace/test_lifecycle.py
+++ b/python/tests/workspace/workspace/test_lifecycle.py
@@ -22,6 +22,8 @@ import pytest
 from mirage.cache.index.config import (IndexConfig, IndexEntry, LookupStatus,
                                        RedisIndexConfig)
 from mirage.commands.cli.types import CLISpec
+from mirage.commands.config import RegisteredCommand
+from mirage.commands.spec import CommandSpec, Operand
 from mirage.io import IOResult
 from mirage.ops.registry import op
 from mirage.resource.ram import RAMResource
@@ -161,7 +163,11 @@ async def test_resource_cannot_be_remounted_while_close_is_pending(
         await asyncio.sleep(0)
         if not cancel:
             await removing
-        ws.add_mount("/data", resource)
+        with pytest.raises(ValueError, match="resource is closed"):
+            ws.add_mount("/data", resource)
+        with pytest.raises(ValueError, match="resource is closed"):
+            Workspace({"/data": resource})
+        ws.add_mount("/data", RAMResource())
     finally:
         release.set()
         await asyncio.gather(removing, return_exceptions=True)
@@ -169,9 +175,10 @@ async def test_resource_cannot_be_remounted_while_close_is_pending(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("shadow", [False, True])
+@pytest.mark.parametrize("change", ["replace", "shadow", "reveal"])
 async def test_retired_command_cannot_cache_bytes_for_replacement_mount(
-        shadow):
+        change):
+    shadow = change == "shadow"
 
     class CachedRAM(RAMResource):
         caches_reads = True
@@ -179,7 +186,10 @@ async def test_retired_command_cannot_cache_bytes_for_replacement_mount(
     old = CachedRAM()
     old.load_state({"files": {"/data/file" if shadow else "/file": b"old"}})
     replacement = CachedRAM()
-    replacement.load_state({"files": {"/file": b"new"}})
+    replacement.load_state(
+        {"files": {
+            "/data/file" if change == "reveal" else "/file": b"new"
+        }})
     entered = asyncio.Event()
     release = asyncio.Event()
 
@@ -189,7 +199,10 @@ async def test_retired_command_cannot_cache_bytes_for_replacement_mount(
         return None, IOResult()
 
     prefix = "/" if shadow else "/data"
-    ws = Workspace({prefix: old})
+    resources = {prefix: old}
+    if change == "reveal":
+        resources["/"] = replacement
+    ws = Workspace(resources)
     ws.register_cli("gate", CLISpec(name="gate", fn=gate))
     retired = ws.mount(prefix).cache_manager
     running = asyncio.create_task(ws.execute("cat /data/file; gate"))
@@ -197,7 +210,8 @@ async def test_retired_command_cannot_cache_bytes_for_replacement_mount(
         await asyncio.wait_for(entered.wait(), timeout=5)
         if not shadow:
             await ws.unmount("/data")
-        ws.add_mount("/data", replacement)
+        if change != "reveal":
+            ws.add_mount("/data", replacement)
         release.set()
         result = await asyncio.wait_for(running, timeout=5)
         assert result.stdout == b"old"
@@ -587,4 +601,141 @@ async def test_close_settles_pending_profile_persistence(
         await asyncio.gather(updating, return_exceptions=True)
         if closing is not None:
             await closing
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["op", "command"])
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("alias", [None, "initial", "dynamic"])
+async def test_unmount_waits_for_admitted_resource_use(monkeypatch, surface,
+                                                       streaming, alias):
+    resource = RAMResource()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    closed = False
+
+    async def chunks():
+        entered.set()
+        await release.wait()
+        assert not closed
+        yield b"value"
+
+    async def read_body():
+        if streaming:
+            return chunks()
+        entered.set()
+        await release.wait()
+        assert not closed
+        return b"value"
+
+    @op("read", resource="ram")
+    async def read(accessor, scope, **kwargs):
+        return await read_body()
+
+    async def command(accessor, paths, texts, opts):
+        return await read_body(), IOResult()
+
+    resource.register_op(read)
+    resources = {"/data": resource}
+    if alias == "initial":
+        resources["/alias"] = resource
+    ws = Workspace(resources)
+    if alias == "dynamic":
+        ws.add_mount("/alias", resource)
+    ws.mount("/data").register(
+        RegisteredCommand(name="readvalue",
+                          spec=CommandSpec(rest=Operand(type="path")),
+                          resource="ram",
+                          filetype=None,
+                          fn=command))
+    close_resource = resource.close
+
+    async def close():
+        nonlocal closed
+        closed = True
+        await close_resource()
+
+    monkeypatch.setattr(resource, "close", close)
+
+    async def consume():
+        if surface == "command":
+            return (await ws.execute("readvalue /data/file")).stdout
+        value, _ = await ws.dispatch("read",
+                                     PathSpec.from_str_path("/data/file"))
+        if isinstance(value, bytes):
+            return value
+        return b"".join([chunk async for chunk in value])
+
+    running = asyncio.create_task(consume())
+    removing = None
+    try:
+        await asyncio.wait_for(entered.wait(), 5)
+        if alias:
+            await ws.unmount("/data")
+            assert not closed
+        removing = asyncio.create_task(
+            ws.unmount("/alias" if alias else "/data"))
+        async with asyncio.timeout(5):
+            while ws._registry.try_mount_for_prefix(
+                    "/alias" if alias else "/data") is not None:
+                await asyncio.sleep(0)
+        assert not removing.done()
+        assert not closed
+        release.set()
+        assert await asyncio.wait_for(running, 5) == b"value"
+        await asyncio.wait_for(removing, 5)
+        assert closed
+    finally:
+        release.set()
+        await asyncio.gather(running,
+                             *([removing] if removing else []),
+                             return_exceptions=True)
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_unmount", [False, True])
+async def test_workspace_close_waits_for_resource_retirements(
+        monkeypatch, cancel_unmount):
+    resource = RAMResource()
+    ws = Workspace({"/data": resource})
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    events = []
+    close_resource = resource.close
+    close_store = ws.state_store.close
+
+    async def retiring_close():
+        entered.set()
+        await release.wait()
+        await close_resource()
+        events.append("resource")
+
+    async def store_close():
+        events.append("store")
+        await close_store()
+
+    monkeypatch.setattr(resource, "close", retiring_close)
+    monkeypatch.setattr(ws.state_store, "close", store_close)
+    removing = asyncio.create_task(ws.unmount("/data"))
+    closing = None
+    try:
+        await asyncio.wait_for(entered.wait(), 5)
+        if cancel_unmount:
+            removing.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await removing
+        closing = asyncio.create_task(ws.close())
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(asyncio.shield(closing), 0.03)
+        assert events == []
+        release.set()
+        await asyncio.wait_for(closing, 5)
+        assert events == ["resource", "store"]
+    finally:
+        release.set()
+        await asyncio.gather(removing,
+                             *([closing] if closing else []),
+                             return_exceptions=True)
         await ws.close()

--- a/python/tests/workspace/workspace/test_lifecycle.py
+++ b/python/tests/workspace/workspace/test_lifecycle.py
@@ -523,3 +523,68 @@ async def test_unmount_preserves_operations_of_each_surviving_resource():
         assert await ws.fs.readdir("/")
     finally:
         await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("secondary", [False, True])
+@pytest.mark.parametrize("failure", [False, True])
+async def test_close_settles_pending_profile_persistence(
+        monkeypatch, secondary, failure):
+    ws = Workspace({})
+    await ws.ensure_sessions_loaded()
+    ws.create_session("peer")
+    await ws.flush_sessions()
+    session_id = "peer" if secondary else ws.default_session_id
+    store = ws.state_store.sessions(ws.workspace_id)
+    entered, release = asyncio.Event(), asyncio.Event()
+    events = []
+    cas_set = store.cas_set
+    close_store = ws.state_store.close
+
+    async def delayed_write(*args):
+        entered.set()
+        await release.wait()
+        try:
+            assert "store-closed" not in events
+            if failure:
+                raise RuntimeError("store unavailable")
+            return await cas_set(*args)
+        finally:
+            events.append("write-finished")
+
+    async def tracked_close():
+        events.append("store-closed")
+        await close_store()
+
+    monkeypatch.setattr(store, "cas_set", delayed_write)
+    monkeypatch.setattr(ws.state_store, "close", tracked_close)
+    updating = asyncio.create_task(
+        ws.set_session_profile(session_id,
+                               {"paths": {
+                                   "hide": ["/data/secret"]
+                               }}))
+    closing = None
+    try:
+        await asyncio.wait_for(entered.wait(), 5)
+        closing = asyncio.create_task(ws.close())
+        await asyncio.sleep(0)
+        assert not closing.done()
+        assert events == []
+        with pytest.raises(RuntimeError, match="Workspace is closed"):
+            await ws.set_session_profile(session_id, {})
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(asyncio.shield(closing), timeout=0.03)
+        release.set()
+        if failure:
+            with pytest.raises(RuntimeError, match="store unavailable"):
+                await updating
+        else:
+            assert await updating is ws.get_session(session_id)
+        await asyncio.wait_for(closing, 5)
+        assert events == ["write-finished", "store-closed"]
+    finally:
+        release.set()
+        await asyncio.gather(updating, return_exceptions=True)
+        if closing is not None:
+            await closing
+        await ws.close()

--- a/python/tests/workspace/workspace/test_lifecycle.py
+++ b/python/tests/workspace/workspace/test_lifecycle.py
@@ -13,9 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import os
+from uuid import uuid4
 
 import pytest
 
+from mirage.cache.index.config import (IndexConfig, IndexEntry, LookupStatus,
+                                       RedisIndexConfig)
 from mirage.commands.cli.types import CLISpec
 from mirage.io import IOResult
 from mirage.resource.ram import RAMResource
@@ -74,14 +78,17 @@ async def test_retired_command_cannot_cache_bytes_for_replacement_mount():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("fail_eviction", [False, True])
+@pytest.mark.parametrize("cache_kind", ["file", "index"])
 async def test_unmount_keeps_prefix_reserved_until_cache_cleanup(
-        monkeypatch, fail_eviction):
+        monkeypatch, fail_eviction, cache_kind):
     resource = RAMResource()
     ws = Workspace({"/data": resource})
     cache = ws.cache
     entered = asyncio.Event()
     release = asyncio.Event()
-    evict = cache.evict_prefix
+    store = cache if cache_kind == "file" else resource.index
+    method = "evict_prefix" if cache_kind == "file" else "invalidate_prefix"
+    evict = getattr(store, method)
 
     async def blocked_evict(prefix):
         entered.set()
@@ -90,7 +97,7 @@ async def test_unmount_keeps_prefix_reserved_until_cache_cleanup(
             raise RuntimeError("cache unavailable")
         await evict(prefix)
 
-    monkeypatch.setattr(cache, "evict_prefix", blocked_evict)
+    monkeypatch.setattr(store, method, blocked_evict)
     await cache.set("/data", b"root")
     await cache.set("/data/file", b"old")
     await cache.set("/database/file", b"peer")
@@ -104,7 +111,7 @@ async def test_unmount_keeps_prefix_reserved_until_cache_cleanup(
             with pytest.raises(RuntimeError, match="cache unavailable"):
                 await removing
             assert ws.mount("/data").resource is resource
-            monkeypatch.setattr(cache, "evict_prefix", evict)
+            monkeypatch.setattr(store, method, evict)
             await ws.unmount("/data")
         else:
             await removing
@@ -115,6 +122,44 @@ async def test_unmount_keeps_prefix_reserved_until_cache_cleanup(
     finally:
         release.set()
         await asyncio.gather(removing, return_exceptions=True)
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("store_kind", ["ram", "redis"])
+async def test_unmount_invalidates_index_before_replacement(store_kind):
+    config = IndexConfig()
+    if store_kind == "redis":
+        url = os.environ.get("REDIS_URL")
+        if not url:
+            pytest.skip("REDIS_URL not set")
+        config = RedisIndexConfig(url=url, key_prefix=f"lifecycle:{uuid4()}:")
+    resource = RAMResource()
+    ws = Workspace({"/data": resource}, index=config)
+    ws.add_mount("/alias", resource)
+    index = resource.index
+    entry = IndexEntry(id="old", name="private.txt", resource_type="file")
+    try:
+        await index.put("/data", entry)
+        for path in ("/data", "/data/nested", "/database", "/alias"):
+            await index.set_dir(path, [("private.txt", entry)])
+        await ws.unmount("/data")
+        replacement = RAMResource()
+        ws.add_mount("/data", replacement)
+        for candidate in (index, replacement.index):
+            for path in ("/data", "/data/private.txt",
+                         "/data/nested/private.txt"):
+                assert (await
+                        candidate.get(path)).status == LookupStatus.NOT_FOUND
+            for path in ("/data", "/data/nested"):
+                assert (
+                    await
+                    candidate.list_dir(path)).status == LookupStatus.NOT_FOUND
+        for path in ("/database", "/alias"):
+            assert (await
+                    index.list_dir(path)).entries == [f"{path}/private.txt"]
+    finally:
+        await index.clear()
         await ws.close()
 
 

--- a/python/tests/workspace/workspace/test_lifecycle.py
+++ b/python/tests/workspace/workspace/test_lifecycle.py
@@ -15,6 +15,7 @@
 import asyncio
 import errno
 import os
+from fnmatch import fnmatchcase
 from uuid import uuid4
 
 import pytest
@@ -33,16 +34,25 @@ from mirage.shell.job_table import JobStatus
 from mirage.types import MountMode, PathSpec
 from mirage.utils.key_prefix import mount_key
 from mirage.workspace import Workspace
+from mirage.workspace.executor.builtins.shared import expand_operands
 from mirage.workspace.types import ExecutionNode
 
 _RELEASE: list[asyncio.Event] = []
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("action", ["glob", "midpath", "provision"])
+@pytest.mark.parametrize("action", [
+    "glob", "midpath", "provision", "metadata", "touch", "chmod", "chown",
+    "chgrp"
+])
 async def test_first_mount_access_prepares_expansion_and_provision(action):
 
     class IndexedRAM(RAMResource):
+
+        def set_index(self, config=None):
+            # Keep the backend's shared index across workspace configuration.
+            if not hasattr(self, "_index"):
+                super().set_index(config)
 
         async def resolve_glob(self, paths, prefix=""):
             listing = await self.index.list_dir(paths[0].directory.rstrip("/")
@@ -50,12 +60,13 @@ async def test_first_mount_access_prepares_expansion_and_provision(action):
             if listing.entries is not None:
                 return [
                     PathSpec.from_str_path(key, mount_key(key, prefix))
-                    for key in listing.entries
+                    for key in listing.entries if fnmatchcase(
+                        key.rsplit("/", 1)[-1], paths[0].pattern or "*")
                 ]
             return await super().resolve_glob(paths, prefix)
 
     ancestor = RAMResource()
-    ws = Workspace({"/": ancestor})
+    ws = Workspace({"/": ancestor}, index=IndexConfig(ttl=600))
     replacement = IndexedRAM()
     replacement._index = ancestor.index
     replacement.load_state({
@@ -72,12 +83,33 @@ async def test_first_mount_access_prepares_expansion_and_provision(action):
         [("stale.txt",
           IndexEntry(id="old", name="stale.txt", resource_type="file"))])
     await ws.cache.set("/data/file", b"old")
-    ws.add_mount("/data", replacement)
+    ws.add_mount("/data", replacement, MountMode.WRITE)
     try:
         if action == "provision":
             result = await ws.execute("cat /data/file", provision=True)
             assert result.cache_hits == 0
             assert (await ws.execute("cat /data/file")).stdout == b"new"
+        elif action == "metadata":
+            expanded = await expand_operands(ws._namespace, [
+                PathSpec(virtual="/data/*.txt",
+                         directory="/data/",
+                         resource_path="*.txt",
+                         pattern="*.txt",
+                         resolved=False)
+            ])
+            assert [p.virtual for p in expanded] == ["/data/fresh.txt"]
+        elif action in {"touch", "chmod", "chown", "chgrp"}:
+            command = {
+                "touch": "touch",
+                "chmod": "chmod 600",
+                "chown": "chown 123",
+                "chgrp": "chgrp 456"
+            }[action]
+            result = await ws.execute(command + " /data/*.txt")
+            assert result.exit_code == 0, result.stderr
+            assert (
+                await
+                ws.execute("echo /data/*.txt")).stdout == b"/data/fresh.txt\n"
         else:
             pattern = "/data/*/*.txt" if action == "midpath" else "/data/*.txt"
             result = await ws.execute("echo " + pattern)
@@ -737,5 +769,58 @@ async def test_workspace_close_waits_for_resource_retirements(
         release.set()
         await asyncio.gather(removing,
                              *([closing] if closing else []),
+                             return_exceptions=True)
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_unmount_drains_metadata_glob_and_its_index_writes(monkeypatch):
+    resource = RAMResource()
+    ws = Workspace({"/data": resource}, index=IndexConfig(ttl=600))
+    entered, release = asyncio.Event(), asyncio.Event()
+    closed = False
+    index = resource.index
+    close_resource = resource.close
+
+    async def close():
+        nonlocal closed
+        closed = True
+        await close_resource()
+
+    async def glob(paths, prefix=""):
+        entered.set()
+        await release.wait()
+        assert not closed
+        await index.set_dir("/data", [
+            ("late", IndexEntry(id="late", name="late", resource_type="file"))
+        ])
+        return []
+
+    monkeypatch.setattr(resource, "resolve_glob", glob)
+    monkeypatch.setattr(resource, "close", close)
+    expanding = asyncio.create_task(
+        expand_operands(ws._namespace, [
+            PathSpec(virtual="/data/*",
+                     directory="/data/",
+                     resource_path="*",
+                     pattern="*",
+                     resolved=False)
+        ]))
+    removing = None
+    try:
+        await asyncio.wait_for(entered.wait(), 5)
+        removing = asyncio.create_task(ws.unmount("/data"))
+        await asyncio.sleep(0.02)
+        assert not removing.done()
+        assert not closed
+        release.set()
+        await expanding
+        await removing
+        assert closed
+        assert (await index.list_dir("/data")).entries is None
+    finally:
+        release.set()
+        await asyncio.gather(expanding,
+                             *([] if removing is None else [removing]),
                              return_exceptions=True)
         await ws.close()

--- a/python/tests/workspace/workspace/test_lifecycle.py
+++ b/python/tests/workspace/workspace/test_lifecycle.py
@@ -22,11 +22,100 @@ from mirage.resource.ram import RAMResource
 from mirage.runtime.base import Runtime
 from mirage.shell.console import Channel
 from mirage.shell.job_table import JobStatus
-from mirage.types import MountMode
+from mirage.types import MountMode, PathSpec
 from mirage.workspace import Workspace
 from mirage.workspace.types import ExecutionNode
 
 _RELEASE: list[asyncio.Event] = []
+
+
+@pytest.mark.asyncio
+async def test_retired_command_cannot_cache_bytes_for_replacement_mount():
+
+    class CachedRAM(RAMResource):
+        caches_reads = True
+
+    old = CachedRAM()
+    old.load_state({"files": {"/file": b"old"}})
+    replacement = CachedRAM()
+    replacement.load_state({"files": {"/file": b"new"}})
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def gate(_inv):
+        entered.set()
+        await release.wait()
+        return None, IOResult()
+
+    ws = Workspace({"/data": old})
+    ws.register_cli("gate", CLISpec(name="gate", fn=gate))
+    retired = ws.mount("/data").cache_manager
+    running = asyncio.create_task(ws.execute("cat /data/file; gate"))
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        await ws.unmount("/data")
+        ws.add_mount("/data", replacement)
+        release.set()
+        result = await asyncio.wait_for(running, timeout=5)
+        assert result.stdout == b"old"
+        assert await ws.cache.get("/data/file") is None
+        assert (await ws.execute("cat /data/file")).stdout == b"new"
+        assert await ws.cache.get("/data/file") == b"new"
+        assert retired is not None
+        assert await retired.cached_bytes(
+            PathSpec(virtual="/data/file",
+                     directory="/data/",
+                     resource_path="file")) is None
+    finally:
+        release.set()
+        await asyncio.gather(running, return_exceptions=True)
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail_eviction", [False, True])
+async def test_unmount_keeps_prefix_reserved_until_cache_cleanup(
+        monkeypatch, fail_eviction):
+    resource = RAMResource()
+    ws = Workspace({"/data": resource})
+    cache = ws.cache
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    evict = cache.evict_prefix
+
+    async def blocked_evict(prefix):
+        entered.set()
+        await release.wait()
+        if fail_eviction:
+            raise RuntimeError("cache unavailable")
+        await evict(prefix)
+
+    monkeypatch.setattr(cache, "evict_prefix", blocked_evict)
+    await cache.set("/data", b"root")
+    await cache.set("/data/file", b"old")
+    await cache.set("/database/file", b"peer")
+    removing = asyncio.create_task(ws.unmount("data/"))
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        with pytest.raises(ValueError, match="duplicate mount prefix"):
+            ws.add_mount("/data", RAMResource())
+        release.set()
+        if fail_eviction:
+            with pytest.raises(RuntimeError, match="cache unavailable"):
+                await removing
+            assert ws.mount("/data").resource is resource
+            monkeypatch.setattr(cache, "evict_prefix", evict)
+            await ws.unmount("/data")
+        else:
+            await removing
+        assert await cache.get("/data") is None
+        assert await cache.get("/data/file") is None
+        assert await cache.get("/database/file") == b"peer"
+        ws.add_mount("/data", RAMResource())
+    finally:
+        release.set()
+        await asyncio.gather(removing, return_exceptions=True)
+        await ws.close()
 
 
 def _workspace() -> Workspace:

--- a/python/tests/workspace/workspace/test_lifecycle.py
+++ b/python/tests/workspace/workspace/test_lifecycle.py
@@ -16,8 +16,10 @@ import asyncio
 
 import pytest
 
+from mirage.commands.cli.types import CLISpec
 from mirage.io import IOResult
 from mirage.resource.ram import RAMResource
+from mirage.runtime.base import Runtime
 from mirage.shell.console import Channel
 from mirage.shell.job_table import JobStatus
 from mirage.types import MountMode
@@ -109,3 +111,67 @@ async def test_close_is_idempotent_with_a_job_running():
         for release in _RELEASE:
             release.set()
         await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocked_phase", ["runtime", "resource"])
+async def test_close_refuses_lifecycle_changes_but_allows_runtime_drain(
+        monkeypatch, blocked_phase):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    resource = RAMResource()
+    ws = Workspace({"/m": (resource, MountMode.WRITE)})
+    closes = []
+    drained = []
+
+    async def cli(_inv):
+        return None, IOResult()
+
+    spec = CLISpec(name="held", fn=cli)
+    ws.register_cli("held", spec)
+
+    class DrainingRuntime(Runtime):
+        name = "draining"
+
+        async def close(self):
+            closes.append("runtime")
+            if blocked_phase == "runtime":
+                entered.set()
+                await release.wait()
+            await ws.fs.write("/m/journal.txt", b"drained")
+
+    close_resource = resource.close
+
+    async def closing_resource():
+        closes.append("resource")
+        if blocked_phase == "resource":
+            entered.set()
+            await release.wait()
+        drained.append(await ws.fs.read("/m/journal.txt"))
+        await close_resource()
+
+    monkeypatch.setattr(resource, "close", closing_resource)
+    runtime = DrainingRuntime()
+    ws.add_runtime(runtime)
+    closing = asyncio.create_task(ws.close())
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        for mutate in (
+                lambda: ws.add_mount("/late", RAMResource()),
+                lambda: ws.set_mount_mode("/m", MountMode.READ),
+                lambda: ws.add_runtime(runtime),
+                lambda: ws.register_cli("late", spec),
+                lambda: ws.unregister_cli("held"),
+        ):
+            with pytest.raises(RuntimeError, match="Workspace is closed"):
+                mutate()
+        with pytest.raises(RuntimeError, match="Workspace is closed"):
+            await ws.unmount("/m")
+        with pytest.raises(RuntimeError, match="Workspace is closed"):
+            await ws.set_session_profile(ws.default_session_id, {})
+    finally:
+        release.set()
+        await asyncio.wait_for(asyncio.gather(closing, ws.close()), timeout=5)
+
+    assert closes == ["runtime", "resource"]
+    assert drained == [b"drained"]

--- a/python/tests/workspace/workspace/test_lifecycle.py
+++ b/python/tests/workspace/workspace/test_lifecycle.py
@@ -34,13 +34,89 @@ _RELEASE: list[asyncio.Event] = []
 
 
 @pytest.mark.asyncio
-async def test_retired_command_cannot_cache_bytes_for_replacement_mount():
+async def test_unmount_waits_for_an_inflight_cache_write(monkeypatch):
 
     class CachedRAM(RAMResource):
         caches_reads = True
 
     old = CachedRAM()
     old.load_state({"files": {"/file": b"old"}})
+    ws = Workspace({"/data": old})
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    write_cache = ws.cache.set
+
+    async def blocked_set(*args, **kwargs):
+        entered.set()
+        await release.wait()
+        await write_cache(*args, **kwargs)
+
+    monkeypatch.setattr(ws.cache, "set", blocked_set)
+    reading = asyncio.create_task(ws.execute("cat /data/file"))
+    removing = None
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        removing = asyncio.create_task(ws.unmount("/data"))
+        await asyncio.sleep(0)
+        assert not removing.done()
+        with pytest.raises(ValueError, match="duplicate mount prefix"):
+            ws.add_mount("/data", CachedRAM())
+        release.set()
+        await asyncio.wait_for(asyncio.gather(reading, removing), timeout=5)
+        assert await ws.cache.get("/data/file") is None
+        replacement = CachedRAM()
+        replacement.load_state({"files": {"/file": b"new"}})
+        ws.add_mount("/data", replacement)
+        assert (await ws.execute("cat /data/file")).stdout == b"new"
+    finally:
+        release.set()
+        await asyncio.gather(reading,
+                             *([removing] if removing else []),
+                             return_exceptions=True)
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_resource_cannot_be_remounted_while_close_is_pending(
+        monkeypatch):
+    resource = RAMResource()
+    ws = Workspace({"/data": resource})
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    close = resource.close
+
+    async def blocked_close():
+        entered.set()
+        await release.wait()
+        await close()
+
+    monkeypatch.setattr(resource, "close", blocked_close)
+    removing = asyncio.create_task(ws.unmount("/data"))
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        for prefix in ("/data", "/alias"):
+            with pytest.raises(ValueError,
+                               match="resource is being unmounted"):
+                ws.add_mount(prefix, resource)
+        release.set()
+        await removing
+        ws.add_mount("/data", resource)
+    finally:
+        release.set()
+        await asyncio.gather(removing, return_exceptions=True)
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shadow", [False, True])
+async def test_retired_command_cannot_cache_bytes_for_replacement_mount(
+        shadow):
+
+    class CachedRAM(RAMResource):
+        caches_reads = True
+
+    old = CachedRAM()
+    old.load_state({"files": {"/data/file" if shadow else "/file": b"old"}})
     replacement = CachedRAM()
     replacement.load_state({"files": {"/file": b"new"}})
     entered = asyncio.Event()
@@ -51,13 +127,15 @@ async def test_retired_command_cannot_cache_bytes_for_replacement_mount():
         await release.wait()
         return None, IOResult()
 
-    ws = Workspace({"/data": old})
+    prefix = "/" if shadow else "/data"
+    ws = Workspace({prefix: old})
     ws.register_cli("gate", CLISpec(name="gate", fn=gate))
-    retired = ws.mount("/data").cache_manager
+    retired = ws.mount(prefix).cache_manager
     running = asyncio.create_task(ws.execute("cat /data/file; gate"))
     try:
         await asyncio.wait_for(entered.wait(), timeout=5)
-        await ws.unmount("/data")
+        if not shadow:
+            await ws.unmount("/data")
         ws.add_mount("/data", replacement)
         release.set()
         result = await asyncio.wait_for(running, timeout=5)
@@ -127,7 +205,9 @@ async def test_unmount_keeps_prefix_reserved_until_cache_cleanup(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("store_kind", ["ram", "redis"])
-async def test_unmount_invalidates_index_before_replacement(store_kind):
+@pytest.mark.parametrize("shadow", [False, True])
+async def test_mount_change_invalidates_index_before_replacement(
+        store_kind, shadow):
     config = IndexConfig()
     if store_kind == "redis":
         url = os.environ.get("REDIS_URL")
@@ -135,7 +215,7 @@ async def test_unmount_invalidates_index_before_replacement(store_kind):
             pytest.skip("REDIS_URL not set")
         config = RedisIndexConfig(url=url, key_prefix=f"lifecycle:{uuid4()}:")
     resource = RAMResource()
-    ws = Workspace({"/data": resource}, index=config)
+    ws = Workspace({"/" if shadow else "/data": resource}, index=config)
     ws.add_mount("/alias", resource)
     index = resource.index
     entry = IndexEntry(id="old", name="private.txt", resource_type="file")
@@ -143,18 +223,19 @@ async def test_unmount_invalidates_index_before_replacement(store_kind):
         await index.put("/data", entry)
         for path in ("/data", "/data/nested", "/database", "/alias"):
             await index.set_dir(path, [("private.txt", entry)])
-        await ws.unmount("/data")
+        if not shadow:
+            await ws.unmount("/data")
         replacement = RAMResource()
         ws.add_mount("/data", replacement)
+        if shadow:
+            assert await ws.fs.readdir("/data") == []
         for candidate in (index, replacement.index):
             for path in ("/data", "/data/private.txt",
                          "/data/nested/private.txt"):
                 assert (await
                         candidate.get(path)).status == LookupStatus.NOT_FOUND
             for path in ("/data", "/data/nested"):
-                assert (
-                    await
-                    candidate.list_dir(path)).status == LookupStatus.NOT_FOUND
+                assert (await candidate.list_dir(path)).entries in (None, [])
         for path in ("/database", "/alias"):
             assert (await
                     index.list_dir(path)).entries == [f"{path}/private.txt"]

--- a/python/tests/workspace/workspace/test_lifecycle.py
+++ b/python/tests/workspace/workspace/test_lifecycle.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import errno
 import os
 from uuid import uuid4
 
@@ -22,15 +23,65 @@ from mirage.cache.index.config import (IndexConfig, IndexEntry, LookupStatus,
                                        RedisIndexConfig)
 from mirage.commands.cli.types import CLISpec
 from mirage.io import IOResult
+from mirage.ops.registry import op
 from mirage.resource.ram import RAMResource
 from mirage.runtime.base import Runtime
 from mirage.shell.console import Channel
 from mirage.shell.job_table import JobStatus
 from mirage.types import MountMode, PathSpec
+from mirage.utils.key_prefix import mount_key
 from mirage.workspace import Workspace
 from mirage.workspace.types import ExecutionNode
 
 _RELEASE: list[asyncio.Event] = []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["glob", "midpath", "provision"])
+async def test_first_mount_access_prepares_expansion_and_provision(action):
+
+    class IndexedRAM(RAMResource):
+
+        async def resolve_glob(self, paths, prefix=""):
+            listing = await self.index.list_dir(paths[0].directory.rstrip("/")
+                                                or "/")
+            if listing.entries is not None:
+                return [
+                    PathSpec.from_str_path(key, mount_key(key, prefix))
+                    for key in listing.entries
+                ]
+            return await super().resolve_glob(paths, prefix)
+
+    ancestor = RAMResource()
+    ws = Workspace({"/": ancestor})
+    replacement = IndexedRAM()
+    replacement._index = ancestor.index
+    replacement.load_state({
+        "dirs": ["/", "/dir"],
+        "files": {
+            "/fresh.txt": b"new",
+            "/dir/fresh.txt": b"new",
+            "/file": b"new"
+        }
+    })
+    directory = "/data/dir" if action == "midpath" else "/data"
+    await ancestor.index.set_dir(
+        directory,
+        [("stale.txt",
+          IndexEntry(id="old", name="stale.txt", resource_type="file"))])
+    await ws.cache.set("/data/file", b"old")
+    ws.add_mount("/data", replacement)
+    try:
+        if action == "provision":
+            result = await ws.execute("cat /data/file", provision=True)
+            assert result.cache_hits == 0
+            assert (await ws.execute("cat /data/file")).stdout == b"new"
+        else:
+            pattern = "/data/*/*.txt" if action == "midpath" else "/data/*.txt"
+            result = await ws.execute("echo " + pattern)
+            assert result.stdout == f"{directory}/fresh.txt\n".encode()
+    finally:
+        await ws.close()
 
 
 @pytest.mark.asyncio
@@ -77,29 +128,39 @@ async def test_unmount_waits_for_an_inflight_cache_write(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
 async def test_resource_cannot_be_remounted_while_close_is_pending(
-        monkeypatch):
+        monkeypatch, cancel):
     resource = RAMResource()
     ws = Workspace({"/data": resource})
     entered = asyncio.Event()
     release = asyncio.Event()
+    closed = asyncio.Event()
     close = resource.close
 
     async def blocked_close():
         entered.set()
         await release.wait()
         await close()
+        closed.set()
 
     monkeypatch.setattr(resource, "close", blocked_close)
     removing = asyncio.create_task(ws.unmount("/data"))
     try:
         await asyncio.wait_for(entered.wait(), timeout=5)
+        if cancel:
+            removing.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await removing
         for prefix in ("/data", "/alias"):
             with pytest.raises(ValueError,
                                match="resource is being unmounted"):
                 ws.add_mount(prefix, resource)
         release.set()
-        await removing
+        await asyncio.wait_for(closed.wait(), timeout=5)
+        await asyncio.sleep(0)
+        if not cancel:
+            await removing
         ws.add_mount("/data", resource)
     finally:
         release.set()
@@ -160,8 +221,11 @@ async def test_retired_command_cannot_cache_bytes_for_replacement_mount(
 async def test_unmount_keeps_prefix_reserved_until_cache_cleanup(
         monkeypatch, fail_eviction, cache_kind):
     resource = RAMResource()
-    ws = Workspace({"/data": resource})
+    resource.load_state({"files": {"/file": b"old"}})
+    ws = Workspace({"/data": resource}, mode=MountMode.WRITE)
     cache = ws.cache
+    ws.add_mount("/alias", resource)
+    alias_entries = await ws.fs.readdir("/alias")
     entered = asyncio.Event()
     release = asyncio.Event()
     store = cache if cache_kind == "file" else resource.index
@@ -182,8 +246,18 @@ async def test_unmount_keeps_prefix_reserved_until_cache_cleanup(
     removing = asyncio.create_task(ws.unmount("data/"))
     try:
         await asyncio.wait_for(entered.wait(), timeout=5)
+        await ws.mount("/alias").ensure_ready()
         with pytest.raises(ValueError, match="duplicate mount prefix"):
             ws.add_mount("/data", RAMResource())
+        with pytest.raises(OSError) as reading:
+            await ws.fs.readdir("/data")
+        assert reading.value.errno == errno.EBUSY
+        with pytest.raises(OSError) as writing:
+            await ws.fs.write("/data/file", b"changed")
+        assert writing.value.errno == errno.EBUSY
+        for line in ("cat /data/file", "echo changed > /data/file"):
+            assert (await ws.execute(line)).exit_code != 0
+        assert resource.get_state()["files"]["/file"] == b"old"
         release.set()
         if fail_eviction:
             with pytest.raises(RuntimeError, match="cache unavailable"):
@@ -196,6 +270,7 @@ async def test_unmount_keeps_prefix_reserved_until_cache_cleanup(
         assert await cache.get("/data") is None
         assert await cache.get("/data/file") is None
         assert await cache.get("/database/file") == b"peer"
+        assert await ws.fs.readdir("/alias") == alias_entries
         ws.add_mount("/data", RAMResource())
     finally:
         release.set()
@@ -390,3 +465,61 @@ async def test_close_refuses_lifecycle_changes_but_allows_runtime_drain(
 
     assert closes == ["runtime", "resource"]
     assert drained == [b"drained"]
+
+
+@pytest.mark.asyncio
+async def test_unmount_preserves_operations_of_each_surviving_resource():
+
+    class LabeledRAM(RAMResource):
+
+        def __init__(self, label, specialized=False):
+            super().__init__()
+            self.closes = 0
+
+            @op("identity", resource="ram")
+            async def identity(accessor, path, **kwargs):
+                if self.closes:
+                    raise RuntimeError("resource closed")
+                return label.encode()
+
+            self.register_op(identity)
+            if specialized:
+
+                @op("unique", resource="ram")
+                async def unique(accessor, path, **kwargs):
+                    return label.encode()
+
+                self.register_op(unique)
+
+        async def close(self):
+            self.closes += 1
+            await super().close()
+
+    first = LabeledRAM("first")
+    second = LabeledRAM("second", specialized=True)
+    third = LabeledRAM("third")
+    ws = Workspace({})
+
+    async def identity(path, name="identity"):
+        result, _ = await ws.dispatch(name, PathSpec.from_str_path(path))
+        return result.decode()
+
+    try:
+        ws.add_mount("/first", first)
+        ws.add_mount("/second", second)
+        ws.add_mount("/third", third)
+        assert await identity("/first/file") == "first"
+        assert await identity("/second/file") == "second"
+        assert await identity("/third/file") == "third"
+        await ws.unmount("/second")
+        assert second.closes == 1
+        assert await identity("/first/file") == "first"
+        assert await identity("/third/file") == "third"
+        with pytest.raises(OSError) as missing:
+            await identity("/first/file", "unique")
+        assert missing.value.errno == errno.ENOTSUP
+        await ws.unmount("/third")
+        assert await identity("/first/file") == "first"
+        assert await ws.fs.readdir("/")
+    finally:
+        await ws.close()

--- a/typescript/packages/core/src/cache/file/io.test.ts
+++ b/typescript/packages/core/src/cache/file/io.test.ts
@@ -193,6 +193,54 @@ describe('edge cases', () => {
 })
 
 describe('background drain', () => {
+  it('retires an evicted fill before a replacement starts at the same path', async () => {
+    const cache = new RAMFileCacheStore()
+    let releaseOld = (): void => undefined
+    let releaseNew = (): void => undefined
+    const oldGate = new Promise<void>((resolve) => {
+      releaseOld = resolve
+    })
+    const newGate = new Promise<void>((resolve) => {
+      releaseNew = resolve
+    })
+    async function* stream(gate: Promise<void>, data: string) {
+      await gate
+      yield ENC.encode(data)
+    }
+    const path = '/data/file'
+    await applyIo(
+      cache,
+      new IOResult({
+        reads: { [path]: new CachableAsyncIterator(stream(oldGate, 'old account')) },
+        cache: [path],
+      }),
+    )
+    const old = cache.drainTasks.get(path)
+    await cache.evictPrefix('/data/')
+    expect(cache.drainTasks.has(path)).toBe(false)
+    await applyIo(
+      cache,
+      new IOResult({
+        reads: { [path]: new CachableAsyncIterator(stream(newGate, 'new account')) },
+        cache: [path],
+      }),
+    )
+    const fresh = cache.drainTasks.get(path)
+    try {
+      releaseOld()
+      await old
+      expect(await cache.get(path)).toBeNull()
+      expect(cache.drainTasks.get(path)).toBe(fresh)
+      releaseNew()
+      await fresh
+      expect(DEC.decode((await cache.get(path)) ?? undefined)).toBe('new account')
+    } finally {
+      releaseOld()
+      releaseNew()
+      await Promise.allSettled([old, fresh])
+    }
+  })
+
   it('does not start a duplicate drain for the same path', async () => {
     const cache = new RAMFileCacheStore()
     const io1 = new IOResult({ reads: { '/f.txt': makeStream('first') }, cache: ['/f.txt'] })

--- a/typescript/packages/core/src/cache/file/io.ts
+++ b/typescript/packages/core/src/cache/file/io.ts
@@ -16,6 +16,19 @@ import { CachableAsyncIterator, concat } from '../../io/cachable_iterator.ts'
 import { materialize, type IOResult } from '../../io/types.ts'
 import type { OpRecord } from '../../observe/record.ts'
 import { drainBudget, type FileCache } from './mixin.ts'
+import { KeyLock } from '../lock.ts'
+
+const mutationLocks = new WeakMap<FileCache, KeyLock>()
+
+/** Serialize cache fills with mount ownership changes, including remote writes. */
+export function withCacheMutation<T>(cache: FileCache, fn: () => Promise<T>): Promise<T> {
+  let lock = mutationLocks.get(cache)
+  if (lock === undefined) {
+    lock = new KeyLock()
+    mutationLocks.set(cache, lock)
+  }
+  return lock.withLock('', fn)
+}
 
 /**
  * Latest backend fingerprint recorded for a read of `path`.
@@ -51,6 +64,19 @@ async function setCached(
   records: readonly OpRecord[] | undefined,
   isCacheable: ((path: string) => boolean) | undefined,
 ): Promise<void> {
+  await withCacheMutation(cache, async () => {
+    if (isCacheable === undefined || isCacheable(path)) {
+      await setCachedLocked(cache, path, data, records)
+    }
+  })
+}
+
+async function setCachedLocked(
+  cache: FileCache,
+  path: string,
+  data: Uint8Array,
+  records: readonly OpRecord[] | undefined,
+): Promise<void> {
   const fingerprint = readFingerprint(records, path)
   if (fingerprint === null && bytesEqual(await cache.get(path), data)) {
     // Warm read: the bytes were served from this cache, so there is no
@@ -59,9 +85,7 @@ async function setCached(
     // force ALWAYS mode to evict and refetch on every read.
     return
   }
-  if (isCacheable === undefined || isCacheable(path)) {
-    await cache.set(path, data, { fingerprint })
-  }
+  await cache.set(path, data, { fingerprint })
 }
 
 export async function applyIo(
@@ -125,9 +149,11 @@ async function backgroundDrain(
   try {
     const materialized = await it.drainBounded(maxBytes)
     if (materialized === null) return
-    if (isCurrent()) {
-      await cache.add(path, materialized, { fingerprint: readFingerprint(records, path) })
-    }
+    await withCacheMutation(cache, async () => {
+      if (isCurrent()) {
+        await cache.add(path, materialized, { fingerprint: readFingerprint(records, path) })
+      }
+    })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     console.warn(`background drain failed for ${path}: ${msg}`)

--- a/typescript/packages/core/src/cache/file/io.ts
+++ b/typescript/packages/core/src/cache/file/io.ts
@@ -49,6 +49,7 @@ async function setCached(
   path: string,
   data: Uint8Array,
   records: readonly OpRecord[] | undefined,
+  isCacheable: ((path: string) => boolean) | undefined,
 ): Promise<void> {
   const fingerprint = readFingerprint(records, path)
   if (fingerprint === null && bytesEqual(await cache.get(path), data)) {
@@ -58,7 +59,9 @@ async function setCached(
     // force ALWAYS mode to evict and refetch on every read.
     return
   }
-  await cache.set(path, data, { fingerprint })
+  if (isCacheable === undefined || isCacheable(path)) {
+    await cache.set(path, data, { fingerprint })
+  }
 }
 
 export async function applyIo(
@@ -73,14 +76,21 @@ export async function applyIo(
     const source = io.reads[path] ?? io.writes[path]
     if (source === undefined) continue
     if (source instanceof Uint8Array) {
-      await setCached(cache, path, source, records)
+      await setCached(cache, path, source, records, isCacheable)
     } else if (source instanceof CachableAsyncIterator) {
       if (source.exhausted) {
-        await setCached(cache, path, concat(source.bufferedChunks), records)
+        await setCached(cache, path, concat(source.bufferedChunks), records, isCacheable)
       } else {
         const tasks = cache.drainTasks
         if (tasks !== undefined && !tasks.has(path) && !(await cache.exists(path))) {
-          const task = backgroundDrain(cache, tasks, path, source, drainBudget(cache), records)
+          const task: Promise<void> = backgroundDrain(
+            cache,
+            path,
+            source,
+            drainBudget(cache),
+            () => tasks.get(path) === task && (isCacheable === undefined || isCacheable(path)),
+            records,
+          )
           tasks.set(path, task)
           void task.finally(() => {
             if (tasks.get(path) === task) tasks.delete(path)
@@ -89,7 +99,7 @@ export async function applyIo(
       }
     } else {
       const data = await materialize(source)
-      await setCached(cache, path, data, records)
+      await setCached(cache, path, data, records, isCacheable)
     }
   }
   for (const path of Object.keys(io.writes)) {
@@ -106,16 +116,16 @@ export async function applyIo(
 // their read record lazily, once the GET response arrives.
 async function backgroundDrain(
   cache: FileCache,
-  tasks: Map<string, Promise<void>>,
   path: string,
   it: CachableAsyncIterator,
   maxBytes: number,
+  isCurrent: () => boolean,
   records?: readonly OpRecord[],
 ): Promise<void> {
   try {
     const materialized = await it.drainBounded(maxBytes)
     if (materialized === null) return
-    if (tasks.has(path)) {
+    if (isCurrent()) {
       await cache.add(path, materialized, { fingerprint: readFingerprint(records, path) })
     }
   } catch (err) {

--- a/typescript/packages/core/src/cache/file/ram.ts
+++ b/typescript/packages/core/src/cache/file/ram.ts
@@ -137,8 +137,10 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
   }
 
   async evictPrefix(prefix: string): Promise<void> {
-    // Snapshot first: remove() mutates entries as it goes.
-    const keys = [...this.entries.keys()].filter((k) => k.startsWith(prefix))
+    // A pending fill may not have installed an entry yet.
+    const keys = [...new Set([...this.entries.keys(), ...this.drainTasks.keys()])].filter((k) =>
+      k.startsWith(prefix),
+    )
     for (const key of keys) await this.remove(key)
   }
 

--- a/typescript/packages/core/src/cache/index/view.test.ts
+++ b/typescript/packages/core/src/cache/index/view.test.ts
@@ -1,0 +1,136 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  IndexEntry,
+  IndexType,
+  LookupStatus,
+  type IndexConfig,
+  type RedisIndexConfig,
+} from './config.ts'
+import { RAMResource } from '../../resource/ram/ram.ts'
+import { Workspace } from '../../workspace/workspace/workspace.ts'
+
+const cases = ['backend', 'store'].flatMap((phase) =>
+  ['put', 'setDir'].flatMap((method) => [false, true].map((shadow) => ({ phase, method, shadow }))),
+)
+
+for (const type of [IndexType.RAM, IndexType.REDIS]) {
+  describe(`index lifecycle (${type})`, () => {
+    it.skipIf(type === IndexType.REDIS && process.env.REDIS_URL === undefined).each(cases)(
+      'fences $phase $method writes across mount changes (shadow=$shadow)',
+      async ({ phase, method, shadow }) => {
+        const url = process.env.REDIS_URL
+        const config: IndexConfig | RedisIndexConfig =
+          type === IndexType.REDIS
+            ? {
+                type,
+                ...(url === undefined ? {} : { url }),
+                keyPrefix: `lifecycle:${crypto.randomUUID()}:`,
+              }
+            : { type }
+        const resource = new RAMResource()
+        const prefix = shadow ? '/' : '/data'
+        const ws = new Workspace({ [prefix]: resource }, { index: config })
+        ws.addMount('/alias', resource)
+        const index = resource.index
+        const entry = new IndexEntry({ id: 'old', name: 'stale', resourceType: 'file' })
+        let enter = (): void => undefined
+        let resume = (): void => undefined
+        const entered = new Promise<void>((resolve) => {
+          enter = resolve
+        })
+        const release = new Promise<void>((resolve) => {
+          resume = resolve
+        })
+        const pause = async (): Promise<void> => {
+          enter()
+          await release
+        }
+        if (phase === 'store') {
+          if (method === 'put') {
+            const original = index.put.bind(index)
+            vi.spyOn(index, 'put').mockImplementation(async (...args) => {
+              await pause()
+              await original(...args)
+            })
+          } else {
+            const original = index.setDir.bind(index)
+            vi.spyOn(index, 'setDir').mockImplementation(async (...args) => {
+              await pause()
+              await original(...args)
+            })
+          }
+        }
+        ws.ops.register({
+          name: 'readdir',
+          resource: 'ram',
+          filetype: null,
+          write: false,
+          fn: async (_accessor, _path, _args, { index }) => {
+            if (index === undefined) throw new Error('missing index')
+            if (phase === 'backend') await pause()
+            if (method === 'put') await index.put('/data/stale', entry)
+            else await index.setDir('/data', [['stale', entry]])
+            return ['/data/stale']
+          },
+        })
+        const reading = ws.fs.readdir('/data')
+        let changing: Promise<unknown> | undefined
+        const replacement = new RAMResource()
+        try {
+          await entered
+          let changed = false
+          if (shadow) {
+            ws.addMount('/data', replacement)
+            changing = ws.fs.readdir('/data').then(() => {
+              changed = true
+            })
+          } else {
+            changing = ws.unmount('/data').then(() => {
+              changed = true
+            })
+          }
+          await Promise.resolve()
+          if (phase === 'store') {
+            expect(changed).toBe(false)
+            resume()
+          }
+          await changing
+          if (!shadow) {
+            ws.addMount('/data', replacement)
+            await ws.fs.readdir('/data')
+          }
+          await replacement.index.put(
+            '/data/fresh',
+            new IndexEntry({ id: 'new', name: 'fresh', resourceType: 'file' }),
+          )
+          resume()
+          await reading
+          for (const candidate of [index, replacement.index]) {
+            expect((await candidate.get('/data/stale')).status).toBe(LookupStatus.NOT_FOUND)
+            expect((await candidate.listDir('/data')).entries ?? []).not.toContain('/data/stale')
+          }
+          expect((await replacement.index.get('/data/fresh')).entry?.id).toBe('new')
+        } finally {
+          resume()
+          await Promise.allSettled([reading, changing])
+          await index.clear()
+          await ws.close()
+        }
+      },
+    )
+  })
+}

--- a/typescript/packages/core/src/cache/index/view.test.ts
+++ b/typescript/packages/core/src/cache/index/view.test.ts
@@ -21,6 +21,9 @@ import {
   type RedisIndexConfig,
 } from './config.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
+import { runWithSession } from '../../context/session_context.ts'
+import { FileStat, FileType, MountMode, PathSpec } from '../../types.ts'
+import { Session } from '../../workspace/session/session.ts'
 import { Workspace } from '../../workspace/workspace/workspace.ts'
 
 const cases = ['backend', 'store'].flatMap((phase) =>
@@ -29,6 +32,90 @@ const cases = ['backend', 'store'].flatMap((phase) =>
 
 for (const type of [IndexType.RAM, IndexType.REDIS]) {
   describe(`index lifecycle (${type})`, () => {
+    it
+      .skipIf(type === IndexType.REDIS && process.env.REDIS_URL === undefined)
+      .each(['readlink', 'rename'])(
+      'fences metadata writes from internal %s probes',
+      async (op) => {
+        const url = process.env.REDIS_URL
+        const config: IndexConfig | RedisIndexConfig =
+          type === IndexType.REDIS
+            ? {
+                type,
+                ...(url === undefined ? {} : { url }),
+                keyPrefix: `lifecycle:${crypto.randomUUID()}:`,
+              }
+            : { type }
+        const resource = new RAMResource()
+        const ws = new Workspace({ '/data': resource }, { index: config, mode: MountMode.WRITE })
+        ws.addMount('/alias', resource)
+        const index = resource.index
+        let enter = (): void => undefined
+        let resume = (): void => undefined
+        const entered = new Promise<void>((resolve) => {
+          enter = resolve
+        })
+        const release = new Promise<void>((resolve) => {
+          resume = resolve
+        })
+        ws.ops.register({
+          name: 'stat',
+          resource: 'ram',
+          filetype: null,
+          write: false,
+          fn: async (_accessor, _path, _args, { index }) => {
+            if (index === undefined) throw new Error('missing index')
+            enter()
+            await release
+            await index.put(
+              '/data/stale',
+              new IndexEntry({ id: 'old', name: 'stale', resourceType: 'file' }),
+            )
+            return new FileStat({
+              name: 'source',
+              type: op === 'rename' ? FileType.DIRECTORY : FileType.FILE,
+            })
+          },
+        })
+        const session = new Session({
+          sessionId: 'agent',
+          hiddenPaths: { paths: ['/data/source/private'] },
+        })
+        const reading = runWithSession(session, () =>
+          ws.dispatch(
+            op,
+            '/data/source',
+            op === 'rename' ? [PathSpec.fromStrPath('/data/destination')] : [],
+          ),
+        ).then(
+          () => undefined,
+          (err: unknown) => (err instanceof Error && 'code' in err ? err.code : undefined),
+        )
+        try {
+          await entered
+          await ws.unmount('/data')
+          const replacement = new RAMResource()
+          ws.addMount('/data', replacement)
+          await ws.fs.readdir('/data')
+          await replacement.index.put(
+            '/data/fresh',
+            new IndexEntry({ id: 'new', name: 'fresh', resourceType: 'file' }),
+          )
+          resume()
+          expect(await reading).toBe(op === 'rename' ? 'EACCES' : 'EINVAL')
+          for (const candidate of [index, replacement.index]) {
+            expect((await candidate.get('/data/stale')).status).toBe(LookupStatus.NOT_FOUND)
+          }
+          expect((await replacement.index.get('/data/fresh')).entry?.id).toBe('new')
+        } finally {
+          resume()
+          await reading
+          await index.clear()
+          await ws.close()
+        }
+      },
+    )
+
     it.skipIf(type === IndexType.REDIS && process.env.REDIS_URL === undefined).each(cases)(
       'fences $phase $method writes across mount changes (shadow=$shadow)',
       async ({ phase, method, shadow }) => {

--- a/typescript/packages/core/src/cache/index/view.ts
+++ b/typescript/packages/core/src/cache/index/view.ts
@@ -1,0 +1,99 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { withCacheMutation } from '../file/io.ts'
+import type { FileCache } from '../file/mixin.ts'
+import { LookupStatus, type IndexEntry, type ListResult, type LookupResult } from './config.ts'
+import { IndexCacheStore } from './store.ts'
+import { rstripSlash } from '../../utils/slash.ts'
+
+/** A mount-owned index view; delayed backend writes retain their original owner. */
+export class IndexView extends IndexCacheStore {
+  constructor(
+    private readonly store: IndexCacheStore,
+    private readonly cache: FileCache,
+    private readonly prefix: string,
+    private readonly owns: (path: string) => boolean,
+  ) {
+    super()
+  }
+
+  async get(path: string): Promise<LookupResult> {
+    // Index lookups may flush queued state; keep them inside the write fence too.
+    return withCacheMutation(this.cache, async () => {
+      if (!this.owns(path)) return { status: LookupStatus.NOT_FOUND }
+      const result = await this.store.get(path)
+      return this.owns(path) ? result : { status: LookupStatus.NOT_FOUND }
+    })
+  }
+
+  async listDir(path: string): Promise<ListResult> {
+    return withCacheMutation(this.cache, async () => {
+      if (!this.owns(path)) return { status: LookupStatus.NOT_FOUND }
+      const result = await this.store.listDir(path)
+      if (!this.owns(path)) return { status: LookupStatus.NOT_FOUND }
+      return result.entries === undefined || result.entries === null
+        ? result
+        : {
+            ...result,
+            entries: result.entries.filter((key) => this.owns(key)),
+          }
+    })
+  }
+
+  put(path: string, entry: IndexEntry): Promise<void> {
+    return withCacheMutation(this.cache, async () => {
+      if (this.owns(path)) await this.store.put(path, entry)
+    })
+  }
+
+  setDir(
+    path: string,
+    entries: readonly [string, IndexEntry][],
+    expiredAt?: Date | null,
+  ): Promise<void> {
+    return withCacheMutation(this.cache, async () => {
+      if (this.owns(path)) {
+        const prefix = rstripSlash(path) + '/'
+        await this.store.setDir(
+          path,
+          entries.filter(([name]) => this.owns(prefix + name)),
+          expiredAt,
+        )
+      }
+    })
+  }
+
+  invalidateDir(path: string): Promise<void> {
+    return withCacheMutation(this.cache, async () => {
+      if (this.owns(path)) await this.store.invalidateDir(path)
+    })
+  }
+
+  invalidatePrefix(path: string): Promise<void> {
+    return withCacheMutation(this.cache, async () => {
+      if (this.owns(path)) await this.store.invalidatePrefix(path)
+    })
+  }
+
+  invalidate(): Promise<void> {
+    return withCacheMutation(this.cache, async () => {
+      if (this.owns(this.prefix)) await this.store.invalidate()
+    })
+  }
+
+  clear(): Promise<void> {
+    return this.invalidatePrefix(this.prefix)
+  }
+}

--- a/typescript/packages/core/src/cache/manager.ts
+++ b/typescript/packages/core/src/cache/manager.ts
@@ -18,6 +18,7 @@ import { rstripSlash } from '../utils/slash.ts'
 import type { FileCache } from './file/mixin.ts'
 import type { IndexCacheStore } from './index/store.ts'
 import { IndexView } from './index/view.ts'
+import { withCacheMutation } from './file/io.ts'
 
 /**
  * Post-mutation cache coherence for one mount.
@@ -49,6 +50,11 @@ export class CacheManager {
     this.prefix = rstripSlash(prefix)
     this.cachesReads = cachesReads
     this.ownsPath = ownsPath
+  }
+
+  /** Drain raw backend index access before mount cache eviction. */
+  withMutation<T>(call: () => Promise<T>): Promise<T> {
+    return this.fileCache === null ? call() : withCacheMutation(this.fileCache, call)
   }
 
   /** Bind backend metadata writes to this mount's lifetime. */

--- a/typescript/packages/core/src/cache/manager.ts
+++ b/typescript/packages/core/src/cache/manager.ts
@@ -34,20 +34,20 @@ export class CacheManager {
   private readonly index: IndexCacheStore | null
   private readonly prefix: string
   private readonly cachesReads: boolean
-  private readonly isActive: () => boolean
+  private readonly ownsPath: (path: string) => boolean
 
   constructor(
     fileCache: FileCache | null,
     index: IndexCacheStore | null,
     prefix: string,
     cachesReads: boolean,
-    isActive: () => boolean = () => true,
+    ownsPath: (path: string) => boolean = () => true,
   ) {
     this.fileCache = fileCache
     this.index = index
     this.prefix = rstripSlash(prefix)
     this.cachesReads = cachesReads
-    this.isActive = isActive
+    this.ownsPath = ownsPath
   }
 
   /**
@@ -101,11 +101,11 @@ export class CacheManager {
    * command knowing about it. No-op for local or non-caching mounts.
    */
   async cachedBytes(path: PathSpec): Promise<Uint8Array | null> {
-    if (!this.cachesReads || this.fileCache === null || !this.isActive()) return null
     const key = this.cacheKey(path)
+    if (!this.cachesReads || this.fileCache === null || !this.ownsPath(key)) return null
     if (await this.fileCache.exists(key)) {
       const cached = await this.fileCache.get(key)
-      return this.isActive() ? cached : null
+      return this.ownsPath(key) ? cached : null
     }
     return null
   }

--- a/typescript/packages/core/src/cache/manager.ts
+++ b/typescript/packages/core/src/cache/manager.ts
@@ -17,6 +17,7 @@ import { mountKey } from '../utils/key_prefix.ts'
 import { rstripSlash } from '../utils/slash.ts'
 import type { FileCache } from './file/mixin.ts'
 import type { IndexCacheStore } from './index/store.ts'
+import { IndexView } from './index/view.ts'
 
 /**
  * Post-mutation cache coherence for one mount.
@@ -48,6 +49,12 @@ export class CacheManager {
     this.prefix = rstripSlash(prefix)
     this.cachesReads = cachesReads
     this.ownsPath = ownsPath
+  }
+
+  /** Bind backend metadata writes to this mount's lifetime. */
+  scopeIndex(index: IndexCacheStore): IndexCacheStore {
+    if (this.fileCache === null || index instanceof IndexView) return index
+    return new IndexView(index, this.fileCache, this.prefix || '/', this.ownsPath)
   }
 
   /**

--- a/typescript/packages/core/src/cache/manager.ts
+++ b/typescript/packages/core/src/cache/manager.ts
@@ -34,17 +34,20 @@ export class CacheManager {
   private readonly index: IndexCacheStore | null
   private readonly prefix: string
   private readonly cachesReads: boolean
+  private readonly isActive: () => boolean
 
   constructor(
     fileCache: FileCache | null,
     index: IndexCacheStore | null,
     prefix: string,
     cachesReads: boolean,
+    isActive: () => boolean = () => true,
   ) {
     this.fileCache = fileCache
     this.index = index
     this.prefix = rstripSlash(prefix)
     this.cachesReads = cachesReads
+    this.isActive = isActive
   }
 
   /**
@@ -98,10 +101,11 @@ export class CacheManager {
    * command knowing about it. No-op for local or non-caching mounts.
    */
   async cachedBytes(path: PathSpec): Promise<Uint8Array | null> {
-    if (!this.cachesReads || this.fileCache === null) return null
+    if (!this.cachesReads || this.fileCache === null || !this.isActive()) return null
     const key = this.cacheKey(path)
     if (await this.fileCache.exists(key)) {
-      return this.fileCache.get(key)
+      const cached = await this.fileCache.get(key)
+      return this.isActive() ? cached : null
     }
     return null
   }

--- a/typescript/packages/core/src/commands/builtin/generic/patch.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/patch.ts
@@ -14,7 +14,7 @@
 
 import { specOf } from '../../spec/builtins.ts'
 import { FlagView } from '../../spec/types.ts'
-import { mountKey, stripMount } from '../../../utils/key_prefix.ts'
+import { mountKey } from '../../../utils/key_prefix.ts'
 import { IOResult, materialize } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -37,15 +37,6 @@ function stripPath(path: string, stripCount: number): string {
 function splitLinesNoTrailing(text: string): string[] {
   const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
   return stripped === '' ? [] : stripped.split('\n')
-}
-
-function makePathSpec(virtual: string): PathSpec {
-  return new PathSpec({
-    virtual,
-    directory: virtual,
-    resourcePath: stripSlash(virtual),
-    resolved: true,
-  })
 }
 
 function applyHunks(
@@ -165,13 +156,7 @@ export async function patchGeneric(
   const mountPrefix = opts.mountPrefix ?? ''
   let patchData: Uint8Array | null = null
   if (iFlag !== null) {
-    const resolved = stripMount(iFlag, mountPrefix)
-    const spec = new PathSpec({
-      virtual: resolved,
-      directory: resolved,
-      resolved: true,
-      resourcePath: mountKey(resolved, mountPrefix),
-    })
+    const spec = PathSpec.fromStrPath(iFlag, mountKey(iFlag, mountPrefix))
     patchData = await materialize(stream(spec))
   } else if (paths.length > 0) {
     const first = paths[0]
@@ -188,14 +173,12 @@ export async function patchGeneric(
   const writes: Record<string, Uint8Array> = {}
 
   for (const [filePath, hunks] of fileHunks) {
+    const spec = PathSpec.fromStrPath(
+      `${mountPrefix.replace(/\/$/, '')}/${lstripSlash(filePath)}`,
+      stripSlash(filePath),
+    )
     let content = ''
     try {
-      const spec = new PathSpec({
-        resourcePath: stripSlash(filePath),
-        virtual: filePath,
-        directory: filePath,
-        resolved: true,
-      })
       content = DEC.decode(await materialize(stream(spec)))
     } catch (err) {
       if (!(err instanceof Error) || !/not found/i.test(err.message)) throw err
@@ -219,7 +202,7 @@ export async function patchGeneric(
 
     const patched = applyHunks(originalLines, effective, forwardOnly)
     const patchedData = ENC.encode(patched.join('\n') + '\n')
-    await write(makePathSpec(filePath), patchedData)
+    await write(spec, patchedData)
     writes[filePath] = patchedData
   }
 

--- a/typescript/packages/core/src/commands/builtin/generic_bind/provision.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/provision.test.ts
@@ -72,24 +72,21 @@ const stat = (_accessor: Accessor, p: PathSpec): Promise<FileStat> =>
         }),
   )
 
-// Backend ops follow the executor contract: specs arrive in the
-// resource view (virtual == mountPath) and entries come back the same
-// way. The fakes translate to the '/data'-prefixed fixture keys.
+// Backend ops retain full virtual paths, matching the executor and its index.
 const readdir = (_accessor: Accessor, p: PathSpec): Promise<string[]> =>
-  Promise.resolve((TREE[`/data${p.virtual}`] ?? []).map((e) => e.slice('/data'.length)))
+  Promise.resolve(TREE[p.virtual] ?? [])
 
 const resolveGlob = (_accessor: Accessor, paths: readonly PathSpec[]): Promise<PathSpec[]> => {
   const out: PathSpec[] = []
   for (const p of paths) {
     if (p.pattern !== null && p.pattern !== '') {
       const suffix = p.pattern.replace(/^\*+/, '')
-      for (const e of TREE[`/data${p.directory}`.replace(/\/$/, '')] ?? []) {
+      for (const e of TREE[p.directory.replace(/\/$/, '')] ?? []) {
         if (e.endsWith(suffix)) {
-          const rel = e.slice('/data'.length)
           out.push(
             new PathSpec({
-              virtual: rel,
-              directory: rel.slice(0, rel.lastIndexOf('/') + 1),
+              virtual: e,
+              directory: e.slice(0, e.lastIndexOf('/') + 1),
               resourcePath: mountKey(e, '/data'),
               resolved: true,
             }),

--- a/typescript/packages/core/src/commands/builtin/generic_bind/provision.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/provision.ts
@@ -68,38 +68,6 @@ function hasPattern(p: PathSpec): boolean {
   return p.pattern !== null && p.pattern !== ''
 }
 
-/**
- * Backend readdir/resolveGlob follow the executor's contract: specs
- * arrive in the resource view (virtual == mountPath). Planner specs
- * are full-virtual, so rebase before the call and restore after.
- */
-function resourceView(p: PathSpec): PathSpec {
-  if (p.virtual === p.mountPath) return p
-  const mp = p.mountPath
-  return new PathSpec({
-    virtual: mp,
-    directory: mp.slice(0, mp.lastIndexOf('/') + 1) || '/',
-    pattern: p.pattern,
-    resolved: p.resolved,
-    resourcePath: p.resourcePath,
-  })
-}
-
-function virtualPrefix(p: PathSpec): string {
-  return p.virtual.slice(0, p.virtual.length - p.mountPath.length)
-}
-
-function restoreView(m: PathSpec, prefix: string): PathSpec {
-  if (prefix === '') return m
-  return new PathSpec({
-    virtual: prefix + m.virtual,
-    directory: prefix + m.directory,
-    pattern: m.pattern,
-    resolved: m.resolved,
-    resourcePath: m.resourcePath,
-  })
-}
-
 async function expandGlobs<A extends Accessor>(
   resolveGlob: ResolveGlobOp<A> | undefined,
   accessor: A,
@@ -109,17 +77,7 @@ async function expandGlobs<A extends Accessor>(
   if (resolveGlob === undefined) return paths
   if (!paths.some(hasPattern)) return paths
   try {
-    const out: PathSpec[] = []
-    for (const p of paths) {
-      if (!hasPattern(p)) {
-        out.push(p)
-        continue
-      }
-      const prefix = virtualPrefix(p)
-      const matched = await resolveGlob(accessor, [resourceView(p)], index)
-      for (const m of matched) out.push(restoreView(m, prefix))
-    }
-    return out
+    return await resolveGlob(accessor, paths, index)
   } catch {
     return paths
   }
@@ -159,15 +117,13 @@ async function walkFiles<A extends Accessor>(
     if (s.type === FileType.DIRECTORY) {
       let entries
       try {
-        entries = await readdir(accessor, resourceView(p), index)
+        entries = await readdir(accessor, p, index)
       } catch {
         complete = false
         continue
       }
-      const prefix = virtualPrefix(p)
-      for (const e of entries) {
-        const full = e.startsWith(prefix) && prefix !== '' ? e : prefix + e
-        queue.push(PathSpec.fromStrPath(full, rekey(p.virtual, p.resourcePath, full)))
+      for (const entry of entries) {
+        queue.push(PathSpec.fromStrPath(entry, rekey(p.virtual, p.resourcePath, entry)))
       }
       continue
     }
@@ -199,7 +155,7 @@ async function resolveSizes<A extends Accessor>(
     }
     if (size === null) {
       try {
-        const fileStat = await stat(accessor, p)
+        const fileStat = await stat(accessor, p, index ?? undefined)
         size = fileStat.size ?? null
       } catch {
         // unresolved paths degrade precision below

--- a/typescript/packages/core/src/commands/builtin/ram/patch.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/patch.test.ts
@@ -14,6 +14,8 @@
 
 import { RAM_COMMANDS } from './index.ts'
 import { describe, expect, it } from 'vitest'
+import { patchGeneric } from '../generic/patch.ts'
+import { PathSpec } from '../../../types.ts'
 import { RAMResource } from '../../../resource/ram/ram.ts'
 const RAM_PATCH = RAM_COMMANDS.filter((c) => c.name === 'patch' && c.filetype == null)
 
@@ -85,3 +87,46 @@ describe('patch', () => {
     expect(DEC.decode(out)).toContain('universe')
   })
 })
+
+it.each(['', '/data', '/nested/data'])(
+  'preserves virtual paths under %s for patch I/O',
+  async (prefix) => {
+    for (const source of ['stdin', 'operand', 'input']) {
+      const diff = ENC.encode(
+        '--- a/hello.txt\n+++ b/hello.txt\n@@ -1,2 +1,2 @@\n hello\n-world\n+universe\n',
+      )
+      const files = new Map<string, Uint8Array>([
+        ['hello.txt', ENC.encode('hello\nworld\n')],
+        ['fix.diff', diff],
+      ])
+      const seen: string[] = []
+      const stream = async function* (path: PathSpec): AsyncIterable<Uint8Array> {
+        expect(path.virtual).toBe(prefix + '/' + path.resourcePath)
+        seen.push(path.resourcePath)
+        const bytes = files.get(path.resourcePath)
+        if (bytes === undefined) throw new Error('missing fixture')
+        yield Promise.resolve(bytes)
+      }
+      const write = (path: PathSpec, data: Uint8Array): Promise<void> => {
+        expect(path.virtual).toBe(prefix + '/' + path.resourcePath)
+        files.set(path.resourcePath, data)
+        return Promise.resolve()
+      }
+      const input = PathSpec.fromStrPath(prefix + '/fix.diff', 'fix.diff')
+      await patchGeneric(
+        source === 'operand' ? [input] : [],
+        {
+          mountPrefix: prefix,
+          filetypeFns: null,
+          cwd: prefix || '/',
+          flags: { p: '1', ...(source === 'input' ? { i: input.virtual } : {}) },
+          stdin: source === 'stdin' ? diff : null,
+        },
+        stream,
+        write,
+      )
+      expect(seen).toContain('hello.txt')
+      expect(DEC.decode(files.get('hello.txt'))).toBe('hello\nuniverse\n')
+    }
+  },
+)

--- a/typescript/packages/core/src/core/generic/find.test.ts
+++ b/typescript/packages/core/src/core/generic/find.test.ts
@@ -235,16 +235,21 @@ describe('isEnoent', () => {
 const SEARCH_DIRS = new Set(['/', '/guides', '/api'])
 const SEARCH_SIZES: Record<string, number> = { '/api/reference': 900 }
 
-function makeSearchDeps(keys: string[]): SearchFindDeps<unknown> & { resolveCalls: number } {
+function makeSearchDeps(
+  keys: string[],
+): SearchFindDeps<unknown> & { resolveCalls: number; probes: PathSpec[] } {
   const deps = {
     resolveCalls: 0,
+    probes: [] as PathSpec[],
     walk: () => Promise.resolve([...keys]),
     resolvePath: (_a: unknown, spec: PathSpec) => {
+      deps.probes.push(spec)
       deps.resolveCalls += 1
       return Promise.resolve({ isDir: SEARCH_DIRS.has(rstripSlash(spec.mountPath) || '/') })
     },
-    stat: (_a: unknown, spec: PathSpec) =>
-      Promise.resolve(
+    stat: (_a: unknown, spec: PathSpec) => {
+      deps.probes.push(spec)
+      return Promise.resolve(
         new FileStat({
           name: spec.mountPath.split('/').pop() ?? '',
           type: SEARCH_DIRS.has(rstripSlash(spec.mountPath) || '/')
@@ -252,12 +257,41 @@ function makeSearchDeps(keys: string[]): SearchFindDeps<unknown> & { resolveCall
             : FileType.FILE,
           size: SEARCH_SIZES[spec.mountPath] ?? null,
         }),
-      ),
+      )
+    },
   }
   return deps
 }
 
 describe('makeSearchBackedFind — -empty', () => {
+  it.each(
+    ['', '/knowledge', '/api', '/nested/mount'].flatMap((prefix) =>
+      ['/', '/api'].map((root) => ({ prefix, root })),
+    ),
+  )(
+    'preserves both paths for metadata probes at $prefix with root $root',
+    async ({ prefix, root }) => {
+      const keys = root === '/' ? ['/', '/api', '/api/reference'] : ['/api', '/api/reference']
+      const deps = makeSearchDeps(keys)
+      const path = PathSpec.fromStrPath(rstripSlash(prefix + root) || '/', root.replace(/^\//, ''))
+      expect(
+        await makeSearchBackedFind(deps)(
+          {},
+          path,
+          { type: 'f', minSize: 1 },
+          new RAMIndexCacheStore(),
+        ),
+      ).toEqual(['/api/reference'])
+      expect(new Set(deps.probes.map((p) => JSON.stringify([p.virtual, p.resourcePath])))).toEqual(
+        new Set(
+          keys.map((key) =>
+            JSON.stringify([rstripSlash(prefix + key) || '/', key.replace(/^\//, '')]),
+          ),
+        ),
+      )
+    },
+  )
+
   it('reads a directory off the walked list', async () => {
     const deps = makeSearchDeps(['/', '/guides', '/api', '/api/reference'])
     const find = makeSearchBackedFind(deps)

--- a/typescript/packages/core/src/core/generic/find.ts
+++ b/typescript/packages/core/src/core/generic/find.ts
@@ -279,7 +279,9 @@ async function searchMatches<A>(
   const rootNorm = rstripSlash(root) !== '' ? rstripSlash(root) : '/'
   const itemNorm = rstripSlash(item) !== '' ? rstripSlash(item) : '/'
   const itemName = itemNorm === rootNorm ? startName : (rstripSlash(item).split('/').pop() ?? '')
-  const spec = PathSpec.fromStrPath(item, mountKey(item, prefix))
+  // The walk strips its mount prefix; backend probes still need both paths.
+  const virtual = rstripSlash(rstripSlash(prefix) + '/' + lstripSlash(item)) || '/'
+  const spec = PathSpec.fromStrPath(virtual, lstripSlash(item))
   let kind: 'd' | 'f' = 'f'
   if (needsKind) {
     const resolved = await deps.resolvePath(accessor, spec, index)

--- a/typescript/packages/core/src/observe/context.ts
+++ b/typescript/packages/core/src/observe/context.ts
@@ -19,6 +19,7 @@ import { rstripSlash } from '../utils/slash.ts'
 interface RecordingState {
   records: OpRecord[]
   mountPrefix: string
+  mountId: string | null
 }
 
 const storage = createAsyncContext<RecordingState>()
@@ -35,7 +36,7 @@ interface RevisionsState {
 const revisionsStorage = createAsyncContext<RevisionsState>()
 
 export async function runWithRecording<T>(fn: () => Promise<T>): Promise<[T, OpRecord[]]> {
-  const state: RecordingState = { records: [], mountPrefix: '' }
+  const state: RecordingState = { records: [], mountPrefix: '', mountId: null }
   const value = await storage.run(state, fn)
   return [value, state.records]
 }
@@ -50,10 +51,23 @@ export async function runWithRecording<T>(fn: () => Promise<T>): Promise<[T, OpR
  *
  * Inert (runs `fn` unchanged) when no recording context is active.
  */
-export function runWithMountPrefix<T>(prefix: string, fn: () => Promise<T>): Promise<T> {
+export function runWithMountPrefix<T>(
+  prefix: string,
+  fn: () => Promise<T>,
+  mountId?: string | null,
+): Promise<T> {
   const state = storage.getStore()
   if (state === undefined) return fn()
-  return Promise.resolve(storage.run({ records: state.records, mountPrefix: prefix }, fn))
+  return Promise.resolve(
+    storage.run(
+      {
+        records: state.records,
+        mountPrefix: prefix,
+        mountId: mountId === undefined ? state.mountId : mountId,
+      },
+      fn,
+    ),
+  )
 }
 
 /**
@@ -66,11 +80,12 @@ export function runWithMountPrefix<T>(prefix: string, fn: () => Promise<T>): Pro
 export async function* withMountPrefix(
   prefix: string,
   it: AsyncIterable<Uint8Array>,
+  mountId?: string | null,
 ): AsyncGenerator<Uint8Array> {
   const iter = it[Symbol.asyncIterator]()
   try {
     for (;;) {
-      const step = await runWithMountPrefix(prefix, () => iter.next())
+      const step = await runWithMountPrefix(prefix, () => iter.next(), mountId)
       if (step.done === true) return
       yield step.value
     }
@@ -147,6 +162,7 @@ export function finishRecord(
     durationMs: elapsed,
     fingerprint: options.fingerprint ?? null,
     revision: options.revision ?? null,
+    mountId: storage.getStore()?.mountId ?? null,
   })
 }
 
@@ -182,6 +198,7 @@ export function recordStream(
     durationMs: 0,
     fingerprint: options.fingerprint ?? null,
     revision: options.revision ?? null,
+    mountId: storage.getStore()?.mountId ?? null,
   })
   state.records.push(rec)
   return rec

--- a/typescript/packages/core/src/observe/record.ts
+++ b/typescript/packages/core/src/observe/record.ts
@@ -35,6 +35,8 @@ export interface OpRecordInit {
    * replay to pin reads to the exact recorded version.
    */
   revision?: string | null
+  /** In-process ownership for snapshot capture; not a persisted backend revision. */
+  mountId?: string | null
 }
 
 export class OpRecord {
@@ -46,6 +48,7 @@ export class OpRecord {
   durationMs: number
   fingerprint: string | null
   revision: string | null
+  readonly mountId: string | null
 
   constructor(init: OpRecordInit) {
     this.op = init.op
@@ -56,6 +59,7 @@ export class OpRecord {
     this.durationMs = init.durationMs
     this.fingerprint = init.fingerprint ?? null
     this.revision = init.revision ?? null
+    this.mountId = init.mountId ?? null
   }
 
   get isCache(): boolean {

--- a/typescript/packages/core/src/ops/registry.ts
+++ b/typescript/packages/core/src/ops/registry.ts
@@ -82,20 +82,40 @@ export function op(name: string, options: OpOptions) {
 
 export class OpsRegistry {
   private readonly registered = new Map<string, RegisteredOp>()
+  private readonly owners = new Map<string, Resource>()
+  private readonly scoped = new WeakMap<Resource, Map<string, RegisteredOp>>()
 
   register(ro: RegisteredOp): void {
-    this.registered.set(keyFor(ro.name, ro.filetype, ro.resource), ro)
+    const key = keyFor(ro.name, ro.filetype, ro.resource)
+    this.registered.set(key, ro)
+    this.owners.delete(key)
   }
 
-  unregisterResource(resourceKind: string): void {
+  unregisterResource(resourceKind: string | Resource): void {
     for (const [key, ro] of this.registered) {
-      if (ro.resource === resourceKind) {
+      if (
+        typeof resourceKind === 'string'
+          ? ro.resource === resourceKind
+          : this.owners.get(key) === resourceKind
+      ) {
         this.registered.delete(key)
+        this.owners.delete(key)
       }
     }
   }
 
-  registerResource(resource: Resource): void {
+  registerResource(resource: Resource, overwrite = true): void {
+    const entries = this.collectResource(resource)
+    this.scoped.set(resource, entries)
+    for (const [key, ro] of entries) {
+      if (!overwrite && this.registered.has(key)) continue
+      this.register(ro)
+      if (this.registered.get(key) === ro) this.owners.set(key, resource)
+    }
+  }
+
+  private collectResource(resource: Resource): Map<string, RegisteredOp> {
+    const entries = new Map<string, RegisteredOp>()
     const chain: object[] = []
     let proto = Object.getPrototypeOf(resource) as object | null
     while (proto !== null && proto !== Object.prototype) {
@@ -107,21 +127,45 @@ export class OpsRegistry {
       if (p === undefined) continue
       for (const key of Object.getOwnPropertyNames(p)) {
         if (key === 'constructor') continue
-        const method = (p as Record<string, unknown>)[key]
+        const method: unknown = Object.getOwnPropertyDescriptor(p, key)?.value
         if (typeof method !== 'function') continue
         const carrier = method as OpFn & OpCarrier
         const ops = carrier[REGISTERED_OPS]
         if (!ops) continue
         const bound = method.bind(resource) as OpFn
         for (const ro of ops) {
-          this.register({ ...ro, fn: bound })
+          entries.set(keyFor(ro.name, ro.filetype, ro.resource), { ...ro, fn: bound })
         }
       }
     }
+    for (const ro of resource.ops?.() ?? []) {
+      entries.set(keyFor(ro.name, ro.filetype, ro.resource), ro)
+    }
+    return entries
   }
 
-  find(name: string, resource: string | null, filetype: string | null = null): RegisteredOp | null {
-    return this.registered.get(keyFor(name, filetype, resource)) ?? null
+  private entry(key: string, resource: Resource | null): RegisteredOp | null {
+    const registered = this.registered.get(key)
+    if (registered === undefined) return null
+    // Explicit registry overrides and removals remain authoritative.
+    if (resource === null || !this.owners.has(key)) return registered
+    let entries = this.scoped.get(resource)
+    if (entries === undefined) {
+      entries = this.collectResource(resource)
+      this.scoped.set(resource, entries)
+    }
+    // An instance-bound operation from a sibling mount is never a fallback.
+    return entries.get(key) ?? null
+  }
+
+  find(
+    name: string,
+    resource: string | Resource | null,
+    filetype: string | null = null,
+  ): RegisteredOp | null {
+    const owner = typeof resource === 'object' ? resource : null
+    const kind = typeof resource === 'object' ? (resource?.kind ?? null) : resource
+    return this.entry(keyFor(name, filetype, kind), owner)
   }
 
   resolve(name: string, resource: string, filetype: string | null = null): OpFn {
@@ -143,25 +187,27 @@ export class OpsRegistry {
 
   async call(
     name: string,
-    resourceKind: string,
+    resourceKind: string | Resource,
     accessor: Accessor,
     path: PathSpec,
     args: readonly unknown[] = [],
     kwargs: OpKwargs = {},
   ): Promise<unknown> {
     const filetype = kwargs.filetype ?? null
+    const owner = typeof resourceKind === 'string' ? null : resourceKind
+    const kind = typeof resourceKind === 'string' ? resourceKind : resourceKind.kind
     const levels: OpFn[] = []
     if (filetype !== null) {
-      const specific = this.registered.get(keyFor(name, filetype, resourceKind))
+      const specific = this.entry(keyFor(name, filetype, kind), owner)
       if (specific) levels.push(specific.fn)
     }
-    const byResource = this.registered.get(keyFor(name, null, resourceKind))
+    const byResource = this.entry(keyFor(name, null, kind), owner)
     if (byResource) levels.push(byResource.fn)
-    const global = this.registered.get(keyFor(name, null, null))
+    const global = this.entry(keyFor(name, null, null), owner)
     if (global) levels.push(global.fn)
 
     if (levels.length === 0) {
-      throw enotsup(resourceKind, name, path)
+      throw enotsup(kind, name, path)
     }
 
     for (const fn of levels) {

--- a/typescript/packages/core/src/policy/policies.test.ts
+++ b/typescript/packages/core/src/policy/policies.test.ts
@@ -806,3 +806,23 @@ describe('Ask in the chain', () => {
     ).toBe(false)
   })
 })
+
+it('removes by identity, refreshes hooks and preserves an admission in progress', async () => {
+  const policies = new Policies()
+  const first: Policy = {
+    preCommand: () => {
+      expect(policies.remove(first)).toBe(true)
+      return null
+    },
+  }
+  const last = new DenyWeird()
+  policies.add(first)
+  policies.add(last)
+  expect(policies.remove(new DenyWeird())).toBe(false)
+  expect(await policies.preCommand(ctx('weird'))).toMatchObject({ kind: 'deny', reason: 'nope' })
+  expect(policies.wants('preCommand')).toBe(true)
+  expect(policies.remove(last)).toBe(true)
+  expect(policies.wants('preCommand')).toBe(false)
+  expect(policies.remove(first)).toBe(false)
+  expect(await policies.preCommand(ctx('weird'))).toBeNull()
+})

--- a/typescript/packages/core/src/policy/policies.ts
+++ b/typescript/packages/core/src/policy/policies.ts
@@ -247,7 +247,7 @@ export class Policies {
    * every session's.
    */
   async wantsFor(hook: Hook, sessionId: string): Promise<boolean> {
-    for (const policy of this.policies) {
+    for (const policy of [...this.policies]) {
       if (policy[hook] === undefined) continue
       if (!isSessionScoped(policy)) return true
       if (await policy.wantsFor(hook, sessionId)) return true
@@ -273,6 +273,15 @@ export class Policies {
     this.rescan()
   }
 
+  /** Remove one registration by identity, preserving the other policies' order. Host-side only. */
+  remove(entry: Policy): boolean {
+    const index = this.policies.indexOf(entry)
+    if (index === -1) return false
+    this.policies.splice(index, 1)
+    this.rescan()
+    return true
+  }
+
   /**
    * One loop for every hook: the first Deny wins (limits are moot once
    * the result is suppressed), Limit actions accumulate and merge
@@ -287,7 +296,9 @@ export class Policies {
   ): Promise<[Deny | Ask | null, Limit | null]> {
     const limits: Limit[] = []
     let asked: Ask | null = null
-    for (const policy of this.policies) {
+    // Keep this gate's order stable if the host edits registrations
+    // while a hook awaits. Changes take effect at the next gate.
+    for (const policy of [...this.policies]) {
       const fn = policy[hook]
       if (fn === undefined) continue
       const name = policy.constructor.name || 'policy'

--- a/typescript/packages/core/src/policy/script.ts
+++ b/typescript/packages/core/src/policy/script.ts
@@ -403,12 +403,12 @@ export class ScriptPolicy implements Policy, SessionScoped {
 
   /**
    * The hooks one profile's program defines, probed on its first
-   * judgment and remembered by program text and language: the probe
-   * asks in the program's own spelling, so one text read as two
-   * languages is two programs.
+   * judgment and remembered by runtime, program text and language.
+   * A runtime change must probe again, including its validation;
+   * a cached absent hook must never bypass a broken new engine.
    */
   private async hooksOf(entry: ProfileScript): Promise<ReadonlySet<ScriptHook>> {
-    const key = `${entry.script.language}\n${entry.script.source}`
+    const key = JSON.stringify([entry.runtime, entry.script.language, entry.script.source])
     let defined = this.defined.get(key)
     if (defined === undefined) {
       defined = definedHooks(entry.script, await this.evaluate(entry, hookProbe(entry.script), {}))

--- a/typescript/packages/core/src/resource/base.ts
+++ b/typescript/packages/core/src/resource/base.ts
@@ -85,6 +85,8 @@ export function resourceRefOf(resource: Resource): string | null {
 }
 
 export interface Resource {
+  /** Closed resource instances cannot be mounted again. */
+  readonly isClosed?: boolean
   readonly kind: string
   readonly prompt?: string
   readonly writePrompt?: string
@@ -254,6 +256,10 @@ export abstract class BaseResource {
    */
   loadState(_state: ResourceStateBase): void | Promise<void> {
     // Nothing to take back.
+  }
+
+  get isClosed(): boolean {
+    return this.#closed
   }
 
   /**

--- a/typescript/packages/core/src/utils/errors.ts
+++ b/typescript/packages/core/src/utils/errors.ts
@@ -49,6 +49,10 @@ export function enoent(path: string | { virtual: string }): FsError {
   return fsError(path, 'ENOENT')
 }
 
+export function ebusy(path: string | { virtual: string }): FsError {
+  return fsError(path, 'EBUSY')
+}
+
 export function enotdir(path: string | { virtual: string }): FsError {
   return fsError(path, 'ENOTDIR')
 }

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -52,6 +52,7 @@ import {
 import type { DispatchFn } from '../../runtime/types.ts'
 import type { DriftQueue } from '../snapshot/drift.ts'
 import type { Namespace } from '../mount/namespace/namespace.ts'
+import type { MountEntry } from '../mount/mount.ts'
 import { mergeOverlayStat } from '../mount/namespace/overlay.ts'
 import { Reconciler } from '../reconcile.ts'
 import { sliceWindow } from '../../utils/ranges.ts'
@@ -376,7 +377,7 @@ export class Dispatcher {
     const filetype = getExtension(p.virtual)
     const fullKwargs: OpKwargs = {
       ...(kwargs ?? {}),
-      ...(kwargs?.index === undefined && mount.index !== undefined ? { index: mount.index } : {}),
+      ...(kwargs?.index === undefined ? this.indexKwargs(mount) : {}),
       ...(filetype !== null && kwargs?.filetype === undefined ? { filetype } : {}),
     }
     let fullArgs = args ?? []
@@ -496,8 +497,9 @@ export class Dispatcher {
    * the door's own raw registry calls: an indexed backend cannot
    * resolve a nested path without it.
    */
-  private indexKwargs(resource: Resource): OpKwargs {
-    return resource.index !== undefined ? { index: resource.index } : {}
+  private indexKwargs(mount: MountEntry | null): OpKwargs {
+    const index = mount?.index
+    return index !== undefined ? { index } : {}
   }
 
   /**
@@ -524,6 +526,7 @@ export class Dispatcher {
     spec: PathSpec,
     issuer?: symbol,
   ): Promise<unknown> {
+    const mount = this.namespace.mountFor(spec.virtual)
     const write = this.opsRegistry.find(opName, resource.kind)?.write === true
     if (write) {
       // The same pre-ops admission a dispatched op answers, with the
@@ -543,7 +546,7 @@ export class Dispatcher {
     // pins have to ride here as on the main path above, or a cascade
     // read answers from the wrong version of a revision-pinned mount.
     // Python's twin gets both bindings from `Mount.execute_op`.
-    const mount = this.namespace.mountFor(spec.virtual)
+    await mount.ensureReady()
     try {
       return await runWithMountPrefix(rstripSlash(mountPrefix), () =>
         runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, () =>
@@ -553,7 +556,7 @@ export class Dispatcher {
             resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
             spec,
             [],
-            this.indexKwargs(resource),
+            this.indexKwargs(mount),
           ),
         ),
       )
@@ -898,6 +901,7 @@ export class Dispatcher {
     const [resource, scope] = resolved
     const mount = this.namespace.tryMountFor(scope.virtual)
     await preOpsGate(this.policies, opName, scope, false, mount?.prefix ?? '', sessionId(), issuer)
+    await mount?.ensureReady()
     const filetype = getExtension(scope.virtual)
     try {
       return await this.opsRegistry.call(
@@ -907,7 +911,7 @@ export class Dispatcher {
         scope,
         [],
         {
-          ...(resource.index !== undefined ? { index: resource.index } : {}),
+          ...this.indexKwargs(mount),
           ...(filetype !== null ? { filetype } : {}),
         },
       )

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -32,7 +32,7 @@ import {
 import { Policies, PolicyDenied, postOpsGate, preOpsGate } from '../../policy/index.ts'
 import { PolicyError } from '../../policy/errors.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
-import { normDir, rstripSlash } from '../../utils/slash.ts'
+import { normDir, ownerPrefix, rstripSlash } from '../../utils/slash.ts'
 import { record, runWithMountPrefix, runWithRevisions, startOp } from '../../observe/context.ts'
 import { wrapOpStream } from '../mount/mount.ts'
 import type { OpRecord } from '../../observe/record.ts'
@@ -40,7 +40,7 @@ import type { OpsRegistry } from '../../ops/registry.ts'
 import { type OpKwargs } from '../../ops/registry.ts'
 import { NO_FOLLOW_OPS, STAMP_WRITE_OPS } from '../../ops/config.ts'
 import { mergeReaddir, namespaceListing, namespaceStat } from '../../ops/namespace_view.ts'
-import { isMissingPath } from '../../utils/errors.ts'
+import { ebusy, isMissingPath } from '../../utils/errors.ts'
 import { cachesReads, type Resource } from '../../resource/base.ts'
 import {
   ConsistencyPolicy,
@@ -262,6 +262,7 @@ export class Dispatcher {
         if (!pathAllowed(p.virtual)) throw hiddenRefusal(opName, p.virtual)
       }
     }
+    const resolvedOwner = this.namespace.tryMountFor(p.virtual)
     let resolved: [Resource, PathSpec, MountMode]
     try {
       resolved = await this.namespace.resolve(p.virtual, false)
@@ -310,6 +311,7 @@ export class Dispatcher {
     // resolve() above already threw for a path outside every mount, so
     // this lookup cannot miss.
     const mount = this.namespace.mountFor(p.virtual)
+    if (mount !== resolvedOwner) throw ebusy(p.virtual)
     const mountPrefix = mount.prefix
     // Admission policies fire at the door, before the warm-cache early
     // return below: a cached read must be refused exactly like a cold
@@ -408,29 +410,32 @@ export class Dispatcher {
     // prefix has to be active while the op runs or the record loses the
     // mount it belongs to. Mirrors Python's Ops._call.
     try {
-      result = await runWithMountPrefix(
-        rstripSlash(mountPrefix),
-        () =>
-          runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, async () =>
-            runWithTimeout(
-              Promise.resolve(
-                opName === 'setattr'
-                  ? this.applySetattr(resource, scope, p, fullKwargs)
-                  : this.opsRegistry.call(
-                      opName,
-                      resource,
-                      resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-                      scope,
-                      fullArgs,
-                      fullKwargs,
-                    ),
+      result = await mount.use(async () => {
+        const answer = await runWithMountPrefix(
+          rstripSlash(mountPrefix),
+          () =>
+            runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, async () =>
+              runWithTimeout(
+                Promise.resolve(
+                  opName === 'setattr'
+                    ? this.applySetattr(resource, scope, p, fullKwargs)
+                    : this.opsRegistry.call(
+                        opName,
+                        resource,
+                        resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+                        scope,
+                        fullArgs,
+                        fullKwargs,
+                      ),
+                ),
+                opTimeout,
+                opName,
               ),
-              opTimeout,
-              opName,
             ),
-          ),
-        mount.mountId,
-      )
+          mount.mountId,
+        )
+        return wrapOpStream(answer, rstripSlash(mountPrefix), mount.mountId, mount.activity)
+      })
     } catch (err) {
       const code = (err as { code?: string }).code
       if (opName === 'rmdir' && (code === 'ENOTEMPTY' || code === 'EEXIST')) {
@@ -446,7 +451,6 @@ export class Dispatcher {
         memoryAnswered(report)
       }
     }
-    result = wrapOpStream(result, rstripSlash(mountPrefix), mount.mountId)
     // The op ran, whatever invalidation, the post gate, or an output
     // cap do next: stamped here so a failure in any of them cannot
     // erase a transfer the backend already made.
@@ -553,21 +557,24 @@ export class Dispatcher {
     // Python's twin gets both bindings from `Mount.execute_op`.
     await mount.ensureReady()
     try {
-      return await runWithMountPrefix(
-        rstripSlash(mountPrefix),
-        () =>
-          runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, () =>
-            this.opsRegistry.call(
-              opName,
-              resource,
-              resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-              spec,
-              [],
-              this.indexKwargs(mount),
+      return await mount.use(async () => {
+        const answer = await runWithMountPrefix(
+          rstripSlash(mountPrefix),
+          () =>
+            runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, () =>
+              this.opsRegistry.call(
+                opName,
+                resource,
+                resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+                spec,
+                [],
+                this.indexKwargs(mount),
+              ),
             ),
-          ),
-        mount.mountId,
-      )
+          mount.mountId,
+        )
+        return wrapOpStream(answer, rstripSlash(mountPrefix), mount.mountId, mount.activity)
+      })
     } finally {
       if (write) await this.invalidateAfterWriteByPath(spec.virtual)
     }
@@ -912,17 +919,19 @@ export class Dispatcher {
     await mount?.ensureReady()
     const filetype = getExtension(scope.virtual)
     try {
-      return await this.opsRegistry.call(
-        opName,
-        resource,
-        resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-        scope,
-        [],
-        {
-          ...this.indexKwargs(mount),
-          ...(filetype !== null ? { filetype } : {}),
-        },
-      )
+      const call = () =>
+        this.opsRegistry.call(
+          opName,
+          resource,
+          resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+          scope,
+          [],
+          {
+            ...this.indexKwargs(mount),
+            ...(filetype !== null ? { filetype } : {}),
+          },
+        )
+      return await (mount === null ? call() : mount.use(call))
     } catch (err) {
       // The "nothing here" set exactly, plus a backend with no such op:
       // a miss on one channel is not absence on its own, so the caller
@@ -1044,13 +1053,10 @@ export class Dispatcher {
       this.namespace.mountPrefixes().map((p) => [p, this.namespace.mountFor(p)]),
     )
     return (path) => {
+      const prefix = ownerPrefix(mounts.keys(), path)
+      const original = prefix === null ? null : mounts.get(prefix)
       const mount = this.namespace.tryMountFor(path)
-      return (
-        mount !== null &&
-        mounts.get(mount.prefix) === mount &&
-        !mount.retiring &&
-        cachesReads(mount.resource)
-      )
+      return mount !== null && original === mount && !mount.retiring && cachesReads(mount.resource)
     }
   }
 

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -360,7 +360,7 @@ export class Dispatcher {
         return [served, new IOResult({ reads: { [p.virtual]: served } })]
       }
     }
-    if (this.opsRegistry.find(opName, resource.kind)?.write === true) {
+    if (this.opsRegistry.find(opName, resource)?.write === true) {
       if (effectivePathMode(p.virtual, mountPrefix, mode) === MountMode.READ) {
         throw erofsReadOnly(`mount at '${p.virtual}' is read-only`, p)
       }
@@ -415,7 +415,7 @@ export class Dispatcher {
                 ? this.applySetattr(resource, scope, p, fullKwargs)
                 : this.opsRegistry.call(
                     opName,
-                    resource.kind,
+                    resource,
                     resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
                     scope,
                     fullArgs,
@@ -527,7 +527,7 @@ export class Dispatcher {
     issuer?: symbol,
   ): Promise<unknown> {
     const mount = this.namespace.mountFor(spec.virtual)
-    const write = this.opsRegistry.find(opName, resource.kind)?.write === true
+    const write = this.opsRegistry.find(opName, resource)?.write === true
     if (write) {
       // The same pre-ops admission a dispatched op answers, with the
       // walk's own child path: the gate that admitted the rmdir judged
@@ -552,7 +552,7 @@ export class Dispatcher {
         runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, () =>
           this.opsRegistry.call(
             opName,
-            resource.kind,
+            resource,
             resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
             spec,
             [],
@@ -906,7 +906,7 @@ export class Dispatcher {
     try {
       return await this.opsRegistry.call(
         opName,
-        resource.kind,
+        resource,
         resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
         scope,
         [],
@@ -941,15 +941,12 @@ export class Dispatcher {
     p: PathSpec,
     kwargs: OpKwargs,
   ): Promise<Record<string, number | string>> {
-    if (
-      this.namespace.isLink(p.virtual) ||
-      this.opsRegistry.find('setattr', resource.kind) === null
-    ) {
+    if (this.namespace.isLink(p.virtual) || this.opsRegistry.find('setattr', resource) === null) {
       return this.overlaySetattr(p, kwargs)
     }
     const raw = await this.opsRegistry.call(
       'setattr',
-      resource.kind,
+      resource,
       resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
       scope,
       [],

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -332,7 +332,11 @@ export class Dispatcher {
     const raw = kwargs?.filetype === null
     if (caches && !raw && DISPATCH_READ_OPS.has(opName)) {
       const cached = await this.cache.get(p.virtual)
-      if (cached !== null && (await this.reconciler.mayServeCached(mount, p.virtual))) {
+      if (
+        cached !== null &&
+        (await this.reconciler.mayServeCached(mount, p.virtual)) &&
+        !mount.retiring
+      ) {
         // The cache holds the whole object, so a ranged read is answered
         // by slicing it, never by handing back the whole file: the
         // window is what the caller asked for instead of the file, and
@@ -1022,10 +1026,30 @@ export class Dispatcher {
   isCacheablePath = (path: string): boolean => {
     const mount = this.namespace.tryMountFor(path)
     if (mount === null) return false
-    return cachesReads(mount.resource)
+    return !mount.retiring && cachesReads(mount.resource)
   }
 
-  async applyIo(io: IOResult, records?: readonly OpRecord[]): Promise<void> {
-    await applyIo(this.cache, io, this.isCacheablePath, records)
+  /** Bind deferred command results to the mounts that produced them. */
+  captureCacheablePaths(): (path: string) => boolean {
+    const mounts = new Map(
+      this.namespace.mountPrefixes().map((p) => [p, this.namespace.mountFor(p)]),
+    )
+    return (path) => {
+      const mount = this.namespace.tryMountFor(path)
+      return (
+        mount !== null &&
+        mounts.get(mount.prefix) === mount &&
+        !mount.retiring &&
+        cachesReads(mount.resource)
+      )
+    }
+  }
+
+  async applyIo(
+    io: IOResult,
+    records?: readonly OpRecord[],
+    isCacheable: (path: string) => boolean = this.isCacheablePath,
+  ): Promise<void> {
+    await applyIo(this.cache, io, isCacheable, records)
   }
 }

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -34,6 +34,7 @@ import { PolicyError } from '../../policy/errors.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import { normDir, rstripSlash } from '../../utils/slash.ts'
 import { record, runWithMountPrefix, runWithRevisions, startOp } from '../../observe/context.ts'
+import { wrapOpStream } from '../mount/mount.ts'
 import type { OpRecord } from '../../observe/record.ts'
 import type { OpsRegistry } from '../../ops/registry.ts'
 import { type OpKwargs } from '../../ops/registry.ts'
@@ -407,25 +408,28 @@ export class Dispatcher {
     // prefix has to be active while the op runs or the record loses the
     // mount it belongs to. Mirrors Python's Ops._call.
     try {
-      result = await runWithMountPrefix(rstripSlash(mountPrefix), () =>
-        runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, async () =>
-          runWithTimeout(
-            Promise.resolve(
-              opName === 'setattr'
-                ? this.applySetattr(resource, scope, p, fullKwargs)
-                : this.opsRegistry.call(
-                    opName,
-                    resource,
-                    resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-                    scope,
-                    fullArgs,
-                    fullKwargs,
-                  ),
+      result = await runWithMountPrefix(
+        rstripSlash(mountPrefix),
+        () =>
+          runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, async () =>
+            runWithTimeout(
+              Promise.resolve(
+                opName === 'setattr'
+                  ? this.applySetattr(resource, scope, p, fullKwargs)
+                  : this.opsRegistry.call(
+                      opName,
+                      resource,
+                      resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+                      scope,
+                      fullArgs,
+                      fullKwargs,
+                    ),
+              ),
+              opTimeout,
+              opName,
             ),
-            opTimeout,
-            opName,
           ),
-        ),
+        mount.mountId,
       )
     } catch (err) {
       const code = (err as { code?: string }).code
@@ -442,6 +446,7 @@ export class Dispatcher {
         memoryAnswered(report)
       }
     }
+    result = wrapOpStream(result, rstripSlash(mountPrefix), mount.mountId)
     // The op ran, whatever invalidation, the post gate, or an output
     // cap do next: stamped here so a failure in any of them cannot
     // erase a transfer the backend already made.
@@ -548,17 +553,20 @@ export class Dispatcher {
     // Python's twin gets both bindings from `Mount.execute_op`.
     await mount.ensureReady()
     try {
-      return await runWithMountPrefix(rstripSlash(mountPrefix), () =>
-        runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, () =>
-          this.opsRegistry.call(
-            opName,
-            resource,
-            resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-            spec,
-            [],
-            this.indexKwargs(mount),
+      return await runWithMountPrefix(
+        rstripSlash(mountPrefix),
+        () =>
+          runWithRevisions(mount.revisions.size > 0 ? mount.revisions : null, () =>
+            this.opsRegistry.call(
+              opName,
+              resource,
+              resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+              spec,
+              [],
+              this.indexKwargs(mount),
+            ),
           ),
-        ),
+        mount.mountId,
       )
     } finally {
       if (write) await this.invalidateAfterWriteByPath(spec.virtual)

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -329,13 +329,15 @@ export class Dispatcher {
     // under the same key, so it must not be served from that cache;
     // nothing populates it from here, so skipping the probe is the
     // whole fix. Mirrors Python's Dispatcher.dispatch.
+    await mount.ensureReady()
     const raw = kwargs?.filetype === null
     if (caches && !raw && DISPATCH_READ_OPS.has(opName)) {
       const cached = await this.cache.get(p.virtual)
       if (
         cached !== null &&
         (await this.reconciler.mayServeCached(mount, p.virtual)) &&
-        !mount.retiring
+        !mount.retiring &&
+        this.namespace.tryMountFor(p.virtual) === mount
       ) {
         // The cache holds the whole object, so a ranged read is answered
         // by slicing it, never by handing back the whole file: the

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -376,9 +376,7 @@ export class Dispatcher {
     const filetype = getExtension(p.virtual)
     const fullKwargs: OpKwargs = {
       ...(kwargs ?? {}),
-      ...(kwargs?.index === undefined && resource.index !== undefined
-        ? { index: resource.index }
-        : {}),
+      ...(kwargs?.index === undefined && mount.index !== undefined ? { index: mount.index } : {}),
       ...(filetype !== null && kwargs?.filetype === undefined ? { filetype } : {}),
     }
     let fullArgs = args ?? []

--- a/typescript/packages/core/src/workspace/empty_profile_pin.test.ts
+++ b/typescript/packages/core/src/workspace/empty_profile_pin.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { MountMode } from '../types.ts'
@@ -40,8 +40,14 @@ const BATTERY = [
 
 const open: Workspace[] = []
 
+beforeEach(() => {
+  // Independent workspaces must render the same fixture timestamps.
+  vi.useFakeTimers({ toFake: ['Date'], now: new Date('2026-01-01T00:00:00Z') })
+})
+
 afterEach(async () => {
   for (const ws of open.splice(0)) await ws.close()
+  vi.useRealTimers()
 })
 
 async function seeded(): Promise<Workspace> {

--- a/typescript/packages/core/src/workspace/executor/builtins/shared.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/shared.ts
@@ -231,7 +231,7 @@ export async function expandOperands(
           resolved: spec.resolved,
           resourcePath: mountKey(spec.virtual, prefix),
         })
-        const expanded = await mount.resource.glob([withPrefix], prefix)
+        const expanded = await mount.expandGlob([withPrefix], prefix)
         for (const p of expanded) if (p instanceof PathSpec) out.push(p)
         continue
       }

--- a/typescript/packages/core/src/workspace/expand/globs.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { childMountNames, namespaceNames } from '../../ops/namespace_view.ts'
+import { withCacheMutation } from '../../cache/file/io.ts'
 import type { NamespaceLinks } from '../../ops/config.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import type { Resource } from '../../resource/base.ts'
@@ -64,6 +65,22 @@ export function globOptions(session: Session): GlobOptions {
 
 export interface ResourceWithGlob extends Resource {
   glob(paths: readonly PathSpec[], prefix?: string): Promise<PathSpec[]>
+}
+
+async function backendGlob(
+  registry: MountRegistry,
+  mount: MountEntry,
+  paths: readonly PathSpec[],
+  prefix: string,
+): Promise<PathSpec[]> {
+  await mount.ensureReady()
+  const resource = mount.resource as Resource & Partial<ResourceWithGlob>
+  const glob = async (): Promise<PathSpec[]> => {
+    await mount.ensureReady()
+    return resource.glob === undefined ? [] : resource.glob(paths, prefix)
+  }
+  // Resource hooks own their index access; drain their writes before eviction.
+  return registry.fileCache === null ? glob() : withCacheMutation(registry.fileCache, glob)
 }
 
 // Virtual paths a directory owes the namespace, matching a segment.
@@ -192,6 +209,7 @@ async function levelMatches(
 ): Promise<string[]> {
   const real = listingDir(links, dirVirtual)
   const owner = mountOf(registry, real, mount)
+  await owner.ensureReady()
   const prefix = rstripSlash(owner.prefix)
   const out: string[] = []
   if (owner.resource.glob !== undefined) {
@@ -203,7 +221,7 @@ async function levelMatches(
       resolved: false,
     })
     try {
-      const matches = await owner.resource.glob([spec], prefix)
+      const matches = await backendGlob(registry, owner, [spec], prefix)
       // A descent step yields children, so a match that is the parent
       // itself is not one. A backend asked to list a path that is really
       // a file answers with that file, which walked back out as a
@@ -423,6 +441,7 @@ export async function resolveGlobs(
         resourcePath: mountKey(item.virtual, prefix),
         rawPath: item.rawPath,
       })
+      await mount.ensureReady()
       try {
         let resolved: PathSpec[]
         if (opts.globstar && hasGlobstarSegment(withPrefix)) {
@@ -445,10 +464,7 @@ export async function resolveGlobs(
           // to `xa.txt` lost its first match to that ambiguity. The
           // directory-shaped spec has no literal to reinstate, so an
           // empty list means no match and every spec returned is one.
-          const own =
-            mount.resource.glob !== undefined
-              ? await mount.resource.glob([withPrefix.dir], prefix)
-              : []
+          const own = await backendGlob(registry, mount, [withPrefix.dir], prefix)
           resolved = mergeNamespace(own, extra, directory, registry, mount)
         }
         if (resolved.length === 0) {

--- a/typescript/packages/core/src/workspace/expand/globs.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.ts
@@ -76,8 +76,9 @@ async function backendGlob(
   await mount.ensureReady()
   const resource = mount.resource as Resource & Partial<ResourceWithGlob>
   const glob = async (): Promise<PathSpec[]> => {
-    await mount.ensureReady()
-    return resource.glob === undefined ? [] : resource.glob(paths, prefix)
+    return mount.use(() =>
+      resource.glob === undefined ? Promise.resolve([]) : resource.glob(paths, prefix),
+    )
   }
   // Resource hooks own their index access; drain their writes before eviction.
   return registry.fileCache === null ? glob() : withCacheMutation(registry.fileCache, glob)

--- a/typescript/packages/core/src/workspace/expand/globs.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.ts
@@ -13,7 +13,6 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { childMountNames, namespaceNames } from '../../ops/namespace_view.ts'
-import { withCacheMutation } from '../../cache/file/io.ts'
 import type { NamespaceLinks } from '../../ops/config.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import type { Resource } from '../../resource/base.ts'
@@ -65,23 +64,6 @@ export function globOptions(session: Session): GlobOptions {
 
 export interface ResourceWithGlob extends Resource {
   glob(paths: readonly PathSpec[], prefix?: string): Promise<PathSpec[]>
-}
-
-async function backendGlob(
-  registry: MountRegistry,
-  mount: MountEntry,
-  paths: readonly PathSpec[],
-  prefix: string,
-): Promise<PathSpec[]> {
-  await mount.ensureReady()
-  const resource = mount.resource as Resource & Partial<ResourceWithGlob>
-  const glob = async (): Promise<PathSpec[]> => {
-    return mount.use(() =>
-      resource.glob === undefined ? Promise.resolve([]) : resource.glob(paths, prefix),
-    )
-  }
-  // Resource hooks own their index access; drain their writes before eviction.
-  return registry.fileCache === null ? glob() : withCacheMutation(registry.fileCache, glob)
 }
 
 // Virtual paths a directory owes the namespace, matching a segment.
@@ -222,7 +204,7 @@ async function levelMatches(
       resolved: false,
     })
     try {
-      const matches = await backendGlob(registry, owner, [spec], prefix)
+      const matches = await owner.expandGlob([spec], prefix)
       // A descent step yields children, so a match that is the parent
       // itself is not one. A backend asked to list a path that is really
       // a file answers with that file, which walked back out as a
@@ -465,7 +447,7 @@ export async function resolveGlobs(
           // to `xa.txt` lost its first match to that ambiguity. The
           // directory-shaped spec has no literal to reinstate, so an
           // empty list means no match and every spec returned is one.
-          const own = await backendGlob(registry, mount, [withPrefix.dir], prefix)
+          const own = await mount.expandGlob([withPrefix.dir], prefix)
           resolved = mergeNamespace(own, extra, directory, registry, mount)
         }
         if (resolved.length === 0) {

--- a/typescript/packages/core/src/workspace/mount/activity.test.ts
+++ b/typescript/packages/core/src/workspace/mount/activity.test.ts
@@ -1,0 +1,109 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { expect, it } from 'vitest'
+import { CachableAsyncIterator } from '../../io/cachable_iterator.ts'
+import { ResourceActivity } from './activity.ts'
+
+it.each(['eof', 'error', 'close', 'bounded'])(
+  'resource usage ends with its stream (%s)',
+  async (finish) => {
+    const activity = new ResourceActivity()
+    async function* chunks(): AsyncGenerator<Uint8Array> {
+      yield await Promise.resolve(new Uint8Array([1]))
+      if (finish === 'error') throw new Error('read failed')
+    }
+    const source = activity.hold(
+      finish === 'bounded' ? new CachableAsyncIterator(chunks()) : chunks(),
+    )
+    if (source instanceof Uint8Array) throw new Error('expected stream')
+    let done = false
+    const waiting = activity.wait().then(() => {
+      done = true
+    })
+    await Promise.resolve()
+    expect(done).toBe(false)
+    const consume = async (): Promise<void> => {
+      for await (const chunk of source) expect(chunk).toEqual(new Uint8Array([1]))
+    }
+    if (finish === 'close') {
+      const iter = source[Symbol.asyncIterator]()
+      await iter.return?.()
+      await iter.return?.()
+    } else if (source instanceof CachableAsyncIterator) {
+      expect(await source.drainBounded(0)).toBeNull()
+    } else if (finish === 'error') {
+      await expect(consume()).rejects.toThrow('read failed')
+    } else {
+      await consume()
+    }
+    await waiting
+    const release = activity.acquire()
+    done = false
+    const next = activity.wait().then(() => {
+      done = true
+    })
+    await Promise.resolve()
+    expect(done).toBe(false)
+    release()
+    await next
+  },
+)
+
+it('exhausted cache streams do not keep a resource active', async () => {
+  async function* chunks(): AsyncGenerator<Uint8Array> {
+    yield await Promise.resolve(new Uint8Array([1]))
+  }
+  const cached = new CachableAsyncIterator(chunks())
+  await cached.drain()
+  const activity = new ResourceActivity()
+  activity.hold(cached)
+  await activity.wait()
+})
+
+it('close waits for a pending pull before releasing usage', async () => {
+  const activity = new ResourceActivity()
+  let entered = (): void => undefined
+  let resume = (): void => undefined
+  const started = new Promise<void>((resolve) => {
+    entered = resolve
+  })
+  const release = new Promise<void>((resolve) => {
+    resume = resolve
+  })
+  async function* chunks(): AsyncGenerator<Uint8Array> {
+    entered()
+    await release
+    yield new Uint8Array([1])
+  }
+  const source = activity.hold(chunks())
+  if (source instanceof Uint8Array) throw new Error('expected stream')
+  const iterator = source[Symbol.asyncIterator]()
+  const pulling = iterator.next()
+  await started
+  let closed = false
+  let idle = false
+  const closing = iterator.return?.().then(() => {
+    closed = true
+  })
+  const waiting = activity.wait().then(() => {
+    idle = true
+  })
+  await Promise.resolve()
+  expect(closed).toBe(false)
+  expect(idle).toBe(false)
+  resume()
+  expect((await pulling).value).toEqual(new Uint8Array([1]))
+  await Promise.all([closing, waiting])
+})

--- a/typescript/packages/core/src/workspace/mount/activity.ts
+++ b/typescript/packages/core/src/workspace/mount/activity.ts
@@ -1,0 +1,90 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { CachableAsyncIterator } from '../../io/cachable_iterator.ts'
+import type { ByteSource } from '../../io/types.ts'
+import { KeyLock } from '../../cache/lock.ts'
+
+/** Calls and streams sharing one resource, including its removed aliases. */
+export class ResourceActivity {
+  private count = 0
+  private waiters: (() => void)[] = []
+
+  acquire(): () => void {
+    this.count++
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      this.count--
+      if (this.count === 0) {
+        for (const resolve of this.waiters.splice(0)) resolve()
+      }
+    }
+  }
+
+  wait(): Promise<void> {
+    if (this.count === 0) return Promise.resolve()
+    return new Promise((resolve) => {
+      this.waiters.push(resolve)
+    })
+  }
+
+  hold(source: ByteSource): ByteSource {
+    if (source instanceof Uint8Array) return source
+    if (source instanceof CachableAsyncIterator) {
+      if (source.exhausted) return source
+      source.wrapSource((inner) => new ActivityStream(inner, this.acquire()))
+      return source
+    }
+    return new ActivityStream(source, this.acquire())
+  }
+}
+
+/** Explicit return releases even a stream that was never pulled. */
+class ActivityStream implements AsyncIterableIterator<Uint8Array> {
+  private readonly source: AsyncIterator<Uint8Array>
+  private readonly pullLock = new KeyLock()
+  constructor(
+    source: AsyncIterable<Uint8Array>,
+    private readonly release: () => void,
+  ) {
+    this.source = source[Symbol.asyncIterator]()
+  }
+  [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array> {
+    return this
+  }
+  next(): Promise<IteratorResult<Uint8Array>> {
+    return this.pullLock.withLock('', async () => {
+      try {
+        const step = await this.source.next()
+        if (step.done === true) this.release()
+        return step
+      } catch (error) {
+        this.release()
+        throw error
+      }
+    })
+  }
+  return(): Promise<IteratorResult<Uint8Array>> {
+    return this.pullLock.withLock('', async () => {
+      try {
+        await this.source.return?.()
+        return { done: true, value: undefined }
+      } finally {
+        this.release()
+      }
+    })
+  }
+}

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { mountKey } from '../../utils/key_prefix.ts'
+import { KeyLock } from '../../cache/lock.ts'
 import { type Accessor, NOOPAccessor } from '../../accessor/base.ts'
 import type {
   CommandFn,
@@ -90,6 +91,8 @@ export class MountEntry {
   mode: MountMode
   readonly consistency: ConsistencyPolicy
   retiring = false
+  beforeUse: (() => Promise<void>) | null = null
+  private readonly readyLock = new KeyLock()
 
   /**
    * Per-path revision pins installed at Workspace.load time. Read
@@ -135,6 +138,17 @@ export class MountEntry {
    * This mount's mode narrowed by the current session's cap. The
    * configured mode is the ceiling; a session's mode can only weaken it.
    */
+  /** Finish deferred mount preparation before any backend or cache read. */
+  async ensureReady(): Promise<void> {
+    if (this.beforeUse === null) return
+    await this.readyLock.withLock('', async () => {
+      if (this.beforeUse !== null) {
+        await this.beforeUse()
+        this.beforeUse = null
+      }
+    })
+  }
+
   effectiveMode(): MountMode {
     return effectiveMountMode(this.prefix, this.mode)
   }
@@ -398,6 +412,7 @@ export class MountEntry {
     flags: Record<string, FlagValue>,
     context: ExecContext = {},
   ): Promise<[ByteSource | null, IOResult]> {
+    await this.ensureReady()
     let extension =
       paths.length > 0 && paths[0] !== undefined ? getExtension(paths[0].virtual) : null
     // A filetype handler is selected from the operand's NAME, and a
@@ -587,6 +602,7 @@ export class MountEntry {
     args: readonly unknown[] = [],
     kwargs: OpKwargs = {},
   ): Promise<unknown> {
+    await this.ensureReady()
     const filetype = getExtension(path)
     const levels = this.resolveCascade(opName, filetype, this.ops, this.generalOps)
     if (levels.length === 0) {

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -89,6 +89,7 @@ export class MountEntry {
   readonly resource: Resource
   mode: MountMode
   readonly consistency: ConsistencyPolicy
+  retiring = false
 
   /**
    * Per-path revision pins installed at Workspace.load time. Read

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -139,6 +139,17 @@ export class MountEntry {
     this.consistency = init.consistency ?? ConsistencyPolicy.LAZY
   }
 
+  /** Prepare and retain the resource while its glob hook reads metadata. */
+  async expandGlob(paths: readonly PathSpec[], prefix: string): Promise<PathSpec[]> {
+    return this.use(async () => {
+      const call = async (): Promise<PathSpec[]> => {
+        await this.ensureReady()
+        return this.resource.glob === undefined ? [...paths] : this.resource.glob(paths, prefix)
+      }
+      return this.cacheManager === null ? call() : this.cacheManager.withMutation(call)
+    })
+  }
+
   /** Metadata access bound to this mount's ownership. */
   get index(): IndexCacheStore | undefined {
     const index = this.resource.index
@@ -493,8 +504,7 @@ export class MountEntry {
           }),
       )
 
-      const expandedPaths =
-        this.resource.glob !== undefined ? await this.resource.glob(prefixedPaths) : prefixedPaths
+      const expandedPaths = await this.expandGlob(prefixedPaths, '')
 
       const accessor = (this.resource as { accessor?: Accessor }).accessor ?? NOOP_ACCESSOR
       const cmdOpts: CommandOpts = {

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -39,6 +39,7 @@ import { runWithCacheManager } from '../../cache/context.ts'
 import type { CacheManager } from '../../cache/manager.ts'
 import { mergeSignals } from '../abort.ts'
 import { runWithMountPrefix, runWithRevisions, withMountPrefix } from '../../observe/context.ts'
+import { uuid7 } from '../../utils/ids.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
 import { type Limit, ConsistencyPolicy, FileType, MountMode, PathSpec } from '../../types.ts'
@@ -87,6 +88,7 @@ export interface MountInit {
 }
 
 export class MountEntry {
+  readonly mountId = uuid7()
   readonly prefix: string
   readonly resource: Resource
   mode: MountMode
@@ -508,103 +510,106 @@ export class MountEntry {
     // this binding is how each write the handler then makes is held to
     // its own region's mode.
     return runWithMountGate(this.prefix, this.mode, () =>
-      runWithMountPrefix(mountPrefix, () =>
-        runWithCacheManager(this.cacheManager, () =>
-          runWithRevisions(
-            this.revisions.size > 0 ? this.revisions : null,
-            async (): Promise<[ByteSource | null, IOResult]> => {
-              // --help / --version short-circuit inside the handler
-              // wrapper and never touch the backend, so a read-only mount
-              // answers them like GNU instead of refusing them as writes.
-              const infoOnly = flags.help === true || flags.version === true
-              for (const cmd of handlers) {
-                // strongestModeUnder, not effectiveMode: a mount whose
-                // only writable region is a show entry still runs the
-                // command, and the op door refuses per path. The
-                // trailing newline is load-bearing: stderr accumulates
-                // across a line, so two refusals in one list ran
-                // together as `...at /ro/rm: read-only mount at /ro/`,
-                // and the node table's twin of this refusal (a symlink
-                // `rm`, rendered by shared.readOnlyError) concatenates
-                // with it.
-                if (
-                  cmd.write &&
-                  !infoOnly &&
-                  strongestModeUnder(this.prefix, this.mode) === MountMode.READ
-                ) {
-                  return [
-                    null,
-                    new IOResult({
-                      exitCode: 1,
-                      stderr: new TextEncoder().encode(
-                        `${cmdName}: read-only mount at ${this.prefix}\n`,
-                      ),
-                    }),
-                  ]
-                }
-                // The dispatch-level guard only sees default limits
-                // (the mount is unknown before routing), so the
-                // mount-resolved timeout must also bound the command
-                // body: eager commands do their work inside cmd.fn,
-                // where the stream-consumption guard never runs.
-                // limitOverride carries the origin mount's cap across
-                // a warm-cache redirect; a null one is "no opinion" and
-                // must not shadow the serving mount's own table (a
-                // path-less command with cwd outside every mount resolves
-                // no origin, but the serving mount's cap still applies —
-                // python always reads the serving mount).
-                const resolvedLimit = resolveLimit(
-                  cmdName,
-                  [],
-                  cmd.limit,
-                  context.limitOverride ?? this.commandLimits.get(cmdName) ?? null,
-                )
-                const cmdTimeout = resolvedLimit !== null ? resolvedLimit.timeoutSeconds : null
-                // runWithTimeout abandons the promise, it cannot cancel
-                // it; the aborted signal lets a runtime kill what it
-                // spawned (python cancels the task instead). The ambient
-                // context.signal is a background job's kill channel, folded
-                // into the same wire. timeoutSeconds rides along so an
-                // engine that executes on the event loop (quickjs) can
-                // interrupt itself when the timer cannot fire.
-                const guard = cmdTimeout !== null && cmdTimeout > 0 ? new AbortController() : null
-                const runSignal = mergeSignals(guard?.signal, context.signal)
-                const runOpts =
-                  runSignal !== undefined
-                    ? {
-                        ...cmdOpts,
-                        signal: runSignal,
-                        ...(cmdTimeout !== null && cmdTimeout > 0
-                          ? { timeoutSeconds: cmdTimeout }
-                          : {}),
-                      }
-                    : cmdOpts
-                let result: CommandFnResult
-                try {
-                  result = await runWithTimeout(
-                    Promise.resolve(cmd.fn(accessor, expandedPaths, texts, runOpts)),
-                    cmdTimeout,
+      runWithMountPrefix(
+        mountPrefix,
+        () =>
+          runWithCacheManager(this.cacheManager, () =>
+            runWithRevisions(
+              this.revisions.size > 0 ? this.revisions : null,
+              async (): Promise<[ByteSource | null, IOResult]> => {
+                // --help / --version short-circuit inside the handler
+                // wrapper and never touch the backend, so a read-only mount
+                // answers them like GNU instead of refusing them as writes.
+                const infoOnly = flags.help === true || flags.version === true
+                for (const cmd of handlers) {
+                  // strongestModeUnder, not effectiveMode: a mount whose
+                  // only writable region is a show entry still runs the
+                  // command, and the op door refuses per path. The
+                  // trailing newline is load-bearing: stderr accumulates
+                  // across a line, so two refusals in one list ran
+                  // together as `...at /ro/rm: read-only mount at /ro/`,
+                  // and the node table's twin of this refusal (a symlink
+                  // `rm`, rendered by shared.readOnlyError) concatenates
+                  // with it.
+                  if (
+                    cmd.write &&
+                    !infoOnly &&
+                    strongestModeUnder(this.prefix, this.mode) === MountMode.READ
+                  ) {
+                    return [
+                      null,
+                      new IOResult({
+                        exitCode: 1,
+                        stderr: new TextEncoder().encode(
+                          `${cmdName}: read-only mount at ${this.prefix}\n`,
+                        ),
+                      }),
+                    ]
+                  }
+                  // The dispatch-level guard only sees default limits
+                  // (the mount is unknown before routing), so the
+                  // mount-resolved timeout must also bound the command
+                  // body: eager commands do their work inside cmd.fn,
+                  // where the stream-consumption guard never runs.
+                  // limitOverride carries the origin mount's cap across
+                  // a warm-cache redirect; a null one is "no opinion" and
+                  // must not shadow the serving mount's own table (a
+                  // path-less command with cwd outside every mount resolves
+                  // no origin, but the serving mount's cap still applies —
+                  // python always reads the serving mount).
+                  const resolvedLimit = resolveLimit(
                     cmdName,
+                    [],
+                    cmd.limit,
+                    context.limitOverride ?? this.commandLimits.get(cmdName) ?? null,
                   )
-                } catch (err) {
-                  if (guard !== null && err instanceof CommandTimeoutError) guard.abort()
-                  throw err
+                  const cmdTimeout = resolvedLimit !== null ? resolvedLimit.timeoutSeconds : null
+                  // runWithTimeout abandons the promise, it cannot cancel
+                  // it; the aborted signal lets a runtime kill what it
+                  // spawned (python cancels the task instead). The ambient
+                  // context.signal is a background job's kill channel, folded
+                  // into the same wire. timeoutSeconds rides along so an
+                  // engine that executes on the event loop (quickjs) can
+                  // interrupt itself when the timer cannot fire.
+                  const guard = cmdTimeout !== null && cmdTimeout > 0 ? new AbortController() : null
+                  const runSignal = mergeSignals(guard?.signal, context.signal)
+                  const runOpts =
+                    runSignal !== undefined
+                      ? {
+                          ...cmdOpts,
+                          signal: runSignal,
+                          ...(cmdTimeout !== null && cmdTimeout > 0
+                            ? { timeoutSeconds: cmdTimeout }
+                            : {}),
+                        }
+                      : cmdOpts
+                  let result: CommandFnResult
+                  try {
+                    result = await runWithTimeout(
+                      Promise.resolve(cmd.fn(accessor, expandedPaths, texts, runOpts)),
+                      cmdTimeout,
+                      cmdName,
+                    )
+                  } catch (err) {
+                    if (guard !== null && err instanceof CommandTimeoutError) guard.abort()
+                    throw err
+                  }
+                  if (result !== null) {
+                    // A warm-cache redirect already resolved the origin
+                    // mount's cap (limitOverride); fold it as the
+                    // declared bound since the origin prefix is not ours.
+                    result[1].producer =
+                      context.limitOverride != null
+                        ? { command: cmdName, prefixes: [], declared: resolvedLimit }
+                        : { command: cmdName, prefixes: [this.prefix], declared: cmd.limit ?? null }
+                    return wrapMountStreams(result, mountPrefix, this.mountId)
+                  }
                 }
-                if (result !== null) {
-                  // A warm-cache redirect already resolved the origin
-                  // mount's cap (limitOverride); fold it as the
-                  // declared bound since the origin prefix is not ours.
-                  result[1].producer =
-                    context.limitOverride != null
-                      ? { command: cmdName, prefixes: [], declared: resolvedLimit }
-                      : { command: cmdName, prefixes: [this.prefix], declared: cmd.limit ?? null }
-                  return wrapMountStreams(result, mountPrefix)
-                }
-              }
-              return [null, new IOResult()]
-            },
+                return [null, new IOResult()]
+              },
+            ),
           ),
-        ),
+        this.mountId,
       ),
     )
   }
@@ -664,20 +669,37 @@ export class MountEntry {
     // the timeout stays here, bounding the backend call itself.
     const opOverride = this.commandLimits.get(opName) ?? null
     const opTimeout = opOverride !== null ? opOverride.timeoutSeconds : null
-    return runWithMountPrefix(mountPrefix, () =>
-      runWithRevisions(this.revisions.size > 0 ? this.revisions : null, async () => {
-        for (const op of levels) {
-          const result = await runWithTimeout(
-            Promise.resolve(op.fn(accessor, scope, args, effectiveKwargs)),
-            opTimeout,
-            opName,
-          )
-          if (result !== null && result !== undefined) return result
-        }
-        return null
-      }),
+    return runWithMountPrefix(
+      mountPrefix,
+      () =>
+        runWithRevisions(this.revisions.size > 0 ? this.revisions : null, async () => {
+          for (const op of levels) {
+            const result = await runWithTimeout(
+              Promise.resolve(op.fn(accessor, scope, args, effectiveKwargs)),
+              opTimeout,
+              opName,
+            )
+            if (result !== null && result !== undefined) {
+              return wrapOpStream(result, mountPrefix, this.mountId)
+            }
+          }
+          return null
+        }),
+      this.mountId,
     )
   }
+}
+
+/** Preserve a streaming operation's recording owner after its dispatch frame exits. */
+export function wrapOpStream(result: unknown, mountPrefix: string, mountId: string): unknown {
+  if (result instanceof CachableAsyncIterator) {
+    result.wrapSource((source) => withMountPrefix(mountPrefix, source, mountId))
+    return result
+  }
+  if (result !== null && typeof result === 'object' && Symbol.asyncIterator in result) {
+    return withMountPrefix(mountPrefix, result as AsyncIterable<Uint8Array>, mountId)
+  }
+  return result
 }
 
 // Push `mountPrefix` back during lazy consumption of anything the command
@@ -688,6 +710,7 @@ export class MountEntry {
 function wrapMountStreams(
   result: [ByteSource | null, IOResult],
   mountPrefix: string,
+  mountId: string,
 ): [ByteSource | null, IOResult] {
   const [stream, io] = result
   const seen = new Map<ByteSource, ByteSource>()
@@ -697,10 +720,10 @@ function wrapMountStreams(
     if (hit !== undefined) return hit
     let wrapped: ByteSource
     if (obj instanceof CachableAsyncIterator) {
-      obj.wrapSource((src) => withMountPrefix(mountPrefix, src))
+      obj.wrapSource((src) => withMountPrefix(mountPrefix, src, mountId))
       wrapped = obj
     } else {
-      wrapped = withMountPrefix(mountPrefix, obj)
+      wrapped = withMountPrefix(mountPrefix, obj, mountId)
     }
     seen.set(obj, wrapped)
     return wrapped

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -87,7 +87,7 @@ export interface MountInit {
 export class MountEntry {
   readonly prefix: string
   readonly resource: Resource
-  readonly mode: MountMode
+  mode: MountMode
   readonly consistency: ConsistencyPolicy
 
   /**

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -40,6 +40,7 @@ import type { CacheManager } from '../../cache/manager.ts'
 import { mergeSignals } from '../abort.ts'
 import { runWithMountPrefix, runWithRevisions, withMountPrefix } from '../../observe/context.ts'
 import { uuid7 } from '../../utils/ids.ts'
+import { ResourceActivity } from './activity.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
 import { type Limit, ConsistencyPolicy, FileType, MountMode, PathSpec } from '../../types.ts'
@@ -93,6 +94,7 @@ export class MountEntry {
   readonly resource: Resource
   mode: MountMode
   readonly consistency: ConsistencyPolicy
+  activity = new ResourceActivity()
   retiring = false
   beforeUse: (() => Promise<void>) | null = null
   private readonly readyLock = new KeyLock()
@@ -144,6 +146,17 @@ export class MountEntry {
   }
 
   /** Finish deferred mount preparation before any backend or cache read. */
+  async use<T>(fn: () => Promise<T>): Promise<T> {
+    await this.ensureReady()
+    this.checkActive()
+    const release = this.activity.acquire()
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+
   async ensureReady(): Promise<void> {
     this.checkActive()
     if (this.beforeUse === null) return
@@ -427,191 +440,197 @@ export class MountEntry {
     flags: Record<string, FlagValue>,
     context: ExecContext = {},
   ): Promise<[ByteSource | null, IOResult]> {
-    await this.ensureReady()
-    let extension =
-      paths.length > 0 && paths[0] !== undefined ? getExtension(paths[0].virtual) : null
-    // A filetype handler is selected from the operand's NAME, and a
-    // directory can carry any extension, so the cascade would hand a
-    // renderer a directory to read. One stat settles it, and only when a
-    // handler for this exact extension exists, so a mount with no
-    // filetype registrations never reaches the probe. The built-in is
-    // what a directory should get: it owns GNU's `Is a directory`
-    // wording, and the renderer owns nothing but its own format.
-    // The DISPATCHER's stat, not the backend's, so a mount root and a
-    // namespace-only directory answer too; null means neither plane saw
-    // anything, in which case the renderer reports its own miss.
-    const first = paths[0]
-    if (
-      extension !== null &&
-      extension !== '' &&
-      first !== undefined &&
-      context.statPath !== undefined &&
-      this.cmds.has(cmdKey(cmdName, extension))
-    ) {
-      const entry = await context.statPath(first.virtual)
-      if (entry !== null && entry.type === FileType.DIRECTORY) extension = null
-    }
+    return this.use(async (): Promise<[ByteSource | null, IOResult]> => {
+      let extension =
+        paths.length > 0 && paths[0] !== undefined ? getExtension(paths[0].virtual) : null
+      // A filetype handler is selected from the operand's NAME, and a
+      // directory can carry any extension, so the cascade would hand a
+      // renderer a directory to read. One stat settles it, and only when a
+      // handler for this exact extension exists, so a mount with no
+      // filetype registrations never reaches the probe. The built-in is
+      // what a directory should get: it owns GNU's `Is a directory`
+      // wording, and the renderer owns nothing but its own format.
+      // The DISPATCHER's stat, not the backend's, so a mount root and a
+      // namespace-only directory answer too; null means neither plane saw
+      // anything, in which case the renderer reports its own miss.
+      const first = paths[0]
+      if (
+        extension !== null &&
+        extension !== '' &&
+        first !== undefined &&
+        context.statPath !== undefined &&
+        this.cmds.has(cmdKey(cmdName, extension))
+      ) {
+        const entry = await context.statPath(first.virtual)
+        if (entry !== null && entry.type === FileType.DIRECTORY) extension = null
+      }
 
-    const handlers = this.resolveCascade(cmdName, extension, this.cmds, this.generalCmds)
-    if (handlers.length === 0) {
-      return [
-        null,
-        new IOResult({
-          exitCode: 127,
-          stderr: new TextEncoder().encode(`${cmdName}: command not found`),
-        }),
-      ]
-    }
+      const handlers = this.resolveCascade(cmdName, extension, this.cmds, this.generalCmds)
+      if (handlers.length === 0) {
+        return [
+          null,
+          new IOResult({
+            exitCode: 127,
+            stderr: new TextEncoder().encode(`${cmdName}: command not found`),
+          }),
+        ]
+      }
 
-    const mountPrefix = rstripSlash(this.prefix)
-    const filetypeFns = this.filetypeHandlers(cmdName)
-    const isFiletypeCmd =
-      extension !== null && extension !== '' && this.cmds.has(cmdKey(cmdName, extension))
+      const mountPrefix = rstripSlash(this.prefix)
+      const filetypeFns = this.filetypeHandlers(cmdName)
+      const isFiletypeCmd =
+        extension !== null && extension !== '' && this.cmds.has(cmdKey(cmdName, extension))
 
-    const prefixedPaths = paths.map(
-      (p) =>
-        new PathSpec({
-          virtual: p.virtual,
-          directory: p.directory,
-          pattern: p.pattern,
-          resolved: p.resolved,
-          resourcePath: mountKey(p.virtual, mountPrefix),
-          rawPath: p.rawPath,
-        }),
-    )
+      const prefixedPaths = paths.map(
+        (p) =>
+          new PathSpec({
+            virtual: p.virtual,
+            directory: p.directory,
+            pattern: p.pattern,
+            resolved: p.resolved,
+            resourcePath: mountKey(p.virtual, mountPrefix),
+            rawPath: p.rawPath,
+          }),
+      )
 
-    const expandedPaths =
-      this.resource.glob !== undefined ? await this.resource.glob(prefixedPaths) : prefixedPaths
+      const expandedPaths =
+        this.resource.glob !== undefined ? await this.resource.glob(prefixedPaths) : prefixedPaths
 
-    const accessor = (this.resource as { accessor?: Accessor }).accessor ?? NOOP_ACCESSOR
-    const cmdOpts: CommandOpts = {
-      stdin: context.stdin ?? null,
-      flags,
-      filetypeFns: isFiletypeCmd ? null : filetypeFns,
-      mountPrefix,
-      cwd: context.cwd ?? ROOT_CWD,
-      ...(this.index !== undefined ? { index: this.index } : {}),
-      ...(context.dispatch !== undefined ? { dispatch: context.dispatch } : {}),
-      ...(context.sessionId !== undefined ? { sessionId: context.sessionId } : {}),
-      ...(context.env !== undefined ? { env: context.env } : {}),
-      ...(context.sessionView !== undefined ? { sessionView: context.sessionView } : {}),
-      ...(context.execAllowed !== undefined ? { execAllowed: context.execAllowed } : {}),
-      ...(context.execPathAllowed !== undefined
-        ? { execPathAllowed: context.execPathAllowed }
-        : {}),
-      ...(context.runtime !== undefined ? { runtime: context.runtime } : {}),
-      ...(context.ns !== undefined ? { ns: context.ns } : {}),
-      ...(context.statPath !== undefined ? { statPath: context.statPath } : {}),
-      ...(context.readdirPath !== undefined ? { readdirPath: context.readdirPath } : {}),
-    }
-
-    // What the command tier's mode guard reads: the write-command gate
-    // below admits a command when any shown subtree grants writes, and
-    // this binding is how each write the handler then makes is held to
-    // its own region's mode.
-    return runWithMountGate(this.prefix, this.mode, () =>
-      runWithMountPrefix(
+      const accessor = (this.resource as { accessor?: Accessor }).accessor ?? NOOP_ACCESSOR
+      const cmdOpts: CommandOpts = {
+        stdin: context.stdin ?? null,
+        flags,
+        filetypeFns: isFiletypeCmd ? null : filetypeFns,
         mountPrefix,
-        () =>
-          runWithCacheManager(this.cacheManager, () =>
-            runWithRevisions(
-              this.revisions.size > 0 ? this.revisions : null,
-              async (): Promise<[ByteSource | null, IOResult]> => {
-                // --help / --version short-circuit inside the handler
-                // wrapper and never touch the backend, so a read-only mount
-                // answers them like GNU instead of refusing them as writes.
-                const infoOnly = flags.help === true || flags.version === true
-                for (const cmd of handlers) {
-                  // strongestModeUnder, not effectiveMode: a mount whose
-                  // only writable region is a show entry still runs the
-                  // command, and the op door refuses per path. The
-                  // trailing newline is load-bearing: stderr accumulates
-                  // across a line, so two refusals in one list ran
-                  // together as `...at /ro/rm: read-only mount at /ro/`,
-                  // and the node table's twin of this refusal (a symlink
-                  // `rm`, rendered by shared.readOnlyError) concatenates
-                  // with it.
-                  if (
-                    cmd.write &&
-                    !infoOnly &&
-                    strongestModeUnder(this.prefix, this.mode) === MountMode.READ
-                  ) {
-                    return [
-                      null,
-                      new IOResult({
-                        exitCode: 1,
-                        stderr: new TextEncoder().encode(
-                          `${cmdName}: read-only mount at ${this.prefix}\n`,
-                        ),
-                      }),
-                    ]
-                  }
-                  // The dispatch-level guard only sees default limits
-                  // (the mount is unknown before routing), so the
-                  // mount-resolved timeout must also bound the command
-                  // body: eager commands do their work inside cmd.fn,
-                  // where the stream-consumption guard never runs.
-                  // limitOverride carries the origin mount's cap across
-                  // a warm-cache redirect; a null one is "no opinion" and
-                  // must not shadow the serving mount's own table (a
-                  // path-less command with cwd outside every mount resolves
-                  // no origin, but the serving mount's cap still applies —
-                  // python always reads the serving mount).
-                  const resolvedLimit = resolveLimit(
-                    cmdName,
-                    [],
-                    cmd.limit,
-                    context.limitOverride ?? this.commandLimits.get(cmdName) ?? null,
-                  )
-                  const cmdTimeout = resolvedLimit !== null ? resolvedLimit.timeoutSeconds : null
-                  // runWithTimeout abandons the promise, it cannot cancel
-                  // it; the aborted signal lets a runtime kill what it
-                  // spawned (python cancels the task instead). The ambient
-                  // context.signal is a background job's kill channel, folded
-                  // into the same wire. timeoutSeconds rides along so an
-                  // engine that executes on the event loop (quickjs) can
-                  // interrupt itself when the timer cannot fire.
-                  const guard = cmdTimeout !== null && cmdTimeout > 0 ? new AbortController() : null
-                  const runSignal = mergeSignals(guard?.signal, context.signal)
-                  const runOpts =
-                    runSignal !== undefined
-                      ? {
-                          ...cmdOpts,
-                          signal: runSignal,
-                          ...(cmdTimeout !== null && cmdTimeout > 0
-                            ? { timeoutSeconds: cmdTimeout }
-                            : {}),
-                        }
-                      : cmdOpts
-                  let result: CommandFnResult
-                  try {
-                    result = await runWithTimeout(
-                      Promise.resolve(cmd.fn(accessor, expandedPaths, texts, runOpts)),
-                      cmdTimeout,
+        cwd: context.cwd ?? ROOT_CWD,
+        ...(this.index !== undefined ? { index: this.index } : {}),
+        ...(context.dispatch !== undefined ? { dispatch: context.dispatch } : {}),
+        ...(context.sessionId !== undefined ? { sessionId: context.sessionId } : {}),
+        ...(context.env !== undefined ? { env: context.env } : {}),
+        ...(context.sessionView !== undefined ? { sessionView: context.sessionView } : {}),
+        ...(context.execAllowed !== undefined ? { execAllowed: context.execAllowed } : {}),
+        ...(context.execPathAllowed !== undefined
+          ? { execPathAllowed: context.execPathAllowed }
+          : {}),
+        ...(context.runtime !== undefined ? { runtime: context.runtime } : {}),
+        ...(context.ns !== undefined ? { ns: context.ns } : {}),
+        ...(context.statPath !== undefined ? { statPath: context.statPath } : {}),
+        ...(context.readdirPath !== undefined ? { readdirPath: context.readdirPath } : {}),
+      }
+
+      // What the command tier's mode guard reads: the write-command gate
+      // below admits a command when any shown subtree grants writes, and
+      // this binding is how each write the handler then makes is held to
+      // its own region's mode.
+      return runWithMountGate(this.prefix, this.mode, () =>
+        runWithMountPrefix(
+          mountPrefix,
+          () =>
+            runWithCacheManager(this.cacheManager, () =>
+              runWithRevisions(
+                this.revisions.size > 0 ? this.revisions : null,
+                async (): Promise<[ByteSource | null, IOResult]> => {
+                  // --help / --version short-circuit inside the handler
+                  // wrapper and never touch the backend, so a read-only mount
+                  // answers them like GNU instead of refusing them as writes.
+                  const infoOnly = flags.help === true || flags.version === true
+                  for (const cmd of handlers) {
+                    // strongestModeUnder, not effectiveMode: a mount whose
+                    // only writable region is a show entry still runs the
+                    // command, and the op door refuses per path. The
+                    // trailing newline is load-bearing: stderr accumulates
+                    // across a line, so two refusals in one list ran
+                    // together as `...at /ro/rm: read-only mount at /ro/`,
+                    // and the node table's twin of this refusal (a symlink
+                    // `rm`, rendered by shared.readOnlyError) concatenates
+                    // with it.
+                    if (
+                      cmd.write &&
+                      !infoOnly &&
+                      strongestModeUnder(this.prefix, this.mode) === MountMode.READ
+                    ) {
+                      return [
+                        null,
+                        new IOResult({
+                          exitCode: 1,
+                          stderr: new TextEncoder().encode(
+                            `${cmdName}: read-only mount at ${this.prefix}\n`,
+                          ),
+                        }),
+                      ]
+                    }
+                    // The dispatch-level guard only sees default limits
+                    // (the mount is unknown before routing), so the
+                    // mount-resolved timeout must also bound the command
+                    // body: eager commands do their work inside cmd.fn,
+                    // where the stream-consumption guard never runs.
+                    // limitOverride carries the origin mount's cap across
+                    // a warm-cache redirect; a null one is "no opinion" and
+                    // must not shadow the serving mount's own table (a
+                    // path-less command with cwd outside every mount resolves
+                    // no origin, but the serving mount's cap still applies —
+                    // python always reads the serving mount).
+                    const resolvedLimit = resolveLimit(
                       cmdName,
+                      [],
+                      cmd.limit,
+                      context.limitOverride ?? this.commandLimits.get(cmdName) ?? null,
                     )
-                  } catch (err) {
-                    if (guard !== null && err instanceof CommandTimeoutError) guard.abort()
-                    throw err
+                    const cmdTimeout = resolvedLimit !== null ? resolvedLimit.timeoutSeconds : null
+                    // runWithTimeout abandons the promise, it cannot cancel
+                    // it; the aborted signal lets a runtime kill what it
+                    // spawned (python cancels the task instead). The ambient
+                    // context.signal is a background job's kill channel, folded
+                    // into the same wire. timeoutSeconds rides along so an
+                    // engine that executes on the event loop (quickjs) can
+                    // interrupt itself when the timer cannot fire.
+                    const guard =
+                      cmdTimeout !== null && cmdTimeout > 0 ? new AbortController() : null
+                    const runSignal = mergeSignals(guard?.signal, context.signal)
+                    const runOpts =
+                      runSignal !== undefined
+                        ? {
+                            ...cmdOpts,
+                            signal: runSignal,
+                            ...(cmdTimeout !== null && cmdTimeout > 0
+                              ? { timeoutSeconds: cmdTimeout }
+                              : {}),
+                          }
+                        : cmdOpts
+                    let result: CommandFnResult
+                    try {
+                      result = await runWithTimeout(
+                        Promise.resolve(cmd.fn(accessor, expandedPaths, texts, runOpts)),
+                        cmdTimeout,
+                        cmdName,
+                      )
+                    } catch (err) {
+                      if (guard !== null && err instanceof CommandTimeoutError) guard.abort()
+                      throw err
+                    }
+                    if (result !== null) {
+                      // A warm-cache redirect already resolved the origin
+                      // mount's cap (limitOverride); fold it as the
+                      // declared bound since the origin prefix is not ours.
+                      result[1].producer =
+                        context.limitOverride != null
+                          ? { command: cmdName, prefixes: [], declared: resolvedLimit }
+                          : {
+                              command: cmdName,
+                              prefixes: [this.prefix],
+                              declared: cmd.limit ?? null,
+                            }
+                      return wrapMountStreams(result, mountPrefix, this.mountId, this.activity)
+                    }
                   }
-                  if (result !== null) {
-                    // A warm-cache redirect already resolved the origin
-                    // mount's cap (limitOverride); fold it as the
-                    // declared bound since the origin prefix is not ours.
-                    result[1].producer =
-                      context.limitOverride != null
-                        ? { command: cmdName, prefixes: [], declared: resolvedLimit }
-                        : { command: cmdName, prefixes: [this.prefix], declared: cmd.limit ?? null }
-                    return wrapMountStreams(result, mountPrefix, this.mountId)
-                  }
-                }
-                return [null, new IOResult()]
-              },
+                  return [null, new IOResult()]
+                },
+              ),
             ),
-          ),
-        this.mountId,
-      ),
-    )
+          this.mountId,
+        ),
+      )
+    })
   }
 
   async executeOp(
@@ -620,84 +639,90 @@ export class MountEntry {
     args: readonly unknown[] = [],
     kwargs: OpKwargs = {},
   ): Promise<unknown> {
-    await this.ensureReady()
-    const filetype = getExtension(path)
-    const levels = this.resolveCascade(opName, filetype, this.ops, this.generalOps)
-    if (levels.length === 0) {
-      throw enotsup(this.resource.kind, opName, path)
-    }
-    // Per path, not per mount: a show entry can hold one subtree below
-    // `w` on a writable mount, or one writable region on a read mount.
-    // A rename mutates its destination too, so both endpoints answer,
-    // and it relocates whole subtrees in one call, so a read-only
-    // region below either endpoint refuses it too.
-    if (levels.some((o) => o.write)) {
-      if (effectivePathMode(path, this.prefix, this.mode) === MountMode.READ) {
-        throw erofsReadOnly(`mount ${this.prefix} is read-only`, path)
+    return this.use(async (): Promise<unknown> => {
+      const filetype = getExtension(path)
+      const levels = this.resolveCascade(opName, filetype, this.ops, this.generalOps)
+      if (levels.length === 0) {
+        throw enotsup(this.resource.kind, opName, path)
       }
-      const dst = kwargs.dst
-      if (
-        dst instanceof PathSpec &&
-        effectivePathMode(dst.virtual, this.prefix, this.mode) === MountMode.READ
-      ) {
-        throw erofsReadOnly(`mount ${this.prefix} is read-only`, dst.virtual)
-      }
-      if (SUBTREE_OPS.has(opName)) {
-        const endpoints = dst instanceof PathSpec ? [path, dst.virtual] : [path]
-        for (const endpoint of endpoints) {
-          const blame = readonlyBelow(endpoint, this.prefix, this.mode)
-          if (blame !== null) {
-            throw erofsReadOnly(`mount ${this.prefix} is read-only`, blame)
+      // Per path, not per mount: a show entry can hold one subtree below
+      // `w` on a writable mount, or one writable region on a read mount.
+      // A rename mutates its destination too, so both endpoints answer,
+      // and it relocates whole subtrees in one call, so a read-only
+      // region below either endpoint refuses it too.
+      if (levels.some((o) => o.write)) {
+        if (effectivePathMode(path, this.prefix, this.mode) === MountMode.READ) {
+          throw erofsReadOnly(`mount ${this.prefix} is read-only`, path)
+        }
+        const dst = kwargs.dst
+        if (
+          dst instanceof PathSpec &&
+          effectivePathMode(dst.virtual, this.prefix, this.mode) === MountMode.READ
+        ) {
+          throw erofsReadOnly(`mount ${this.prefix} is read-only`, dst.virtual)
+        }
+        if (SUBTREE_OPS.has(opName)) {
+          const endpoints = dst instanceof PathSpec ? [path, dst.virtual] : [path]
+          for (const endpoint of endpoints) {
+            const blame = readonlyBelow(endpoint, this.prefix, this.mode)
+            if (blame !== null) {
+              throw erofsReadOnly(`mount ${this.prefix} is read-only`, blame)
+            }
           }
         }
       }
-    }
-    const mountPrefix = rstripSlash(this.prefix)
-    const lastSlash = path.lastIndexOf('/')
-    const scope = new PathSpec({
-      virtual: path,
-      directory: lastSlash > 0 ? path.slice(0, lastSlash + 1) : '/',
-      resourcePath: mountKey(path, mountPrefix),
-    })
-    const effectiveKwargs: OpKwargs = {
-      ...kwargs,
-      ...(kwargs.index === undefined && this.index !== undefined ? { index: this.index } : {}),
-      ...(filetype !== null && kwargs.filetype === undefined ? { filetype } : {}),
-    }
-    const accessor = this.resource.accessor ?? NOOP_ACCESSOR
-    // Per-op caps are policy and fire at the op door (postOps); only
-    // the timeout stays here, bounding the backend call itself.
-    const opOverride = this.commandLimits.get(opName) ?? null
-    const opTimeout = opOverride !== null ? opOverride.timeoutSeconds : null
-    return runWithMountPrefix(
-      mountPrefix,
-      () =>
-        runWithRevisions(this.revisions.size > 0 ? this.revisions : null, async () => {
-          for (const op of levels) {
-            const result = await runWithTimeout(
-              Promise.resolve(op.fn(accessor, scope, args, effectiveKwargs)),
-              opTimeout,
-              opName,
-            )
-            if (result !== null && result !== undefined) {
-              return wrapOpStream(result, mountPrefix, this.mountId)
+      const mountPrefix = rstripSlash(this.prefix)
+      const lastSlash = path.lastIndexOf('/')
+      const scope = new PathSpec({
+        virtual: path,
+        directory: lastSlash > 0 ? path.slice(0, lastSlash + 1) : '/',
+        resourcePath: mountKey(path, mountPrefix),
+      })
+      const effectiveKwargs: OpKwargs = {
+        ...kwargs,
+        ...(kwargs.index === undefined && this.index !== undefined ? { index: this.index } : {}),
+        ...(filetype !== null && kwargs.filetype === undefined ? { filetype } : {}),
+      }
+      const accessor = this.resource.accessor ?? NOOP_ACCESSOR
+      // Per-op caps are policy and fire at the op door (postOps); only
+      // the timeout stays here, bounding the backend call itself.
+      const opOverride = this.commandLimits.get(opName) ?? null
+      const opTimeout = opOverride !== null ? opOverride.timeoutSeconds : null
+      return runWithMountPrefix(
+        mountPrefix,
+        () =>
+          runWithRevisions(this.revisions.size > 0 ? this.revisions : null, async () => {
+            for (const op of levels) {
+              const result = await runWithTimeout(
+                Promise.resolve(op.fn(accessor, scope, args, effectiveKwargs)),
+                opTimeout,
+                opName,
+              )
+              if (result !== null && result !== undefined) {
+                return wrapOpStream(result, mountPrefix, this.mountId, this.activity)
+              }
             }
-          }
-          return null
-        }),
-      this.mountId,
-    )
+            return null
+          }),
+        this.mountId,
+      )
+    })
   }
 }
 
 /** Preserve a streaming operation's recording owner after its dispatch frame exits. */
-export function wrapOpStream(result: unknown, mountPrefix: string, mountId: string): unknown {
+export function wrapOpStream(
+  result: unknown,
+  mountPrefix: string,
+  mountId: string,
+  activity: ResourceActivity,
+): unknown {
   if (result instanceof CachableAsyncIterator) {
     result.wrapSource((source) => withMountPrefix(mountPrefix, source, mountId))
-    return result
+    return activity.hold(result)
   }
   if (result !== null && typeof result === 'object' && Symbol.asyncIterator in result) {
-    return withMountPrefix(mountPrefix, result as AsyncIterable<Uint8Array>, mountId)
+    return activity.hold(withMountPrefix(mountPrefix, result as AsyncIterable<Uint8Array>, mountId))
   }
   return result
 }
@@ -711,6 +736,7 @@ function wrapMountStreams(
   result: [ByteSource | null, IOResult],
   mountPrefix: string,
   mountId: string,
+  activity: ResourceActivity,
 ): [ByteSource | null, IOResult] {
   const [stream, io] = result
   const seen = new Map<ByteSource, ByteSource>()
@@ -725,6 +751,7 @@ function wrapMountStreams(
     } else {
       wrapped = withMountPrefix(mountPrefix, obj, mountId)
     }
+    wrapped = activity.hold(wrapped)
     seen.set(obj, wrapped)
     return wrapped
   }

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -42,7 +42,7 @@ import { runWithMountPrefix, runWithRevisions, withMountPrefix } from '../../obs
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
 import { type Limit, ConsistencyPolicy, FileType, MountMode, PathSpec } from '../../types.ts'
-import { enotsup, erofsReadOnly } from '../../utils/errors.ts'
+import { ebusy, enotsup, erofsReadOnly } from '../../utils/errors.ts'
 import { rstripSlash } from '../../utils/slash.ts'
 import {
   effectiveMountMode,
@@ -143,6 +143,7 @@ export class MountEntry {
 
   /** Finish deferred mount preparation before any backend or cache read. */
   async ensureReady(): Promise<void> {
+    this.checkActive()
     if (this.beforeUse === null) return
     await this.readyLock.withLock('', async () => {
       if (this.beforeUse !== null) {
@@ -150,6 +151,11 @@ export class MountEntry {
         this.beforeUse = null
       }
     })
+    this.checkActive()
+  }
+
+  private checkActive(): void {
+    if (this.retiring) throw ebusy(this.prefix)
   }
 
   /**

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -14,6 +14,7 @@
 
 import { mountKey } from '../../utils/key_prefix.ts'
 import { KeyLock } from '../../cache/lock.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { type Accessor, NOOPAccessor } from '../../accessor/base.ts'
 import type {
   CommandFn,
@@ -134,10 +135,12 @@ export class MountEntry {
     this.consistency = init.consistency ?? ConsistencyPolicy.LAZY
   }
 
-  /**
-   * This mount's mode narrowed by the current session's cap. The
-   * configured mode is the ceiling; a session's mode can only weaken it.
-   */
+  /** Metadata access bound to this mount's ownership. */
+  get index(): IndexCacheStore | undefined {
+    const index = this.resource.index
+    return index === undefined ? undefined : (this.cacheManager?.scopeIndex(index) ?? index)
+  }
+
   /** Finish deferred mount preparation before any backend or cache read. */
   async ensureReady(): Promise<void> {
     if (this.beforeUse === null) return
@@ -149,6 +152,10 @@ export class MountEntry {
     })
   }
 
+  /**
+   * This mount's mode narrowed by the current session's cap. The
+   * configured mode is the ceiling; a session's mode can only weaken it.
+   */
   effectiveMode(): MountMode {
     return effectiveMountMode(this.prefix, this.mode)
   }
@@ -475,7 +482,7 @@ export class MountEntry {
       filetypeFns: isFiletypeCmd ? null : filetypeFns,
       mountPrefix,
       cwd: context.cwd ?? ROOT_CWD,
-      ...(this.resource.index !== undefined ? { index: this.resource.index } : {}),
+      ...(this.index !== undefined ? { index: this.index } : {}),
       ...(context.dispatch !== undefined ? { dispatch: context.dispatch } : {}),
       ...(context.sessionId !== undefined ? { sessionId: context.sessionId } : {}),
       ...(context.env !== undefined ? { env: context.env } : {}),
@@ -643,9 +650,7 @@ export class MountEntry {
     })
     const effectiveKwargs: OpKwargs = {
       ...kwargs,
-      ...(kwargs.index === undefined && this.resource.index !== undefined
-        ? { index: this.resource.index }
-        : {}),
+      ...(kwargs.index === undefined && this.index !== undefined ? { index: this.index } : {}),
       ...(filetype !== null && kwargs.filetype === undefined ? { filetype } : {}),
     }
     const accessor = this.resource.accessor ?? NOOP_ACCESSOR

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -458,6 +458,7 @@ export class MountRegistry {
       mount = this.mountForCommand(cmdName)
     }
     if (mount === null) return null
+    await mount.ensureReady()
     // Warm reads are served in place by withReadCache, so a read-only command
     // stays on its real mount. Single-mount reads do not go through the
     // dispatcher, so this is where they reconcile against backend truth: the

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -121,6 +121,7 @@ export class MountRegistry {
       m.resource.index ?? null,
       m.prefix,
       cachesReads(m.resource),
+      () => !m.retiring,
     )
   }
 

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -65,6 +65,7 @@ export interface OpsMountInfo {
 
 export class MountRegistry {
   private readonly mountList: MountEntry[]
+  readonly retiringResources = new Set<Resource>()
   private rootRef: MountEntry | null = null
   private consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
   private readonly defaultMode: MountMode
@@ -121,7 +122,7 @@ export class MountRegistry {
       m.resource.index ?? null,
       m.prefix,
       cachesReads(m.resource),
-      () => !m.retiring,
+      (path) => !m.retiring && this.tryMountFor(path) === m,
     )
   }
 
@@ -163,6 +164,16 @@ export class MountRegistry {
     return this.consistency
   }
 
+  /** Refuse reuse until the previous lifecycle has finished closing. */
+  checkResourceAvailable(resource: Resource): void {
+    if (
+      this.retiringResources.has(resource) ||
+      this.mountList.some((m) => m.resource === resource && m.retiring)
+    ) {
+      throw new Error('resource is being unmounted')
+    }
+  }
+
   /**
    * Add a mount dynamically. Mirrors Python's `registry.mount(...)`.
    * Registers the resource's commands and ops on the new mount and
@@ -174,6 +185,7 @@ export class MountRegistry {
     mode: MountMode = MountMode.READ,
     consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY,
   ): MountEntry {
+    this.checkResourceAvailable(resource)
     const norm = normalizePrefix(prefix)
     for (const existing of this.mountList) {
       if (existing.prefix === norm) {

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -65,7 +65,8 @@ export interface OpsMountInfo {
 
 export class MountRegistry {
   private readonly mountList: MountEntry[]
-  readonly retiringResources = new Set<Resource>()
+  readonly retiringResources = new Map<Resource, Promise<void>>()
+  readonly retiredResources = new WeakSet<Resource>()
   private rootRef: MountEntry | null = null
   private consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
   private readonly defaultMode: MountMode
@@ -147,9 +148,14 @@ export class MountRegistry {
       if (seen.has(prefix)) {
         throw new Error(`duplicate mount prefix: ${prefix}`)
       }
+      if (resource.isClosed === true)
+        throw new Error('resource is closed; create a new resource instance')
       seen.add(prefix)
       const mode = overrides[prefix] ?? defaultMode
-      mounts.push(new MountEntry({ prefix, resource, mode }))
+      const entry = new MountEntry({ prefix, resource, mode })
+      const alias = mounts.find((existing) => existing.resource === resource)
+      if (alias !== undefined) entry.activity = alias.activity
+      mounts.push(entry)
     }
     mounts.sort((a, b) => b.prefix.length - a.prefix.length)
     this.mountList = mounts
@@ -164,13 +170,16 @@ export class MountRegistry {
     return this.consistency
   }
 
-  /** Refuse reuse until the previous lifecycle has finished closing. */
+  /** A removed resource instance cannot start a second lifecycle. */
   checkResourceAvailable(resource: Resource): void {
     if (
       this.retiringResources.has(resource) ||
       this.mountList.some((m) => m.resource === resource && m.retiring)
     ) {
       throw new Error('resource is being unmounted')
+    }
+    if (resource.isClosed === true || this.retiredResources.has(resource)) {
+      throw new Error('resource is closed; create a new resource instance')
     }
   }
 
@@ -193,6 +202,8 @@ export class MountRegistry {
       }
     }
     const m = new MountEntry({ prefix: norm, resource, mode, consistency })
+    const alias = this.mountList.find((existing) => existing.resource === resource)
+    if (alias !== undefined) m.activity = alias.activity
     const cmds = resource.commands?.()
     if (cmds !== undefined) {
       for (const cmd of cmds) {

--- a/typescript/packages/core/src/workspace/provision/command.ts
+++ b/typescript/packages/core/src/workspace/provision/command.ts
@@ -149,77 +149,78 @@ export async function handleCommandProvision(
     return new ProvisionResult({ command: cmdStr, precision: Precision.UNKNOWN })
   }
 
-  await mount.ensureReady()
-  const extension = firstScope !== null ? getExtension(firstScope.virtual) : null
-  const cmd = mount.resolveCommand(cmdName, extension)
-  if (cmd?.provisionFn == null) {
-    return new ProvisionResult({ command: cmdStr, precision: Precision.UNKNOWN })
-  }
-
-  const mountPrefix = rstripSlash(mount.prefix)
-  const scopedParts: (string | PathSpec)[] = [parts2[0] ?? '']
-  const resourceScopes: PathSpec[] = []
-  for (let i = 1; i < parts2.length; i++) {
-    const p = parts2[i]
-    if (p instanceof PathSpec) {
-      const scoped = new PathSpec({
-        virtual: p.virtual,
-        directory: p.directory,
-        pattern: p.pattern,
-        resolved: p.resolved,
-        resourcePath: mountKey(p.virtual, mountPrefix),
-      })
-      scopedParts.push(scoped)
-      resourceScopes.push(scoped)
-    } else if (p !== undefined) {
-      scopedParts.push(p)
+  return mount.use(async (): Promise<ProvisionResult> => {
+    const extension = firstScope !== null ? getExtension(firstScope.virtual) : null
+    const cmd = mount.resolveCommand(cmdName, extension)
+    if (cmd?.provisionFn == null) {
+      return new ProvisionResult({ command: cmdStr, precision: Precision.UNKNOWN })
     }
-  }
 
-  const argv = scopedParts.slice(1).map((p) => (p instanceof PathSpec ? p.virtual : p))
-  const spec = mount.specFor(cmdName)
-  let flagKwargs: Record<string, FlagValue> = {}
-  let textArgs: string[]
-  if (spec !== null) {
-    const parsed = parseCommand(spec, argv, session.cwd)
-    flagKwargs = parseToKwargs(parsed)
-    textArgs = parsed.texts()
-  } else {
-    textArgs = scopedParts.slice(1).filter((p): p is string => typeof p === 'string')
-  }
+    const mountPrefix = rstripSlash(mount.prefix)
+    const scopedParts: (string | PathSpec)[] = [parts2[0] ?? '']
+    const resourceScopes: PathSpec[] = []
+    for (let i = 1; i < parts2.length; i++) {
+      const p = parts2[i]
+      if (p instanceof PathSpec) {
+        const scoped = new PathSpec({
+          virtual: p.virtual,
+          directory: p.directory,
+          pattern: p.pattern,
+          resolved: p.resolved,
+          resourcePath: mountKey(p.virtual, mountPrefix),
+        })
+        scopedParts.push(scoped)
+        resourceScopes.push(scoped)
+      } else if (p !== undefined) {
+        scopedParts.push(p)
+      }
+    }
 
-  const resource = mount.resource as Resource & { accessor?: Accessor }
-  const accessor = resource.accessor
-  if (accessor === undefined) {
-    return new ProvisionResult({ command: cmdStr, precision: Precision.UNKNOWN })
-  }
+    const argv = scopedParts.slice(1).map((p) => (p instanceof PathSpec ? p.virtual : p))
+    const spec = mount.specFor(cmdName)
+    let flagKwargs: Record<string, FlagValue> = {}
+    let textArgs: string[]
+    if (spec !== null) {
+      const parsed = parseCommand(spec, argv, session.cwd)
+      flagKwargs = parseToKwargs(parsed)
+      textArgs = parsed.texts()
+    } else {
+      textArgs = scopedParts.slice(1).filter((p): p is string => typeof p === 'string')
+    }
 
-  const rawIndex = mount.index ?? null
-  const opts: CommandOpts = {
-    flags: flagKwargs,
-    stdin: null,
-    cwd: session.cwd,
-    filetypeFns: null,
-    mountPrefix,
-    command: cmdStr,
-    ...(spec !== null ? { spec } : {}),
-    index: rawIndex,
-  }
+    const resource = mount.resource as Resource & { accessor?: Accessor }
+    const accessor = resource.accessor
+    if (accessor === undefined) {
+      return new ProvisionResult({ command: cmdStr, precision: Precision.UNKNOWN })
+    }
 
-  const raw = await cmd.provisionFn(accessor, resourceScopes, textArgs, opts)
-  const result = raw instanceof ProvisionResult ? raw : new ProvisionResult({ command: cmdStr })
-  if (result.command === '') {
-    result.command = cmdStr
-  }
+    const rawIndex = mount.index ?? null
+    const opts: CommandOpts = {
+      flags: flagKwargs,
+      stdin: null,
+      cwd: session.cwd,
+      filetypeFns: null,
+      mountPrefix,
+      command: cmdStr,
+      ...(spec !== null ? { spec } : {}),
+      index: rawIndex,
+    }
 
-  const hits = await checkCacheHits(registry.fileCache, scopedParts)
-  if (hits > 0) {
-    result.cacheHits = hits
-    result.cacheReadLow = result.networkReadLow
-    result.cacheReadHigh = result.networkReadHigh
-    result.networkReadLow = 0
-    result.networkReadHigh = 0
-  }
+    const raw = await cmd.provisionFn(accessor, resourceScopes, textArgs, opts)
+    const result = raw instanceof ProvisionResult ? raw : new ProvisionResult({ command: cmdStr })
+    if (result.command === '') {
+      result.command = cmdStr
+    }
 
-  return result
+    const hits = await checkCacheHits(registry.fileCache, scopedParts)
+    if (hits > 0) {
+      result.cacheHits = hits
+      result.cacheReadLow = result.networkReadLow
+      result.cacheReadHigh = result.networkReadHigh
+      result.networkReadLow = 0
+      result.networkReadHigh = 0
+    }
+
+    return result
+  })
 }

--- a/typescript/packages/core/src/workspace/provision/command.ts
+++ b/typescript/packages/core/src/workspace/provision/command.ts
@@ -15,7 +15,6 @@
 import { isCrossMount } from '../../commands/builtin/generic/crossmount/index.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import type { FileCache } from '../../cache/file/mixin.ts'
-import type { IndexCacheStore } from '../../cache/index/index.ts'
 import { parseCommand, parseToKwargs } from '../../commands/spec/parser.ts'
 import { getExtension } from '../../commands/resolve.ts'
 import { Precision, ProvisionResult, combineSum } from '../../provision/types.ts'
@@ -150,6 +149,7 @@ export async function handleCommandProvision(
     return new ProvisionResult({ command: cmdStr, precision: Precision.UNKNOWN })
   }
 
+  await mount.ensureReady()
   const extension = firstScope !== null ? getExtension(firstScope.virtual) : null
   const cmd = mount.resolveCommand(cmdName, extension)
   if (cmd?.provisionFn == null) {
@@ -194,7 +194,7 @@ export async function handleCommandProvision(
     return new ProvisionResult({ command: cmdStr, precision: Precision.UNKNOWN })
   }
 
-  const rawIndex = (resource as { index?: IndexCacheStore | null }).index ?? null
+  const rawIndex = mount.index ?? null
   const opts: CommandOpts = {
     flags: flagKwargs,
     stdin: null,

--- a/typescript/packages/core/src/workspace/reconcile.ts
+++ b/typescript/packages/core/src/workspace/reconcile.ts
@@ -83,7 +83,7 @@ export class Reconciler {
     try {
       remoteStat = await this.opsRegistry.call(
         'stat',
-        resource.kind,
+        resource,
         resource.accessor ?? NOOP_ACCESSOR,
         scope,
       )

--- a/typescript/packages/core/src/workspace/session/manager.test.ts
+++ b/typescript/packages/core/src/workspace/session/manager.test.ts
@@ -13,8 +13,9 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { seedVar } from './state.ts'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { AdmissionRules, Decision } from '../../policy/types.ts'
+import type { CompiledProfile } from '../../policy/profile.ts'
 import { Outcome, Scope } from '../../policy/types.ts'
 import { ScriptSource } from '../../runtime/routing/types.ts'
 import { MountMode } from '../../types.ts'
@@ -606,3 +607,81 @@ describe('seed merge on hydration', () => {
     expect(record.managed?.TOKEN?.ref).toBe('p')
   })
 })
+
+it.each([false, true])(
+  'publishes profile changes only after persistence (failure=%s)',
+  async (failure) => {
+    const store = new RAMSessionStore()
+    const manager = new SessionManager('default', store)
+    const original: CompiledProfile = {
+      mountModes: new Map([['/data', MountMode.READ]]),
+      hiddenPaths: { paths: ['/data/secret'], patterns: [] },
+      hiddenVars: { names: ['TOKEN'], patterns: [] },
+      env: null,
+      cwd: null,
+      commands: { allow: ['cat'], ask: [], deny: [] },
+      script: { profile: 'judge', script: new ScriptSource('null', 'js'), runtime: 'quickjs' },
+    }
+    manager.defaultProfile = original
+    await manager.flush()
+    const session = manager.get('default')
+    const before = session.toJSON()
+    const persisted = await store.load()
+    let enter = (): void => undefined
+    let resume = (): void => undefined
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      resume = resolve
+    })
+    const casSet = store.casSet.bind(store)
+    const spy = vi.spyOn(store, 'casSet').mockImplementation(async (...args) => {
+      enter()
+      await release
+      if (failure) throw new Error('store unavailable')
+      return casSet(...args)
+    })
+    const cleared: CompiledProfile = {
+      mountModes: null,
+      hiddenPaths: null,
+      hiddenVars: null,
+      env: null,
+      cwd: null,
+      commands: null,
+    }
+    const updating = manager.setProfile('default', cleared).then(
+      (value) => value,
+      (error: unknown) => error,
+    )
+    try {
+      await entered
+      expect(session.toJSON()).toEqual(before)
+      expect(manager.commandsOf('')).toEqual(original.commands)
+      expect(manager.scriptOf('')).toEqual(original.script)
+      session.cwd = '/changed-during-write'
+      resume()
+      if (failure) {
+        expect(await updating).toEqual(new Error('store unavailable'))
+        expect(session.toJSON()).toEqual({ ...before, cwd: session.cwd })
+        expect(await store.load()).toEqual(persisted)
+        expect(manager.commandsOf('')).toEqual(original.commands)
+        expect(manager.scriptOf('')).toEqual(original.script)
+      } else {
+        expect(await updating).toBe(session)
+        expect(session.mountModes).toBeNull()
+        expect(session.hiddenPaths).toBeNull()
+        expect(manager.commandsOf('')).toBeNull()
+        expect(manager.scriptOf('')).toBeNull()
+      }
+      expect(session.cwd).toBe('/changed-during-write')
+      spy.mockRestore()
+      await manager.flush()
+      expect((await store.load()).get('default')).toEqual(session.toJSON())
+    } finally {
+      resume()
+      await updating
+      spy.mockRestore()
+    }
+  },
+)

--- a/typescript/packages/core/src/workspace/session/manager.test.ts
+++ b/typescript/packages/core/src/workspace/session/manager.test.ts
@@ -685,3 +685,57 @@ it.each([false, true])(
     }
   },
 )
+
+it.each([false, true])(
+  'session close waits for profile persistence (failure=%s)',
+  async (failure) => {
+    const store = new RAMSessionStore()
+    const manager = new SessionManager('default', store)
+    manager.create('agent')
+    let enter = (): void => undefined
+    let resume = (): void => undefined
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      resume = resolve
+    })
+    const casSet = store.casSet.bind(store)
+    const spy = vi.spyOn(store, 'casSet').mockImplementation(async (...args) => {
+      enter()
+      await release
+      if (failure) throw new Error('store unavailable')
+      return casSet(...args)
+    })
+    const updating = manager
+      .setProfile('agent', {
+        mountModes: null,
+        hiddenPaths: null,
+        hiddenVars: null,
+        env: null,
+        cwd: null,
+        commands: null,
+      })
+      .catch((error: unknown) => error)
+    let closing: Promise<void> | undefined
+    try {
+      await entered
+      let closed = false
+      closing = manager.close('agent').then(() => {
+        closed = true
+      })
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      expect(closed).toBe(false)
+      resume()
+      await updating
+      await closing
+      expect(() => manager.get('agent')).toThrow('unknown session')
+      expect((await store.load()).has('agent')).toBe(false)
+    } finally {
+      resume()
+      await updating
+      await closing
+      spy.mockRestore()
+    }
+  },
+)

--- a/typescript/packages/core/src/workspace/session/manager.ts
+++ b/typescript/packages/core/src/workspace/session/manager.ts
@@ -142,6 +142,14 @@ export class SessionManager {
     if (compiled !== null) applyProfile(this.defaultSession(), compiled)
   }
 
+  /** Replace an existing, hydrated session's restrictions, preserving its scratch state. */
+  setProfile(sessionId: string, compiled: CompiledProfile): Session {
+    const session = this.get(sessionId)
+    narrow(session, compiled)
+    if (sessionId === this.defaultId) this.defaultProfileInternal = compiled
+    return session
+  }
+
   /**
    * The admission rules one session runs under (SessionCommandsQuery).
    * The default profile's rules for an id this manager does not know, the

--- a/typescript/packages/core/src/workspace/session/manager.ts
+++ b/typescript/packages/core/src/workspace/session/manager.ts
@@ -332,6 +332,13 @@ export class SessionManager {
     }
   }
 
+  /** Wait for admitted session writes before their store closes. */
+  async settle(): Promise<void> {
+    for (const sessionId of this.sessions.keys()) {
+      await this.persistLock.withLock(sessionId, () => Promise.resolve())
+    }
+  }
+
   /** Persist one session, retrying when another writer races us. */
   private async flushOne(session: Session): Promise<void> {
     const sid = session.sessionId

--- a/typescript/packages/core/src/workspace/session/manager.ts
+++ b/typescript/packages/core/src/workspace/session/manager.ts
@@ -22,6 +22,7 @@ import type { AdmissionRules, Decision, HideReason, ProfileScript } from '../../
 import type { EnvEntries } from '../../secrets/config.ts'
 import type { ShellVar } from '../../shell/variable.ts'
 import type { MountMode } from '../../types.ts'
+import { KeyLock } from '../../cache/lock.ts'
 
 type StoredSession = Parameters<typeof Session.fromJSON>[0]
 
@@ -59,6 +60,7 @@ function mergeSeedVars(session: Session, seedVars: Record<string, ShellVar>): vo
  */
 export class SessionManager {
   private readonly sessions = new Map<string, Session>()
+  private readonly persistLock = new KeyLock()
   private readonly sessionStore: SessionStore
   private defaultIdInternal: string
   private loaded = false
@@ -143,11 +145,17 @@ export class SessionManager {
   }
 
   /** Replace an existing, hydrated session's restrictions, preserving its scratch state. */
-  setProfile(sessionId: string, compiled: CompiledProfile): Session {
-    const session = this.get(sessionId)
-    narrow(session, compiled)
-    if (sessionId === this.defaultId) this.defaultProfileInternal = compiled
-    return session
+  async setProfile(sessionId: string, compiled: CompiledProfile): Promise<Session> {
+    return this.persistLock.withLock(sessionId, async () => {
+      const session = this.get(sessionId)
+      const candidate = Session.fromJSON(session.toJSON() as StoredSession)
+      narrow(candidate, compiled)
+      await this.flushOne(candidate)
+      narrow(session, compiled)
+      session.generation = candidate.generation
+      if (sessionId === this.defaultId) this.defaultProfileInternal = compiled
+      return session
+    })
   }
 
   /**
@@ -320,7 +328,7 @@ export class SessionManager {
   /** Write dirty sessions through the store's generation gate. */
   async flush(): Promise<void> {
     for (const session of [...this.sessions.values()]) {
-      await this.flushOne(session)
+      await this.persistLock.withLock(session.sessionId, () => this.flushOne(session))
     }
   }
 

--- a/typescript/packages/core/src/workspace/session/manager.ts
+++ b/typescript/packages/core/src/workspace/session/manager.ts
@@ -417,15 +417,17 @@ export class SessionManager {
   }
 
   async close(sessionId: string): Promise<void> {
-    if (sessionId === this.defaultId) {
-      throw new Error('Cannot close the default session')
-    }
-    if (!this.sessions.has(sessionId)) {
-      throw new Error(`unknown session: ${sessionId}`)
-    }
-    this.sessions.delete(sessionId)
-    this.persisted.delete(sessionId)
-    await this.sessionStore.delete([sessionId])
+    await this.persistLock.withLock(sessionId, async () => {
+      if (sessionId === this.defaultId) {
+        throw new Error('Cannot close the default session')
+      }
+      if (!this.sessions.has(sessionId)) {
+        throw new Error(`unknown session: ${sessionId}`)
+      }
+      this.sessions.delete(sessionId)
+      this.persisted.delete(sessionId)
+      await this.sessionStore.delete([sessionId])
+    })
   }
 
   async closeAll(): Promise<void> {

--- a/typescript/packages/core/src/workspace/snapshot/drift.ts
+++ b/typescript/packages/core/src/workspace/snapshot/drift.ts
@@ -73,7 +73,7 @@ export interface MountLookup {
  * state. Mirrors the Python `DriftQueue` in `snapshot/drift.py`.
  */
 export class DriftQueue {
-  private entries: { path: string; fingerprint: string }[] = []
+  private entries: { path: string; fingerprint: string; mountId: string | null }[] = []
   private isPending = false
 
   get pending(): boolean {
@@ -91,8 +91,8 @@ export class DriftQueue {
     this.isPending = false
   }
 
-  queue(path: string, fingerprint: string): void {
-    this.entries.push({ path, fingerprint })
+  queue(path: string, fingerprint: string, mountId: string | null = null): void {
+    this.entries.push({ path, fingerprint, mountId })
     this.isPending = true
   }
 
@@ -107,7 +107,7 @@ export class DriftQueue {
     const pending = this.entries
     this.entries = []
     const results = await Promise.allSettled(
-      pending.map((p) => checkDrift(registry, statFn, p.path, p.fingerprint)),
+      pending.map((p) => checkDrift(registry, statFn, p.path, p.fingerprint, p.mountId)),
     )
     for (const r of results) {
       if (r.status === 'rejected') throw r.reason as Error
@@ -150,7 +150,7 @@ export function installDriftState(
       continue
     }
     if (e.fingerprint !== undefined && e.fingerprint !== null) {
-      drift.queue(e.path, e.fingerprint)
+      drift.queue(e.path, e.fingerprint, mount.mountId)
     }
   }
   const liveOnly = state.live_only_mounts ?? []
@@ -228,19 +228,22 @@ export async function checkDrift(
   statFn: (path: string) => Promise<unknown>,
   path: string,
   recorded: string,
+  mountId: string | null = null,
 ): Promise<void> {
   const mount = registry.tryMountFor(path)
-  if (mount === null) return
+  if (mount === null || (mountId !== null && mount.mountId !== mountId)) return
   if (mount.resource.supportsSnapshot !== true) return
   let stat: FileStat
   try {
     stat = (await statFn(path)) as FileStat
   } catch (err) {
     if ((err as { code?: string } | null)?.code === 'ENOENT') {
+      if (registry.tryMountFor(path) !== mount) return
       throw new ContentDriftError(path, recorded, null)
     }
     throw err
   }
+  if (registry.tryMountFor(path) !== mount) return
   const live = stat.fingerprint
   if (live === null) return
   if (live !== recorded) throw new ContentDriftError(path, recorded, live)

--- a/typescript/packages/core/src/workspace/snapshot/drift.ts
+++ b/typescript/packages/core/src/workspace/snapshot/drift.ts
@@ -186,9 +186,9 @@ export function captureFingerprints(
   for (const rec of records) {
     if (rec.op !== 'read' || seen.has(rec.path)) continue
     if (rec.fingerprint === null && rec.revision === null) continue
-    seen.add(rec.path)
     const mount = registry.tryMountFor(rec.path)
-    if (mount === null) continue
+    if (mount === null || (rec.mountId !== null && rec.mountId !== mount.mountId)) continue
+    seen.add(rec.path)
     if (mount.resource.supportsSnapshot !== true) continue
     const entry: FingerprintEntry = { path: rec.path, mount_prefix: mount.prefix }
     if (rec.fingerprint !== null) entry.fingerprint = rec.fingerprint

--- a/typescript/packages/core/src/workspace/snapshot/state.ts
+++ b/typescript/packages/core/src/workspace/snapshot/state.ts
@@ -75,7 +75,9 @@ const VALID_MODES: readonly string[] = [MountMode.READ, MountMode.WRITE, MountMo
 
 export async function toStateDict(ws: Workspace): Promise<WorkspaceStateDict> {
   const skip = new Set(['/dev/', normMountPrefix(HISTORY_PREFIX)])
-  const mounts = [...ws.registry.allMounts()].filter((m) => !skip.has(m.prefix))
+  const mounted = [...ws.registry.allMounts()]
+  for (const mount of mounted) await mount.ensureReady()
+  const mounts = mounted.filter((m) => !skip.has(m.prefix))
   const mountSnapshots: MountSnapshot[] = []
   for (let i = 0; i < mounts.length; i++) {
     const m = mounts[i]
@@ -155,6 +157,10 @@ export async function toStateDict(ws: Workspace): Promise<WorkspaceStateDict> {
   const historyEvents = (await ws.observer.events()).filter(
     (e) => e.type === EVENT_COMMAND || e.type === EVENT_CLEAR || e.type === EVENT_DELETE,
   )
+  const current = ws.registry.allMounts()
+  if (current.length !== mounted.length || mounted.some((m, i) => m !== current[i] || m.retiring)) {
+    throw new Error('mounts changed during snapshot')
+  }
   const fingerprints: FingerprintEntrySnapshot[] = captureFingerprints(ws.records, ws.registry)
   const liveOnly = liveOnlyMountPrefixes(ws.registry)
   const nodes: Record<string, NodeMetaSnapshot> = {}

--- a/typescript/packages/core/src/workspace/snapshot_drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot_drift.test.ts
@@ -474,3 +474,39 @@ it('snapshot rejects fingerprints from a retired lazy op', async () => {
     await ws.close()
   }
 })
+
+it.each([false, true])(
+  'restored drift checks do not follow replaced mounts (shadow=%s)',
+  async (shadow) => {
+    const prefix = shadow ? '/remote' : '/remote/data'
+    const ancestor = new FakeRemoteResource(new FakeRemoteAccessor())
+    const fresh = new FakeRemoteAccessor()
+    fresh.put('/remote/data/file', new TextEncoder().encode('new'))
+    const ops = new OpsRegistry()
+    ops.register(readOp)
+    ops.register(statOp)
+    const source = new Workspace({ [prefix]: ancestor }, { ops, shellParser: parser })
+    let loaded: Workspace | undefined
+    try {
+      const state = await toStateDict(source)
+      state.fingerprints = [
+        { path: '/remote/data/file', mount_prefix: prefix, fingerprint: 'old-account' },
+      ]
+      loaded = await Workspace.fromState(
+        state,
+        { ops, shellParser: parser },
+        { [prefix]: ancestor },
+      )
+      if (!shadow) await loaded.unmount('/remote/data')
+      loaded.addMount('/remote/data', new FakeRemoteResource(fresh))
+      ops.register(readOp)
+      ops.register(statOp)
+      expect(await loaded.dispatch('read', '/remote/data/file')).toEqual(
+        new TextEncoder().encode('new'),
+      )
+    } finally {
+      await loaded?.close()
+      await source.close()
+    }
+  },
+)

--- a/typescript/packages/core/src/workspace/snapshot_drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot_drift.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { Accessor } from '../accessor/base.ts'
 import { record, revisionFor, runWithRecording, startOp } from '../observe/context.ts'
 import { type OpKwargs, OpsRegistry, type RegisteredOp } from '../ops/registry.ts'
@@ -463,9 +463,13 @@ it('snapshot rejects fingerprints from a retired lazy op', async () => {
     const id = ws.mount('/remote').mountId
     const [, records] = await runWithRecording(async () => {
       const stream = (await ws.dispatch('read', '/remote/file')) as AsyncIterable<Uint8Array>
-      await ws.unmount('/remote')
+      const removing = ws.unmount('/remote')
+      await vi.waitFor(() => {
+        expect(ws.registry.tryMountForPrefix('/remote')).toBeNull()
+      })
       ws.addMount('/remote', new FakeRemoteResource(new FakeRemoteAccessor()))
       for await (const chunk of stream) expect(chunk).toEqual(new TextEncoder().encode('old'))
+      await removing
     })
     ws.records.push(...records)
     expect(records[0]?.mountId).toBe(id)

--- a/typescript/packages/core/src/workspace/snapshot_drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot_drift.test.ts
@@ -317,3 +317,160 @@ describe('Workspace snapshot: capture and replay drift detection', () => {
     await loaded.close()
   })
 })
+
+it.each(['state', 'copy'])(
+  'snapshot prepares new mounts before capturing cache (%s)',
+  async (capture) => {
+    const accessor = new FakeRemoteAccessor()
+    accessor.put('/remote/data/file', new TextEncoder().encode('old'))
+    accessor.put('/remote/outside', new TextEncoder().encode('keep'))
+    accessor.put('/remote/data2/file', new TextEncoder().encode('sibling'))
+    const ws = build(accessor)
+    const fresh = new FakeRemoteAccessor()
+    fresh.put('/remote/data/file', new TextEncoder().encode('new'))
+    const replacement = new FakeRemoteResource(fresh)
+    let clone: Workspace | undefined
+    try {
+      for (const path of ['/remote/data/file', '/remote/outside', '/remote/data2/file']) {
+        const bytes = await recordedDispatch(ws, 'read', path)
+        if (!(bytes instanceof Uint8Array)) throw new Error('expected read bytes')
+        await ws.cache.set(path, bytes)
+      }
+      expect(await ws.cache.get('/remote/data/file')).toEqual(new TextEncoder().encode('old'))
+      ws.addMount('/remote/data', replacement)
+      if (capture === 'copy') {
+        clone = await ws.copy()
+      } else {
+        const state = await toStateDict(ws)
+        expect(state.cache.entries.map((e) => e.key)).not.toContain('/remote/data/file')
+        const ops = new OpsRegistry()
+        ops.register(readOp)
+        ops.register(statOp)
+        clone = await Workspace.fromState(
+          state,
+          { ops, shellParser: parser },
+          {
+            '/remote': ws.mount('/remote').resource,
+            '/remote/data': replacement,
+          },
+        )
+      }
+      expect(await clone.cache.get('/remote/data/file')).toBeNull()
+      expect(await clone.cache.get('/remote/outside')).toEqual(new TextEncoder().encode('keep'))
+      expect(await clone.cache.get('/remote/data2/file')).toEqual(
+        new TextEncoder().encode('sibling'),
+      )
+      const bytes = await clone.dispatch('read', '/remote/data/file')
+      expect(bytes).toEqual(new TextEncoder().encode('new'))
+    } finally {
+      await clone?.close()
+      await ws.close()
+    }
+  },
+)
+
+it.each([
+  { shadow: false, delayed: false },
+  { shadow: true, delayed: false },
+  { shadow: false, delayed: true },
+  { shadow: true, delayed: true },
+])(
+  'snapshot keeps read mount ownership (shadow=$shadow, delayed=$delayed)',
+  async ({ shadow, delayed }) => {
+    const old = new FakeRemoteAccessor()
+    const fresh = new FakeRemoteAccessor()
+    old.put('/remote/data/file', new TextEncoder().encode('old'))
+    fresh.put('/remote/data/file', new TextEncoder().encode('new'))
+    fresh.put('/remote/data/file', new TextEncoder().encode('newer'))
+    const keep = new FakeRemoteAccessor()
+    keep.put('/remote/data/nested/file', new TextEncoder().encode('keep'))
+    const ops = new OpsRegistry()
+    ops.register(readOp)
+    ops.register(statOp)
+    const ws = new Workspace(
+      {
+        [shadow ? '/remote' : '/remote/data']: new FakeRemoteResource(old),
+        '/remote/data/nested': new FakeRemoteResource(keep),
+      },
+      { ops, shellParser: parser },
+    )
+    let enter = (): void => undefined
+    let resume = (): void => undefined
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      resume = resolve
+    })
+    let reading: Promise<unknown> | undefined
+    try {
+      await recordedDispatch(ws, 'read', '/remote/data/nested/file')
+      if (delayed) {
+        reading = runWithRecording(async () => {
+          const result = await ws.dispatch('read', '/remote/data/file')
+          enter()
+          await release
+          return result
+        }).then(([result, records]) => {
+          ws.records.push(...records)
+          return result
+        })
+        await entered
+      } else {
+        await recordedDispatch(ws, 'read', '/remote/data/file')
+      }
+      if (!shadow) await ws.unmount('/remote/data')
+      ws.addMount('/remote/data', new FakeRemoteResource(fresh))
+      resume()
+      await reading
+      const before = await toStateDict(ws)
+      expect(before.fingerprints?.map((e) => e.path)).toEqual(['/remote/data/nested/file'])
+      await recordedDispatch(ws, 'read', '/remote/data/file')
+      const after = await toStateDict(ws)
+      expect(after.fingerprints).toContainEqual({
+        path: '/remote/data/file',
+        mount_prefix: '/remote/data/',
+        fingerprint: fresh.blobs.get('/remote/data/file')?.fingerprint,
+        revision: fresh.blobs.get('/remote/data/file')?.revision,
+      })
+      expect(after.fingerprints?.map((e) => e.path)).toContain('/remote/data/nested/file')
+    } finally {
+      resume()
+      await reading
+      await ws.close()
+    }
+  },
+)
+
+it('snapshot rejects fingerprints from a retired lazy op', async () => {
+  const old = new FakeRemoteAccessor()
+  old.put('/remote/file', new TextEncoder().encode('old'))
+  const ops = new OpsRegistry()
+  ops.register({
+    ...readOp,
+    fn: async function* (accessor, scope) {
+      const entry = (accessor as FakeRemoteAccessor).blobs.get(scope.virtual)
+      if (entry === undefined) throw new Error('missing fixture')
+      record('read', scope.virtual, 'fake-remote', entry.bytes.length, startOp(), {
+        fingerprint: entry.fingerprint,
+        revision: entry.revision,
+      })
+      yield await Promise.resolve(entry.bytes)
+    },
+  })
+  const ws = new Workspace({ '/remote': new FakeRemoteResource(old) }, { ops, shellParser: parser })
+  try {
+    const id = ws.mount('/remote').mountId
+    const [, records] = await runWithRecording(async () => {
+      const stream = (await ws.dispatch('read', '/remote/file')) as AsyncIterable<Uint8Array>
+      await ws.unmount('/remote')
+      ws.addMount('/remote', new FakeRemoteResource(new FakeRemoteAccessor()))
+      for await (const chunk of stream) expect(chunk).toEqual(new TextEncoder().encode('old'))
+    })
+    ws.records.push(...records)
+    expect(records[0]?.mountId).toBe(id)
+    expect((await toStateDict(ws)).fingerprints).toEqual([])
+  } finally {
+    await ws.close()
+  }
+})

--- a/typescript/packages/core/src/workspace/store/workspace_wiring.test.ts
+++ b/typescript/packages/core/src/workspace/store/workspace_wiring.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { RAMObserverStore } from '../../observe/store.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import { MountMode } from '../../types.ts'
@@ -21,6 +21,14 @@ import { Workspace } from '../workspace/workspace.ts'
 import { RAMWorkspaceStateStore } from './ram.ts'
 
 const UUID7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = (): void => undefined
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
 
 // Yields to the microtask queue on meta reads so two concurrent
 // attaches both observe the record as absent before either writes.
@@ -109,6 +117,55 @@ describe('Workspace on a WorkspaceStateStore', () => {
     open.push(wsB)
     await wsB.ensureSessionsLoaded()
     expect(wsB.defaultSessionId).toBe('pinned')
+  })
+
+  it.each(['default', 'named'])(
+    'changes the %s session profile after hydration',
+    async (target) => {
+      const store = new RAMWorkspaceStateStore()
+      const writer = await mkWs(store, 'shared')
+      writer.createSession('named')
+      await writer.ensureSessionsLoaded()
+      await writer.flushSessions()
+      const attached = await mkWs(store, 'shared')
+      const provisional = attached.defaultSessionId
+      const requested = target === 'default' ? provisional : 'named'
+      const expected = target === 'default' ? writer.defaultSessionId : 'named'
+      const session = await attached.setSessionProfile(requested, { commands: { allow: ['cat'] } })
+      expect(session.sessionId).toBe(expected)
+      expect(attached.defaultSessionId).toBe(writer.defaultSessionId)
+      expect(attached.defaultSessionId).not.toBe(provisional)
+      expect(session.commands?.allow).toEqual(['cat'])
+      const persisted = await store.sessions('shared').load()
+      expect(persisted.get(expected)?.commands).toMatchObject({ allow: ['cat'] })
+    },
+  )
+
+  it('refuses a profile change if shutdown starts during hydration', async () => {
+    const store = new RAMWorkspaceStateStore()
+    const ws = await mkWs(store, 'shared')
+    const entered = deferred()
+    const release = deferred()
+    const sessions = store.sessions('shared')
+    const load = sessions.load.bind(sessions)
+    vi.spyOn(sessions, 'load').mockImplementationOnce(async () => {
+      entered.resolve()
+      await release.promise
+      return load()
+    })
+    const session = ws.getSession(ws.defaultSessionId)
+    const commands = session.commands
+    const changing = ws.setSessionProfile(ws.defaultSessionId, { commands: { allow: ['cat'] } })
+    const refused = expect(changing).rejects.toThrow('Workspace is closed')
+    try {
+      await entered.promise
+      await ws.close()
+    } finally {
+      release.resolve()
+      await refused
+    }
+    expect(session.commands).toBe(commands)
+    expect(await load()).toEqual(new Map())
   })
 
   it('an existing discovery record wins', async () => {

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest'
 import type { CacheConfig } from '../cache/file/config.ts'
 import type { FileCache } from '../cache/file/mixin.ts'
 import { OpsRegistry } from '../ops/registry.ts'
-import { MountMode, ResourceName, type PathSpec } from '../types.ts'
+import { FileType, MountMode, ResourceName, type PathSpec } from '../types.ts'
 import { BaseResource, type Resource } from '../resource/base.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { LanguageRuntime } from '../runtime/language.ts'
@@ -180,6 +180,72 @@ describe('Workspace.execute AbortSignal', () => {
 })
 
 describe('Workspace.unmount', () => {
+  it.each([false, true])(
+    'preserves root operations after removing every user RAM mount (explicit root: %s)',
+    async (explicitRoot) => {
+      const resources: Record<string, RAMResource> = { '/data': new RAMResource() }
+      if (explicitRoot) resources['/'] = new RAMResource()
+      const ws = new Workspace(resources, { shellParser: await getTestParser() })
+      try {
+        await ws.unmount('/data')
+        await expect(ws.fs.readdir('/')).resolves.toContain('/dev')
+        await expect(ws.fs.stat('/')).resolves.toMatchObject({ type: FileType.DIRECTORY })
+        const result = await ws.execute('ls /')
+        expect(result.exitCode).toBe(0)
+        expect(result.stdoutText).toBe('dev\n')
+        expect(result.stderrText).toBe('')
+      } finally {
+        await ws.close()
+      }
+    },
+  )
+
+  it('keeps a different RAM instance readable after unmounting its peer', async () => {
+    const a = new RAMResource()
+    const b = new RAMResource()
+    const content = new TextEncoder().encode('surviving mount\n')
+    b.store.files.set('/file.txt', content)
+    const ws = new Workspace({ '/a': a, '/b': b })
+    try {
+      await ws.unmount('/a')
+      await expect(ws.fs.readFile('/b/file.txt')).resolves.toEqual(content)
+      await ws.unmount('/b')
+      await expect(ws.fs.readdir('/')).resolves.toContain('/dev')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('closes each resource separately and unregisters operations after the last of its kind', async () => {
+    const a = new MockResource()
+    const b = new MockResource()
+    const content = new TextEncoder().encode('mock data\n')
+    const ops = new OpsRegistry()
+    ops.register({
+      name: 'read',
+      resource: 'mock',
+      filetype: null,
+      write: false,
+      fn: () => content,
+    })
+    const ws = new Workspace({ '/a': a, '/b': b }, { ops })
+    try {
+      await ws.fs.readFile('/a/file.txt')
+      await ws.fs.readFile('/b/file.txt')
+      await ws.unmount('/a')
+      expect(a.closes).toBe(1)
+      expect(b.closes).toBe(0)
+      await expect(ws.fs.readFile('/b/file.txt')).resolves.toEqual(content)
+      await ws.unmount('/b')
+      expect(b.closes).toBe(1)
+      expect(ops.find('read', 'mock')).toBeNull()
+    } finally {
+      await ws.close()
+    }
+    expect(a.closes).toBe(1)
+    expect(b.closes).toBe(1)
+  })
+
   it('removes a mount from mounts(); the path falls through to the root anchor', async () => {
     const a = new RAMResource()
     const b = new RAMResource()
@@ -531,4 +597,42 @@ describe('runtime-visible mounts', () => {
     expect(probe.resolver?.prefixes() ?? []).toContain('/')
     await ws.close()
   })
+})
+
+it('changes mount modes without remounting and refuses invalid modes atomically', async () => {
+  const ws = new Workspace({ '/data': new RAMResource() }, { mode: MountMode.WRITE })
+  try {
+    const fs = ws.fs
+    const mount = ws.mount('/data')
+    await fs.writeFile('/data/file', new TextEncoder().encode('kept'))
+    for (const mode of [MountMode.READ, MountMode.EXEC, MountMode.WRITE]) {
+      ws.setMountMode('data/', mode)
+      expect(ws.fs).toBe(fs)
+      expect(ws.mount('/data')).toBe(mount)
+      expect(mount.mode).toBe(mode)
+      expect(new TextDecoder().decode(await fs.readFile('/data/file'))).toBe('kept')
+    }
+    expect(() => {
+      ws.setMountMode('/data', 'invalid' as MountMode)
+    }).toThrow()
+    expect(mount.mode).toBe(MountMode.WRITE)
+  } finally {
+    await ws.close()
+  }
+})
+
+it('updates default-profile policy for unbound ops without replacing the session', async () => {
+  const ws = new Workspace({ '/data': new RAMResource() }, { mode: MountMode.WRITE })
+  try {
+    const session = ws.getSession(ws.defaultSessionId)
+    await ws.fs.writeFile('/data/file', new TextEncoder().encode('kept'))
+    const profile = { commands: { deny: [{ paths: ['/data/file'], reason: 'sealed' }] } }
+    expect(await ws.setSessionProfile(ws.defaultSessionId, profile)).toBe(session)
+    await expect(ws.fs.readFile('/data/file')).rejects.toThrow()
+    await ws.setSessionProfile(ws.defaultSessionId, {})
+    expect(ws.getSession(ws.defaultSessionId)).toBe(session)
+    expect(new TextDecoder().decode(await ws.fs.readFile('/data/file'))).toBe('kept')
+  } finally {
+    await ws.close()
+  }
 })

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -12,13 +12,15 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { CacheConfig } from '../cache/file/config.ts'
 import type { FileCache } from '../cache/file/mixin.ts'
 import { IndexType, LookupStatus } from '../cache/index/config.ts'
 import { RedisIndexCacheStore } from '../cache/index/redis.ts'
+import { CLISpec } from '../commands/cli/types.ts'
+import { IOResult } from '../io/types.ts'
 import { OpsRegistry } from '../ops/registry.ts'
-import { FileType, MountMode, ResourceName, type PathSpec } from '../types.ts'
+import { FileType, MountMode, ResourceName, PathSpec } from '../types.ts'
 import { BaseResource, type Resource } from '../resource/base.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { LanguageRuntime } from '../runtime/language.ts'
@@ -42,6 +44,62 @@ class MockResource extends BaseResource implements Resource {
 }
 
 describe('Workspace lifecycle', () => {
+  it('does not cache a retired command result for a replacement mount', async () => {
+    class CachedRAM extends RAMResource {
+      override readonly cachesReads = true
+    }
+    const old = new CachedRAM()
+    old.loadState({ type: 'ram', files: { '/file': new TextEncoder().encode('old') } })
+    const replacement = new CachedRAM()
+    replacement.loadState({ type: 'ram', files: { '/file': new TextEncoder().encode('new') } })
+    let enter = (): void => undefined
+    let resume = (): void => undefined
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      resume = resolve
+    })
+    const ws = new Workspace({ '/data': old }, { shellParser: await getTestParser() })
+    ws.registerCli(
+      'gate',
+      new CLISpec({
+        name: 'gate',
+        fn: async () => {
+          enter()
+          await release
+          return [null, new IOResult()]
+        },
+      }),
+    )
+    const retired = ws.mount('/data').cacheManager
+    const running = ws.execute('cat /data/file; gate')
+    try {
+      await entered
+      await ws.unmount('/data')
+      ws.addMount('/data', replacement)
+      resume()
+      expect(new TextDecoder().decode((await running).stdout)).toBe('old')
+      expect(await ws.cache.get('/data/file')).toBeNull()
+      expect(new TextDecoder().decode((await ws.execute('cat /data/file')).stdout)).toBe('new')
+      expect(await ws.cache.get('/data/file')).toEqual(new TextEncoder().encode('new'))
+      expect(retired).not.toBeNull()
+      expect(
+        await retired?.cachedBytes(
+          new PathSpec({
+            virtual: '/data/file',
+            directory: '/data/',
+            resourcePath: 'file',
+          }),
+        ),
+      ).toBeNull()
+    } finally {
+      resume()
+      await running
+      await ws.close()
+    }
+  })
+
   it('does not open resources at construction time', () => {
     const ram = new MockResource()
     new Workspace({ '/data': ram })
@@ -233,6 +291,59 @@ describe('Workspace.execute AbortSignal', () => {
 })
 
 describe('Workspace.unmount', () => {
+  it.each([false, true])(
+    'retains a prefix until cache cleanup succeeds (failure=%s)',
+    async (fails) => {
+      const resource = new RAMResource()
+      const ws = new Workspace({ '/data': resource })
+      const cache = ws.cache
+      let enter = (): void => undefined
+      let resume = (): void => undefined
+      const entered = new Promise<void>((resolve) => {
+        enter = resolve
+      })
+      const release = new Promise<void>((resolve) => {
+        resume = resolve
+      })
+      const evict = cache.evictPrefix.bind(cache)
+      vi.spyOn(cache, 'evictPrefix').mockImplementationOnce(async (prefix) => {
+        enter()
+        await release
+        if (fails) throw new Error('cache unavailable')
+        await evict(prefix)
+      })
+      const bytes = new TextEncoder()
+      await cache.set('/data', bytes.encode('root'))
+      await cache.set('/data/file', bytes.encode('old'))
+      await cache.set('/database/file', bytes.encode('peer'))
+      const removing = ws.unmount('data/').then(
+        () => null,
+        (error: unknown) => error,
+      )
+      try {
+        await entered
+        expect(() => ws.addMount('/data', new RAMResource())).toThrow('duplicate mount prefix')
+        resume()
+        const result = await removing
+        if (fails) {
+          expect(result).toEqual(new Error('cache unavailable'))
+          expect(ws.mount('/data').resource).toBe(resource)
+          await ws.unmount('/data')
+        } else {
+          expect(result).toBeNull()
+        }
+        expect(await cache.get('/data')).toBeNull()
+        expect(await cache.get('/data/file')).toBeNull()
+        expect(await cache.get('/database/file')).toEqual(bytes.encode('peer'))
+        ws.addMount('/data', new RAMResource())
+      } finally {
+        resume()
+        await removing
+        await ws.close()
+      }
+    },
+  )
+
   it.each([false, true])(
     'preserves root operations after removing every user RAM mount (explicit root: %s)',
     async (explicitRoot) => {

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -177,7 +177,9 @@ describe('Workspace lifecycle', () => {
       }
       resume()
       await removing
-      ws.addMount('/data', resource)
+      expect(() => ws.addMount('/data', resource)).toThrow('resource is closed')
+      expect(() => new Workspace({ '/data': resource })).toThrow('resource is closed')
+      ws.addMount('/data', new RAMResource())
     } finally {
       resume()
       await removing
@@ -185,9 +187,10 @@ describe('Workspace lifecycle', () => {
     }
   })
 
-  it.each([false, true])(
-    'does not cache a retired command result for a replacement mount (shadow=%s)',
-    async (shadow) => {
+  it.each(['replace', 'shadow', 'reveal'])(
+    'does not cache a retired command result for a different owner (%s)',
+    async (change) => {
+      const shadow = change === 'shadow'
       class CachedRAM extends RAMResource {
         override readonly cachesReads = true
       }
@@ -197,7 +200,10 @@ describe('Workspace lifecycle', () => {
         files: { [shadow ? '/data/file' : '/file']: new TextEncoder().encode('old') },
       })
       const replacement = new CachedRAM()
-      replacement.loadState({ type: 'ram', files: { '/file': new TextEncoder().encode('new') } })
+      replacement.loadState({
+        type: 'ram',
+        files: { [change === 'reveal' ? '/data/file' : '/file']: new TextEncoder().encode('new') },
+      })
       let enter = (): void => undefined
       let resume = (): void => undefined
       const entered = new Promise<void>((resolve) => {
@@ -207,7 +213,9 @@ describe('Workspace lifecycle', () => {
         resume = resolve
       })
       const prefix = shadow ? '/' : '/data'
-      const ws = new Workspace({ [prefix]: old }, { shellParser: await getTestParser() })
+      const resources: Record<string, Resource> = { [prefix]: old }
+      if (change === 'reveal') resources['/'] = replacement
+      const ws = new Workspace(resources, { shellParser: await getTestParser() })
       ws.registerCli(
         'gate',
         new CLISpec({
@@ -224,7 +232,7 @@ describe('Workspace lifecycle', () => {
       try {
         await entered
         if (!shadow) await ws.unmount('/data')
-        ws.addMount('/data', replacement)
+        if (change !== 'reveal') ws.addMount('/data', replacement)
         resume()
         expect(new TextDecoder().decode((await running).stdout)).toBe('old')
         expect(await ws.cache.get('/data/file')).toBeNull()

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -23,9 +23,11 @@ import {
   type RedisIndexConfig,
 } from '../cache/index/config.ts'
 import { RedisIndexCacheStore } from '../cache/index/redis.ts'
+import type { IndexCacheStore } from '../cache/index/store.ts'
+import { mountKey } from '../utils/key_prefix.ts'
 import { CLISpec } from '../commands/cli/types.ts'
 import { IOResult } from '../io/types.ts'
-import { OpsRegistry } from '../ops/registry.ts'
+import { op, OpsRegistry } from '../ops/registry.ts'
 import { FileType, MountMode, ResourceName, PathSpec } from '../types.ts'
 import { BaseResource, type Resource } from '../resource/base.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
@@ -50,6 +52,59 @@ class MockResource extends BaseResource implements Resource {
 }
 
 describe('Workspace lifecycle', () => {
+  it.each(['glob', 'midpath', 'provision'])(
+    'prepares the first %s access to a dynamic mount',
+    async (action) => {
+      class IndexedRAM extends RAMResource {
+        constructor(index: IndexCacheStore) {
+          super()
+          this._index = index
+        }
+        override async glob(paths: readonly PathSpec[], prefix = ''): Promise<PathSpec[]> {
+          const parent = paths[0]?.directory.replace(/\/$/, '') ?? ''
+          const directory = parent === '' ? '/' : parent
+          const listing = await this.index.listDir(directory)
+          if (listing.entries != null)
+            return listing.entries.map((key) => PathSpec.fromStrPath(key, mountKey(key, prefix)))
+          return super.glob(paths, prefix)
+        }
+      }
+      const ancestor = new RAMResource()
+      const ws = new Workspace({ '/': ancestor }, { shellParser: await getTestParser() })
+      const replacement = new IndexedRAM(ancestor.index)
+      const bytes = new TextEncoder()
+      replacement.loadState({
+        type: 'ram',
+        dirs: ['/', '/dir'],
+        files: {
+          '/fresh.txt': bytes.encode('new'),
+          '/dir/fresh.txt': bytes.encode('new'),
+          '/file': bytes.encode('new'),
+        },
+      })
+      const directory = action === 'midpath' ? '/data/dir' : '/data'
+      await ancestor.index.setDir(directory, [
+        ['stale.txt', new IndexEntry({ id: 'old', name: 'stale.txt', resourceType: 'file' })],
+      ])
+      await ws.cache.set('/data/file', bytes.encode('old'))
+      ws.addMount('/data', replacement)
+      try {
+        if (action === 'provision') {
+          const result = await ws.provision('cat /data/file')
+          expect(result.cacheHits).toBe(0)
+          expect((await ws.execute('cat /data/file')).stdout).toEqual(bytes.encode('new'))
+        } else {
+          const pattern = action === 'midpath' ? '/data/*/*.txt' : '/data/*.txt'
+          expect((await ws.execute('echo ' + pattern)).stdout).toEqual(
+            bytes.encode(`${directory}/fresh.txt\n`),
+          )
+        }
+      } finally {
+        await ws.close()
+      }
+    },
+  )
+
   it('waits for an inflight cache write before releasing a mount', async () => {
     class CachedRAM extends RAMResource {
       override readonly cachesReads = true
@@ -432,6 +487,56 @@ describe('Workspace.execute AbortSignal', () => {
 })
 
 describe('Workspace.unmount', () => {
+  it('keeps decorated operations bound to each surviving resource', async () => {
+    class LabeledRAM extends RAMResource {
+      closes = 0
+      override async close(): Promise<void> {
+        this.closes++
+        await super.close()
+      }
+      constructor(readonly label: string) {
+        super()
+      }
+      @op('identity', { resource: 'ram' })
+      identity(): Uint8Array {
+        if (this.closes > 0) throw new Error('resource closed')
+        return new TextEncoder().encode(this.label)
+      }
+    }
+    class SpecializedRAM extends LabeledRAM {
+      @op('unique', { resource: 'ram' })
+      unique(): Uint8Array {
+        return this.identity()
+      }
+    }
+    const ws = new Workspace({})
+    const first = new LabeledRAM('first')
+    const second = new SpecializedRAM('second')
+    const third = new LabeledRAM('third')
+    const identity = async (path: string, name = 'identity'): Promise<string> => {
+      const result = await ws.dispatch(name, path)
+      return new TextDecoder().decode(result as Uint8Array)
+    }
+    try {
+      ws.addMount('/first', first)
+      ws.addMount('/second', second)
+      ws.addMount('/third', third)
+      expect(await identity('/first/file')).toBe('first')
+      expect(await identity('/second/file')).toBe('second')
+      expect(await identity('/third/file')).toBe('third')
+      await ws.unmount('/second')
+      expect(second.closes).toBe(1)
+      expect(await identity('/first/file')).toBe('first')
+      expect(await identity('/third/file')).toBe('third')
+      await expect(identity('/first/file', 'unique')).rejects.toMatchObject({ code: 'ENOTSUP' })
+      await ws.unmount('/third')
+      expect(await identity('/first/file')).toBe('first')
+      expect((await ws.fs.readdir('/')).length).toBeGreaterThan(0)
+    } finally {
+      await ws.close()
+    }
+  })
+
   it.each([
     [false, 'file'],
     [true, 'file'],
@@ -441,8 +546,14 @@ describe('Workspace.unmount', () => {
     'retains a prefix until cache cleanup succeeds (failure=%s, store=%s)',
     async (fails, store) => {
       const resource = new RAMResource()
-      const ws = new Workspace({ '/data': resource })
+      resource.loadState({ type: 'ram', files: { '/file': new TextEncoder().encode('old') } })
+      const ws = new Workspace(
+        { '/data': resource },
+        { mode: MountMode.WRITE, shellParser: await getTestParser() },
+      )
       const cache = ws.cache
+      ws.addMount('/alias', resource)
+      const aliasEntries = await ws.fs.readdir('/alias')
       let enter = (): void => undefined
       let resume = (): void => undefined
       const entered = new Promise<void>((resolve) => {
@@ -475,7 +586,16 @@ describe('Workspace.unmount', () => {
       )
       try {
         await entered
+        expect((await ws.resolve('/alias'))[0]).toBe(resource)
         expect(() => ws.addMount('/data', new RAMResource())).toThrow('duplicate mount prefix')
+        await expect(ws.fs.readdir('/data')).rejects.toMatchObject({ code: 'EBUSY' })
+        await expect(ws.fs.writeFile('/data/file', bytes.encode('changed'))).rejects.toMatchObject({
+          code: 'EBUSY',
+        })
+        for (const line of ['cat /data/file', 'echo changed > /data/file']) {
+          expect((await ws.execute(line)).exitCode).not.toBe(0)
+        }
+        expect(resource.getState().files?.['/file']).toEqual(bytes.encode('old'))
         resume()
         const result = await removing
         if (fails) {
@@ -488,6 +608,7 @@ describe('Workspace.unmount', () => {
         expect(await cache.get('/data')).toBeNull()
         expect(await cache.get('/data/file')).toBeNull()
         expect(await cache.get('/database/file')).toEqual(bytes.encode('peer'))
+        expect(await ws.fs.readdir('/alias')).toEqual(aliasEntries)
         ws.addMount('/data', new RAMResource())
       } finally {
         resume()

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -25,6 +25,7 @@ import {
 import { RedisIndexCacheStore } from '../cache/index/redis.ts'
 import type { IndexCacheStore } from '../cache/index/store.ts'
 import { mountKey } from '../utils/key_prefix.ts'
+import { globNameMatches, globPattern } from '../utils/glob_walk.ts'
 import { CLISpec } from '../commands/cli/types.ts'
 import { IOResult } from '../io/types.ts'
 import { op, OpsRegistry } from '../ops/registry.ts'
@@ -36,6 +37,7 @@ import type { MountResolver } from '../runtime/resolver.ts'
 import type { BridgeDispatchFn, RunArgs, RunResult } from '../runtime/types.ts'
 import { getTestParser } from './fixtures/workspace_fixture.ts'
 import { Workspace } from './workspace/workspace.ts'
+import { expandOperands } from './executor/builtins/shared.ts'
 
 class MockResource extends BaseResource implements Resource {
   readonly kind = 'mock'
@@ -52,7 +54,7 @@ class MockResource extends BaseResource implements Resource {
 }
 
 describe('Workspace lifecycle', () => {
-  it.each(['glob', 'midpath', 'provision'])(
+  it.each(['glob', 'midpath', 'provision', 'metadata', 'touch', 'chmod', 'chown', 'chgrp'])(
     'prepares the first %s access to a dynamic mount',
     async (action) => {
       class IndexedRAM extends RAMResource {
@@ -65,7 +67,11 @@ describe('Workspace lifecycle', () => {
           const directory = parent === '' ? '/' : parent
           const listing = await this.index.listDir(directory)
           if (listing.entries != null)
-            return listing.entries.map((key) => PathSpec.fromStrPath(key, mountKey(key, prefix)))
+            return listing.entries
+              .filter((key) =>
+                globNameMatches(key.split('/').at(-1) ?? '', globPattern(paths[0]?.pattern ?? '*')),
+              )
+              .map((key) => PathSpec.fromStrPath(key, mountKey(key, prefix)))
           return super.glob(paths, prefix)
         }
       }
@@ -87,12 +93,35 @@ describe('Workspace lifecycle', () => {
         ['stale.txt', new IndexEntry({ id: 'old', name: 'stale.txt', resourceType: 'file' })],
       ])
       await ws.cache.set('/data/file', bytes.encode('old'))
-      ws.addMount('/data', replacement)
+      ws.addMount('/data', replacement, MountMode.WRITE)
       try {
         if (action === 'provision') {
           const result = await ws.provision('cat /data/file')
           expect(result.cacheHits).toBe(0)
           expect((await ws.execute('cat /data/file')).stdout).toEqual(bytes.encode('new'))
+        } else if (action === 'metadata') {
+          const expanded = await expandOperands(ws.namespace, [
+            new PathSpec({
+              virtual: '/data/*.txt',
+              directory: '/data/',
+              resourcePath: '*.txt',
+              pattern: '*.txt',
+              resolved: false,
+            }),
+          ])
+          expect(expanded.map((p) => p.virtual)).toEqual(['/data/fresh.txt'])
+        } else if (['touch', 'chmod', 'chown', 'chgrp'].includes(action)) {
+          const command = {
+            touch: 'touch',
+            chmod: 'chmod 600',
+            chown: 'chown 123',
+            chgrp: 'chgrp 456',
+          }[action as 'touch' | 'chmod' | 'chown' | 'chgrp']
+          const result = await ws.execute(command + ' /data/*.txt')
+          expect(result.exitCode, new TextDecoder().decode(result.stderr)).toBe(0)
+          expect((await ws.execute('echo /data/*.txt')).stdout).toEqual(
+            bytes.encode('/data/fresh.txt\n'),
+          )
         } else {
           const pattern = action === 'midpath' ? '/data/*/*.txt' : '/data/*.txt'
           expect((await ws.execute('echo ' + pattern)).stdout).toEqual(
@@ -1079,6 +1108,65 @@ it('updates default-profile policy for unbound ops without replacing the session
     expect(ws.getSession(ws.defaultSessionId)).toBe(session)
     expect(new TextDecoder().decode(await ws.fs.readFile('/data/file'))).toBe('kept')
   } finally {
+    await ws.close()
+  }
+})
+
+it('unmount drains metadata globs and their index writes', async () => {
+  const resource = new RAMResource()
+  const ws = new Workspace({ '/data': resource })
+  await ws.resolve('/data')
+  let enter = (): void => undefined
+  let resume = (): void => undefined
+  const entered = new Promise<void>((resolve) => {
+    enter = resolve
+  })
+  const release = new Promise<void>((resolve) => {
+    resume = resolve
+  })
+  let closed = false
+  const index = resource.index
+  const closeResource = resource.close.bind(resource)
+  vi.spyOn(resource, 'close').mockImplementation(async () => {
+    closed = true
+    await closeResource()
+  })
+  vi.spyOn(resource, 'glob').mockImplementation(async () => {
+    enter()
+    await release
+    expect(closed).toBe(false)
+    await index.setDir('/data', [
+      ['late', new IndexEntry({ id: 'late', name: 'late', resourceType: 'file' })],
+    ])
+    return []
+  })
+  const expanding = expandOperands(ws.namespace, [
+    new PathSpec({
+      virtual: '/data/*',
+      directory: '/data/',
+      resourcePath: '*',
+      pattern: '*',
+      resolved: false,
+    }),
+  ])
+  let removing: Promise<void> | undefined
+  try {
+    await entered
+    let removed = false
+    removing = ws.unmount('/data').then(() => {
+      removed = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(removed).toBe(false)
+    expect(closed).toBe(false)
+    resume()
+    await expanding
+    await removing
+    expect(closed).toBe(true)
+    expect((await index.listDir('/data')).entries).toBeUndefined()
+  } finally {
+    resume()
+    await Promise.allSettled([expanding, ...(removing === undefined ? [] : [removing])])
     await ws.close()
   }
 })

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -50,14 +50,13 @@ class MockResource extends BaseResource implements Resource {
 }
 
 describe('Workspace lifecycle', () => {
-  it('does not cache a retired command result for a replacement mount', async () => {
+  it('waits for an inflight cache write before releasing a mount', async () => {
     class CachedRAM extends RAMResource {
       override readonly cachesReads = true
     }
     const old = new CachedRAM()
     old.loadState({ type: 'ram', files: { '/file': new TextEncoder().encode('old') } })
-    const replacement = new CachedRAM()
-    replacement.loadState({ type: 'ram', files: { '/file': new TextEncoder().encode('new') } })
+    const ws = new Workspace({ '/data': old }, { shellParser: await getTestParser() })
     let enter = (): void => undefined
     let resume = (): void => undefined
     const entered = new Promise<void>((resolve) => {
@@ -66,45 +65,133 @@ describe('Workspace lifecycle', () => {
     const release = new Promise<void>((resolve) => {
       resume = resolve
     })
-    const ws = new Workspace({ '/data': old }, { shellParser: await getTestParser() })
-    ws.registerCli(
-      'gate',
-      new CLISpec({
-        name: 'gate',
-        fn: async () => {
-          enter()
-          await release
-          return [null, new IOResult()]
-        },
-      }),
-    )
-    const retired = ws.mount('/data').cacheManager
-    const running = ws.execute('cat /data/file; gate')
+    const writeCache = ws.cache.set.bind(ws.cache)
+    vi.spyOn(ws.cache, 'set').mockImplementationOnce(async (...args) => {
+      enter()
+      await release
+      await writeCache(...args)
+    })
+    const reading = ws.execute('cat /data/file')
+    let removing: Promise<void> | undefined
     try {
       await entered
-      await ws.unmount('/data')
-      ws.addMount('/data', replacement)
+      let removed = false
+      removing = ws.unmount('/data').then(() => {
+        removed = true
+      })
+      await Promise.resolve()
+      expect(removed).toBe(false)
+      expect(() => ws.addMount('/data', new CachedRAM())).toThrow('duplicate mount prefix')
       resume()
-      expect(new TextDecoder().decode((await running).stdout)).toBe('old')
+      await Promise.all([reading, removing])
       expect(await ws.cache.get('/data/file')).toBeNull()
+      const replacement = new CachedRAM()
+      replacement.loadState({ type: 'ram', files: { '/file': new TextEncoder().encode('new') } })
+      ws.addMount('/data', replacement)
       expect(new TextDecoder().decode((await ws.execute('cat /data/file')).stdout)).toBe('new')
-      expect(await ws.cache.get('/data/file')).toEqual(new TextEncoder().encode('new'))
-      expect(retired).not.toBeNull()
-      expect(
-        await retired?.cachedBytes(
-          new PathSpec({
-            virtual: '/data/file',
-            directory: '/data/',
-            resourcePath: 'file',
-          }),
-        ),
-      ).toBeNull()
     } finally {
       resume()
-      await running
+      await Promise.allSettled([reading, removing])
       await ws.close()
     }
   })
+
+  it('refuses resource reuse until asynchronous close finishes', async () => {
+    const resource = new RAMResource()
+    const ws = new Workspace({ '/data': resource })
+    await ws.resolve('/data')
+    let enter = (): void => undefined
+    let resume = (): void => undefined
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      resume = resolve
+    })
+    const close = resource.close.bind(resource)
+    vi.spyOn(resource, 'close').mockImplementationOnce(async () => {
+      enter()
+      await release
+      await close()
+    })
+    const removing = ws.unmount('/data')
+    try {
+      await entered
+      for (const prefix of ['/data', '/alias']) {
+        expect(() => ws.addMount(prefix, resource)).toThrow('resource is being unmounted')
+      }
+      resume()
+      await removing
+      ws.addMount('/data', resource)
+    } finally {
+      resume()
+      await removing
+      await ws.close()
+    }
+  })
+
+  it.each([false, true])(
+    'does not cache a retired command result for a replacement mount (shadow=%s)',
+    async (shadow) => {
+      class CachedRAM extends RAMResource {
+        override readonly cachesReads = true
+      }
+      const old = new CachedRAM()
+      old.loadState({
+        type: 'ram',
+        files: { [shadow ? '/data/file' : '/file']: new TextEncoder().encode('old') },
+      })
+      const replacement = new CachedRAM()
+      replacement.loadState({ type: 'ram', files: { '/file': new TextEncoder().encode('new') } })
+      let enter = (): void => undefined
+      let resume = (): void => undefined
+      const entered = new Promise<void>((resolve) => {
+        enter = resolve
+      })
+      const release = new Promise<void>((resolve) => {
+        resume = resolve
+      })
+      const prefix = shadow ? '/' : '/data'
+      const ws = new Workspace({ [prefix]: old }, { shellParser: await getTestParser() })
+      ws.registerCli(
+        'gate',
+        new CLISpec({
+          name: 'gate',
+          fn: async () => {
+            enter()
+            await release
+            return [null, new IOResult()]
+          },
+        }),
+      )
+      const retired = ws.mount(prefix).cacheManager
+      const running = ws.execute('cat /data/file; gate')
+      try {
+        await entered
+        if (!shadow) await ws.unmount('/data')
+        ws.addMount('/data', replacement)
+        resume()
+        expect(new TextDecoder().decode((await running).stdout)).toBe('old')
+        expect(await ws.cache.get('/data/file')).toBeNull()
+        expect(new TextDecoder().decode((await ws.execute('cat /data/file')).stdout)).toBe('new')
+        expect(await ws.cache.get('/data/file')).toEqual(new TextEncoder().encode('new'))
+        expect(retired).not.toBeNull()
+        expect(
+          await retired?.cachedBytes(
+            new PathSpec({
+              virtual: '/data/file',
+              directory: '/data/',
+              resourcePath: 'file',
+            }),
+          ),
+        ).toBeNull()
+      } finally {
+        resume()
+        await running
+        await ws.close()
+      }
+    },
+  )
 
   it('does not open resources at construction time', () => {
     const ram = new MockResource()
@@ -170,48 +257,51 @@ describe('Workspace lifecycle', () => {
 
 describe('Workspace dynamic mount index', () => {
   for (const type of [IndexType.RAM, IndexType.REDIS]) {
-    it.skipIf(type === IndexType.REDIS && process.env.REDIS_URL === undefined)(
-      `invalidates the ${type} index before remounting`,
-      async () => {
-        const url = process.env.REDIS_URL
-        const config: IndexConfig | RedisIndexConfig =
-          type === IndexType.REDIS
-            ? {
-                type,
-                ...(url === undefined ? {} : { url }),
-                keyPrefix: `lifecycle:${crypto.randomUUID()}:`,
+    for (const shadow of [false, true]) {
+      it.skipIf(type === IndexType.REDIS && process.env.REDIS_URL === undefined)(
+        `invalidates the ${type} index before mount replacement (shadow=${String(shadow)})`,
+        async () => {
+          const url = process.env.REDIS_URL
+          const config: IndexConfig | RedisIndexConfig =
+            type === IndexType.REDIS
+              ? {
+                  type,
+                  ...(url === undefined ? {} : { url }),
+                  keyPrefix: `lifecycle:${crypto.randomUUID()}:`,
+                }
+              : { type }
+          const resource = new RAMResource()
+          const ws = new Workspace({ [shadow ? '/' : '/data']: resource }, { index: config })
+          ws.addMount('/alias', resource)
+          const index = resource.index
+          const entry = new IndexEntry({ id: 'old', name: 'private.txt', resourceType: 'file' })
+          try {
+            await index.put('/data', entry)
+            for (const path of ['/data', '/data/nested', '/database', '/alias']) {
+              await index.setDir(path, [['private.txt', entry]])
+            }
+            if (!shadow) await ws.unmount('/data')
+            const replacement = new RAMResource()
+            ws.addMount('/data', replacement)
+            if (shadow) expect(await ws.fs.readdir('/data')).toEqual([])
+            for (const candidate of [index, replacement.index]) {
+              for (const path of ['/data', '/data/private.txt', '/data/nested/private.txt']) {
+                expect((await candidate.get(path)).status).toBe(LookupStatus.NOT_FOUND)
               }
-            : { type }
-        const resource = new RAMResource()
-        const ws = new Workspace({ '/data': resource }, { index: config })
-        ws.addMount('/alias', resource)
-        const index = resource.index
-        const entry = new IndexEntry({ id: 'old', name: 'private.txt', resourceType: 'file' })
-        try {
-          await index.put('/data', entry)
-          for (const path of ['/data', '/data/nested', '/database', '/alias']) {
-            await index.setDir(path, [['private.txt', entry]])
-          }
-          await ws.unmount('/data')
-          const replacement = new RAMResource()
-          ws.addMount('/data', replacement)
-          for (const candidate of [index, replacement.index]) {
-            for (const path of ['/data', '/data/private.txt', '/data/nested/private.txt']) {
-              expect((await candidate.get(path)).status).toBe(LookupStatus.NOT_FOUND)
+              for (const path of ['/data', '/data/nested']) {
+                expect((await candidate.listDir(path)).entries ?? []).toEqual([])
+              }
             }
-            for (const path of ['/data', '/data/nested']) {
-              expect((await candidate.listDir(path)).status).toBe(LookupStatus.NOT_FOUND)
+            for (const path of ['/database', '/alias']) {
+              expect((await index.listDir(path)).entries).toEqual([`${path}/private.txt`])
             }
+          } finally {
+            await index.clear()
+            await ws.close()
           }
-          for (const path of ['/database', '/alias']) {
-            expect((await index.listDir(path)).entries).toEqual([`${path}/private.txt`])
-          }
-        } finally {
-          await index.clear()
-          await ws.close()
-        }
-      },
-    )
+        },
+      )
+    }
   }
 
   it('applies the workspace Redis index to added mounts', async () => {

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -15,7 +15,13 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { CacheConfig } from '../cache/file/config.ts'
 import type { FileCache } from '../cache/file/mixin.ts'
-import { IndexType, LookupStatus } from '../cache/index/config.ts'
+import {
+  IndexEntry,
+  IndexType,
+  LookupStatus,
+  type IndexConfig,
+  type RedisIndexConfig,
+} from '../cache/index/config.ts'
 import { RedisIndexCacheStore } from '../cache/index/redis.ts'
 import { CLISpec } from '../commands/cli/types.ts'
 import { IOResult } from '../io/types.ts'
@@ -163,6 +169,51 @@ describe('Workspace lifecycle', () => {
 })
 
 describe('Workspace dynamic mount index', () => {
+  for (const type of [IndexType.RAM, IndexType.REDIS]) {
+    it.skipIf(type === IndexType.REDIS && process.env.REDIS_URL === undefined)(
+      `invalidates the ${type} index before remounting`,
+      async () => {
+        const url = process.env.REDIS_URL
+        const config: IndexConfig | RedisIndexConfig =
+          type === IndexType.REDIS
+            ? {
+                type,
+                ...(url === undefined ? {} : { url }),
+                keyPrefix: `lifecycle:${crypto.randomUUID()}:`,
+              }
+            : { type }
+        const resource = new RAMResource()
+        const ws = new Workspace({ '/data': resource }, { index: config })
+        ws.addMount('/alias', resource)
+        const index = resource.index
+        const entry = new IndexEntry({ id: 'old', name: 'private.txt', resourceType: 'file' })
+        try {
+          await index.put('/data', entry)
+          for (const path of ['/data', '/data/nested', '/database', '/alias']) {
+            await index.setDir(path, [['private.txt', entry]])
+          }
+          await ws.unmount('/data')
+          const replacement = new RAMResource()
+          ws.addMount('/data', replacement)
+          for (const candidate of [index, replacement.index]) {
+            for (const path of ['/data', '/data/private.txt', '/data/nested/private.txt']) {
+              expect((await candidate.get(path)).status).toBe(LookupStatus.NOT_FOUND)
+            }
+            for (const path of ['/data', '/data/nested']) {
+              expect((await candidate.listDir(path)).status).toBe(LookupStatus.NOT_FOUND)
+            }
+          }
+          for (const path of ['/database', '/alias']) {
+            expect((await index.listDir(path)).entries).toEqual([`${path}/private.txt`])
+          }
+        } finally {
+          await index.clear()
+          await ws.close()
+        }
+      },
+    )
+  }
+
   it('applies the workspace Redis index to added mounts', async () => {
     const ws = new Workspace({}, { index: { type: IndexType.REDIS } })
     const resource = new RAMResource()
@@ -291,9 +342,14 @@ describe('Workspace.execute AbortSignal', () => {
 })
 
 describe('Workspace.unmount', () => {
-  it.each([false, true])(
-    'retains a prefix until cache cleanup succeeds (failure=%s)',
-    async (fails) => {
+  it.each([
+    [false, 'file'],
+    [true, 'file'],
+    [false, 'index'],
+    [true, 'index'],
+  ] as const)(
+    'retains a prefix until cache cleanup succeeds (failure=%s, store=%s)',
+    async (fails, store) => {
       const resource = new RAMResource()
       const ws = new Workspace({ '/data': resource })
       const cache = ws.cache
@@ -305,8 +361,15 @@ describe('Workspace.unmount', () => {
       const release = new Promise<void>((resolve) => {
         resume = resolve
       })
-      const evict = cache.evictPrefix.bind(cache)
-      vi.spyOn(cache, 'evictPrefix').mockImplementationOnce(async (prefix) => {
+      const evict =
+        store === 'file'
+          ? cache.evictPrefix.bind(cache)
+          : resource.index.invalidatePrefix.bind(resource.index)
+      const spy =
+        store === 'file'
+          ? vi.spyOn(cache, 'evictPrefix')
+          : vi.spyOn(resource.index, 'invalidatePrefix')
+      spy.mockImplementationOnce(async (prefix) => {
         enter()
         await release
         if (fails) throw new Error('cache unavailable')

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -15,6 +15,8 @@
 import { describe, expect, it } from 'vitest'
 import type { CacheConfig } from '../cache/file/config.ts'
 import type { FileCache } from '../cache/file/mixin.ts'
+import { IndexType, LookupStatus } from '../cache/index/config.ts'
+import { RedisIndexCacheStore } from '../cache/index/redis.ts'
 import { OpsRegistry } from '../ops/registry.ts'
 import { FileType, MountMode, ResourceName, type PathSpec } from '../types.ts'
 import { BaseResource, type Resource } from '../resource/base.ts'
@@ -99,6 +101,57 @@ describe('Workspace lifecycle', () => {
     const ws = new Workspace({ '/data': new MockResource() })
     await ws.close()
     await expect(ws.resolve('/data/x')).rejects.toThrow(/closed/)
+  })
+})
+
+describe('Workspace dynamic mount index', () => {
+  it('applies the workspace Redis index to added mounts', async () => {
+    const ws = new Workspace({}, { index: { type: IndexType.REDIS } })
+    const resource = new RAMResource()
+    ws.addMount('/late', resource)
+    try {
+      expect(resource.index).toBeInstanceOf(RedisIndexCacheStore)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('applies the same index TTL to initial and added mounts', async () => {
+    const initial = new RAMResource()
+    const ws = new Workspace({ '/initial': initial }, { index: { ttl: -1 } })
+    const added = new RAMResource()
+    ws.addMount('/late', added)
+    try {
+      for (const resource of [initial, added]) {
+        await resource.index.setDir('/listing', [])
+        expect((await resource.index.listDir('/listing')).status).toBe(LookupStatus.EXPIRED)
+      }
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('keeps the index coherent across aliases and duplicate attempts', async () => {
+    const ws = new Workspace({}, { index: { ttl: 3600 } })
+    const resource = new RAMResource()
+    ws.addMount('/late', resource, MountMode.WRITE)
+    const index = resource.index
+    const rejected = new RAMResource()
+    const rejectedIndex = rejected.index
+    try {
+      await index.setDir('/late', [])
+      ws.addMount('/alias', resource)
+      expect(resource.index).toBe(index)
+      expect((await index.listDir('/late')).entries).toEqual([])
+      expect(() => ws.addMount('late/', rejected)).toThrow('duplicate mount prefix')
+      expect(rejected.index).toBe(rejectedIndex)
+      // Mutations must evict the configured store, including after aliasing.
+      await ws.fs.writeFile('/late/new.txt', 'new')
+      expect((await index.listDir('/late')).status).toBe(LookupStatus.NOT_FOUND)
+    } finally {
+      await ws.close()
+      await rejected.close()
+    }
   })
 })
 

--- a/typescript/packages/core/src/workspace/workspace/execute.ts
+++ b/typescript/packages/core/src/workspace/workspace/execute.ts
@@ -357,6 +357,7 @@ async function runParsedLine(
   reparse: (line: string) => TSNodeLike,
   nested: NestedRefusal,
 ): Promise<ExecuteResult> {
+  const cacheable = env.dispatcher.captureCacheablePaths()
   const callAgentId = options.agentId ?? env.agentId ?? ''
   // The line-reader decision (GNU: history is appended where the typed
   // line is read, never inside the evaluator). Internal evaluations run
@@ -571,7 +572,7 @@ async function runParsedLine(
   targetSession.lastExitCode = io.exitCode
   let stdoutBytes: Uint8Array
   try {
-    await env.dispatcher.applyIo(io, opRecords)
+    await env.dispatcher.applyIo(io, opRecords, cacheable)
     stdoutBytes = materialized === null ? new Uint8Array() : await materialize(materialized)
   } catch (err) {
     // Lazy reads can fail while draining (e.g. head/tail that open the

--- a/typescript/packages/core/src/workspace/workspace/lifecycle.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/lifecycle.test.ts
@@ -14,6 +14,8 @@
 
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { command } from '../../commands/config.ts'
+import { CommandSpec, Operand } from '../../commands/spec/types.ts'
 import { IOResult } from '../../io/types.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import { type JobRunner, JobStatus } from '../../shell/job_table/index.ts'
@@ -177,3 +179,179 @@ it.each([
     }
   },
 )
+
+it.each(
+  [null, 'initial', 'dynamic'].flatMap((alias) =>
+    [false, true].flatMap((streaming) =>
+      ['op', 'command'].map((surface) => ({ alias, streaming, surface })),
+    ),
+  ),
+)(
+  'unmount waits for admitted resource use ($surface, streaming=$streaming, alias=$alias)',
+  async ({ surface, streaming, alias }) => {
+    const resource = new RAMResource()
+    let entered = (): void => undefined
+    let resume = (): void => undefined
+    const started = new Promise<void>((resolve) => {
+      entered = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      resume = resolve
+    })
+    let closed = false
+    async function* chunks(): AsyncGenerator<Uint8Array> {
+      entered()
+      await release
+      expect(closed).toBe(false)
+      yield new TextEncoder().encode('value')
+    }
+    const read = async (): Promise<Uint8Array | AsyncIterable<Uint8Array>> => {
+      if (streaming) return chunks()
+      entered()
+      await release
+      expect(closed).toBe(false)
+      return new TextEncoder().encode('value')
+    }
+    const resources: Record<string, RAMResource> = { '/data': resource }
+    if (alias === 'initial') resources['/alias'] = resource
+    const ws = new Workspace(resources, { shellParser: parser })
+    if (alias === 'dynamic') ws.addMount('/alias', resource)
+    ws.ops.register({ name: 'read', resource: 'ram', filetype: null, write: false, fn: read })
+    const [registered] = command({
+      name: 'readvalue',
+      resource: 'ram',
+      spec: new CommandSpec({ rest: new Operand({ type: 'path' }) }),
+      fn: async () => [await read(), new IOResult()],
+    })
+    if (registered === undefined) throw new Error('missing command')
+    ws.mount('/data').register(registered)
+    const closeResource = resource.close.bind(resource)
+    vi.spyOn(resource, 'close').mockImplementation(async () => {
+      closed = true
+      await closeResource()
+    })
+    const running = (async () => {
+      if (surface === 'command')
+        return new TextDecoder().decode((await ws.execute('readvalue /data/file')).stdout)
+      const value = (await ws.dispatch('read', '/data/file')) as
+        | Uint8Array
+        | AsyncIterable<Uint8Array>
+      if (value instanceof Uint8Array) return new TextDecoder().decode(value)
+      let result = ''
+      for await (const chunk of value) result += new TextDecoder().decode(chunk)
+      return result
+    })()
+    let removing: Promise<void> | undefined
+    try {
+      await started
+      if (alias) {
+        await ws.unmount('/data')
+        expect(closed).toBe(false)
+      }
+      let removed = false
+      const prefix = alias ? '/alias' : '/data'
+      removing = ws.unmount(prefix).then(() => {
+        removed = true
+      })
+      await vi.waitFor(() => {
+        expect(ws.registry.tryMountForPrefix(prefix)).toBeNull()
+      })
+      expect(removed).toBe(false)
+      expect(closed).toBe(false)
+      resume()
+      expect(await running).toBe('value')
+      await removing
+      expect(closed).toBe(true)
+    } finally {
+      resume()
+      await Promise.allSettled([running, ...(removing === undefined ? [] : [removing])])
+      await ws.close()
+    }
+  },
+)
+
+it('workspace close waits for resource retirements before closing stores', async () => {
+  const resource = new RAMResource()
+  const ws = new Workspace({ '/data': resource }, { shellParser: parser })
+  await ws.dispatch('stat', '/data')
+  let entered = (): void => undefined
+  let resume = (): void => undefined
+  const started = new Promise<void>((resolve) => {
+    entered = resolve
+  })
+  const release = new Promise<void>((resolve) => {
+    resume = resolve
+  })
+  const events: string[] = []
+  const closeResource = resource.close.bind(resource)
+  vi.spyOn(resource, 'close').mockImplementation(async () => {
+    entered()
+    await release
+    await closeResource()
+    events.push('resource')
+  })
+  const closeStore = ws.stateStore.close.bind(ws.stateStore)
+  vi.spyOn(ws.stateStore, 'close').mockImplementation(async () => {
+    events.push('store')
+    await closeStore()
+  })
+  const removing = ws.unmount('/data')
+  let closing: Promise<void> | undefined
+  try {
+    await started
+    let closed = false
+    closing = ws.close().then(() => {
+      closed = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(closed).toBe(false)
+    expect(events).toEqual([])
+    resume()
+    await closing
+    expect(events).toEqual(['resource', 'store'])
+  } finally {
+    resume()
+    await Promise.allSettled([removing, ...(closing === undefined ? [] : [closing])])
+    await ws.close()
+  }
+})
+
+it('unmount drains an admitted resource open before closing it', async () => {
+  const resource = new RAMResource()
+  const ws = new Workspace({ '/data': resource }, { shellParser: parser })
+  let entered = (): void => undefined
+  let resume = (): void => undefined
+  const started = new Promise<void>((resolve) => {
+    entered = resolve
+  })
+  const release = new Promise<void>((resolve) => {
+    resume = resolve
+  })
+  let closed = false
+  vi.spyOn(resource, 'open').mockImplementation(async () => {
+    entered()
+    await release
+  })
+  vi.spyOn(resource, 'close').mockImplementation(() => {
+    closed = true
+    return Promise.resolve()
+  })
+  const reading = ws.dispatch('read', '/data/file').catch((error: unknown) => error)
+  let removing: Promise<void> | undefined
+  try {
+    await started
+    removing = ws.unmount('/data')
+    await vi.waitFor(() => {
+      expect(ws.registry.tryMountForPrefix('/data')).toBeNull()
+    })
+    expect(closed).toBe(false)
+    resume()
+    await removing
+    expect(closed).toBe(true)
+    expect(await reading).toMatchObject({ code: 'EBUSY' })
+  } finally {
+    resume()
+    await Promise.allSettled([reading, ...(removing === undefined ? [] : [removing])])
+    await ws.close()
+  }
+})

--- a/typescript/packages/core/src/workspace/workspace/lifecycle.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/lifecycle.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { IOResult } from '../../io/types.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
@@ -98,3 +98,82 @@ describe('closeWorkspace', () => {
     release.fire?.()
   })
 })
+
+it.each([
+  { secondary: false, failure: false },
+  { secondary: false, failure: true },
+  { secondary: true, failure: false },
+  { secondary: true, failure: true },
+])(
+  'close settles profile persistence (secondary=$secondary, failure=$failure)',
+  async ({ secondary, failure }) => {
+    const ws = buildWs()
+    await ws.ensureSessionsLoaded()
+    ws.createSession('peer')
+    await ws.flushSessions()
+    const sessionId = secondary ? 'peer' : ws.defaultSessionId
+    const store = ws.stateStore.sessions(ws.workspaceId)
+    const events: string[] = []
+    let enter = (): void => undefined
+    let resume = (): void => undefined
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      resume = resolve
+    })
+    const casSet = store.casSet.bind(store)
+    const closeStore = ws.stateStore.close.bind(ws.stateStore)
+    vi.spyOn(store, 'casSet').mockImplementation(async (...args) => {
+      enter()
+      await release
+      try {
+        expect(events).not.toContain('store-closed')
+        if (failure) throw new Error('store unavailable')
+        return await casSet(...args)
+      } finally {
+        events.push('write-finished')
+      }
+    })
+    vi.spyOn(ws.stateStore, 'close').mockImplementation(async () => {
+      events.push('store-closed')
+      await closeStore()
+    })
+    const updating = ws.setSessionProfile(sessionId, { paths: { hide: ['/data/secret'] } }).then(
+      (value) => value,
+      (error: unknown) => error,
+    )
+    let closing: Promise<void> | undefined
+    let closed = false
+    try {
+      await entered
+      closing = ws.close().then(() => {
+        closed = true
+      })
+      await Promise.resolve()
+      expect(closed).toBe(false)
+      expect(events).toEqual([])
+      await expect(ws.setSessionProfile(sessionId, {})).rejects.toThrow('Workspace is closed')
+      const finished = await Promise.race([
+        closing.then(() => true),
+        new Promise<boolean>((resolve) => {
+          setTimeout(() => {
+            resolve(false)
+          }, 30)
+        }),
+      ])
+      expect(finished).toBe(false)
+      resume()
+      expect(await updating).toEqual(
+        failure ? new Error('store unavailable') : ws.getSession(sessionId),
+      )
+      await closing
+      expect(events).toEqual(['write-finished', 'store-closed'])
+    } finally {
+      resume()
+      await updating
+      await closing
+      await ws.close()
+    }
+  },
+)

--- a/typescript/packages/core/src/workspace/workspace/lifecycle.ts
+++ b/typescript/packages/core/src/workspace/workspace/lifecycle.ts
@@ -67,6 +67,10 @@ export async function closeWorkspace(deps: CloseDeps): Promise<void> {
       // keep tearing down; swallow subsystem-cleanup failures
     }
   }
+  const retirements = await Promise.allSettled([...deps.registry.retiringResources.values()])
+  for (const result of retirements) {
+    if (result.status === 'rejected') throw result.reason as Error
+  }
   const drainTasks = [...(deps.cache.drainTasks?.values() ?? [])]
   for (const task of drainTasks) {
     await task

--- a/typescript/packages/core/src/workspace/workspace/mounts.ts
+++ b/typescript/packages/core/src/workspace/workspace/mounts.ts
@@ -62,9 +62,10 @@ export interface UnmountDeps {
 
 /**
  * Remove one mount, closing its resource if the workspace had opened it
- * and no other mount still references it. The virtual root, the device
- * mount, and the history view are permanent. Mirrors the Python
- * `unmount` in `workspace/mounts.py`.
+ * and no other mount still references it. Operations are shared by kind,
+ * so they remain registered while any mount uses that kind. The virtual
+ * root, the device mount, and the history view are permanent. Mirrors the
+ * Python `unmount` in `workspace/mounts.py`.
  */
 export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<void> {
   const stripped = stripSlash(prefix)
@@ -80,9 +81,11 @@ export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<
   }
   const removed = deps.registry.unmount(prefix)
   const resource = removed.resource
-  const stillMounted = deps.registry.allMounts().some((m) => m.resource === resource)
+  const remaining = deps.registry.allMounts()
+  const stillMounted = remaining.some((m) => m.resource === resource)
+  const kindStillMounted = remaining.some((m) => m.resource.kind === resource.kind)
+  if (!kindStillMounted) deps.opsRegistry.unregisterResource(resource.kind)
   if (!stillMounted) {
-    deps.opsRegistry.unregisterResource(resource.kind)
     const idx = deps.openOrder.indexOf(resource)
     if (idx !== -1) deps.openOrder.splice(idx, 1)
     if (deps.opened.has(resource)) {

--- a/typescript/packages/core/src/workspace/workspace/mounts.ts
+++ b/typescript/packages/core/src/workspace/workspace/mounts.ts
@@ -19,6 +19,10 @@ import type { Limit, MountMode } from '../../types.ts'
 import { stripSlash } from '../../utils/slash.ts'
 import type { MountRegistry } from '../mount/registry.ts'
 import type { MountSpec } from './types.ts'
+import type { MountEntry } from '../mount/mount.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import type { FileCache } from '../../cache/file/mixin.ts'
+import { withCacheMutation } from '../../cache/file/io.ts'
 
 /**
  * The `resources` mapping in resolved form: every accepted spelling
@@ -53,6 +57,36 @@ export function normalizeResources(resources: Record<string, MountSpec>): Normal
   return { bare, modes, commandLimits }
 }
 
+/** Drop mount cache state atomically with deferred file-cache fills. */
+async function clearMountCache(
+  cache: FileCache | null,
+  prefix: string,
+  indices: readonly IndexCacheStore[],
+): Promise<void> {
+  const clearIndices = async (): Promise<void> => {
+    for (const index of new Set(indices)) await index.invalidatePrefix(prefix.slice(0, -1))
+  }
+  if (cache === null) return clearIndices()
+  await withCacheMutation(cache, async () => {
+    await cache.remove(prefix.slice(0, -1))
+    await cache.evictPrefix(prefix)
+    await clearIndices()
+  })
+}
+
+/** Keep synchronous registration; I/O awaits removal of shadowed state. */
+export function prepareAddedMount(
+  registry: MountRegistry,
+  entry: MountEntry,
+  previous: readonly MountEntry[],
+): void {
+  const indices = [
+    entry.resource.index,
+    ...previous.filter((m) => entry.prefix.startsWith(m.prefix)).map((m) => m.resource.index),
+  ].filter((index): index is IndexCacheStore => index !== undefined)
+  entry.beforeUse = () => clearMountCache(registry.fileCache, entry.prefix, indices)
+}
+
 export interface UnmountDeps {
   registry: MountRegistry
   opsRegistry: OpsRegistry
@@ -85,14 +119,11 @@ export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<
   if (entry.retiring) throw new Error(`mount is being unmounted: ${norm}`)
   entry.retiring = true
   try {
-    const cache = deps.registry.fileCache
-    if (cache !== null) {
-      // Retain the mount until cleanup succeeds; retiring prevents new
-      // cache fills while a replacement is waiting for this prefix.
-      await cache.remove(norm.slice(0, -1))
-      await cache.evictPrefix(norm)
-    }
-    await entry.resource.index?.invalidatePrefix(norm.slice(0, -1))
+    await clearMountCache(
+      deps.registry.fileCache,
+      norm,
+      entry.resource.index === undefined ? [] : [entry.resource.index],
+    )
     if (deps.isShuttingDown()) throw new Error('Workspace is closed')
     if (deps.registry.tryMountForPrefix(prefix) !== entry) {
       throw new Error(`mount changed while unmounting: ${prefix}`)
@@ -112,7 +143,12 @@ export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<
     if (idx !== -1) deps.openOrder.splice(idx, 1)
     if (deps.opened.has(resource)) {
       deps.opened.delete(resource)
-      await resource.close()
+      deps.registry.retiringResources.add(resource)
+      try {
+        await resource.close()
+      } finally {
+        deps.registry.retiringResources.delete(resource)
+      }
     }
   }
 }

--- a/typescript/packages/core/src/workspace/workspace/mounts.ts
+++ b/typescript/packages/core/src/workspace/workspace/mounts.ts
@@ -144,16 +144,23 @@ export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<
     }
   }
   if (!stillMounted) {
-    const idx = deps.openOrder.indexOf(resource)
-    if (idx !== -1) deps.openOrder.splice(idx, 1)
-    if (deps.opened.has(resource)) {
-      deps.opened.delete(resource)
-      deps.registry.retiringResources.add(resource)
-      try {
-        await resource.close()
-      } finally {
-        deps.registry.retiringResources.delete(resource)
-      }
+    const closing = closeResource(deps, entry)
+    deps.registry.retiringResources.set(resource, closing)
+    try {
+      await closing
+    } finally {
+      deps.registry.retiringResources.delete(resource)
     }
+  }
+}
+
+async function closeResource(deps: UnmountDeps, entry: MountEntry): Promise<void> {
+  await entry.activity.wait()
+  const resource = entry.resource
+  const idx = deps.openOrder.indexOf(resource)
+  if (idx !== -1) deps.openOrder.splice(idx, 1)
+  if (deps.opened.delete(resource)) {
+    deps.registry.retiredResources.add(resource)
+    await resource.close()
   }
 }

--- a/typescript/packages/core/src/workspace/workspace/mounts.ts
+++ b/typescript/packages/core/src/workspace/workspace/mounts.ts
@@ -137,7 +137,12 @@ export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<
   const remaining = deps.registry.allMounts()
   const stillMounted = remaining.some((m) => m.resource === resource)
   const kindStillMounted = remaining.some((m) => m.resource.kind === resource.kind)
-  if (!kindStillMounted) deps.opsRegistry.unregisterResource(resource.kind)
+  deps.opsRegistry.unregisterResource(kindStillMounted ? resource : resource.kind)
+  for (const survivor of remaining) {
+    if (survivor.resource.kind === resource.kind) {
+      deps.opsRegistry.registerResource(survivor.resource, false)
+    }
+  }
   if (!stillMounted) {
     const idx = deps.openOrder.indexOf(resource)
     if (idx !== -1) deps.openOrder.splice(idx, 1)

--- a/typescript/packages/core/src/workspace/workspace/mounts.ts
+++ b/typescript/packages/core/src/workspace/workspace/mounts.ts
@@ -92,6 +92,7 @@ export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<
       await cache.remove(norm.slice(0, -1))
       await cache.evictPrefix(norm)
     }
+    await entry.resource.index?.invalidatePrefix(norm.slice(0, -1))
     if (deps.isShuttingDown()) throw new Error('Workspace is closed')
     if (deps.registry.tryMountForPrefix(prefix) !== entry) {
       throw new Error(`mount changed while unmounting: ${prefix}`)

--- a/typescript/packages/core/src/workspace/workspace/mounts.ts
+++ b/typescript/packages/core/src/workspace/workspace/mounts.ts
@@ -58,6 +58,7 @@ export interface UnmountDeps {
   opsRegistry: OpsRegistry
   opened: Set<Resource>
   openOrder: Resource[]
+  isShuttingDown: () => boolean
 }
 
 /**
@@ -79,8 +80,28 @@ export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<
   if (norm === HISTORY_PREFIX + '/') {
     throw new Error(`cannot unmount history view: ${HISTORY_PREFIX}`)
   }
-  const removed = deps.registry.unmount(prefix)
-  const resource = removed.resource
+  const entry = deps.registry.tryMountForPrefix(prefix)
+  if (entry === null) throw new Error(`no mount at prefix: ${norm}`)
+  if (entry.retiring) throw new Error(`mount is being unmounted: ${norm}`)
+  entry.retiring = true
+  try {
+    const cache = deps.registry.fileCache
+    if (cache !== null) {
+      // Retain the mount until cleanup succeeds; retiring prevents new
+      // cache fills while a replacement is waiting for this prefix.
+      await cache.remove(norm.slice(0, -1))
+      await cache.evictPrefix(norm)
+    }
+    if (deps.isShuttingDown()) throw new Error('Workspace is closed')
+    if (deps.registry.tryMountForPrefix(prefix) !== entry) {
+      throw new Error(`mount changed while unmounting: ${prefix}`)
+    }
+    deps.registry.unmount(prefix)
+  } catch (error) {
+    entry.retiring = false
+    throw error
+  }
+  const resource = entry.resource
   const remaining = deps.registry.allMounts()
   const stillMounted = remaining.some((m) => m.resource === resource)
   const kindStillMounted = remaining.some((m) => m.resource.kind === resource.kind)

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -356,11 +356,7 @@ export class Workspace {
     this.sessionManager.defaultProfile =
       defaultBase === null ? null : compileProfile(defaultBase, this.profileName(null))
     for (const resource of [...this.registry.allMounts().map((m) => m.resource), this.cache]) {
-      const resourceOps = resource.ops?.()
-      if (resourceOps === undefined) continue
-      for (const op of resourceOps) {
-        this.opsRegistry.register(op)
-      }
+      this.opsRegistry.registerResource(resource)
     }
     for (const mount of this.registry.allMounts()) {
       const cmds = mount.resource.commands?.()
@@ -729,9 +725,7 @@ export class Workspace {
     await this.ensureSessionsLoaded()
     if (this.isShuttingDown()) throw new Error('Workspace is closed')
     if (wasDefault) sessionId = this.defaultSessionId
-    const session = this.sessionManager.setProfile(sessionId, compiled)
-    await this.sessionManager.flush()
-    return session
+    return this.sessionManager.setProfile(sessionId, compiled)
   }
 
   listSessions(): Session[] {
@@ -855,10 +849,6 @@ export class Workspace {
     const m = this.registry.mount(prefix, resource, mode)
     prepareAddedMount(this.registry, m, previous)
     this.opsRegistry.registerResource(resource)
-    const resourceOps = resource.ops?.()
-    if (resourceOps !== undefined) {
-      for (const op of resourceOps) this.opsRegistry.register(op)
-    }
     return m
   }
 
@@ -1015,14 +1005,12 @@ export class Workspace {
     }
     const result = this.registry.resolve(path)
     const [resource] = result
+    await this.registry.mountFor(path).ensureReady()
     await this.ensureOpen(resource)
     return result
   }
 
   private async ensureOpen(resource: Resource): Promise<void> {
-    for (const mount of this.registry.allMounts()) {
-      if (mount.resource === resource) await mount.ensureReady()
-    }
     if (this.opened.has(resource)) return
     await resource.open()
     this.opened.add(resource)

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -48,7 +48,7 @@ import {
 import { readSnapshotTar } from '../snapshot/tar_io.ts'
 import type { WorkspaceStateDict, MountSnapshot } from '../snapshot/types.ts'
 import type { FileEvent } from '../../types.ts'
-import { ConsistencyPolicy, DriftPolicy, MountMode, PathSpec } from '../../types.ts'
+import { ConsistencyPolicy, DriftPolicy, MountMode, PathSpec, parseMountMode } from '../../types.ts'
 import type { Explanation, Policies } from '../../policy/index.ts'
 import type { RoutePolicy } from '../../runtime/routing/index.ts'
 import type { TSNodeLike } from '../../shell/types.ts'
@@ -429,6 +429,7 @@ export class Workspace {
 
   /** Append a runtime entry to the workspace's ordered world (last, first capturer still wins). */
   addRuntime(runtime: RuntimeEntry): Runtime {
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     return this.runtimes.add(runtime)
   }
 
@@ -448,11 +449,13 @@ export class Workspace {
     spec: CLISpec,
     config: Record<string, unknown> | null = null,
   ): CLIInstall {
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     return this.registry.clis.install(name, spec, config)
   }
 
   /** Remove an installed CLI; its head word stops resolving (127). */
   unregisterCli(name: string): void {
+    if (this.shuttingDown) throw new Error('Workspace is closed')
     this.registry.clis.uninstall(name)
   }
 
@@ -704,6 +707,26 @@ export class Workspace {
     return this.sessionManager.get(sessionId)
   }
 
+  /**
+   * Replace a live session's permissions, including its policy runtime.
+   * Compilation succeeds before anything changes. Cwd/env presets apply only
+   * at creation; cwd, variables, functions and history survive this change.
+   * Null selects the workspace default; an empty document clears restrictions.
+   * This is a host-side operation, like creating a session.
+   */
+  async setSessionProfile(
+    sessionId: string,
+    profile: string | SessionProfile | null,
+  ): Promise<Session> {
+    if (this.shuttingDown) throw new Error('Workspace is closed')
+    const compiled = compileProfile(this.baseProfile(profile), this.profileName(profile))
+    checkCliVerbs(compiled.commands, this.cliVerbs())
+    await this.ensureSessionsLoaded()
+    const session = this.sessionManager.setProfile(sessionId, compiled)
+    await this.sessionManager.flush()
+    return session
+  }
+
   listSessions(): Session[] {
     return this.sessionManager.list()
   }
@@ -818,6 +841,13 @@ export class Workspace {
       for (const op of resourceOps) this.opsRegistry.register(op)
     }
     return m
+  }
+
+  /** Change an exact mount's ceiling, retaining its data and every session's cap. */
+  setMountMode(prefix: string, mode: MountMode): void {
+    if (this.shuttingDown) throw new Error('Workspace is closed')
+    const parsed = parseMountMode(mode)
+    this.registry.mountForPrefix(prefix).mode = parsed
   }
 
   /**

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -1336,6 +1336,7 @@ export class Workspace {
   }
 
   private async runClose(): Promise<void> {
+    await this.sessionManager.settle()
     await this.scriptPolicy.close()
     await closeWorkspace({
       watch: this.watchManager,

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -14,6 +14,7 @@
 
 import { checkCliVerbs } from '../session/validate.ts'
 import type { FileCache } from '../../cache/file/mixin.ts'
+import type { IndexConfig } from '../../cache/index/config.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import { IOResult } from '../../io/types.ts'
 import { type EventDict, Observer } from '../../observe/observer.ts'
@@ -112,6 +113,7 @@ export class Workspace {
   private readonly sharedResources = new Set<Resource>()
   private readonly meta: WorkspaceMeta
   private readonly opsRegistry: OpsRegistry
+  private readonly indexConfig: IndexConfig | undefined
   private shellParser: ShellParser | null
   private readonly shellParserFactory: (() => Promise<ShellParser>) | null
   private shellParserPromise: Promise<ShellParser> | null = null
@@ -164,6 +166,7 @@ export class Workspace {
 
   constructor(resources: Record<string, MountSpec>, options: WorkspaceOptions = {}) {
     const normalized = normalizeResources(resources)
+    this.indexConfig = options.index
     this.registry = new MountRegistry(
       normalized.bare,
       options.mode ?? MountMode.READ,
@@ -834,6 +837,15 @@ export class Workspace {
    */
   addMount(prefix: string, resource: Resource, mode: MountMode = MountMode.READ): MountEntry {
     if (this.shuttingDown) throw new Error('Workspace is closed')
+    // Configure before mount() captures the index in its CacheManager.
+    // An alias must retain the index used by the resource's other mounts.
+    if (
+      this.indexConfig !== undefined &&
+      this.registry.tryMountForPrefix(prefix) === null &&
+      !this.registry.allMounts().some((mount) => mount.resource === resource)
+    ) {
+      resource.setIndex?.(this.indexConfig)
+    }
     const m = this.registry.mount(prefix, resource, mode)
     this.opsRegistry.registerResource(resource)
     const resourceOps = resource.ops?.()

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -880,6 +880,7 @@ export class Workspace {
         opsRegistry: this.opsRegistry,
         opened: this.opened,
         openOrder: this.openOrder,
+        isShuttingDown: () => this.isShuttingDown(),
       },
       prefix,
     )

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -93,7 +93,7 @@ import { resolveControlStores } from './build.ts'
 import { executeLine, type ExecuteEnv } from './execute.ts'
 import { closeWorkspace } from './lifecycle.ts'
 import { WorkspaceMeta } from './meta.ts'
-import { normalizeResources, unmountPrefix } from './mounts.ts'
+import { normalizeResources, prepareAddedMount, unmountPrefix } from './mounts.ts'
 import { Router } from './routing.ts'
 import { Runtimes } from './runtimes.ts'
 import type { ExecuteResult } from './types.ts'
@@ -841,6 +841,8 @@ export class Workspace {
    */
   addMount(prefix: string, resource: Resource, mode: MountMode = MountMode.READ): MountEntry {
     if (this.isShuttingDown()) throw new Error('Workspace is closed')
+    this.registry.checkResourceAvailable(resource)
+    const previous = this.registry.allMounts()
     // Configure before mount() captures the index in its CacheManager.
     // An alias must retain the index used by the resource's other mounts.
     if (
@@ -851,6 +853,7 @@ export class Workspace {
       resource.setIndex?.(this.indexConfig)
     }
     const m = this.registry.mount(prefix, resource, mode)
+    prepareAddedMount(this.registry, m, previous)
     this.opsRegistry.registerResource(resource)
     const resourceOps = resource.ops?.()
     if (resourceOps !== undefined) {
@@ -1017,6 +1020,9 @@ export class Workspace {
   }
 
   private async ensureOpen(resource: Resource): Promise<void> {
+    for (const mount of this.registry.allMounts()) {
+      if (mount.resource === resource) await mount.ensureReady()
+    }
     if (this.opened.has(resource)) return
     await resource.open()
     this.opened.add(resource)

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -138,9 +138,10 @@ export class Workspace {
    * runtime can still replay its journal, and that window would otherwise let
    * a caller start a job after `killAll`, or add a mount after the close list
    * was taken. Internal dispatch and recursive execution stay open until
-   * teardown finishes; their public doors do not.
+   * teardown finishes; their public doors do not. A method keeps TypeScript
+   * from treating a pre-await check as proof that the state is still open.
    */
-  private get shuttingDown(): boolean {
+  private isShuttingDown(): boolean {
     return this.closing !== null || this.closed
   }
   private readonly watchManager: WatchManager
@@ -392,7 +393,7 @@ export class Workspace {
     // ledger, which is its own; the sink is only the observer's copy.
     this.fs = new Ops(
       (op, path, args, kwargs, report) => {
-        if (this.shuttingDown) throw new Error('Workspace is closed')
+        if (this.isShuttingDown()) throw new Error('Workspace is closed')
         return this.dispatcher.dispatch(op, path, args, kwargs, report)
       },
       async (rec) => {
@@ -432,7 +433,7 @@ export class Workspace {
 
   /** Append a runtime entry to the workspace's ordered world (last, first capturer still wins). */
   addRuntime(runtime: RuntimeEntry): Runtime {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     return this.runtimes.add(runtime)
   }
 
@@ -452,13 +453,13 @@ export class Workspace {
     spec: CLISpec,
     config: Record<string, unknown> | null = null,
   ): CLIInstall {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     return this.registry.clis.install(name, spec, config)
   }
 
   /** Remove an installed CLI; its head word stops resolving (127). */
   unregisterCli(name: string): void {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     this.registry.clis.uninstall(name)
   }
 
@@ -721,10 +722,13 @@ export class Workspace {
     sessionId: string,
     profile: string | SessionProfile | null,
   ): Promise<Session> {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     const compiled = compileProfile(this.baseProfile(profile), this.profileName(profile))
     checkCliVerbs(compiled.commands, this.cliVerbs())
+    const wasDefault = sessionId === this.defaultSessionId
     await this.ensureSessionsLoaded()
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
+    if (wasDefault) sessionId = this.defaultSessionId
     const session = this.sessionManager.setProfile(sessionId, compiled)
     await this.sessionManager.flush()
     return session
@@ -813,7 +817,7 @@ export class Workspace {
   }
 
   attachWatchRuntime(runtime: WatchRuntime): void {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     this.watchManager.attach(runtime)
   }
 
@@ -822,12 +826,12 @@ export class Workspace {
   }
 
   watch(path: string | PathSpec | readonly (string | PathSpec)[]): AsyncIterable<FileEvent> {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     return this.watchManager.watch(path)
   }
 
   async notify(change: FileEvent): Promise<void> {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     await this.watchManager.notify(change)
   }
 
@@ -836,7 +840,7 @@ export class Workspace {
    * on this workspace's OpsRegistry so dispatch can find them.
    */
   addMount(prefix: string, resource: Resource, mode: MountMode = MountMode.READ): MountEntry {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     // Configure before mount() captures the index in its CacheManager.
     // An alias must retain the index used by the resource's other mounts.
     if (
@@ -857,7 +861,7 @@ export class Workspace {
 
   /** Change an exact mount's ceiling, retaining its data and every session's cap. */
   setMountMode(prefix: string, mode: MountMode): void {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     const parsed = parseMountMode(mode)
     this.registry.mountForPrefix(prefix).mode = parsed
   }
@@ -869,7 +873,7 @@ export class Workspace {
    * In-flight ops that already resolved their Mount are not interrupted.
    */
   async unmount(prefix: string): Promise<void> {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     await unmountPrefix(
       {
         registry: this.registry,
@@ -970,7 +974,7 @@ export class Workspace {
     args: readonly unknown[] = [],
     kwargs: OpKwargs = {},
   ): Promise<unknown> {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     return this.dispatchInternal(opName, path, args, kwargs)
   }
 
@@ -997,7 +1001,7 @@ export class Workspace {
   }
 
   async resolve(path: string): Promise<[Resource, PathSpec, MountMode]> {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     return this.resolveInternal(path)
   }
 
@@ -1168,7 +1172,7 @@ export class Workspace {
     // teardown then never stops, and resources would close under it. The
     // internal dispatch path stays open, which is what the journal replay
     // uses.
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     return this.executeInternal(command, options)
   }
 
@@ -1197,7 +1201,7 @@ export class Workspace {
    * runtime throws.
    */
   async executePythonRepl(code: string, options: { sessionId?: string } = {}): Promise<EvalResult> {
-    if (this.shuttingDown) throw new Error('Workspace is closed')
+    if (this.isShuttingDown()) throw new Error('Workspace is closed')
     const sessionId = options.sessionId ?? this.sessionManager.defaultId
     const bound = this.runtimes.bindings.python3
     if (bound === undefined || !isEvaluator(bound)) {

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -863,7 +863,8 @@ export class Workspace {
    * Remove a mount by prefix. Closes the resource if the workspace had opened
    * it and no other mount still references it. Drops cache entries under the
    * unmounted prefix. Forbidden prefixes: cache root, history view, /dev/.
-   * In-flight ops that already resolved their Mount are not interrupted.
+   * Waits for admitted calls and returned streams before closing the resource.
+   * Callers must consume or close streams; closed instances cannot be remounted.
    */
   async unmount(prefix: string): Promise<void> {
     if (this.isShuttingDown()) throw new Error('Workspace is closed')
@@ -1012,9 +1013,13 @@ export class Workspace {
 
   private async ensureOpen(resource: Resource): Promise<void> {
     if (this.opened.has(resource)) return
-    await resource.open()
-    this.opened.add(resource)
-    this.openOrder.push(resource)
+    const mount = this.registry.allMounts().find((m) => m.resource === resource && !m.retiring)
+    if (mount === undefined) throw new Error('resource is no longer mounted')
+    await mount.use(async () => {
+      await resource.open()
+      this.opened.add(resource)
+      this.openOrder.push(resource)
+    })
   }
 
   /**

--- a/typescript/packages/dsh/src/approval.test.ts
+++ b/typescript/packages/dsh/src/approval.test.ts
@@ -172,24 +172,22 @@ describe('an asked line with an approval channel', () => {
     expect(asked[0]?.reason).toBe('deletes are reviewed: rm /data/notes.txt')
   })
 
-  it('does not re-prompt the retry of a line just refused, then asks afresh', async () => {
+  it('spends an inline refusal on that line and asks again on each retry', async () => {
     const { shell, asked } = await world(ASK_RM, 'rejected')
     const first = await shell.run(shell.resolve({ command: 'rm /data/notes.txt' }))
     expect(first.exitCode).toBe(126)
     expect(asked).toHaveLength(1)
-    // The refusal was recorded, and a ONCE answer covers the exact line it
-    // was given for: the retry is refused from that record rather than
-    // putting the same question to the human again.
+    // The inline ONCE answer was spent by the line that asked for it.
+    // Each subsequent invocation needs its own answer, even for the same line.
     const retry = await shell.run(shell.resolve({ command: 'rm /data/notes.txt' }))
     expect(retry.exitCode).toBe(126)
-    expect(asked).toHaveLength(1)
-    // Having answered that retry, the ONCE record is spent, so the line is
-    // an open question once more rather than refused forever.
+    expect(asked).toHaveLength(2)
     const third = await shell.run(shell.resolve({ command: 'rm /data/notes.txt' }))
     expect(third.exitCode).toBe(126)
-    expect(asked).toHaveLength(2)
-    // Both questions were the same line, so both quote one identity.
+    expect(asked).toHaveLength(3)
+    // All questions were the same line, so they quote one identity.
     expect(asked[0]?.callId).toBe(asked[1]?.callId)
+    expect(asked[1]?.callId).toBe(asked[2]?.callId)
   })
 
   it('grants once and never for the session, so the next line asks again', async () => {


### PR DESCRIPTION
Removing a RAM mount could unregister operations for the entire resource kind, leaving the surviving root mount unable to list `/`. Bind operations to the resource instance being accessed and retain kind-level registrations while mounts of that kind survive, and give Python the matching dynamic mount API without replacing its filesystem facade. Newly added mounts inherit the workspace index configuration in both implementations before cache managers attach; aliases retain their shared resource index.

This also adds matching host APIs for changing mount modes, replacing a live session's permission profile, and removing policies. Session closure and profile changes use the same per-session persistence lock, preventing a delayed write from recreating a revoked named session. Profile replacement persists a candidate before publishing its permissions or changing the default fallback; store failures leave the old restrictions active. Shutdown waits for admitted session writes before closing the state store, including writes for named sessions and writes that fail. It preserves cwd, variables, functions and history, including changes made while persistence is pending. Policy hook discovery keys its cache by runtime as well as source and language, so switching an already-probed script to an invalid engine fails closed. Policy removal preserves the order of an admission already in progress. Python rejects lifecycle mutations from the start of shutdown while still allowing runtime journals to drain before resources close. Profile changes in both languages retarget a provisional default session ID after hydration and recheck shutdown before mutating or persisting permissions.

Unmounting now retires a mount before evicting its root and descendant file-cache keys and metadata index subtree, and keeps the prefix reserved until cleanup succeeds. Deferred command results and streaming cache fills remain bound to the original owner of each path, so neither a replacement backend nor an ancestor revealed by unmount can receive the retired backend's cached bytes. File-cache or index eviction failure leaves the original mount attached for retry. New mounts prepare their cache state before the first backend/cache read, clearing any shadowed ancestor data while keeping registration synchronous. Cache fills and mount eviction share a lock, including the awaited store write. Warm reads also verify the current path owner so a running ancestor command cannot consume a new child mount's cache. New calls on a retiring mount fail before reaching its backend, while surviving aliases remain usable. Resource identities remain reserved during asynchronous close, even when the Python unmount caller is cancelled. Shared activity tracking keeps resources open until admitted calls and lazy streams finish, including work through removed aliases. Workspace shutdown awaits outstanding resource retirements before closing stores. Closed instances cannot be mounted again; callers create a new resource instance for a new lifecycle. Backend metadata access uses a mount-owned index view: writes and lookups that flush queued snapshots share the eviction lock and check current ownership, preventing an in-flight backend call from repopulating a retired or shadowed mount's index. Internal presence probes and remnant walks use the same view. All workspace backend glob hooks use one mount-owned path that prepares the mount, retains the resource, and fences raw index access against eviction. This includes metadata builtins and TypeScript command resolution as well as ordinary and midpath expansion. Provision-only calls and snapshot/copy capture also await dynamic mount preparation before reading state. Snapshot capture rejects a mount table that changes while state is being collected. Read records carry the serving mount instance identity through eager and lazy operations, so snapshot fingerprints and revision pins cannot be attributed to a replacement resource; observational history is retained. Internal mount IDs are omitted from serialized command and FUSE operation records, preserving the public record shape. Pending drift checks installed during restore carry the same ownership and become obsolete when that mount is shadowed or replaced, including a replacement while the check awaits metadata.

The shared JSON lifecycle suite covers mount/unmount/remount, CLI registration and runtime switches, coded and scripted policy changes, READ/WRITE/EXEC transitions, hide/unhide patterns, session isolation, cache-enabled backend replacement, metadata globs after mounting and unmounting a child, and lifecycle refusals. Both integration CI jobs run it. Browser coverage uses the browser workspace wrapper under Node.

Search-backed find probes now reconstruct the virtual path from the mount prefix and the walked resource key in the shared Python/TypeScript helper. This preserves type, size and empty predicates on non-root mounts without backend-specific exceptions. Patch-generated file paths and `-i` reads retain their virtual mount prefix too, fixing the shared Dropbox, Box and Google Drive integration failures. TypeScript provisioning now retains full virtual paths through glob expansion and recursive walks, matching Python, and forwards the index to stat fallbacks.

The CI corrections align the decision ledger's tuple annotation with its callers, apply the required Python formatting, and update the dsh retry test to the existing rule that an inline ONCE answer is consumed by the command that asked for it.

Validation:

- Full Python suite: **17,993 passed, 521 skipped, 1 xfailed** (`uv run pytest -n 8 --dist worksteal`). The pinned optional 1Password SDK was supplied from a temporary directory for collection.
- **735 lifecycle integration steps** pass across Python, Node and the browser wrapper.
- All **10,860 core TypeScript tests** and **193 dsh tests** pass against this checkout's source.
- Regression tests cover shutdown races, runtime journal draining, index TTL/backend inheritance, alias preservation, duplicate mount attempts, cache eviction failure, delayed command completion, retired stream fills, sibling cache preservation, shared Redis index cleanup, shadowed ancestor state, delayed file and index store writes, queued index snapshots, resource reuse during and after close, admitted calls and streams across initial and dynamic aliases, shutdown during pending retirement, removal revealing an ancestor, serialized record field parity, session closure during profile persistence, persisted default-session adoption and shutdown during session hydration, first-access globs and provisioning, cancellation during resource close, resource-specific decorated operations, and failed profile-store writes and shutdown while persistence is pending, immediate snapshot/copy after shadowing, and retired read fingerprints including delayed records and lazy operation streams, and restored drift checks after shadowing or replacing a mount.
- `pre-commit run --all-files` passes, including mypy and integration mock-server typechecking with generated Prisma clients.
- Real Redis lifecycle regressions pass in both Python and TypeScript. The Dify integration battery passes all 76 cases, including the three previously failing find predicates.
- The shared cloud storage batteries pass **12,251 cases in each language** across Dropbox, Dropbox root, Box, Google Drive and Google Drive folder targets.
- Core TypeScript typechecking and strict layout parity pass.
