### PR TITLE
fix: evict stale cache entries when unmounting

### DIFF
--- a/python/mirage/cache/manager.py
+++ b/python/mirage/cache/manager.py
@@ -180,7 +180,7 @@ class CacheManager:
             await self._evict_dir(parent or "/")
 
     async def drop_prefix(self) -> None:
-        """Drop every cached body under this mount, path unspecified.
+        """Drop the mount key and every cached body beneath it.
 
         For a mutation that names no path: an account CLI writes to its
         service by id, so nothing here can say which file changed, only
@@ -194,6 +194,7 @@ class CacheManager:
         """
         if not self._caches_reads or self._file_cache is None:
             return
+        await self._file_cache.remove(self._prefix or "/")
         await self._file_cache.evict_prefix(self._prefix + "/")
 
     async def _invalidate_parent(self, key: str) -> None:

--- a/python/mirage/workspace/workspace/mounts.py
+++ b/python/mirage/workspace/workspace/mounts.py
@@ -137,7 +137,7 @@ def install_mounts(registry: MountRegistry, specs: list[MountSpec],
 
 
 async def unmount(registry: MountRegistry, ops: Ops, prefix: str) -> None:
-    """Remove one mount, closing its resource if nothing else uses it.
+    """Remove one mount, its cached scope, and any unshared resource.
 
     The virtual root, the device mount, and the history view are
     permanent. The resource is closed only when no remaining mount
@@ -160,6 +160,12 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str) -> None:
         raise ValueError("cannot unmount reserved prefix: '/dev/'")
     if norm == HISTORY_PREFIX + "/":
         raise ValueError(f"cannot unmount history view: {HISTORY_PREFIX!r}")
+    removed = registry.try_mount_for_prefix(prefix)
+    if removed is None:
+        registry.unmount(prefix)
+        return
+    if removed.cache_manager is not None:
+        await removed.cache_manager.drop_prefix()
     removed = registry.unmount(prefix)
     ops.unmount(prefix)
     remaining = registry.mounts()

--- a/python/tests/cache/test_manager.py
+++ b/python/tests/cache/test_manager.py
@@ -157,20 +157,23 @@ def test_null_index_is_tolerated():
     assert _run(_no_index_case()) is False
 
 
-async def _drop_prefix_case() -> tuple[bool, bool, bool]:
+async def _drop_prefix_case() -> tuple[bool, bool, bool, bool]:
     cache, index = _stores()
     await _seed(cache, index)
+    await cache.set("/data", b"exact\n")
     await cache.set("/other/keep.txt", b"safe\n")
     manager = CacheManager(cache, index, "/data/", True)
     await manager.drop_prefix()
-    return (await cache.exists("/data/arch/h.txt"), await
+    return (await cache.exists("/data"), await
+            cache.exists("/data/arch/h.txt"), await
             cache.exists("/other/keep.txt"), manager._caches_reads)
 
 
 def test_drop_prefix_evicts_this_mount_only():
     """A path-unknown mutation drops the mount's bodies without reaching
     into a neighbouring mount's keyspace."""
-    dropped, kept, _ = _run(_drop_prefix_case())
+    exact, dropped, kept, _ = _run(_drop_prefix_case())
+    assert exact is False
     assert dropped is False
     assert kept is True
 

--- a/python/tests/workspace/test_workspace.py
+++ b/python/tests/workspace/test_workspace.py
@@ -2708,6 +2708,78 @@ def test_unmount_closes_resource_when_owned():
     assert closed == ["yes"]
 
 
+def test_unmount_evicts_cached_mount_scope_only():
+    """Removed ownership cannot leak cached bytes into fallback routing."""
+    root = RAMResource()
+    root.caches_reads = True
+    removed = RAMResource()
+    removed.caches_reads = True
+    nested = RAMResource()
+    nested.caches_reads = True
+    root._store.files["/m/x"] = b"root\n"
+    root._store.files["/more/x"] = b"sibling\n"
+    removed._store.files["/x"] = b"child-secret\n"
+    nested._store.files["/y"] = b"nested\n"
+    ws = Workspace({
+        "/": (root, MountMode.WRITE),
+        "/m": (removed, MountMode.WRITE),
+        "/m/n": (nested, MountMode.WRITE),
+    })
+
+    assert _stdout(_exec(ws, "cat /m/x")) == b"child-secret\n"
+    assert _stdout(_exec(ws, "cat /more/x")) == b"sibling\n"
+    assert _stdout(_exec(ws, "cat /m/n/y")) == b"nested\n"
+    asyncio.run(ws.cache.set("/m", b"exact-stale"))
+
+    asyncio.run(ws.unmount("/m"))
+
+    assert asyncio.run(ws.cache.get("/m")) is None
+    assert asyncio.run(ws.cache.get("/m/x")) is None
+    assert asyncio.run(ws.cache.get("/m/n/y")) is None
+    assert asyncio.run(ws.cache.get("/more/x")) == b"sibling\n"
+    assert _stdout(_exec(ws, "cat /m/x")) == b"root\n"
+    assert _stdout(_exec(ws, "cat /m/n/y")) == b"nested\n"
+
+
+def test_unmount_shared_resource_keeps_other_owner_open():
+    """Removing one route does not close a resource another route owns."""
+    closed = []
+
+    class SharedRAM(RAMResource):
+        caches_reads = True
+
+        async def close(self):
+            closed.append("yes")
+
+    shared = SharedRAM()
+    ws = Workspace({
+        "/m": (shared, MountMode.WRITE),
+        "/other": (shared, MountMode.WRITE),
+    })
+    asyncio.run(ws.unmount("/m"))
+
+    assert closed == []
+    assert ws.mount("/other/x").resource is shared
+
+
+def test_unmount_cache_failure_keeps_mount_attached(monkeypatch):
+    """A failed eviction leaves routing intact so unmount can be retried."""
+    resource = RAMResource()
+    resource.caches_reads = True
+    ws = Workspace({"/m": resource})
+    mount = ws.mount("/m")
+    assert mount.cache_manager is not None
+
+    async def fail():
+        raise RuntimeError("cache unavailable")
+
+    monkeypatch.setattr(mount.cache_manager, "drop_prefix", fail)
+    with pytest.raises(RuntimeError, match="cache unavailable"):
+        asyncio.run(ws.unmount("/m"))
+
+    assert ws.mount("/m/x") is mount
+
+
 def test_unmount_rejects_reserved_prefixes():
     """unmount of virtual root / history view / dev / unknown prefix raises."""
     ws = _ws()

--- a/typescript/packages/core/src/cache/manager.test.ts
+++ b/typescript/packages/core/src/cache/manager.test.ts
@@ -105,9 +105,11 @@ describe('CacheManager', () => {
 
   it("drops this mount's bodies without touching a neighbour", async () => {
     const [cache, index] = await seeded()
+    await cache.set('/data', new TextEncoder().encode('exact'))
     await cache.set('/other/keep.txt', new TextEncoder().encode('safe'))
     const manager = new CacheManager(cache, index, '/data/', true)
     await manager.dropPrefix()
+    expect(await cache.exists('/data')).toBe(false)
     expect(await cache.exists('/data/arch/h.txt')).toBe(false)
     expect(await cache.exists('/other/keep.txt')).toBe(true)
   })

--- a/typescript/packages/core/src/cache/manager.ts
+++ b/typescript/packages/core/src/cache/manager.ts
@@ -169,7 +169,7 @@ export class CacheManager {
   }
 
   /**
-   * Drop every cached body under this mount, path unspecified.
+   * Drop the mount key and every cached body beneath it.
    *
    * For a mutation that names no path: an account CLI writes to its service by
    * id, so nothing here can say which file changed, only that this mount's
@@ -183,6 +183,7 @@ export class CacheManager {
    */
   async dropPrefix(): Promise<void> {
     if (!this.cachesReads || this.fileCache === null) return
+    await this.fileCache.remove(this.prefix === '' ? '/' : this.prefix)
     await this.fileCache.evictPrefix(this.prefix + '/')
   }
 

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -39,6 +39,10 @@ class MockResource extends BaseResource implements Resource {
   }
 }
 
+class CachingRAMResource extends RAMResource {
+  override readonly cachesReads = true
+}
+
 describe('Workspace lifecycle', () => {
   it('does not open resources at construction time', () => {
     const ram = new MockResource()
@@ -209,6 +213,70 @@ describe('Workspace.unmount', () => {
     const ws = new Workspace({ '/x': r })
     await ws.unmount('/x')
     expect(r.closes).toBe(0)
+    await ws.close()
+  })
+
+  it('evicts the removed cache scope without touching a slash-adjacent sibling', async () => {
+    const enc = new TextEncoder()
+    const parser = await getTestParser()
+    const ops = new OpsRegistry()
+    const root = new CachingRAMResource()
+    const removed = new CachingRAMResource()
+    const nested = new CachingRAMResource()
+    for (const resource of [root, removed, nested]) ops.registerResource(resource)
+    root.store.files.set('/m/x', enc.encode('root\n'))
+    root.store.files.set('/more/x', enc.encode('sibling\n'))
+    removed.store.files.set('/x', enc.encode('child-secret\n'))
+    nested.store.files.set('/y', enc.encode('nested\n'))
+    const ws = new Workspace(
+      { '/': root, '/m': removed, '/m/n': nested },
+      { mode: MountMode.WRITE, ops, shellParser: parser },
+    )
+
+    expect((await ws.execute('cat /m/x')).stdoutText).toBe('child-secret\n')
+    expect((await ws.execute('cat /more/x')).stdoutText).toBe('sibling\n')
+    expect((await ws.execute('cat /m/n/y')).stdoutText).toBe('nested\n')
+    await ws.cache.set('/m', enc.encode('exact-stale'))
+
+    await ws.unmount('/m')
+
+    expect(await ws.cache.get('/m')).toBeNull()
+    expect(await ws.cache.get('/m/x')).toBeNull()
+    expect(await ws.cache.get('/m/n/y')).toBeNull()
+    expect(await ws.cache.get('/more/x')).toEqual(enc.encode('sibling\n'))
+    expect((await ws.execute('cat /m/x')).stdoutText).toBe('root\n')
+    expect((await ws.execute('cat /m/n/y')).stdoutText).toBe('nested\n')
+    await ws.close()
+  })
+
+  it('keeps a shared resource open while another mount owns it', async () => {
+    class SharedRAM extends CachingRAMResource {
+      closes = 0
+      override close(): Promise<void> {
+        this.closes++
+        return Promise.resolve()
+      }
+    }
+    const shared = new SharedRAM()
+    const ws = new Workspace({ '/m': shared, '/other': shared })
+    await ws.resolve('/m/x')
+
+    await ws.unmount('/m')
+
+    expect(shared.closes).toBe(0)
+    expect(ws.registry.mountFor('/other/x').resource).toBe(shared)
+    await ws.close()
+  })
+
+  it('keeps the mount attached when cache eviction fails', async () => {
+    const ws = new Workspace({ '/m': new CachingRAMResource() })
+    const mount = ws.registry.mountForPrefix('/m')
+    if (mount.cacheManager === null) throw new Error('missing cache manager')
+    mount.cacheManager.dropPrefix = () => Promise.reject(new Error('cache unavailable'))
+
+    await expect(ws.unmount('/m')).rejects.toThrow('cache unavailable')
+
+    expect(ws.registry.mountFor('/m/x')).toBe(mount)
     await ws.close()
   })
 

--- a/typescript/packages/core/src/workspace/workspace/mounts.ts
+++ b/typescript/packages/core/src/workspace/workspace/mounts.ts
@@ -61,10 +61,10 @@ export interface UnmountDeps {
 }
 
 /**
- * Remove one mount, closing its resource if the workspace had opened it
- * and no other mount still references it. The virtual root, the device
- * mount, and the history view are permanent. Mirrors the Python
- * `unmount` in `workspace/mounts.py`.
+ * Remove one mount and its cached scope, closing its resource if the
+ * workspace had opened it and no other mount still references it. The
+ * virtual root, the device mount, and the history view are permanent.
+ * Mirrors the Python `unmount` in `workspace/mounts.py`.
  */
 export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<void> {
   const stripped = stripSlash(prefix)
@@ -78,6 +78,12 @@ export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<
   if (norm === HISTORY_PREFIX + '/') {
     throw new Error(`cannot unmount history view: ${HISTORY_PREFIX}`)
   }
+  const mounted = deps.registry.tryMountForPrefix(prefix)
+  if (mounted === null) {
+    deps.registry.unmount(prefix)
+    return
+  }
+  await mounted.cacheManager?.dropPrefix()
   const removed = deps.registry.unmount(prefix)
   const resource = removed.resource
   const stillMounted = deps.registry.allMounts().some((m) => m.resource === resource)


### PR DESCRIPTION
## Summary

- evict the exact mount cache key and its slash-delimited descendants before detaching the mount
- preserve slash-adjacent cache entries while keeping nested mounts routable and shared resources open
- leave the mount attached when cache eviction fails, so unmount can be retried

## Before / after

Before, reading `/m/x` through a caching mount could leave `child-secret` in the workspace file cache. After unmounting `/m`, the same path fell through to the root resource but still returned the removed mount's cached bytes.

After, unmount evicts `/m` and `/m/*` before changing routing. A later `/m/x` read reaches the current owner, `/more/*` remains cached, and a surviving nested mount refills through its own route.

## Verification

- Python focused cache-manager and unmount tests: 10 passed
- TypeScript focused cache-manager and unmount tests: 10 passed
- TypeScript strict typecheck: passed
- targeted formatting, Ruff, Prettier, ESLint, and Knip: passed
- structured local review: no actionable findings

## Current base blockers

- Python and pre-commit mypy report the existing `python/mirage/policy/decisions.py:344` mismatch: `Sequence[str]` is passed where `tuple[str, ...]` is required.
- The TypeScript full suite reports an unrelated failure at `typescript/packages/dsh/src/approval.test.ts:185`, where the retry records two prompts instead of one.
- The full-tree pre-commit run also reports that YAPF would modify an unrelated file; all Python files changed here pass the targeted YAPF hook.

This branch deliberately does not modify or bypass those checks. It should be rebased after the separate maintainer fixes land.

## Scope

Concurrent operations that resolved the old mount before eviction can still fill the cache late. Preventing that race requires generation or cancellation coordination and is intentionally separate from this focused route-removal fix. Direct-op rename and rmdir invalidation are unchanged.
