### PR TITLE
Run the pyodide wrappers synchronously so a deadline can stop a busy loop, and test on Node 24 only

### DIFF
--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["22", "24"]
+        node-version: ["24"]
     services:
       redis:
         image: redis:7

--- a/typescript/packages/core/src/runtime/python/loader.ts
+++ b/typescript/packages/core/src/runtime/python/loader.ts
@@ -43,6 +43,7 @@ export interface PyodideInterface {
     get: (key: string) => unknown
     delete?: (key: string) => void
   }
+  runPython: (code: string, options?: { globals?: unknown }) => unknown
   runPythonAsync: (code: string, options?: { globals?: unknown }) => Promise<unknown>
   toPy: (obj: unknown) => unknown
   isPyProxy?: (obj: unknown) => boolean

--- a/typescript/packages/core/src/runtime/python/pyodide.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide.ts
@@ -370,7 +370,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
     pyodide.globals.set('_eval_inputs', inputsPy)
     const armed = this.interrupter !== null ? this.interrupter.arm(EVAL_INTERRUPT_SECONDS) : null
     try {
-      await pyodide.runPythonAsync(PYTHON_EVAL_WRAPPER)
+      pyodide.runPython(PYTHON_EVAL_WRAPPER)
       if (armed?.disarm() === 'deadline') {
         throw new EvalError(`pyodide eval timed out after ${String(EVAL_INTERRUPT_SECONDS)}s`)
       }
@@ -702,10 +702,9 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
     // raises KeyboardInterrupt in the guest, whose wrapper-reported
     // exit code (1) stands, like the local runtime's killed child.
     // The wrapper arms right before the user code and disarms right
-    // after it: pyodide runs the whole wrapper as one webloop task step,
-    // so a trip landing in the wrapper's own preamble or epilogue would
-    // escape the task as a KeyboardInterrupt nothing catches, which the
-    // host sees as an unhandled rejection and a lost deadline.
+    // after it, so a trip can only land inside the wrapper's own
+    // handlers, never in its preamble or epilogue where it would escape
+    // as a KeyboardInterrupt nothing catches and the deadline is lost.
     const slot: { armed: ArmedInterrupt | null } = { armed: null }
     pyodide.globals.set('_arm_interrupt', () => {
       if (this.interrupter !== null && slot.armed === null) {
@@ -716,7 +715,15 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
       slot.armed?.disarm()
     })
     try {
-      await pyodide.runPythonAsync(PYTHON_WRAPPER)
+      // The wrapper runs through the synchronous entry point on purpose.
+      // Every wrapper is straight-line Python with no top-level await,
+      // and the interrupt buffer is only honored reliably on that path:
+      // under runPythonAsync the trip is consumed by the eval loop but the
+      // KeyboardInterrupt does not reach the running code often enough,
+      // so a busy loop past its deadline ran unbounded and wedged the
+      // host's event loop (observed on Node 24.20 in CI, reproducible on
+      // 24.15 with bare pyodide, with or without JSPI).
+      pyodide.runPython(PYTHON_WRAPPER)
       if (slot.armed?.disarm() === 'deadline' && args.timeoutSeconds !== undefined) {
         throw new CommandTimeoutError(this.name, args.timeoutSeconds)
       }
@@ -801,7 +808,7 @@ export class PyodideRuntime extends PythonRuntime implements Evaluator {
     pyodide.globals.set('_repl_inputs', pyodide.toPy(inputs))
 
     try {
-      await pyodide.runPythonAsync(PYTHON_REPL_WRAPPER)
+      pyodide.runPython(PYTHON_REPL_WRAPPER)
       const flushFailures = await this.drainMutations()
       const resultProxy = pyodide.globals.get('_repl_result') as
         | {


### PR DESCRIPTION
The TypeScript (Node 24) job on #1035 hung for over two hours on `src/workspace/command_timeout.test.ts`, the only one of 798 core test files that never completed, while the Node 22 job passed in 17 minutes. Reproduced locally by installing CI's Node 24.20.0: the busy pyodide loop test hangs every time.

The cause is below mirage. With bare pyodide, `setInterruptBuffer` is honored reliably only through the synchronous `runPython` entry point. Under `runPythonAsync` the trip is consumed by the eval loop but the KeyboardInterrupt does not reach the running code often enough, so a bare busy loop past its deadline runs unbounded and wedges the host's event loop. The matrix below is a bare pyodide script writing the interrupt cell from a worker thread after 300 ms, run on Node 24.20.0 and 24.15.0, with and without JSPI:

| entry point | `while True: pass` | time-bounded loop |
| --- | --- | --- |
| `runPython` | KeyboardInterrupt at ~320 ms | KeyboardInterrupt at ~320 ms |
| `runPythonAsync` | hangs | runs to its own end, cell consumed, nothing raised |

Every wrapper mirage runs (run, eval, REPL) is straight-line Python with no top-level await, so they now go through `runPython`. The interface type gains `runPython`. The arming comment is reworded since the wrapper no longer runs as a webloop task step.

Verified on Node 24.20.0: the timeout file passes three of three where it hung deterministically before, the Python runtime suite passes, and two full core-suite runs pass with zero unhandled errors.

The TypeScript test matrix drops Node 22 and runs on Node 24 only.