### PR TITLE
Report interpreter versions and bump Python/TypeScript packages to alpha 2

### DIFF
--- a/integ/runtime/monty.json
+++ b/integ/runtime/monty.json
@@ -53,7 +53,7 @@
           "command": "python -m json.tool",
           "expect": {
             "exit": 1,
-            "stderr": "python3: -m is not supported by the 'monty' runtime\n"
+            "stderr": "python: -m is not supported by the 'monty' runtime\n"
           }
         }
       ]

--- a/integ/runtime/policy.json
+++ b/integ/runtime/policy.json
@@ -409,7 +409,7 @@
           "command": "python -c \"print(1)\"",
           "expect": {
             "exit": 127,
-            "stderr_contains": "python3: command not found"
+            "stderr_contains": "python: command not found"
           }
         }
       ]

--- a/python/mirage/commands/builtin/general/interpreter.py
+++ b/python/mirage/commands/builtin/general/interpreter.py
@@ -42,6 +42,16 @@ def run_output(result: RunResult) -> CommandOutput:
     )
 
 
+async def runtime_version(label: str, runtime: Runtime | None,
+                          env: dict[str, str] | None,
+                          unavailable: str | None) -> CommandOutput:
+    if not isinstance(runtime, LanguageRuntime):
+        hint = unavailable or "command not found"
+        return None, IOResult(exit_code=127,
+                              stderr=f"{label}: {hint}\n".encode())
+    return run_output(await runtime.version(env or {}))
+
+
 # Which of an interpreter's four doors the source came through. The
 # mode is what decides argv[0], so the two travel together: CPython
 # spells it "-c" for a payload, the module's file for -m, the file as

--- a/python/mirage/commands/builtin/general/js.py
+++ b/python/mirage/commands/builtin/general/js.py
@@ -30,12 +30,13 @@ async def _js(
     texts: list[str],
     opts: CommandOpts,
 ) -> CommandOutput:
+    label = opts.command or "js"
     fl = FlagView(opts.flags, spec=SPECS["js"])
     if fl.as_bool("version"):
-        return await runtime_version("js", opts.runtime, opts.env,
+        return await runtime_version(label, opts.runtime, opts.env,
                                      opts.runtime_unavailable)
     error, prepared = await resolve_source(
-        "js",
+        label,
         paths,
         texts,
         fl.as_str("e"),
@@ -50,7 +51,7 @@ async def _js(
     as_module = fl.as_bool("module") or (
         prepared.script_path is not None
         and prepared.script_path.virtual.endswith(".mjs"))
-    return await run_code("js", prepared, opts.env, {"module": as_module},
+    return await run_code(label, prepared, opts.env, {"module": as_module},
                           opts.runtime, opts.runtime_unavailable)
 
 

--- a/python/mirage/commands/builtin/general/js.py
+++ b/python/mirage/commands/builtin/general/js.py
@@ -14,7 +14,8 @@
 
 from mirage.accessor.base import Accessor
 from mirage.commands.builtin.general.interpreter import (resolve_source,
-                                                         run_code)
+                                                         run_code,
+                                                         runtime_version)
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -30,6 +31,9 @@ async def _js(
     opts: CommandOpts,
 ) -> CommandOutput:
     fl = FlagView(opts.flags, spec=SPECS["js"])
+    if fl.as_bool("version"):
+        return await runtime_version("js", opts.runtime, opts.env,
+                                     opts.runtime_unavailable)
     error, prepared = await resolve_source(
         "js",
         paths,

--- a/python/mirage/commands/builtin/general/python.py
+++ b/python/mirage/commands/builtin/general/python.py
@@ -33,12 +33,13 @@ async def _python3(
     texts: list[str],
     opts: CommandOpts,
 ) -> CommandOutput:
+    label = opts.command or "python3"
     fl = FlagView(opts.flags, spec=SPECS["python3"])
     if fl.as_bool("version"):
-        return await runtime_version("python3", opts.runtime, opts.env,
+        return await runtime_version(label, opts.runtime, opts.env,
                                      opts.runtime_unavailable)
     error, prepared = await resolve_source(
-        "python3",
+        label,
         paths,
         texts,
         fl.as_str("c"),
@@ -73,8 +74,8 @@ async def _python3(
         "X": fl.as_list("X"),
         "check_hash_based_pycs": fl.as_str("check_hash_based_pycs"),
     }
-    return await run_code("python3", prepared, opts.env, init_flags,
-                          opts.runtime, opts.runtime_unavailable)
+    return await run_code(label, prepared, opts.env, init_flags, opts.runtime,
+                          opts.runtime_unavailable)
 
 
 python3 = command("python3", resource=None, spec=SPECS["python3"])(_python3)

--- a/python/mirage/commands/builtin/general/python.py
+++ b/python/mirage/commands/builtin/general/python.py
@@ -17,7 +17,8 @@ from typing import Any
 from mirage.accessor.base import Accessor
 from mirage.commands.builtin.general.interpreter import (CPYTHON_ARGV0,
                                                          resolve_source,
-                                                         run_code)
+                                                         run_code,
+                                                         runtime_version)
 from mirage.commands.config import CommandOpts
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -33,6 +34,9 @@ async def _python3(
     opts: CommandOpts,
 ) -> CommandOutput:
     fl = FlagView(opts.flags, spec=SPECS["python3"])
+    if fl.as_bool("version"):
+        return await runtime_version("python3", opts.runtime, opts.env,
+                                     opts.runtime_unavailable)
     error, prepared = await resolve_source(
         "python3",
         paths,

--- a/python/mirage/commands/config.py
+++ b/python/mirage/commands/config.py
@@ -251,11 +251,13 @@ def _with_help_support(
 
     Mirrors GNU coreutils: every registered command accepts both flags,
     prints to stdout, and exits 0 without running the command body.
+    A command declaring its own --version handles that flag itself.
     """
     extras: list[Option] = []
     if not any(o.long == "--help" for o in spec.options):
         extras.append(HELP_OPTION)
-    if not any(o.long == "--version" for o in spec.options):
+    has_version = any(o.long == "--version" for o in spec.options)
+    if not has_version:
         extras.append(_VERSION_OPTION)
     new_spec = (spec if not extras else replace(
         spec, options=spec.options + tuple(extras)))
@@ -267,7 +269,7 @@ def _with_help_support(
                       texts: list[str], opts: CommandOpts) -> CommandFnResult:
         if opts.flags.get("help") is True:
             return yield_bytes(help_text), IOResult()
-        if opts.flags.get("version") is True:
+        if not has_version and opts.flags.get("version") is True:
             return yield_bytes(version_text), IOResult()
         return await fn(accessor, paths, texts, opts)
 

--- a/python/mirage/commands/config.py
+++ b/python/mirage/commands/config.py
@@ -222,6 +222,15 @@ def _version_line(name: str) -> bytes:
     return f"{name} (Mirage) {__version__}\n".encode()
 
 
+def has_injected_version(spec: CommandSpec | None) -> bool:
+    """Whether the wrapper supplies this spec's version response.
+
+    Args:
+        spec (CommandSpec | None): the registered command spec.
+    """
+    return spec is not None and any(o is _VERSION_OPTION for o in spec.options)
+
+
 def version_request(name: str, spec: CommandSpec | None,
                     argv: list[str]) -> bytes | None:
     """Version output when argv asks a command for the injected --version.
@@ -234,7 +243,7 @@ def version_request(name: str, spec: CommandSpec | None,
         spec (CommandSpec | None): the command's registered spec.
         argv (list[str]): the words after the command name.
     """
-    if spec is None or not any(o is _VERSION_OPTION for o in spec.options):
+    if not has_injected_version(spec):
         return None
     for arg in argv:
         if arg == "--":

--- a/python/mirage/commands/spec/builtin_specs/runtime.py
+++ b/python/mirage/commands/spec/builtin_specs/runtime.py
@@ -79,12 +79,7 @@ _PYTHON_OPTIONS: tuple[Option, ...] = (
            type="str",
            choices=("always", "default", "never"),
            description="How to validate hash-based .pyc files."),
-    # Aliases of the injected help/version options, not new behavior:
-    # sharing their long spelling means they share their dest, so
-    # _with_help_support short-circuits them on the one path every
-    # command uses. CPython's -VV adds build info; mirage has no
-    # CPython build to report, so -VV clusters into -V and prints the
-    # same line.
+    # -VV shares the concise version line; build details are not exposed.
     Option(short="-h",
            long="--help",
            description="Show this help message and exit."),
@@ -115,6 +110,9 @@ SPECS: dict[str, CommandSpec] = {
     CommandSpec(
         description="Run JavaScript on a sandboxed quickjs engine.",
         options=(
+            Option(short="-v",
+                   long="--version",
+                   description="Show runtime version information and exit."),
             Option(short="-e",
                    type="str",
                    description="Evaluate the next argument as a script."),
@@ -130,6 +128,9 @@ SPECS: dict[str, CommandSpec] = {
     CommandSpec(
         description="Run JavaScript on a sandboxed quickjs engine.",
         options=(
+            Option(short="-v",
+                   long="--version",
+                   description="Show runtime version information and exit."),
             Option(short="-e",
                    type="str",
                    description="Evaluate the next argument as a script."),

--- a/python/mirage/runtime/js/quickjs.py
+++ b/python/mirage/runtime/js/quickjs.py
@@ -134,6 +134,14 @@ class QuickJsRuntime(JsRuntime, EvaluatorMixin):
             self._dispatch = dispatch
             self._resolver = resolver
 
+    async def version(self, env: dict[str, str]) -> RunResult:
+        stdout, stderr, exit_code = await self._runtime.run(
+            ["qjs", "--version"], None, list(env.items()), WasmVFS())
+        if exit_code == 0:
+            version = stdout.decode().strip()
+            stdout = f"JavaScript (quickjs-ng {version})\n".encode()
+        return RunResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
+
     async def run(self, args: RunArgs) -> RunResult:
         # --std exposes the std/os globals (stdin via std.in); -m selects
         # ES-module mode for .mjs sources. Trailing args become scriptArgs.

--- a/python/mirage/runtime/language.py
+++ b/python/mirage/runtime/language.py
@@ -53,6 +53,17 @@ class LanguageRuntime(Runtime):
 
     language: ClassVar[Language]
 
+    async def version(self, env: dict[str, str]) -> RunResult:
+        """Report the bound interpreter's version.
+
+        Args:
+            env (dict[str, str]): the session environment.
+        """
+        return RunResult(
+            stdout=b"",
+            stderr=f"{self.name}: version information unavailable\n".encode(),
+            exit_code=1)
+
     def attach(self, dispatch: DispatchFn, resolver: MountResolver) -> None:
         """Late-wire workspace I/O into a user-constructed instance.
 

--- a/python/mirage/runtime/python/base.py
+++ b/python/mirage/runtime/python/base.py
@@ -15,7 +15,7 @@
 from typing import ClassVar
 
 from mirage.runtime.language import LanguageRuntime
-from mirage.runtime.types import Language
+from mirage.runtime.types import Language, RunArgs, RunResult
 
 
 class PythonRuntime(LanguageRuntime):
@@ -36,3 +36,11 @@ class PythonRuntime(LanguageRuntime):
     # system to find a module with. A capability of the tier, declared
     # here rather than probed, so a refusal can name the runtime.
     runs_modules: ClassVar[bool] = True
+    version_suffix: ClassVar[str] = ""
+
+    async def version(self, env: dict[str, str]) -> RunResult:
+        return await self.run(
+            RunArgs(code=("import sys\n"
+                          "print('Python ' + sys.version.split()[0] + "
+                          f"{self.version_suffix!r})"),
+                    env=env))

--- a/python/mirage/runtime/python/base.py
+++ b/python/mirage/runtime/python/base.py
@@ -39,6 +39,9 @@ class PythonRuntime(LanguageRuntime):
     version_suffix: ClassVar[str] = ""
 
     async def version(self, env: dict[str, str]) -> RunResult:
+        # Process runtimes must supply a probe that cannot run startup hooks.
+        if self.reach != "vfs":
+            return await super().version(env)
         return await self.run(
             RunArgs(code=("import sys\n"
                           "print('Python ' + sys.version.split()[0] + "

--- a/python/mirage/runtime/python/local.py
+++ b/python/mirage/runtime/python/local.py
@@ -69,26 +69,35 @@ class LocalRuntime(PythonRuntime):
         else:
             self._python = sys.executable
 
+    async def version(self, env: dict[str, str]) -> RunResult:
+        return await self._run(["--version"], env)
+
     async def run(self, args: RunArgs) -> RunResult:
         # Honoring the init switches is just handing them back to the
         # real interpreter, which is why this tier gets them exactly
         # right (sys.flags included) where an in-process engine cannot.
+        return await self._run([
+            *init_argv(args.flags), "-c",
+            bootstrap(args.code, args.prog), *args.args
+        ], args.env, args.stdin)
+
+    async def _run(self,
+                   argv: list[str],
+                   env: dict[str, str],
+                   stdin: bytes | None = None) -> RunResult:
         proc = await asyncio.create_subprocess_exec(
             self._python,
-            *init_argv(args.flags),
-            "-c",
-            bootstrap(args.code, args.prog),
-            *args.args,
+            *argv,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env={
                 **os.environ,
-                **args.env
+                **env
             },
         )
         try:
-            stdout, stderr = await proc.communicate(input=args.stdin)
+            stdout, stderr = await proc.communicate(input=stdin)
         except asyncio.CancelledError:
             proc.kill()
             await proc.wait()

--- a/python/mirage/runtime/python/local.py
+++ b/python/mirage/runtime/python/local.py
@@ -70,7 +70,8 @@ class LocalRuntime(PythonRuntime):
             self._python = sys.executable
 
     async def version(self, env: dict[str, str]) -> RunResult:
-        return await self._run(["--version"], env)
+        # Session loader variables can execute code before --version is read.
+        return await self._run(["--version"], {})
 
     async def run(self, args: RunArgs) -> RunResult:
         # Honoring the init switches is just handing them back to the

--- a/python/mirage/runtime/python/monty/runtime.py
+++ b/python/mirage/runtime/python/monty/runtime.py
@@ -55,6 +55,7 @@ class MontyRuntime(PythonRuntime, EvaluatorMixin):
     """
 
     name = "monty"
+    version_suffix = " (monty)"
     # The pooled worker subprocess exists for crash isolation, not
     # host access: the interpreter inside it has no host filesystem,
     # environment, or network door, and its file I/O is serviced only

--- a/python/mirage/runtime/python/sandlock/runtime.py
+++ b/python/mirage/runtime/python/sandlock/runtime.py
@@ -135,27 +135,36 @@ class SandlockRuntime(PythonRuntime):
             argv += ["-m", self.config.max_memory]
         return argv
 
+    async def version(self, env: dict[str, str]) -> RunResult:
+        return await self._run(["--version"], env)
+
     async def run(self, args: RunArgs) -> RunResult:
+        return await self._run([
+            *init_argv(args.flags), "-c",
+            bootstrap(args.code, args.prog), *args.args
+        ], args.env, args.stdin)
+
+    async def _run(self,
+                   argv: list[str],
+                   env: dict[str, str],
+                   stdin: bytes | None = None) -> RunResult:
         proc = await asyncio.create_subprocess_exec(
             self._sandlock,
             "run",
             *self.policy_argv(),
             "--",
             self._python,
-            *init_argv(args.flags),
-            "-c",
-            bootstrap(args.code, args.prog),
-            *args.args,
+            *argv,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env={
                 **self.config.env,
-                **args.env
+                **env
             },
         )
         try:
-            stdout, stderr = await proc.communicate(input=args.stdin)
+            stdout, stderr = await proc.communicate(input=stdin)
         except asyncio.CancelledError:
             proc.kill()
             await proc.wait()

--- a/python/mirage/runtime/python/sandlock/runtime.py
+++ b/python/mirage/runtime/python/sandlock/runtime.py
@@ -136,7 +136,8 @@ class SandlockRuntime(PythonRuntime):
         return argv
 
     async def version(self, env: dict[str, str]) -> RunResult:
-        return await self._run(["--version"], env)
+        # Loader variables affect the wrapper before confinement starts.
+        return await self._run(["--version"], {})
 
     async def run(self, args: RunArgs) -> RunResult:
         return await self._run([

--- a/python/mirage/runtime/python/wasi.py
+++ b/python/mirage/runtime/python/wasi.py
@@ -72,6 +72,7 @@ class WasiRuntime(PythonRuntime):
     """
 
     name = "wasi"
+    version_suffix = " (wasi)"
     # Guest file I/O can only travel the workspace bridge; the one
     # host surface is the interpreter's own build directory, served
     # read-only (mutations raise PermissionError in WasmVFS), so

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -617,6 +617,7 @@ class MountEntry:
             # reads the fields it wants and ignores the rest, so there is no
             # opt-in registry (mirrors Mount.executeCmd building CommandOpts).
             opts = CommandOpts(
+                command=cmd_name,
                 stdin=stdin,
                 flags=flags,
                 cwd=PathSpec(

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -24,7 +24,8 @@ from mirage.cache.context import push_cache_manager
 from mirage.cache.index.store import IndexCacheStore
 from mirage.cache.manager import CacheManager
 from mirage.commands.builtin.utils.limit import run_with_timeout
-from mirage.commands.config import CommandOpts, ExecContext, RegisteredCommand
+from mirage.commands.config import (CommandOpts, ExecContext,
+                                    RegisteredCommand, has_injected_version)
 from mirage.commands.resolve import get_extension
 from mirage.commands.spec import CommandSpec
 from mirage.commands.spec.types import FlagValue
@@ -651,12 +652,11 @@ class MountEntry:
             # makes is held to its own region's mode.
             gate_token = set_mount_gate(self.prefix, self.mode)
             try:
-                # --help / --version short-circuit inside the handler wrapper
-                # and never touch the backend, so a read-only mount answers
-                # them like GNU instead of refusing them as writes.
-                info_only = (flags.get("help") is True
-                             or flags.get("version") is True)
                 for cmd in handlers:
+                    # Only wrapper-owned responses bypass the write guard.
+                    info_only = (flags.get("help") is True
+                                 or (flags.get("version") is True
+                                     and has_injected_version(cmd.spec)))
                     # strongest_mode_under, not effective_mode: a mount
                     # whose only writable region is a show entry still runs
                     # the command, and the op door refuses per path. The

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirage-ai"
-version = "0.0.7a1"
+version = "0.0.7a2"
 description = "A unified virtual filesystem for AI agents. Mount S3, Google Drive, Slack, Gmail, GitHub, Linear, Notion, Postgres, MongoDB, SSH, and more behind one filesystem so agents read, write, and pipe across services with familiar shell commands."
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/tests/commands/builtin/general/test_python.py
+++ b/python/tests/commands/builtin/general/test_python.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import sys
+
 import pytest
 import pytest_asyncio
 
@@ -68,11 +70,46 @@ async def test_payload_option_without_its_argument_exits_2(ws):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("line", ["python3 -V", "python3 -VV"])
-async def test_dash_v_aliases_the_version_tier(ws, line):
+@pytest.mark.parametrize("name", ["python", "python3"])
+@pytest.mark.parametrize("flag", ["--version", "-V", "-VV"])
+async def test_version_reports_the_monty_guest(ws, name, flag):
+    io = await ws.execute(f"{name} {flag}")
+    assert io.exit_code == 0
+    assert await materialize(io.stdout) == b"Python 3.14.0 (monty)\n"
+    assert await materialize(io.stderr) == b""
+
+
+@pytest.mark.asyncio
+async def test_version_reports_the_local_interpreter(ws_cpython):
+    io = await ws_cpython.execute("python3 --version")
+    assert io.exit_code == 0
+    assert await materialize(
+        io.stdout) == f"Python {sys.version.split()[0]}\n".encode()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line", [
+    "python3 -c 'print(argv[-1])' --version",
+    "python3 /version.py --version",
+    "echo 'print(argv[-1])' | python3 - --version",
+])
+async def test_program_version_operand_is_not_intercepted(ws, line):
+    await ws.execute("echo 'print(argv[-1])' > /version.py")
     io = await ws.execute(line)
     assert io.exit_code == 0
-    assert b"(Mirage)" in (await materialize(io.stdout))
+    assert await materialize(io.stdout) == b"--version\n"
+
+
+@pytest.mark.asyncio
+async def test_version_without_a_runtime_does_not_claim_mirage():
+    ws = Workspace({"/": RAMResource()}, runtimes=[])
+    try:
+        io = await ws.execute("python3 --version")
+        assert io.exit_code == 127
+        assert await materialize(io.stdout) == b""
+        assert b"command not found" in await materialize(io.stderr)
+    finally:
+        await ws.close()
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/general/test_python.py
+++ b/python/tests/commands/builtin/general/test_python.py
@@ -101,15 +101,25 @@ async def test_program_version_operand_is_not_intercepted(ws, line):
 
 
 @pytest.mark.asyncio
-async def test_version_without_a_runtime_does_not_claim_mirage():
+@pytest.mark.parametrize("name", ["python", "python3", "js", "node"])
+async def test_version_without_a_runtime_uses_the_invoked_name(name):
     ws = Workspace({"/": RAMResource()}, runtimes=[])
     try:
-        io = await ws.execute("python3 --version")
+        io = await ws.execute(f"{name} --version")
         assert io.exit_code == 127
         assert await materialize(io.stdout) == b""
-        assert b"command not found" in await materialize(io.stderr)
+        assert await materialize(io.stderr
+                                 ) == f"{name}: command not found\n".encode()
     finally:
         await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["python", "python3", "js", "node"])
+async def test_missing_script_uses_the_invoked_name(ws, name):
+    io = await ws.execute(f"{name} /missing-script")
+    assert io.exit_code == 1
+    assert await io.stderr_str() == f"{name}: /missing-script: No such file\n"
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/test_config.py
+++ b/python/tests/commands/test_config.py
@@ -201,6 +201,16 @@ class TestVersionSupport:
         assert b"Services:\n  drive\n" in asyncio.run(_collect(stdout))
         assert result.exit_code == 0
 
+    def test_declared_version_reaches_the_handler(self):
+        _HANDLER_CALLS.clear()
+        registered = command("custom",
+                             resource=None,
+                             spec=CommandSpec(options=(Option(
+                                 long="--version"), )))(_recording_handler)
+        asyncio.run(registered._registered_commands[0].fn(
+            None, [], [], CommandOpts(flags={"version": True})))
+        assert _HANDLER_CALLS == ["called"]
+
 
 class TestVersionRequest:
 

--- a/python/tests/runtime/js/test_quickjs.py
+++ b/python/tests/runtime/js/test_quickjs.py
@@ -19,11 +19,13 @@ from pathlib import Path
 import pytest
 
 from mirage import MountMode, Workspace
+from mirage.io.types import materialize
 from mirage.resource.ram import RAMResource
 from mirage.runtime.errors import EvalError
 from mirage.runtime.js import QuickJsRuntime
 from mirage.runtime.js.quickjs import QUICKJS_HOME_ENV
 from mirage.runtime.types import RunArgs
+from mirage.runtime.wasm import WasmVFS
 
 
 def _home_dir() -> str | None:
@@ -98,6 +100,28 @@ async def test_module_mode_is_still_the_interpreters_own_switch():
     rt = _spied_runtime()
     await rt.run(RunArgs(code="CODE", flags={"module": True}))
     assert rt._runtime.argv == ["qjs", "--std", "-m", "-e", "CODE", "--"]
+
+
+@live
+@pytest.mark.asyncio
+async def test_version_commands_report_the_quickjs_engine():
+    runtime = QuickJsRuntime()
+    raw, _, code = await runtime._runtime.run(argv=["qjs", "--version"],
+                                              stdin=None,
+                                              env=[],
+                                              fs=WasmVFS())
+    assert code == 0
+    ws = Workspace({"/": RAMResource()}, runtimes=[runtime, "vfs"])
+    try:
+        for line in ["js --version", "node --version", "js -v", "node -v"]:
+            io = await ws.execute(line)
+            assert io.exit_code == 0
+            assert await materialize(io.stdout
+                                     ) == (b"JavaScript (quickjs-ng " +
+                                           raw.strip() + b")\n")
+            assert await materialize(io.stderr) == b""
+    finally:
+        await ws.close()
 
 
 @live

--- a/python/tests/runtime/python/sandlock/test_runtime.py
+++ b/python/tests/runtime/python/sandlock/test_runtime.py
@@ -144,16 +144,23 @@ async def test_run_wraps_the_interpreter_in_the_sandlock_cli(cli, spawned):
 
 
 @pytest.mark.asyncio
-async def test_read_only_version_keeps_confinement_and_uses_native_flag(
-        cli, spawned, monkeypatch):
+@pytest.mark.parametrize("mode",
+                         [MountMode.READ, MountMode.WRITE, MountMode.EXEC])
+async def test_version_keeps_confinement_and_uses_only_config_environment(
+        cli, spawned, monkeypatch, mode):
     monkeypatch.setenv("MIRAGE_TEST_HOST_ONLY", "not-in-child")
     runtime = SandlockRuntime(config={"home": "python", "env": {"TZ": "UTC"}})
-    ws = Workspace({"/": RAMResource()},
-                   mode=MountMode.READ,
-                   runtimes=[runtime, "vfs"])
+    ws = Workspace({"/": RAMResource()}, mode=mode, runtimes=[runtime, "vfs"])
     try:
         io = await ws.execute("python --version",
-                              env={"PYTHONPATH": "/startup"})
+                              env={
+                                  "PYTHONPATH": "/startup",
+                                  "LD_PRELOAD": "/session/library.so",
+                                  "DYLD_INSERT_LIBRARIES":
+                                  "/session/library.dylib",
+                                  "PATH": "/session/bin",
+                                  "TZ": "session-override",
+                              })
         assert io.exit_code == 0
         assert await io.stdout_str() == "out"
         assert spawned == [{
@@ -162,9 +169,7 @@ async def test_read_only_version_keeps_confinement_and_uses_native_flag(
                 "/usr/bin/python", "--version"
             ],
             "env": {
-                "TZ": "UTC",
-                "PWD": "/",
-                "PYTHONPATH": "/startup"
+                "TZ": "UTC"
             },
         }]
     finally:

--- a/python/tests/runtime/python/sandlock/test_runtime.py
+++ b/python/tests/runtime/python/sandlock/test_runtime.py
@@ -18,6 +18,7 @@ import sys
 
 import pytest
 
+from mirage import MountMode, RAMResource, Workspace
 from mirage.runtime.python.sandlock import (SandlockRuntime,
                                             interpreter_readable)
 from mirage.runtime.types import RunArgs
@@ -140,6 +141,34 @@ async def test_run_wraps_the_interpreter_in_the_sandlock_cli(cli, spawned):
     assert ["-w", "/mnt/ws"] == argv[separator - 2:separator]
     assert argv[separator + 1] == sys.executable
     assert "-c" in argv[separator:]
+
+
+@pytest.mark.asyncio
+async def test_read_only_version_keeps_confinement_and_uses_native_flag(
+        cli, spawned, monkeypatch):
+    monkeypatch.setenv("MIRAGE_TEST_HOST_ONLY", "not-in-child")
+    runtime = SandlockRuntime(config={"home": "python", "env": {"TZ": "UTC"}})
+    ws = Workspace({"/": RAMResource()},
+                   mode=MountMode.READ,
+                   runtimes=[runtime, "vfs"])
+    try:
+        io = await ws.execute("python --version",
+                              env={"PYTHONPATH": "/startup"})
+        assert io.exit_code == 0
+        assert await io.stdout_str() == "out"
+        assert spawned == [{
+            "argv": [
+                SANDLOCK_BIN, "run", *runtime.policy_argv(), "--",
+                "/usr/bin/python", "--version"
+            ],
+            "env": {
+                "TZ": "UTC",
+                "PWD": "/",
+                "PYTHONPATH": "/startup"
+            },
+        }]
+    finally:
+        await ws.close()
 
 
 @pytest.mark.asyncio

--- a/python/tests/runtime/python/test_base.py
+++ b/python/tests/runtime/python/test_base.py
@@ -1,0 +1,49 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, RAMResource, Workspace
+from mirage.runtime.python.base import PythonRuntime
+from mirage.runtime.types import RunArgs, RunResult
+
+
+class ProcessRuntime(PythonRuntime):
+    name = "custom-process"
+    runs = 0
+
+    async def run(self, args: RunArgs) -> RunResult:
+        self.runs += 1
+        return RunResult(stdout=b"unexpected execution",
+                         stderr=None,
+                         exit_code=0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode",
+                         [MountMode.READ, MountMode.WRITE, MountMode.EXEC])
+async def test_custom_process_version_never_executes_code(mode):
+    runtime = ProcessRuntime()
+    assert runtime.reach == "process"
+    ws = Workspace({"/": RAMResource()}, mode=mode, runtimes=[runtime, "vfs"])
+    try:
+        for line in ["python --version", "python3 -V", "python -VV"]:
+            io = await ws.execute(line, env={"PYTHONPATH": "/startup"})
+            assert io.exit_code == 1
+            assert await io.stdout_str() == ""
+            assert await io.stderr_str(
+            ) == "custom-process: version information unavailable\n"
+            assert runtime.runs == 0
+    finally:
+        await ws.close()

--- a/python/tests/runtime/python/test_local.py
+++ b/python/tests/runtime/python/test_local.py
@@ -13,10 +13,12 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import sys
 import time
 
 import pytest
 
+from mirage import MountMode, RAMResource, Workspace
 from mirage.runtime.python import LocalRuntime
 from mirage.runtime.types import RunArgs
 
@@ -64,6 +66,34 @@ def test_local_exit_code_and_stderr():
 
 def test_local_name():
     assert LocalRuntime().name == "local"
+
+
+@pytest.mark.asyncio
+async def test_read_only_version_does_not_run_startup_code(tmp_path):
+    marker = tmp_path / "startup-ran"
+    (tmp_path / "sitecustomize.py"
+     ).write_text(f"open({str(marker)!r}, 'w').write('ran')\n")
+    env = {"PYTHONPATH": str(tmp_path)}
+    runtime = LocalRuntime(config={"home": sys.executable})
+    ws = Workspace({"/": RAMResource()},
+                   mode=MountMode.READ,
+                   runtimes=[runtime, "vfs"])
+    try:
+        for line in ["python --version", "python3 -V", "python -VV"]:
+            io = await ws.execute(line, env=env)
+            assert io.exit_code == 0
+            assert await io.stdout_str(
+            ) == f"Python {sys.version.split()[0]}\n"
+            assert await io.stderr_str() == ""
+            assert not marker.exists()
+        refused = await ws.execute("python -c 'pass'", env=env)
+        assert refused.exit_code == 126
+        assert not marker.exists()
+        control = await runtime.run(RunArgs(code="pass", env=env))
+        assert control.exit_code == 0
+        assert marker.read_text() == "ran"
+    finally:
+        await ws.close()
 
 
 @pytest.mark.asyncio

--- a/python/tests/runtime/python/test_local.py
+++ b/python/tests/runtime/python/test_local.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import json
 import sys
 import time
 
@@ -66,6 +67,41 @@ def test_local_exit_code_and_stderr():
 
 def test_local_name():
     assert LocalRuntime().name == "local"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode",
+                         [MountMode.READ, MountMode.WRITE, MountMode.EXEC])
+async def test_version_process_uses_only_host_environment(
+        tmp_path, monkeypatch, mode):
+    monkeypatch.setenv("MIRAGE_TEST_VERSION_ENV", "host")
+    session = {
+        "LD_PRELOAD": str(tmp_path / "session.so"),
+        "LD_LIBRARY_PATH": str(tmp_path),
+        "DYLD_INSERT_LIBRARIES": str(tmp_path / "session.dylib"),
+        "DYLD_LIBRARY_PATH": str(tmp_path),
+        "PATH": str(tmp_path),
+        "MIRAGE_TEST_VERSION_ENV": "session",
+    }
+    probe = tmp_path / "python-probe"
+    probe.write_text(
+        f"#!{sys.executable}\nimport json, os\n"
+        f"keys = {list(session)!r}\n"
+        "print(json.dumps({k: os.environ.get(k) for k in keys}))\n")
+    probe.chmod(0o755)
+    runtime = LocalRuntime(config={"home": str(probe)})
+    baseline = await runtime.version({})
+    expected = json.loads(baseline.stdout)
+    assert expected["MIRAGE_TEST_VERSION_ENV"] == "host"
+    ws = Workspace({"/": RAMResource()}, mode=mode, runtimes=[runtime, "vfs"])
+    try:
+        for line in ["python --version", "python3 -V", "python -VV"]:
+            io = await ws.execute(line, env=session)
+            assert io.exit_code == 0
+            assert json.loads(await io.stdout_str()) == expected
+            assert await io.stderr_str() == ""
+    finally:
+        await ws.close()
 
 
 @pytest.mark.asyncio

--- a/python/tests/runtime/sandbox/test_base.py
+++ b/python/tests/runtime/sandbox/test_base.py
@@ -47,6 +47,28 @@ class RecordingSandbox(RemoteSandbox):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("line", [
+    "python3 --version",
+    "python -V",
+    "node --version",
+    "node -v",
+    "tsc --version",
+])
+async def test_version_commands_reach_the_remote_environment(line):
+    box = RecordingSandbox()
+    ws = Workspace({"/data": RAMResource()},
+                   mode=MountMode.EXEC,
+                   runtimes=[box, "vfs"])
+    try:
+        io = await ws.execute(line)
+        assert io.exit_code == 0
+        assert await materialize(io.stdout) == b"ran:" + line.encode()
+        assert box.execs[0][0] == line
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
 async def test_first_line_connects_once():
     box = RecordingSandbox(captures=("python3", ))
     ws = Workspace({"/data": RAMResource()},

--- a/python/tests/workspace/mount/test_mount.py
+++ b/python/tests/workspace/mount/test_mount.py
@@ -17,6 +17,11 @@ import errno
 
 import pytest
 
+from mirage.accessor.ram import RAMAccessor
+from mirage.commands.config import command
+from mirage.commands.spec import CommandSpec
+from mirage.commands.spec.types import Option
+from mirage.io.types import IOResult, materialize
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode, PathSpec
 from mirage.utils.errors import OperationNotSupportedError, ReadOnlyError
@@ -85,6 +90,47 @@ def test_read_only_blocks_write_cmd():
     stdout, io = _run(mount.execute_cmd("mkdir", [scope], [], {}))
     assert io.exit_code != 0
     assert b"read-only" in io.stderr
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", [MountMode.READ, MountMode.WRITE])
+@pytest.mark.parametrize("declared", [False, True])
+@pytest.mark.parametrize("flag", ["help", "version"])
+async def test_only_wrapper_responses_bypass_the_write_guard(
+        mode, declared, flag):
+    resource = RAMResource()
+    mount = MountEntry("/ram/", resource, mode)
+    calls: list[str] = []
+    options = (Option(long="--version", type="bool"), ) if declared else ()
+
+    @command("mutate",
+             resource="ram",
+             spec=CommandSpec(options=options),
+             write=True)
+    async def mutate(accessor: RAMAccessor, paths, texts, opts):
+        calls.append("handler")
+        accessor.store.files["/changed"] = b"changed"
+        return b"custom version\n", IOResult()
+
+    mount.register_fns([mutate])
+    stdout, io = await mount.execute_cmd("mutate", [], [], {flag: True})
+    output = await materialize(stdout)
+    if declared and flag == "version":
+        if mode == MountMode.READ:
+            assert io.exit_code == 1
+            assert io.stderr == b"mutate: read-only mount at /ram/\n"
+            assert not calls
+            assert "/changed" not in resource.accessor.store.files
+        else:
+            assert io.exit_code == 0
+            assert output == b"custom version\n"
+            assert calls == ["handler"]
+            assert resource.accessor.store.files["/changed"] == b"changed"
+    else:
+        assert io.exit_code == 0
+        assert output
+        assert not calls
+        assert "/changed" not in resource.accessor.store.files
 
 
 def test_the_read_only_refusal_is_newline_terminated():

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -5812,7 +5812,7 @@ wheels = [
 
 [[package]]
 name = "mirage-ai"
-version = "0.0.7a1"
+version = "0.0.7a2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/spec/python/general/js.json
+++ b/spec/python/general/js.json
@@ -17,6 +17,12 @@
   "description": "Run JavaScript on a sandboxed quickjs engine.",
   "options": [
     {
+      "description": "Show runtime version information and exit.",
+      "long": "--version",
+      "short": "-v",
+      "type": "bool"
+    },
+    {
       "description": "Evaluate the next argument as a script.",
       "short": "-e",
       "type": "str"

--- a/spec/python/general/node.json
+++ b/spec/python/general/node.json
@@ -17,6 +17,12 @@
   "description": "Run JavaScript on a sandboxed quickjs engine.",
   "options": [
     {
+      "description": "Show runtime version information and exit.",
+      "long": "--version",
+      "short": "-v",
+      "type": "bool"
+    },
+    {
       "description": "Evaluate the next argument as a script.",
       "short": "-e",
       "type": "str"

--- a/spec/typescript/browser/general/js.json
+++ b/spec/typescript/browser/general/js.json
@@ -17,6 +17,12 @@
   "description": "Run JavaScript on a sandboxed quickjs engine.",
   "options": [
     {
+      "description": "Show runtime version information and exit.",
+      "long": "--version",
+      "short": "-v",
+      "type": "bool"
+    },
+    {
       "description": "Evaluate the next argument as a script.",
       "short": "-e",
       "type": "str"

--- a/spec/typescript/browser/general/node.json
+++ b/spec/typescript/browser/general/node.json
@@ -17,6 +17,12 @@
   "description": "Run JavaScript on a sandboxed quickjs engine.",
   "options": [
     {
+      "description": "Show runtime version information and exit.",
+      "long": "--version",
+      "short": "-v",
+      "type": "bool"
+    },
+    {
       "description": "Evaluate the next argument as a script.",
       "short": "-e",
       "type": "str"

--- a/spec/typescript/node/general/js.json
+++ b/spec/typescript/node/general/js.json
@@ -17,6 +17,12 @@
   "description": "Run JavaScript on a sandboxed quickjs engine.",
   "options": [
     {
+      "description": "Show runtime version information and exit.",
+      "long": "--version",
+      "short": "-v",
+      "type": "bool"
+    },
+    {
       "description": "Evaluate the next argument as a script.",
       "short": "-e",
       "type": "str"

--- a/spec/typescript/node/general/node.json
+++ b/spec/typescript/node/general/node.json
@@ -17,6 +17,12 @@
   "description": "Run JavaScript on a sandboxed quickjs engine.",
   "options": [
     {
+      "description": "Show runtime version information and exit.",
+      "long": "--version",
+      "short": "-v",
+      "type": "bool"
+    },
+    {
       "description": "Evaluate the next argument as a script.",
       "short": "-e",
       "type": "str"

--- a/typescript/packages/agents/package.json
+++ b/typescript/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-agents",
-  "version": "0.0.7-alpha.1",
+  "version": "0.0.7-alpha.2",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/browser/package.json
+++ b/typescript/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-browser",
-  "version": "0.0.7-alpha.1",
+  "version": "0.0.7-alpha.2",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/cli/package.json
+++ b/typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-cli",
-  "version": "0.0.7-alpha.1",
+  "version": "0.0.7-alpha.2",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-core",
-  "version": "0.0.7-alpha.1",
+  "version": "0.0.7-alpha.2",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/core/src/commands/builtin/general/interpreter.ts
+++ b/typescript/packages/core/src/commands/builtin/general/interpreter.ts
@@ -13,7 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { IOResult } from '../../../io/types.ts'
+import type { LanguageRuntime } from '../../../runtime/language.ts'
+import { QuickJsUnavailableError } from '../../../runtime/js/types.ts'
+import { MontyUnavailableError } from '../../../runtime/python/monty/binding.ts'
+import { PyodideUnavailableError } from '../../../runtime/python/types.ts'
 import type { RunResult } from '../../../runtime/types.ts'
+import { CommandTimeoutError } from '../../errors.ts'
 
 /**
  * Convert one interpreter outcome into a command's output pair.
@@ -29,6 +34,32 @@ export function runOutput(result: RunResult): [Uint8Array | null, IOResult] {
     result.stdout.length > 0 ? result.stdout : null,
     new IOResult({ exitCode: result.exitCode, stderr: result.stderr }),
   ]
+}
+
+export async function runtimeVersion(
+  label: string,
+  runtime: LanguageRuntime,
+  env: Record<string, string>,
+  signal?: AbortSignal,
+  timeoutSeconds?: number,
+): Promise<[Uint8Array | null, IOResult]> {
+  try {
+    return runOutput(await runtime.version(env, signal, timeoutSeconds))
+  } catch (err) {
+    if (err instanceof CommandTimeoutError) throw err
+    const unavailable =
+      err instanceof QuickJsUnavailableError ||
+      err instanceof MontyUnavailableError ||
+      err instanceof PyodideUnavailableError
+    const message = err instanceof Error ? err.message : String(err)
+    return [
+      null,
+      new IOResult({
+        exitCode: unavailable ? 127 : 1,
+        stderr: new TextEncoder().encode(`${label}: ${message}\n`),
+      }),
+    ]
+  }
 }
 
 // Which of an interpreter's four doors the source came through. The

--- a/typescript/packages/core/src/commands/builtin/general/js.ts
+++ b/typescript/packages/core/src/commands/builtin/general/js.ts
@@ -32,19 +32,20 @@ async function jsCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
+  const label = opts.command ?? 'js'
   if (!(opts.runtime instanceof LanguageRuntime)) {
     return [
       null,
       new IOResult({
         exitCode: 127,
-        stderr: ENC.encode('js: command not found\n'),
+        stderr: ENC.encode(`${label}: command not found\n`),
       }),
     ]
   }
 
   const fl = new FlagView(opts.flags, specOf('js'))
   if (fl.asBool('version')) {
-    return runtimeVersion('js', opts.runtime, opts.env ?? {}, opts.signal, opts.timeoutSeconds)
+    return runtimeVersion(label, opts.runtime, opts.env ?? {}, opts.signal, opts.timeoutSeconds)
   }
 
   if (opts.dispatch === undefined) {
@@ -52,7 +53,7 @@ async function jsCommand(
       null,
       new IOResult({
         exitCode: 1,
-        stderr: ENC.encode('js: no dispatch available\n'),
+        stderr: ENC.encode(`${label}: no dispatch available\n`),
       }),
     ]
   }
@@ -91,7 +92,7 @@ async function jsCommand(
         null,
         new IOResult({
           exitCode: 126,
-          stderr: ENC.encode(`js: ${display}: not in EXEC mode\n`),
+          stderr: ENC.encode(`${label}: ${display}: not in EXEC mode\n`),
         }),
       ]
     }
@@ -100,7 +101,7 @@ async function jsCommand(
       null,
       new IOResult({
         exitCode: 126,
-        stderr: ENC.encode("js: root mount '/' is not in EXEC mode\n"),
+        stderr: ENC.encode(`${label}: root mount '/' is not in EXEC mode\n`),
       }),
     ]
   }
@@ -120,6 +121,7 @@ async function jsCommand(
     scriptPath,
     argStrs,
     {
+      command: label,
       stdin: stdinForRuntime,
       env: opts.env ?? {},
       code: resolvedCode,

--- a/typescript/packages/core/src/commands/builtin/general/js.ts
+++ b/typescript/packages/core/src/commands/builtin/general/js.ts
@@ -21,7 +21,7 @@ import { LanguageRuntime } from '../../../runtime/language.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { resolveScript } from '../utils/operands.ts'
 import { FlagView } from '../../spec/types.ts'
-import { STDIN_OPERAND } from './interpreter.ts'
+import { runtimeVersion, STDIN_OPERAND } from './interpreter.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -42,6 +42,11 @@ async function jsCommand(
     ]
   }
 
+  const fl = new FlagView(opts.flags, specOf('js'))
+  if (fl.asBool('version')) {
+    return runtimeVersion('js', opts.runtime, opts.env ?? {}, opts.signal, opts.timeoutSeconds)
+  }
+
   if (opts.dispatch === undefined) {
     return [
       null,
@@ -52,7 +57,6 @@ async function jsCommand(
     ]
   }
 
-  const fl = new FlagView(opts.flags, specOf('js'))
   const code = fl.asStr('e') ?? null
   const hasCode = code !== null
   const module = fl.asBool('module')

--- a/typescript/packages/core/src/commands/builtin/general/python.ts
+++ b/typescript/packages/core/src/commands/builtin/general/python.ts
@@ -23,6 +23,7 @@ import { resolveScript } from '../utils/operands.ts'
 import { FlagView } from '../../spec/types.ts'
 import {
   moduleSource,
+  runtimeVersion,
   PAYLOAD_ARGV0,
   STDIN_ARGV0,
   STDIN_OPERAND,
@@ -73,6 +74,11 @@ async function pythonCommand(
     ]
   }
 
+  const fl = new FlagView(opts.flags, specOf('python3'))
+  if (fl.asBool('version')) {
+    return runtimeVersion('python3', opts.runtime, opts.env ?? {}, opts.signal, opts.timeoutSeconds)
+  }
+
   if (opts.dispatch === undefined) {
     return [
       null,
@@ -83,7 +89,6 @@ async function pythonCommand(
     ]
   }
 
-  const fl = new FlagView(opts.flags, specOf('python3'))
   const code = fl.asStr('c') ?? null
   const moduleName = fl.asStr('m') ?? null
   const hasCode = code !== null

--- a/typescript/packages/core/src/commands/builtin/general/python.ts
+++ b/typescript/packages/core/src/commands/builtin/general/python.ts
@@ -64,19 +64,20 @@ async function pythonCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
+  const label = opts.command ?? 'python3'
   if (!(opts.runtime instanceof LanguageRuntime)) {
     return [
       null,
       new IOResult({
         exitCode: 127,
-        stderr: ENC.encode('python3: command not found\n'),
+        stderr: ENC.encode(`${label}: command not found\n`),
       }),
     ]
   }
 
   const fl = new FlagView(opts.flags, specOf('python3'))
   if (fl.asBool('version')) {
-    return runtimeVersion('python3', opts.runtime, opts.env ?? {}, opts.signal, opts.timeoutSeconds)
+    return runtimeVersion(label, opts.runtime, opts.env ?? {}, opts.signal, opts.timeoutSeconds)
   }
 
   if (opts.dispatch === undefined) {
@@ -84,7 +85,7 @@ async function pythonCommand(
       null,
       new IOResult({
         exitCode: 1,
-        stderr: ENC.encode('python3: no dispatch available\n'),
+        stderr: ENC.encode(`${label}: no dispatch available\n`),
       }),
     ]
   }
@@ -146,7 +147,7 @@ async function pythonCommand(
         null,
         new IOResult({
           exitCode: 126,
-          stderr: ENC.encode(`python3: ${display}: not in EXEC mode\n`),
+          stderr: ENC.encode(`${label}: ${display}: not in EXEC mode\n`),
         }),
       ]
     }
@@ -155,12 +156,12 @@ async function pythonCommand(
       null,
       new IOResult({
         exitCode: 126,
-        stderr: ENC.encode("python3: root mount '/' is not in EXEC mode\n"),
+        stderr: ENC.encode(`${label}: root mount '/' is not in EXEC mode\n`),
       }),
     ]
   }
 
-  let resolvedCode: string | null = moduleName !== null ? moduleSource(moduleName, 'python3') : code
+  let resolvedCode: string | null = moduleName !== null ? moduleSource(moduleName, label) : code
   let stdinForRuntime = opts.stdin
   if (resolvedCode === null && scriptPath === null && opts.stdin !== null) {
     const bytes = await materialize(opts.stdin)
@@ -175,6 +176,7 @@ async function pythonCommand(
     scriptPath,
     argStrs,
     {
+      command: label,
       stdin: stdinForRuntime,
       env: opts.env ?? {},
       code: resolvedCode,

--- a/typescript/packages/core/src/commands/config.test.ts
+++ b/typescript/packages/core/src/commands/config.test.ts
@@ -12,9 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { command, crossCommand, RegisteredCommand } from './config.ts'
-import { CommandSpec, Operand } from './spec/types.ts'
+import { CommandSpec, Operand, Option } from './spec/types.ts'
 
 const STUB_SPEC = new CommandSpec({ rest: new Operand({ type: 'path' }) })
 const STUB_FN = () => Promise.resolve([null, { exitCode: 0 } as never] as [null, never])
@@ -37,6 +37,24 @@ describe('RegisteredCommand', () => {
 })
 
 describe('command()', () => {
+  it('lets a declared --version reach the handler', async () => {
+    const fn = vi.fn(STUB_FN)
+    const [rc] = command({
+      name: 'custom',
+      resource: null,
+      spec: new CommandSpec({ options: [new Option({ long: '--version' })] }),
+      fn,
+    })
+    if (rc === undefined) throw new Error('expected a registered command')
+    await rc.fn({} as never, [], [], {
+      stdin: null,
+      flags: { version: true },
+      filetypeFns: null,
+      cwd: '/',
+    })
+    expect(fn).toHaveBeenCalledOnce()
+  })
+
   it('returns one RegisteredCommand per resource when given a single string', () => {
     const out = command({ name: 'cat', resource: 'ram', spec: STUB_SPEC, fn: STUB_FN })
     expect(out).toHaveLength(1)

--- a/typescript/packages/core/src/commands/config.ts
+++ b/typescript/packages/core/src/commands/config.ts
@@ -283,12 +283,17 @@ export function versionRequest(
   spec: CommandSpec | null,
   argv: string[],
 ): Uint8Array | null {
-  if (!spec?.options.some((o) => o === VERSION_OPTION)) return null
+  if (!hasInjectedVersion(spec)) return null
   for (const arg of argv) {
     if (arg === '--') return null
     if (arg === '--version') return HELP_ENC.encode(versionLine(name))
   }
   return null
+}
+
+/** Whether the wrapper supplies this spec's version response. */
+export function hasInjectedVersion(spec: CommandSpec | null): boolean {
+  return spec?.options.some((o) => o === VERSION_OPTION) ?? false
 }
 
 /**

--- a/typescript/packages/core/src/commands/config.ts
+++ b/typescript/packages/core/src/commands/config.ts
@@ -295,6 +295,7 @@ export function versionRequest(
  * Inject --help / --version and short-circuit them before the handler.
  * Mirrors GNU coreutils: every registered command accepts both flags,
  * prints to stdout, and exits 0 without running the command body.
+ * A command declaring its own --version handles that flag itself.
  */
 function withHelpSupport(
   name: string,
@@ -321,7 +322,7 @@ function withHelpSupport(
     if (opts.flags.help === true) {
       return [HELP_ENC.encode(helpText), new IOResult()]
     }
-    if (opts.flags.version === true) {
+    if (!hasVersion && opts.flags.version === true) {
       return [HELP_ENC.encode(versionText), new IOResult()]
     }
     return fn(accessor, paths, texts, opts)

--- a/typescript/packages/core/src/commands/spec/builtin_specs/runtime.ts
+++ b/typescript/packages/core/src/commands/spec/builtin_specs/runtime.ts
@@ -95,11 +95,7 @@ const PYTHON_OPTIONS: readonly Option[] = [
     choices: ['always', 'default', 'never'],
     description: 'How to validate hash-based .pyc files.',
   }),
-  // Aliases of the injected help/version options, not new behavior:
-  // sharing their long spelling means they share their dest, so the
-  // help/version tier short-circuits them on the one path every command
-  // uses. CPython's -VV adds build info; mirage has no CPython build to
-  // report, so -VV clusters into -V and prints the same line.
+  // -VV shares the concise version line; build details are not exposed.
   new Option({ short: '-h', long: '--help', description: 'Show this help message and exit.' }),
   new Option({
     short: '-V',
@@ -196,6 +192,11 @@ export const SPECS: Record<string, CommandSpec> = {
     description: 'Run JavaScript on a sandboxed quickjs engine.',
     options: [
       new Option({
+        short: '-v',
+        long: '--version',
+        description: 'Show runtime version information and exit.',
+      }),
+      new Option({
         short: '-e',
         type: 'str',
         description: 'Evaluate the next argument as a script.',
@@ -225,6 +226,11 @@ export const SPECS: Record<string, CommandSpec> = {
   node: new CommandSpec({
     description: 'Run JavaScript on a sandboxed quickjs engine.',
     options: [
+      new Option({
+        short: '-v',
+        long: '--version',
+        description: 'Show runtime version information and exit.',
+      }),
       new Option({
         short: '-e',
         type: 'str',

--- a/typescript/packages/core/src/runtime/js/quickjs.ts
+++ b/typescript/packages/core/src/runtime/js/quickjs.ts
@@ -180,6 +180,26 @@ export class QuickJsRuntime extends JsRuntime implements Evaluator {
     }
   }
 
+  override async version(): Promise<RunResult> {
+    const newAsyncModule = await this.loadModule()
+    const QuickJS = await newAsyncModule()
+    const ctx = QuickJS.newContext()
+    try {
+      // JS_DumpMemoryUsage prints the engine's compiled-in version.
+      const version = /^QuickJS memory usage -- (\S+) version,/.exec(
+        ctx.runtime.dumpMemoryUsage(),
+      )?.[1]
+      if (version === undefined) throw new Error('could not read the QuickJS engine version')
+      return {
+        stdout: ENC.encode(`JavaScript (quickjs ${version})\n`),
+        stderr: null,
+        exitCode: 0,
+      }
+    } finally {
+      ctx.dispose()
+    }
+  }
+
   async run(args: RunArgs): Promise<RunResult> {
     const newAsyncModule = await this.loadModule()
     const QuickJS = await newAsyncModule()

--- a/typescript/packages/core/src/runtime/language.ts
+++ b/typescript/packages/core/src/runtime/language.ts
@@ -49,6 +49,19 @@ import type { BridgeDispatchFn, RunArgs, RunResult, RuntimeLanguage } from './ty
 export abstract class LanguageRuntime extends Runtime {
   abstract readonly language: RuntimeLanguage
 
+  /** Report the bound interpreter's version. */
+  version(
+    _env: Record<string, string>,
+    _signal?: AbortSignal,
+    _timeoutSeconds?: number,
+  ): Promise<RunResult> {
+    return Promise.resolve({
+      stdout: new Uint8Array(),
+      stderr: new TextEncoder().encode(`${this.name}: version information unavailable\n`),
+      exitCode: 1,
+    })
+  }
+
   /**
    * Late-wire workspace I/O into a user-constructed instance. The
    * workspace attaches its dispatch at construction; runtimes that

--- a/typescript/packages/core/src/runtime/python/base.test.ts
+++ b/typescript/packages/core/src/runtime/python/base.test.ts
@@ -1,0 +1,62 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { PythonRuntime } from './base.ts'
+import type { RunArgs, RunResult } from '../types.ts'
+import { RAMResource } from '../../resource/ram/ram.ts'
+import { MountMode } from '../../types.ts'
+import { Workspace } from '../../workspace/workspace/workspace.ts'
+import { getTestParser } from '../../workspace/fixtures/workspace_fixture.ts'
+
+class ProcessRuntime extends PythonRuntime {
+  readonly name = 'custom-process'
+  runs = 0
+
+  run(_args: RunArgs): Promise<RunResult> {
+    this.runs += 1
+    return Promise.resolve({
+      stdout: new TextEncoder().encode('unexpected execution'),
+      stderr: null,
+      exitCode: 0,
+    })
+  }
+}
+
+describe('PythonRuntime version defaults', () => {
+  it.each([MountMode.READ, MountMode.WRITE, MountMode.EXEC])(
+    'never executes custom process code in %s mode',
+    async (mode) => {
+      const runtime = new ProcessRuntime()
+      expect(runtime.reach).toBe('process')
+      const ws = new Workspace(
+        { '/': new RAMResource() },
+        { mode, runtimes: [runtime, 'vfs'], shellParser: await getTestParser() },
+      )
+      try {
+        for (const line of ['python --version', 'python3 -V', 'python -VV']) {
+          const io = await ws.execute(line, { env: { PYTHONPATH: '/startup' } })
+          expect(io.exitCode).toBe(1)
+          expect(new TextDecoder().decode(io.stdout)).toBe('')
+          expect(new TextDecoder().decode(io.stderr)).toBe(
+            'custom-process: version information unavailable\n',
+          )
+          expect(runtime.runs).toBe(0)
+        }
+      } finally {
+        await ws.close()
+      }
+    },
+  )
+})

--- a/typescript/packages/core/src/runtime/python/base.ts
+++ b/typescript/packages/core/src/runtime/python/base.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { LanguageRuntime } from '../language.ts'
-import type { RuntimeLanguage, RuntimeOptions } from '../types.ts'
+import type { RunResult, RuntimeLanguage, RuntimeOptions } from '../types.ts'
 
 /**
  * The python tier: every runtime that interprets Python source.
@@ -40,6 +40,22 @@ export abstract class PythonRuntime extends LanguageRuntime {
    * probed, so a refusal can name the runtime.
    */
   readonly runsModules: boolean = true
+  protected readonly versionSuffix: string = ''
+
+  override version(
+    env: Record<string, string>,
+    signal?: AbortSignal,
+    timeoutSeconds?: number,
+  ): Promise<RunResult> {
+    return this.run({
+      code: `import sys\nprint('Python ' + sys.version.split()[0] + ${JSON.stringify(this.versionSuffix)})`,
+      args: [],
+      env,
+      stdin: null,
+      ...(signal !== undefined ? { signal } : {}),
+      ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
+    })
+  }
 
   constructor(options: RuntimeOptions<object> = {}, configKeys: readonly string[] = []) {
     super(options, PythonRuntime.commands, configKeys)

--- a/typescript/packages/core/src/runtime/python/base.ts
+++ b/typescript/packages/core/src/runtime/python/base.ts
@@ -47,6 +47,8 @@ export abstract class PythonRuntime extends LanguageRuntime {
     signal?: AbortSignal,
     timeoutSeconds?: number,
   ): Promise<RunResult> {
+    // Process runtimes must supply a probe that cannot run startup hooks.
+    if (this.reach !== 'vfs') return super.version(env, signal, timeoutSeconds)
     return this.run({
       code: `import sys\nprint('Python ' + sys.version.split()[0] + ${JSON.stringify(this.versionSuffix)})`,
       args: [],

--- a/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
@@ -12,9 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { afterAll, describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it, vi } from 'vitest'
 import type { BridgeDispatchFn } from '../../types.ts'
 import { MontyRuntime } from './index.ts'
+import { MontyUnavailableError } from './binding.ts'
 import { PyodideRuntime } from '../pyodide.ts'
 import { buildRuntime } from '../../table.ts'
 import { getTestParser } from '../../../workspace/fixtures/workspace_fixture.ts'
@@ -796,6 +797,59 @@ describe('MontyRuntime', () => {
 })
 
 describe('Workspace with the monty runtime', () => {
+  it('reports an unavailable version runtime as command not found', async () => {
+    const runtime = new MontyRuntime()
+    vi.spyOn(runtime, 'version').mockRejectedValue(
+      new MontyUnavailableError('install @pydantic/monty'),
+    )
+    const ws = new Workspace(
+      { '/data': new RAMResource() },
+      { shellParser: await getTestParser(), runtimes: [runtime, 'vfs'] },
+    )
+    try {
+      const io = await ws.execute('python3 --version')
+      expect(io.exitCode).toBe(127)
+      expect(new TextDecoder().decode(io.stdout)).toBe('')
+      expect(new TextDecoder().decode(io.stderr)).toBe('python3: install @pydantic/monty\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('does not print Mirage versions for unbound interpreter commands', async () => {
+    const ws = new Workspace(
+      { '/data': new RAMResource() },
+      { shellParser: await getTestParser(), runtimes: ['vfs'] },
+    )
+    try {
+      for (const line of ['python3 --version', 'python -V', 'node --version', 'js -v']) {
+        const io = await ws.execute(line)
+        expect(io.exitCode).toBe(127)
+        expect(new TextDecoder().decode(io.stdout)).toBe('')
+        expect(new TextDecoder().decode(io.stderr)).toContain('command not found')
+      }
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('reports the guest Python version for --version and -V', async () => {
+    const ws = new Workspace(
+      { '/data': new RAMResource() },
+      { shellParser: await getTestParser(), runtimes: ['monty', 'vfs'] },
+    )
+    try {
+      for (const line of ['python3 --version', 'python -V', 'python3 -VV']) {
+        const io = await ws.execute(line)
+        expect(io.exitCode).toBe(0)
+        expect(new TextDecoder().decode(io.stdout)).toBe('Python 3.14.0 (monty)\n')
+        expect(new TextDecoder().decode(io.stderr)).toBe('')
+      }
+    } finally {
+      await ws.close()
+    }
+  })
+
   it('python3 reads a virtualized file end to end', async () => {
     const parser = await getTestParser()
     const data = new RAMResource()
@@ -846,6 +900,7 @@ describe('monty unavailable', () => {
       config: {},
       attach: () => undefined,
       run: () => Promise.reject(new MontyUnavailableError('install @pydantic/monty')),
+      version: () => Promise.reject(new MontyUnavailableError('install @pydantic/monty')),
       close: () => Promise.resolve(),
     }
     const dispatch = (() => Promise.reject(new Error('unused'))) as never

--- a/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.test.ts
@@ -822,11 +822,11 @@ describe('Workspace with the monty runtime', () => {
       { shellParser: await getTestParser(), runtimes: ['vfs'] },
     )
     try {
-      for (const line of ['python3 --version', 'python -V', 'node --version', 'js -v']) {
-        const io = await ws.execute(line)
+      for (const name of ['python3', 'python', 'node', 'js']) {
+        const io = await ws.execute(`${name} --version`)
         expect(io.exitCode).toBe(127)
         expect(new TextDecoder().decode(io.stdout)).toBe('')
-        expect(new TextDecoder().decode(io.stderr)).toContain('command not found')
+        expect(new TextDecoder().decode(io.stderr)).toBe(`${name}: command not found\n`)
       }
     } finally {
       await ws.close()

--- a/typescript/packages/core/src/runtime/python/monty/runtime.ts
+++ b/typescript/packages/core/src/runtime/python/monty/runtime.ts
@@ -101,6 +101,7 @@ function toEvalValue(value: unknown): EvalValue {
  */
 export class MontyRuntime extends PythonRuntime implements Evaluator {
   readonly name = 'monty'
+  protected override readonly versionSuffix = ' (monty)'
   // The interpreter is an in-process guest with no host syscalls: its
   // file I/O can only travel the VFS bridge, so every effect passes
   // the workspace gate (mount modes, policy, recording).

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -257,6 +257,7 @@ const EVAL_INTERRUPT_SECONDS = 10
 
 export class PyodideRuntime extends PythonRuntime implements Evaluator {
   readonly name = 'pyodide'
+  protected override readonly versionSuffix = ' (pyodide)'
   // The WASM guest's filesystem is the workspace-backed Emscripten FS,
   // so file effects pass the workspace gate, and loader.ts seals the
   // `js` module (null-prototype jsglobals) so guest code cannot reach

--- a/typescript/packages/core/src/runtime/sandbox/base.test.ts
+++ b/typescript/packages/core/src/runtime/sandbox/base.test.ts
@@ -62,6 +62,22 @@ async function sandboxWorkspace(box: RecordingSandbox): Promise<Workspace> {
 }
 
 describe('RemoteSandbox', () => {
+  it.each(['python3 --version', 'python -V', 'node --version', 'node -v', 'tsc --version'])(
+    'passes %s and its output through the remote environment',
+    async (line) => {
+      const box = new RecordingSandbox()
+      const ws = await sandboxWorkspace(box)
+      try {
+        const io = await ws.execute(line)
+        expect(io.exitCode).toBe(0)
+        expect(DEC.decode(io.stdout)).toBe(`ran:${line}`)
+        expect(box.execs[0]?.[0]).toBe(line)
+      } finally {
+        await ws.close()
+      }
+    },
+  )
+
   it('connects on the first line only', async () => {
     const box = new RecordingSandbox({ captures: ['python3'] })
     const ws = await sandboxWorkspace(box)

--- a/typescript/packages/core/src/workspace/executor/interpreter.ts
+++ b/typescript/packages/core/src/workspace/executor/interpreter.ts
@@ -31,6 +31,7 @@ interface InterpreterDeps {
 }
 
 interface InterpreterOpts {
+  command?: string
   stdin: ByteSource | null
   env: Record<string, string>
   code: string | null
@@ -109,21 +110,20 @@ export function makeInterpreterHandler(spec: InterpreterSpec): InterpreterHandle
     opts: InterpreterOpts,
     deps: InterpreterDeps,
   ): Promise<Result> {
+    const label = opts.command ?? spec.label
     let code = opts.code
     const cmdStr =
-      pathScope !== null
-        ? `${spec.label} ${pathScope.virtual}`
-        : `${spec.label} ${spec.payloadFlag}`
+      pathScope !== null ? `${label} ${pathScope.virtual}` : `${label} ${spec.payloadFlag}`
 
     if (code === null) {
-      if (pathScope === null) return errorResult(cmdStr, `${spec.label}: no input\n`, 1)
+      if (pathScope === null) return errorResult(cmdStr, `${label}: no input\n`, 1)
       try {
         const [data] = await dispatch('read', toPathSpec(pathScope))
         const bytes = await readAllBytes(data)
         code = new TextDecoder('utf-8', { fatal: false }).decode(bytes)
         if (opts.transformSource !== undefined) code = opts.transformSource(code)
       } catch {
-        return errorResult(cmdStr, `${spec.label}: ${pathScope.virtual}: No such file\n`, 1)
+        return errorResult(cmdStr, `${label}: ${pathScope.virtual}: No such file\n`, 1)
       }
     }
 
@@ -152,10 +152,10 @@ export function makeInterpreterHandler(spec: InterpreterSpec): InterpreterHandle
       // failure: let it reach the workspace's 124 handler.
       if (err instanceof CommandTimeoutError) throw err
       if (spec.isUnavailable(err)) {
-        return errorResult(cmdStr, `${spec.label}: ${(err as Error).message}\n`, 127)
+        return errorResult(cmdStr, `${label}: ${(err as Error).message}\n`, 127)
       }
       const msg = err instanceof Error ? err.message : String(err)
-      return errorResult(cmdStr, `${spec.label}: ${msg}\n`, 1)
+      return errorResult(cmdStr, `${label}: ${msg}\n`, 1)
     }
   }
 }

--- a/typescript/packages/core/src/workspace/executor/js/handle.ts
+++ b/typescript/packages/core/src/workspace/executor/js/handle.ts
@@ -37,6 +37,7 @@ export async function handleJs(
   pathScope: PathSpec | null,
   args: string[],
   opts: {
+    command?: string
     stdin: ByteSource | null
     env: Record<string, string>
     code: string | null
@@ -53,6 +54,7 @@ export async function handleJs(
     pathScope,
     args,
     {
+      command: opts.command ?? 'js',
       stdin: opts.stdin,
       env: opts.env,
       code: opts.code,

--- a/typescript/packages/core/src/workspace/executor/js/js.test.ts
+++ b/typescript/packages/core/src/workspace/executor/js/js.test.ts
@@ -18,6 +18,40 @@ import { makeWorkspace, stderrStr, stdoutStr } from '../../fixtures/workspace_fi
 // Mirrors the Python `node`/`js` command tests; both run on quickjs so a
 // script behaves identically across languages.
 describe('node/js: quickjs runtime', () => {
+  it('identifies QuickJS for both aliases and both version flags', async () => {
+    const { ws } = await makeWorkspace()
+    try {
+      for (const name of ['js', 'node']) {
+        for (const flag of ['--version', '-v']) {
+          const io = await ws.execute(`${name} ${flag}`)
+          expect(io.exitCode).toBe(0)
+          expect(stdoutStr(io)).toMatch(/^JavaScript \(quickjs \d{4}-\d{2}-\d{2}\)\n$/)
+          expect(stderrStr(io)).toBe('')
+        }
+      }
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('passes --version to scripts and inline programs', async () => {
+    const { ws } = await makeWorkspace()
+    try {
+      await ws.execute("echo 'console.log(scriptArgs[0])' > /ram/version.js")
+      for (const line of [
+        'node -e "console.log(scriptArgs[0])" -- --version',
+        'js /ram/version.js --version',
+        "echo 'console.log(scriptArgs[0])' | node - --version",
+      ]) {
+        const io = await ws.execute(line)
+        expect(io.exitCode).toBe(0)
+        expect(stdoutStr(io)).toBe('--version\n')
+      }
+    } finally {
+      await ws.close()
+    }
+  })
+
   it('js -e: modern syntax + compute', async () => {
     const { ws } = await makeWorkspace()
     const io = await ws.execute(

--- a/typescript/packages/core/src/workspace/executor/js/js.test.ts
+++ b/typescript/packages/core/src/workspace/executor/js/js.test.ts
@@ -18,6 +18,19 @@ import { makeWorkspace, stderrStr, stdoutStr } from '../../fixtures/workspace_fi
 // Mirrors the Python `node`/`js` command tests; both run on quickjs so a
 // script behaves identically across languages.
 describe('node/js: quickjs runtime', () => {
+  it('uses the invoked alias in script errors', async () => {
+    const { ws } = await makeWorkspace()
+    try {
+      for (const name of ['python', 'python3', 'js', 'node']) {
+        const io = await ws.execute(`${name} /missing-script`)
+        expect(io.exitCode).toBe(1)
+        expect(stderrStr(io)).toBe(`${name}: /missing-script: No such file\n`)
+      }
+    } finally {
+      await ws.close()
+    }
+  })
+
   it('identifies QuickJS for both aliases and both version flags', async () => {
     const { ws } = await makeWorkspace()
     try {

--- a/typescript/packages/core/src/workspace/executor/python/handle.ts
+++ b/typescript/packages/core/src/workspace/executor/python/handle.ts
@@ -41,10 +41,14 @@ const runPython = makeInterpreterHandler({
 // `-m` against a runtime that cannot run modules. Exit 1 is CPython's code
 // for a `-m` that could not run, but not its "No module named" wording:
 // nothing was searched for, so naming the runtime is the honest report.
-function moduleRefusal(mode: SourceMode | undefined, runtime: LanguageRuntime): string | null {
+function moduleRefusal(
+  mode: SourceMode | undefined,
+  runtime: LanguageRuntime,
+  label: string,
+): string | null {
   if (mode !== 'module') return null
   if (!(runtime instanceof PythonRuntime) || runtime.runsModules) return null
-  return `python3: -m is not supported by the '${runtime.name}' runtime\n`
+  return `${label}: -m is not supported by the '${runtime.name}' runtime\n`
 }
 
 export async function handlePython(
@@ -52,6 +56,7 @@ export async function handlePython(
   pathScope: PathSpec | null,
   args: string[],
   opts: {
+    command?: string
     stdin: ByteSource | null
     env: Record<string, string>
     code: string | null
@@ -74,10 +79,12 @@ export async function handlePython(
     pathScope,
     args,
     {
+      command: opts.command ?? 'python3',
       stdin: opts.stdin,
       env: opts.env,
       code: opts.code,
-      refuse: (runtime: LanguageRuntime) => moduleRefusal(opts.mode, runtime),
+      refuse: (runtime: LanguageRuntime) =>
+        moduleRefusal(opts.mode, runtime, opts.command ?? 'python3'),
       ...(opts.prog !== undefined ? { prog: opts.prog } : {}),
       ...(opts.initFlags !== undefined ? { flags: opts.initFlags as Record<string, unknown> } : {}),
       ...(opts.skipFirstLine === true ? { transformSource: skipFirstLine } : {}),

--- a/typescript/packages/core/src/workspace/executor/python/python.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/python.test.ts
@@ -19,6 +19,43 @@ import { makeWorkspace, stderrStr, stdoutStr } from '../../fixtures/workspace_fi
 // in tests/workspace/test_workspace.py. Citations are in the `it()` title.
 
 describe('python3: core (ports of Python tests_workspace)', { timeout: 30000 }, () => {
+  it('reports the Pyodide guest version through every version spelling', async () => {
+    const { ws } = await makeWorkspace()
+    try {
+      const guest = await ws.execute("python3 -c 'import sys; print(sys.version.split()[0])'")
+      expect(guest.exitCode).toBe(0)
+      const expected = `Python ${stdoutStr(guest).trim()} (pyodide)\n`
+      for (const name of ['python', 'python3']) {
+        for (const flag of ['--version', '-V', '-VV']) {
+          const io = await ws.execute(`${name} ${flag}`)
+          expect(io.exitCode).toBe(0)
+          expect(stdoutStr(io)).toBe(expected)
+          expect(stderrStr(io)).toBe('')
+        }
+      }
+    } finally {
+      await ws.close()
+    }
+  }, 60_000)
+
+  it('passes a program its own --version argument', async () => {
+    const { ws } = await makeWorkspace()
+    try {
+      await ws.execute("echo 'import sys; print(sys.argv[-1])' > /ram/version.py")
+      for (const line of [
+        "python3 -c 'import sys; print(sys.argv[-1])' --version",
+        'python3 /ram/version.py --version',
+        "echo 'import sys; print(sys.argv[-1])' | python3 - --version",
+      ]) {
+        const io = await ws.execute(line)
+        expect(io.exitCode).toBe(0)
+        expect(stdoutStr(io)).toBe('--version\n')
+      }
+    } finally {
+      await ws.close()
+    }
+  }, 60_000)
+
   it('test_python3_c_simple (L1364): print(42) → "42\\n"', async () => {
     const { ws } = await makeWorkspace()
     const io = await ws.execute('python3 -c "print(42)"')

--- a/typescript/packages/core/src/workspace/mount/mount.test.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.test.ts
@@ -21,9 +21,11 @@ import {
   type ExecContext,
   RegisteredCommand,
 } from '../../commands/config.ts'
-import { CommandSpec, Operand } from '../../commands/spec/types.ts'
-import { IOResult } from '../../io/types.ts'
+import { CommandSpec, Operand, Option } from '../../commands/spec/types.ts'
+import { IOResult, materialize } from '../../io/types.ts'
 import type { Accessor } from '../../accessor/base.ts'
+import type { RAMAccessor } from '../../accessor/ram.ts'
+import { RAMResource } from '../../resource/ram/ram.ts'
 import { revisionFor } from '../../observe/context.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import { BaseResource, type Resource } from '../../resource/base.ts'
@@ -160,6 +162,61 @@ describe('Mount.unregister', () => {
 })
 
 describe('Mount.executeCmd', () => {
+  it.each([
+    [MountMode.READ, false, 'version'],
+    [MountMode.READ, true, 'version'],
+    [MountMode.WRITE, false, 'version'],
+    [MountMode.WRITE, true, 'version'],
+    [MountMode.READ, false, 'help'],
+    [MountMode.READ, true, 'help'],
+    [MountMode.WRITE, false, 'help'],
+    [MountMode.WRITE, true, 'help'],
+  ] as const)(
+    'only wrapper responses bypass the write guard: %s declared=%s %s',
+    async (mode, declared, flag) => {
+      const resource = new RAMResource()
+      const m = new MountEntry({ prefix: '/ram/', resource, mode })
+      const calls: string[] = []
+      const [cmd] = command<RAMAccessor>({
+        name: 'mutate',
+        resource: 'ram',
+        spec: new CommandSpec({
+          options: declared ? [new Option({ long: '--version', type: 'bool' })] : [],
+        }),
+        write: true,
+        fn: (accessor) => {
+          calls.push('handler')
+          accessor.store.files.set('/changed', new TextEncoder().encode('changed'))
+          return [new TextEncoder().encode('custom version\n'), new IOResult()]
+        },
+      })
+      if (cmd === undefined) throw new Error('missing command')
+      m.register(cmd)
+      const [stdout, io] = await m.executeCmd('mutate', [], [], { [flag]: true })
+      const output = new TextDecoder().decode(await materialize(stdout))
+      if (declared && flag === 'version') {
+        if (mode === MountMode.READ) {
+          expect(io.exitCode).toBe(1)
+          expect(new TextDecoder().decode(io.stderr as Uint8Array)).toBe(
+            'mutate: read-only mount at /ram/\n',
+          )
+          expect(calls).toEqual([])
+          expect(resource.store.files.has('/changed')).toBe(false)
+        } else {
+          expect(io.exitCode).toBe(0)
+          expect(output).toBe('custom version\n')
+          expect(calls).toEqual(['handler'])
+          expect(new TextDecoder().decode(resource.store.files.get('/changed'))).toBe('changed')
+        }
+      } else {
+        expect(io.exitCode).toBe(0)
+        expect(output).not.toBe('')
+        expect(calls).toEqual([])
+        expect(resource.store.files.has('/changed')).toBe(false)
+      }
+    },
+  )
+
   it('returns 127 for unknown command', async () => {
     const m = makeMount()
     const [, io] = await m.executeCmd('nope', [], [], {})

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -23,6 +23,7 @@ import type {
   ExecContext,
   RegisteredCommand,
 } from '../../commands/config.ts'
+import { hasInjectedVersion } from '../../commands/config.ts'
 import { ROOT_CWD } from '../../commands/constants.ts'
 import type { OpKwargs } from '../../ops/registry.ts'
 
@@ -541,11 +542,11 @@ export class MountEntry {
               runWithRevisions(
                 this.revisions.size > 0 ? this.revisions : null,
                 async (): Promise<[ByteSource | null, IOResult]> => {
-                  // --help / --version short-circuit inside the handler
-                  // wrapper and never touch the backend, so a read-only mount
-                  // answers them like GNU instead of refusing them as writes.
-                  const infoOnly = flags.help === true || flags.version === true
                   for (const cmd of handlers) {
+                    // Only wrapper-owned responses bypass the write guard.
+                    const infoOnly =
+                      flags.help === true ||
+                      (flags.version === true && hasInjectedVersion(cmd.spec))
                     // strongestModeUnder, not effectiveMode: a mount whose
                     // only writable region is a show entry still runs the
                     // command, and the op door refuses per path. The

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -512,6 +512,7 @@ export class MountEntry {
         flags,
         filetypeFns: isFiletypeCmd ? null : filetypeFns,
         mountPrefix,
+        command: cmdName,
         cwd: context.cwd ?? ROOT_CWD,
         ...(this.index !== undefined ? { index: this.index } : {}),
         ...(context.dispatch !== undefined ? { dispatch: context.dispatch } : {}),

--- a/typescript/packages/dsh/package.json
+++ b/typescript/packages/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-dsh",
-  "version": "0.0.7-alpha.1",
+  "version": "0.0.7-alpha.2",
   "description": "DeepSeek Harness (dsh) providers backed by a mirage workspace: ctx.fs and ctx.shell over mounted resources",
   "homepage": "https://github.com/strukto-ai/mirage#readme",
   "bugs": {

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-node",
-  "version": "0.0.7-alpha.1",
+  "version": "0.0.7-alpha.2",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/node/src/runtime/python/local.test.ts
+++ b/typescript/packages/node/src/runtime/python/local.test.ts
@@ -13,12 +13,56 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { buildRuntime } from '@struktoai/mirage-core/runtime/table'
+import { RAMResource } from '@struktoai/mirage-core/resource/ram/ram'
+import { MountMode } from '@struktoai/mirage-core/types'
+import { Workspace } from '../../workspace.ts'
 import { LocalRuntime } from './local.ts'
 
 const DEC = new TextDecoder()
 
 describe('LocalRuntime', () => {
+  it('reports versions in READ mode without running Python startup code', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mirage-local-version-'))
+    const marker = join(dir, 'startup-ran')
+    const python = execFileSync('python3', ['-c', 'import sys; print(sys.executable)'], {
+      encoding: 'utf8',
+    }).trim()
+    const expected = execFileSync(python, ['--version'], { encoding: 'utf8' })
+    await writeFile(
+      join(dir, 'sitecustomize.py'),
+      `open(${JSON.stringify(marker)}, 'w').write('ran')\n`,
+    )
+    const env = { PYTHONPATH: dir }
+    const rt = new LocalRuntime({ config: { home: python } })
+    const ws = new Workspace(
+      { '/': new RAMResource() },
+      { mode: MountMode.READ, runtimes: [rt, 'vfs'] },
+    )
+    try {
+      for (const line of ['python --version', 'python3 -V', 'python -VV']) {
+        const io = await ws.execute(line, { env })
+        expect(io.exitCode).toBe(0)
+        expect(DEC.decode(io.stdout)).toBe(expected)
+        expect(DEC.decode(io.stderr)).toBe('')
+        await expect(readFile(marker)).rejects.toMatchObject({ code: 'ENOENT' })
+      }
+      const refused = await ws.execute("python -c 'pass'", { env })
+      expect(refused.exitCode).toBe(126)
+      await expect(readFile(marker)).rejects.toMatchObject({ code: 'ENOENT' })
+      const control = await rt.run({ code: 'pass', args: [], stdin: null, env })
+      expect(control.exitCode).toBe(0)
+      expect(await readFile(marker, 'utf8')).toBe('ran')
+    } finally {
+      await ws.close()
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   it('runs code on the host python with argv, stdin and env', async () => {
     const rt = new LocalRuntime()
     const result = await rt.run({

--- a/typescript/packages/node/src/runtime/python/local.test.ts
+++ b/typescript/packages/node/src/runtime/python/local.test.ts
@@ -12,9 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { buildRuntime } from '@struktoai/mirage-core/runtime/table'
@@ -26,6 +26,48 @@ import { LocalRuntime } from './local.ts'
 const DEC = new TextDecoder()
 
 describe('LocalRuntime', () => {
+  it.each([MountMode.READ, MountMode.WRITE, MountMode.EXEC])(
+    'uses only the host environment for the version process in %s mode',
+    async (mode) => {
+      const dir = await mkdtemp(join(tmpdir(), 'mirage-local-version-env-'))
+      vi.stubEnv('MIRAGE_TEST_VERSION_ENV', 'host')
+      const session = {
+        LD_PRELOAD: join(dir, 'session.so'),
+        LD_LIBRARY_PATH: dir,
+        DYLD_INSERT_LIBRARIES: join(dir, 'session.dylib'),
+        DYLD_LIBRARY_PATH: dir,
+        PATH: dir,
+        MIRAGE_TEST_VERSION_ENV: 'session',
+      }
+      const python = execFileSync('python3', ['-c', 'import sys; print(sys.executable)'], {
+        encoding: 'utf8',
+      }).trim()
+      const probe = join(dir, 'python-probe')
+      await writeFile(
+        probe,
+        `#!${python}\nimport json, os\nprint(json.dumps({k: os.environ.get(k) for k in ${JSON.stringify(Object.keys(session))}}))\n`,
+      )
+      await chmod(probe, 0o755)
+      const rt = new LocalRuntime({ config: { home: probe } })
+      const baseline = await rt.version({})
+      const expected: unknown = JSON.parse(DEC.decode(baseline.stdout))
+      expect(expected).toMatchObject({ MIRAGE_TEST_VERSION_ENV: 'host' })
+      const ws = new Workspace({ '/': new RAMResource() }, { mode, runtimes: [rt, 'vfs'] })
+      try {
+        for (const line of ['python --version', 'python3 -V', 'python -VV']) {
+          const io = await ws.execute(line, { env: session })
+          expect(io.exitCode).toBe(0)
+          expect(JSON.parse(DEC.decode(io.stdout))).toEqual(expected)
+          expect(DEC.decode(io.stderr)).toBe('')
+        }
+      } finally {
+        await ws.close()
+        vi.unstubAllEnvs()
+        await rm(dir, { recursive: true, force: true })
+      }
+    },
+  )
+
   it('reports versions in READ mode without running Python startup code', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'mirage-local-version-'))
     const marker = join(dir, 'startup-ran')

--- a/typescript/packages/node/src/runtime/python/local.ts
+++ b/typescript/packages/node/src/runtime/python/local.ts
@@ -49,15 +49,28 @@ export class LocalRuntime extends PythonRuntime {
     this.python = chosen !== undefined && chosen !== '' ? chosen : 'python3'
   }
 
+  override version(env: Record<string, string>, signal?: AbortSignal): Promise<RunResult> {
+    return this.runProcess(['--version'], env, null, signal)
+  }
+
   run(args: RunArgs): Promise<RunResult> {
+    return this.runProcess(['-c', args.code, ...args.args], args.env, args.stdin, args.signal)
+  }
+
+  private runProcess(
+    argv: string[],
+    env: Record<string, string>,
+    stdin: Uint8Array | null,
+    signal?: AbortSignal,
+  ): Promise<RunResult> {
     return new Promise((resolve, reject) => {
       // The signal aborts when the command's limit timeout trips:
       // spawn then SIGKILLs the child (matching the python runtime's
       // proc.kill() on cancellation) and 'close' settles the promise.
-      const child = spawn(this.python, ['-c', args.code, ...args.args], {
+      const child = spawn(this.python, argv, {
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env, ...args.env },
-        ...(args.signal !== undefined ? { signal: args.signal, killSignal: 'SIGKILL' } : {}),
+        env: { ...process.env, ...env },
+        ...(signal !== undefined ? { signal, killSignal: 'SIGKILL' } : {}),
       })
       this.children.add(child)
       const out: Buffer[] = []
@@ -91,7 +104,7 @@ export class LocalRuntime extends PythonRuntime {
       child.stdin.on('error', (error: NodeJS.ErrnoException) => {
         if (error.code !== 'EPIPE') reject(error)
       })
-      if (args.stdin !== null) child.stdin.write(args.stdin)
+      if (stdin !== null) child.stdin.write(stdin)
       child.stdin.end()
     })
   }

--- a/typescript/packages/node/src/runtime/python/local.ts
+++ b/typescript/packages/node/src/runtime/python/local.ts
@@ -49,8 +49,9 @@ export class LocalRuntime extends PythonRuntime {
     this.python = chosen !== undefined && chosen !== '' ? chosen : 'python3'
   }
 
-  override version(env: Record<string, string>, signal?: AbortSignal): Promise<RunResult> {
-    return this.runProcess(['--version'], env, null, signal)
+  override version(_env: Record<string, string>, signal?: AbortSignal): Promise<RunResult> {
+    // Session loader variables can execute code before --version is read.
+    return this.runProcess(['--version'], {}, null, signal)
   }
 
   run(args: RunArgs): Promise<RunResult> {

--- a/typescript/packages/server/package.json
+++ b/typescript/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-server",
-  "version": "0.0.7-alpha.1",
+  "version": "0.0.7-alpha.2",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",


### PR DESCRIPTION
Interpreter version flags currently print Mirage's package version. They now query the selected runtime: Python prints its guest version with `(monty)`, `(pyodide)`, or `(wasi)` where applicable; local Python prints its ordinary version. Embedded `js` and `node` aliases report the actual QuickJS engine version in both SDKs. Commands captured by SSH/E2B keep the remote program's output unchanged, including `node` and `tsc`.

Local and Sandlock Python runtimes invoke their configured executable with native `--version`, so a version check in a READ workspace cannot execute Python startup hooks through `-c`. These probes ignore all session environment overrides, including loader variables such as `LD_PRELOAD` and `DYLD_INSERT_LIBRARIES`: Local uses the host environment and Sandlock uses only its configured environment. Sandlock retains its confinement flags, and subprocess cancellation/cleanup use the same path as ordinary execution. Custom process-backed Python runtimes return version information unavailable unless they implement their own safe probe; inherited version checks never call `run()`. VFS runtimes continue to query the guest interpreter.

Explicitly declared `--version` options reach their command handler and remain subject to the mount's write guard. Only wrapper-owned help and injected version responses bypass that guard. Automatically injected versions retain the existing Mirage output. Interpreter diagnostics and shared integration expectations use the invoked alias (`python`, `python3`, `js`, or `node`). Regression coverage checks aliases, missing runtimes, script arguments named `--version`, remote passthrough, startup-hook side effects, and direct accessor mutation attempts on READ mounts.

Bump `mirage-ai` to `0.0.7a2` and the seven TypeScript release packages to `0.0.7-alpha.2`. OpenCode remains at `0.0.0`; documentation is unchanged.

Validation:

- Final-commit Python CI passed: 19,368 tests passed, 117 skipped, and 1 xfailed; the additional 279 CLI tests and 22 example tests also passed.
- Repository-wide pre-commit checks passed in CI, including mypy, TypeScript/integ lint, Knip, and integration type checks. Local core and Node package type checking passed.
- Version, alias, mount write-guard, native startup-hook, and custom process-runtime regressions passed in both SDKs, including Monty and Pyodide. The loader-environment fix passed 29 Python and 11 TypeScript tests, with READ/WRITE/EXEC coverage.
- Shared Monty/policy integration cases passed in both SDKs (49 Python cases and 48 TypeScript cases).
- Command-spec parity and strict layout parity passed.
- All final-commit CI checks are green: 46 passed and 4 skipped. Both TypeScript Node 22/24 suites, runtime integration (SDKs, CLI and daemons), shared/data integration, snapshot interop, install checks, and all workflow gates passed.
