### PR TITLE
fix(cache): recover evicted metadata and verify live freshness

### DIFF
--- a/docs/home/cache.mdx
+++ b/docs/home/cache.mdx
@@ -11,6 +11,10 @@ Every `Workspace` ships with a **two-layer cache** so repeated work against remo
 - **Index cache.** Listings and metadata. The first directory walk hits the API; subsequent ones serve from the index until the TTL expires.
 - **File cache.** Object bytes. The first read streams from origin; later pipelines read from cache.
 
+Under `ConsistencyPolicy.ALWAYS`, cached file bytes are checked against live backend metadata, bypassing the index. A changed fingerprint triggers a fresh read; a deleted file is evicted. If the backend cannot supply a fingerprint or its probe fails, the read must fetch current bytes or report an error. `LAZY` continues to trust cached bytes.
+
+A fresh directory listing proves a child absent only when that child is not listed. If a listed child's metadata has been evicted independently, object-store stat fetches it from the backend.
+
 ## Stores
 
 Each layer is a pluggable store with two built-ins:

--- a/python/mirage/core/object_store/stat.py
+++ b/python/mirage/core/object_store/stat.py
@@ -77,11 +77,12 @@ def make_stat(driver: ObjectStoreDriver[A, C]) -> StatFn[A]:
         # probe speculatively (e.g. .git, HEAD, .hg during cd).
         parent = virtual_key.rsplit("/", 1)[0] or "/"
         parent_listing = await index.list_dir(parent)
-        if parent_listing.entries is not None:
+        if (parent_listing.entries is not None
+                and virtual_key not in parent_listing.entries):
             raise enoent(virtual)
 
-        # Slow path: no index cache available, or parent directory not
-        # yet listed. Hit the store.
+        # A listed child can lose its metadata to independent eviction.
+        # Missing cache information must fall back to the store.
         kpfx = driver.key_prefix_of(accessor)
         key = kp.apply(kpfx, path)
         async with driver.connect(accessor) as conn:

--- a/python/mirage/workspace/reconcile.py
+++ b/python/mirage/workspace/reconcile.py
@@ -16,6 +16,7 @@ import logging
 from enum import Enum
 
 from mirage.cache.file.mixin import FileCacheMixin
+from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.types import ConsistencyPolicy
 from mirage.workspace.mount.mount import MountEntry
 from mirage.workspace.mount.namespace import Namespace
@@ -65,15 +66,22 @@ class Reconciler:
             mount (MountEntry): the resolved mount for ``path``.
             path (str): absolute virtual path to probe.
         """
+        # Resolve backend IDs without reusing cached metadata.
         try:
-            remote_stat = await mount.execute_op("stat", path)
+            remote_stat = await mount.execute_op("stat",
+                                                 path,
+                                                 index=RAMIndexCacheStore())
         except FileNotFoundError:
             await self.on_missing(path)
+            await mount.index.clear()
             return Verdict.GONE
         if remote_stat is None or remote_stat.fingerprint is None:
+            await self._cache.remove(path)
+            await mount.index.clear()
             return Verdict.UNKNOWN
         if not await self._cache.is_fresh(path, remote_stat.fingerprint):
             await self._cache.remove(path)
+            await mount.index.clear()
             return Verdict.STALE
         return Verdict.FRESH
 
@@ -98,11 +106,12 @@ class Reconciler:
             return True
         if not mount.resource.SUPPORTS_SNAPSHOT:
             await self._cache.remove(path)
+            await mount.index.clear()
             return False
         verdict = await self._probe(mount, path)
         if verdict is Verdict.GONE:
             raise FileNotFoundError(path)
-        return verdict is not Verdict.STALE
+        return verdict is Verdict.FRESH
 
     async def reconcile_read(self, mount: MountEntry, path: str) -> None:
         """Reconcile a single-mount shell read before the command runs.
@@ -128,6 +137,8 @@ class Reconciler:
         try:
             await self._probe(mount, path)
         except Exception as exc:
+            await self._cache.remove(path)
+            await mount.index.clear()
             logger.debug("reconcile_read probe failed for %s: %s", path, exc)
 
     async def on_op_missing(self, op: str, path: str) -> None:

--- a/python/mirage/workspace/snapshot/drift.py
+++ b/python/mirage/workspace/snapshot/drift.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, Callable
 
+from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.types import DriftPolicy
 from mirage.workspace.mount.mount import MountEntry
 from mirage.workspace.snapshot.keys import FingerprintKey
@@ -252,8 +253,9 @@ async def check_drift(mount_for: TryMountFor,
         return
     if not getattr(mount.resource, "SUPPORTS_SNAPSHOT", False):
         return
+    # Resolve backend IDs afresh without consulting the restored index.
     try:
-        stat = await mount.execute_op("stat", path)
+        stat = await mount.execute_op("stat", path, index=RAMIndexCacheStore())
     except FileNotFoundError as exc:
         if mount_for(path) is not mount:
             return

--- a/python/tests/core/object_store/test_stat.py
+++ b/python/tests/core/object_store/test_stat.py
@@ -13,10 +13,14 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import os
+from uuid import uuid4
 
 import pytest
+import pytest_asyncio
 
 from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.cache.index.redis import RedisIndexCacheStore
 from mirage.core.object_store.readdir import make_readdir
 from mirage.core.object_store.stat import make_stat
 from mirage.types import FileType
@@ -84,3 +88,56 @@ def test_stat_listed_parent_negative_caches_enoent(accessor):
     with pytest.raises(FileNotFoundError):
         asyncio.run(make_stat(driver)(accessor, spec("/.git"), index=index))
     assert store.connects == connects
+
+
+@pytest_asyncio.fixture(params=["ram", "redis"])
+async def index_store(request):
+    if request.param == "redis":
+        url = os.environ.get("REDIS_URL")
+        if not url:
+            pytest.skip("REDIS_URL not set")
+        index = RedisIndexCacheStore(url=url, key_prefix=f"stat:{uuid4()}:")
+    else:
+        index = RAMIndexCacheStore()
+    try:
+        yield index
+    finally:
+        await index.clear()
+        await index.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path,kind", [("/a.txt", FileType.FILE),
+                                       ("/dir", FileType.DIRECTORY)])
+async def test_stat_listed_child_without_metadata(accessor, index_store, path,
+                                                  kind):
+    store = FakeStore({"a.txt": b"hi", "dir/f.txt": b"x"})
+    driver = make_driver(store)
+    await make_readdir(driver)(accessor, spec("/"), index=index_store)
+    # Drop only this child's metadata, leaving fresh membership intact.
+    await index_store.invalidate_prefix("/mnt" + path)
+    assert (await index_store.get("/mnt" + path)).entry is None
+    assert "/mnt" + path in (await index_store.list_dir("/mnt")).entries
+    connects = store.connects
+    st = await make_stat(driver)(accessor, spec(path), index=index_store)
+    assert st.type == kind
+    assert store.connects > connects
+    if kind == FileType.FILE:
+        assert st.size == 2
+        assert st.fingerprint == "fp-a.txt"
+    connects = store.connects
+    with pytest.raises(FileNotFoundError):
+        await make_stat(driver)(accessor, spec("/.git"), index=index_store)
+    assert store.connects == connects
+
+
+@pytest.mark.asyncio
+async def test_stat_stale_membership_cannot_prove_absence(
+        accessor, index_store):
+    store = FakeStore({"a.txt": b"hi"})
+    driver = make_driver(store)
+    await make_readdir(driver)(accessor, spec("/"), index=index_store)
+    await index_store.invalidate()
+    store.objects["new.txt"] = b"new"
+    st = await make_stat(driver)(accessor, spec("/new.txt"), index=index_store)
+    assert st.size == 3

--- a/python/tests/resource/github/test_lazy_hydration.py
+++ b/python/tests/resource/github/test_lazy_hydration.py
@@ -20,7 +20,9 @@ from mirage.core.github.readdir import readdir
 from mirage.core.github.tree import ensure_tree
 from mirage.core.github.tree_entry import TreeEntry
 from mirage.resource.github.github import GitHubResource
-from mirage.types import PathSpec
+from mirage.types import ConsistencyPolicy, PathSpec
+from mirage.workspace import Workspace
+from mirage.workspace.reconcile import Reconciler
 
 CONFIG = GitHubConfig(token="ghp_test")
 TREE = {
@@ -119,3 +121,53 @@ async def test_an_unpinned_mount_is_on_the_default_branch_before_any_fetch(
         GitHubConfig(token="ghp_test", owner="o", repo="r"))
     assert resource.is_default_branch is True
     assert GitHubResource(CONFIG, "o", "r", "dev").is_default_branch is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_private_index_can_resolve_github_ids(tree_calls):
+    resource = GitHubResource(CONFIG, "o", "r", "main")
+    ws = Workspace({"/gh": resource})
+    try:
+        path = "/gh/src/main.py"
+        await ws.namespace.ensure_loaded()
+        mount = ws.namespace.mount_for(path)
+        await mount.execute_op("stat", path)
+        await ws.cache.set(path, b"cached", fingerprint="b")
+        await ws.namespace.set_attrs(path, mode=0o600)
+        rec = Reconciler(ws.cache, ws.namespace, ConsistencyPolicy.ALWAYS)
+        await rec.reconcile_read(mount, path)
+        assert await ws.cache.exists(path)
+        assert ws.namespace.meta_for(path) is not None
+        assert len(tree_calls) == 2
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["shell", "fs"])
+async def test_always_reads_current_github_blob_after_probe(
+        monkeypatch, surface):
+    sha = "v1"
+
+    async def fetch_tree(*args, **kwargs):
+        return {
+            "f.txt": TreeEntry(path="f.txt", type="blob", sha=sha, size=2)
+        }, False
+
+    async def read_bytes(config, owner, repo, blob_sha, session=None):
+        return blob_sha.encode()
+
+    monkeypatch.setattr("mirage.core.github.tree.fetch_tree", fetch_tree)
+    monkeypatch.setattr("mirage.core.github.read.read_bytes", read_bytes)
+    resource = GitHubResource(CONFIG, "o", "r", "main")
+    ws = Workspace({"/gh": resource}, consistency=ConsistencyPolicy.ALWAYS)
+    try:
+        assert (await ws.execute("cat /gh/f.txt")).stdout == b"v1"
+        assert (await resource.index.get("/gh/f.txt")).entry.id == "v1"
+        sha = "v2"
+        if surface == "shell":
+            assert (await ws.execute("cat /gh/f.txt")).stdout == b"v2"
+        else:
+            assert await ws.fs.read("/gh/f.txt") == b"v2"
+    finally:
+        await ws.close()

--- a/python/tests/workspace/test_reconcile.py
+++ b/python/tests/workspace/test_reconcile.py
@@ -12,12 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import os
+from uuid import uuid4
+
 import pytest
 
 from mirage import MountMode, Workspace
+from mirage.cache.index.config import RedisIndexConfig
 from mirage.resource.ram import RAMResource
-from mirage.types import ConsistencyPolicy
+from mirage.resource.s3 import S3Config, S3Resource
+from mirage.types import ConsistencyPolicy, FileStat, FileType
 from mirage.workspace.reconcile import Reconciler
+from tests.e2e.s3_mock import patch_s3_multi
 
 
 async def _ws_with_overlay():
@@ -117,3 +123,85 @@ async def test_reconcile_read_skips_under_lazy():
     rec = Reconciler(ws.cache, ws.namespace, ConsistencyPolicy.LAZY)
     await rec.reconcile_read(mount, "/data/gone.txt")
     assert ws.namespace.meta_for("/data/gone.txt") is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("index_type", ["ram", "redis"])
+@pytest.mark.parametrize("surface", ["shell", "fs"])
+@pytest.mark.parametrize("change", ["overwrite", "delete"])
+async def test_always_probes_live_s3_with_warm_index(index_type, surface,
+                                                     change):
+    index = None
+    if index_type == "redis":
+        url = os.environ.get("REDIS_URL")
+        if not url:
+            pytest.skip("REDIS_URL not set")
+        index = RedisIndexConfig(url=url, key_prefix=f"reconcile:{uuid4()}:")
+    objects = {"f.txt": b"v1"}
+    resource = S3Resource(
+        S3Config(bucket="test-bucket",
+                 region="us-east-1",
+                 aws_access_key_id="fake",
+                 aws_secret_access_key="fake"))
+    with patch_s3_multi({"test-bucket": objects}):
+        ws = Workspace({"/s3": resource},
+                       index=index,
+                       consistency=ConsistencyPolicy.ALWAYS)
+        try:
+            assert (await ws.execute("ls /s3/")).exit_code == 0
+            assert (await resource.index.get("/s3/f.txt")).entry is not None
+            assert (await ws.execute("cat /s3/f.txt")).stdout == b"v1"
+            assert await ws.cache.exists("/s3/f.txt")
+            if change == "overwrite":
+                objects["f.txt"] = b"v2"
+            else:
+                del objects["f.txt"]
+            if surface == "shell":
+                result = await ws.execute("cat /s3/f.txt")
+                assert result.stdout == (b"v2"
+                                         if change == "overwrite" else b"")
+                assert result.exit_code == (0 if change == "overwrite" else 1)
+            elif change == "overwrite":
+                assert await ws.fs.read("/s3/f.txt") == b"v2"
+            else:
+                with pytest.raises(FileNotFoundError):
+                    await ws.fs.read("/s3/f.txt")
+        finally:
+            await resource.index.clear()
+            await ws.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("probe", ["unknown", "none", "failed", "fresh"])
+@pytest.mark.parametrize("surface", ["shell", "gate"])
+async def test_unverified_probe_cannot_serve_cached_bytes(
+        monkeypatch, probe, surface):
+    ws = Workspace({"/data": RAMResource()})
+    try:
+        mount = ws.namespace.mount_for("/data/f.txt")
+        monkeypatch.setattr(mount.resource, "SUPPORTS_SNAPSHOT", True)
+        await ws.cache.set("/data/f.txt", b"v1", fingerprint="fp1")
+
+        async def stat(*args, **kwargs):
+            if probe == "failed":
+                raise OSError("probe unavailable")
+            if probe == "none":
+                return None
+            return FileStat(name="f.txt",
+                            type=FileType.FILE,
+                            fingerprint="fp1" if probe == "fresh" else None)
+
+        monkeypatch.setattr(mount, "execute_op", stat)
+        rec = Reconciler(ws.cache, ws.namespace, ConsistencyPolicy.ALWAYS)
+        if surface == "shell":
+            await rec.reconcile_read(mount, "/data/f.txt")
+            assert await ws.cache.exists("/data/f.txt") == (probe == "fresh")
+        elif probe == "failed":
+            with pytest.raises(OSError, match="probe unavailable"):
+                await rec.may_serve_cached(mount, "/data/f.txt")
+        else:
+            assert await rec.may_serve_cached(
+                mount, "/data/f.txt") == (probe == "fresh")
+            assert await ws.cache.exists("/data/f.txt") == (probe == "fresh")
+    finally:
+        await ws.close()

--- a/python/tests/workspace/test_snapshot_drift.py
+++ b/python/tests/workspace/test_snapshot_drift.py
@@ -17,6 +17,7 @@ from contextlib import ExitStack
 
 import pytest
 
+from mirage.cache.index import IndexEntry
 from mirage.commands.cli.types import CLISpec
 from mirage.io import IOResult
 from mirage.observe.context import RecordingScope, record, start_op
@@ -78,6 +79,7 @@ def test_strict_load_raises_when_s3_etag_drifts(tmp_path):
         stack.enter_context(patch_s3_multi({"test-bucket": store}))
         src = Workspace({"/s3": (S3Resource(_config()), MountMode.WRITE)},
                         mode=MountMode.WRITE)
+        asyncio.run(src.execute("ls /s3/"))
         result = asyncio.run(src.execute("cat /s3/data.csv"))
         assert b"version 1" in result.stdout
 
@@ -85,7 +87,18 @@ def test_strict_load_raises_when_s3_etag_drifts(tmp_path):
         asyncio.run(src.snapshot(snap))
         store["data.csv"] = b"VERSION 2 DRIFTED\n"
 
-        dst = _load(snap, resources={"/s3": S3Resource(_config())})
+        resource = S3Resource(_config())
+        dst = _load(snap, resources={"/s3": resource})
+        # A warm index must not hide the backend fingerprint from drift.
+        asyncio.run(
+            resource.index.put(
+                "/s3/data.csv",
+                IndexEntry(id="data.csv",
+                           name="data.csv",
+                           resource_type="file",
+                           size=len(b"version 1 bytes\n"))))
+        assert asyncio.run(
+            resource.index.get("/s3/data.csv")).entry is not None
         with pytest.raises(ContentDriftError) as exc_info:
             asyncio.run(dst.execute("cat /s3/data.csv"))
         assert exc_info.value.path == "/s3/data.csv"

--- a/typescript/packages/core/src/core/object_store/stat.test.ts
+++ b/typescript/packages/core/src/core/object_store/stat.test.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import { RedisIndexCacheStore } from '../../cache/index/redis.ts'
 import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
 import { FileType } from '../../types.ts'
 import { codeOf, FakeAccessor, FakeStore, makeDriver, MODIFIED, spec } from './fakes.ts'
@@ -84,3 +85,50 @@ describe('object_store stat', () => {
     expect(store.connects).toBe(connects)
   })
 })
+
+for (const type of ['ram', 'redis']) {
+  describe.skipIf(type === 'redis' && process.env.REDIS_URL === undefined)(
+    `object_store stat membership (${type})`,
+    () => {
+      it.each(['/a.txt', '/dir'])(
+        'resolves listed %s from the backend after metadata eviction',
+        async (path) => {
+          const index =
+            type === 'redis'
+              ? new RedisIndexCacheStore({
+                  ...(process.env.REDIS_URL === undefined ? {} : { url: process.env.REDIS_URL }),
+                  keyPrefix: `stat:${crypto.randomUUID()}:`,
+                })
+              : new RAMIndexCacheStore()
+          try {
+            const store = new FakeStore({ 'a.txt': 'hi', 'dir/f.txt': 'x' })
+            const driver = makeDriver(store)
+            await makeReaddir(driver)(accessor, spec('/'), index)
+            await index.invalidatePrefix('/mnt' + path)
+            expect((await index.get('/mnt' + path)).entry).toBeUndefined()
+            expect((await index.listDir('/mnt')).entries).toContain('/mnt' + path)
+            const connects = store.connects
+            const st = await makeStat(driver)(accessor, spec(path), index)
+            expect(st.type).toBe(path === '/dir' ? FileType.DIRECTORY : FileType.FILE)
+            expect(store.connects).toBeGreaterThan(connects)
+            if (path === '/a.txt') {
+              expect(st.size).toBe(2)
+              expect(st.fingerprint).toBe('fp-a.txt')
+            }
+            const beforeMissing = store.connects
+            await expect(codeOf(makeStat(driver)(accessor, spec('/.git'), index))).resolves.toBe(
+              'ENOENT',
+            )
+            expect(store.connects).toBe(beforeMissing)
+            await index.invalidate()
+            store.objects.set('new.txt', new TextEncoder().encode('new'))
+            expect((await makeStat(driver)(accessor, spec('/new.txt'), index)).size).toBe(3)
+          } finally {
+            await index.clear()
+            await index.close()
+          }
+        },
+      )
+    },
+  )
+}

--- a/typescript/packages/core/src/core/object_store/stat.ts
+++ b/typescript/packages/core/src/core/object_store/stat.ts
@@ -70,13 +70,17 @@ export function makeStat<A extends Accessor, C>(driver: ObjectStoreDriver<A, C>)
       // (e.g. .git, HEAD, .hg during cd).
       const parent = virtualKey.replace(/\/[^/]*$/, '') || '/'
       const parentListing = await index.listDir(parent)
-      if (parentListing.entries !== undefined && parentListing.entries !== null) {
+      if (
+        parentListing.entries !== undefined &&
+        parentListing.entries !== null &&
+        !parentListing.entries.includes(virtualKey)
+      ) {
         throw enoent(path)
       }
     }
 
-    // Slow path: no index cache available, or parent directory not yet
-    // listed. Hit the store.
+    // A listed child can lose its metadata to independent eviction.
+    // Missing cache information must fall back to the store.
     const kpfx = driver.keyPrefixOf(accessor)
     const key = kp.apply(kpfx, rawPath)
     const { conn, close } = await driver.connect(accessor)

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
 import { NOOPAccessor } from '../../accessor/base.ts'
 import { applyIo } from '../../cache/file/io.ts'
 import type { FileCache } from '../../cache/file/mixin.ts'
@@ -207,8 +208,11 @@ export class Dispatcher {
     // clears pending before it stats, so its own probes cannot recurse
     // into it.
     if (this.drift?.pending === true) {
+      // Resolve backend IDs afresh without consulting the restored index.
       await this.drift.drain(this.namespace, async (p) => {
-        const [stat] = await this.dispatch('stat', PathSpec.fromStrPath(p))
+        const [stat] = await this.dispatch('stat', PathSpec.fromStrPath(p), [], {
+          index: new RAMIndexCacheStore(),
+        })
         return stat
       })
     }

--- a/typescript/packages/core/src/workspace/reconcile.test.ts
+++ b/typescript/packages/core/src/workspace/reconcile.test.ts
@@ -12,9 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { GitHubAccessor } from '../accessor/github.ts'
+import { read as githubRead } from '../core/github/read.ts'
+import { stat as githubStat } from '../core/github/stat.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
-import { ConsistencyPolicy } from '../types.ts'
+import { ConsistencyPolicy, FileStat, FileType, PathSpec } from '../types.ts'
 import type { MountEntry } from './mount/mount.ts'
 import { Reconciler } from './reconcile.ts'
 import { Workspace } from './workspace/workspace.ts'
@@ -122,4 +125,85 @@ describe('Reconciler', () => {
     expect(ws.namespace.metaFor('/data/gone.txt')).not.toBeNull()
     await ws.close()
   })
+})
+
+describe('unverified freshness probes', () => {
+  it.each(['unknown', 'none', 'failed', 'fresh'])(
+    '%s cannot silently certify cached bytes',
+    async (probe) => {
+      const ws = new Workspace({ '/data': new RAMResource() })
+      try {
+        const path = '/data/f.txt'
+        const mount = mountOf(ws, path)
+        Object.defineProperty(mount.resource, 'supportsSnapshot', { value: true })
+        vi.spyOn(ws.ops, 'call').mockImplementation(() => {
+          if (probe === 'failed') return Promise.reject(new Error('probe unavailable'))
+          if (probe === 'none') return Promise.resolve(null)
+          return Promise.resolve(
+            new FileStat({
+              name: 'f.txt',
+              type: FileType.FILE,
+              fingerprint: probe === 'fresh' ? 'fp1' : null,
+            }),
+          )
+        })
+        const rec = new Reconciler(ws.cache, ws.namespace, ws.ops, ConsistencyPolicy.ALWAYS)
+        await ws.cache.set(path, new TextEncoder().encode('v1'), { fingerprint: 'fp1' })
+        if (probe === 'failed') {
+          await expect(rec.mayServeCached(mount, path)).rejects.toThrow('probe unavailable')
+        } else {
+          expect(await rec.mayServeCached(mount, path)).toBe(probe === 'fresh')
+          expect(await ws.cache.exists(path)).toBe(probe === 'fresh')
+        }
+        await ws.cache.set(path, new TextEncoder().encode('v1'), { fingerprint: 'fp1' })
+        await rec.reconcileRead(mount, path)
+        expect(await ws.cache.exists(path)).toBe(probe === 'fresh')
+      } finally {
+        vi.restoreAllMocks()
+        await ws.close()
+      }
+    },
+  )
+})
+
+it.each(['gate', 'shell'])('reconciles GitHub IDs before the %s reread', async (surface) => {
+  let sha = 'v1'
+  const accessor = new GitHubAccessor({
+    owner: 'o',
+    repo: 'r',
+    ref: 'main',
+    defaultBranch: 'main',
+    transport: {
+      get: (path) =>
+        Promise.resolve(
+          path.includes('/blobs/')
+            ? { encoding: 'base64', content: btoa(path.split('/').pop() ?? '') }
+            : { tree: [{ path: 'f.txt', type: 'blob', sha, size: 2 }], truncated: false },
+        ),
+      request: () => Promise.reject(new Error('unexpected request')),
+    },
+  })
+  const resource = new RAMResource()
+  Object.defineProperty(resource, 'supportsSnapshot', { value: true })
+  const ws = new Workspace({ '/gh': resource })
+  try {
+    const path = '/gh/f.txt'
+    const scope = new PathSpec({ virtual: path, resourcePath: 'f.txt', directory: '/gh/' })
+    await githubStat(accessor, scope, resource.index)
+    await ws.cache.set(path, new TextEncoder().encode('v1'), { fingerprint: 'v1' })
+    vi.spyOn(ws.ops, 'call').mockImplementation((_op, _resource, _accessor, p, _args, kwargs) =>
+      githubStat(accessor, p, kwargs?.index),
+    )
+    const mount = mountOf(ws, path)
+    const rec = new Reconciler(ws.cache, ws.namespace, ws.ops, ConsistencyPolicy.ALWAYS)
+    // An unchanged live object must not be mistaken for a missing path.
+    expect(await rec.mayServeCached(mount, path)).toBe(true)
+    sha = 'v2'
+    if (surface === 'gate') expect(await rec.mayServeCached(mount, path)).toBe(false)
+    else await rec.reconcileRead(mount, path)
+    expect(new TextDecoder().decode(await githubRead(accessor, scope, resource.index))).toBe('v2')
+  } finally {
+    vi.restoreAllMocks()
+    await ws.close()
+  }
 })

--- a/typescript/packages/core/src/workspace/reconcile.ts
+++ b/typescript/packages/core/src/workspace/reconcile.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { RAMIndexCacheStore } from '../cache/index/ram.ts'
 import { NOOPAccessor } from '../accessor/base.ts'
 import type { FileCache } from '../cache/file/mixin.ts'
 import type { OpsRegistry } from '../ops/registry.ts'
@@ -86,18 +87,26 @@ export class Reconciler {
         resource,
         resource.accessor ?? NOOP_ACCESSOR,
         scope,
+        [],
+        { index: new RAMIndexCacheStore() },
       )
     } catch (err) {
       if (isEnoent(err)) {
         await this.onMissing(path)
+        await mount.index?.clear()
         return Verdict.GONE
       }
       throw err
     }
     const fp = remoteStat instanceof FileStat ? remoteStat.fingerprint : null
-    if (fp === null) return Verdict.UNKNOWN
+    if (fp === null) {
+      await this.cache.remove(path)
+      await mount.index?.clear()
+      return Verdict.UNKNOWN
+    }
     if (!(await this.cache.isFresh(path, fp))) {
       await this.cache.remove(path)
+      await mount.index?.clear()
       return Verdict.STALE
     }
     return Verdict.FRESH
@@ -113,11 +122,12 @@ export class Reconciler {
     if (this.consistency !== ConsistencyPolicy.ALWAYS) return true
     if (mount.resource.supportsSnapshot !== true) {
       await this.cache.remove(path)
+      await mount.index?.clear()
       return false
     }
     const verdict = await this.probe(mount, path)
     if (verdict === Verdict.GONE) throw enoent(path)
-    return verdict !== Verdict.STALE
+    return verdict === Verdict.FRESH
   }
 
   // Reconcile a single-mount shell read before the command runs.
@@ -134,6 +144,8 @@ export class Reconciler {
       await this.probe(mount, path)
     } catch {
       // transient probe error: let the command read the backend directly
+      await this.cache.remove(path)
+      await mount.index?.clear()
     }
   }
 

--- a/typescript/packages/core/src/workspace/snapshot_drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot_drift.test.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { IndexEntry } from '../cache/index/config.ts'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
@@ -149,7 +150,11 @@ const statOp: RegisteredOp = {
   resource: 'fake-remote',
   filetype: null,
   write: false,
-  fn: (accessor: Accessor, scope: PathSpec) => {
+  fn: async (accessor: Accessor, scope: PathSpec, _args, { index }) => {
+    const cached = await index?.get(scope.virtual)
+    if (cached?.entry !== undefined && cached.entry !== null) {
+      return new FileStat({ name: cached.entry.name, type: FileType.FILE })
+    }
     const acc = accessor as unknown as FakeRemoteAccessor
     const entry = acc.blobs.get(scope.virtual)
     if (entry === undefined) {
@@ -226,37 +231,50 @@ describe('Workspace snapshot: capture and replay drift detection', () => {
     await loaded.close()
   })
 
-  it('STRICT load raises ContentDriftError when fingerprint drifts (no revision pin)', async () => {
-    const accessor = new FakeRemoteAccessor()
-    accessor.put('/remote/a.txt', new TextEncoder().encode('v1'))
-    const ws = build(accessor)
-    await recordedDispatch(ws, 'read', '/remote/a.txt')
-    const state = await toStateDict(ws)
-    // Strip revisions so the loader queues a drift check instead of pinning.
-    state.fingerprints = (state.fingerprints ?? []).map((e) => ({
-      path: e.path,
-      mount_prefix: e.mount_prefix,
-      fingerprint: e.fingerprint ?? null,
-    }))
-    const snap = join(tempDir, 'drift.tar')
-    const [manifest, blobs] = splitManifestAndBlobs(state as unknown as Record<string, unknown>)
-    const { writeFileSync } = await import('node:fs')
-    writeFileSync(snap, await writeSnapshotTar(manifest, blobs))
+  it.each(['shell', 'dispatch'])(
+    'STRICT load probes beyond warm metadata via %s',
+    async (surface) => {
+      const accessor = new FakeRemoteAccessor()
+      accessor.put('/remote/a.txt', new TextEncoder().encode('v1'))
+      const ws = build(accessor)
+      await recordedDispatch(ws, 'read', '/remote/a.txt')
+      const state = await toStateDict(ws)
+      // Strip revisions so the loader queues a drift check instead of pinning.
+      state.fingerprints = (state.fingerprints ?? []).map((e) => ({
+        path: e.path,
+        mount_prefix: e.mount_prefix,
+        fingerprint: e.fingerprint ?? null,
+      }))
+      const snap = join(tempDir, 'drift.tar')
+      const [manifest, blobs] = splitManifestAndBlobs(state as unknown as Record<string, unknown>)
+      const { writeFileSync } = await import('node:fs')
+      writeFileSync(snap, await writeSnapshotTar(manifest, blobs))
 
-    accessor.put('/remote/a.txt', new TextEncoder().encode('v2'))
+      accessor.put('/remote/a.txt', new TextEncoder().encode('v2'))
 
-    const ops = new OpsRegistry()
-    ops.register(readOp)
-    ops.register(statOp)
-    const loaded = await Workspace.load(
-      snap,
-      { mode: MountMode.WRITE, ops, shellParser: parser, driftPolicy: DriftPolicy.STRICT },
-      { '/remote/': new FakeRemoteResource(accessor) },
-    )
-    await expect(loaded.dispatch('read', '/remote/a.txt')).rejects.toBeInstanceOf(ContentDriftError)
-    await ws.close()
-    await loaded.close()
-  })
+      const ops = new OpsRegistry()
+      ops.register(readOp)
+      ops.register(statOp)
+      const loaded = await Workspace.load(
+        snap,
+        { mode: MountMode.WRITE, ops, shellParser: parser, driftPolicy: DriftPolicy.STRICT },
+        { '/remote/': new FakeRemoteResource(accessor) },
+      )
+      const index = loaded.namespace.mountFor('/remote/a.txt').index
+      if (index === undefined) throw new Error('missing index')
+      await index.put(
+        '/remote/a.txt',
+        new IndexEntry({ id: 'a', name: 'a.txt', resourceType: 'file', size: 2 }),
+      )
+      const read =
+        surface === 'shell'
+          ? loaded.execute('cat /remote/a.txt')
+          : loaded.dispatch('read', '/remote/a.txt')
+      await expect(read).rejects.toBeInstanceOf(ContentDriftError)
+      await ws.close()
+      await loaded.close()
+    },
+  )
 
   it('STRICT load checks drift on the fs facade too, not only Workspace.dispatch', async () => {
     // The fs facade (the FUSE path) reaches the dispatcher without

--- a/typescript/packages/core/src/workspace/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace/workspace.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
 import { checkCliVerbs } from '../session/validate.ts'
 import type { FileCache } from '../../cache/file/mixin.ts'
 import type { IndexConfig } from '../../cache/index/config.ts'
@@ -1132,7 +1133,7 @@ export class Workspace {
       parser: () => this.getShellParser(),
       meta: this.meta,
       drift: this.drift,
-      statFn: (p) => this.dispatchInternal('stat', p),
+      statFn: (p) => this.dispatchInternal('stat', p, [], { index: new RAMIndexCacheStore() }),
       namespace: this.namespace,
       sessions: this.sessionManager,
       registry: this.registry,

--- a/typescript/packages/node/src/resource/s3/s3_consistency.test.ts
+++ b/typescript/packages/node/src/resource/s3/s3_consistency.test.ts
@@ -12,6 +12,11 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import {
+  IndexType,
+  type IndexConfig,
+  type RedisIndexConfig,
+} from '@struktoai/mirage-core/cache/index/config'
 import { ConsistencyPolicy, MountMode } from '@struktoai/mirage-core/types'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { Workspace } from '../../workspace.ts'
@@ -52,19 +57,52 @@ describe('S3 cache consistency (mocked)', () => {
     mock.restore()
   })
 
-  it('ALWAYS refetches after the remote object changes out-of-band', async () => {
-    const ws = new Workspace(
-      { '/s3/': new S3Resource(makeConfig()) },
-      { mode: MountMode.WRITE, consistency: ConsistencyPolicy.ALWAYS },
-    )
-    const first = await ws.execute('cat /s3/c.txt')
-    expect(DEC.decode(first.stdout)).toBe('v1')
-    // Mutate the object behind the cache's back (different content => new ETag).
-    mock.store.set(BUCKET, 'c.txt', ENC.encode('v2'))
-    const second = await ws.execute('cat /s3/c.txt')
-    expect(DEC.decode(second.stdout)).toBe('v2')
-    await ws.close()
-  })
+  for (const type of [IndexType.RAM, IndexType.REDIS]) {
+    it
+      .skipIf(type === IndexType.REDIS && process.env.REDIS_URL === undefined)
+      .each(['shell', 'fs'])(`ALWAYS checks a warm ${type} index via %s`, async (surface) => {
+      const index: IndexConfig | RedisIndexConfig =
+        type === IndexType.REDIS
+          ? {
+              type,
+              ...(process.env.REDIS_URL === undefined ? {} : { url: process.env.REDIS_URL }),
+              keyPrefix: `consistency:${crypto.randomUUID()}:`,
+            }
+          : { type }
+      const resource = new S3Resource(makeConfig())
+      const ws = new Workspace(
+        { '/s3/': resource },
+        {
+          mode: MountMode.WRITE,
+          consistency: ConsistencyPolicy.ALWAYS,
+          index,
+        },
+      )
+      try {
+        expect((await ws.execute('ls /s3/')).exitCode).toBe(0)
+        expect((await resource.index.get('/s3/c.txt')).entry).toBeDefined()
+        expect(DEC.decode((await ws.execute('cat /s3/c.txt')).stdout)).toBe('v1')
+        expect(await ws.cache.exists('/s3/c.txt')).toBe(true)
+        mock.store.set(BUCKET, 'c.txt', ENC.encode('v2'))
+        if (surface === 'shell') {
+          expect(DEC.decode((await ws.execute('cat /s3/c.txt')).stdout)).toBe('v2')
+        } else {
+          expect(DEC.decode(await ws.fs.readFile('/s3/c.txt'))).toBe('v2')
+        }
+        mock.store.objects(BUCKET).delete('c.txt')
+        if (surface === 'shell') {
+          const result = await ws.execute('cat /s3/c.txt')
+          expect(result.exitCode).toBe(1)
+          expect(result.stdout.byteLength).toBe(0)
+        } else {
+          await expect(ws.fs.readFile('/s3/c.txt')).rejects.toMatchObject({ code: 'ENOENT' })
+        }
+      } finally {
+        await resource.index.clear()
+        await ws.close()
+      }
+    })
+  }
 
   it('LAZY keeps serving the cached bytes after an out-of-band change', async () => {
     const ws = new Workspace(


### PR DESCRIPTION
Closes #1011.

- Fix `ALWAYS` reads returning old content after a directory listing.
- Recover when a directory listing survives but a child's cached metadata is evicted.
- Apply both fixes in Python and TypeScript.
- Fully resolve #1011; address partial eviction from #1010. Broader cache performance work stays in #1010.

## Why #1011 happens

- **Index cache:** directory listings and file metadata.
- **File cache:** file contents and their fingerprints.
- **Bug:** validate cached content using cached metadata; accept an unknown fingerprint as fresh enough.
- Example: `/s3/o.txt`, contents `v1`, then an external overwrite to `v2`.
- `E1` and `E2` below stand for the two versions' backend fingerprints.

```text
SETUP
  Backend: o.txt = "v1", fingerprint E1
       |
       +-- ls /s3/ --------> index caches o.txt metadata
       |                    (no fingerprint)
       +-- cat /s3/o.txt --> file cache stores "v1", E1
       |
  External write: o.txt = "v2", fingerprint E2

CURRENT
  cat /s3/o.txt [ALWAYS]
       |
       v
  stat --> cached index --> no fingerprint --> UNKNOWN
                                                |
                                                v
                                      return cached "v1"  BUG
  Backend E2 is never checked.

AFTER THIS PR
  cat /s3/o.txt [ALWAYS]
       |
       v
  live backend stat --> E2
       |
       v
  compare with cached E1 --> different
       |
       v
  discard cached bytes + stale index metadata
       |
       v
  backend read --> "v2"
```

- Matching fingerprint: reuse cached bytes.
- Deleted object: report missing; do not return old bytes.
- Missing fingerprint: discard cached content and read the backend.
- Failed probe: shell reads retry through a fresh backend read; direct read checks propagate the error.
- Fresh, temporary probe index: preserve backend file-ID resolution without consulting stale metadata.
- Clear stale IDs too: `path -> old blob ID -> old bytes` must not survive a rejected freshness check.

## Partial metadata eviction

- Directory membership and child metadata are separate cache entries.
- Losing one child's metadata does not prove the child was deleted.
- Example: backend still contains `/s3/report.csv` with contents `sales,42`.

```text
1. List /s3/

   Backend                        Index cache
   report.csv = "sales,42"  --->  /s3/ children = [report.csv]
                                  /s3/report.csv metadata = FILE

2. Evict only the child's metadata

   /s3/ children = [report.csv]    still cached
   /s3/report.csv metadata = ?     evicted
   Backend report.csv             still exists

3. stat /s3/report.csv

   CURRENT
     metadata missing + parent listing cached
       --> treat child as absent                    BUG

   AFTER
     metadata missing --> parent lists report.csv
       --> backend stat --> FILE
       --> subsequent read returns "sales,42"
```

- Preserve negative lookups when a valid cached listing excludes the child:

```text
stat /s3/missing.csv
  --> child metadata missing
  --> cached /s3/ children = [report.csv]
  --> missing.csv is NOT listed
  --> report missing; no backend request
```

## Snapshot drift and revision pins

- **Unpinned snapshot:** compare the recorded fingerprint against live backend metadata.
- **Fix:** a warm or restored index must not hide a changed backend fingerprint.
- Example under strict drift policy:

```text
Read /s3/data.csv = "version 1 bytes" [E1]
  --> save snapshot with fingerprint E1
  --> external overwrite = "VERSION 2 DRIFTED" [E2]
  --> load snapshot; index still has old file metadata
  --> next read triggers live backend stat --> E2
  --> compare recorded E1 with live E2
  --> ContentDriftError; do not silently accept changed content
```

- **Revision-pinned snapshot:** keep reading the recorded version; behavior unchanged.
- Example with S3 versioning enabled (`V1`/`V2` stand for VersionIds):

```text
Read /s3/data.csv = "original" [VersionId V1]
  --> save snapshot with revision V1
  --> external overwrite = "mutated bytes" [VersionId V2]
  --> load snapshot; pin data.csv to V1
  --> backend read requests VersionId V1
  --> return "original", even though latest is V2
```

## Validation

- Focused tests: **115 Python + 158 TypeScript passed**.
- Coverage: RAM/Redis indexes; shell/filesystem reads; external overwrite/delete; partial eviction; unknown/failed probes; GitHub file IDs; snapshot drift and revision pins.
- Affected package typechecks and applicable pre-commit hooks passed.
- Local full TypeScript run: unrelated native jq 1.6/BSD sed conformance failures. Remote TypeScript workflow passed.
- [CI](https://github.com/strukto-ai/mirage/pull/1040/checks): **45 passed, 5 skipped**.
- Local and PR reviews: no actionable findings.
