### PR TITLE
ci: standardize on Node 24 and cache native build dependencies

### DIFF
--- a/.github/actions/integ-battery-setup/action.yml
+++ b/.github/actions/integ-battery-setup/action.yml
@@ -30,16 +30,10 @@ runs:
       working-directory: python
       shell: bash
       run: uv sync --all-extras --no-extra camel
-    - name: Set up pnpm
-      uses: pnpm/action-setup@v6
-      with:
-        version: 10.32.1
-    - name: Set up Node
-      uses: actions/setup-node@v7
+    - name: Set up Node and pnpm
+      uses: ./.github/actions/setup-node-pnpm
       with:
         node-version: '24'
-        cache: pnpm
-        cache-dependency-path: typescript/pnpm-lock.yaml
     - name: Install dependencies
       working-directory: typescript
       shell: bash

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -20,10 +20,14 @@ runs:
         version: ${{ inputs.pnpm-version }}
 
     - name: Set up Node
-      id: node
       uses: actions/setup-node@v7
       with:
         node-version: ${{ inputs.node-version }}
+
+    - name: Read the installed Node version
+      id: node
+      shell: bash
+      run: echo "node-version=$(node --version)" >> "$GITHUB_OUTPUT"
 
     - name: Locate the pnpm store
       id: store

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,60 @@
+name: Set up Node and pnpm
+description: >-
+  pnpm plus Node, with the pnpm store and node-gyp's header cache both keyed
+  on the Node version the job actually runs.
+inputs:
+  node-version:
+    description: >-
+      Node major version to install. It is part of both cache keys, so two
+      jobs on different majors never share a store.
+    required: true
+  pnpm-version:
+    description: pnpm version to install.
+    default: "10.32.1"
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@v6.0.10
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - name: Set up Node
+      id: node
+      uses: actions/setup-node@v7
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Locate the pnpm store
+      id: store
+      shell: bash
+      run: echo "dir=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    # Not `cache: pnpm` on setup-node: that keys the store on the lockfile
+    # alone, so every job in the repo shared one store whatever Node it ran.
+    # pnpm caches a package's build side-effects in the store, and those are
+    # per-ABI, so the Node 24 jobs restored a store holding the Node 22 build
+    # of @zkochan/fuse-native (the one onlyBuiltDependencies entry) and
+    # recompiled it, which sends node-gyp to nodejs.org for the headers.
+    # The restore was an exact key hit, so nothing ever re-saved and the Node
+    # 24 build was never kept: every Node 24 job re-fetched, every run.
+    - name: Cache the pnpm store
+      uses: actions/cache@v6
+      with:
+        path: ${{ steps.store.outputs.dir }}
+        key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-node${{ inputs.node-version }}-${{ hashFiles('typescript/pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-store-${{ runner.os }}-${{ runner.arch }}-node${{ inputs.node-version }}-
+
+    # The headers node-gyp downloads, so a cold store still compiles without
+    # reaching the network. node-gyp does not retry that fetch: `attempt 1
+    # failed with ECONNRESET` is the end of the install, and on 2026-09-05 one
+    # reset socket in the integ bootstrap job failed the 13 jobs waiting on
+    # its build artifact. Keyed on the resolved version rather than the major,
+    # so a runner's Node minor bump misses and re-saves instead of pinning the
+    # cache to headers nobody wants any more.
+    - name: Cache the node-gyp headers
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/node-gyp
+        key: node-gyp-${{ runner.os }}-${{ runner.arch }}-${{ steps.node.outputs.node-version }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -49,17 +49,10 @@ jobs:
           version: "0.12.9"
           enable-cache: true
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: "22"
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install node-gyp
         run: npm install -g node-gyp

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Node and pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Install node-gyp
         run: npm install -g node-gyp

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Node and pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Install node-gyp
         run: npm install -g node-gyp
@@ -378,7 +378,7 @@ jobs:
       - name: Set up Node and pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Install node-gyp
         run: npm install -g node-gyp

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -10,6 +10,7 @@ permissions:
       - python/**
       - typescript/**
       - .github/workflows/test_cli.yml
+      - .github/actions/setup-node-pnpm/action.yml
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -53,6 +54,7 @@ jobs:
               - 'integ/fixtures/resource/**'
               - 'integ/fixtures/runtime/**'
               - '.github/workflows/test_cli.yml'
+              - '.github/actions/setup-node-pnpm/action.yml'
 
   typescript-build:
     needs: changes
@@ -62,17 +64,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: "22"
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install node-gyp
         run: npm install -g node-gyp
@@ -380,17 +375,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: "22"
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install node-gyp
         run: npm install -g node-gyp
@@ -703,17 +691,10 @@ jobs:
         working-directory: python
         run: uv sync --all-extras --no-extra camel
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: "24"
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install TypeScript dependencies
         working-directory: typescript

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -10,6 +10,7 @@ permissions:
       - python/**
       - typescript/**
       - .github/workflows/test_install.yml
+      - .github/actions/setup-node-pnpm/action.yml
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -35,6 +36,7 @@ jobs:
               - 'python/**'
               - 'typescript/**'
               - '.github/workflows/test_install.yml'
+              - '.github/actions/setup-node-pnpm/action.yml'
 
   python-install:
     needs: changes
@@ -143,17 +145,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: "22"
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install TypeScript dependencies
         working-directory: typescript

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Node and pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Install TypeScript dependencies
         working-directory: typescript

--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -12,6 +12,7 @@ permissions:
       - python/**
       - typescript/**
       - .github/workflows/test_integ.yml
+      - .github/actions/setup-node-pnpm/action.yml
       - .github/actions/integ-battery-setup/action.yml
   pull_request:
     branches: [main]
@@ -50,11 +51,13 @@ jobs:
               - 'data/**'
               - 'python/**'
               - '.github/workflows/test_integ.yml'
+              - '.github/actions/setup-node-pnpm/action.yml'
               - '.github/actions/integ-battery-setup/action.yml'
             ts:
               - 'integ/**'
               - 'typescript/**'
               - '.github/workflows/test_integ.yml'
+              - '.github/actions/setup-node-pnpm/action.yml'
               - '.github/actions/integ-battery-setup/action.yml'
             database:
               - 'integ/resources/mongodb/**'
@@ -81,11 +84,13 @@ jobs:
               - 'python/mirage/resource/qdrant/**'
               - 'typescript/**'
               - '.github/workflows/test_integ.yml'
+              - '.github/actions/setup-node-pnpm/action.yml'
               - '.github/actions/integ-battery-setup/action.yml'
             data:
               - 'integ/**'
               - 'python/**'
               - '.github/workflows/test_integ.yml'
+              - '.github/actions/setup-node-pnpm/action.yml'
               - '.github/actions/integ-battery-setup/action.yml'
             observability:
               - 'integ/server/langfuse_compose.yml'
@@ -109,6 +114,7 @@ jobs:
               - 'typescript/packages/node/src/resource/langfuse/**'
               - 'typescript/packages/node/src/resource/jaeger/**'
               - '.github/workflows/test_integ.yml'
+              - '.github/actions/setup-node-pnpm/action.yml'
             fuse:
               - 'integ/fuse/**'
               - 'integ/check_json.py'
@@ -119,6 +125,7 @@ jobs:
               - 'typescript/packages/node/src/workspace/fuse.ts'
               - 'typescript/packages/node/src/workspace.ts'
               - '.github/workflows/test_integ.yml'
+              - '.github/actions/setup-node-pnpm/action.yml'
               - '.github/actions/integ-battery-setup/action.yml'
 
   typescript-build:
@@ -129,17 +136,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '24'
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install TypeScript dependencies
         working-directory: typescript
@@ -269,17 +269,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '24'
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: typescript
@@ -689,17 +682,10 @@ jobs:
         working-directory: python
         run: uv sync --all-extras --no-extra camel
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '24'
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: typescript
@@ -799,17 +785,10 @@ jobs:
       # The notion fake is a Node server shared by both hosts, so this
       # otherwise python-only job needs node to start it. No package build is
       # required: the notion fake imports only node, prisma and the MCP sdk.
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '24'
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: typescript
@@ -1022,17 +1001,10 @@ jobs:
           ./python/.venv/bin/python integ/fuse/fuse.py 2>&1 \
             | ./python/.venv/bin/python integ/check_json.py integ/fuse/truth_fuse.json
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '24'
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install dependencies (builds @zkochan/fuse-native against libfuse3)
         working-directory: typescript
@@ -1278,17 +1250,10 @@ jobs:
         working-directory: python
         run: uv sync --all-extras --no-extra camel
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '24'
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install TypeScript dependencies
         working-directory: typescript
@@ -1403,17 +1368,10 @@ jobs:
         working-directory: python
         run: uv sync --all-extras --no-extra camel
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '24'
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: typescript
@@ -1504,17 +1462,10 @@ jobs:
         working-directory: python
         run: uv sync --all-extras --no-extra camel
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '24'
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: typescript

--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -975,7 +975,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install libfuse (fusermount3 + libfuse2 for mfusepy, libfuse3 headers for fuse-native)
+      # fuse-native does not build against any of these. Its binding.gyp
+      # takes both its include dir and its library from the vendored
+      # fuse-shared-library-linux npm package, so what apt is for here is
+      # fusermount3 (to mount at all) and libfuse2 (for python's mfusepy).
+      - name: Install libfuse (fusermount3 to mount, libfuse2 for mfusepy)
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse3 libfuse3-dev libfuse2t64 || \
@@ -1006,7 +1010,7 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install dependencies (builds @zkochan/fuse-native against libfuse3)
+      - name: Install dependencies
         working-directory: typescript
         run: pnpm install --frozen-lockfile=false
 

--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -12,6 +12,7 @@ permissions:
       - integ/**
       - conformance/**
       - .github/workflows/test_typescript.yml
+      - .github/actions/setup-node-pnpm/action.yml
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -39,6 +40,7 @@ jobs:
               - 'integ/**'
               - 'conformance/**'
               - '.github/workflows/test_typescript.yml'
+              - '.github/actions/setup-node-pnpm/action.yml'
 
   test:
     needs: changes
@@ -58,17 +60,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: "22"
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install node-gyp
         run: npm install -g node-gyp
@@ -145,17 +140,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.10
-        with:
-          version: 10.32.1
-
-      - name: Set up Node 24
-        uses: actions/setup-node@v7
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: "24"
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
 
       - name: Install node-gyp
         run: npm install -g node-gyp

--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Node and pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Install node-gyp
         run: npm install -g node-gyp
@@ -174,9 +174,7 @@ jobs:
         with:
           version: 10.32.1
 
-      # 24 rather than the 22 the test job uses: this step runs no project
-      # code, so it is free to track the newer line the integ workflow is
-      # already on. No `cache: pnpm` here on purpose: the audit step below
+      # No `cache: pnpm` here on purpose: the audit step below
       # resolves straight from the lockfile and never installs, so the pnpm
       # store does not exist and the post-run save fails path validation on
       # every cache miss.

--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -45,7 +45,12 @@ jobs:
   test:
     needs: changes
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.hit == 'true') }}
+    name: TypeScript (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["22", "24"]
     services:
       redis:
         image: redis:7
@@ -63,7 +68,7 @@ jobs:
       - name: Set up Node and pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node-version }}
 
       - name: Install node-gyp
         run: npm install -g node-gyp


### PR DESCRIPTION
A node-gyp header download failed with `ECONNRESET` in main’s TypeScript integration bootstrap, leaving 13 dependent jobs without their build artifact. The pnpm cache used a lockfile-only key shared by Node 22 and Node 24 jobs; exact cache hits prevented the Node 24 build side effects from being saved, so those jobs repeatedly rebuilt the native binding and fetched headers.

This change makes Node 24 the default throughout CI, retains Node 22 compatibility coverage in the main TypeScript test job, and adds a reusable `.github/actions/setup-node-pnpm` action:

- Keys the pnpm store by OS, architecture, requested Node version, and lockfile, with restores restricted to the same Node version.
- Caches node-gyp headers by OS, architecture, and the installed Node version, captured explicitly with `node --version`.
- Routes 16 setup call sites through the shared action and includes it in workflow path filters.
- Keeps the audit job’s direct setup without a pnpm cache because it reads the lockfile without installing dependencies.

Build, install, CLI, lint, integration, and audit jobs use Node 24. The main TypeScript test job uses a Node 22/24 matrix to build, typecheck, test, and verify examples on both versions. Fail-fast is disabled so both runs report their results, and the required TypeScript gate covers the matrix.

Both caches can still miss on a new Node version; the initial header download remains dependent on the network.

Validation:

- Pre-commit checks on the updated action and workflows: passed.
- actionlint 1.7.12 across all six workflows: passed.
- Checked the Node 22/24 matrix wiring and its required gate; the remaining CI Node setup call sites select Node 24.
- Executed the version-capture shell step and verified that its output reaches the header cache key.
- Full runtime suites were not run locally; changes are limited to `.github/**`.