### PR TITLE
Release 0.0.7-alpha.1

### DIFF
--- a/integ/cli/hf.json
+++ b/integ/cli/hf.json
@@ -175,7 +175,7 @@
       "targets": [
         "cli-hf"
       ],
-      "command": "hf version | sed 's/[0-9][0-9.]*/N/'",
+      "command": "hf version | sed 's/[0-9][^ ]*/N/'",
       "expect": {
         "exit": 0,
         "stdout": "hf version N (mirage)\n",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirage-ai"
-version = "0.0.6"
+version = "0.0.7a1"
 description = "A unified virtual filesystem for AI agents. Mount S3, Google Drive, Slack, Gmail, GitHub, Linear, Notion, Postgres, MongoDB, SSH, and more behind one filesystem so agents read, write, and pipe across services with familiar shell commands."
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -5812,7 +5812,7 @@ wheels = [
 
 [[package]]
 name = "mirage-ai"
-version = "0.0.6"
+version = "0.0.7a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/typescript/packages/agents/package.json
+++ b/typescript/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-agents",
-  "version": "0.0.6",
+  "version": "0.0.7-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/browser/package.json
+++ b/typescript/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-browser",
-  "version": "0.0.6",
+  "version": "0.0.7-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/cli/package.json
+++ b/typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-cli",
-  "version": "0.0.6",
+  "version": "0.0.7-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-core",
-  "version": "0.0.6",
+  "version": "0.0.7-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/dsh/package.json
+++ b/typescript/packages/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-dsh",
-  "version": "0.0.6",
+  "version": "0.0.7-alpha.1",
   "description": "DeepSeek Harness (dsh) providers backed by a mirage workspace: ctx.fs and ctx.shell over mounted resources",
   "homepage": "https://github.com/strukto-ai/mirage#readme",
   "bugs": {

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-node",
-  "version": "0.0.6",
+  "version": "0.0.7-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/server/package.json
+++ b/typescript/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-server",
-  "version": "0.0.6",
+  "version": "0.0.7-alpha.1",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",


### PR DESCRIPTION
Cut 0.0.7-alpha.1 from main at 4ba3ff91a, 11 PRs since v0.0.6.

Two commits, version lines only: `Release Python 0.0.7a1` bumps `python/pyproject.toml` and its one `uv.lock` entry, `Release TypeScript 0.0.7-alpha.1` bumps the seven published packages (agents, browser, cli, core, dsh, node, server). `opencode` stays at 0.0.0.

The spelling follows the 0.0.5 precedent: PyPI `0.0.5a1` paired with npm `0.0.5-alpha.1` on the `alpha` dist-tag, so this pairs `0.0.7a1` with `0.0.7-alpha.1`.

## Verification

- `pre-commit run --all-files`: 20/20 hooks pass.
- Python: 18751 passed, 522 skipped, 1 xfailed.
- TypeScript: `pnpm -r typecheck` clean, 15154 tests passed across all eight packages.
- `mirage.__version__` reads `0.0.7a1` and core's built `VERSION` reads `0.0.7-alpha.1`, so the prerelease suffix survives both metadata paths and the `--version` assertions that allow it.

## What is in it

Features: a read-only Weights & Biases VFS with an API mock and SDK conformance coverage (#1030); the shell fails loud on unsupported descriptors and arithmetic errors and gains `PIPESTATUS`, `RANDOM`, `test -nt`/`-ot`/`-ef` and `find -exec`/`-newer` (#1001); E2B runs in browsers with stdin, cancellation and validation aligned across runtimes (#1029).

Bugfixes: `&` inside a compound body launches a job instead of running in the foreground (#1027); an inline ask answer is spent on the line that asked for it (#1000); Redis keeps index entry metadata and answers a zero-length range read correctly (#1004, #1005); resource state stays readable during unmount and the workspace lifecycle matches across the two implementations (#1025, #1006).

Changes: CI standardizes on Node 24 and caches native build dependencies per Node version (#1026); `dsh` ships the same README as the other packages (#999).
