### PR TITLE
Retain resource state reads during unmount

### DIFF
--- a/python/mirage/cache/manager.py
+++ b/python/mirage/cache/manager.py
@@ -68,6 +68,12 @@ class CacheManager:
         async with mutation_lock(self._file_cache):
             yield
 
+    async def clear_index(self, index: IndexCacheStore) -> None:
+        """Clear the whole backend index while this mount still owns it."""
+        async with self.mutation():
+            if self._owns_path(self._prefix or "/"):
+                await index.clear()
+
     def scope_index(self, index: IndexCacheStore) -> IndexCacheStore:
         """Bind backend metadata writes to this mount's lifetime."""
         if self._file_cache is None or isinstance(index, IndexView):

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -920,7 +920,11 @@ class Dispatcher:
         if self._cache is not None:
             await self._cache.clear()
         for mount in self._namespace.registry.mounts():
-            await mount.resource.index.clear()
+            if mount.cache_manager is not None:
+                await mount.cache_manager.clear_index(mount.resource.index)
+            else:
+                async with mount.use():
+                    await mount.resource.index.clear()
 
     async def invalidate_after_write(self,
                                      mount: MountEntry,

--- a/python/mirage/workspace/executor/builtins/df/df.py
+++ b/python/mirage/workspace/executor/builtins/df/df.py
@@ -343,7 +343,8 @@ async def handle_df(
 
     data: list[list[str]] = []
     for mount in mounts:
-        cap = await mount.resource.statfs()
+        async with mount.use():
+            cap = await mount.resource.statfs()
         cells = [mount.resource.name]
         if show_type:
             cells.append(mount.resource.name)

--- a/python/mirage/workspace/executor/command/run.py
+++ b/python/mirage/workspace/executor/command/run.py
@@ -296,7 +296,7 @@ async def drop_service_caches(registry: MountRegistry,
         # listing (github seeds the whole tree once) cannot tell the drop
         # from an empty repository and reports the mount as gone. Expiring
         # keeps that distinction and the next read refetches.
-        await mount.resource.index.invalidate()
+        await mount.index.invalidate()
         if mount.cache_manager is not None:
             await mount.cache_manager.drop_prefix()
 

--- a/python/mirage/workspace/snapshot/state.py
+++ b/python/mirage/workspace/snapshot/state.py
@@ -149,6 +149,8 @@ async def to_state_dict(ws) -> dict[str, Any]:
     mounts_state = []
     for idx, m in enumerate(mt for mt in mounted
                             if mt.prefix not in auto_prefixes):
+        async with m.use():
+            resource_state = m.resource.get_state()
         mounts_state.append({
             MountKey.INDEX: idx,
             MountKey.PREFIX: m.prefix,
@@ -157,7 +159,7 @@ async def to_state_dict(ws) -> dict[str, Any]:
             MountKey.RESOURCE_CLASS:
             f"{type(m.resource).__module__}.{type(m.resource).__name__}",
             MountKey.RESOURCE_REF: m.resource.resource_ref,
-            MountKey.RESOURCE_STATE: m.resource.get_state(),
+            MountKey.RESOURCE_STATE: resource_state,
         })
 
     cache = ws._cache

--- a/python/mirage/workspace/workspace/mounts.py
+++ b/python/mirage/workspace/workspace/mounts.py
@@ -172,7 +172,8 @@ def prepare_added_mount(registry: MountRegistry, entry: MountEntry,
 
 
 async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
-                  is_shutting_down: Callable[[], bool]) -> None:
+                  is_shutting_down: Callable[[], bool],
+                  shared_resources: set[int]) -> None:
     """Remove one mount, closing its resource if nothing else uses it.
 
     The virtual root, the device mount, and the history view are
@@ -187,6 +188,7 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
         ops (Ops): the ops facade to detach the prefix from.
         prefix (str): the mount's virtual prefix.
         is_shutting_down: live admission check after asynchronous cleanup.
+        shared_resources: instances owned by another workspace.
 
     Raises:
         ValueError: the prefix names a permanent mount.
@@ -221,7 +223,7 @@ async def unmount(registry: MountRegistry, ops: Ops, prefix: str,
     still_instance = any(m.resource is removed.resource for m in remaining)
     # The mount owns its op table, so dropping the mount drops the ops
     # with it; the facade keeps no second registry to clean up.
-    if not still_instance:
+    if not still_instance and id(removed.resource) not in shared_resources:
         identity = id(removed.resource)
         registry.retired_resources[identity] = removed.resource
         closing = asyncio.create_task(_close_resource(removed))

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -518,7 +518,8 @@ class Workspace:
         if self._shutting_down:
             raise RuntimeError("Workspace is closed")
         await unmount_prefix(self._registry, self._ops, prefix,
-                             lambda: self._shutting_down)
+                             lambda: self._shutting_down,
+                             self._shared_resources)
 
     def set_mount_mode(self, prefix: str, mode: MountMode) -> None:
         """Change an exact mount's ceiling, retaining data and session caps.

--- a/python/tests/workspace/workspace/test_lifecycle.py
+++ b/python/tests/workspace/workspace/test_lifecycle.py
@@ -31,10 +31,13 @@ from mirage.resource.ram import RAMResource
 from mirage.runtime.base import Runtime
 from mirage.shell.console import Channel
 from mirage.shell.job_table import JobStatus
-from mirage.types import MountMode, PathSpec
+from mirage.types import (CapacityResult, CapacityState, MountMode, PathSpec,
+                          ResourceName)
 from mirage.utils.key_prefix import mount_key
 from mirage.workspace import Workspace
 from mirage.workspace.executor.builtins.shared import expand_operands
+from mirage.workspace.executor.command.run import drop_service_caches
+from mirage.workspace.snapshot import to_state_dict
 from mirage.workspace.types import ExecutionNode
 
 _RELEASE: list[asyncio.Event] = []
@@ -637,8 +640,10 @@ async def test_close_settles_pending_profile_persistence(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("surface", ["op", "command"])
-@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("surface,streaming", [("op", False), ("op", True),
+                                               ("command", False),
+                                               ("command", True),
+                                               ("df", False)])
 @pytest.mark.parametrize("alias", [None, "initial", "dynamic"])
 async def test_unmount_waits_for_admitted_resource_use(monkeypatch, surface,
                                                        streaming, alias):
@@ -668,6 +673,13 @@ async def test_unmount_waits_for_admitted_resource_use(monkeypatch, surface,
     async def command(accessor, paths, texts, opts):
         return await read_body(), IOResult()
 
+    async def statfs():
+        entered.set()
+        await release.wait()
+        assert not closed
+        return CapacityResult(state=CapacityState.UNKNOWN)
+
+    monkeypatch.setattr(resource, "statfs", statfs)
     resource.register_op(read)
     resources = {"/data": resource}
     if alias == "initial":
@@ -691,6 +703,10 @@ async def test_unmount_waits_for_admitted_resource_use(monkeypatch, surface,
     monkeypatch.setattr(resource, "close", close)
 
     async def consume():
+        if surface == "df":
+            result = await ws.execute("df /data")
+            assert result.exit_code == 0
+            return b"value"
         if surface == "command":
             return (await ws.execute("readvalue /data/file")).stdout
         value, _ = await ws.dispatch("read",
@@ -823,4 +839,71 @@ async def test_unmount_drains_metadata_glob_and_its_index_writes(monkeypatch):
         await asyncio.gather(expanding,
                              *([] if removing is None else [removing]),
                              return_exceptions=True)
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["service", "clear"])
+async def test_unmount_drains_service_index_invalidation(monkeypatch, kind):
+    resource = RAMResource()
+    ws = Workspace({"/data": resource})
+    entered, release = asyncio.Event(), asyncio.Event()
+    index = resource.index
+    method = "invalidate" if kind == "service" else "clear"
+    invalidate = getattr(index, method)
+    await index.put("/outside-scope",
+                    IndexEntry(id="stale", name="stale", resource_type="ram"))
+
+    async def delayed_invalidate():
+        entered.set()
+        await release.wait()
+        assert not resource.is_closed
+        await invalidate()
+
+    monkeypatch.setattr(index, method, delayed_invalidate)
+    manager = ws.mount("/data").cache_manager
+    assert manager is not None
+    updating = asyncio.create_task(
+        drop_service_caches(ws._registry, (ResourceName.RAM, )) if kind ==
+        "service" else manager.clear_index(index))
+    removing = None
+    try:
+        await asyncio.wait_for(entered.wait(), 5)
+        removing = asyncio.create_task(ws.unmount("/data"))
+        await asyncio.sleep(0.02)
+        assert not removing.done()
+        assert not resource.is_closed
+        release.set()
+        await updating
+        await removing
+        assert resource.is_closed
+        if kind == "clear":
+            assert (await index.get("/outside-scope")).entry is None
+    finally:
+        release.set()
+        await asyncio.gather(updating,
+                             *([] if removing is None else [removing]),
+                             return_exceptions=True)
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("used", [False, True])
+async def test_unmount_leaves_borrowed_resources_open(used):
+    resource = RAMResource()
+    resource.load_state({"files": {"/file": b"seed"}})
+    ws = Workspace({"/data": resource})
+    state = await to_state_dict(ws)
+    replica = await Workspace.from_state(state, resources={"/data": resource})
+    try:
+        if used:
+            assert (await replica.execute("cat /data/file")).stdout == b"seed"
+        await replica.unmount("/data")
+        assert not resource.is_closed
+        await replica.close()
+        assert not resource.is_closed
+        await ws.close()
+        assert resource.is_closed
+    finally:
+        await replica.close()
         await ws.close()

--- a/typescript/packages/core/src/cache/manager.ts
+++ b/typescript/packages/core/src/cache/manager.ts
@@ -57,6 +57,13 @@ export class CacheManager {
     return this.fileCache === null ? call() : withCacheMutation(this.fileCache, call)
   }
 
+  /** Clear the whole backend index while this mount still owns it. */
+  clearIndex(index: IndexCacheStore | undefined): Promise<void> {
+    return this.withMutation(async () => {
+      if (this.ownsPath(this.prefix || '/')) await index?.clear()
+    })
+  }
+
   /** Bind backend metadata writes to this mount's lifetime. */
   scopeIndex(index: IndexCacheStore): IndexCacheStore {
     if (this.fileCache === null || index instanceof IndexView) return index

--- a/typescript/packages/core/src/workspace/close_ownership.test.ts
+++ b/typescript/packages/core/src/workspace/close_ownership.test.ts
@@ -54,6 +54,25 @@ describe('workspace close ownership', () => {
     expect(resource.closeCalls).toBe(1)
   })
 
+  it.each([false, true])('unmount leaves borrowed resources open (used=%s)', async (used) => {
+    const resource = new ProbeRAMResource()
+    const ws = new Workspace({ '/data': resource })
+    const state = await toStateDict(ws)
+    const replica = await Workspace.fromState(state, {}, { '/data': resource })
+    try {
+      if (used) await replica.resolve('/data')
+      await replica.unmount('/data')
+      expect(resource.closeCalls).toBe(0)
+      await replica.close()
+      expect(resource.closeCalls).toBe(0)
+      await ws.close()
+      expect(resource.closeCalls).toBe(1)
+    } finally {
+      await replica.close()
+      await ws.close()
+    }
+  })
+
   it('does not close a caller-passed session store', async () => {
     const sessionStore = new ProbeSessionStore()
     const ws = new Workspace({ '/data': new RAMResource() }, { sessionStore })

--- a/typescript/packages/core/src/workspace/executor/builtins/df/df.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/df/df.ts
@@ -276,9 +276,9 @@ export async function handleDf(
 
   const data: string[][] = []
   for (const mount of mounts) {
-    const cap = mount.resource.statfs
-      ? await mount.resource.statfs()
-      : { state: CapacityState.UNKNOWN }
+    const cap = await mount.use(async () =>
+      mount.resource.statfs ? mount.resource.statfs() : { state: CapacityState.UNKNOWN },
+    )
     const cells = [mount.resource.kind]
     if (showType) cells.push(mount.resource.kind)
     cells.push(...numCells(cap, human, si, block, inodes))

--- a/typescript/packages/core/src/workspace/executor/command/run.ts
+++ b/typescript/packages/core/src/workspace/executor/command/run.ts
@@ -191,7 +191,7 @@ export async function dropServiceCaches(
     // that was never filled, so a backend whose index *is* its listing
     // (github seeds the whole tree once) cannot tell the drop from an empty
     // repository. Expiring keeps that distinction and the next read refetches.
-    await mount.resource.index?.invalidate()
+    await mount.index?.invalidate()
     await mount.cacheManager?.dropPrefix()
   }
 }

--- a/typescript/packages/core/src/workspace/snapshot/state.ts
+++ b/typescript/packages/core/src/workspace/snapshot/state.ts
@@ -86,7 +86,7 @@ export async function toStateDict(ws: Workspace): Promise<WorkspaceStateDict> {
     // the contract carries it, so a resource missing one fails to compile
     // rather than throwing here at save time. What remains narrows the
     // returned state to the snapshot format's union.
-    const state = (await Promise.resolve(m.resource.getState())) as ResourceState
+    const state = (await m.use(() => Promise.resolve(m.resource.getState()))) as ResourceState
     mountSnapshots.push({
       index: i,
       prefix: m.prefix,

--- a/typescript/packages/core/src/workspace/snapshot_drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot_drift.test.ts
@@ -514,3 +514,65 @@ it.each([false, true])(
     }
   },
 )
+
+it.each(
+  ['snapshot', 'copy'].flatMap((surface) => [false, true].map((opened) => ({ surface, opened }))),
+)(
+  'unmount waits for asynchronous $surface state reads (opened=$opened)',
+  async ({ surface, opened }) => {
+    let enter = (): void => undefined
+    let resume = (): void => undefined
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      resume = resolve
+    })
+    let closed = false
+    class AsyncStateResource extends BaseResource {
+      readonly kind = 'ram'
+      open(): Promise<void> {
+        return Promise.resolve()
+      }
+      override async getState(): Promise<{ type: string }> {
+        enter()
+        await release
+        expect(closed).toBe(false)
+        return { type: 'ram' }
+      }
+      override async close(): Promise<void> {
+        closed = true
+        await super.close()
+      }
+    }
+    const resource = new AsyncStateResource()
+    const ws = new Workspace({ '/data': resource }, { shellParser: parser })
+    if (opened) await ws.resolve('/data')
+    const capture = (
+      surface === 'copy' ? ws.copy() : ws.snapshot(join(tempDir, 'retired.tar'))
+    ).catch((error: unknown) => error)
+    let removing: Promise<void> | undefined
+    try {
+      await entered
+      let removed = false
+      removing = ws.unmount('/data').then(() => {
+        removed = true
+      })
+      await vi.waitFor(() => {
+        expect(ws.registry.tryMountForPrefix('/data')).toBeNull()
+      })
+      expect(removed).toBe(false)
+      expect(closed).toBe(false)
+      resume()
+      const result: unknown = await capture
+      expect(result).toBeInstanceOf(Error)
+      expect(String(result)).toContain('mounts changed during snapshot')
+      await removing
+      expect(closed).toBe(true)
+    } finally {
+      resume()
+      await Promise.allSettled([capture, ...(removing === undefined ? [] : [removing])])
+      await ws.close()
+    }
+  },
+)

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -745,12 +745,13 @@ describe('Workspace.unmount', () => {
     expect(r.closes).toBe(1)
   })
 
-  it('does not close a resource that was never opened', async () => {
+  it('closes an owned resource even when it was never explicitly opened', async () => {
     const r = new MockResource()
     const ws = new Workspace({ '/x': r })
     await ws.unmount('/x')
-    expect(r.closes).toBe(0)
+    expect(r.closes).toBe(1)
     await ws.close()
+    expect(r.closes).toBe(1)
   })
 
   it('throws on root, history view, /dev/, and unknown prefix', async () => {

--- a/typescript/packages/core/src/workspace/workspace/lifecycle.test.ts
+++ b/typescript/packages/core/src/workspace/workspace/lifecycle.test.ts
@@ -14,9 +14,11 @@
 
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { IndexEntry } from '../../cache/index/config.ts'
 import { command } from '../../commands/config.ts'
 import { CommandSpec, Operand } from '../../commands/spec/types.ts'
 import { IOResult } from '../../io/types.ts'
+import { CapacityState, ResourceName } from '../../types.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import { type JobRunner, JobStatus } from '../../shell/job_table/index.ts'
 import type { ShellParser } from '../../shell/parse/index.ts'
@@ -24,6 +26,7 @@ import { MountMode } from '../../types.ts'
 import { ExecutionNode } from '../types.ts'
 import { getTestParser } from '../fixtures/workspace_fixture.ts'
 import { Workspace } from './workspace.ts'
+import { dropServiceCaches } from '../executor/command/run.ts'
 
 let parser: ShellParser
 
@@ -182,8 +185,12 @@ it.each([
 
 it.each(
   [null, 'initial', 'dynamic'].flatMap((alias) =>
-    [false, true].flatMap((streaming) =>
-      ['op', 'command'].map((surface) => ({ alias, streaming, surface })),
+    ['op', 'command', 'df'].flatMap((surface) =>
+      (surface === 'df' ? [false] : [false, true]).map((streaming) => ({
+        alias,
+        streaming,
+        surface,
+      })),
     ),
   ),
 )(
@@ -216,6 +223,12 @@ it.each(
     if (alias === 'initial') resources['/alias'] = resource
     const ws = new Workspace(resources, { shellParser: parser })
     if (alias === 'dynamic') ws.addMount('/alias', resource)
+    vi.spyOn(resource, 'statfs').mockImplementation(async () => {
+      entered()
+      await release
+      expect(closed).toBe(false)
+      return { state: CapacityState.UNKNOWN }
+    })
     ws.ops.register({ name: 'read', resource: 'ram', filetype: null, write: false, fn: read })
     const [registered] = command({
       name: 'readvalue',
@@ -231,6 +244,11 @@ it.each(
       await closeResource()
     })
     const running = (async () => {
+      if (surface === 'df') {
+        const result = await ws.execute('df /data')
+        expect(result.exitCode).toBe(0)
+        return 'value'
+      }
       if (surface === 'command')
         return new TextDecoder().decode((await ws.execute('readvalue /data/file')).stdout)
       const value = (await ws.dispatch('read', '/data/file')) as
@@ -352,6 +370,59 @@ it('unmount drains an admitted resource open before closing it', async () => {
   } finally {
     resume()
     await Promise.allSettled([reading, ...(removing === undefined ? [] : [removing])])
+    await ws.close()
+  }
+})
+
+it.each(['service', 'clear'])('unmount drains index invalidation (%s)', async (kind) => {
+  const resource = new RAMResource()
+  const ws = new Workspace({ '/data': resource })
+  await ws.resolve('/data')
+  let enter = (): void => undefined
+  let resume = (): void => undefined
+  const entered = new Promise<void>((resolve) => {
+    enter = resolve
+  })
+  const release = new Promise<void>((resolve) => {
+    resume = resolve
+  })
+  const index = resource.index
+  const method = kind === 'service' ? 'invalidate' : 'clear'
+  const invalidate = index[method].bind(index)
+  await index.put(
+    '/outside-scope',
+    new IndexEntry({ id: 'stale', name: 'stale', resourceType: 'ram' }),
+  )
+  vi.spyOn(index, method).mockImplementation(async () => {
+    enter()
+    await release
+    expect(resource.isClosed).toBe(false)
+    await invalidate()
+  })
+  const manager = ws.mount('/data').cacheManager
+  if (manager === null) throw new Error('missing cache manager')
+  const updating =
+    kind === 'service'
+      ? dropServiceCaches(ws.registry, [ResourceName.RAM])
+      : manager.clearIndex(index)
+  let removing: Promise<void> | undefined
+  try {
+    await entered
+    let removed = false
+    removing = ws.unmount('/data').then(() => {
+      removed = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(removed).toBe(false)
+    expect(resource.isClosed).toBe(false)
+    resume()
+    await updating
+    await removing
+    expect(resource.isClosed).toBe(true)
+    if (kind === 'clear') expect((await index.get('/outside-scope')).entry).toBeUndefined()
+  } finally {
+    resume()
+    await Promise.allSettled([updating, ...(removing === undefined ? [] : [removing])])
     await ws.close()
   }
 })

--- a/typescript/packages/core/src/workspace/workspace/mounts.ts
+++ b/typescript/packages/core/src/workspace/workspace/mounts.ts
@@ -92,12 +92,12 @@ export interface UnmountDeps {
   opsRegistry: OpsRegistry
   opened: Set<Resource>
   openOrder: Resource[]
+  sharedResources: Set<Resource>
   isShuttingDown: () => boolean
 }
 
 /**
- * Remove one mount, closing its resource if the workspace had opened it
- * and no other mount still references it. Operations are shared by kind,
+ * Remove one mount, closing its owned resource when its last alias leaves. Operations are shared by kind,
  * so they remain registered while any mount uses that kind. The virtual
  * root, the device mount, and the history view are permanent. Mirrors the
  * Python `unmount` in `workspace/mounts.py`.
@@ -155,12 +155,13 @@ export async function unmountPrefix(deps: UnmountDeps, prefix: string): Promise<
 }
 
 async function closeResource(deps: UnmountDeps, entry: MountEntry): Promise<void> {
-  await entry.activity.wait()
   const resource = entry.resource
+  const shared = deps.sharedResources.has(resource)
+  if (!shared) await entry.activity.wait()
   const idx = deps.openOrder.indexOf(resource)
   if (idx !== -1) deps.openOrder.splice(idx, 1)
-  if (deps.opened.delete(resource)) {
-    deps.registry.retiredResources.add(resource)
-    await resource.close()
-  }
+  deps.opened.delete(resource)
+  if (shared) return
+  deps.registry.retiredResources.add(resource)
+  await resource.close()
 }

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -860,8 +860,8 @@ export class Workspace {
   }
 
   /**
-   * Remove a mount by prefix. Closes the resource if the workspace had opened
-   * it and no other mount still references it. Drops cache entries under the
+   * Remove a mount by prefix. Closes the owned resource when its last alias
+   * leaves, including resources used without an explicit open. Drops cache entries under the
    * unmounted prefix. Forbidden prefixes: cache root, history view, /dev/.
    * Waits for admitted calls and returned streams before closing the resource.
    * Callers must consume or close streams; closed instances cannot be remounted.
@@ -874,6 +874,7 @@ export class Workspace {
         opsRegistry: this.opsRegistry,
         opened: this.opened,
         openOrder: this.openOrder,
+        sharedResources: this.sharedResources,
         isShuttingDown: () => this.isShuttingDown(),
       },
       prefix,
@@ -1032,7 +1033,8 @@ export class Workspace {
   private async invalidateAllAfterRemote(): Promise<void> {
     await this.dispatcher.clearFileCache()
     for (const m of this.registry.allMounts()) {
-      await m.resource.index?.clear()
+      if (m.cacheManager !== null) await m.cacheManager.clearIndex(m.resource.index)
+      else await m.use(() => m.resource.index?.clear() ?? Promise.resolve())
     }
   }
 


### PR DESCRIPTION
A concurrent unmount could close a resource while snapshot/copy was awaiting its state or `df` was awaiting capacity. Retain the mount activity lease around those reads in Python and TypeScript, so the last owned alias closes only after admitted work finishes. Snapshot/copy still rejects a mount table changed during capture.

Also route service-index invalidation and remote whole-index clearing through the existing ownership and cache-eviction lock. Preserve whole-index clearing for remote execution. Align TypeScript unmount with workspace shutdown by closing owned resources even when they were used without an explicit open; both languages now preserve resources borrowed from another workspace.

This addresses the final review comment on #1006, which was merged while this fix was being validated: https://github.com/strukto-ai/mirage/pull/1006#discussion_r3940509939.

Validation:

- Python: **18,000 passed, 521 skipped, 1 xfailed**.
- TypeScript core: **10,870 passed, 22 skipped**; final focused cache/runtime/lifecycle checks: **46 passed**.
- Shared JSON lifecycle: **735 steps** across Python, Node and the browser wrapper under Node.
- New regressions cover concurrent snapshot/copy state reads with opened and unopened resources, `df` through initial and dynamic aliases, unmount during index invalidation, preservation of whole-index clearing, and borrowed resource ownership.
- Repository pre-commit checks, core TypeScript typechecking, and strict layout parity pass.
